### PR TITLE
fix(voice-call): use sliceUtf16Safe for bounded child output tail cap

### DIFF
--- a/extensions/voice-call/src/bounded-child-output.test.ts
+++ b/extensions/voice-call/src/bounded-child-output.test.ts
@@ -15,4 +15,17 @@ describe("bounded child output", () => {
     expect(second).toEqual({ text: "fghij", truncated: true });
     expect(formatBoundedChildOutput(second)).toBe("[output truncated]\nfghij");
   });
+
+  it("does not split a surrogate pair at the tail cap boundary", () => {
+    // 🤖 is U+1F916 — two UTF-16 code units (U+D83E U+DD16).
+    // Cap of 5 starts on the low surrogate: raw .slice(-5) keeps lone U+DD16 + "kept".
+    // sliceUtf16Safe advances past that dangling low half and retains "kept".
+    const chunk = `${"p".repeat(10)}🤖kept`;
+    const rawTail = chunk.slice(-5);
+    expect(rawTail.charCodeAt(0)).toBe(0xdd16);
+
+    const result = appendBoundedChildOutput(emptyBoundedChildOutput(), chunk, 5);
+    expect(result).toEqual({ text: "kept", truncated: true });
+    expect(formatBoundedChildOutput(result)).toBe("[output truncated]\nkept");
+  });
 });

--- a/extensions/voice-call/src/bounded-child-output.ts
+++ b/extensions/voice-call/src/bounded-child-output.ts
@@ -1,4 +1,5 @@
 // Bounded child-process output buffer for voice-call tunnel/process diagnostics.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const DEFAULT_MAX_OUTPUT_CHARS = 16_384;
 
@@ -24,7 +25,7 @@ export function appendBoundedChildOutput(
     return { text: appended, truncated: current.truncated };
   }
   return {
-    text: appended.slice(-maxChars),
+    text: sliceUtf16Safe(appended, -maxChars),
     truncated: true,
   };
 }

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -1,5 +1,6 @@
 // Voice Call plugin module implements tunnel behavior.
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   appendBoundedChildOutput,
   emptyBoundedChildOutput,
@@ -170,7 +171,9 @@ export async function startNgrokTunnel(config: {
       const lines = (outputBuffer + data.toString()).split("\n");
       outputBuffer = lines.pop() || "";
       if (outputBuffer.length > NGROK_LOG_BUFFER_MAX_CHARS) {
-        outputBuffer = outputBuffer.slice(-NGROK_LOG_BUFFER_MAX_CHARS);
+        // Same UTF-16 contract as appendBoundedChildOutput: do not leave a lone
+        // surrogate when an incomplete ngrok log line is trimmed to the ring cap.
+        outputBuffer = sliceUtf16Safe(outputBuffer, -NGROK_LOG_BUFFER_MAX_CHARS);
       }
 
       for (const line of lines) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where the voice-call plugin's child-process output ring buffer can produce invalid Unicode when tunnel/process diagnostics output contains emoji or other supplementary-plane characters near the tail cap.

`appendBoundedChildOutput()` capped accumulated child output with `appended.slice(-maxChars)`, and the ngrok incomplete-line buffer used the same raw negative slice. Child process stdout/stderr is unfiltered, so output containing characters like `🤖` can land on a UTF-16 surrogate boundary and leave a lone low surrogate in the diagnostic text surfaced to operators.

**Concrete example:** with `maxChars = 5` and input `"pppppppppp🤖kept"` (16 code units), raw `.slice(-5)` keeps `U+DD16` + `"kept"` — a lone low surrogate without its high half `U+D83E`.

## Why This Change Was Made

Replace raw negative slicing with `sliceUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime` at both voice-call diagnostic truncation sites:

- `appendBoundedChildOutput` ring buffer (stderr/stdout for ngrok/Tailscale child processes)
- ngrok incomplete-line `outputBuffer` trim in `startNgrokTunnel`

This matches the established tail-truncation pattern in `src/infra/restart-sentinel.ts` and the SCP/file-transfer UTF-16 fixes. Ring-buffer size and voice-call diagnostic behavior are unchanged; only the truncation boundary is surrogate-safe.

## User Impact

**Before:** Voice-call tunnel/process diagnostic output can surface replacement glyphs or invalid Unicode in operator-visible text when subprocess output contains emoji near the ring-buffer cap.

**After:** Child output tails remain well-formed Unicode; boundary emoji halves are dropped instead of split.

## Evidence

- `extensions/voice-call/src/bounded-child-output.ts` — `appendBoundedChildOutput` uses `sliceUtf16Safe` for the tail cap
- `extensions/voice-call/src/tunnel.ts` — ngrok incomplete-line buffer uses the same UTF-16-safe trim
- `src/plugin-sdk/text-utility-runtime.ts` — exports `sliceUtf16Safe` as a proper SDK subpath for bundled plugins
- Regression: `extensions/voice-call/src/bounded-child-output.test.ts` — cap that begins on the low surrogate asserts exact retained tail `"kept"` (fails on raw `.slice`)
- Live subprocess proof: real `node` child process wiring matching `runNgrokCommand` (stdout/stderr → `appendBoundedChildOutput` → `formatBoundedChildOutput` error message) with production `16_384` cap bisecting `🤖`

## Real behavior proof

- **Behavior or issue addressed:** Voice-call child-process diagnostic truncation no longer leaves unpaired UTF-16 surrogates when supplementary-plane output crosses the production ring-buffer cap.
- **Canonical reachability path:** voice-call tunnel/process subprocess → stdout/stderr chunks → `appendBoundedChildOutput` ring buffer → `formatBoundedChildOutput` → `ngrok command failed: …` / Tailscale failure detail surfaced to operators.
- **Boundary crossed:** local-runtime; real Node child process using the same stdout/stderr listener wiring as `runNgrokCommand` (no Vitest mock of the helper path for the live proof).
- **Shared helper / provider constraint check:** Reused `sliceUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime`; no provider/channel constraints — this is plugin-local subprocess diagnostic handling.
- **Real environment tested:** macOS (darwin), Node v22.22.0, branch `fix/voice-call-bounded-child-output-utf16` rebased onto current `upstream/main`.
- **Exact steps or command run after this patch:**

```text
# 1) Focused regression (fails on raw .slice; passes with sliceUtf16Safe)
$ node scripts/run-vitest.mjs extensions/voice-call/src/bounded-child-output.test.ts --reporter=verbose

# 2) Live child-process diagnostic path (production 16_384 cap bisects 🤖)
$ pnpm exec tsx .voice-call-utf16-proof.mjs
# spawn(node -e 'stderr.write(x+🤖+y*16383); exit(1)')
# → appendBoundedChildOutput / formatBoundedChildOutput as in runNgrokCommand
```

- **Evidence after fix:**

```text
$ node scripts/run-vitest.mjs extensions/voice-call/src/bounded-child-output.test.ts --reporter=verbose

 ✓ |extension-voice-call| … > keeps a bounded tail and records truncation 77ms
 ✓ |extension-voice-call| … > does not split a surrogate pair at the tail cap boundary 0ms
 Test Files  1 passed (1)
      Tests  2 passed (2)

$ pnpm exec tsx .voice-call-utf16-proof.mjs
=== Real subprocess proof: voice-call bounded child output UTF-16 ===
platform: darwin, node: v22.22.0
payload code units: 16386
production cap: 16384

--- Raw .slice (pre-fix main behavior on same bytes) ---
raw tail first code unit: U+DD16
raw unpaired_surrogates: true
raw starts with lone low surrogate: true

--- Production appendBoundedChildOutput + formatBoundedChildOutput ---
truncated: true
buffer length: 16383
buffer first 8 code units: "yyyyyyyy"
unpaired_surrogates: false
message prefix: "ngrok command failed: [output truncated]"
message unpaired_surrogates: false
exact safe tail retained: true

[proof] PASS live child-process diagnostic path
```

- **Observed result after fix:** Real child stderr crossing the production `16_384` cap starts on the low surrogate of `🤖` under raw `.slice` (`U+DD16`, unpaired). Production `appendBoundedChildOutput` drops that dangling half, retains the exact `y`×16383 tail, and surfaces a well-formed `ngrok command failed: [output truncated]\n…` message with `unpaired_surrogates=false`. Focused regression asserts the exact `"kept"` tail for the low-surrogate cap case.
- **What was not tested:** Live ngrok/Tailscale binary with real emoji in process output; full gateway/voice roundtrip.
- **Fix classification:** Root cause fix.

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
- Single commit on `upstream/main`; no bundled `scripts/` or release-script changes
