### PR TITLE
fix(reply): prevent hung pre-delivery hooks from blocking lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,7 @@ Docs: https://docs.openclaw.ai
 - **Bedrock Mantle discovery:** bound model-catalog fetch time and response size, and release rejected response bodies so stalled, oversized, or failed provider responses fall back safely. (#99961) Thanks @zhangguiping-xydt.
 - **Discord thread-title prompts:** truncate generated-title message and channel context on UTF-16 boundaries so emoji cannot leave malformed model prompt text. (#101551) Thanks @Alix-007.
 - **Task state migration:** canonicalize legacy `not-requested` delivery statuses during sidecar import and existing shared-database open so upgraded task registries and linked TaskFlows recover without manual SQL, and surface rejected persisted values in compact console diagnostics. (#103946) Thanks @bek91.
+- **Reply pre-delivery recovery:** bound each pre-delivery callback with an owner-overridable deadline, release serialized reply lanes after hung plugin work, and preserve durable final-delivery retry state only when transport never started. (#104256) Thanks @NianJiuZst.
 
 ## 2026.7.1
 

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-bb271cf38aba8ab7cc8c589e3572903bc2c01b9a6042863aa6960cf8c8462c6c  plugin-sdk-api-baseline.json
-cfe1aaf737cf007b2b774ed4cfba346de4e59e1b294d0113d88814f2fd620997  plugin-sdk-api-baseline.jsonl
+932d2ee1e91d51c62fb4cfd43ef18249598492d6c4d158743f5db98864864ec0  plugin-sdk-api-baseline.json
+9cc400611e720a2399e7c314a91d596ec011c74808b7b90a16247a125f991eb8  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c0447455392f121e17fd2e27a257006b22b144cd7a7fea2cf3a603ffbf886c1e  plugin-sdk-api-baseline.json
-8b06d4fe6d1ccf1a7d125839962250ba82bfa1d6eb435d3cb5761ceaee4b6552  plugin-sdk-api-baseline.jsonl
+bb271cf38aba8ab7cc8c589e3572903bc2c01b9a6042863aa6960cf8c8462c6c  plugin-sdk-api-baseline.json
+cfe1aaf737cf007b2b774ed4cfba346de4e59e1b294d0113d88814f2fd620997  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-1a655db74b630c67a5549e4254fd4dbb2965dbb8f1420ba425eafde5c6e41ad9  plugin-sdk-api-baseline.json
-da435187b9793395e7555949d1e2ca483e9ed4d8478d666bbb20586b33a62c32  plugin-sdk-api-baseline.jsonl
+c0447455392f121e17fd2e27a257006b22b144cd7a7fea2cf3a603ffbf886c1e  plugin-sdk-api-baseline.json
+8b06d4fe6d1ccf1a7d125839962250ba82bfa1d6eb435d3cb5761ceaee4b6552  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-932d2ee1e91d51c62fb4cfd43ef18249598492d6c4d158743f5db98864864ec0  plugin-sdk-api-baseline.json
-9cc400611e720a2399e7c314a91d596ec011c74808b7b90a16247a125f991eb8  plugin-sdk-api-baseline.jsonl
+d8383ea9819598d92e1d1052eeb9adb61f79cd5b16e0991fc60e17a99612848d  plugin-sdk-api-baseline.json
+b9c7eed49500d9f5d371a25c0bc7b968d55e6272081a6e9be2113f81c2415689  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -93,6 +93,12 @@ receive a cancellation signal. The hook dispatch can release its Gateway
 admission while that plugin work is still in progress. Plugins that own
 long-running work must provide their own cancellation and shutdown lifecycle.
 
+Outbound modifying hooks `message_sending` and `reply_payload_sending` use a
+15-second default per handler. If one times out, OpenClaw logs the plugin error
+and continues with the latest payload so the serialized delivery lane can
+settle. Set a larger per-hook budget for plugins that intentionally do slower
+work before delivery.
+
 Each hook receives `event.context.pluginConfig`, the resolved config for the
 plugin that registered that handler. OpenClaw injects it per handler without
 mutating the shared event object other plugins see.

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -99,6 +99,12 @@ and continues with the latest payload so the serialized delivery lane can
 settle. Set a larger per-hook budget for plugins that intentionally do slower
 work before delivery.
 
+Channel plugins that use `createReplyDispatcher` can likewise declare a larger
+positive per-stage budget with `beforeDeliverOptions: { timeoutMs }`, or when
+appending work with `dispatcher.appendBeforeDeliver(handler, { timeoutMs })`.
+Without an owner-declared budget, those callbacks use the same 15-second
+default so a hung callback cannot retain the serialized delivery lane.
+
 Each hook receives `event.context.pluginConfig`, the resolved config for the
 plugin that registered that handler. OpenClaw injects it per handler without
 mutating the shared event object other plugins see.

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -856,18 +856,24 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             onReplyStart: typingCallbacks?.onReplyStart,
           });
 
-        await core.channel.reply.dispatchReplyFromConfig({
-          ctx: ctxPayload,
-          cfg,
+        await core.channel.reply.withReplyDispatcher({
           dispatcher,
-          replyOptions: {
-            ...replyOptions,
-            disableBlockStreaming:
-              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-            onModelSelected,
+          onSettled: () => {
+            markDispatchIdle();
           },
+          run: () =>
+            core.channel.reply.dispatchReplyFromConfig({
+              ctx: ctxPayload,
+              cfg,
+              dispatcher,
+              replyOptions: {
+                ...replyOptions,
+                disableBlockStreaming:
+                  typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+                onModelSelected,
+              },
+            }),
         });
-        markDispatchIdle();
       },
       log: (msg) => runtime.log?.(msg),
     }),

--- a/scripts/lib/session-accessor-debt-baseline.json
+++ b/scripts/lib/session-accessor-debt-baseline.json
@@ -22,7 +22,6 @@
   "sessionAccessorWrite": {
     "src/agents/session-suspension.ts": 2,
     "src/agents/subagent-spawn.test-helpers.ts": 1,
-    "src/auto-reply/reply/dispatch-from-config.ts": 2,
     "src/commands/doctor-heartbeat-main-session-repair.ts": 2,
     "src/commands/doctor-session-snapshots.ts": 2,
     "src/commands/doctor-session-state-providers.ts": 2,

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -195,7 +195,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10553,
+      10554,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -177,6 +177,53 @@ describe("foreground reply freshness", () => {
     expect(cancellationReasons).toEqual([undefined]);
   });
 
+  it("releases a WhatsApp-shaped lane after beforeDeliver times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const deliveries: Delivery[] = [];
+      const hookStarted = createDeferred<void>();
+      const onSettled = vi.fn();
+      let hookCalls = 0;
+      const beforeDeliver = vi.fn((payload: ReplyPayload) => {
+        hookCalls += 1;
+        if (hookCalls === 1) {
+          hookStarted.resolve();
+          return new Promise<ReplyPayload>(() => {});
+        }
+        return payload;
+      });
+      hoisted.dispatchReplyFromConfigMock.mockImplementation(
+        async (params: DispatchReplyFromConfigParams) => {
+          params.dispatcher.sendFinalReply({ text: "stuck final" });
+          params.dispatcher.sendFinalReply({ text: "follow-up final" });
+          return {
+            queuedFinal: true,
+            counts: { tool: 0, block: 0, final: 2 },
+          };
+        },
+      );
+
+      const dispatch = dispatchWithDeliveries(buildForegroundCtx(), deliveries, {
+        beforeDeliver,
+        onSettled,
+      });
+      await hookStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await expect(dispatch).resolves.toEqual({
+        queuedFinal: true,
+        counts: { tool: 0, block: 0, final: 1 },
+        failedCounts: { tool: 0, block: 0, final: 1 },
+      });
+      expect(beforeDeliver).toHaveBeenCalledTimes(2);
+      expect(deliveries).toEqual([{ kind: "final", text: "follow-up final" }]);
+      expect(onSettled).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps an older foreground final when a newer inbound has no visible delivery while beforeDeliver is pending", async () => {
     const deliveries: Delivery[] = [];
     const beforeDeliverStarted = createDeferred<void>();

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -5,6 +5,7 @@ import { OutboundDeliveryError } from "../infra/outbound/deliver-types.js";
 import { resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { getReplyPayloadMetadata } from "./reply-payload.js";
 import type { ReplyDispatchBeforeDeliver } from "./reply/reply-dispatcher.js";
+import type { ReplyDispatchBeforeDeliverOptions } from "./reply/reply-dispatcher.types.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { ReplyPayload } from "./types.js";
@@ -64,6 +65,7 @@ function dispatchWithDeliveries(
   deliveries: Delivery[],
   dispatcherOptions: {
     beforeDeliver?: ReplyDispatchBeforeDeliver;
+    beforeDeliverOptions?: ReplyDispatchBeforeDeliverOptions;
     deliver?: (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => Promise<object | void>;
     onBeforeDeliverCancelled?: (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => void;
     onSettled?: () => object | void | Promise<object | void>;
@@ -218,6 +220,41 @@ describe("foreground reply freshness", () => {
       expect(beforeDeliver).toHaveBeenCalledTimes(2);
       expect(deliveries).toEqual([{ kind: "final", text: "follow-up final" }]);
       expect(onSettled).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honors a configured beforeDeliver budget inside the foreground fence", async () => {
+    vi.useFakeTimers();
+    try {
+      const deliveries: Delivery[] = [];
+      const hookStarted = createDeferred<void>();
+      hoisted.dispatchReplyFromConfigMock.mockImplementation(
+        async (params: DispatchReplyFromConfigParams) => {
+          params.dispatcher.sendFinalReply({ text: "budgeted final" });
+          return queuedFinalResult();
+        },
+      );
+
+      const dispatch = dispatchWithDeliveries(buildForegroundCtx(), deliveries, {
+        beforeDeliver: async (payload) => {
+          hookStarted.resolve();
+          await new Promise((resolve) => {
+            setTimeout(resolve, 16_000);
+          });
+          return payload;
+        },
+        beforeDeliverOptions: { timeoutMs: 20_000 },
+      });
+      await hookStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(deliveries).toEqual([]);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(dispatch).resolves.toEqual(queuedFinalResult());
+      expect(deliveries).toEqual([{ kind: "final", text: "budgeted final" }]);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -30,8 +30,10 @@ import type {
 } from "./reply/get-reply.types.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
+  composeReplyDispatchBeforeDeliver,
   createReplyDispatcher,
   createReplyDispatcherWithTyping,
+  markReplyDispatchBeforeDeliverDeadlineOwned,
   type ReplyDispatchBeforeDeliver,
   type ReplyDispatcherOptions,
   type ReplyDispatcherWithTypingOptions,
@@ -362,24 +364,26 @@ function buildMessageSendingBeforeDeliver(
   const hookCtx = deriveInboundMessageHookContext(finalized);
   const replyTarget = resolveInboundReplyHookTarget(finalized, hookCtx);
 
-  return async (payload: ReplyPayload): Promise<ReplyPayload | null> => {
-    if (!payload.text) {
+  return markReplyDispatchBeforeDeliverDeadlineOwned(
+    async (payload: ReplyPayload): Promise<ReplyPayload | null> => {
+      if (!payload.text) {
+        return payload;
+      }
+
+      const result = await hookRunner.runMessageSending(
+        { content: payload.text, to: replyTarget },
+        toPluginMessageContext(hookCtx),
+      );
+
+      if (result?.cancel) {
+        return null;
+      }
+      if (result?.content != null) {
+        return copyReplyPayloadMetadata(payload, { ...payload, text: result.content });
+      }
       return payload;
-    }
-
-    const result = await hookRunner.runMessageSending(
-      { content: payload.text, to: replyTarget },
-      toPluginMessageContext(hookCtx),
-    );
-
-    if (result?.cancel) {
-      return null;
-    }
-    if (result?.content != null) {
-      return copyReplyPayloadMetadata(payload, { ...payload, text: result.content });
-    }
-    return payload;
-  };
+    },
+  );
 }
 
 function buildReplyPayloadSendingBeforeDeliver(
@@ -389,22 +393,24 @@ function buildReplyPayloadSendingBeforeDeliver(
   const finalized = finalizeInboundContext(ctx);
   const hookCtx = deriveInboundMessageHookContext(finalized);
 
-  return async (payload: ReplyPayload, info): Promise<ReplyPayload | null> => {
-    const runId = runState.runId;
-    const hookedPayload = await runReplyPayloadSendingHook({
-      payload,
-      kind: info.kind,
-      channel: finalized.Surface ?? finalized.Provider,
-      sessionKey: finalized.SessionKey,
-      runId,
-      usageState: consumeReplyUsageState(runId),
-      context: {
-        ...toPluginMessageContext(hookCtx),
+  return markReplyDispatchBeforeDeliverDeadlineOwned(
+    async (payload: ReplyPayload, info): Promise<ReplyPayload | null> => {
+      const runId = runState.runId;
+      const hookedPayload = await runReplyPayloadSendingHook({
+        payload,
+        kind: info.kind,
+        channel: finalized.Surface ?? finalized.Provider,
+        sessionKey: finalized.SessionKey,
         runId,
-      },
-    });
-    return hookedPayload && hasOutboundReplyContent(hookedPayload) ? hookedPayload : null;
-  };
+        usageState: consumeReplyUsageState(runId),
+        context: {
+          ...toPluginMessageContext(hookCtx),
+          runId,
+        },
+      });
+      return hookedPayload && hasOutboundReplyContent(hookedPayload) ? hookedPayload : null;
+    },
+  );
 }
 
 function bindReplyPayloadRunState(
@@ -444,27 +450,6 @@ function markReplyPayloadSendingBeforeDeliverInstalled(
   if (beforeDeliver) {
     replyPayloadSendingDispatchers.add(dispatcher);
   }
-}
-
-function combineBeforeDeliverHooks(
-  ...hooks: Array<ReplyDispatchBeforeDeliver | undefined>
-): ReplyDispatchBeforeDeliver | undefined {
-  const activeHooks = hooks.filter((hook): hook is ReplyDispatchBeforeDeliver => Boolean(hook));
-  if (activeHooks.length === 0) {
-    return undefined;
-  }
-
-  return async (payload, info) => {
-    let current: ReplyPayload | null = payload;
-    for (const hook of activeHooks) {
-      if (!current) {
-        return null;
-      }
-      const next = await hook(current, info);
-      current = next ? copyReplyPayloadMetadata(current, next) : null;
-    }
-    return current;
-  };
 }
 
 function buildDispatchTimelineAttributes(ctx: MsgContext | FinalizedMsgContext) {
@@ -603,16 +588,19 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     finalized,
     replyPayloadRunState,
   );
-  const globalBeforeDeliver = combineBeforeDeliverHooks(
+  const globalBeforeDeliver = composeReplyDispatchBeforeDeliver(
     replyPayloadBeforeDeliver,
     buildMessageSendingBeforeDeliver(finalized),
   );
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? composeReplyDispatchBeforeDeliver(
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+      )
     : globalBeforeDeliver;
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
-      ? async (payload, info) => {
+      ? markReplyDispatchBeforeDeliverDeadlineOwned(async (payload, info) => {
           // Check both before and after hooks because hooks can await while newer replies finish.
           if (await shouldCancelForegroundReplyDelivery(foregroundReplyFence)) {
             // Only the foreground fence proves "not shown because stale"; hook
@@ -635,7 +623,7 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
             return null;
           }
           return deliverPayload;
-        }
+        })
       : undefined;
   const deliver: ReplyDispatcherWithTypingOptions["deliver"] = async (payload, info) => {
     try {
@@ -715,12 +703,15 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     params.ctx,
     replyPayloadRunState,
   );
-  const globalBeforeDeliver = combineBeforeDeliverHooks(
+  const globalBeforeDeliver = composeReplyDispatchBeforeDeliver(
     replyPayloadBeforeDeliver,
     buildMessageSendingBeforeDeliver(params.ctx),
   );
   const composedBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? composeReplyDispatchBeforeDeliver(
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+      )
     : globalBeforeDeliver;
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -594,7 +594,10 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   );
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
     ? composeReplyDispatchBeforeDeliver(
-        params.dispatcherOptions.beforeDeliver,
+        {
+          hook: params.dispatcherOptions.beforeDeliver,
+          options: params.dispatcherOptions.beforeDeliverOptions,
+        },
         replyPayloadBeforeDeliver,
       )
     : globalBeforeDeliver;
@@ -709,7 +712,10 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   );
   const composedBeforeDeliver = params.dispatcherOptions.beforeDeliver
     ? composeReplyDispatchBeforeDeliver(
-        params.dispatcherOptions.beforeDeliver,
+        {
+          hook: params.dispatcherOptions.beforeDeliver,
+          options: params.dispatcherOptions.beforeDeliverOptions,
+        },
         replyPayloadBeforeDeliver,
       )
     : globalBeforeDeliver;

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -221,6 +221,8 @@ export type ReplyPayloadMetadata = {
   };
   /** Opaque owner for one final-delivery transcript capture on a shared dispatcher. */
   finalDeliveryCapture?: object;
+  /** Durable pending-final intent represented by this runtime payload. */
+  pendingFinalDeliveryIntentId?: string;
   /** replyToId existed before reply threading could inject an implicit target. */
   replyToIdExplicit?: boolean;
   /** Canonical reply policy used by both message-tool dedupe and final delivery routing. */

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -223,6 +223,8 @@ export type ReplyPayloadMetadata = {
   finalDeliveryCapture?: object;
   /** Durable pending-final intent represented by this runtime payload. */
   pendingFinalDeliveryIntentId?: string;
+  /** Restart-safe text this payload contributes to its pending-final intent. */
+  pendingFinalDeliveryRetryText?: string;
   /** replyToId existed before reply threading could inject an implicit target. */
   replyToIdExplicit?: boolean;
   /** Canonical reply policy used by both message-tool dedupe and final delivery routing. */

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -748,12 +748,19 @@ describe("runReplyAgent pending final delivery capture", () => {
       storePath,
     });
 
-    await run();
+    const result = await run();
 
     const stored = await readStoredMainSession(storePath);
     expect(stored.pendingFinalDelivery).toBe(true);
     expect(stored.pendingFinalDeliveryText).toBe("visible final");
     expect(stored.pendingFinalDeliveryIntentId).toEqual(expect.any(String));
+    const visiblePayload = (Array.isArray(result) ? result : [result]).find(
+      (payload) => payload?.text === "visible final",
+    );
+    expect(getReplyPayloadMetadata(visiblePayload ?? {})).toMatchObject({
+      pendingFinalDeliveryIntentId: stored.pendingFinalDeliveryIntentId,
+      pendingFinalDeliveryRetryText: "visible final",
+    });
   });
 
   it("persists auto-reply delivery context for restart recovery", async () => {
@@ -959,11 +966,16 @@ describe("runReplyAgent pending final delivery capture", () => {
       storePath,
     });
 
-    await run();
+    const result = await run();
 
     const stored = await readStoredMainSession(storePath);
     expect(stored.pendingFinalDelivery).toBe(true);
     expect(stored.pendingFinalDeliveryText).toBe(longRemainder);
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(getReplyPayloadMetadata(payload ?? {})).toMatchObject({
+      pendingFinalDeliveryIntentId: stored.pendingFinalDeliveryIntentId,
+      pendingFinalDeliveryRetryText: longRemainder,
+    });
   });
 });
 
@@ -3115,4 +3127,5 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 });
 
+import { getReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -753,6 +753,7 @@ describe("runReplyAgent pending final delivery capture", () => {
     const stored = await readStoredMainSession(storePath);
     expect(stored.pendingFinalDelivery).toBe(true);
     expect(stored.pendingFinalDeliveryText).toBe("visible final");
+    expect(stored.pendingFinalDeliveryIntentId).toEqual(expect.any(String));
   });
 
   it("persists auto-reply delivery context for restart recovery", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2702,6 +2702,7 @@ export async function runReplyAgent(params: {
           })()
         : pendingText;
       if (resolvedPendingText) {
+        const pendingFinalDeliveryIntentId = crypto.randomUUID();
         const pendingFinalDeliveryContext = resolveReplyRunDeliveryContext({
           cfg,
           sessionCtx,
@@ -2715,6 +2716,7 @@ export async function runReplyAgent(params: {
           () => ({
             pendingFinalDelivery: true,
             pendingFinalDeliveryText: resolvedPendingText,
+            pendingFinalDeliveryIntentId,
             pendingFinalDeliveryContext,
             pendingFinalDeliveryCreatedAt: Date.now(),
             updatedAt: Date.now(),

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2703,6 +2703,9 @@ export async function runReplyAgent(params: {
         : pendingText;
       if (resolvedPendingText) {
         const pendingFinalDeliveryIntentId = crypto.randomUUID();
+        for (const payload of finalPayloads) {
+          setReplyPayloadMetadata(payload, { pendingFinalDeliveryIntentId });
+        }
         const pendingFinalDeliveryContext = resolveReplyRunDeliveryContext({
           cfg,
           sessionCtx,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -108,7 +108,10 @@ import { createFollowupRunner } from "./followup-runner.js";
 import { REPLY_RUN_STILL_SHUTTING_DOWN_TEXT } from "./get-reply-run-queue.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
-import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
+import {
+  buildPendingFinalDeliveryText,
+  sanitizePendingFinalDeliveryText,
+} from "./pending-final-delivery.js";
 import { drainPendingToolTasks } from "./pending-tool-task-drain.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
 import {
@@ -998,15 +1001,6 @@ function joinCommitmentAssistantText(payloads: ReplyPayload[]): string {
     .filter((text): text is string => Boolean(text))
     .join("\n")
     .trim();
-}
-
-function buildPendingFinalDeliveryText(payloads: ReplyPayload[]): string {
-  const text = payloads
-    .filter((payload) => payload.isReasoning !== true)
-    .map((payload) => payload.text)
-    .filter((textLocal): textLocal is string => Boolean(textLocal))
-    .join("\n\n");
-  return sanitizePendingFinalDeliveryText(text);
 }
 
 function normalizeAssistantFinalDeliveryText(text: string): string {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -177,6 +177,18 @@ function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): ReplyPaylo
   );
 }
 
+function resolvePendingFinalDeliveryRetryText(params: {
+  isHeartbeat: boolean;
+  payload: ReplyPayload;
+}): string {
+  const pendingText = buildPendingFinalDeliveryText([params.payload]);
+  if (!params.isHeartbeat) {
+    return pendingText;
+  }
+  const stripped = stripHeartbeatToken(pendingText, { mode: "message" });
+  return stripped.shouldSkip ? "" : stripped.text || pendingText;
+}
+
 function buildSilentFallbackFailurePayload(params: {
   fallbackTransition: ReturnType<typeof resolveFallbackTransition>;
   fallbackFailureKnown: boolean;
@@ -2704,7 +2716,13 @@ export async function runReplyAgent(params: {
       if (resolvedPendingText) {
         const pendingFinalDeliveryIntentId = crypto.randomUUID();
         for (const payload of finalPayloads) {
-          setReplyPayloadMetadata(payload, { pendingFinalDeliveryIntentId });
+          setReplyPayloadMetadata(payload, {
+            pendingFinalDeliveryIntentId,
+            pendingFinalDeliveryRetryText: resolvePendingFinalDeliveryRetryText({
+              isHeartbeat,
+              payload,
+            }),
+          });
         }
         const pendingFinalDeliveryContext = resolveReplyRunDeliveryContext({
           cfg,

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -115,7 +115,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       .mockImplementation(() => sessionStoreMocks.currentEntry);
     sessionStoreMocks.resolveStorePath.mockReset().mockReturnValue("/tmp/mock-sessions.json");
     sessionStoreMocks.resolveSessionStoreEntry.mockReset().mockReturnValue({ existing: undefined });
-    sessionStoreMocks.updateSessionStoreEntry.mockClear();
+    sessionStoreMocks.updateSessionEntry.mockClear();
     acpManagerRuntimeMocks.getAcpSessionManager.mockReset();
     acpManagerRuntimeMocks.getAcpSessionManager.mockImplementation(() => ({
       resolveSession: () => ({ kind: "none" as const }),
@@ -232,7 +232,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     });
     await dispatcher.waitForIdle();
     await vi.waitFor(() => {
-      expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+      expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledOnce();
     });
 
     expect(result.queuedFinal).toBe(true);
@@ -302,7 +302,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
     expect(deliver).toHaveBeenCalledOnce();
     expect(result.queuedFinal).toBe(false);
-    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledOnce();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBeUndefined();
@@ -335,7 +335,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     });
 
     expect(result.queuedFinal).toBe(false);
-    expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+    expect(sessionStoreMocks.updateSessionEntry).not.toHaveBeenCalled();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
@@ -382,7 +382,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       expect(result.queuedFinal).toBe(true);
       expect(deliver).not.toHaveBeenCalled();
       expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
-      expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+      expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledOnce();
       expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
       expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
       expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toEqual({
@@ -709,7 +709,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     });
 
     expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
-    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledOnce();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
   });
@@ -739,7 +739,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     });
     await dispatcher.waitForIdle();
     await vi.waitFor(() => {
-      expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+      expect(sessionStoreMocks.updateSessionEntry).toHaveBeenCalledOnce();
     });
 
     expect(result.queuedFinal).toBe(true);

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -110,7 +110,9 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       () => sessionStoreMocks.currentEntry,
     );
     sessionStoreMocks.loadSessionStore.mockReset().mockReturnValue({});
-    sessionStoreMocks.readSessionEntry.mockReset().mockReturnValue(undefined);
+    sessionStoreMocks.readSessionEntry.mockReset().mockImplementation(
+      () => sessionStoreMocks.currentEntry,
+    );
     sessionStoreMocks.resolveStorePath.mockReset().mockReturnValue("/tmp/mock-sessions.json");
     sessionStoreMocks.resolveSessionStoreEntry.mockReset().mockReturnValue({ existing: undefined });
     sessionStoreMocks.updateSessionStoreEntry.mockClear();
@@ -548,6 +550,59 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
       expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
       expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let an older settlement rewrite a newer pending-final intent", async () => {
+    vi.useFakeTimers();
+    try {
+      hookMocks.runner.hasHooks.mockReturnValue(false);
+      sessionStoreMocks.currentEntry = {
+        sessionKey: "agent:test:session",
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "older reply",
+        pendingFinalDeliveryCreatedAt: 1,
+        pendingFinalDeliveryIntentId: "older-intent",
+      };
+      sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+        existing: sessionStoreMocks.currentEntry,
+      });
+      const hookStarted = createDeferred<void>();
+      const dispatcher = createReplyDispatcher({
+        deliver: vi.fn().mockResolvedValue(undefined),
+        beforeDeliver: () => {
+          hookStarted.resolve();
+          return new Promise<never>(() => {});
+        },
+      });
+
+      const resultPromise = withReplyDispatcher({
+        dispatcher,
+        run: () =>
+          dispatchReplyFromConfig({
+            ctx: createHookCtx(),
+            cfg: emptyConfig,
+            dispatcher,
+            replyResolver: async () => ({ text: "older reply" }),
+          }),
+      });
+      await hookStarted.promise;
+      sessionStoreMocks.currentEntry = {
+        ...sessionStoreMocks.currentEntry,
+        pendingFinalDeliveryText: "newer reply",
+        pendingFinalDeliveryCreatedAt: 2,
+        pendingFinalDeliveryIntentId: "newer-intent",
+      };
+      await vi.advanceTimersByTimeAsync(15_000);
+      await resultPromise;
+
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("newer reply");
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(2);
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryIntentId).toBe("newer-intent");
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -556,6 +556,73 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     }
   });
 
+  it("narrows heartbeat-normalized retry text using its originating payloads", async () => {
+    vi.useFakeTimers();
+    try {
+      hookMocks.runner.hasHooks.mockReturnValue(false);
+      sessionStoreMocks.currentEntry = {
+        sessionKey: "agent:test:session",
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "auxiliary durable reply",
+        pendingFinalDeliveryCreatedAt: 1,
+        pendingFinalDeliveryIntentId: "heartbeat-intent",
+      };
+      sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+        existing: sessionStoreMocks.currentEntry,
+      });
+      const hookStarted = createDeferred<void>();
+      let hookCalls = 0;
+      const dispatcher = createReplyDispatcher({
+        deliver: vi.fn().mockResolvedValue(undefined),
+        beforeDeliver: (payload) => {
+          hookCalls += 1;
+          if (hookCalls === 2) {
+            hookStarted.resolve();
+            return new Promise<never>(() => {});
+          }
+          return payload;
+        },
+      });
+
+      const resultPromise = withReplyDispatcher({
+        dispatcher,
+        run: () =>
+          dispatchReplyFromConfig({
+            ctx: createHookCtx(),
+            cfg: emptyConfig,
+            dispatcher,
+            replyResolver: async () => [
+              setReplyPayloadMetadata(
+                { text: "auxiliary" },
+                {
+                  pendingFinalDeliveryIntentId: "heartbeat-intent",
+                  pendingFinalDeliveryRetryText: "auxiliary",
+                },
+              ),
+              setReplyPayloadMetadata(
+                { text: "durable reply" },
+                {
+                  pendingFinalDeliveryIntentId: "heartbeat-intent",
+                  pendingFinalDeliveryRetryText: "durable reply",
+                },
+              ),
+            ],
+          }),
+      });
+      await hookStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+      await resultPromise;
+
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryIntentId).toBe("heartbeat-intent");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not let an older settlement rewrite a newer pending-final intent", async () => {
     vi.useFakeTimers();
     try {

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -380,7 +380,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       expect(result.queuedFinal).toBe(true);
       expect(deliver).not.toHaveBeenCalled();
       expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
-      expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+      expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
       expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
       expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
       expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toEqual({
@@ -443,6 +443,111 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
       expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
       expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves the durable final when an earlier auxiliary final succeeds", async () => {
+    vi.useFakeTimers();
+    try {
+      hookMocks.runner.hasHooks.mockReturnValue(false);
+      sessionStoreMocks.currentEntry = {
+        sessionKey: "agent:test:session",
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "durable reply",
+        pendingFinalDeliveryCreatedAt: 1,
+      };
+      sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+        existing: sessionStoreMocks.currentEntry,
+      });
+      const hookStarted = createDeferred<void>();
+      const deliver = vi.fn().mockResolvedValue(undefined);
+      let hookCalls = 0;
+      const dispatcher = createReplyDispatcher({
+        deliver,
+        beforeDeliver: (payload) => {
+          hookCalls += 1;
+          if (hookCalls === 2) {
+            hookStarted.resolve();
+            return new Promise<never>(() => {});
+          }
+          return payload;
+        },
+      });
+
+      const resultPromise = withReplyDispatcher({
+        dispatcher,
+        run: () =>
+          dispatchReplyFromConfig({
+            ctx: createHookCtx(),
+            cfg: emptyConfig,
+            dispatcher,
+            replyResolver: async () => [{ text: "auxiliary" }, { text: "durable reply" }],
+          }),
+      });
+      await hookStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+      await resultPromise;
+
+      expect(deliver).toHaveBeenCalledOnce();
+      expect(deliver).toHaveBeenCalledWith(
+        expect.objectContaining({ text: "auxiliary" }),
+        expect.objectContaining({ kind: "final" }),
+      );
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("narrows combined retry text to finals that failed before transport", async () => {
+    vi.useFakeTimers();
+    try {
+      hookMocks.runner.hasHooks.mockReturnValue(false);
+      sessionStoreMocks.currentEntry = {
+        sessionKey: "agent:test:session",
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "auxiliary\n\ndurable reply",
+        pendingFinalDeliveryCreatedAt: 1,
+      };
+      sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+        existing: sessionStoreMocks.currentEntry,
+      });
+      const hookStarted = createDeferred<void>();
+      let hookCalls = 0;
+      const dispatcher = createReplyDispatcher({
+        deliver: vi.fn().mockResolvedValue(undefined),
+        beforeDeliver: (payload) => {
+          hookCalls += 1;
+          if (hookCalls === 2) {
+            hookStarted.resolve();
+            return new Promise<never>(() => {});
+          }
+          return payload;
+        },
+      });
+
+      const resultPromise = withReplyDispatcher({
+        dispatcher,
+        run: () =>
+          dispatchReplyFromConfig({
+            ctx: createHookCtx(),
+            cfg: emptyConfig,
+            dispatcher,
+            replyResolver: async () => [{ text: "auxiliary" }, { text: "durable reply" }],
+          }),
+      });
+      await hookStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+      await resultPromise;
+
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -110,9 +110,9 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       () => sessionStoreMocks.currentEntry,
     );
     sessionStoreMocks.loadSessionStore.mockReset().mockReturnValue({});
-    sessionStoreMocks.readSessionEntry.mockReset().mockImplementation(
-      () => sessionStoreMocks.currentEntry,
-    );
+    sessionStoreMocks.readSessionEntry
+      .mockReset()
+      .mockImplementation(() => sessionStoreMocks.currentEntry);
     sessionStoreMocks.resolveStorePath.mockReset().mockReturnValue("/tmp/mock-sessions.json");
     sessionStoreMocks.resolveSessionStoreEntry.mockReset().mockReturnValue({ existing: undefined });
     sessionStoreMocks.updateSessionStoreEntry.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -586,7 +586,11 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
             ctx: createHookCtx(),
             cfg: emptyConfig,
             dispatcher,
-            replyResolver: async () => ({ text: "older reply" }),
+            replyResolver: async () =>
+              setReplyPayloadMetadata(
+                { text: "older reply" },
+                { pendingFinalDeliveryIntentId: "older-intent" },
+              ),
           }),
       });
       await hookStarted.promise;

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearAgentHarnesses } from "../../agents/harness/registry.js";
 import type { PluginHookReplyDispatchResult } from "../../plugins/hooks.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
+import { withReplyDispatcher } from "../dispatch-dispatcher.js";
 import { setReplyPayloadMetadata, type ReplyPayload } from "../types.js";
 import {
   acpManagerRuntimeMocks,
@@ -50,6 +51,14 @@ function firstReplyDispatchCall() {
         },
       ]
     | undefined;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
 }
 
 describe("dispatchReplyFromConfig reply_dispatch hook", () => {
@@ -211,11 +220,17 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     sessionStoreMocks.loadSessionStore.mockClear();
     mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
 
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
     const result = await dispatchReplyFromConfig({
       ctx: createHookCtx(),
       cfg: emptyConfig,
-      dispatcher: createDispatcher(),
+      dispatcher,
       replyResolver: async () => ({ text: "durable reply" }),
+    });
+    await dispatcher.waitForIdle();
+    await vi.waitFor(() => {
+      expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
     });
 
     expect(result.queuedFinal).toBe(true);
@@ -228,6 +243,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     });
     expect(sessionStoreMocks.loadSessionStore).not.toHaveBeenCalled();
     expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(deliver).toHaveBeenCalledOnce();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBeUndefined();
@@ -258,23 +274,31 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       existing: sessionStoreMocks.currentEntry,
     });
     const abortController = new AbortController();
-    const dispatcher = createDispatcher();
-    vi.mocked(dispatcher.sendFinalReply).mockImplementation(() => {
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
+    const sendFinalReply = dispatcher.sendFinalReply.bind(dispatcher);
+    vi.spyOn(dispatcher, "sendFinalReply").mockImplementation((payload) => {
+      const queued = sendFinalReply(payload);
       abortController.abort();
-      return true;
+      return queued;
     });
 
-    const result = await dispatchReplyFromConfig({
-      ctx: createHookCtx(),
-      cfg: emptyConfig,
+    const result = await withReplyDispatcher({
       dispatcher,
-      replyOptions: { abortSignal: abortController.signal },
-      replyResolver: async () => ({ text: "durable reply" }),
+      run: () =>
+        dispatchReplyFromConfig({
+          ctx: createHookCtx(),
+          cfg: emptyConfig,
+          dispatcher,
+          replyOptions: { abortSignal: abortController.signal },
+          replyResolver: async () => ({ text: "durable reply" }),
+        }),
     });
 
     // Abort landed after delivery: the run is still surfaced as aborted
     // (queuedFinal:false), but the pending-final state is fully cleared.
     expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
+    expect(deliver).toHaveBeenCalledOnce();
     expect(result.queuedFinal).toBe(false);
     expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
@@ -313,6 +337,186 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
+  });
+
+  it("preserves pending final delivery when beforeDeliver times out", async () => {
+    vi.useFakeTimers();
+    try {
+      hookMocks.runner.hasHooks.mockReturnValue(false);
+      sessionStoreMocks.currentEntry = {
+        sessionKey: "agent:test:session",
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "durable reply",
+        pendingFinalDeliveryCreatedAt: 1,
+        pendingFinalDeliveryContext: { channel: "whatsapp", to: "+1000" },
+      };
+      sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+        existing: sessionStoreMocks.currentEntry,
+      });
+      const hookStarted = createDeferred<void>();
+      const deliver = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = createReplyDispatcher({
+        deliver,
+        beforeDeliver: () => {
+          hookStarted.resolve();
+          return new Promise<never>(() => {});
+        },
+      });
+
+      const resultPromise = withReplyDispatcher({
+        dispatcher,
+        run: () =>
+          dispatchReplyFromConfig({
+            ctx: createHookCtx(),
+            cfg: emptyConfig,
+            dispatcher,
+            replyResolver: async () => ({ text: "durable reply" }),
+          }),
+      });
+      await hookStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+      const result = await resultPromise;
+
+      expect(result.queuedFinal).toBe(true);
+      expect(deliver).not.toHaveBeenCalled();
+      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+      expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toEqual({
+        channel: "whatsapp",
+        to: "+1000",
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears pending final delivery when a later queued final succeeds", async () => {
+    vi.useFakeTimers();
+    try {
+      hookMocks.runner.hasHooks.mockReturnValue(false);
+      sessionStoreMocks.currentEntry = {
+        sessionKey: "agent:test:session",
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "durable reply",
+        pendingFinalDeliveryCreatedAt: 1,
+      };
+      sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+        existing: sessionStoreMocks.currentEntry,
+      });
+      const hookStarted = createDeferred<void>();
+      const deliver = vi.fn().mockResolvedValue(undefined);
+      let hookCalls = 0;
+      const dispatcher = createReplyDispatcher({
+        deliver,
+        beforeDeliver: (payload) => {
+          hookCalls += 1;
+          if (hookCalls === 1) {
+            hookStarted.resolve();
+            return new Promise<never>(() => {});
+          }
+          return payload;
+        },
+      });
+
+      const resultPromise = withReplyDispatcher({
+        dispatcher,
+        run: () =>
+          dispatchReplyFromConfig({
+            ctx: createHookCtx(),
+            cfg: emptyConfig,
+            dispatcher,
+            replyResolver: async () => [{ text: "first" }, { text: "durable reply" }],
+          }),
+      });
+      await hookStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+      await resultPromise;
+
+      expect(deliver).toHaveBeenCalledOnce();
+      expect(deliver).toHaveBeenCalledWith(
+        expect.objectContaining({ text: "durable reply" }),
+        expect.objectContaining({ kind: "final" }),
+      );
+      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
+      expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears pending final delivery after transport delivery has started", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "possibly visible reply",
+      pendingFinalDeliveryCreatedAt: 1,
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => {
+        throw new Error("transport failed after send started");
+      },
+    });
+
+    await withReplyDispatcher({
+      dispatcher,
+      run: () =>
+        dispatchReplyFromConfig({
+          ctx: createHookCtx(),
+          cfg: emptyConfig,
+          dispatcher,
+          replyResolver: async () => ({ text: "possibly visible reply" }),
+        }),
+    });
+
+    expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
+  });
+
+  it("clears pending final delivery after intentional pre-delivery cancellation", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "policy-suppressed reply",
+      pendingFinalDeliveryCreatedAt: 1,
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      beforeDeliver: () => null,
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "policy-suppressed reply" }),
+    });
+    await dispatcher.waitForIdle();
+    await vi.waitFor(() => {
+      expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(deliver).not.toHaveBeenCalled();
+    expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+    expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
   });
 
   it("delivers a generated final reply before queued follow-up admission", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -244,7 +244,6 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       clone: false,
     });
     expect(sessionStoreMocks.loadSessionStore).not.toHaveBeenCalled();
-    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
     expect(deliver).toHaveBeenCalledOnce();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -125,6 +125,22 @@ const sessionStoreMocks = vi.hoisted(() => ({
       return sessionStoreMocks.currentEntry;
     },
   ),
+  updateSessionEntry: vi.fn(
+    async (
+      _scope: unknown,
+      update: (entry: Record<string, unknown>) => Promise<Record<string, unknown> | null>,
+    ) => {
+      if (!sessionStoreMocks.currentEntry) {
+        return null;
+      }
+      const patch = await update(sessionStoreMocks.currentEntry);
+      if (!patch) {
+        return sessionStoreMocks.currentEntry;
+      }
+      sessionStoreMocks.currentEntry = { ...sessionStoreMocks.currentEntry, ...patch };
+      return sessionStoreMocks.currentEntry;
+    },
+  ),
 }));
 const acpManagerRuntimeMocks = vi.hoisted(() => ({
   getAcpSessionManager: vi.fn(),
@@ -241,6 +257,11 @@ vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => {
   return {
     ...actual,
     loadSessionEntry: (...args: unknown[]) => sessionStoreMocks.loadSessionEntry(...args),
+    updateSessionEntry: (scope: unknown, update: unknown) =>
+      sessionStoreMocks.updateSessionEntry(
+        scope,
+        update as Parameters<typeof sessionStoreMocks.updateSessionEntry>[1],
+      ),
   };
 });
 vi.mock("./dispatch-from-config.runtime.js", () => ({

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1089,6 +1089,53 @@ type SettledFinalDelivery = {
   payload: ReplyPayload;
 };
 
+type PendingFinalDeliveryIdentity = {
+  createdAt?: number;
+  intentId?: string;
+  present: boolean;
+  text?: string;
+};
+
+function capturePendingFinalDeliveryIdentity(params: {
+  storePath?: string;
+  sessionKey?: string;
+}): PendingFinalDeliveryIdentity | undefined {
+  if (!params.storePath || !params.sessionKey) {
+    return undefined;
+  }
+  try {
+    const entry = readSessionEntry(params.storePath, params.sessionKey);
+    return {
+      present: Boolean(entry?.pendingFinalDelivery || entry?.pendingFinalDeliveryText),
+      intentId: normalizeOptionalString(entry?.pendingFinalDeliveryIntentId),
+      createdAt:
+        typeof entry?.pendingFinalDeliveryCreatedAt === "number"
+          ? entry.pendingFinalDeliveryCreatedAt
+          : undefined,
+      text: normalizeOptionalString(entry?.pendingFinalDeliveryText),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function matchesPendingFinalDeliveryIdentity(
+  entry: SessionEntry,
+  expected: PendingFinalDeliveryIdentity,
+): boolean {
+  const currentPresent = Boolean(entry.pendingFinalDelivery || entry.pendingFinalDeliveryText);
+  if (currentPresent !== expected.present) {
+    return false;
+  }
+  if (expected.intentId) {
+    return normalizeOptionalString(entry.pendingFinalDeliveryIntentId) === expected.intentId;
+  }
+  return (
+    entry.pendingFinalDeliveryCreatedAt === expected.createdAt &&
+    normalizeOptionalString(entry.pendingFinalDeliveryText) === expected.text
+  );
+}
+
 function resolvePendingFinalDeliveryPayloads(params: {
   pendingText: string;
   replies: ReplyPayload[];
@@ -1107,11 +1154,12 @@ function resolvePendingFinalDeliveryPayloads(params: {
 
 async function reconcilePendingFinalDeliveryAfterSettlement(params: {
   deliveries: SettledFinalDelivery[];
+  identity?: PendingFinalDeliveryIdentity;
   replies: ReplyPayload[];
   storePath?: string;
   sessionKey?: string;
 }): Promise<void> {
-  if (!params.storePath || !params.sessionKey) {
+  if (!params.storePath || !params.sessionKey || !params.identity?.present) {
     return;
   }
   await updateSessionStoreEntry({
@@ -1120,6 +1168,9 @@ async function reconcilePendingFinalDeliveryAfterSettlement(params: {
     skipMaintenance: true,
     takeCacheOwnership: true,
     update: async (entry) => {
+      if (!matchesPendingFinalDeliveryIdentity(entry, params.identity)) {
+        return null;
+      }
       const pendingText = normalizeOptionalString(entry.pendingFinalDeliveryText);
       if (!entry.pendingFinalDelivery && !pendingText) {
         return null;
@@ -4321,6 +4372,8 @@ async function dispatchReplyFromConfigInner(
         storePath: sessionStoreEntry.storePath,
         sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
       };
+      const pendingFinalDeliveryIdentity =
+        capturePendingFinalDeliveryIdentity(pendingFinalDelivery);
       if (queuedFinal && allQueuedFinalsObserved) {
         // Delivery observers run from the queue itself, so direct low-level callers
         // reconcile too; the settle task only makes lifecycle owners await it.
@@ -4334,6 +4387,7 @@ async function dispatchReplyFromConfigInner(
             await reconcilePendingFinalDeliveryAfterSettlement({
               ...pendingFinalDelivery,
               deliveries,
+              identity: pendingFinalDeliveryIdentity,
               replies,
             });
           })

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -57,6 +57,7 @@ import { shouldSuppressLocalExecApprovalPrompt } from "../../channels/plugins/ex
 import { applyMergePatch } from "../../config/merge-patch.js";
 import { normalizeExplicitSessionKey } from "../../config/sessions/explicit-session-key-normalization.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
+import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { isRecoverableTerminalSessionStatus } from "../../config/sessions/terminal-status.js";
 import {
   appendAssistantMessageToSessionTranscript,
@@ -144,7 +145,6 @@ import {
   loadSessionStoreEntry,
   resolveStorePath,
   triggerInternalHook,
-  updateSessionStoreEntry,
 } from "./dispatch-from-config.runtime.js";
 import type {
   DispatchFromConfigParams,
@@ -1065,12 +1065,9 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
   if (!params.storePath || !params.sessionKey || !identity?.present) {
     return;
   }
-  await updateSessionStoreEntry({
-    storePath: params.storePath,
-    sessionKey: params.sessionKey,
-    skipMaintenance: true,
-    takeCacheOwnership: true,
-    update: async (entry) => {
+  await updateSessionEntry(
+    { storePath: params.storePath, sessionKey: params.sessionKey },
+    async (entry) => {
       if (!matchesPendingFinalDeliveryIdentity(entry, identity)) {
         return null;
       }
@@ -1089,7 +1086,8 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
         updatedAt: Date.now(),
       };
     },
-  });
+    { skipMaintenance: true, takeCacheOwnership: true },
+  );
 }
 
 type SettledFinalDelivery = {
@@ -1113,7 +1111,12 @@ function capturePendingFinalDeliveryIdentity(params: {
     return undefined;
   }
   try {
-    const entry = readSessionEntry(params.storePath, params.sessionKey);
+    const entry = loadSessionEntry({
+      storePath: params.storePath,
+      sessionKey: params.sessionKey,
+      hydrateSkillPromptRefs: false,
+      readConsistency: "latest",
+    });
     if (
       params.intentId &&
       normalizeOptionalString(entry?.pendingFinalDeliveryIntentId) !== params.intentId
@@ -1211,12 +1214,9 @@ async function reconcilePendingFinalDeliveryAfterSettlement(params: {
   if (!params.storePath || !params.sessionKey || !identity?.present) {
     return;
   }
-  await updateSessionStoreEntry({
-    storePath: params.storePath,
-    sessionKey: params.sessionKey,
-    skipMaintenance: true,
-    takeCacheOwnership: true,
-    update: async (entry) => {
+  await updateSessionEntry(
+    { storePath: params.storePath, sessionKey: params.sessionKey },
+    async (entry) => {
       if (!matchesPendingFinalDeliveryIdentity(entry, identity)) {
         return null;
       }
@@ -1271,7 +1271,8 @@ async function reconcilePendingFinalDeliveryAfterSettlement(params: {
         updatedAt: Date.now(),
       };
     },
-  });
+    { skipMaintenance: true, takeCacheOwnership: true },
+  );
 }
 
 async function mirrorDeliveredReplyToTranscript(params: {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -156,6 +156,7 @@ import type { ReplySessionBinding } from "./get-reply.types.js";
 import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
 import { hasInboundAudio } from "./inbound-media.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
+import { buildPendingFinalDeliveryText } from "./pending-final-delivery.js";
 import {
   appendReplyDispatcherBeforeDeliverCancelled,
   captureReplyDispatchDeliveryOutcome,
@@ -1067,6 +1068,92 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
     update: async (entry) => {
       if (!entry.pendingFinalDelivery && !entry.pendingFinalDeliveryText) {
         return null;
+      }
+      return {
+        pendingFinalDelivery: undefined,
+        pendingFinalDeliveryText: undefined,
+        pendingFinalDeliveryCreatedAt: undefined,
+        pendingFinalDeliveryLastAttemptAt: undefined,
+        pendingFinalDeliveryAttemptCount: undefined,
+        pendingFinalDeliveryLastError: undefined,
+        pendingFinalDeliveryContext: undefined,
+        pendingFinalDeliveryIntentId: undefined,
+        updatedAt: Date.now(),
+      };
+    },
+  });
+}
+
+type SettledFinalDelivery = {
+  outcome: ReplyDispatchDeliveryOutcome;
+  payload: ReplyPayload;
+};
+
+function resolvePendingFinalDeliveryPayloads(params: {
+  pendingText: string;
+  replies: ReplyPayload[];
+}): ReplyPayload[] | undefined {
+  const contributingReplies = params.replies.filter(
+    (reply) => buildPendingFinalDeliveryText([reply]) !== "",
+  );
+  if (buildPendingFinalDeliveryText(contributingReplies) === params.pendingText) {
+    return contributingReplies;
+  }
+  const exactMatches = contributingReplies.filter(
+    (reply) => buildPendingFinalDeliveryText([reply]) === params.pendingText,
+  );
+  return exactMatches.length === 1 ? exactMatches : undefined;
+}
+
+async function reconcilePendingFinalDeliveryAfterSettlement(params: {
+  deliveries: SettledFinalDelivery[];
+  replies: ReplyPayload[];
+  storePath?: string;
+  sessionKey?: string;
+}): Promise<void> {
+  if (!params.storePath || !params.sessionKey) {
+    return;
+  }
+  await updateSessionStoreEntry({
+    storePath: params.storePath,
+    sessionKey: params.sessionKey,
+    skipMaintenance: true,
+    takeCacheOwnership: true,
+    update: async (entry) => {
+      const pendingText = normalizeOptionalString(entry.pendingFinalDeliveryText);
+      if (!entry.pendingFinalDelivery && !pendingText) {
+        return null;
+      }
+      const pendingPayloads = pendingText
+        ? resolvePendingFinalDeliveryPayloads({ pendingText, replies: params.replies })
+        : undefined;
+      const pendingPayloadSet = pendingPayloads ? new Set(pendingPayloads) : undefined;
+      const relevantDeliveries = pendingPayloadSet
+        ? params.deliveries.filter((delivery) => pendingPayloadSet.has(delivery.payload))
+        : params.deliveries;
+      const ownsEveryPendingPayload =
+        !pendingPayloadSet || relevantDeliveries.length === pendingPayloadSet.size;
+      const failedBeforeDeliver = relevantDeliveries.filter(
+        (delivery) => delivery.outcome === "failed-before-deliver",
+      );
+
+      if (
+        relevantDeliveries.length > 0 &&
+        failedBeforeDeliver.length === relevantDeliveries.length
+      ) {
+        return null;
+      }
+      if (pendingPayloadSet && ownsEveryPendingPayload && failedBeforeDeliver.length > 0) {
+        const retryText = buildPendingFinalDeliveryText(
+          failedBeforeDeliver.map((delivery) => delivery.payload),
+        );
+        if (retryText) {
+          return {
+            pendingFinalDelivery: true,
+            pendingFinalDeliveryText: retryText,
+            updatedAt: Date.now(),
+          };
+        }
       }
       return {
         pendingFinalDelivery: undefined,
@@ -4164,7 +4251,10 @@ async function dispatchReplyFromConfigInner(
     let routedFinalCount = 0;
     let attemptedFinalDelivery = false;
     let finalDeliveryFailed = false;
-    const finalDeliveryOutcomes: Array<Promise<ReplyDispatchDeliveryOutcome>> = [];
+    const finalDeliveries: Array<{
+      outcome: Promise<ReplyDispatchDeliveryOutcome>;
+      payload: ReplyPayload;
+    }> = [];
     let allQueuedFinalsObserved = true;
     // Explicit command turns (native or authorized text-slash like /compact) are
     // user-initiated, so a marked terminal reply for the command bypasses
@@ -4216,7 +4306,7 @@ async function dispatchReplyFromConfigInner(
       routedFinalCount += finalReply.routedFinalCount;
       if (finalReply.queuedFinal) {
         if (finalReply.dispatcherOutcome) {
-          finalDeliveryOutcomes.push(finalReply.dispatcherOutcome);
+          finalDeliveries.push({ outcome: finalReply.dispatcherOutcome, payload: reply });
         } else {
           allQueuedFinalsObserved = false;
         }
@@ -4234,12 +4324,18 @@ async function dispatchReplyFromConfigInner(
       if (queuedFinal && allQueuedFinalsObserved) {
         // Delivery observers run from the queue itself, so direct low-level callers
         // reconcile too; the settle task only makes lifecycle owners await it.
-        const reconcilePendingFinal = Promise.all(finalDeliveryOutcomes)
-          .then(async (outcomes) => {
-            if (outcomes.every((outcome) => outcome === "failed-before-deliver")) {
-              return;
-            }
-            await clearPendingFinalDeliveryAfterSuccess(pendingFinalDelivery);
+        const reconcilePendingFinal = Promise.all(
+          finalDeliveries.map(async (delivery) => ({
+            outcome: await delivery.outcome,
+            payload: delivery.payload,
+          })),
+        )
+          .then(async (deliveries) => {
+            await reconcilePendingFinalDeliveryAfterSettlement({
+              ...pendingFinalDelivery,
+              deliveries,
+              replies,
+            });
           })
           .catch((error: unknown) => {
             logVerbose(

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -156,7 +156,10 @@ import type { ReplySessionBinding } from "./get-reply.types.js";
 import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
 import { hasInboundAudio } from "./inbound-media.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
-import { buildPendingFinalDeliveryText } from "./pending-final-delivery.js";
+import {
+  buildPendingFinalDeliveryText,
+  sanitizePendingFinalDeliveryText,
+} from "./pending-final-delivery.js";
 import {
   appendReplyDispatcherBeforeDeliverCancelled,
   captureReplyDispatchDeliveryOutcome,
@@ -1149,9 +1152,29 @@ function matchesPendingFinalDeliveryIdentity(
 }
 
 function resolvePendingFinalDeliveryPayloads(params: {
+  intentId?: string;
   pendingText: string;
   replies: ReplyPayload[];
 }): ReplyPayload[] | undefined {
+  const intentReplies = params.intentId
+    ? params.replies.filter((reply) => {
+        const metadata = getReplyPayloadMetadata(reply);
+        return (
+          metadata?.pendingFinalDeliveryIntentId === params.intentId &&
+          metadata.pendingFinalDeliveryRetryText !== undefined
+        );
+      })
+    : [];
+  const intentContributors = intentReplies.filter(
+    (reply) => getReplyPayloadMetadata(reply)?.pendingFinalDeliveryRetryText,
+  );
+  const intentText = buildPendingFinalDeliveryRetryText(intentContributors);
+  if (
+    intentReplies.length > 0 &&
+    intentText.replace(/\s+/g, " ").trim() === params.pendingText.replace(/\s+/g, " ").trim()
+  ) {
+    return intentContributors;
+  }
   const contributingReplies = params.replies.filter(
     (reply) => buildPendingFinalDeliveryText([reply]) !== "",
   );
@@ -1162,6 +1185,19 @@ function resolvePendingFinalDeliveryPayloads(params: {
     (reply) => buildPendingFinalDeliveryText([reply]) === params.pendingText,
   );
   return exactMatches.length === 1 ? exactMatches : undefined;
+}
+
+function buildPendingFinalDeliveryRetryText(payloads: ReplyPayload[]): string {
+  return sanitizePendingFinalDeliveryText(
+    payloads
+      .map(
+        (payload) =>
+          getReplyPayloadMetadata(payload)?.pendingFinalDeliveryRetryText ??
+          buildPendingFinalDeliveryText([payload]),
+      )
+      .filter(Boolean)
+      .join("\n\n"),
+  );
 }
 
 async function reconcilePendingFinalDeliveryAfterSettlement(params: {
@@ -1189,7 +1225,11 @@ async function reconcilePendingFinalDeliveryAfterSettlement(params: {
         return null;
       }
       const pendingPayloads = pendingText
-        ? resolvePendingFinalDeliveryPayloads({ pendingText, replies: params.replies })
+        ? resolvePendingFinalDeliveryPayloads({
+            intentId: identity.intentId,
+            pendingText,
+            replies: params.replies,
+          })
         : undefined;
       const pendingPayloadSet = pendingPayloads ? new Set(pendingPayloads) : undefined;
       const relevantDeliveries = pendingPayloadSet
@@ -1208,7 +1248,7 @@ async function reconcilePendingFinalDeliveryAfterSettlement(params: {
         return null;
       }
       if (pendingPayloadSet && ownsEveryPendingPayload && failedBeforeDeliver.length > 0) {
-        const retryText = buildPendingFinalDeliveryText(
+        const retryText = buildPendingFinalDeliveryRetryText(
           failedBeforeDeliver.map((delivery) => delivery.payload),
         );
         if (retryText) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1054,10 +1054,12 @@ function shouldBypassPluginOwnedBindingForCommand(
 }
 
 async function clearPendingFinalDeliveryAfterSuccess(params: {
+  identity?: PendingFinalDeliveryIdentity;
   storePath?: string;
   sessionKey?: string;
 }): Promise<void> {
-  if (!params.storePath || !params.sessionKey) {
+  const identity = params.identity;
+  if (!params.storePath || !params.sessionKey || !identity?.present) {
     return;
   }
   await updateSessionStoreEntry({
@@ -1066,6 +1068,9 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
     skipMaintenance: true,
     takeCacheOwnership: true,
     update: async (entry) => {
+      if (!matchesPendingFinalDeliveryIdentity(entry, identity)) {
+        return null;
+      }
       if (!entry.pendingFinalDelivery && !entry.pendingFinalDeliveryText) {
         return null;
       }
@@ -1097,6 +1102,7 @@ type PendingFinalDeliveryIdentity = {
 };
 
 function capturePendingFinalDeliveryIdentity(params: {
+  intentId?: string;
   storePath?: string;
   sessionKey?: string;
 }): PendingFinalDeliveryIdentity | undefined {
@@ -1105,9 +1111,15 @@ function capturePendingFinalDeliveryIdentity(params: {
   }
   try {
     const entry = readSessionEntry(params.storePath, params.sessionKey);
+    if (
+      params.intentId &&
+      normalizeOptionalString(entry?.pendingFinalDeliveryIntentId) !== params.intentId
+    ) {
+      return { present: false };
+    }
     return {
       present: Boolean(entry?.pendingFinalDelivery || entry?.pendingFinalDeliveryText),
-      intentId: normalizeOptionalString(entry?.pendingFinalDeliveryIntentId),
+      intentId: params.intentId ?? normalizeOptionalString(entry?.pendingFinalDeliveryIntentId),
       createdAt:
         typeof entry?.pendingFinalDeliveryCreatedAt === "number"
           ? entry.pendingFinalDeliveryCreatedAt
@@ -1115,7 +1127,7 @@ function capturePendingFinalDeliveryIdentity(params: {
       text: normalizeOptionalString(entry?.pendingFinalDeliveryText),
     };
   } catch {
-    return undefined;
+    return params.intentId ? { present: true, intentId: params.intentId } : undefined;
   }
 }
 
@@ -1159,7 +1171,8 @@ async function reconcilePendingFinalDeliveryAfterSettlement(params: {
   storePath?: string;
   sessionKey?: string;
 }): Promise<void> {
-  if (!params.storePath || !params.sessionKey || !params.identity?.present) {
+  const identity = params.identity;
+  if (!params.storePath || !params.sessionKey || !identity?.present) {
     return;
   }
   await updateSessionStoreEntry({
@@ -1168,7 +1181,7 @@ async function reconcilePendingFinalDeliveryAfterSettlement(params: {
     skipMaintenance: true,
     takeCacheOwnership: true,
     update: async (entry) => {
-      if (!matchesPendingFinalDeliveryIdentity(entry, params.identity)) {
+      if (!matchesPendingFinalDeliveryIdentity(entry, identity)) {
         return null;
       }
       const pendingText = normalizeOptionalString(entry.pendingFinalDeliveryText);
@@ -4286,6 +4299,19 @@ async function dispatchReplyFromConfigInner(
     }
 
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
+    const pendingFinalDelivery = {
+      storePath: sessionStoreEntry.storePath,
+      sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+    };
+    const replyPendingIntentIds = new Set(
+      replies
+        .map((reply) => getReplyPayloadMetadata(reply)?.pendingFinalDeliveryIntentId)
+        .filter((intentId): intentId is string => Boolean(intentId)),
+    );
+    const pendingFinalDeliveryIdentity = capturePendingFinalDeliveryIdentity({
+      ...pendingFinalDelivery,
+      intentId: replyPendingIntentIds.size === 1 ? [...replyPendingIntentIds][0] : undefined,
+    });
     // Final delivery is outside the progress wrappers. Wait until every source-ordered callback
     // has at least started so a delayed tool/reasoning transition cannot appear after the final.
     if (preserveProgressCallbackStartOrder) {
@@ -4368,12 +4394,6 @@ async function dispatchReplyFromConfigInner(
     }
 
     if (attemptedFinalDelivery && !finalDeliveryFailed) {
-      const pendingFinalDelivery = {
-        storePath: sessionStoreEntry.storePath,
-        sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
-      };
-      const pendingFinalDeliveryIdentity =
-        capturePendingFinalDeliveryIdentity(pendingFinalDelivery);
       if (queuedFinal && allQueuedFinalsObserved) {
         // Delivery observers run from the queue itself, so direct low-level callers
         // reconcile too; the settle task only makes lifecycle owners await it.
@@ -4400,7 +4420,10 @@ async function dispatchReplyFromConfigInner(
       } else {
         // Routed delivery has a transport result already. Custom dispatchers that
         // do not expose the core observer retain the legacy queue-admission behavior.
-        await clearPendingFinalDeliveryAfterSuccess(pendingFinalDelivery);
+        await clearPendingFinalDeliveryAfterSuccess({
+          ...pendingFinalDelivery,
+          identity: pendingFinalDeliveryIdentity,
+        });
       }
       // Register successful queued cleanup before honoring a late abort. The
       // outer settle owner still runs it from finally (#89115).

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -158,6 +158,8 @@ import { hasInboundAudio } from "./inbound-media.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import {
   appendReplyDispatcherBeforeDeliverCancelled,
+  captureReplyDispatchDeliveryOutcome,
+  type ReplyDispatchDeliveryOutcome,
   waitForReplyDispatcherIdle,
 } from "./reply-dispatcher.js";
 import type {
@@ -2958,7 +2960,11 @@ async function dispatchReplyFromConfigInner(
     const sendFinalPayload = async (
       payload: ReplyPayload,
       options: { abortSignal?: AbortSignal; deliveryId?: string } = {},
-    ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
+    ): Promise<{
+      queuedFinal: boolean;
+      routedFinalCount: number;
+      dispatcherOutcome?: Promise<ReplyDispatchDeliveryOutcome>;
+    }> => {
       const abortSignal = options.abortSignal ?? getDispatchAbortSignal();
       const throwIfFinalDeliveryAborted = () => {
         if (abortSignal?.aborted) {
@@ -3081,7 +3087,10 @@ async function dispatchReplyFromConfigInner(
       if (finalDeliveryCapture) {
         setReplyPayloadMetadata(normalizedPayload, { finalDeliveryCapture });
       }
+      const deliveryOutcome = captureReplyDispatchDeliveryOutcome(normalizedPayload);
       const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
+      const dispatcherOutcome =
+        queuedFinal && deliveryOutcome.isTracked() ? deliveryOutcome.promise : undefined;
       if (queuedFinal && deliveredTranscriptMirror && finalOutcomeBefore) {
         // The common settle owner runs this after successful delivery or
         // cancellation. Keeping reconciliation out of the reply operation lets a
@@ -3098,6 +3107,7 @@ async function dispatchReplyFromConfigInner(
       return {
         queuedFinal,
         routedFinalCount: 0,
+        ...(queuedFinal && dispatcherOutcome ? { dispatcherOutcome } : {}),
       };
     };
 
@@ -4154,6 +4164,8 @@ async function dispatchReplyFromConfigInner(
     let routedFinalCount = 0;
     let attemptedFinalDelivery = false;
     let finalDeliveryFailed = false;
+    const finalDeliveryOutcomes: Array<Promise<ReplyDispatchDeliveryOutcome>> = [];
+    let allQueuedFinalsObserved = true;
     // Explicit command turns (native or authorized text-slash like /compact) are
     // user-initiated, so a marked terminal reply for the command bypasses
     // room_event suppression. Ambient marked notices (no CommandTurn) stay
@@ -4202,20 +4214,46 @@ async function dispatchReplyFromConfigInner(
       const finalReply = await sendFinalPayload(reply, { deliveryId: String(replyIndex) });
       queuedFinal = finalReply.queuedFinal || queuedFinal;
       routedFinalCount += finalReply.routedFinalCount;
+      if (finalReply.queuedFinal) {
+        if (finalReply.dispatcherOutcome) {
+          finalDeliveryOutcomes.push(finalReply.dispatcherOutcome);
+        } else {
+          allQueuedFinalsObserved = false;
+        }
+      }
       if (!finalReply.queuedFinal && finalReply.routedFinalCount === 0) {
         finalDeliveryFailed = true;
       }
     }
 
     if (attemptedFinalDelivery && !finalDeliveryFailed) {
-      // The final reply already shipped, so clear the durable pending-final
-      // bookkeeping before honoring a late abort. A stuck-session recovery abort
-      // racing this window (#89115) otherwise strands pendingFinalDelivery=true,
-      // and the get-reply redelivery short-circuit then silently blocks all inbound.
-      await clearPendingFinalDeliveryAfterSuccess({
+      const pendingFinalDelivery = {
         storePath: sessionStoreEntry.storePath,
         sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
-      });
+      };
+      if (queuedFinal && allQueuedFinalsObserved) {
+        // Delivery observers run from the queue itself, so direct low-level callers
+        // reconcile too; the settle task only makes lifecycle owners await it.
+        const reconcilePendingFinal = Promise.all(finalDeliveryOutcomes)
+          .then(async (outcomes) => {
+            if (outcomes.every((outcome) => outcome === "failed-before-deliver")) {
+              return;
+            }
+            await clearPendingFinalDeliveryAfterSuccess(pendingFinalDelivery);
+          })
+          .catch((error: unknown) => {
+            logVerbose(
+              `dispatch-from-config: pending final reconciliation failed: ${formatErrorMessage(error)}`,
+            );
+          });
+        registerReplyDispatcherSettledTask(dispatcher, () => reconcilePendingFinal);
+      } else {
+        // Routed delivery has a transport result already. Custom dispatchers that
+        // do not expose the core observer retain the legacy queue-admission behavior.
+        await clearPendingFinalDeliveryAfterSuccess(pendingFinalDelivery);
+      }
+      // Register successful queued cleanup before honoring a late abort. The
+      // outer settle owner still runs it from finally (#89115).
       throwIfDispatchOperationAborted();
     }
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1161,7 +1161,7 @@ function resolvePendingFinalDeliveryPayloads(params: {
         const metadata = getReplyPayloadMetadata(reply);
         return (
           metadata?.pendingFinalDeliveryIntentId === params.intentId &&
-          metadata.pendingFinalDeliveryRetryText !== undefined
+          metadata?.pendingFinalDeliveryRetryText !== undefined
         );
       })
     : [];

--- a/src/auto-reply/reply/pending-final-delivery.ts
+++ b/src/auto-reply/reply/pending-final-delivery.ts
@@ -1,4 +1,5 @@
 /** Sanitizes pending final delivery text before channel-visible output. */
+import type { ReplyPayload } from "../types.js";
 import {
   isSilentReplyPayloadText,
   isSilentReplyText,
@@ -8,6 +9,16 @@ import {
   stripSilentToken,
 } from "../tokens.js";
 import { stripInternalMetadataForDisplay } from "./display-text-sanitize.js";
+
+/** Build the restart-recovery text represented by one or more final payloads. */
+export function buildPendingFinalDeliveryText(payloads: ReplyPayload[]): string {
+  const text = payloads
+    .filter((payload) => payload.isReasoning !== true)
+    .map((payload) => payload.text)
+    .filter((textLocal): textLocal is string => Boolean(textLocal))
+    .join("\n\n");
+  return sanitizePendingFinalDeliveryText(text);
+}
 
 /** Sanitizes final pending-delivery text and removes silent control tokens. */
 export function sanitizePendingFinalDeliveryText(text: string): string {

--- a/src/auto-reply/reply/pending-final-delivery.ts
+++ b/src/auto-reply/reply/pending-final-delivery.ts
@@ -1,5 +1,3 @@
-/** Sanitizes pending final delivery text before channel-visible output. */
-import type { ReplyPayload } from "../types.js";
 import {
   isSilentReplyPayloadText,
   isSilentReplyText,
@@ -8,6 +6,8 @@ import {
   stripLeadingSilentToken,
   stripSilentToken,
 } from "../tokens.js";
+/** Sanitizes pending final delivery text before channel-visible output. */
+import type { ReplyPayload } from "../types.js";
 import { stripInternalMetadataForDisplay } from "./display-text-sanitize.js";
 
 /** Build the restart-recovery text represented by one or more final payloads. */

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -142,7 +142,9 @@ function resolveReplyDispatchBeforeDeliverStages(
     );
   }
   const existingStages = beforeDeliverStagesByHook.get(input.hook);
-  if (input.options === undefined && existingStages) {
+  // Internal composition already assigned each real stage its owner budget.
+  // Wrapping that chain again would turn one stage budget into an aggregate deadline.
+  if (existingStages) {
     return existingStages;
   }
   return [

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -13,6 +13,7 @@ import { registerDispatcher } from "./dispatcher-registry.js";
 import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
 import type {
   ReplyDispatchBeforeDeliver,
+  ReplyDispatchBeforeDeliverOptions,
   ReplyDispatchKind,
   ReplyDispatchRuntimeInfo,
   ReplyDispatcher,
@@ -69,6 +70,14 @@ type ReplyDispatchBeforeDeliverStage = {
   timeoutMs?: number;
 };
 
+type ReplyDispatchBeforeDeliverStageInput =
+  | ReplyDispatchBeforeDeliver
+  | {
+      hook: ReplyDispatchBeforeDeliver;
+      options?: ReplyDispatchBeforeDeliverOptions;
+    }
+  | undefined;
+
 const beforeDeliverStagesByHook = new WeakMap<
   ReplyDispatchBeforeDeliver,
   readonly ReplyDispatchBeforeDeliverStage[]
@@ -79,6 +88,16 @@ class ReplyDispatchBeforeDeliverTimeoutError extends Error {
     super(`beforeDeliver timed out after ${timeoutMs}ms`);
     this.name = "ReplyDispatchBeforeDeliverTimeoutError";
   }
+}
+
+function resolveReplyDispatchBeforeDeliverTimeoutMs(
+  options: ReplyDispatchBeforeDeliverOptions | undefined,
+): number {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_BEFORE_DELIVER_TIMEOUT_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError("beforeDeliver timeoutMs must be a positive finite number");
+  }
+  return timeoutMs;
 }
 
 async function runReplyDispatchBeforeDeliverStage(
@@ -110,16 +129,33 @@ async function runReplyDispatchBeforeDeliverStage(
 }
 
 function resolveReplyDispatchBeforeDeliverStages(
-  hook: ReplyDispatchBeforeDeliver,
+  input: ReplyDispatchBeforeDeliverStageInput,
 ): readonly ReplyDispatchBeforeDeliverStage[] {
-  return (
-    beforeDeliverStagesByHook.get(hook) ?? [{ hook, timeoutMs: DEFAULT_BEFORE_DELIVER_TIMEOUT_MS }]
-  );
+  if (!input) {
+    return [];
+  }
+  if (typeof input === "function") {
+    return (
+      beforeDeliverStagesByHook.get(input) ?? [
+        { hook: input, timeoutMs: DEFAULT_BEFORE_DELIVER_TIMEOUT_MS },
+      ]
+    );
+  }
+  const existingStages = beforeDeliverStagesByHook.get(input.hook);
+  if (input.options === undefined && existingStages) {
+    return existingStages;
+  }
+  return [
+    {
+      hook: input.hook,
+      timeoutMs: resolveReplyDispatchBeforeDeliverTimeoutMs(input.options),
+    },
+  ];
 }
 
 /** Compose core delivery stages while retaining a separate deadline for each actual hook. */
 export function composeReplyDispatchBeforeDeliver(
-  ...hooks: Array<ReplyDispatchBeforeDeliver | undefined>
+  ...hooks: ReplyDispatchBeforeDeliverStageInput[]
 ): ReplyDispatchBeforeDeliver | undefined {
   const stages: ReplyDispatchBeforeDeliverStage[] = [];
   for (const hook of hooks) {
@@ -245,6 +281,8 @@ export type ReplyDispatcherOptions = {
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
   beforeDeliver?: ReplyDispatchBeforeDeliver;
+  /** Owner-declared deadline for the constructor before-delivery callback. */
+  beforeDeliverOptions?: ReplyDispatchBeforeDeliverOptions;
   onBeforeDeliverCancelled?: ReplyDispatchCancelHandler;
   /** Observe each queued payload settling, including cancellation and delivery failure. */
   onDeliverySettled?: (info: ReplyDispatchRuntimeInfo) => void;
@@ -301,7 +339,11 @@ function normalizeReplyPayloadInternal(
 }
 
 export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDispatcher {
-  let beforeDeliver = composeReplyDispatchBeforeDeliver(options.beforeDeliver);
+  let beforeDeliver = composeReplyDispatchBeforeDeliver(
+    options.beforeDeliver
+      ? { hook: options.beforeDeliver, options: options.beforeDeliverOptions }
+      : undefined,
+  );
   const appendedBeforeDeliverCancelledHooks: ReplyDispatchCancelHandler[] = [];
   let sendChain: Promise<void> = Promise.resolve();
   // Track in-flight deliveries so we can emit a reliable "idle" signal.
@@ -489,8 +531,11 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     sendToolResult: (payload) => enqueue("tool", payload),
     sendBlockReply: (payload) => enqueue("block", payload),
     sendFinalReply: (payload) => enqueue("final", payload),
-    appendBeforeDeliver: (hook) => {
-      beforeDeliver = composeReplyDispatchBeforeDeliver(beforeDeliver, hook);
+    appendBeforeDeliver: (hook, stageOptions) => {
+      beforeDeliver = composeReplyDispatchBeforeDeliver(beforeDeliver, {
+        hook,
+        options: stageOptions,
+      });
     },
     waitForIdle: () => sendChain,
     getQueuedCounts: () => ({ ...queuedCounts }),

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -38,6 +38,18 @@ type ReplyDispatchCancelHandler = (
   info: ReplyDispatchRuntimeInfo,
 ) => Promise<void> | void;
 
+export type ReplyDispatchDeliveryOutcome =
+  | "delivered"
+  | "cancelled"
+  | "failed-before-deliver"
+  | "failed-deliver";
+
+type ReplyDispatchDeliveryOutcomeTracker = {
+  promise: Promise<ReplyDispatchDeliveryOutcome>;
+  resolve: (outcome: ReplyDispatchDeliveryOutcome) => void;
+  tracked: boolean;
+};
+
 type ReplyDispatchDeliverer = (
   payload: ReplyPayload,
   info: ReplyDispatchRuntimeInfo,
@@ -47,8 +59,99 @@ export type { ReplyDispatchBeforeDeliver };
 
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
+const DEFAULT_BEFORE_DELIVER_TIMEOUT_MS = 15_000;
 const silentReplyLogger = createSubsystemLogger("silent-reply/dispatcher");
 const beforeDeliverCancelledHooks = new WeakMap<ReplyDispatcher, ReplyDispatchCancelHandler[]>();
+const deliveryOutcomeTrackers = new WeakMap<ReplyPayload, ReplyDispatchDeliveryOutcomeTracker>();
+
+type ReplyDispatchBeforeDeliverStage = {
+  hook: ReplyDispatchBeforeDeliver;
+  timeoutMs?: number;
+};
+
+const beforeDeliverStagesByHook = new WeakMap<
+  ReplyDispatchBeforeDeliver,
+  readonly ReplyDispatchBeforeDeliverStage[]
+>();
+
+class ReplyDispatchBeforeDeliverTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`beforeDeliver timed out after ${timeoutMs}ms`);
+    this.name = "ReplyDispatchBeforeDeliverTimeoutError";
+  }
+}
+
+async function runReplyDispatchBeforeDeliverStage(
+  stage: ReplyDispatchBeforeDeliverStage,
+  payload: ReplyPayload,
+  info: ReplyDispatchRuntimeInfo,
+): Promise<ReplyPayload | null> {
+  const timeoutMs = stage.timeoutMs;
+  if (!timeoutMs) {
+    return await stage.hook(payload, info);
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  // The hook promise cannot be cancelled. The deadline releases the serialized
+  // delivery owner; Promise.race still observes any late rejection.
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new ReplyDispatchBeforeDeliverTimeoutError(timeoutMs)),
+      timeoutMs,
+    );
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([Promise.resolve(stage.hook(payload, info)), timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function resolveReplyDispatchBeforeDeliverStages(
+  hook: ReplyDispatchBeforeDeliver,
+): readonly ReplyDispatchBeforeDeliverStage[] {
+  return (
+    beforeDeliverStagesByHook.get(hook) ?? [{ hook, timeoutMs: DEFAULT_BEFORE_DELIVER_TIMEOUT_MS }]
+  );
+}
+
+/** Compose core delivery stages while retaining a separate deadline for each actual hook. */
+export function composeReplyDispatchBeforeDeliver(
+  ...hooks: Array<ReplyDispatchBeforeDeliver | undefined>
+): ReplyDispatchBeforeDeliver | undefined {
+  const stages: ReplyDispatchBeforeDeliverStage[] = [];
+  for (const hook of hooks) {
+    if (hook) {
+      stages.push(...resolveReplyDispatchBeforeDeliverStages(hook));
+    }
+  }
+  if (stages.length === 0) {
+    return undefined;
+  }
+  const composed: ReplyDispatchBeforeDeliver = async (payload, info) => {
+    let current: ReplyPayload | null = payload;
+    for (const stage of stages) {
+      if (!current) {
+        return null;
+      }
+      const next = await runReplyDispatchBeforeDeliverStage(stage, current, info);
+      current = next ? copyReplyPayloadMetadata(current, next) : null;
+    }
+    return current;
+  };
+  beforeDeliverStagesByHook.set(composed, stages);
+  return composed;
+}
+
+/** Mark a core hook whose lifecycle owner controls settlement and any deadline. */
+export function markReplyDispatchBeforeDeliverDeadlineOwned(
+  hook: ReplyDispatchBeforeDeliver,
+): ReplyDispatchBeforeDeliver {
+  beforeDeliverStagesByHook.set(hook, [{ hook }]);
+  return hook;
+}
 
 /** Adds a core-internal cancellation observer without expanding the plugin-facing dispatcher. */
 export function appendReplyDispatcherBeforeDeliverCancelled(
@@ -61,6 +164,23 @@ export function appendReplyDispatcherBeforeDeliverCancelled(
   }
   hooks.push(hook);
   return true;
+}
+
+/** Capture one core-dispatcher delivery outcome without changing send* return types. */
+export function captureReplyDispatchDeliveryOutcome(payload: ReplyPayload): {
+  promise: Promise<ReplyDispatchDeliveryOutcome>;
+  isTracked: () => boolean;
+} {
+  let resolveOutcome!: (outcome: ReplyDispatchDeliveryOutcome) => void;
+  const tracker: ReplyDispatchDeliveryOutcomeTracker = {
+    promise: new Promise((resolve) => {
+      resolveOutcome = resolve;
+    }),
+    resolve: (outcome) => resolveOutcome(outcome),
+    tracked: false,
+  };
+  deliveryOutcomeTrackers.set(payload, tracker);
+  return { promise: tracker.promise, isTracked: () => tracker.tracked };
 }
 
 function buildReplyDispatchRuntimeInfo(
@@ -181,7 +301,7 @@ function normalizeReplyPayloadInternal(
 }
 
 export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDispatcher {
-  let beforeDeliver = options.beforeDeliver;
+  let beforeDeliver = composeReplyDispatchBeforeDeliver(options.beforeDeliver);
   const appendedBeforeDeliverCancelledHooks: ReplyDispatchCancelHandler[] = [];
   let sendChain: Promise<void> = Promise.resolve();
   // Track in-flight deliveries so we can emit a reliable "idle" signal.
@@ -228,7 +348,17 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     ];
     for (const observer of observers) {
       try {
-        await observer(payload, info);
+        await runReplyDispatchBeforeDeliverStage(
+          {
+            hook: async (current, currentInfo) => {
+              await observer(current, currentInfo);
+              return current;
+            },
+            timeoutMs: DEFAULT_BEFORE_DELIVER_TIMEOUT_MS,
+          },
+          payload,
+          info,
+        );
       } catch (err: unknown) {
         reportObserverError(err, info);
       }
@@ -261,12 +391,18 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     }
     queuedCounts[kind] += 1;
     pending += 1;
+    const deliveryOutcomeTracker = deliveryOutcomeTrackers.get(payload);
+    if (deliveryOutcomeTracker) {
+      deliveryOutcomeTracker.tracked = true;
+    }
 
     // Determine if we should add human-like delay (only for block replies after the first).
     const shouldDelay = kind === "block" && sentFirstBlock;
     if (kind === "block") {
       sentFirstBlock = true;
     }
+    let deliveryStarted = false;
+    let deliveryOutcome: ReplyDispatchDeliveryOutcome = "failed-before-deliver";
 
     sendChain = sendChain
       .then(async () => {
@@ -287,20 +423,26 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             throw err;
           }
           if (!deliverPayload) {
+            deliveryOutcome = "cancelled";
             cancelledCounts[kind] += 1;
             await notifyBeforeDeliverCancelled(normalized, dispatchInfo);
             return;
           }
           deliverPayload = copyReplyPayloadMetadata(normalized, deliverPayload);
         }
+        deliveryStarted = true;
         await options.deliver(deliverPayload, dispatchInfo);
+        deliveryOutcome = "delivered";
       })
       .catch((err: unknown) => {
+        deliveryOutcome = deliveryStarted ? "failed-deliver" : "failed-before-deliver";
         failedCounts[kind] += 1;
         void options.onError?.(err, buildReplyDispatchRuntimeInfo(normalized, kind));
       })
       .finally(() => {
         const dispatchInfo = buildReplyDispatchRuntimeInfo(normalized, kind);
+        deliveryOutcomeTracker?.resolve(deliveryOutcome);
+        deliveryOutcomeTrackers.delete(payload);
         try {
           options.onDeliverySettled?.(dispatchInfo);
         } catch (err: unknown) {
@@ -348,15 +490,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     sendBlockReply: (payload) => enqueue("block", payload),
     sendFinalReply: (payload) => enqueue("final", payload),
     appendBeforeDeliver: (hook) => {
-      const previousBeforeDeliver = beforeDeliver;
-      beforeDeliver = previousBeforeDeliver
-        ? async (payload, info) => {
-            const previousPayload = await previousBeforeDeliver(payload, info);
-            return previousPayload
-              ? hook(copyReplyPayloadMetadata(payload, previousPayload), info)
-              : null;
-          }
-        : hook;
+      beforeDeliver = composeReplyDispatchBeforeDeliver(beforeDeliver, hook);
     },
     waitForIdle: () => sendChain,
     getQueuedCounts: () => ({ ...queuedCounts }),

--- a/src/auto-reply/reply/reply-dispatcher.types.ts
+++ b/src/auto-reply/reply/reply-dispatcher.types.ts
@@ -20,11 +20,20 @@ export type ReplyDispatchBeforeDeliver = (
   info: ReplyDispatchRuntimeInfo,
 ) => Promise<ReplyPayload | null> | ReplyPayload | null;
 
+/** An owner-declared settlement budget for one before-delivery callback. */
+export type ReplyDispatchBeforeDeliverOptions = {
+  /** Positive finite per-callback deadline in milliseconds; omit for the dispatcher default. */
+  timeoutMs?: number;
+};
+
 export type ReplyDispatcher = {
   sendToolResult: (payload: ReplyPayload) => boolean;
   sendBlockReply: (payload: ReplyPayload) => boolean;
   sendFinalReply: (payload: ReplyPayload) => boolean;
-  appendBeforeDeliver?: (hook: ReplyDispatchBeforeDeliver) => void;
+  appendBeforeDeliver?: (
+    hook: ReplyDispatchBeforeDeliver,
+    options?: ReplyDispatchBeforeDeliverOptions,
+  ) => void;
   waitForIdle: () => Promise<void>;
   getQueuedCounts: () => Record<ReplyDispatchKind, number>;
   getCancelledCounts?: () => Record<ReplyDispatchKind, number>;

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -13,6 +13,14 @@ function deliveredText(deliver: DeliverMock, index = 0) {
   return payload?.text;
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe("createReplyDispatcher", () => {
   it("drops empty payloads and exact silent tokens without media", async () => {
     const deliver = vi.fn().mockResolvedValue(undefined);
@@ -152,6 +160,134 @@ describe("createReplyDispatcher", () => {
 
     await dispatcher.waitForIdle();
     expect(delivered).toEqual(["tool", "block", "final"]);
+  });
+
+  it("releases the same dispatcher after a beforeDeliver timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const hookStarted = createDeferred<void>();
+      const delivered: string[] = [];
+      const errors: string[] = [];
+      let hookCalls = 0;
+      const dispatcher = createReplyDispatcher({
+        deliver: async (payload) => {
+          delivered.push(payload.text ?? "");
+        },
+        beforeDeliver: (payload) => {
+          hookCalls += 1;
+          if (hookCalls === 1) {
+            hookStarted.resolve();
+            return new Promise<never>(() => {});
+          }
+          return payload;
+        },
+        onError: (error) => {
+          errors.push(error instanceof Error ? error.message : String(error));
+        },
+      });
+
+      dispatcher.sendFinalReply({ text: "stuck final" });
+      dispatcher.sendFinalReply({ text: "follow-up final" });
+      dispatcher.markComplete();
+      await hookStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+      await dispatcher.waitForIdle();
+
+      expect(delivered).toEqual(["follow-up final"]);
+      expect(errors).toEqual(["beforeDeliver timed out after 15000ms"]);
+      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+      expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds hooks appended after dispatcher construction", async () => {
+    vi.useFakeTimers();
+    try {
+      const hookStarted = createDeferred<void>();
+      const delivered: string[] = [];
+      let hookCalls = 0;
+      const dispatcher = createReplyDispatcher({
+        deliver: async (payload) => {
+          delivered.push(payload.text ?? "");
+        },
+      });
+      dispatcher.appendBeforeDeliver?.((payload) => {
+        hookCalls += 1;
+        if (hookCalls === 1) {
+          hookStarted.resolve();
+          return new Promise<never>(() => {});
+        }
+        return payload;
+      });
+
+      dispatcher.sendFinalReply({ text: "stuck final" });
+      dispatcher.sendFinalReply({ text: "follow-up final" });
+      dispatcher.markComplete();
+      await hookStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+      await dispatcher.waitForIdle();
+
+      expect(delivered).toEqual(["follow-up final"]);
+      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+      expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives each beforeDeliver hook its own deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: string[] = [];
+      const dispatcher = createReplyDispatcher({
+        deliver: async (payload) => {
+          delivered.push(payload.text ?? "");
+        },
+        beforeDeliver: async (payload) => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 10_000);
+          });
+          return { ...payload, text: `${payload.text}:first` };
+        },
+      });
+      dispatcher.appendBeforeDeliver?.(async (payload) => {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10_000);
+        });
+        return { ...payload, text: `${payload.text}:second` };
+      });
+
+      dispatcher.sendFinalReply({ text: "final" });
+      dispatcher.markComplete();
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(delivered).toEqual([]);
+      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await dispatcher.waitForIdle();
+
+      expect(delivered).toEqual(["final:first:second"]);
+      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("applies a hook appended after enqueue before the chain starts", async () => {
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    dispatcher.sendFinalReply({ text: "queued" });
+    dispatcher.appendBeforeDeliver?.((payload) => ({ ...payload, text: "appended" }));
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(deliveredText(deliver)).toBe("appended");
   });
 
   it("fires onIdle when the queue drains", async () => {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -239,6 +239,23 @@ describe("createReplyDispatcher", () => {
     }
   });
 
+  it("rejects non-positive and non-finite beforeDeliver budgets", () => {
+    for (const timeoutMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() =>
+        createReplyDispatcher({
+          deliver: async () => {},
+          beforeDeliver: (payload) => payload,
+          beforeDeliverOptions: { timeoutMs },
+        }),
+      ).toThrow("beforeDeliver timeoutMs must be a positive finite number");
+
+      const dispatcher = createReplyDispatcher({ deliver: async () => {} });
+      expect(() => dispatcher.appendBeforeDeliver?.((payload) => payload, { timeoutMs })).toThrow(
+        "beforeDeliver timeoutMs must be a positive finite number",
+      );
+    }
+  });
+
   it("honors owner-declared budgets for constructor and appended callbacks", async () => {
     vi.useFakeTimers();
     try {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -239,6 +239,55 @@ describe("createReplyDispatcher", () => {
     }
   });
 
+  it("honors owner-declared budgets for constructor and appended callbacks", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: string[] = [];
+      const errors: string[] = [];
+      const dispatcher = createReplyDispatcher({
+        deliver: async (payload) => {
+          delivered.push(payload.text ?? "");
+        },
+        beforeDeliver: async (payload) => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 16_000);
+          });
+          return { ...payload, text: `${payload.text}:constructor` };
+        },
+        beforeDeliverOptions: { timeoutMs: 20_000 },
+        onError: (error) => {
+          errors.push(error instanceof Error ? error.message : String(error));
+        },
+      });
+      dispatcher.appendBeforeDeliver?.(
+        async (payload) => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 16_000);
+          });
+          return { ...payload, text: `${payload.text}:appended` };
+        },
+        { timeoutMs: 20_000 },
+      );
+
+      dispatcher.sendFinalReply({ text: "final" });
+      dispatcher.markComplete();
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(delivered).toEqual([]);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(delivered).toEqual([]);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await dispatcher.waitForIdle();
+
+      expect(delivered).toEqual(["final:constructor:appended"]);
+      expect(errors).toEqual([]);
+      expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("gives each beforeDeliver hook its own deadline", async () => {
     vi.useFakeTimers();
     try {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -316,13 +316,17 @@ describe("createReplyDispatcher", () => {
       const beforeDeliver = composeReplyDispatchBeforeDeliver(
         {
           hook: async (payload) => {
-            await new Promise((resolve) => setTimeout(resolve, 16_000));
+            await new Promise((resolve) => {
+              setTimeout(resolve, 16_000);
+            });
             return { ...payload, text: `${payload.text}:owner` };
           },
           options: { timeoutMs: 20_000 },
         },
         async (payload) => {
-          await new Promise((resolve) => setTimeout(resolve, 10_000));
+          await new Promise((resolve) => {
+            setTimeout(resolve, 10_000);
+          });
           return { ...payload, text: `${payload.text}:plugin` };
         },
       );

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -2,7 +2,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../tokens.js";
-import { createReplyDispatcher, waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
+import {
+  composeReplyDispatchBeforeDeliver,
+  createReplyDispatcher,
+  waitForReplyDispatcherIdle,
+} from "./reply-dispatcher.js";
 import { createReplyToModeFilter } from "./reply-threading.js";
 
 type DeliverPayload = Parameters<Parameters<typeof createReplyDispatcher>[0]["deliver"]>[0];
@@ -299,6 +303,46 @@ describe("createReplyDispatcher", () => {
       expect(delivered).toEqual(["final:constructor:appended"]);
       expect(errors).toEqual([]);
       expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not turn a composed stage budget into a whole-chain deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const delivered: string[] = [];
+      const beforeDeliver = composeReplyDispatchBeforeDeliver(
+        {
+          hook: async (payload) => {
+            await new Promise((resolve) => setTimeout(resolve, 16_000));
+            return { ...payload, text: `${payload.text}:owner` };
+          },
+          options: { timeoutMs: 20_000 },
+        },
+        async (payload) => {
+          await new Promise((resolve) => setTimeout(resolve, 10_000));
+          return { ...payload, text: `${payload.text}:plugin` };
+        },
+      );
+      const dispatcher = createReplyDispatcher({
+        deliver: async (payload) => {
+          delivered.push(payload.text ?? "");
+        },
+        beforeDeliver,
+        beforeDeliverOptions: { timeoutMs: 20_000 },
+      });
+
+      dispatcher.sendFinalReply({ text: "final" });
+      dispatcher.markComplete();
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(delivered).toEqual([]);
+      await vi.advanceTimersByTimeAsync(6_000);
+      await dispatcher.waitForIdle();
+
+      expect(delivered).toEqual(["final:owner:plugin"]);
+      expect(dispatcher.getFailedCounts()).toEqual({ tool: 0, block: 0, final: 0 });
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -46,6 +46,7 @@ export {
   createReplyDispatcherWithTyping,
 } from "../auto-reply/reply/reply-dispatcher.js";
 export type {
+  ReplyDispatchBeforeDeliverOptions,
   ReplyDispatchKind,
   ReplyDispatcher,
   ReplyFollowupAdmissionBarrierTimeoutPolicy,

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -23,7 +23,11 @@ import type {
   PluginRuntime as CorePluginRuntime,
 } from "openclaw/plugin-sdk/core";
 import * as providerEntrySdk from "openclaw/plugin-sdk/provider-entry";
-import type { GetReplyOptions as ReplyRuntimeGetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
+import type {
+  GetReplyOptions as ReplyRuntimeGetReplyOptions,
+  ReplyDispatchBeforeDeliverOptions as ReplyRuntimeBeforeDeliverOptions,
+  ReplyDispatcher as ReplyRuntimeDispatcher,
+} from "openclaw/plugin-sdk/reply-runtime";
 import * as zalouserSdk from "openclaw/plugin-sdk/zalouser";
 import ts from "typescript";
 import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
@@ -1345,6 +1349,12 @@ describe("plugin-sdk subpath exports", () => {
       "requestedSessionId" | "resumeRequestedSession"
     >;
     expectTypeOf<PrivateResumeOptionKeys>().toEqualTypeOf<never>();
+    type ReplyRuntimeAppendBeforeDeliverOptions = Parameters<
+      NonNullable<ReplyRuntimeDispatcher["appendBeforeDeliver"]>
+    >[1];
+    expectTypeOf<ReplyRuntimeAppendBeforeDeliverOptions>().toEqualTypeOf<
+      ReplyRuntimeBeforeDeliverOptions | undefined
+    >();
   });
 
   it("keeps runtime entry subpaths importable", async () => {

--- a/src/plugins/hooks.test-helpers.ts
+++ b/src/plugins/hooks.test-helpers.ts
@@ -11,6 +11,8 @@ export function createMockPluginRegistry(
     hookName: string;
     handler: (...args: unknown[]) => unknown;
     pluginId?: string;
+    priority?: number;
+    timeoutMs?: number;
   }>,
 ): PluginRegistry {
   const pluginIds =
@@ -32,7 +34,8 @@ export function createMockPluginRegistry(
       pluginId: h.pluginId ?? "test-plugin",
       hookName: h.hookName,
       handler: h.handler,
-      priority: 0,
+      priority: h.priority ?? 0,
+      ...(h.timeoutMs !== undefined ? { timeoutMs: h.timeoutMs } : {}),
       source: "test",
     })) as PluginRegistry["typedHooks"],
   };
@@ -115,6 +118,8 @@ export function createHookRunnerWithRegistry(
     hookName: string;
     handler: (...args: unknown[]) => unknown;
     pluginId?: string;
+    priority?: number;
+    timeoutMs?: number;
   }>,
   options?: Parameters<typeof createHookRunner>[1],
 ) {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -239,6 +239,10 @@ const DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, 
   // unresolved; timeout fail-opens with the original final answer.
   before_agent_finalize: 15_000,
   before_prompt_build: 15_000,
+  // Outbound modifying hooks run inside the serialized reply delivery lane.
+  // A hung plugin must fail open so later hooks and queued replies can settle.
+  message_sending: 15_000,
+  reply_payload_sending: 15_000,
   resolve_exec_env: 15_000,
 };
 

--- a/src/plugins/wired-hooks-message.test.ts
+++ b/src/plugins/wired-hooks-message.test.ts
@@ -11,6 +11,14 @@ import type {
   PluginHookMessageSentEvent,
 } from "./types.js";
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 async function expectMessageHookCall(params: {
   hookName: "message_sending" | "message_sent";
   event: PluginHookMessageSendingEvent | PluginHookMessageSentEvent;
@@ -62,6 +70,73 @@ describe("message_sending hook runner", () => {
       expectedResult: expected,
       channelCtx: demoChannelCtx,
     });
+  });
+
+  it("fails open after the default per-handler timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const logger = { warn: vi.fn(), error: vi.fn() };
+      const firstStarted = createDeferred<void>();
+      const first = vi.fn(() => {
+        firstStarted.resolve();
+        return new Promise<PluginHookMessageSendingResult>(() => {});
+      });
+      const second = vi.fn().mockResolvedValue({ content: "after timeout" });
+      const { runner } = createHookRunnerWithRegistry(
+        [
+          { hookName: "message_sending", handler: first },
+          { hookName: "message_sending", handler: second },
+        ],
+        { logger },
+      );
+
+      const resultPromise = runner.runMessageSending(
+        { to: "user-123", content: "original content" },
+        demoChannelCtx,
+      );
+      await firstStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await expect(resultPromise).resolves.toEqual({ content: "after timeout" });
+      expect(second).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        "[hooks] message_sending handler from test-plugin failed: timed out after 15000ms",
+      );
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves a handler-specific timeout longer than the default", async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = vi.fn(
+        () =>
+          new Promise<PluginHookMessageSendingResult>((resolve) => {
+            setTimeout(() => resolve({ content: "slow result" }), 16_000);
+          }),
+      );
+      const { runner } = createHookRunnerWithRegistry([
+        { hookName: "message_sending", handler, timeoutMs: 20_000 },
+      ]);
+      const resultPromise = runner.runMessageSending(
+        { to: "user-123", content: "original content" },
+        demoChannelCtx,
+      );
+      let settled = false;
+      void resultPromise.then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(resultPromise).resolves.toEqual({ content: "slow result" });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/plugins/wired-hooks-reply-payload-sending.test.ts
+++ b/src/plugins/wired-hooks-reply-payload-sending.test.ts
@@ -8,6 +8,14 @@ import {
 import type { PluginHookReplyPayload } from "./hook-types.js";
 import { createHookRunnerWithRegistry } from "./hooks.test-helpers.js";
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 const replyPayloadSendingEvent = {
   payload: { text: "hello" } satisfies ReplyPayload,
   kind: "final" as const,
@@ -29,6 +37,46 @@ function firstErrorLog(logger: { error: ReturnType<typeof vi.fn> }) {
 }
 
 describe("reply_payload_sending hook runner", () => {
+  it("fails open after the default per-handler timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const logger = { warn: vi.fn(), error: vi.fn() };
+      const firstStarted = createDeferred<void>();
+      const first = vi.fn(() => {
+        firstStarted.resolve();
+        return new Promise<never>(() => {});
+      });
+      const second = vi.fn().mockResolvedValue({ payload: { text: "after timeout" } });
+      const { runner } = createHookRunnerWithRegistry(
+        [
+          { hookName: "reply_payload_sending", handler: first },
+          { hookName: "reply_payload_sending", handler: second },
+        ],
+        { logger },
+      );
+
+      const resultPromise = runner.runReplyPayloadSending(
+        replyPayloadSendingEvent,
+        replyPayloadSendingCtx,
+      );
+      await firstStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await expect(resultPromise).resolves.toEqual({
+        payload: { text: "after timeout" },
+        cancel: undefined,
+        reason: undefined,
+      });
+      expect(second).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        "[hooks] reply_payload_sending handler from test-plugin failed: timed out after 15000ms",
+      );
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("passes the latest payload between handlers", async () => {
     const first = vi.fn().mockResolvedValue({
       payload: {


### PR DESCRIPTION
Closes #103684.


## What Problem This Solves

Fixes an issue where a final channel reply could remain undelivered and keep the serialized reply lane busy forever when a pre-delivery callback never settled. Affected users could see reactions but no answer, while later messages accumulated behind the stuck lane.

The original report was captured on WhatsApp 2026.6.11. The exact callback was not isolated, so this change covers every remaining production pre-delivery owner without changing the foreground freshness contract.

## Why This Change Was Made

The dispatcher keeps one flattened internal stage list. Constructor, channel-custom, and post-construction stages each receive their own 15-second settlement deadline; appended stages cannot escape the policy, and two individually valid slow stages do not share an aggregate deadline. The foreground freshness fence remains lifecycle-owned and unbounded because timing it out could release a stale older reply.

`message_sending` and `reply_payload_sending` use the hook runner's existing 15-second per-handler default and fail-open behavior. Explicit plugin/operator hook timeout overrides remain authoritative.

The shipped `openclaw/plugin-sdk/reply-runtime` dispatcher contract now also lets channel-plugin owners declare a positive finite budget for their own callback: `beforeDeliverOptions: { timeoutMs }` at construction, or `dispatcher.appendBeforeDeliver(handler, { timeoutMs })` for appended work. The default remains 15 seconds, while an explicit budget is still per stage. This adds no config key, environment variable, protocol field, or general SDK configuration surface.

A timeout is recorded as `failed-before-deliver`, not as an intentional cancellation. Per-payload completion preserves `pendingFinalDelivery` only when every relevant final failed before transport started; delivery, explicit suppression, or an error after transport began retains the existing no-blind-retry behavior. The public `send*(): boolean` contracts are unchanged.

The one bundled Mattermost button-click caller that skipped dispatcher settlement now uses the existing shared lifecycle owner; all other bundled/core callers were already settled. There is no persistent data-model or migration change: the documentation update describes the public callback contract only.

## User Impact

A hung pre-delivery callback releases the owning lane after a bounded wait, so subsequent replies can continue. Plugin hook timeouts continue with the latest safe payload. Channel plugins with legitimate slower `beforeDeliver` work can declare a larger per-callback deadline instead of being forced into the new 15-second default. A final that definitely failed before send keeps its durable pending state instead of being silently marked delivered.

## Evidence

Deterministic repository regressions cover:

- constructor and appended hooks that never settle, including recovery of the same dispatcher and a WhatsApp-shaped buffered lane;
- a constructor or appended callback completing after 15 seconds under its explicit 20-second budget, including the foreground freshness-fence path;
- two 10-second internal stages succeeding under separate 15-second budgets;
- registration-specific plugin hook timeouts longer than the default;
- successful, cancelled, pre-send failed, after-send failed, and mixed multi-final pending-state transitions;
- enqueue-then-append timing compatibility and the public Plugin SDK type contract.

Completed with the exact pushed content (`625b270e6fff00a0958a9f402791352e93dda6be`):

- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-flow.test.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/auto-reply/dispatch.freshness.test.ts src/plugins/wired-hooks-message.test.ts src/plugins/wired-hooks-reply-payload-sending.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts` — passed: 6 files / 82 tests across 3 Vitest shards.
- `node scripts/build-all.mjs` — passed.
- `node scripts/package-openclaw-for-docker.mjs --allow-unreleased-changelog --skip-build --output-dir <temp> --output-name openclaw-current.tgz` — passed the package inventory and tarball import-graph checks.
- Fresh temporary npm project installed that tarball; `openclaw/plugin-sdk/reply-runtime` resolved to the installed package's `dist/plugin-sdk/reply-runtime.js`.
- Installed-runtime lane recovery through that public SDK entrypoint: after 15,007 ms, the unresolved first final failed with `beforeDeliver timed out after 15000ms`; the same dispatcher delivered `follow-up-final`, with failed counts `{ tool: 0, block: 0, final: 1 }`.
- Installed-runtime declared-budget proof: constructor and appended callbacks each waited 15,250 ms under explicit 20-second budgets; after 30,509 ms the installed dispatcher delivered `budget-final:constructor:appended` with no errors and final failed count `0`.
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` — passed after refreshing the committed SDK baseline hash.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs <touched TypeScript files>` and `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — no accepted/actionable findings reported.

Runtime proof boundary:

- This is an installed-package public-SDK lane-recovery proof, not a live WhatsApp delivery. No WhatsApp credentials were available.
- Sanitized direct AWS Crabbox was attempted from a clean trusted `main` checkout, with public networking and no hydration. It could not acquire broker credentials because this environment has no EC2 IMDS role; no credentialed Testbox or live-channel run was used.
- Exact-head GitHub Actions are in progress for this update.
