### PR TITLE
fix: run local audio doctor health check

### DIFF
--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1502,6 +1502,10 @@ async function runProviderCatalogProjectionHealth(ctx: DoctorHealthFlowContext):
   await runCoreHealthFindingNote(ctx, "core/doctor/provider-catalog-projection");
 }
 
+async function runLocalAudioAccelerationHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  await runCoreHealthFindingNote(ctx, "core/doctor/local-audio-acceleration");
+}
+
 async function runRuntimeToolSchemasHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   await runCoreHealthFindingNote(ctx, "core/doctor/runtime-tool-schemas");
 }
@@ -2025,6 +2029,12 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       label: "Provider catalog projection",
       healthCheckIds: ["core/doctor/provider-catalog-projection"],
       run: runProviderCatalogProjectionHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:local-audio-acceleration",
+      label: "Local audio acceleration",
+      healthCheckIds: ["core/doctor/local-audio-acceleration"],
+      run: runLocalAudioAccelerationHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:runtime-tool-schemas",


### PR DESCRIPTION
Related: #104210

## What Problem This Solves

Fixes an issue where the CI ownership invariant failed because the new local audio acceleration health check was implemented in the core registry but absent from the ordered doctor contribution list.

## Why This Change Was Made

The existing core health check now has a matching ordered contribution that uses the same generic core-finding runner as adjacent provider and runtime checks. No duplicate detection logic or compatibility path is added.

## User Impact

`openclaw doctor` can execute the local audio acceleration check through its canonical ordered flow, and unrelated PRs no longer fail the doctor contribution ownership test.

## Evidence

- Exact failure on PR #104229 CI run `29142753546`: `doctor-health-contributions.test.ts` expected `core/doctor/local-audio-acceleration` in the ordered contribution IDs.
- Before fix, the focused test reproduced the same 1/90 failure on the PR tree.
- After fix, the focused local fallback passed 90/90 tests; Testbox replacement allocation was unavailable due provider 429/reclamation.
- Structured autoreview completed clean.
- Exact-head hosted CI is required before merge through `scripts/pr`.
