### PR TITLE
fix(perplexity): forward the execution abort signal to web search HTTP requests

### DIFF
--- a/extensions/perplexity/src/perplexity-abort-proof.test.ts
+++ b/extensions/perplexity/src/perplexity-abort-proof.test.ts
@@ -1,0 +1,53 @@
+// Perplexity abort-signal proof: exercises the real Perplexity search
+// client → withTrustedWebSearchEndpoint → guarded fetch chain with
+// only globalThis.fetch replaced, so the full guarded-fetch stack
+// runs end-to-end.
+import { describe, expect, it, vi } from "vitest";
+
+describe("perplexity abort signal proof", () => {
+  const priorFetch = globalThis.fetch;
+
+  it("forwards the execution abort signal through guarded fetch to the HTTP request", async () => {
+    vi.stubEnv("PERPLEXITY_API_KEY", "test-proof-key");
+
+    const controller = new AbortController();
+    let capturedSignal: AbortSignal | null | undefined;
+
+    const mockFetch = vi.fn(async (_input?: unknown, init?: unknown) => {
+      capturedSignal = (init as RequestInit)?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        capturedSignal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("The operation was aborted", "AbortError")),
+          { once: true },
+        );
+      });
+    });
+    globalThis.fetch = mockFetch as typeof globalThis.fetch;
+    global.fetch = mockFetch as typeof global.fetch;
+
+    try {
+      // Import the real (unmocked) Perplexity client directly so the full
+      // production chain runs: executePerplexitySearch →
+      // withTrustedWebSearchEndpoint → guarded fetch → fetch.
+      const { executePerplexitySearch } =
+        await import("./perplexity-web-search-provider.runtime.js");
+      const executePromise = executePerplexitySearch(
+        { query: "abort propagation proof" },
+        undefined,
+        controller.signal,
+      );
+      await new Promise((r) => {
+        setTimeout(r, 10);
+      });
+
+      expect(capturedSignal).toBeDefined();
+
+      controller.abort();
+      await expect(executePromise).rejects.toThrow("The operation was aborted");
+    } finally {
+      globalThis.fetch = priorFetch;
+      global.fetch = priorFetch;
+    }
+  });
+});

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -209,6 +209,7 @@ async function runPerplexitySearchApi(params: {
   searchBeforeDate?: string;
   maxTokens?: number;
   maxTokensPerPage?: number;
+  signal?: AbortSignal;
 }): Promise<Array<Record<string, unknown>>> {
   const body: Record<string, unknown> = {
     query: params.query,
@@ -243,6 +244,7 @@ async function runPerplexitySearchApi(params: {
     {
       url: PERPLEXITY_SEARCH_ENDPOINT,
       timeoutSeconds: params.timeoutSeconds,
+      signal: params.signal,
       init: {
         method: "POST",
         headers: buildPerplexityRequestHeaders(params.apiKey, true),
@@ -275,6 +277,7 @@ async function runPerplexitySearch(params: {
   model: string;
   timeoutSeconds: number;
   freshness?: string;
+  signal?: AbortSignal;
 }): Promise<{ content: string; citations: string[] }> {
   const endpoint = `${params.baseUrl.trim().replace(/\/$/, "")}/chat/completions`;
   const body: Record<string, unknown> = {
@@ -289,6 +292,7 @@ async function runPerplexitySearch(params: {
     {
       url: endpoint,
       timeoutSeconds: params.timeoutSeconds,
+      signal: params.signal,
       init: {
         method: "POST",
         headers: buildPerplexityRequestHeaders(params.apiKey),
@@ -311,6 +315,7 @@ async function runPerplexitySearch(params: {
 export async function executePerplexitySearch(
   args: Record<string, unknown>,
   searchConfig?: SearchConfigRecord,
+  signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
   const perplexityConfig = resolvePerplexityConfig(searchConfig);
   const runtime = resolvePerplexityTransport(perplexityConfig);
@@ -500,6 +505,7 @@ export async function executePerplexitySearch(
               model: runtime.model,
               timeoutSeconds,
               freshness,
+              signal,
             });
             return {
               content: wrapWebContent(result.content, "web_search"),
@@ -529,6 +535,7 @@ export async function executePerplexitySearch(
             searchLanguageFilter: language ? [language] : undefined,
             searchAfterDate: dateAfter ? isoToPerplexityDate(dateAfter) : undefined,
             searchBeforeDate: dateBefore ? isoToPerplexityDate(dateBefore) : undefined,
+            signal,
             maxTokens: maxTokens ?? undefined,
             maxTokensPerPage: maxTokensPerPage ?? undefined,
           }),

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -196,9 +196,9 @@ describe("perplexity web search provider", () => {
   it("forwards the execution abort signal to the Perplexity HTTP request", async () => {
     await withEnvAsync({ [perplexityApiKeyEnv]: directPerplexityApiKey }, async () => {
       const controller = new AbortController();
-      let capturedSignal: AbortSignal | undefined;
+      let capturedSignal: AbortSignal | null | undefined;
       const mockFetch = vi.fn(async (_input?: unknown, init?: unknown) => {
-        capturedSignal = (init as RequestInit)?.signal;
+        capturedSignal = (init as RequestInit)?.signal ?? undefined;
         // Hold the request open and only resolve on the forwarded signal
         // abort. If the provider drops the signal, the captured signal is
         // undefined and the first expectation below fails.

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -12,6 +12,8 @@ const directPerplexityApiKey = ["pplx", "test"].join("-");
 const enterprisePerplexityApiKey = ["enterprise", "perplexity", "test"].join("-");
 
 describe("perplexity web search provider", () => {
+  const priorFetch = global.fetch;
+
   it("points missing-key users to fetch/browser alternatives", async () => {
     await withEnvAsync(
       { [perplexityApiKeyEnv]: undefined, [openRouterApiKeyEnv]: undefined },
@@ -189,5 +191,33 @@ describe("perplexity web search provider", () => {
     expect(streamed.getReadCount()).toBeLessThan(32);
     expect(streamed.wasCanceled()).toBe(true);
     expect(jsonSpy).not.toHaveBeenCalled();
+  });
+
+  it("forwards the execution abort signal to the Perplexity HTTP request", async () => {
+    await withEnvAsync({ [perplexityApiKeyEnv]: directPerplexityApiKey }, async () => {
+      const controller = new AbortController();
+      const mockFetch = vi.fn(async (_input?: unknown, _init?: unknown) => {
+        controller.abort();
+        throw new DOMException("The operation was aborted", "AbortError");
+      });
+      global.fetch = mockFetch as typeof global.fetch;
+
+      try {
+        const provider = createPerplexityWebSearchProvider();
+        const tool = provider.createTool({
+          config: {},
+          searchConfig: { apiKey: directPerplexityApiKey },
+        });
+        if (!tool) {
+          throw new Error("Expected tool definition");
+        }
+
+        await expect(
+          tool.execute({ query: "abort propagation" }, { signal: controller.signal }),
+        ).rejects.toThrow("The operation was aborted");
+      } finally {
+        global.fetch = priorFetch;
+      }
+    });
   });
 });

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -227,7 +227,9 @@ describe("perplexity web search provider", () => {
           { signal: controller.signal },
         );
         // Yield so the mock fetch runs and captures the signal.
-        await new Promise((r) => setTimeout(r, 10));
+        await new Promise((r) => {
+          setTimeout(r, 10);
+        });
 
         // Fails if the provider drops the signal.
         expect(capturedSignal).toBeDefined();

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -196,9 +196,19 @@ describe("perplexity web search provider", () => {
   it("forwards the execution abort signal to the Perplexity HTTP request", async () => {
     await withEnvAsync({ [perplexityApiKeyEnv]: directPerplexityApiKey }, async () => {
       const controller = new AbortController();
-      const mockFetch = vi.fn(async (_input?: unknown, _init?: unknown) => {
-        controller.abort();
-        throw new DOMException("The operation was aborted", "AbortError");
+      let capturedSignal: AbortSignal | undefined;
+      const mockFetch = vi.fn(async (_input?: unknown, init?: unknown) => {
+        capturedSignal = (init as RequestInit)?.signal;
+        // Hold the request open and only resolve on the forwarded signal
+        // abort. If the provider drops the signal, the captured signal is
+        // undefined and the first expectation below fails.
+        return new Promise<Response>((_resolve, reject) => {
+          capturedSignal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("The operation was aborted", "AbortError")),
+            { once: true },
+          );
+        });
       });
       global.fetch = mockFetch as typeof global.fetch;
 
@@ -212,9 +222,19 @@ describe("perplexity web search provider", () => {
           throw new Error("Expected tool definition");
         }
 
-        await expect(
-          tool.execute({ query: "abort propagation" }, { signal: controller.signal }),
-        ).rejects.toThrow("The operation was aborted");
+        const executePromise = tool.execute(
+          { query: "abort propagation" },
+          { signal: controller.signal },
+        );
+        // Yield so the mock fetch runs and captures the signal.
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Fails if the provider drops the signal.
+        expect(capturedSignal).toBeDefined();
+
+        controller.abort();
+        // Fails if the forwarded signal does not propagate the abort.
+        await expect(executePromise).rejects.toThrow("The operation was aborted");
       } finally {
         global.fetch = priorFetch;
       }

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -97,9 +97,9 @@ function createPerplexityToolDefinition(
         ? "Search the web using Perplexity Sonar via Perplexity/OpenRouter chat completions. Returns AI-synthesized answers with citations from web-grounded search."
         : "Search the web using Perplexity. Runtime routing decides between native Search API and Sonar chat-completions compatibility. Structured filters are available on the native Search API path.",
     parameters: createPerplexityParameters(schemaTransport),
-    execute: async (args) => {
+    execute: async (args, context) => {
       const { executePerplexitySearch } = await loadPerplexityWebSearchRuntime();
-      return await executePerplexitySearch(args, searchConfig);
+      return await executePerplexitySearch(args, searchConfig, context?.signal);
     },
   };
 }

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -828,6 +828,50 @@ describe("web search runtime", () => {
     });
   });
 
+  it("does not fall back to another provider after parent cancellation", async () => {
+    const controller = new AbortController();
+    const firstExecute = vi.fn(
+      async (_args: Record<string, unknown>, context?: { signal?: AbortSignal }) => {
+        expect(context?.signal).toBe(controller.signal);
+        controller.abort();
+        throw controller.signal.reason;
+      },
+    );
+    const fallbackExecute = vi.fn(async () => ({ ok: true }));
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
+      createCustomSearchProvider({
+        credentialPath: "",
+        createTool: () => ({
+          description: "first",
+          parameters: {},
+          execute: firstExecute,
+        }),
+      }),
+      createCustomSearchProvider({
+        pluginId: "fallback-search",
+        id: "fallback",
+        credentialPath: "",
+        autoDetectOrder: 2,
+        getConfiguredCredentialValue: () => "configured",
+        createTool: () => ({
+          description: "fallback",
+          parameters: {},
+          execute: fallbackExecute,
+        }),
+      }),
+    ]);
+
+    await expect(
+      runWebSearch({
+        config: createCustomSearchConfig("custom-config-key"),
+        args: { query: "abort fallback" },
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(firstExecute).toHaveBeenCalledOnce();
+    expect(fallbackExecute).not.toHaveBeenCalled();
+  });
+
   it("does not fall back when an auto-selected provider returns a validation error payload", async () => {
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([
       createGoogleSearchProvider({

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -4,6 +4,12 @@ import {
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import {
+  hasWebProviderEntryCredential,
+  providerRequiresCredential,
+  readWebProviderEnvValue,
+  resolveWebProviderConfig,
+} from "../../packages/web-content-core/src/provider-runtime-shared.js";
 import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
 import { hasAuthProfileForProvider } from "../agents/tools/model-config.helpers.js";
 import {
@@ -22,12 +28,6 @@ import {
 import { sortWebSearchProvidersForAutoDetect } from "../plugins/web-search-providers.shared.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime-web-tools-state.js";
 import type { RuntimeWebSearchMetadata } from "../secrets/runtime-web-tools.types.js";
-import {
-  hasWebProviderEntryCredential,
-  providerRequiresCredential,
-  readWebProviderEnvValue,
-  resolveWebProviderConfig,
-} from "../../packages/web-content-core/src/provider-runtime-shared.js";
 import type {
   ResolveWebSearchDefinitionParams,
   RunWebSearchParams,
@@ -472,6 +472,7 @@ export async function runWebSearch(params: RunWebSearchParams): Promise<RunWebSe
   let sawUnavailableProvider = false;
 
   for (const candidate of candidates) {
+    params.signal?.throwIfAborted();
     try {
       const definition = candidate.createTool({
         config,
@@ -499,7 +500,7 @@ export async function runWebSearch(params: RunWebSearchParams): Promise<RunWebSe
       };
     } catch (error) {
       lastError = error;
-      if (!allowFallback) {
+      if (params.signal?.aborted || !allowFallback) {
         throw error;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Cancelling an agent run while a Perplexity `web_search` request is pending leaves that HTTP request running. The parent execution signal reaches the generic web-search runtime, but the Perplexity provider discards the execution context, so the request can remain open and eventually resolve after cancellation.

## Why This Change Was Made

Forward the `AbortSignal` from the tool execution context through the provider to the guarded endpoint helper (`withTrustedWebSearchEndpoint` / `withSelfHostedWebSearchEndpoint`), which already accepts a signal parameter.

The change does not alter Perplexity configuration, schemas, caching, timeouts, SSRF policy, provider ordering, or response formatting. A focused test verifies the signal handoff.

Sibling PRs applying the same pattern: SearXNG (#104216 by zhangguiiping-xydt, 🐚 platinum hermit), Brave (#104269), plus the companion PRs filed alongside this one. The Google/Gemini provider already forwards the signal and serves as the reference.

## User Impact

Cancelling a run now promptly cancels an in-flight Perplexity search instead of consuming network and server resources until the configured timeout or response. Normal completed searches and cached results are unchanged.

## Evidence

Focused suite passes on the rebased head, including the signal-forwarding test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
