### PR TITLE
fix(goals): preserve durable owner across completion wakes

### DIFF
--- a/docs/tools/goal.md
+++ b/docs/tools/goal.md
@@ -20,6 +20,10 @@ Goals are session state: they move with the session key, survive process
 restarts, and appear in `/goal`, the model-facing goal tools, and the TUI
 footer.
 
+Detached command completions return to the originating user-facing thread, so
+the next turn continues to see the same goal even when command execution used
+a separate sandbox policy session.
+
 ## Quick start
 
 ```text

--- a/src/agents/agent-tools.exec-notify-session.test.ts
+++ b/src/agents/agent-tools.exec-notify-session.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import "./test-helpers/fast-bash-tools.js";
+import "./test-helpers/fast-coding-tools.js";
+import { createOpenClawCodingTools } from "./agent-tools.js";
+
+const createLazyExecToolMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./lazy-exec-tool.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./lazy-exec-tool.js")>();
+  return {
+    ...actual,
+    createLazyExecTool: (defaults: unknown) => {
+      createLazyExecToolMock(defaults);
+      return {
+        name: "exec",
+        description: "exec stub",
+        parameters: { type: "object", properties: {} },
+        execute: vi.fn(),
+      };
+    },
+  };
+});
+
+describe("createOpenClawCodingTools exec notification routing", () => {
+  it("routes detached completions to the live session without changing process scope", () => {
+    const liveSessionKey = "agent:main:channel:group:example:thread:25";
+    const policySessionKey = "agent:main:runtime-policy";
+
+    createOpenClawCodingTools({
+      sessionKey: policySessionKey,
+      runSessionKey: liveSessionKey,
+      toolConstructionPlan: {
+        includeBaseCodingTools: false,
+        includeShellTools: true,
+        includeChannelTools: false,
+        includeOpenClawTools: false,
+        includePluginTools: false,
+      },
+    });
+
+    expect(createLazyExecToolMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: policySessionKey,
+        sessionKey: policySessionKey,
+        notifySessionKey: liveSessionKey,
+      }),
+    );
+  });
+});

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -761,13 +761,15 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
         scopeKey,
         sessionKey: options?.sessionKey,
         runId: options?.runId,
+        // Detached completions return to the live session, not the sandbox policy scope.
+        notifySessionKey: options?.runSessionKey ?? options?.sessionKey,
         sessionId: options?.sessionId,
         sessionStore: options?.config?.session?.store,
         mainKey: options?.config?.session?.mainKey,
         sessionScope: options?.config?.session?.scope,
         eventRouting: resolveEventSessionRoutingPolicy({
           cfg: options?.config,
-          sessionKey: options?.sessionKey,
+          sessionKey: options?.runSessionKey ?? options?.sessionKey,
           channel: options?.messageProvider,
           accountId: options?.agentAccountId,
         }),

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -56,6 +56,8 @@ export type ExecToolDefaults = {
   sessionKey?: string;
   /** Stable agent run that owns any approval created by this tool. */
   runId?: string;
+  /** Durable session that receives detached exec completion events and approval followups. */
+  notifySessionKey?: string;
   /** Ephemeral session UUID active when this exec tool was built. Regenerated
    *  on `/new` and `/reset`, so it pins exec-approval followups to the original
    *  session instance and lets stale followups drop after a session rebind. */

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1362,7 +1362,9 @@ export function createExecTool(
   }
   const notifyOnExit = defaults?.notifyOnExit !== false;
   const notifyOnExitEmptySuccess = resolveNotifyOnExitEmptySuccess(defaults);
-  const notifySessionKey = normalizeOptionalString(defaults?.sessionKey);
+  const notifySessionKey = normalizeOptionalString(
+    defaults?.notifySessionKey ?? defaults?.sessionKey,
+  );
   const notifyDeliveryContext = normalizeDeliveryContext({
     channel: defaults?.messageProvider,
     to: defaults?.currentChannelId,


### PR DESCRIPTION
## What Problem This Solves

Background `exec` completions could be queued under a sandbox or runtime-policy session instead of the live user-facing session. The completion wake then ran outside the thread that owns its goal, so `get_goal` appeared to lose a still-persisted goal.

## Why This Change Was Made

Tool assembly now sends detached completion notifications and derives event-routing policy from the existing `runSessionKey`, while retaining `sessionKey` as the fallback. Process and approval scope remain bound to the sandbox policy session.

This uses the session identity already propagated by PI, Codex, and Copilot instead of adding a second durable-owner option. The focused regression verifies that process scope stays on the policy session while notifications target the live thread.

## User Impact

Goals remain visible after background command completions in sandboxed and policy-scoped runs. Existing session data and configuration require no migration.

## Evidence

- `node scripts/run-vitest.mjs src/agents/agent-tools.exec-notify-session.test.ts src/agents/bash-tools.test.ts src/agents/tools/goal-tools.test.ts` — 3 files passed, 41 tests passed.
- `node scripts/check-changed.mjs -- <touched files>` — formatting, guards, core production/test typechecks passed; Blacksmith allocation timed out, so the trusted-source local fallback was used. A pre-existing `bash-tools.test.ts` max-lines lint failure from the superseded contributor test was removed with that test; targeted changed-file lint then passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- `git diff --check origin/main...HEAD` — passed.

Credit: based on the original fix and reproduction by @goldmar; the rewritten commit retains `Co-authored-by: Mark Goldenstein <bigandevil@gmail.com>`.
