### PR TITLE
fix(qa-lab): keep bounded web snapshots UTF-16 safe

### DIFF
--- a/extensions/qa-lab/src/web-runtime.test.ts
+++ b/extensions/qa-lab/src/web-runtime.test.ts
@@ -157,6 +157,16 @@ describe("qa web runtime", () => {
     expect(browserClose).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps bounded snapshot text on UTF-16 boundaries", async () => {
+    bodyLocator.textContent.mockResolvedValueOnce(`${"a".repeat(1999)}😀tail`);
+    const opened = await qaWebOpenPage({ url: "http://127.0.0.1:3000/chat" });
+
+    const snapshot = await qaWebSnapshot({ pageId: opened.pageId, maxChars: 2000 });
+
+    expect(snapshot.text).toBe("a".repeat(1999));
+    await closeQaWebSessions();
+  });
+
   it("launches an explicit Chromium executable override when configured", async () => {
     vi.stubEnv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH", "/custom/chromium");
     existsSync.mockImplementation((candidate) => candidate === "/custom/chromium");

--- a/extensions/qa-lab/src/web-runtime.test.ts
+++ b/extensions/qa-lab/src/web-runtime.test.ts
@@ -13,6 +13,7 @@ const {
   locatorFill,
   locatorPress,
   locatorWaitFor,
+  pageOn,
   pageEvaluate,
   pageTitle,
   pageUrl,
@@ -33,6 +34,7 @@ const {
   locatorFill: vi.fn(async () => undefined),
   locatorPress: vi.fn(async () => undefined),
   locatorWaitFor: vi.fn(async () => undefined),
+  pageOn: vi.fn(),
   pageEvaluate: vi.fn(async () => "ok"),
   pageTitle: vi.fn(async () => "QA"),
   pageUrl: vi.fn(() => "http://127.0.0.1:3000/chat"),
@@ -67,7 +69,7 @@ import {
 
 beforeEach(async () => {
   const page = {
-    on: vi.fn(),
+    on: pageOn,
     goto,
     title: pageTitle,
     url: pageUrl,
@@ -157,13 +159,24 @@ describe("qa web runtime", () => {
     expect(browserClose).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps bounded snapshot text on UTF-16 boundaries", async () => {
+  it("keeps bounded web text on UTF-16 boundaries", async () => {
     bodyLocator.textContent.mockResolvedValueOnce(`${"a".repeat(1999)}😀tail`);
     const opened = await qaWebOpenPage({ url: "http://127.0.0.1:3000/chat" });
+    const consoleHandler = pageOn.mock.calls.find(([event]) => event === "console")?.[1] as
+      | ((message: { type: () => string; text: () => string }) => void)
+      | undefined;
+    if (!consoleHandler) {
+      throw new Error("expected console handler");
+    }
+    consoleHandler({
+      type: () => "log",
+      text: () => `${"a".repeat(1993)}😀tail`,
+    });
 
     const snapshot = await qaWebSnapshot({ pageId: opened.pageId, maxChars: 2000 });
 
     expect(snapshot.text).toBe("a".repeat(1999));
+    expect(snapshot.diagnostics).toEqual([{ kind: "console", text: `[log] ${"a".repeat(1993)}` }]);
     await closeQaWebSessions();
   });
 

--- a/extensions/qa-lab/src/web-runtime.ts
+++ b/extensions/qa-lab/src/web-runtime.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { resolvePositiveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright-core";
 
 type QaWebSession = {
@@ -225,7 +226,7 @@ export async function qaWebSnapshot(params: QaWebSnapshotParams) {
   return {
     url: session.page.url(),
     title: await session.page.title().catch(() => ""),
-    text: maxChars ? text.slice(0, maxChars) : text,
+    text: maxChars ? truncateUtf16Safe(text, maxChars) : text,
     diagnostics: [...session.diagnostics],
   };
 }

--- a/extensions/qa-lab/src/web-runtime.ts
+++ b/extensions/qa-lab/src/web-runtime.ts
@@ -70,7 +70,7 @@ const SYSTEM_CHROMIUM_EXECUTABLE_CANDIDATES = [
 function appendDiagnostic(diagnostics: QaWebDiagnosticEntry[], entry: QaWebDiagnosticEntry): void {
   diagnostics.push({
     kind: entry.kind,
-    text: entry.text.slice(0, MAX_DIAGNOSTIC_TEXT_CHARS),
+    text: truncateUtf16Safe(entry.text, MAX_DIAGNOSTIC_TEXT_CHARS),
   });
   if (diagnostics.length > MAX_DIAGNOSTIC_ENTRIES) {
     diagnostics.splice(0, diagnostics.length - MAX_DIAGNOSTIC_ENTRIES);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA Lab users requesting bounded web text could receive a dangling UTF-16 surrogate when a snapshot or diagnostic limit landed between the two code units of an emoji. The malformed text then flowed into suite results instead of ending at the last complete character.

## Why This Change Was Made

Both bounded text producers in the QA Lab web runtime now use OpenClaw's canonical UTF-16-safe truncation helper. Existing snapshot and diagnostic character budgets are preserved while partial surrogate pairs are dropped. This does not change snapshot defaults, browser lifecycle, diagnostic retention, schemas, configuration, or persistence.

## User Impact

QA Lab snapshots and captured browser diagnostics remain valid Unicode at their character limits. Pages or diagnostic messages containing emoji and other supplementary-plane characters no longer produce a broken boundary character.

## Evidence

Stock-main Chromium reproduction on the pinned discovery snapshot:

```text
SNAPSHOT_LENGTH=2000
LAST_CODE_UNIT=0xd83d
LONE_HIGH_SURROGATE=true
BOUNDARY_SUFFIX_JSON="aaaaaaa\ud83d"
EXPECTED_EMOJI_PRESENT=false
```

After the fix, a real isolated OpenClaw gateway was started and the production QA Lab web runtime opened a real headless Chromium page containing 1,999 ASCII characters followed by an emoji. Requesting `maxChars=2000` produced:

```text
GATEWAY_READY_STATUS=200
SNAPSHOT_LENGTH=1999
LAST_CODE_UNIT=0x61
LONE_SURROGATE=false
BOUNDARY_SUFFIX_JSON="aaaaaaaa"
JSON_ROUND_TRIP_STABLE=true
PARTIAL_EMOJI_DROPPED=true
```

Maintainer validation:

```text
Reviewed contributor head: 85efcfd6777104b23915ae0299844cdbf83ccab6
Sanitized AWS: cbx_93b135a9875e / run_0494b5bb8c53
Focused suite: 1 file, 7 tests passed
Final prepared head: e8b1c8ef43f2d6707114e7762d45ba16f59603b8
Autoreview: clean, 0.99
Patch-identical exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29151325138
Final-head CI: https://github.com/openclaw/openclaw/actions/runs/29151541365
```

Canonical formatting and `git diff --check` passed. The impact-surface sweep found `qaWebSnapshot` is exposed only through the QA Lab scenario dependency object; callers retain the same shape and budgets. The sibling diagnostic path now shares the same canonical Unicode boundary rule instead of retaining a second raw `slice()` implementation.
