### PR TITLE
fix: webChat scrollback history is too limited — older assistant replies and tool outputs disappear when scrolling…

### DIFF
--- a/src/config/sessions/transcript-tree.ts
+++ b/src/config/sessions/transcript-tree.ts
@@ -261,6 +261,40 @@ export function scanSessionTranscriptTree<T>(entries: readonly T[]): SessionTran
   };
 }
 
+export function selectSessionTranscriptActiveEntries<T, R>(params: {
+  entries: readonly T[];
+  records: readonly R[];
+  tree?: SessionTranscriptTree<R>;
+  failClosedOnInvalidLeafControl?: boolean;
+}): T[] {
+  const tree = params.tree ?? scanSessionTranscriptTree(params.records);
+  if (params.failClosedOnInvalidLeafControl === true && tree.hasInvalidLeafControl) {
+    return [];
+  }
+  if (!tree.hasExplicitLeafUpdate) {
+    return [...params.entries];
+  }
+  const activePath = selectSessionTranscriptTreePathNodes(tree, tree.leafId);
+  const activeEntries = activePath.flatMap((node) => {
+    const entry = params.entries[node.index];
+    return entry === undefined ? [] : [entry];
+  });
+  const firstActiveNode = activePath[0];
+  for (let index = (firstActiveNode?.index ?? 0) - 1; index >= 0; index -= 1) {
+    const record = params.records[index];
+    if (
+      typeof record === "object" &&
+      record !== null &&
+      !Array.isArray(record) &&
+      (record as TranscriptRecord).type === "compaction"
+    ) {
+      const entry = params.entries[index];
+      return entry === undefined ? activeEntries : [entry, ...activeEntries];
+    }
+  }
+  return activeEntries;
+}
+
 /** Select one normalized path, retaining a reachable suffix after missing ancestors. */
 export function selectSessionTranscriptTreePathNodes<T>(
   tree: SessionTranscriptTree<T>,

--- a/src/config/sessions/transcript-tree.ts
+++ b/src/config/sessions/transcript-tree.ts
@@ -263,11 +263,12 @@ export function scanSessionTranscriptTree<T>(entries: readonly T[]): SessionTran
 
 export function selectSessionTranscriptActiveEntries<T, R>(params: {
   entries: readonly T[];
-  records: readonly R[];
+  recordOf: (entry: T) => R;
   tree?: SessionTranscriptTree<R>;
   failClosedOnInvalidLeafControl?: boolean;
 }): T[] {
-  const tree = params.tree ?? scanSessionTranscriptTree(params.records);
+  const records = params.entries.map(params.recordOf);
+  const tree = params.tree ?? scanSessionTranscriptTree(records);
   if (params.failClosedOnInvalidLeafControl === true && tree.hasInvalidLeafControl) {
     return [];
   }
@@ -281,7 +282,7 @@ export function selectSessionTranscriptActiveEntries<T, R>(params: {
   });
   const firstActiveNode = activePath[0];
   for (let index = (firstActiveNode?.index ?? 0) - 1; index >= 0; index -= 1) {
-    const record = params.records[index];
+    const record = records[index];
     if (
       typeof record === "object" &&
       record !== null &&

--- a/src/gateway/session-transcript-index.fs.ts
+++ b/src/gateway/session-transcript-index.fs.ts
@@ -5,6 +5,7 @@ import { StringDecoder } from "node:string_decoder";
 import {
   parseSessionTranscriptTreeEntry,
   scanSessionTranscriptTree,
+  selectSessionTranscriptActiveEntries,
 } from "../config/sessions/transcript-tree.js";
 import {
   extractJsonNullableStringFieldPrefix,
@@ -190,43 +191,6 @@ async function visitTranscriptJsonLines(
   }
 }
 
-function buildActiveTreeEntries(params: {
-  byId: Map<string, IndexedRawEntry>;
-  leafId?: string | null;
-}): IndexedRawEntry[] {
-  const out: IndexedRawEntry[] = [];
-  const seen = new Set<string>();
-  let currentId = params.leafId;
-  while (currentId) {
-    if (seen.has(currentId)) {
-      return [];
-    }
-    seen.add(currentId);
-    const entry = params.byId.get(currentId);
-    if (!entry) {
-      break;
-    }
-    out.push(entry);
-    currentId = entry.parentId ?? undefined;
-  }
-  return out.toReversed();
-}
-
-function includePrecedingCompaction(
-  rawEntries: IndexedRawEntry[],
-  activeEntries: IndexedRawEntry[],
-): IndexedRawEntry[] {
-  const firstActiveEntry = activeEntries[0];
-  const firstActiveIndex = firstActiveEntry ? rawEntries.indexOf(firstActiveEntry) : -1;
-  for (let index = firstActiveIndex - 1; index >= 0; index -= 1) {
-    const entry = rawEntries[index];
-    if (entry?.record.type === "compaction") {
-      return [entry, ...activeEntries];
-    }
-  }
-  return activeEntries;
-}
-
 function toIndexedEntries(rawEntries: IndexedRawEntry[]): IndexedTranscriptEntry[] {
   const entries: IndexedTranscriptEntry[] = [];
   let seq = 0;
@@ -295,17 +259,17 @@ async function buildSessionTranscriptIndex(
 
   const tree = scanSessionTranscriptTree(rawEntries.map((entry) => entry.record));
   const rawByRecord = new Map(rawEntries.map((entry) => [entry.record, entry]));
-  const byId = new Map<string, IndexedRawEntry>();
   for (const node of tree.nodes) {
     const rawEntry = rawByRecord.get(node.entry);
     if (rawEntry) {
       rawEntry.parentId = node.parentId;
-      byId.set(node.id, rawEntry);
     }
   }
-  const activeRawEntries = tree.hasExplicitLeafUpdate
-    ? includePrecedingCompaction(rawEntries, buildActiveTreeEntries({ byId, leafId: tree.leafId }))
-    : rawEntries;
+  const activeRawEntries = selectSessionTranscriptActiveEntries({
+    entries: rawEntries,
+    records: rawEntries.map((entry) => entry.record),
+    tree,
+  });
   return {
     filePath,
     mtimeMs: stat.mtimeMs,

--- a/src/gateway/session-transcript-index.fs.ts
+++ b/src/gateway/session-transcript-index.fs.ts
@@ -212,6 +212,21 @@ function buildActiveTreeEntries(params: {
   return out.toReversed();
 }
 
+function includePrecedingCompaction(
+  rawEntries: IndexedRawEntry[],
+  activeEntries: IndexedRawEntry[],
+): IndexedRawEntry[] {
+  const firstActiveEntry = activeEntries[0];
+  const firstActiveIndex = firstActiveEntry ? rawEntries.indexOf(firstActiveEntry) : -1;
+  for (let index = firstActiveIndex - 1; index >= 0; index -= 1) {
+    const entry = rawEntries[index];
+    if (entry?.record.type === "compaction") {
+      return [entry, ...activeEntries];
+    }
+  }
+  return activeEntries;
+}
+
 function toIndexedEntries(rawEntries: IndexedRawEntry[]): IndexedTranscriptEntry[] {
   const entries: IndexedTranscriptEntry[] = [];
   let seq = 0;
@@ -289,7 +304,7 @@ async function buildSessionTranscriptIndex(
     }
   }
   const activeRawEntries = tree.hasExplicitLeafUpdate
-    ? buildActiveTreeEntries({ byId, leafId: tree.leafId })
+    ? includePrecedingCompaction(rawEntries, buildActiveTreeEntries({ byId, leafId: tree.leafId }))
     : rawEntries;
   return {
     filePath,

--- a/src/gateway/session-transcript-index.fs.ts
+++ b/src/gateway/session-transcript-index.fs.ts
@@ -3,7 +3,6 @@
 import fs from "node:fs";
 import { StringDecoder } from "node:string_decoder";
 import {
-  parseSessionTranscriptTreeEntry,
   scanSessionTranscriptTree,
   selectSessionTranscriptActiveEntries,
 } from "../config/sessions/transcript-tree.js";
@@ -43,7 +42,6 @@ type SessionTranscriptIndex = {
 
 type IndexedRawEntry = {
   id?: string;
-  parentId?: string | null;
   offset: number;
   byteLength: number;
   record: ParsedTranscriptRecord;
@@ -136,10 +134,8 @@ function buildOversizedIndexedRawEntry(params: {
       __openclaw: { truncated: true, reason: "oversized" },
     },
   };
-  const treeEntry = parseSessionTranscriptTreeEntry(record);
   return {
     ...(id ? { id } : {}),
-    ...(treeEntry ? { parentId: treeEntry.parentId } : parentId !== undefined ? { parentId } : {}),
     offset: params.offset,
     byteLength: params.byteLength,
     record,
@@ -238,18 +234,8 @@ async function buildSessionTranscriptIndex(
       return;
     }
     const id = readNonBlankStringPreservingWhitespace(parsed.id);
-    const parentId =
-      parsed.parentId === null
-        ? null
-        : (readNonBlankStringPreservingWhitespace(parsed.parentId) ?? undefined);
-    const treeEntry = parseSessionTranscriptTreeEntry(parsed);
     const rawEntry: IndexedRawEntry = {
       ...(id ? { id } : {}),
-      ...(treeEntry
-        ? { parentId: treeEntry.parentId }
-        : parentId !== undefined
-          ? { parentId }
-          : {}),
       offset,
       byteLength,
       record: parsed,
@@ -258,16 +244,9 @@ async function buildSessionTranscriptIndex(
   });
 
   const tree = scanSessionTranscriptTree(rawEntries.map((entry) => entry.record));
-  const rawByRecord = new Map(rawEntries.map((entry) => [entry.record, entry]));
-  for (const node of tree.nodes) {
-    const rawEntry = rawByRecord.get(node.entry);
-    if (rawEntry) {
-      rawEntry.parentId = node.parentId;
-    }
-  }
   const activeRawEntries = selectSessionTranscriptActiveEntries({
     entries: rawEntries,
-    records: rawEntries.map((entry) => entry.record),
+    recordOf: (entry) => entry.record,
     tree,
   });
   return {

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -17,6 +17,7 @@ import {
   readSessionMessageCountAsync,
   readSessionMessagesAsync,
   readSessionMessages,
+  readSessionMessagesPageWithStatsAsync,
   readSessionTitleFieldsFromTranscript,
   readSessionTitleFieldsFromTranscriptAsync,
   readSessionPreviewItemsFromTranscript,
@@ -1324,6 +1325,70 @@ describe("readSessionMessages", () => {
       { role: "user", content: "active prompt", kind: undefined },
       { role: "assistant", content: "active answer", kind: undefined },
     ]);
+  });
+
+  test("keeps active-branch compaction markers reachable through pagination", async () => {
+    const sessionId = "paginated-branch-with-compaction";
+    const sessionFile = writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 3, id: sessionId },
+      {
+        type: "message",
+        id: "old-user",
+        parentId: null,
+        message: { role: "user", content: "old prompt" },
+      },
+      {
+        type: "message",
+        id: "old-assistant",
+        parentId: "old-user",
+        message: { role: "assistant", content: "old answer" },
+      },
+      {
+        type: "compaction",
+        id: "comp-1",
+        timestamp: "2026-02-07T00:00:00.000Z",
+        summary: "Compacted history",
+      },
+      {
+        type: "message",
+        id: "active-user",
+        parentId: null,
+        message: { role: "user", content: "active prompt" },
+      },
+      {
+        type: "message",
+        id: "active-assistant",
+        parentId: "active-user",
+        message: { role: "assistant", content: "active answer" },
+      },
+      {
+        type: "message",
+        id: "side-branch",
+        parentId: "active-assistant",
+        message: { role: "assistant", content: "side branch" },
+      },
+      { type: "leaf", id: "active-leaf", parentId: "side-branch", targetId: "active-assistant" },
+    ]);
+    clearSessionTranscriptIndexCache();
+
+    const newest = await readSessionMessagesPageWithStatsAsync(sessionId, storePath, sessionFile, {
+      offset: 0,
+      maxMessages: 2,
+    });
+    const oldest = await readSessionMessagesPageWithStatsAsync(sessionId, storePath, sessionFile, {
+      offset: 2,
+      maxMessages: 1,
+    });
+
+    expect(newest.totalMessages).toBe(3);
+    expectMessageFields(newest.messages[0], { content: "active prompt", openclaw: { seq: 2 } });
+    expectMessageFields(newest.messages[1], { content: "active answer", openclaw: { seq: 3 } });
+    expect(oldest.totalMessages).toBe(3);
+    expectMessageFields(oldest.messages[0], {
+      role: "system",
+      content: [{ type: "text", text: "Compaction" }],
+      openclaw: { kind: "compaction", id: "comp-1", seq: 1 },
+    });
   });
 
   test("keeps blocked hook messages on the current active branch", () => {

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -1369,8 +1369,6 @@ describe("readSessionMessages", () => {
       },
       { type: "leaf", id: "active-leaf", parentId: "side-branch", targetId: "active-assistant" },
     ]);
-    clearSessionTranscriptIndexCache();
-
     const newest = await readSessionMessagesPageWithStatsAsync(sessionId, storePath, sessionFile, {
       offset: 0,
       maxMessages: 2,

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -17,6 +17,7 @@ import {
 import { materializeSessionArchiveForRead } from "../config/sessions/archive-compression.js";
 import {
   scanSessionTranscriptTree,
+  selectSessionTranscriptActiveEntries,
   selectSessionTranscriptTreePathNodes,
 } from "../config/sessions/transcript-tree.js";
 import { readFileWindowFully, readFileWindowFullySync } from "../infra/file-read.js";
@@ -376,29 +377,12 @@ function selectBoundedActiveTailRecords(
   entries: TailTranscriptRecord[],
   opts?: { failClosedOnInvalidLeafControl?: boolean },
 ): TailTranscriptRecord[] {
-  const tree = scanSessionTranscriptTree(entries.map((entry) => entry.record));
-  if (opts?.failClosedOnInvalidLeafControl === true && tree.hasInvalidLeafControl) {
-    return [];
-  }
-  if (!tree.hasExplicitLeafUpdate) {
-    return entries;
-  }
-  const recordsByValue = new Map(entries.map((entry) => [entry.record, entry]));
-  const activeBranch = selectSessionTranscriptTreePathNodes(tree, tree.leafId).flatMap((node) => {
-    const entry = recordsByValue.get(node.entry);
-    return entry ? [entry] : [];
+  const records = entries.map((entry) => entry.record);
+  return selectSessionTranscriptActiveEntries({
+    entries,
+    records,
+    failClosedOnInvalidLeafControl: opts?.failClosedOnInvalidLeafControl,
   });
-  const firstActiveRecord = activeBranch[0];
-  const firstActiveIndex = firstActiveRecord ? entries.indexOf(firstActiveRecord) : -1;
-  if (firstActiveIndex > 0) {
-    for (let index = firstActiveIndex - 1; index >= 0; index -= 1) {
-      const entry = entries[index];
-      if (entry?.record.type === "compaction") {
-        return [entry, ...activeBranch];
-      }
-    }
-  }
-  return activeBranch;
 }
 
 function readTranscriptRecords(filePath: string): TailTranscriptRecord[] {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -18,7 +18,6 @@ import { materializeSessionArchiveForRead } from "../config/sessions/archive-com
 import {
   scanSessionTranscriptTree,
   selectSessionTranscriptActiveEntries,
-  selectSessionTranscriptTreePathNodes,
 } from "../config/sessions/transcript-tree.js";
 import { readFileWindowFully, readFileWindowFullySync } from "../infra/file-read.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -15,10 +15,7 @@ import {
   type ContextUsage,
 } from "../agents/usage.js";
 import { materializeSessionArchiveForRead } from "../config/sessions/archive-compression.js";
-import {
-  scanSessionTranscriptTree,
-  selectSessionTranscriptActiveEntries,
-} from "../config/sessions/transcript-tree.js";
+import { selectSessionTranscriptActiveEntries } from "../config/sessions/transcript-tree.js";
 import { readFileWindowFully, readFileWindowFullySync } from "../infra/file-read.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { hasInterSessionUserProvenance } from "../sessions/input-provenance.js";
@@ -376,10 +373,9 @@ function selectBoundedActiveTailRecords(
   entries: TailTranscriptRecord[],
   opts?: { failClosedOnInvalidLeafControl?: boolean },
 ): TailTranscriptRecord[] {
-  const records = entries.map((entry) => entry.record);
   return selectSessionTranscriptActiveEntries({
     entries,
-    records,
+    recordOf: (entry) => entry.record,
     failClosedOnInvalidLeafControl: opts?.failClosedOnInvalidLeafControl,
   });
 }


### PR DESCRIPTION
Related to #92317.

## What Problem This Solves

Full filesystem history retained the nearest compaction marker before the selected active transcript branch, but the byte-offset pagination index selected branch nodes only. On affected branched transcripts, full history exposed three visible rows while pagination omitted the compaction row, reported a lower `totalMessages`, shifted sequence IDs, and could never retrieve the boundary at any offset.

## Why This Change Was Made

One canonical transcript-history selector now owns the invariant: when explicit branch selection is active, return the selected path plus the nearest preceding compaction marker. Both bounded/full readers and the byte-offset index use that selector before projecting messages or assigning sequence numbers.

The selector accepts one entries array plus a `recordOf` projection, so wrapper entries and parsed records cannot drift out of alignment. The index's old duplicate `parentId` normalization map and traversal were removed.

This is intentionally narrower than #87111: it changes no WebChat UI, public protocol, cursor, config, persistence format, or page-size policy. The broader pagination PR must retain this shared selector when integrated.

## User Impact

Paginated history can reach the same compaction boundary as full history, and `totalMessages`/sequence metadata now describe the same visible active transcript.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/session-utils.fs.test.ts` — 70 passed.
- `node scripts/run-vitest.mjs src/config/sessions/transcript-tree.test.ts` — 18 passed.
- The real JSONL regression excludes abandoned/side branches, returns the compaction row at the oldest offset, and asserts consistent totals and sequence values.
- `node scripts/check-changed.mjs -- src/config/sessions/transcript-tree.ts src/gateway/session-transcript-index.fs.ts src/gateway/session-utils.fs.ts src/gateway/session-utils.fs.test.ts` — passed on Blacksmith Testbox `tbx_01ky1ny21d3x4y9jdvwbhgw0a7`, run 29807268988.
- Full-branch AutoReview — clean, no accepted/actionable findings (0.94 confidence).
- `git diff --check` — passed.

Contributor credit is preserved in mikasa's original commits.
