### PR TITLE
fix(line): record every LINE push message id in send receipts

### DIFF
--- a/extensions/line/src/auto-reply-delivery.test-helpers.ts
+++ b/extensions/line/src/auto-reply-delivery.test-helpers.ts
@@ -69,7 +69,7 @@ export function createDeps(overrides?: Partial<LineAutoReplyDeps>) {
   const pushMessagesLine = vi.fn(async () => ({
     messageId: "push",
     chatId: "u1",
-    receipt: createLineSendReceipt({ messageId: "push", chatId: "u1", kind: "text" }),
+    receipt: createLineSendReceipt({ parts: [{ messageId: "push", kind: "text" }], chatId: "u1" }),
   }));
   const deps: LineAutoReplyDeps = {
     buildTemplateMessageFromPayload: () => null,

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -58,7 +58,7 @@ function lineResult(messageId: string, chatId = "c1") {
   return {
     messageId,
     chatId,
-    receipt: createLineSendReceipt({ messageId, chatId, kind: "text" }),
+    receipt: createLineSendReceipt({ parts: [{ messageId, kind: "text" }], chatId }),
   };
 }
 

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -291,7 +291,10 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         result = {
           messageId: "processed",
           chatId: to,
-          receipt: createLineSendReceipt({ messageId: "processed", chatId: to, kind: "card" }),
+          receipt: createLineSendReceipt({
+            parts: [{ messageId: "processed", kind: "card" }],
+            chatId: to,
+          }),
         };
       }
       for (const flexMsg of processed.flexMessages) {
@@ -325,9 +328,8 @@ function toLineMessageSendResult(
     result.receipt ??
     (result.messageId
       ? createLineSendReceipt({
-          messageId: result.messageId,
+          parts: [{ messageId: result.messageId, kind }],
           chatId: source.chatId ?? "",
-          kind,
         })
       : undefined);
   if (!receipt) {

--- a/extensions/line/src/send-receipt.ts
+++ b/extensions/line/src/send-receipt.ts
@@ -6,28 +6,30 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 
 export function createLineSendReceipt(params: {
-  messageId: string;
+  // Ordered physical LINE messages this send produced (media + caption is two).
+  // Each id is paired with its own kind so a media + caption send records kinds
+  // [media, text]; the two cannot drift because they travel together. The first
+  // stays primary.
+  parts: { messageId: string; kind: MessageReceiptPartKind }[];
   chatId: string;
-  kind?: MessageReceiptPartKind;
   messageCount?: number;
 }): MessageReceipt {
-  const messageId = params.messageId.trim();
   const chatId = params.chatId.trim();
+  const parts = params.parts
+    .map((part) => ({ messageId: part.messageId.trim(), kind: part.kind }))
+    .filter((part) => part.messageId.length > 0);
   return createMessageReceiptFromOutboundResults({
-    results: messageId
-      ? [
-          {
-            channel: "line",
-            messageId,
-            chatId,
-            conversationId: chatId,
-            meta: {
-              messageCount: params.messageCount ?? 1,
-            },
-          },
-        ]
-      : [],
+    // Each id carries its own kind on its result so the two cannot drift.
+    results: parts.map((part) => ({
+      channel: "line",
+      messageId: part.messageId,
+      chatId,
+      conversationId: chatId,
+      kind: part.kind,
+      meta: {
+        messageCount: params.messageCount ?? parts.length,
+      },
+    })),
     ...(chatId ? { threadId: chatId } : {}),
-    kind: params.kind ?? "unknown",
   });
 }

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -149,8 +149,8 @@ describe("LINE send helpers", () => {
       hostname: "example.com",
       addresses: ["93.184.216.34"],
     });
-    pushMessageMock.mockResolvedValue({});
-    replyMessageMock.mockResolvedValue({});
+    pushMessageMock.mockResolvedValue({ sentMessages: [{ id: "push-msg-id" }] });
+    replyMessageMock.mockResolvedValue({ sentMessages: [{ id: "reply-msg-id" }] });
     showLoadingAnimationMock.mockResolvedValue({});
   });
 
@@ -411,31 +411,31 @@ describe("LINE send helpers", () => {
     expect(logVerboseMock).toHaveBeenCalledWith("line: pushed image to U123");
     expect(result).toEqual({
       chatId: "U123",
-      messageId: "push",
+      messageId: "push-msg-id",
       receipt: {
         parts: [
           {
             index: 0,
             kind: "media",
-            platformMessageId: "push",
+            platformMessageId: "push-msg-id",
             raw: {
               channel: "line",
               chatId: "U123",
               conversationId: "U123",
-              messageId: "push",
+              messageId: "push-msg-id",
               meta: { messageCount: 1 },
             },
             threadId: "U123",
           },
         ],
-        platformMessageIds: ["push"],
-        primaryPlatformMessageId: "push",
+        platformMessageIds: ["push-msg-id"],
+        primaryPlatformMessageId: "push-msg-id",
         raw: [
           {
             channel: "line",
             chatId: "U123",
             conversationId: "U123",
-            messageId: "push",
+            messageId: "push-msg-id",
             meta: { messageCount: 1 },
           },
         ],
@@ -445,7 +445,52 @@ describe("LINE send helpers", () => {
     });
   });
 
-  it("replies when reply token is provided", async () => {
+  it("adopts the real LINE platform message id from the push response", async () => {
+    pushMessageMock.mockResolvedValueOnce({
+      sentMessages: [{ id: "line-real-id-123" }],
+    });
+
+    const result = await sendModule.sendMessageLine("line:user:U123", "Hello", {
+      cfg: LINE_TEST_CFG,
+    });
+
+    expect(result.messageId).toBe("line-real-id-123");
+    expect(result.receipt?.primaryPlatformMessageId).toBe("line-real-id-123");
+    expect(result.receipt?.platformMessageIds).toEqual(["line-real-id-123"]);
+  });
+
+  it("records every returned id when a push delivers multiple messages", async () => {
+    // media + caption is delivered as two LINE messages, so the response carries
+    // two sent-message ids; both must reach the receipt.
+    pushMessageMock.mockResolvedValueOnce({
+      sentMessages: [{ id: "line-media-id" }, { id: "line-caption-id" }],
+    });
+
+    const result = await sendModule.sendMessageLine("line:user:U123", "Caption", {
+      cfg: LINE_TEST_CFG,
+      mediaUrl: "https://example.com/photo.jpg",
+    });
+
+    // First id stays primary for LineSendResult.messageId parity with siblings.
+    expect(result.messageId).toBe("line-media-id");
+    expect(result.receipt?.primaryPlatformMessageId).toBe("line-media-id");
+    expect(result.receipt?.platformMessageIds).toEqual(["line-media-id", "line-caption-id"]);
+    expect(result.receipt?.parts.map((part) => part.platformMessageId)).toEqual([
+      "line-media-id",
+      "line-caption-id",
+    ]);
+    // Each id keeps its own kind: the image is media, the caption is text.
+    expect(result.receipt?.parts.map((part) => part.kind)).toEqual(["media", "text"]);
+  });
+
+  it("records every returned id and per-message kinds on a media + caption reply", async () => {
+    // A media + caption reply is delivered as two LINE messages, so the response
+    // carries two ordered sent-message ids. Both real ids and their [media, text]
+    // kinds must reach the receipt instead of a single "reply" literal/kind.
+    replyMessageMock.mockResolvedValueOnce({
+      sentMessages: [{ id: "line-reply-media-id" }, { id: "line-reply-caption-id" }],
+    });
+
     const result = await sendModule.sendMessageLine("line:group:C1", "Hello", {
       cfg: LINE_TEST_CFG,
       replyToken: "reply-token",
@@ -472,31 +517,51 @@ describe("LINE send helpers", () => {
     expect(logVerboseMock).toHaveBeenCalledWith("line: replied to C1");
     expect(result).toEqual({
       chatId: "C1",
-      messageId: "reply",
+      messageId: "line-reply-media-id",
       receipt: {
         parts: [
           {
             index: 0,
             kind: "media",
-            platformMessageId: "reply",
+            platformMessageId: "line-reply-media-id",
             raw: {
               channel: "line",
               chatId: "C1",
               conversationId: "C1",
-              messageId: "reply",
+              messageId: "line-reply-media-id",
+              meta: { messageCount: 2 },
+            },
+            threadId: "C1",
+          },
+          {
+            index: 1,
+            kind: "text",
+            platformMessageId: "line-reply-caption-id",
+            raw: {
+              channel: "line",
+              chatId: "C1",
+              conversationId: "C1",
+              messageId: "line-reply-caption-id",
               meta: { messageCount: 2 },
             },
             threadId: "C1",
           },
         ],
-        platformMessageIds: ["reply"],
-        primaryPlatformMessageId: "reply",
+        platformMessageIds: ["line-reply-media-id", "line-reply-caption-id"],
+        primaryPlatformMessageId: "line-reply-media-id",
         raw: [
           {
             channel: "line",
             chatId: "C1",
             conversationId: "C1",
-            messageId: "reply",
+            messageId: "line-reply-media-id",
+            meta: { messageCount: 2 },
+          },
+          {
+            channel: "line",
+            chatId: "C1",
+            conversationId: "C1",
+            messageId: "line-reply-caption-id",
             meta: { messageCount: 2 },
           },
         ],

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -246,10 +246,16 @@ function buildLineSendResult(
   // each returned id with its own message's kind; the first stays primary.
   const parts = sentMessages.map((sent, index) => ({
     messageId: sent.id,
-    kind: resolveLineReceiptKind([messages[index]]),
+    kind: resolveLineReceiptKind(messages.slice(index, index + 1)),
   }));
+  const [primary] = parts;
+  if (!primary) {
+    // LINE documents one SentMessage per delivered message, so an empty list on
+    // a resolved send is a contract violation rather than a state to paper over.
+    throw new Error("LINE returned no sent messages for a delivered send");
+  }
   return {
-    messageId: parts[0].messageId,
+    messageId: primary.messageId,
     chatId,
     receipt: createLineSendReceipt({ parts, chatId, messageCount: messages.length }),
   };

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -1,6 +1,7 @@
 // Line plugin module implements send behavior.
 import { messagingApi } from "@line/bot-sdk";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import type { MessageReceiptPartKind } from "openclaw/plugin-sdk/channel-outbound";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
@@ -14,6 +15,7 @@ import { createLineSendReceipt } from "./send-receipt.js";
 import type { LineOutboundMediaKind, LineSendResult } from "./types.js";
 
 type Message = messagingApi.Message;
+type SentMessage = messagingApi.SentMessage;
 type TextMessage = messagingApi.TextMessage;
 type ImageMessage = messagingApi.ImageMessage;
 type VideoMessage = messagingApi.VideoMessage & { trackingId?: string };
@@ -213,7 +215,7 @@ function recordLineOutboundActivity(accountId: string): void {
   });
 }
 
-function resolveLineReceiptKind(messages: readonly Message[]) {
+function resolveLineReceiptKind(messages: readonly Message[]): MessageReceiptPartKind {
   const types = new Set(messages.map((message) => message.type));
   if (types.has("audio")) {
     return "voice";
@@ -228,6 +230,29 @@ function resolveLineReceiptKind(messages: readonly Message[]) {
     return "text";
   }
   return "unknown";
+}
+
+// LINE returns one SentMessage per delivered message (media + caption sends
+// several), in request order. Record every id with its own kind so receipt
+// parts read [media, text] rather than one aggregate kind, and keep the first
+// id primary (previously a "push"/"reply" literal) so tracking/dedup/audit
+// consumers see every physical message.
+function buildLineSendResult(
+  chatId: string,
+  messages: Message[],
+  sentMessages: readonly SentMessage[],
+): LineSendResult {
+  // LINE returns sentMessages in submitted-message order (documented), so pair
+  // each returned id with its own message's kind; the first stays primary.
+  const parts = sentMessages.map((sent, index) => ({
+    messageId: sent.id,
+    kind: resolveLineReceiptKind([messages[index]]),
+  }));
+  return {
+    messageId: parts[0].messageId,
+    chatId,
+    receipt: createLineSendReceipt({ parts, chatId, messageCount: messages.length }),
+  };
 }
 
 async function pushLineMessages(
@@ -247,14 +272,12 @@ async function pushLineMessages(
     messages: normalizedMessages,
   });
 
-  if (behavior.errorContext) {
-    await pushRequest.catch((err: unknown) => {
-      logLineHttpError(err, behavior.errorContext!);
-      throw err;
-    });
-  } else {
-    await pushRequest;
-  }
+  const response = behavior.errorContext
+    ? await pushRequest.catch((err: unknown) => {
+        logLineHttpError(err, behavior.errorContext!);
+        throw err;
+      })
+    : await pushRequest;
 
   recordLineOutboundActivity(account.accountId);
 
@@ -265,16 +288,7 @@ async function pushLineMessages(
     logVerbose(logMessage);
   }
 
-  return {
-    messageId: "push",
-    chatId,
-    receipt: createLineSendReceipt({
-      messageId: "push",
-      chatId,
-      kind: resolveLineReceiptKind(messages),
-      messageCount: messages.length,
-    }),
-  };
+  return buildLineSendResult(chatId, messages, response.sentMessages);
 }
 
 async function replyLineMessages(
@@ -282,11 +296,13 @@ async function replyLineMessages(
   messages: Message[],
   opts: LinePushOpts,
   behavior: LineReplyBehavior = {},
-): Promise<void> {
+): Promise<readonly SentMessage[]> {
   const { account, client } = createLineMessagingClient(opts);
   const normalizedMessages = messages.map(normalizeLineMessageActions);
 
-  await client.replyMessage({
+  // Reply returns the same ordered sentMessages contract as push; capture it so
+  // the receipt records real ids/kinds instead of a "reply" literal.
+  const response = await client.replyMessage({
     replyToken,
     messages: normalizedMessages,
   });
@@ -299,6 +315,8 @@ async function replyLineMessages(
         `line: replied with ${messages.length} messages`,
     );
   }
+
+  return response.sentMessages;
 }
 
 export async function sendMessageLine(
@@ -346,20 +364,11 @@ export async function sendMessageLine(
   }
 
   if (opts.replyToken) {
-    await replyLineMessages(opts.replyToken, messages, opts, {
+    const sentMessages = await replyLineMessages(opts.replyToken, messages, opts, {
       verboseMessage: () => `line: replied to ${chatId}`,
     });
 
-    return {
-      messageId: "reply",
-      chatId,
-      receipt: createLineSendReceipt({
-        messageId: "reply",
-        chatId,
-        kind: resolveLineReceiptKind(messages),
-        messageCount: messages.length,
-      }),
-    };
+    return buildLineSendResult(chatId, messages, sentMessages);
   }
 
   return pushLineMessages(chatId, messages, opts, {

--- a/src/channels/message/receipt.test.ts
+++ b/src/channels/message/receipt.test.ts
@@ -36,6 +36,24 @@ describe("createMessageReceiptFromOutboundResults", () => {
     ]);
   });
 
+  it("uses each flat result's own kind, falling back to the aggregate kind, and keeps kind out of raw", () => {
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [
+        { channel: "line", messageId: "media-id", kind: "media" },
+        { channel: "line", messageId: "caption-id", kind: "text" },
+        // Explicit `kind: undefined` must fall back and still not leak the key.
+        { channel: "line", messageId: "extra-id", kind: undefined },
+      ],
+      kind: "unknown",
+      sentAt: 123,
+    });
+
+    expect(receipt.parts.map((part) => part.kind)).toEqual(["media", "text", "unknown"]);
+    // `kind` is receipt-layer metadata and must not leak into the raw platform result.
+    expect(receipt.parts.every((part) => !("kind" in (part.raw ?? {})))).toBe(true);
+    expect(receipt.raw?.every((result) => !("kind" in result))).toBe(true);
+  });
+
   it("uses alternate platform ids when messageId is unavailable", () => {
     const receipt = createMessageReceiptFromOutboundResults({
       results: [{ channel: "whatsapp", messageId: "", toJid: "jid-1" }],

--- a/src/channels/message/receipt.ts
+++ b/src/channels/message/receipt.ts
@@ -12,7 +12,25 @@ import type {
 
 type MessageReceiptInputResult = MessageReceiptSourceResult & {
   receipt?: MessageReceipt;
+  // Optional receipt kind for this single physical platform message. Adapters
+  // that deliver several kinds in one logical send (e.g. LINE media + caption)
+  // set it per result so each part keeps its own kind; the kind travels with its
+  // id so the two cannot drift, unlike a separate parallel array. Ignored for
+  // nested-receipt results, which carry their own part kinds.
+  kind?: MessageReceiptPartKind;
 };
+
+// The per-result `kind` is receipt-layer metadata, not a platform field, so keep
+// it out of `raw`, which mirrors the raw platform send result.
+function stripResultKind(result: MessageReceiptInputResult): MessageReceiptInputResult {
+  // Own-key check, not `=== undefined`: an explicit `{ kind: undefined }` still
+  // carries the key and must be stripped so `kind` never appears in `raw`.
+  if (!Object.hasOwn(result, "kind")) {
+    return result;
+  }
+  const { kind: _kind, ...rest } = result;
+  return rest;
+}
 
 function resolveReceiptMessageId(result: MessageReceiptInputResult): string | undefined {
   return (
@@ -45,6 +63,7 @@ function appendUnique(values: string[], value: string | undefined): void {
 /** Builds one normalized receipt from platform send results or nested adapter receipts. */
 export function createMessageReceiptFromOutboundResults(params: {
   results: readonly MessageReceiptInputResult[];
+  // Fallback kind for flat results that do not carry their own `kind`.
   kind?: MessageReceiptPartKind;
   threadId?: string;
   replyToId?: string;
@@ -80,11 +99,11 @@ export function createMessageReceiptFromOutboundResults(params: {
     return [
       {
         platformMessageId,
-        kind: params.kind ?? "unknown",
+        kind: result.kind ?? params.kind ?? "unknown",
         index: resultIndex,
         ...(params.threadId ? { threadId: params.threadId } : {}),
         ...(params.replyToId ? { replyToId: params.replyToId } : {}),
-        raw: result,
+        raw: stripResultKind(result),
       },
     ];
   });
@@ -116,7 +135,7 @@ export function createMessageReceiptFromOutboundResults(params: {
       ? { replyToId: params.replyToId ?? firstNestedReceipt?.replyToId }
       : {}),
     sentAt: params.sentAt ?? firstNestedReceipt?.sentAt ?? Date.now(),
-    raw: params.results,
+    raw: params.results.map(stripResultKind),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

LINE send receipts throw away every real message id and mislabel multi-part sends.

`pushLineMessages` returned a hardcoded `messageId: "push"`, and the reply branch returned `"reply"` while discarding the response body, so neither path ever recorded an id LINE actually assigned. A single logical send can produce several physical messages — media + caption is two, one `sentMessages[].id` each — and all of them were dropped. The receipt also stamped one aggregate `kind` across every id, so a media + caption send was recorded as `[media, media]` rather than `[media, text]`.

Both are still present on `upstream/main`: `send.ts` returns the `"push"` and `"reply"` literals in the two branches today.

## Why This Change Was Made

Push and reply now build their receipt through one ordered path, `buildLineSendResult`. The first returned id becomes the singular `messageId`, every id becomes an ordered `parts` entry, and each id carries its own kind, derived from `sentMessages[i]` ↔ `messages[i]`.

The per-message kind travels on each flat receipt-input result as an additive optional `kind`, rather than as a parallel array beside the ids. An id and its kind cannot drift apart if they are the same object. The shared normalizer already owns id dedup, primary-id derivation, and part assembly, and only accepted one uniform kind; the alternative — LINE assembling its own `MessageReceipt` — would fork all of that into the plugin. Results without a `kind` keep falling back to the uniform one, nested-receipt adapters are untouched, and `kind` stays out of the raw platform result.

Both paths share the same broken invariant, so fixing one and not the other would leave the receipt half-correct. They land together.

`@line/bot-sdk` 11.2.0 — the version pinned in `extensions/line/package.json` on this head — declares `sentMessages` on both `PushMessageResponse` and `ReplyMessageResponse` as `Minimum items: 1` / `Maximum items: 5`, one entry per submitted message. That is a documented contract rather than a runtime guarantee, and the code does not quietly assume it: an empty array reaches `if (!primary)` in `buildLineSendResult` and throws `LINE returned no sent messages for a delivered send`.

**One limit, stated because the mapping is broader than the citation behind it.** The adapter applies `sentMessages[i]` ↔ `messages[i]` to every message type it can send. LINE documents that ordering on its quote-token page, whose enumeration does not cover all of those types — audio and location among them. For image and text the ordering is documented *and* demonstrated live below; for the rest the same index mapping is applied without a document that names them and without a live capture. The exposure is a mislabelled `kind` on a multi-part send of those types, not a lost or wrong id, since the ids are recorded in the order LINE returns them either way. Narrowing the mapping to the documented set would mean two code paths over one array; if that is preferred, it is a small change at `resolveLineReceiptKind`'s caller and better decided now than after merge.

## User Impact

Consumers of LINE send receipts get the real LINE message id for every sent message, on push and on reply. The receipt schema does not change: `messageId` / `primaryPlatformMessageId` change *value* (a real id instead of the `"push"` / `"reply"` placeholder), and `platformMessageIds` / `parts` change *cardinality* — a media + caption send now exposes both ordered ids, one `parts` entry each, with kinds `[media, text]`.

Scope is 8 paths: `send.ts`, `send-receipt.ts` and `outbound.ts` for the LINE side, one additive option in `receipt.ts` for the shared normalizer, and four test paths (`send.test.ts`, `channel.sendPayload.test.ts`, `receipt.test.ts`, `auto-reply-delivery.test-helpers.ts`).

## Evidence

```
head:       03752750cf6c34b3065a849b9540283de807428f
merge base: de5e09ac27317626e5101fada406f308f4d8f4ae
```

This is the previously reviewed change, rebased. Its earlier head could not be tested at all: that head's base commit was no longer fetchable, so every CI job died during checkout (`Base commit still unavailable after fetch attempts`, plus checkout timeouts) — visible on this PR's own checks for the prior head.

The production change survived the rebase unaltered. Comparing only the `+`/`-` lines in `outbound.ts`, `send.ts`, `send-receipt.ts` and `receipt.ts` between the previous head `9c5dfe4b29` and this one gives the same 145 lines on both sides (+90 / −55). Context lines did move — upstream changed the surrounding code, notably `normalizeLineMessageActions` ([#113081](https://github.com/openclaw/openclaw/pull/113081)) and the canonical `MediaKind` consolidation ([#112063](https://github.com/openclaw/openclaw/pull/112063)) — and the test files are consequently *not* byte-identical, because hunks that used to sit in unchanged context are now part of the diff.

### Against the real LINE Messaging API

A `node --import tsx` harness drives the production `sendMessageLine` path against LINE with a real channel access token, for a media + caption send, on both push and reply; the reply token is captured live from an inbound webhook event. No build step is involved — the harness imports the production source module (`extensions/line/src/send.ts`) through the repo's tsconfig paths, so no `dist` can go stale between the code under review and the code that ran.

The user id, the reply token, and the tunnel hostname serving the test image are redacted. The LINE message ids are shown in full, because telling the two returned ids apart is the point.

```
[capture] inbound message from user U094…e0; replyToken 54fb…71 captured.
[capture] running REPLY proof first (token is single-use, short-lived)…

REPLY (real LINE API, media + caption)
  result.messageId (primary)        : 624895558297583626
  receipt.primaryPlatformMessageId  : 624895558297583626
  receipt.platformMessageIds        : ["624895558297583626","624895558330614226"]
  receipt.parts[].kind              : [media, text]
  => PASS: two real ids + kinds [media, text] + first primary

PUSH (real LINE API, media + caption)
  result.messageId (primary)        : 624895558565495068
  receipt.primaryPlatformMessageId  : 624895558565495068
  receipt.platformMessageIds        : ["624895558565495068","624895558717014191"]
  receipt.parts[].kind              : [media, text]
  => PASS: two real ids + kinds [media, text] + first primary

OVERALL: reply=PASS push=PASS
```

Each leg asserts that `platformMessageIds` holds both returned ids in order, that `messageId` and `primaryPlatformMessageId` equal the first, and that `parts[].kind` is `[media, text]`.

### Before the fix

That live run costs a single-use reply token and a person sending a DM, so it was captured once, against the fixed code. The before contrast comes from the focused tests instead — a regression reproduction rather than a second live capture. The four production files are checked out from `upstream/main` as it stood at capture time (`5578d01777`, later than this branch's merge base, so the comparison is against a newer `main`); this PR's tests run unchanged in both legs.

`node scripts/run-vitest.mjs extensions/line/src/send.test.ts src/channels/message/receipt.test.ts`:

```
 × src/channels/message/receipt.test.ts > uses each flat result's own kind, falling back to the aggregate kind, and keeps kind out of raw
 × extensions/line/src/send.test.ts > pushes images via normalized LINE target
 × extensions/line/src/send.test.ts > adopts the real LINE platform message id from the push response
 × extensions/line/src/send.test.ts > records every returned id when a push delivers multiple messages
 × extensions/line/src/send.test.ts > records every returned id and per-message kinds on a media + caption reply
   → AssertionError: expected { messageId: 'reply', …(2) } to deeply equal { chatId: 'C1', …(2) }
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯
 Test Files  2 failed (2)
      Tests  5 failed | 29 passed (34)
```

`messageId: 'reply'` in that assertion is the defect verbatim — the literal placeholder standing where the real platform id belongs. With the fix in place the same command reports `34 passed (34)`.

`extensions/line/src/channel.sendPayload.test.ts` is deliberately left out of that before leg. Its helper is part of this PR and passes the new receipt shape, so against reverted production it throws inside `createLineSendReceipt` — 13 failures that would pad the count while saying nothing about the defect.

### Wider checks

`pnpm test extensions/line` and `pnpm test src/channels/message` are green on this head, 183 passing across the changed lanes. `tsgo`, `oxfmt --check` and `git diff --check` are clean. The media + caption reply test asserts both ids in order with kinds `[media, text]` and the first primary; the push test asserts the same; a normalizer test asserts that each flat result's own `kind` applies, that the aggregate kind is still the fallback, and that `kind` stays out of `raw`.

### What is not covered

No audio, video, location, flex or template send is exercised live — only image + text, as described above. The harness talks to one LINE channel, so nothing here says anything about behaviour across multiple configured accounts.
