### PR TITLE
fix(ui): floating chat rail toggles overlap message bubbles and block window dragging

### DIFF
--- a/ui/src/app/native-window-drag.test.ts
+++ b/ui/src/app/native-window-drag.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { beginNativeWindowDrag } from "./native-window-drag.ts";
+import { beginNativeWindowDrag, beginNativeWindowDragFromTopInset } from "./native-window-drag.ts";
 
 afterEach(() => {
   document.body.replaceChildren();
@@ -87,6 +87,60 @@ describe("native window drag", () => {
 
     const event = mouseDown(header);
 
+    expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe("native window drag from top inset", () => {
+  function buildThread() {
+    const thread = document.createElement("div");
+    thread.style.paddingTop = "44px";
+    const inner = document.createElement("div");
+    thread.append(inner);
+    thread.addEventListener("mousedown", beginNativeWindowDragFromTopInset);
+    document.body.append(thread);
+    return { thread, inner };
+  }
+
+  function mouseDownAtOffset(target: Element, offsetY: number) {
+    const event = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      button: 0,
+    });
+    Object.defineProperty(event, "offsetY", { value: offsetY });
+    target.dispatchEvent(event);
+    return event;
+  }
+
+  it("drags from bare container background inside the top padding", () => {
+    const postMessage = installBridge();
+    const { thread } = buildThread();
+
+    const event = mouseDownAtOffset(thread, 20);
+
+    expect(postMessage).toHaveBeenCalledWith({ type: "window-drag" });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("ignores presses below the padding band", () => {
+    const postMessage = installBridge();
+    const { thread } = buildThread();
+
+    const event = mouseDownAtOffset(thread, 60);
+
+    expect(postMessage).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("ignores presses that land on content instead of the container", () => {
+    const postMessage = installBridge();
+    const { inner } = buildThread();
+
+    const event = mouseDownAtOffset(inner, 20);
+
+    expect(postMessage).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
   });
 });

--- a/ui/src/app/native-window-drag.ts
+++ b/ui/src/app/native-window-drag.ts
@@ -47,3 +47,21 @@ export function beginNativeWindowDrag(event: MouseEvent): void {
   // page still starts a text selection underneath the moving window.
   event.preventDefault();
 }
+
+/**
+ * mousedown handler for scroll containers whose top padding doubles as
+ * titlebar chrome (the chat thread's titlebar band): presses on the bare
+ * container background inside that padding start a native window drag.
+ * Content scrolled under the band hits its own elements, not the container,
+ * so selection and clicks there keep default behavior.
+ */
+export function beginNativeWindowDragFromTopInset(event: MouseEvent): void {
+  if (event.target !== event.currentTarget || !(event.currentTarget instanceof HTMLElement)) {
+    return;
+  }
+  const inset = Number.parseFloat(getComputedStyle(event.currentTarget).paddingTop);
+  if (!Number.isFinite(inset) || event.offsetY > inset) {
+    return;
+  }
+  beginNativeWindowDrag(event);
+}

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -408,14 +408,22 @@ export function renderChat(props: ChatProps) {
         <div class="chat-workbench__main">
           <!-- Floating openers share the top-right corner with the detail
                panel's header controls; hide them while the sidebar is open. -->
-          ${props.sessionWorkspace?.collapsed && !props.paneHeaderActive && !sidebarOpen
-            ? renderSessionWorkspaceToggle(props.sessionWorkspace, "floating")
-            : nothing}
-          ${props.backgroundTasks?.collapsed && !props.paneHeaderActive && !sidebarOpen
-            ? renderBackgroundTasksToggle(props.backgroundTasks, "floating")
-            : nothing}
-          ${props.sessionWorkspace?.collapsed && !props.paneHeaderActive && !sidebarOpen
-            ? renderSessionDiffToggle(props.sessionWorkspace, "floating")
+          ${!props.paneHeaderActive &&
+          !sidebarOpen &&
+          (props.sessionWorkspace?.collapsed || props.backgroundTasks?.collapsed)
+            ? html`
+                <div class="chat-floating-toggles">
+                  ${props.sessionWorkspace?.collapsed
+                    ? renderSessionDiffToggle(props.sessionWorkspace, "floating")
+                    : nothing}
+                  ${props.backgroundTasks?.collapsed
+                    ? renderBackgroundTasksToggle(props.backgroundTasks, "floating")
+                    : nothing}
+                  ${props.sessionWorkspace?.collapsed
+                    ? renderSessionWorkspaceToggle(props.sessionWorkspace, "floating")
+                    : nothing}
+                </div>
+              `
             : nothing}
           <div
             class="chat-split-container ${sidebarOpen

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -6,6 +6,7 @@ import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import { classifySessionKind } from "../../../../../src/sessions/classify-session-kind.js";
 import type { SessionsListResult } from "../../../api/types.ts";
+import { beginNativeWindowDrag } from "../../../app/native-window-drag.ts";
 import { resolveLocalUserName } from "../../../app/user-identity.ts";
 import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
@@ -756,6 +757,21 @@ export function renderChatThread(props: ChatThreadProps) {
     maybeExpandChatHistoryRenderWindow(state, event, requestUpdate);
     props.onChatScroll?.(event);
   };
+  const handleChatThreadMouseDown = (event: MouseEvent) => {
+    // The thread's top padding is a titlebar band in the native macOS app:
+    // presses on bare thread background inside it start a window drag.
+    // Message content scrolled under the band hits its own elements, not the
+    // thread itself, so selection and clicks there stay untouched.
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    const thread = event.currentTarget as HTMLElement;
+    const bandHeight = Number.parseFloat(getComputedStyle(thread).paddingTop);
+    if (!Number.isFinite(bandHeight) || event.offsetY > bandHeight) {
+      return;
+    }
+    beginNativeWindowDrag(event);
+  };
 
   return html`
     <div
@@ -772,6 +788,7 @@ export function renderChatThread(props: ChatThreadProps) {
         );
       })}
       @scroll=${handleChatThreadScroll}
+      @mousedown=${handleChatThreadMouseDown}
       @click=${(event: Event) => {
         handleMarkdownCodeBlockCopy(event);
         const target = markdownFileLinkFromEvent(event);

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -6,7 +6,7 @@ import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import { classifySessionKind } from "../../../../../src/sessions/classify-session-kind.js";
 import type { SessionsListResult } from "../../../api/types.ts";
-import { beginNativeWindowDrag } from "../../../app/native-window-drag.ts";
+import { beginNativeWindowDragFromTopInset } from "../../../app/native-window-drag.ts";
 import { resolveLocalUserName } from "../../../app/user-identity.ts";
 import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
@@ -757,21 +757,6 @@ export function renderChatThread(props: ChatThreadProps) {
     maybeExpandChatHistoryRenderWindow(state, event, requestUpdate);
     props.onChatScroll?.(event);
   };
-  const handleChatThreadMouseDown = (event: MouseEvent) => {
-    // The thread's top padding is a titlebar band in the native macOS app:
-    // presses on bare thread background inside it start a window drag.
-    // Message content scrolled under the band hits its own elements, not the
-    // thread itself, so selection and clicks there stay untouched.
-    if (event.target !== event.currentTarget) {
-      return;
-    }
-    const thread = event.currentTarget as HTMLElement;
-    const bandHeight = Number.parseFloat(getComputedStyle(thread).paddingTop);
-    if (!Number.isFinite(bandHeight) || event.offsetY > bandHeight) {
-      return;
-    }
-    beginNativeWindowDrag(event);
-  };
 
   return html`
     <div
@@ -788,7 +773,7 @@ export function renderChatThread(props: ChatThreadProps) {
         );
       })}
       @scroll=${handleChatThreadScroll}
-      @mousedown=${handleChatThreadMouseDown}
+      @mousedown=${beginNativeWindowDragFromTopInset}
       @click=${(event: Event) => {
         handleMarkdownCodeBlockCopy(event);
         const target = markdownFileLinkFromEvent(event);

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -77,12 +77,24 @@ openclaw-chat-page {
   /* Grow, shrink, and use 0 base for proper scrolling */
   overflow-y: auto;
   overflow-x: hidden;
-  padding: clamp(20px, 3vh, 28px) clamp(6px, 1vw, 12px) 6px;
+  /* The tall top inset is a titlebar band: it keeps the floating rail
+     openers (.chat-floating-toggles, 28px at top 10px) clear of the first
+     message and gives the native macOS app an empty strip that starts a
+     window drag (see the thread mousedown handler in chat-thread.ts). */
+  padding: clamp(44px, 5vh, 52px) clamp(6px, 1vw, 12px) 6px;
   margin: 0 0 0 0;
   min-height: 0;
   /* Allow shrinking for flex scroll behavior */
   border-radius: var(--radius-md);
   background: transparent;
+}
+
+/* Split panes spend their top row on the pane header (which is both the
+   toggle host and the drag surface), so their threads keep a compact inset.
+   The single-pane view is also an openclaw-chat-pane but renders no header,
+   hence the :has() guard. */
+openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
+  padding-top: clamp(20px, 3vh, 28px);
 }
 
 .chat-thread-inner > :first-child {

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -48,27 +48,30 @@
   grid-template-columns: minmax(0, 1fr) minmax(230px, 280px) minmax(230px, 280px);
 }
 
-/* Floating opener shown in single-pane mode while the rail is collapsed
-   (split panes host the same toggle in their header row instead). */
-.chat-workspace-open {
+/* Floating openers shown in single-pane mode while a rail is collapsed
+   (split panes host the same toggles in their header row instead). One
+   horizontal row inside the thread's titlebar band (see .chat-thread top
+   padding) so the buttons never cover the first message and the band stays
+   free as a window-drag surface in the native macOS app. */
+.chat-floating-toggles {
   position: absolute;
   top: 10px;
   right: 10px;
   z-index: 12;
-  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-  background: color-mix(in srgb, var(--panel) 92%, transparent);
-  box-shadow: var(--shadow-sm);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  display: flex;
+  gap: 6px;
 }
 
-/* Floating background-tasks opener stacks under the workspace one so both
-   stay reachable regardless of which rail is open. */
-.chat-tasks-open {
-  position: absolute;
-  top: 48px;
-  right: 10px;
-  z-index: 12;
+.chat-workspace-open,
+.chat-tasks-open,
+.chat-diff-open {
+  /* Match the 28px pane-header/split-view openers; .btn--icon's
+     min-width/height of 36px would win otherwise. */
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
+  padding: 5px;
   border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
   background: color-mix(in srgb, var(--panel) 92%, transparent);
   box-shadow: var(--shadow-sm);
@@ -88,10 +91,10 @@
   }
 }
 
-/* Positioning context for the badge; the floating variant already gets one
-   from its own position: absolute, so scope this to the pane-header variant. */
-.chat-pane__actions .chat-workspace-toggle,
-.chat-pane__actions .chat-tasks-toggle {
+/* Positioning context for the badge on both the pane-header and floating
+   variants (the floating buttons are static children of the toggle row). */
+.chat-workspace-toggle,
+.chat-tasks-toggle {
   position: relative;
 }
 
@@ -1738,18 +1741,8 @@
 
 /* ── Session diff panel (sessions.diff sidebar content) ── */
 
-/* Floating opener stacks under the workspace (10px) and tasks (48px) ones. */
-.chat-diff-open {
-  position: absolute;
-  top: 86px;
-  right: 10px;
-  z-index: 12;
-  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-  background: color-mix(in srgb, var(--panel) 92%, transparent);
-  box-shadow: var(--shadow-sm);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-}
+/* The floating diff opener sits in the .chat-floating-toggles row and shares
+   the .chat-workspace-open sizing/chrome rules near the top of this file. */
 
 .session-diff {
   display: flex;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the two floating chat-rail openers (workspace files and background tasks) stacked vertically in the top-right corner of the chat thread and overlapped message bubbles. In the macOS app the stack also forced the native window-drag regions above the chat to stay 12px/6px thin (see the constraint comment in `DashboardWindowController.swift`), leaving almost no surface to drag the window from the top of the chat column.

## Why This Change Was Made

The two toggles now render side by side in a single 28px row (`.chat-floating-toggles`, matching the 28px pane-header/split-view openers), and the chat thread reserves a `clamp(44px, 5vh, 52px)` top inset that acts as a titlebar band: the first message starts below the buttons, and presses on bare band background start a native window drag through the same `beginNativeWindowDrag` contract split-pane headers already use. Split panes keep the previous compact inset since their header row already hosts the toggles and the drag surface; the bottom-right split-view opener is unchanged. After rebasing onto #104184, the new floating session-diff opener joins the same row instead of stacking as a third absolutely-positioned button at `top: 86px`, and the row respects that PR's `!sidebarOpen` guard.

## User Impact

Chat content no longer runs under the floating buttons, and macOS app users get a full-width strip at the top of the chat column where they can grab and move the window. Browser users see the same tidier single-row toggles with a bit more breathing room above the thread.

## Evidence

Mock Control UI (`pnpm dev:ui:mock`), 1440x900.

Before — toggles stacked over the message text:

![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-floating-toggles-titlebar-band/before-top.png)

After — one row inside the reserved band, first message clear of the buttons:

![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-floating-toggles-titlebar-band/after-top.png)

Measured after state: thread `padding-top: 45px`, toggle row 28px tall at `top: 10px` / `right: 10px` (7px clearance to the band edge). Split view verified: pane headers keep hosting the toggles and pane threads keep the compact inset via the `:has(> .chat-pane__header)` guard (the single-pane view is also an `openclaw-chat-pane`, so the guard keys off the header, not the element). `oxfmt --check` and `scripts/run-oxlint.mjs` clean on touched files; UI tests select toggles by class (`.chat-workspace-open`), which is preserved. The band drag handler lives in `native-window-drag.ts` next to the pane-header handler and is covered by three new jsdom tests (in-band background press drags, below-band press doesn't, presses on scrolled-under content don't); `chat-view.test.ts` (152 tests) and `native-window-drag.test.ts` (8 tests) pass.

