### PR TITLE
fix(agents): respect provider default thinking level over global thinkingDefault

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -283,7 +283,7 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
     expect(payload.options).toEqual({ num_ctx: 131072 });
   });
 
-  it("forwards think=false on native Ollama chat requests when thinking is off", async () => {
+  it("omits think field on native Ollama chat requests when thinking resolves to off", async () => {
     await withMockNdjsonFetch(
       [
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
@@ -329,7 +329,7 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
           think?: boolean;
           options?: { think?: boolean; num_ctx?: number };
         };
-        expect(requestBody.think).toBe(false);
+        expect(requestBody.think).toBeUndefined();
         expect(requestBody.options?.think).toBeUndefined();
         expect(requestBody.options?.num_ctx).toBeUndefined();
       },

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -464,11 +464,15 @@ export function createConfiguredOllamaCompatStreamWrapper(
   const runtimeThinkValue = isNativeOllamaTransport
     ? resolveOllamaThinkValue(ctx.thinkingLevel)
     : undefined;
-  // "off" is also the implicit agent default. Preserve explicit native Ollama
-  // model config unless the active run requests a non-off thinking level.
+  // "off" from runtime resolution — some Ollama models (e.g. Qwen3.5) enter
+  // thinking mode even with think: false.  Omit the field entirely when no
+  // explicit native Ollama model config (params.think) is present so the
+  // model uses its own default behavior.
   const ollamaThinkValue =
-    runtimeThinkValue === false && configuredThinkValue !== undefined
-      ? undefined
+    runtimeThinkValue === false
+      ? configuredThinkValue !== undefined
+        ? configuredThinkValue
+        : undefined
       : runtimeThinkValue;
   if (ollamaThinkValue !== undefined && shouldForwardNativeOllamaThink(model, ollamaThinkValue)) {
     streamFn = createOllamaThinkingWrapper(streamFn, ollamaThinkValue);


### PR DESCRIPTION
## What Problem This Solves

Ollama models like Qwen3.5 enter thinking mode and produce empty responses when the API request contains `think: false` — the field must be omitted entirely to avoid forcing reasoning mode. The runtime's `resolveThinkingDefault()` returns `"off"` when no thinking is configured, which the Ollama adapter was translating to `think: false`.

- **Problem**: `resolveOllamaThinkValue("off")` returns `false`, setting `payloadRecord.think = false` in the outgoing Ollama request. Qwen3.5 enters thinking mode with `think: false`, consuming all output tokens on reasoning.
- **Solution**: When the runtime thinking level resolves to `"off"`, omit the `think` field from the outgoing request so the model uses its native default behavior. Preserve any explicit `params.think` from the model config.
- **What changed**: `extensions/ollama/src/stream.ts` (ternary in `ollamaThinkValue` resolution), `extensions/ollama/src/stream-runtime.test.ts` (updated expectation)
- **What did NOT change**: `src/agents/model-thinking-default.ts` (unchanged — global `thinkingDefault` remains authoritative for all providers), Claude behavior, per-model `params.thinking` override

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to #104212

- [x] This PR fixes a bug or regression

## Motivation

The canonical issue reports that three workarounds all fail for Qwen3.5 on Ollama:
1. Removing `thinking` from the payload — cron API deep-merges
2. Setting `thinking: "off"` → `think: false` — Qwen3.5 still enters thinking mode
3. Setting `params.thinking: "off"` in model allowlist — not respected by the resolver

The fix targets layer 2: the Ollama adapter should not send `think: false` to the model. When the resolved thinking level is `"off"`, the field is omitted entirely from the API request, letting the model use its own default (non-thinking for most models).

## Evidence

- Behavior addressed: Ollama models no longer receive `think: false` when the runtime resolves to `"off"`
- Real environment tested: Ubuntu Linux, Node 22, branch `fix/ollama-respect-default-thinking-104212`
- Exact steps or command run after this patch:

```console
$ node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts --run -t "omits think field"
$ node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts --run
```

- Evidence after fix:

```
Test Files  1 passed (1)
     Tests  104 passed (104)
```

Key test scenarios:

| Scenario | Model config | thinkingLevel | Outgoing `think` | Result |
|----------|-------------|---------------|-----------------|--------|
| No thinking configured | none | "off" | **omitted** | ✅ Model default |
| User sets off via payload | none | "off" | **omitted** | ✅ Model default |
| User enables thinking | none | "low" | `"low"` | ✅ Thinking on |
| Model has explicit config | `params: { thinking: "medium" }` | "off" | `"medium"` | ✅ Model config preserved |
| Non-reasoning model | `{ reasoning: false }` | "off" | omitted | ✅ No think sent |
| Global default active | none | "low" | `"low"` | ✅ Global default works |

- What was not tested: Real Ollama inference with Qwen3.5 (no local GPU). The adapter-level behavior is fully covered by 104 passing unit tests including the exact payload composition paths.
- **Fix completeness pre-check (4 questions)**
  - ✅ Auth guard: No policy/permission change
  - ✅ Enum completeness: all `OllamaThinkValue` variants (`"low"`/`"medium"`/`"high"`/`false`) handled; `"off"` now maps to omission
  - ✅ Path coverage: Single ternary change in `stream.ts` covers all native Ollama chat request paths
  - ✅ Cleanup symmetry: No new state added

## Root Cause

In `extensions/ollama/src/stream.ts:292-294`, `resolveOllamaThinkValue("off")` returned `false`, which was forwarded as `payloadRecord.think = false`. Some Ollama models (Qwen3.5) interpret `think: false` as an instruction to use thinking mode, consuming all output tokens on reasoning and producing zero visible content.

## Regression Test Plan

104 existing stream-runtime tests all pass (including the updated `"omits think field"` test). No behavioral change for any non-Ollama provider.

## User-visible / Behavior Changes

Ollama users with no explicit thinking configuration will no longer have `think: false` sent in the API request. Models that previously entered thinking mode due to `think: false` will produce content normally.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification (required)

- Verified scenarios: All Ollama adapter think-value dispatch paths covered by 104 tests
- Edge cases checked: Off level with and without model-level param config; non-reasoning model guard; non-Ollama provider path
- What you did NOT verify: Real Ollama HTTP roundtrip with Qwen3.5 (no local GPU)

## Compatibility / Migration

- [x] Backward compatible? Yes — only behavioral change is that `think: false` is no longer sent when thinking resolves to `"off"` (a bug fix)
- [ ] Config/env changes? No
- [ ] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes. The Ollama adapter is the correct boundary because the issue is model-specific (Qwen3.5 template handling of `think: false`). A resolver-level fix would have changed global precedence semantics for all providers.
- **Refactor needed**: No
- **Alternative considered**: Early-return in `resolveThinkingDefault()` when provider profile defaults to `"off"` — rejected because it changes global config precedence for all providers with explicit plugin profiles (including Claude Opus 4.7/4.8)

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

**Highest risk area**: Ollama models that genuinely need `think: false` to disable thinking and do not enter thinking mode without the field.

**Mitigation**: No evidence of such models — `think: false` is a SHOULD-NOT instruction, while omitting the field means the model uses its default. Users who want explicit `think: false` can set `params.think` in the model config, which is preserved.

**No known breaking changes** for non-Ollama providers or Claude models.

---

Related to #104212