### PR TITLE
fix(sessions): derive list channels from agent keys

### DIFF
--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -23,6 +23,7 @@ export {
 import { normalizeOptionalString, type FastMode } from "@openclaw/normalization-core/string-coerce";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { toAgentRequestSessionKey } from "../../routing/session-key.js";
 import type { FastModeSource } from "../../shared/fast-mode.js";
 
 /** Coarse session category used by session list/status tools. */
@@ -157,11 +158,10 @@ export function deriveChannel(params: {
   if (lastChannel) {
     return lastChannel;
   }
-  const parts = params.key.split(":").filter(Boolean);
-  const scope = parts.at(1);
-  const keyChannel = parts.at(0);
-  if (parts.length >= 3 && keyChannel && (scope === "group" || scope === "channel")) {
-    return keyChannel;
+  const requestKey = toAgentRequestSessionKey(params.key) ?? params.key;
+  const parts = requestKey.split(":").filter(Boolean);
+  if (parts.length >= 3 && (parts[1] === "group" || parts[1] === "channel")) {
+    return parts[0];
   }
   return "unknown";
 }

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -23,7 +23,7 @@ export {
 import { normalizeOptionalString, type FastMode } from "@openclaw/normalization-core/string-coerce";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { toAgentRequestSessionKey } from "../../routing/session-key.js";
+import { parseRawSessionConversationRef } from "../../sessions/session-key-utils.js";
 import type { FastModeSource } from "../../shared/fast-mode.js";
 
 /** Coarse session category used by session list/status tools. */
@@ -158,10 +158,5 @@ export function deriveChannel(params: {
   if (lastChannel) {
     return lastChannel;
   }
-  const requestKey = toAgentRequestSessionKey(params.key) ?? params.key;
-  const parts = requestKey.split(":").filter(Boolean);
-  if (parts.length >= 3 && (parts[1] === "group" || parts[1] === "channel")) {
-    return parts[0];
-  }
-  return "unknown";
+  return parseRawSessionConversationRef(params.key)?.channel ?? "unknown";
 }

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -44,6 +44,7 @@ vi.mock("./sessions-helpers.js", async (importActual) => {
 
 type SessionsListDetails = {
   sessions?: Array<{
+    channel?: string;
     deliveryContext?: {
       accountId?: string;
       channel?: string;
@@ -200,6 +201,31 @@ describe("sessions-list-tool", () => {
       accountId: "acct-1",
       threadId: 99,
     });
+  });
+
+  it("derives channel from agent-scoped group session keys", async () => {
+    mocks.gatewayCall.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [
+            {
+              key: "agent:main:slack:channel:C123:thread:1710000000.000100",
+              kind: "group",
+              sessionId: "sess-slack-thread",
+            },
+          ],
+        };
+      }
+      return {};
+    });
+    const tool = createSessionsListTool({ config: {} as never });
+
+    const result = await tool.execute("call-agent-scoped-channel", {});
+    const details = getSessionsListDetails(result);
+
+    expect(details.sessions?.[0]?.channel).toBe("slack");
   });
 
   it("keeps live session setting metadata in sessions_list results", async () => {

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -203,7 +203,7 @@ describe("sessions-list-tool", () => {
     });
   });
 
-  it("derives channel from agent-scoped group session keys", async () => {
+  it("derives channels only from structurally valid group session keys", async () => {
     mocks.gatewayCall.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string };
       if (request.method === "sessions.list") {
@@ -215,6 +215,26 @@ describe("sessions-list-tool", () => {
               kind: "group",
               sessionId: "sess-slack-thread",
             },
+            {
+              key: "discord:group:ops",
+              kind: "group",
+              sessionId: "sess-discord-group",
+            },
+            {
+              key: "agent:main:matrix:channel:!room:[2001:db8::1]",
+              kind: "group",
+              sessionId: "sess-matrix-room",
+            },
+            {
+              key: "agent:main:agent:plugin:slack:channel:C123",
+              kind: "group",
+              sessionId: "sess-nested-agent",
+            },
+            {
+              key: "agent::slack:channel:C123",
+              kind: "group",
+              sessionId: "sess-malformed-agent",
+            },
           ],
         };
       }
@@ -225,7 +245,13 @@ describe("sessions-list-tool", () => {
     const result = await tool.execute("call-agent-scoped-channel", {});
     const details = getSessionsListDetails(result);
 
-    expect(details.sessions?.[0]?.channel).toBe("slack");
+    expect(details.sessions?.map((session) => session.channel)).toEqual([
+      "slack",
+      "discord",
+      "matrix",
+      "unknown",
+      "unknown",
+    ]);
   });
 
   it("keeps live session setting metadata in sessions_list results", async () => {


### PR DESCRIPTION
## What Problem This Solves

Archived or gateway-less group/channel sessions could be reported by `sessions_list` with `channel: "unknown"` when the only routing metadata was a canonical agent-scoped session key such as `agent:main:slack:channel:...`.

## Why This Change Was Made

The sessions list fallback now delegates key ownership to `parseRawSessionConversationRef`, the canonical structural parser already shared by channel, policy, plugin, and Gateway paths. Explicit `channel`, origin, delivery-context, and `lastChannel` precedence remains unchanged. Valid raw and one-level agent-scoped group/channel keys derive their normalized channel; malformed and nested-agent identities fail closed to `unknown`.

The original positional split was replaced because it duplicated session-key grammar and would have accepted structurally invalid nested identities.

AI-assisted: yes. The changed helper, caller, parser, sibling consumers, malformed/nested behavior, tests, and current `main` were reviewed.

## User Impact

`sessions_list` preserves useful transport labels for Slack, Discord, Matrix, Telegram, and similar canonical group/channel sessions even when older or lightweight rows lack separate routing metadata.

## Evidence

- Current head: `d2ff303c9688dd2cbc0fd5122ddd8d0d0348fce3`
- Blacksmith Testbox `tbx_01kxbtcpcwhzt9z067yg37a9fd`: 54/54 focused session-list and session-key preservation tests passed
- Path-scoped `pnpm check:changed`: production/test types, lint/format, SDK baseline, dependency and architecture guards, and import-cycle checks passed
- Fresh post-rebase autoreview: clean, confidence 0.97
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29205459725
- Runtime proof: the real `sessions_list` tool returned `channel: "slack"` from `agent:main:slack:channel:C123:thread:1710000000.000100` without separate channel metadata
