### PR TITLE
fix: escalate stalled managed mac app shutdown

### DIFF
--- a/scripts/restart-mac.sh
+++ b/scripts/restart-mac.sh
@@ -253,6 +253,15 @@ kill_managed_openclaw() {
     done <<< "${pids}"
     sleep 0.3
   done
+  # The app can keep handling SIGTERM while shutting down. Escalate only for
+  # the two exact executables target-only mode has already classified as safe.
+  local remaining_pids=""
+  remaining_pids="$(managed_openclaw_process_pids)"
+  while IFS= read -r pid; do
+    [[ -n "${pid}" ]] || continue
+    kill -KILL "${pid}" 2>/dev/null || true
+  done <<< "${remaining_pids}"
+  sleep 0.3
   [[ -z "$(managed_openclaw_process_pids)" ]]
 }
 

--- a/test/scripts/restart-mac.test.ts
+++ b/test/scripts/restart-mac.test.ts
@@ -386,6 +386,22 @@ describe("scripts/restart-mac.sh", () => {
     expect(script).toContain("target-only restart deferred");
   });
 
+  it("escalates only exact managed app processes when graceful shutdown stalls", () => {
+    const script = readFileSync(restartScriptPath, "utf8");
+    const managedKillBlock = script.slice(
+      script.indexOf("kill_managed_openclaw()"),
+      script.indexOf("stop_launch_agent()"),
+    );
+    const broadKillBlock = script.slice(
+      script.indexOf("kill_all_openclaw()"),
+      script.indexOf("known_openclaw_executables()"),
+    );
+
+    expect(managedKillBlock).toContain('kill -KILL "${pid}"');
+    expect(managedKillBlock).toContain("managed_openclaw_process_pids");
+    expect(broadKillBlock).not.toContain("kill -KILL");
+  });
+
   it("treats the canonical installed app as managed but temp bundles as foreign", () => {
     const result = runForeignProcessClassifier(
       [


### PR DESCRIPTION
## Summary

- escalate from graceful shutdown to `SIGKILL` only for the exact managed installed/target OpenClaw executables
- keep broad and foreign-process cleanup unchanged
- cover the target-only safety boundary with a regression assertion

## Proof

- `pnpm exec vitest run test/scripts/restart-mac.test.ts` (21 passed)
- reproduced by the live updater against `/Applications/OpenClaw.app`: repeated `SIGTERM` left the exact managed process alive
