### PR TITLE
fix(qa-lab): use truncateUtf16Safe for web snapshot maxChars cap

### DIFF
--- a/extensions/qa-lab/src/web-runtime.test.ts
+++ b/extensions/qa-lab/src/web-runtime.test.ts
@@ -233,6 +233,21 @@ describe("qa web runtime", () => {
     await closeQaWebSessions();
   });
 
+  it("does not split a surrogate pair when truncating snapshot text at maxChars", async () => {
+    // 🤖 is U+1F916 — two UTF-16 code units. maxChars=4 lands inside the pair.
+    // raw .slice(0, 4) keeps "abc" + U+D83E (lone high surrogate);
+    // truncateUtf16Safe backs off to the safe boundary.
+    bodyLocator.textContent.mockResolvedValueOnce("abc🤖end");
+    const opened = await qaWebOpenPage({ url: "http://127.0.0.1:3000/chat" });
+    const snapshot = await qaWebSnapshot({ pageId: opened.pageId, maxChars: 4 });
+    await closeQaWebSessions();
+
+    const hasUnpairedSurrogate =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(snapshot.text);
+    expect(hasUnpairedSurrogate).toBe(false);
+    expect(snapshot.text.length).toBeLessThanOrEqual(4);
+  });
+
   it("caps oversized web runtime timeouts", async () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where `qaWebSnapshot` can produce invalid Unicode when a page's body text contains emoji or other supplementary-plane characters near the `maxChars` truncation boundary.

`qaWebSnapshot` caps the body text returned to QA scenarios with `text.slice(0, maxChars)`. QA scenarios use `maxChars: 12000` to snapshot the OpenClaw control UI, which can contain agent messages with emoji. When the page text reaches the cap with an emoji at the boundary, `slice` leaves a lone high surrogate in `snapshot.text` — which is then passed through `normalizeLowercaseStringOrEmpty` and used in `text.includes(needle)` assertions, potentially causing spurious needle misses.

**Concrete example:** `text = "abc🤖end"` (🤖 = U+1F916, two code units) with `maxChars: 4` — raw `.slice(0, 4)` keeps `"abc" + U+D83E`, a lone high surrogate.

## Why This Change Was Made

Replace `text.slice(0, maxChars)` with `truncateUtf16Safe(text, maxChars)` from `openclaw/plugin-sdk/text-utility-runtime`, matching the established pattern used across `src/infra/restart-sentinel.ts`, `src/auto-reply/reply/stage-sandbox-media.ts`, and others. No behavioral change when `maxChars` is unset or the text fits within the cap.

## User Impact

**Before:** QA scenarios that call `webSnapshot({ maxChars: 12000, … })` on a page whose text hits the cap with an emoji at the boundary receive `snapshot.text` with a lone surrogate, which can silently corrupt needle searches and produce unexpected scan misses.

**After:** `snapshot.text` is always well-formed Unicode; boundary emoji are dropped whole instead of split.

## Evidence

- `extensions/qa-lab/src/web-runtime.ts` — `qaWebSnapshot` uses `truncateUtf16Safe` for the head cap
- `qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml` — live QA scenario using `webSnapshot({ maxChars: 12000, … })` with emoji needle checks as canonical reachability
- `src/plugin-sdk/text-utility-runtime.ts` — exports `truncateUtf16Safe` as a proper SDK subpath for bundled plugins
- Regression: `extensions/qa-lab/src/web-runtime.test.ts` — new `does not split a surrogate pair when truncating snapshot text at maxChars` case

## Real behavior proof

- **Behavior or issue addressed:** `qaWebSnapshot` with an active `maxChars` cap no longer leaves unpaired UTF-16 surrogates when page body text contains emoji at the truncation boundary.
- **Canonical reachability path:** QA scenario `webSnapshot({ pageId, maxChars: 12000, … })` → `qaWebSnapshot` → `body.textContent()` → `truncateUtf16Safe(text, maxChars)` → `snapshot.text` → `normalizeLowercaseStringOrEmpty(snapshot.text).includes(needle)` in scenario assertion.
- **Boundary crossed:** local-runtime; no real browser needed — `bodyLocator.textContent` mock in the colocated Vitest injects the surrogate-boundary input directly into the production `qaWebSnapshot` code path.
- **Shared helper / provider constraint check:** Reused `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime`; no provider/channel constraints — this is plugin-local web snapshot text handling.
- **Real environment tested:** macOS (darwin 24.3.0), Node v22, branch `fix/qa-lab-web-snapshot-utf16`.
- **Exact steps or command run after this patch:**

```text
# 1. Real Chromium integration proof (playwright-core, headless)
$ cat playwright-utf16-proof.mts   # proof script (runs from repo root)
# launches real Chromium via playwright-core, calls page.setContent() with
# emoji content, reads body.textContent(), then shows raw .slice vs truncateUtf16Safe
$ pnpm exec tsx playwright-utf16-proof.mts

# 2. Regression suite
$ node scripts/run-vitest.mjs extensions/qa-lab/src/web-runtime.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
$ pnpm exec tsx playwright-utf16-proof.mts
=== real Chromium body.textContent() proof ===
body.textContent() length (code units): 8 | value: "abc🤖end"

raw .slice(0, 4):
  length: 4
  unpaired_surrogates: true
  hex: U+0061 U+0062 U+0063 U+D83E

truncateUtf16Safe(text, 4):
  length: 3
  unpaired_surrogates: false
  value: "abc"

$ node scripts/run-vitest.mjs extensions/qa-lab/src/web-runtime.test.ts --reporter=verbose
 RUN  v4.1.9 /Users/shen/Documents/GitHub/openclaw

 ✓ |extension-qa| extensions/qa-lab/src/web-runtime.test.ts > qa web runtime > opens, interacts with, snapshots, and closes a page 78ms
 ✓ |extension-qa| extensions/qa-lab/src/web-runtime.test.ts > qa web runtime > launches an explicit Chromium executable override when configured 1ms
 ✓ |extension-qa| extensions/qa-lab/src/web-runtime.test.ts > qa web runtime > launches detected system Chromium without requiring branded Chrome 0ms
 ✓ |extension-qa| extensions/qa-lab/src/web-runtime.test.ts > qa web runtime > keeps an explicit browser channel request explicit 0ms
 ✓ |extension-qa| extensions/qa-lab/src/web-runtime.test.ts > qa web runtime > can close only selected page sessions 1ms
 ✓ |extension-qa| extensions/qa-lab/src/web-runtime.test.ts > qa web runtime > does not split a surrogate pair when truncating snapshot text at maxChars 0ms
 ✓ |extension-qa| extensions/qa-lab/src/web-runtime.test.ts > qa web runtime > caps oversized web runtime timeouts 1ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  15:22:37
   Duration  535ms (transform 475ms, setup 321ms, import 44ms, tests 83ms, environment 0ms)
```

- **Observed result after fix:** Real headless Chromium (playwright-core, Chrome Headless Shell 149) loads `"abc🤖end"` via `page.setContent()` and `body.textContent()` returns an 8-code-unit JS string. Raw `.slice(0, 4)` leaves `U+D83E` alone (`unpaired_surrogates: true`). `truncateUtf16Safe(text, 4)` returns `"abc"` (`unpaired_surrogates: false`). This is the same real Playwright `locator("body").textContent()` call path that `qaWebSnapshot` uses. Regression suite: 7/7 pass including the new surrogate-boundary test. The only failing CI shard (`src/flows/doctor-health-contributions.test.ts`) is pre-existing on `upstream/main` — reproduced locally without this patch.
- **What was not tested:** Full live QA E2E scenario (`control-ui-qa-channel-image-roundtrip`) with a real OpenClaw gateway rendering 12,000+ code units of agent output with emoji at the boundary. The Playwright `body.textContent()` → `truncateUtf16Safe` path is fully verified above.
- **Fix classification:** Root cause fix.

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
- Single commit on `upstream/main`; no bundled `scripts/` or release-script changes
