### PR TITLE
fix(code-mode): report UTF-8 API file byte counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
+- **Code Mode API file sizes:** report UTF-8 byte counts for virtual MCP declaration files through both `API.list()` and `API.read()`, including non-ASCII schema documentation. (#104244) Thanks @qingminglong.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.
 - **Gateway client watchdog:** keep transport-stall detection active for unbounded and mixed pending requests so dead sockets reject pending requests, reconnect, and never replay rejected requests. (#103407) Thanks @NianJiuZst.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
-- **Code Mode API file sizes:** report UTF-8 byte counts for virtual MCP declaration files through both `API.list()` and `API.read()`, including non-ASCII schema documentation. (#104244) Thanks @qingminglong.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.
 - **Gateway client watchdog:** keep transport-stall detection active for unbounded and mixed pending requests so dead sockets reject pending requests, reconnect, and never replay rejected requests. (#103407) Thanks @NianJiuZst.

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -574,6 +574,7 @@ export type CodeModeApiVirtualFile = {
   path: string;
   description?: string;
   content: string;
+  bytes: number;
 };
 
 function buildMcpParamDocs(schema: unknown): McpApiParamDoc[] {
@@ -872,18 +873,22 @@ export function createCodeModeApiVirtualFiles(
   if (!model) {
     return [];
   }
+  const rootContent = renderMcpRootFile(model.docs);
   const files: CodeModeApiVirtualFile[] = [
     {
       path: "mcp/index.d.ts",
       description: "Root MCP namespace declaration and server list.",
-      content: renderMcpRootFile(model.docs),
+      content: rootContent,
+      bytes: Buffer.byteLength(rootContent, "utf8"),
     },
   ];
   for (const server of model.docs) {
+    const content = renderMcpServerHeader(server, server.tools);
     files.push({
       path: `mcp/${server.identifier}.d.ts`,
       description: `MCP server declaration for ${server.serverName}.`,
-      content: renderMcpServerHeader(server, server.tools),
+      content,
+      bytes: Buffer.byteLength(content, "utf8"),
     });
   }
   return files;

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -886,7 +886,7 @@ describe("Code Mode", () => {
         type: "object",
         properties: {
           owner: { type: "string" },
-          repo: { type: "string", description: "Repository name" },
+          repo: { type: "string", description: "Repository 名称" },
           title: { type: "string", description: "Issue title\nShown in tracker" },
           body: { type: "string", default: "" },
         },
@@ -939,6 +939,9 @@ describe("Code Mode", () => {
         return {
           apiHeader: api.header,
           apiFilePaths: apiFiles.files.map((file) => file.path),
+          listedServerFileBytes: apiFiles.files.find((file) => file.path === "mcp/github.d.ts").bytes,
+          serverFileBytes: serverFile.bytes,
+          serverFileContent: serverFile.content,
           rootFileHasReference: rootFile.content.includes('./github.d.ts'),
           serverFileHasCreateIssue: serverFile.content.includes('function createIssue('),
           serverFileHasTitleDoc: serverFile.content.includes('@param title Issue title Shown in tracker'),
@@ -987,65 +990,27 @@ describe("Code Mode", () => {
       apiSchemaTitle: "object",
       apiHeader: expect.stringContaining("function createIssue("),
       apiFilePaths: ["mcp/index.d.ts", "mcp/github.d.ts"],
+      listedServerFileBytes: expect.any(Number),
+      serverFileBytes: expect.any(Number),
+      serverFileContent: expect.stringContaining("Repository 名称"),
       rootFileHasReference: true,
       serverFileHasCreateIssue: true,
       serverFileHasTitleDoc: true,
       rootServers: [{ identifier: "github", serverName: "github", toolCount: 1 }],
     });
-    const value = details.value as { apiHeader: string };
+    const value = details.value as {
+      apiHeader: string;
+      listedServerFileBytes: number;
+      serverFileBytes: number;
+      serverFileContent: string;
+    };
+    expect(value.listedServerFileBytes).toBe(value.serverFileBytes);
+    expect(value.serverFileBytes).toBe(Buffer.byteLength(value.serverFileContent, "utf8"));
+    expect(value.serverFileBytes).toBeGreaterThan(value.serverFileContent.length);
     expect(value.apiHeader).toContain("@param title Issue title Shown in tracker");
     expect(value.apiHeader).not.toContain("@param title Issue title\n");
     expect(value.apiHeader).toContain("title: string;");
     expect(githubCreate.execute).toHaveBeenCalledTimes(1);
-  });
-
-  it("reports UTF-8 byte counts for MCP API files", async () => {
-    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
-    const githubCreate = mcpTool({
-      name: "github__create_issue",
-      serverName: "github",
-      toolName: "create_issue",
-      parameters: {
-        type: "object",
-        properties: {
-          repo: { type: "string", description: "仓库名称" },
-        },
-      },
-    });
-    applyCodeModeCatalog({
-      tools: [...codeModeTools, githubCreate],
-      config,
-      sessionId: "session-code-mode",
-      sessionKey: "agent:main:main",
-      runId: "run-code-mode",
-      catalogRef,
-    });
-
-    const details = await runUntilCompleted({
-      execTool: codeModeTools[0],
-      waitTool: codeModeTools[1],
-      code: `
-        const listed = (await API.list("mcp")).files.find((file) => file.path === "mcp/github.d.ts");
-        const read = await API.read("mcp/github.d.ts");
-        return {
-          listedBytes: listed.bytes,
-          readBytes: read.bytes,
-          content: read.content,
-          chars: read.content.length,
-        };
-      `,
-    });
-
-    expect(details.status).toBe("completed");
-    const value = details.value as {
-      listedBytes: number;
-      readBytes: number;
-      content: string;
-      chars: number;
-    };
-    expect(value.listedBytes).toBe(value.readBytes);
-    expect(value.readBytes).toBe(Buffer.byteLength(value.content, "utf8"));
-    expect(value.readBytes).toBeGreaterThan(value.chars);
   });
 
   it("lets agents inspect MCP declaration files before calling MCP tools", async () => {

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -999,6 +999,55 @@ describe("Code Mode", () => {
     expect(githubCreate.execute).toHaveBeenCalledTimes(1);
   });
 
+  it("reports UTF-8 byte counts for MCP API files", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const githubCreate = mcpTool({
+      name: "github__create_issue",
+      serverName: "github",
+      toolName: "create_issue",
+      parameters: {
+        type: "object",
+        properties: {
+          repo: { type: "string", description: "仓库名称" },
+        },
+      },
+    });
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, githubCreate],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = await runUntilCompleted({
+      execTool: codeModeTools[0],
+      waitTool: codeModeTools[1],
+      code: `
+        const listed = (await API.list("mcp")).files.find((file) => file.path === "mcp/github.d.ts");
+        const read = await API.read("mcp/github.d.ts");
+        return {
+          listedBytes: listed.bytes,
+          readBytes: read.bytes,
+          content: read.content,
+          chars: read.content.length,
+        };
+      `,
+    });
+
+    expect(details.status).toBe("completed");
+    const value = details.value as {
+      listedBytes: number;
+      readBytes: number;
+      content: string;
+      chars: number;
+    };
+    expect(value.listedBytes).toBe(value.readBytes);
+    expect(value.readBytes).toBe(Buffer.byteLength(value.content, "utf8"));
+    expect(value.readBytes).toBeGreaterThan(value.chars);
+  });
+
   it("lets agents inspect MCP declaration files before calling MCP tools", async () => {
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
     const githubCreate = mcpTool({

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -312,7 +312,7 @@ const CONTROLLER_SOURCE = String.raw`
       path,
       content,
       description: typeof file.description === "string" ? file.description : undefined,
-      bytes: content.length,
+      bytes: file.bytes,
     }));
   }
   const api = Object.freeze({
@@ -459,7 +459,11 @@ async function createVm(params: {
   } finally {
     namespacesHandle.dispose();
   }
-  const apiFilesHandle = vm.hostToHandle(params.apiFiles);
+  const apiFiles = params.apiFiles.map((file) => ({
+    ...file,
+    bytes: Buffer.byteLength(file.content, "utf8"),
+  }));
+  const apiFilesHandle = vm.hostToHandle(apiFiles);
   try {
     vm.setProp(vm.global, "__openclawApiFiles", apiFilesHandle);
   } finally {

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -7,6 +7,7 @@ import { createRequire } from "node:module";
 import { parentPort, workerData } from "node:worker_threads";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { EvalFlags, Intrinsics, JSException, QuickJS, type JSValueHandle } from "quickjs-wasi";
+import type { CodeModeApiVirtualFile } from "./code-mode-namespaces.js";
 const require = createRequire(import.meta.url);
 const QUICKJS_WASM_PATH = require.resolve("quickjs-wasi/quickjs.wasm");
 let quickJsWasmModulePromise: Promise<WebAssembly.Module> | undefined;
@@ -44,12 +45,6 @@ type CodeModeNamespaceDescriptor = {
   globalName: string;
   description?: string;
   scope: SerializedCodeModeNamespaceValue;
-};
-
-type CodeModeApiVirtualFile = {
-  path: string;
-  description?: string;
-  content: string;
 };
 
 type CodeModeWorkerInput =
@@ -459,11 +454,7 @@ async function createVm(params: {
   } finally {
     namespacesHandle.dispose();
   }
-  const apiFiles = params.apiFiles.map((file) => ({
-    ...file,
-    bytes: Buffer.byteLength(file.content, "utf8"),
-  }));
-  const apiFilesHandle = vm.hostToHandle(apiFiles);
+  const apiFilesHandle = vm.hostToHandle(params.apiFiles);
   try {
     vm.setProp(vm.global, "__openclawApiFiles", apiFilesHandle);
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Code Mode virtual API files reported JavaScript UTF-16 string length as `bytes`. MCP declaration files containing non-ASCII text were therefore shown with an underestimated byte count through both `API.list()` and `API.read()`.

## Why This Change Was Made

Virtual-file construction now owns both the declaration content and its immutable UTF-8 byte size. The prepared metadata is carried through the worker into QuickJS, so list and read projections share one canonical value without recomputing it on every VM start. The maintainer refactor also folds the regression into the existing real Code Mode MCP/API test instead of retaining a second 49-line harness.

## User Impact

Agents inspecting MCP declaration files receive accurate UTF-8 byte metadata, including declarations with internationalized schema documentation. API paths, response shapes, file contents, filtering, and namespace visibility remain unchanged.

## Evidence

Contributor real Code Mode runtime proof on the original head:

```json
{
  "path": "mcp/github.d.ts",
  "listedBytes": 674,
  "readBytes": 674,
  "expectedUtf8Bytes": 674,
  "contentChars": 654,
  "sameListReadBytes": true,
  "bytesExceedChars": true
}
```

Maintainer validation:

```text
Final prepared head: 77db71b73a49e4651cbbb7891abc2dd4741a187c
Blacksmith Testbox through Crabbox: tbx_01kx8ge44b23czdjt1v0fah1yt
Code Mode/QuickJS suite: 1 file, 60 tests passed
check:changed: passed (core and core-test typechecks, lint, architecture guards)
Canonical oxfmt and git diff --check: passed
Fresh branch autoreview: clean, 0.97
GitHub CI: https://github.com/openclaw/openclaw/actions/runs/29151985824
```

The final diff is 3 files, 25 additions and 11 deletions relative to current `main`; production code carries the prepared fact earlier and removes the worker-side repair path. Release-note context and contributor attribution remain in this PR body because `CHANGELOG.md` is release-owned.
