### PR TITLE
fix(workboard): avoid timing leaks in claim authorization

### DIFF
--- a/extensions/workboard/src/store-card-helpers.ts
+++ b/extensions/workboard/src/store-card-helpers.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   BLOCKED_TOO_LONG_MS,
@@ -347,10 +348,9 @@ export function assertCanMutateClaimedCard(
   }
   const ownerId = normalizeOptionalString(scope.ownerId);
   const token = normalizeOptionalString(scope.token);
-  if (claim.ownerId === ownerId || (token && claim.token === token)) {
-    return;
+  if (claim.ownerId !== ownerId && !safeEqualSecret(token, claim.token)) {
+    throw new Error(`card is claimed by ${claim.ownerId}.`);
   }
-  throw new Error(`card is claimed by ${claim.ownerId}.`);
 }
 
 export function retryBudgetExhausted(card: WorkboardCard): boolean {

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -52,11 +52,21 @@ import { WorkboardPromoteStore } from "./store-promote.js";
 import type {
   WorkboardArtifact,
   WorkboardCard,
+  WorkboardClaim,
   WorkboardNotification,
   WorkboardRunAttempt,
 } from "./types.js";
 
-const CLAIM_TOKEN_MISMATCH = "claim token does not match.";
+function assertClaimIdentity(claim: WorkboardClaim, input: WorkboardHeartbeatInput): void {
+  const token = normalizeOptionalString(input.token);
+  const ownerId = normalizeOptionalString(input.ownerId);
+  if (token && !safeEqualSecret(token, claim.token)) {
+    throw new Error("claim token does not match.");
+  }
+  if (!token && ownerId && ownerId !== claim.ownerId) {
+    throw new Error("claim owner does not match.");
+  }
+}
 
 export class WorkboardWorkflowStore extends WorkboardPromoteStore {
   async claim(
@@ -143,12 +153,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
         throw new Error("card is not claimed.");
       }
       const now = Math.max(Date.now(), claim.lastHeartbeatAt + 1);
-      const token = normalizeOptionalString(input.token);
-      const ownerId = normalizeOptionalString(input.ownerId);
-      if (token && !safeEqualSecret(token, claim.token)) throw new Error(CLAIM_TOKEN_MISMATCH);
-      if (!token && ownerId && ownerId !== claim.ownerId) {
-        throw new Error("claim owner does not match.");
-      }
+      assertClaimIdentity(claim, input);
       const nextClaim = {
         ...claim,
         lastHeartbeatAt: now,
@@ -193,12 +198,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
           : normalizeStatus(input.status, existing.status);
       const claim = existing.metadata?.claim;
       if (claim) {
-        const token = normalizeOptionalString(input.token);
-        const ownerId = normalizeOptionalString(input.ownerId);
-        if (token && !safeEqualSecret(token, claim.token)) throw new Error(CLAIM_TOKEN_MISMATCH);
-        if (!token && ownerId && ownerId !== claim.ownerId) {
-          throw new Error("claim owner does not match.");
-        }
+        assertClaimIdentity(claim, input);
       }
       return await this.updateCard(
         id,

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { isFutureDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
+import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import {
   appendEvent,
   assertCanMutateClaimedCard,
@@ -54,6 +55,8 @@ import type {
   WorkboardNotification,
   WorkboardRunAttempt,
 } from "./types.js";
+
+const CLAIM_TOKEN_MISMATCH = "claim token does not match.";
 
 export class WorkboardWorkflowStore extends WorkboardPromoteStore {
   async claim(
@@ -142,9 +145,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
       const now = Math.max(Date.now(), claim.lastHeartbeatAt + 1);
       const token = normalizeOptionalString(input.token);
       const ownerId = normalizeOptionalString(input.ownerId);
-      if (token && token !== claim.token) {
-        throw new Error("claim token does not match.");
-      }
+      if (token && !safeEqualSecret(token, claim.token)) throw new Error(CLAIM_TOKEN_MISMATCH);
       if (!token && ownerId && ownerId !== claim.ownerId) {
         throw new Error("claim owner does not match.");
       }
@@ -194,9 +195,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
       if (claim) {
         const token = normalizeOptionalString(input.token);
         const ownerId = normalizeOptionalString(input.ownerId);
-        if (token && token !== claim.token) {
-          throw new Error("claim token does not match.");
-        }
+        if (token && !safeEqualSecret(token, claim.token)) throw new Error(CLAIM_TOKEN_MISMATCH);
         if (!token && ownerId && ownerId !== claim.ownerId) {
           throw new Error("claim owner does not match.");
         }

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1038,6 +1038,25 @@ describe("WorkboardStore", () => {
     const released = await store.releaseClaim(card.id, { ownerId: "main", status: "review" });
     expect(released.status).toBe("review");
     expect(released.metadata?.claim).toBeUndefined();
+
+    const tokenCard = await store.create({ title: "Token-authorized worker", status: "todo" });
+    const tokenClaim = await store.claim(tokenCard.id, { ownerId: "main", ttlSeconds: 60 });
+
+    await expect(
+      store.heartbeat(tokenCard.id, { ownerId: "other", token: "wrong-token" }),
+    ).rejects.toThrow(/token does not match/);
+    await expect(
+      store.heartbeat(tokenCard.id, { ownerId: "other", token: tokenClaim.token }),
+    ).resolves.toMatchObject({ metadata: { claim: { ownerId: "main" } } });
+
+    await expect(
+      store.releaseClaim(tokenCard.id, { ownerId: "other", token: "wrong-token" }),
+    ).rejects.toThrow(/token does not match/);
+    const tokenReleased = await store.releaseClaim(tokenCard.id, {
+      ownerId: "other",
+      token: tokenClaim.token,
+    });
+    expect(tokenReleased.metadata?.claim).toBeUndefined();
   });
 
   it("atomically guards and adopts dispatcher workspace authority", async () => {

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1931,6 +1931,29 @@ describe("WorkboardStore", () => {
     });
   });
 
+  it("checks matching claim tokens inside queued card writes", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({ title: "Token-scoped mutation" });
+    await store.claim(card.id, { ownerId: "main", token: "test-auth-token" });
+
+    await expect(
+      store.addComment(
+        card.id,
+        { body: "rejected write" },
+        { ownerId: "other", token: "test-token-placeholder" },
+      ),
+    ).rejects.toThrow(/claimed by main/);
+    await expect(
+      store.addComment(
+        card.id,
+        { body: "accepted write" },
+        { ownerId: "other", token: "test-auth-token" },
+      ),
+    ).resolves.toMatchObject({
+      metadata: { comments: [expect.objectContaining({ body: "accepted write" })] },
+    });
+  });
+
   it("clears resolved proof diagnostics when adding proof", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -310,6 +310,13 @@ describe("workboard tools", () => {
     ).rejects.toThrow(/claimed by main/);
     expect(await store.list()).toHaveLength(1);
 
+    await expect(
+      otherTools.get("workboard_create")?.execute("call-2b", {
+        title: "Wrong token child",
+        parents: [parent.id],
+        token: "test-token-placeholder",
+      }),
+    ).rejects.toThrow(/claimed by main/);
     await otherTools.get("workboard_create")?.execute("call-2", {
       title: "Scoped child",
       parents: [parent.id],

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -2,6 +2,7 @@
 import { jsonResult, readStringParam } from "openclaw/plugin-sdk/core";
 import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
+import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { Type } from "typebox";
 import { WorkboardStore } from "./store.js";
 import type { WorkboardCard } from "./types.js";
@@ -18,10 +19,7 @@ function contextOwner(ctx: OpenClawPluginToolContext | undefined): string {
 
 function canMutateCard(card: WorkboardCard, ownerId: string, token?: string): boolean {
   const claim = card.metadata?.claim;
-  if (!claim) {
-    return true;
-  }
-  return claim.ownerId === ownerId || (Boolean(token) && claim.token === token);
+  return !claim || claim.ownerId === ownerId || safeEqualSecret(token, claim.token);
 }
 
 function readParentIds(value: unknown): string[] {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Workboard claim authorization compared claim tokens with ordinary string equality. Claim tokens are redacted credentials that let a worker other than the recorded owner heartbeat, release, or mutate a claimed card, so their validation should use the same timing-safe primitive as other OpenClaw secret-bearing authorization surfaces.

## Why This Change Was Made

Routes all four Workboard claim-token checks through the existing `safeEqualSecret` Plugin SDK contract while leaving owner-id comparisons and authorization behavior unchanged. This covers both tool-level preflight checks and store-level heartbeat, release, and mutation enforcement without adding configuration or dependencies.

## User Impact

Workboard claim authorization now avoids data-dependent string comparison timing for claim tokens. Existing valid and invalid token behavior, error messages, and card workflows remain unchanged.

## Evidence

Exact head: `5d83f2eeb`.

Runtime: Windows, Node `24.18.0`, Vitest `4.1.9`. Testbox and brokered Crabbox were unavailable to this external contributor, so these are the repository-approved narrow local fallback commands:

- `node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts --reporter=verbose -t "claims cards, heartbeats, and releases the claim"` -> 1 passed; proves owner success plus valid-token success and wrong-token rejection for heartbeat and release.
- `node scripts/run-vitest.mjs extensions/workboard/src/tools.test.ts --reporter=verbose -t "requires claim scope before creating or linking dependencies against claimed cards"` -> 1 passed; proves owner/valid-token mutation success and wrong-token rejection.
- `oxfmt --check extensions/workboard/src/store.test.ts` -> passed.
- `git diff --check` -> passed.
- Fresh `autoreview --mode uncommitted --engine claude --thinking high` (`claude-fable-5`) -> patch correct, no accepted/actionable findings.

A broader two-file run reached 83 passing tests and one unrelated existing Windows cleanup failure (`EPERM` removing the network-backed SQLite temp directory); the changed authorization test initially exposed an assertion-shape mistake, which was corrected before the focused green reruns above.
