### PR TITLE
fix(gateway): cap history when numeric limit is huge

### DIFF
--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -611,6 +611,34 @@ describe("session history HTTP endpoints", () => {
     });
   });
 
+  test("caps all-digit direct REST history limits that exceed safe integer range", async () => {
+    const { storePath } = await seedSession({ text: "first message" });
+    await appendVisibleAssistantMessage({
+      sessionKey: "agent:main:main",
+      text: "second message",
+      storePath,
+    });
+    await appendVisibleAssistantMessage({
+      sessionKey: "agent:main:main",
+      text: "third message",
+      storePath,
+    });
+
+    await withGatewayHarness(async (harness) => {
+      const body = await readSessionHistoryBody(harness.port, "agent:main:main", {
+        query: `?limit=${"9".repeat(100)}`,
+      });
+
+      expect(body.messages?.map((message) => message.content?.[0]?.text)).toEqual([
+        "first message",
+        "second message",
+        "third message",
+      ]);
+      expect(body.hasMore).toBe(false);
+      expect(body.nextCursor).toBeUndefined();
+    });
+  });
+
   test("streams bounded history windows over SSE", async () => {
     const { storePath } = await seedSession({ text: "first message" });
 

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -73,9 +73,12 @@ function resolveLimit(req: IncomingMessage): number | undefined {
     return undefined;
   }
   const trimmed = raw.trim();
-  const value = /^\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
-  if (!Number.isSafeInteger(value) || value < 1) {
+  if (!/^\d+$/.test(trimmed)) {
     return 1;
+  }
+  const value = Number(trimmed);
+  if (!Number.isSafeInteger(value)) {
+    return MAX_SESSION_HISTORY_LIMIT;
   }
   return Math.min(MAX_SESSION_HISTORY_LIMIT, Math.max(1, value));
 }

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -73,14 +73,11 @@ function resolveLimit(req: IncomingMessage): number | undefined {
     return undefined;
   }
   const trimmed = raw.trim();
-  if (!/^\d+$/.test(trimmed)) {
+  const value = /^\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
+  if (Number.isNaN(value) || value < 1) {
     return 1;
   }
-  const value = Number(trimmed);
-  if (!Number.isSafeInteger(value)) {
-    return MAX_SESSION_HISTORY_LIMIT;
-  }
-  return Math.min(MAX_SESSION_HISTORY_LIMIT, Math.max(1, value));
+  return Math.min(MAX_SESSION_HISTORY_LIMIT, value);
 }
 
 function sseWrite(res: ServerResponse, event: string, payload: unknown): void {


### PR DESCRIPTION
## What Problem This Solves

Gateway HTTP session history treated an all-digit `limit` above JavaScript's safe integer range as invalid and returned the minimum one-message page instead of the endpoint's bounded maximum history window.

## Why This Change Was Made

The parser now distinguishes malformed or zero values from numeric overflow, then relies on the existing `MAX_SESSION_HISTORY_LIMIT` clamp. Because the endpoint cap is 1,000, precision above that cap is immaterial: finite unsafe numbers and `Infinity` have the same bounded result. This removes the submitted extra branch while preserving one canonical limit path.

## User Impact

Direct REST and SSE history callers that pass a very large numeric limit receive a useful bounded page instead of an unexpected one-message response. Cursor pagination, authentication, scopes, transcript reads, response shapes, and configuration are unchanged.

## Evidence

Contributor production Gateway proof used a 100-digit `limit` and returned all three seeded messages with `hasMore: false` instead of one message.

Maintainer validation:

```text
Final prepared head: 5869870e8b7fcdfbdbff734101f595e19dc0fff7
Blacksmith Testbox through Crabbox: tbx_01kx8ge44b23czdjt1v0fah1yt
Gateway HTTP history suite: 1 file, 21 tests passed
check:changed: passed (core and core-test typechecks, lint, architecture guards)
Canonical oxfmt and git diff --check: passed
Fresh local-diff autoreview: clean
```

The regression originated in commit `45e6af5e571f` on 2026-05-27; no associated pull request was traceable. Release-note context and contributor attribution remain here because `CHANGELOG.md` is release-owned.
