### PR TITLE
fix(tasks): reset omitted lifecycle start time

### DIFF
--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -170,7 +170,11 @@ describe("startGatewayEventSubscriptions", () => {
   it("logs lazy agent event handler failures", async () => {
     unsubs = startGatewayEventSubscriptions(createParams());
 
-    emitAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "start" } });
+    emitAgentEvent({
+      runId: "run-1",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
 
     await waitForFast(() => expect(warn).toHaveBeenCalledTimes(1));
     expect(warn).toHaveBeenCalledWith(

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -142,7 +142,11 @@ describe("startGatewayEventSubscriptions", () => {
     unsubs = startGatewayEventSubscriptions(createParams());
 
     expect(auditTestState.created).toBe(1);
-    emitAgentAuditEvent({ runId: "enabled-audit", stream: "lifecycle", data: { phase: "start" } });
+    emitAgentAuditEvent({
+      runId: "enabled-audit",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
     expect(auditTestState.recorded).toBe(1);
     await unsubs.agentUnsub();
     expect(auditTestState.stopped).toBe(1);
@@ -156,9 +160,13 @@ describe("startGatewayEventSubscriptions", () => {
     emitAgentAuditEvent({
       runId: "disabled-private",
       stream: "lifecycle",
-      data: { phase: "start" },
+      data: { phase: "start", startedAt: 1_000 },
     });
-    emitAgentEvent({ runId: "disabled-public", stream: "lifecycle", data: { phase: "start" } });
+    emitAgentEvent({
+      runId: "disabled-public",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
     expect(auditTestState.recorded).toBe(0);
     await waitForFast(() => expect(warn).toHaveBeenCalledOnce());
     warn.mockClear();

--- a/src/infra/agent-event-lifecycle.ts
+++ b/src/infra/agent-event-lifecycle.ts
@@ -1,0 +1,11 @@
+/** Returns true when a lifecycle start omits its producer-owned finite timestamp. */
+export function hasInvalidLifecycleStartTimestamp(stream: string, data: unknown): boolean {
+  if (stream !== "lifecycle" || !data || typeof data !== "object" || Array.isArray(data)) {
+    return false;
+  }
+  const lifecycle = data as { phase?: unknown; startedAt?: unknown };
+  return (
+    lifecycle.phase === "start" &&
+    (typeof lifecycle.startedAt !== "number" || !Number.isFinite(lifecycle.startedAt))
+  );
+}

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -81,7 +81,7 @@ describe("agent-events sequencing", () => {
       runId: "audit-only-run",
       sessionKey: "agent:main:acp:session",
       stream: "lifecycle",
-      data: { phase: "start" },
+      data: { phase: "start", startedAt: 1_000 },
     });
     emitAgentAuditEvent({
       runId: "audit-only-run",
@@ -93,7 +93,7 @@ describe("agent-events sequencing", () => {
       runId: "audit-only-run",
       sessionKey: "agent:main:acp:session",
       stream: "lifecycle",
-      data: { phase: "start" },
+      data: { phase: "start", startedAt: 1_000 },
     });
 
     stopShared();
@@ -299,7 +299,7 @@ describe("agent-events sequencing", () => {
       runId: "shared-run",
       lifecycleGeneration: activeGeneration,
       stream: "lifecycle",
-      data: { phase: "start" },
+      data: { phase: "start", startedAt: 1_000 },
     });
     stop();
 
@@ -672,7 +672,7 @@ describe("agent-events sequencing", () => {
     emitAgentEvent({
       runId: "run-unscoped",
       stream: "lifecycle",
-      data: { phase: "start" },
+      data: { phase: "start", startedAt: 1_000 },
     });
     stop();
 

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -445,6 +445,30 @@ describe("agent-events sequencing", () => {
     expect(seen.find((evt) => evt.stream === "item")?.sessionId).toBeUndefined();
   });
 
+  test("rejects lifecycle starts without a finite producer timestamp", () => {
+    const seen: unknown[] = [];
+    const stop = onAgentEvent((evt) => seen.push(evt));
+
+    emitAgentEvent({ runId: "missing", stream: "lifecycle", data: { phase: "start" } });
+    emitAgentEvent({
+      runId: "invalid",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: Number.NaN },
+    });
+    emitAgentEvent({
+      runId: "valid",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_234 },
+    });
+    stop();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      runId: "valid",
+      data: { phase: "start", startedAt: 1_234 },
+    });
+  });
+
   test("rejects old runs after restart and stamps the new generation", () => {
     const oldGeneration = getAgentEventLifecycleGeneration();
     registerAgentRunContext("old-run", { sessionKey: "main" });
@@ -461,7 +485,11 @@ describe("agent-events sequencing", () => {
     });
 
     emitAgentEvent({ runId: "old-run", stream: "lifecycle", data: { phase: "end" } });
-    emitAgentEvent({ runId: "new-run", stream: "lifecycle", data: { phase: "start" } });
+    emitAgentEvent({
+      runId: "new-run",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_234 },
+    });
     stop();
 
     expect(newGeneration).not.toBe(oldGeneration);

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -641,6 +641,13 @@ function enrichAgentEvent(
   if (ownedLifecycleGeneration && ownedLifecycleGeneration !== state.lifecycleGeneration) {
     return undefined;
   }
+  if (
+    event.stream === "lifecycle" &&
+    event.data.phase === "start" &&
+    (typeof event.data.startedAt !== "number" || !Number.isFinite(event.data.startedAt))
+  ) {
+    return undefined;
+  }
   const nextSeq = (state.seqByRun.get(event.runId) ?? 0) + 1;
   state.seqByRun.set(event.runId, nextSeq);
   if (context) {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -5,6 +5,7 @@ import type { VerboseLevel } from "../auto-reply/thinking.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { notifyListeners, registerListener } from "../shared/listeners.js";
 import { createAbortError } from "./abort-signal.js";
+import { hasInvalidLifecycleStartTimestamp } from "./agent-event-lifecycle.js";
 
 /** Stream name for agent events delivered to gateway listeners and plugin host hooks. */
 export type AgentEventStream =
@@ -641,11 +642,7 @@ function enrichAgentEvent(
   if (ownedLifecycleGeneration && ownedLifecycleGeneration !== state.lifecycleGeneration) {
     return undefined;
   }
-  if (
-    event.stream === "lifecycle" &&
-    event.data.phase === "start" &&
-    (typeof event.data.startedAt !== "number" || !Number.isFinite(event.data.startedAt))
-  ) {
+  if (hasInvalidLifecycleStartTimestamp(event.stream, event.data)) {
     return undefined;
   }
   const nextSeq = (state.seqByRun.get(event.runId) ?? 0) + 1;

--- a/src/plugins/agent-event-emission.ts
+++ b/src/plugins/agent-event-emission.ts
@@ -71,6 +71,17 @@ export function emitPluginAgentEvent(params: {
       reason: `stream ${stream} must be scoped to plugin ${params.pluginId}`,
     };
   }
+  if (
+    stream === "lifecycle" &&
+    params.event.data &&
+    typeof params.event.data === "object" &&
+    !Array.isArray(params.event.data) &&
+    params.event.data.phase === "start" &&
+    (typeof params.event.data.startedAt !== "number" ||
+      !Number.isFinite(params.event.data.startedAt))
+  ) {
+    return { emitted: false, reason: "lifecycle start requires a finite startedAt timestamp" };
+  }
   emitAgentEvent({
     runId,
     stream,

--- a/src/plugins/agent-event-emission.ts
+++ b/src/plugins/agent-event-emission.ts
@@ -1,5 +1,6 @@
 // Emits agent events requested by plugin hook contracts.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { hasInvalidLifecycleStartTimestamp } from "../infra/agent-event-lifecycle.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import {
   isPluginJsonValue,
@@ -71,15 +72,7 @@ export function emitPluginAgentEvent(params: {
       reason: `stream ${stream} must be scoped to plugin ${params.pluginId}`,
     };
   }
-  if (
-    stream === "lifecycle" &&
-    params.event.data &&
-    typeof params.event.data === "object" &&
-    !Array.isArray(params.event.data) &&
-    params.event.data.phase === "start" &&
-    (typeof params.event.data.startedAt !== "number" ||
-      !Number.isFinite(params.event.data.startedAt))
-  ) {
+  if (hasInvalidLifecycleStartTimestamp(stream, params.event.data)) {
     return { emitted: false, reason: "lifecycle start requires a finite startedAt timestamp" };
   }
   emitAgentEvent({

--- a/src/plugins/contracts/session-actions.contract.test.ts
+++ b/src/plugins/contracts/session-actions.contract.test.ts
@@ -748,6 +748,23 @@ describe("plugin session actions", () => {
         }),
       ).toEqual({ emitted: true, stream: "approval" });
       expect(
+        bundledApi?.agent?.events.emitAgentEvent({
+          runId: "run-emit",
+          stream: "lifecycle",
+          data: { phase: "start" },
+        }),
+      ).toEqual({
+        emitted: false,
+        reason: "lifecycle start requires a finite startedAt timestamp",
+      });
+      expect(
+        bundledApi?.agent?.events.emitAgentEvent({
+          runId: "run-emit",
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: 1_234 },
+        }),
+      ).toEqual({ emitted: true, stream: "lifecycle" });
+      expect(
         workspaceApi?.emitAgentEvent({
           runId: "run-emit",
           stream: "lifecycle",

--- a/src/plugins/contracts/session-actions.contract.test.ts
+++ b/src/plugins/contracts/session-actions.contract.test.ts
@@ -806,7 +806,7 @@ describe("plugin session actions", () => {
       unsubscribe();
     }
 
-    expect(observed).toHaveLength(2);
+    expect(observed).toHaveLength(3);
     const bundledEvent = requireObservedEvent(observed, 0);
     expect(bundledEvent.runId).toBe("run-emit");
     expect(bundledEvent.sessionKey).toBe("agent:main:main");
@@ -816,7 +816,15 @@ describe("plugin session actions", () => {
       pluginId: "event-plugin",
       pluginName: "Event Plugin",
     });
-    const workspaceEvent = requireObservedEvent(observed, 1);
+    const lifecycleEvent = requireObservedEvent(observed, 1);
+    expect(lifecycleEvent.stream).toBe("lifecycle");
+    expect(lifecycleEvent.data).toEqual({
+      phase: "start",
+      startedAt: 1_234,
+      pluginId: "event-plugin",
+      pluginName: "Event Plugin",
+    });
+    const workspaceEvent = requireObservedEvent(observed, 2);
     expect(workspaceEvent.runId).toBe("run-emit");
     expect(workspaceEvent.sessionKey).toBeUndefined();
     expect(workspaceEvent.stream).toBe("workspace-event-plugin.workflow");

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -670,6 +670,42 @@ describe("task-registry", () => {
     );
   });
 
+  it("ignores a non-finite lifecycle timestamp during durable terminal projection", async () => {
+    await withTaskRegistryTempDir(
+      async () => {
+        resetTaskRegistryForTests({ persist: false });
+        createTaskRecord({
+          runtime: "acp",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          requesterSessionKey: "agent:main:main",
+          runId: "run-non-finite-terminal",
+          task: "Keep the accepted producer timestamp",
+          status: "running",
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+          startedAt: 1_000,
+        });
+
+        emitAgentEvent({
+          runId: "run-non-finite-terminal",
+          stream: "lifecycle",
+          data: { phase: "end", startedAt: Number.NaN, endedAt: 1_500 },
+        });
+
+        resetTaskRegistryForTests({ persist: false });
+        reloadTaskRegistryFromStore();
+
+        expectRecordFields(requireTaskByRunId("run-non-finite-terminal"), {
+          status: "succeeded",
+          startedAt: 1_000,
+          endedAt: 1_500,
+        });
+      },
+      { durableStore: true },
+    );
+  });
+
   it("tracks tool activity from tool-start events", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
@@ -712,7 +748,7 @@ describe("task-registry", () => {
         toolUseCount: 2,
         lastToolName: "exec",
       });
-      });
+    });
   });
 
   it("keeps subagent abort lifecycle projections provisional", async () => {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -633,6 +633,43 @@ describe("task-registry", () => {
     );
   });
 
+  it("persists an accepted zero lifecycle start timestamp over stale state", async () => {
+    await withTaskRegistryTempDir(
+      async () => {
+        resetTaskRegistryForTests({ persist: false });
+        createTaskRecord({
+          runtime: "acp",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          requesterSessionKey: "agent:main:main",
+          runId: "run-zero-lifecycle",
+          task: "Replace a stale task timestamp",
+          status: "queued",
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+          startedAt: 1_000,
+        });
+
+        emitAcpLifecycleStart({ runId: "run-zero-lifecycle", startedAt: 0 });
+        emitAgentEvent({
+          runId: "run-zero-lifecycle",
+          stream: "lifecycle",
+          data: { phase: "end", endedAt: 500 },
+        });
+
+        resetTaskRegistryForTests({ persist: false });
+        reloadTaskRegistryFromStore();
+
+        expectRecordFields(requireTaskByRunId("run-zero-lifecycle"), {
+          status: "succeeded",
+          startedAt: 0,
+          endedAt: 500,
+        });
+      },
+      { durableStore: true },
+    );
+  });
+
   it("tracks tool activity from tool-start events", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
@@ -675,7 +712,7 @@ describe("task-registry", () => {
         toolUseCount: 2,
         lastToolName: "exec",
       });
-    });
+      });
   });
 
   it("keeps subagent abort lifecycle projections provisional", async () => {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -633,7 +633,7 @@ describe("task-registry", () => {
         toolUseCount: 2,
         lastToolName: "exec",
       });
-    });
+      });
   });
 
   it("keeps subagent abort lifecycle projections provisional", async () => {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AcpSessionStoreEntry } from "../acp/runtime/session-meta.js";
 import { startAcpSpawnParentStreamRelay } from "../agents/acp-spawn-parent-stream.js";
+import { emitAcpLifecycleStart } from "../agents/command/attempt-execution.js";
 import { resetCronActiveJobs } from "../cron/active-jobs.js";
 import {
   emitAgentEvent,
@@ -591,6 +592,47 @@ describe("task-registry", () => {
     });
   });
 
+  it("persists an ACP producer timestamp across lifecycle projection and SQLite reload", async () => {
+    await withTaskRegistryTempDir(
+      async () => {
+        resetTaskRegistryForTests({ persist: false });
+        createTaskRecord({
+          runtime: "acp",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          requesterSessionKey: "agent:main:main",
+          runId: "run-reused-lifecycle",
+          task: "Reuse a persisted task row",
+          status: "queued",
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+          startedAt: 1_000,
+          lastEventAt: 1_000,
+        });
+
+        emitAcpLifecycleStart({
+          runId: "run-reused-lifecycle",
+          startedAt: 2_000,
+        });
+        emitAgentEvent({
+          runId: "run-reused-lifecycle",
+          stream: "lifecycle",
+          data: { phase: "end", endedAt: 2_500 },
+        });
+
+        resetTaskRegistryForTests({ persist: false });
+        reloadTaskRegistryFromStore();
+
+        expectRecordFields(requireTaskByRunId("run-reused-lifecycle"), {
+          status: "succeeded",
+          startedAt: 2_000,
+          endedAt: 2_500,
+        });
+      },
+      { durableStore: true },
+    );
+  });
+
   it("tracks tool activity from tool-start events", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
@@ -633,7 +675,7 @@ describe("task-registry", () => {
         toolUseCount: 2,
         lastToolName: "exec",
       });
-      });
+    });
   });
 
   it("keeps subagent abort lifecycle projections provisional", async () => {

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1807,8 +1807,11 @@ function ensureListener() {
       };
       if (evt.stream === "lifecycle") {
         const phase = typeof evt.data?.phase === "string" ? evt.data.phase : undefined;
+        const eventStartedAt = evt.data?.startedAt;
         const startedAt =
-          typeof evt.data?.startedAt === "number" ? evt.data.startedAt : current.startedAt;
+          typeof eventStartedAt === "number" && Number.isFinite(eventStartedAt)
+            ? eventStartedAt
+            : current.startedAt;
         const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : undefined;
         if (startedAt !== undefined) {
           patch.startedAt = startedAt;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1810,7 +1810,7 @@ function ensureListener() {
         const startedAt =
           typeof evt.data?.startedAt === "number" ? evt.data.startedAt : current.startedAt;
         const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : undefined;
-        if (startedAt) {
+        if (startedAt !== undefined) {
           patch.startedAt = startedAt;
         }
         if (phase === "start") {

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1808,11 +1808,7 @@ function ensureListener() {
       if (evt.stream === "lifecycle") {
         const phase = typeof evt.data?.phase === "string" ? evt.data.phase : undefined;
         const startedAt =
-          typeof evt.data?.startedAt === "number"
-            ? evt.data.startedAt
-            : phase === "start"
-              ? now
-              : current.startedAt;
+          typeof evt.data?.startedAt === "number" ? evt.data.startedAt : current.startedAt;
         const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : undefined;
         if (startedAt) {
           patch.startedAt = startedAt;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1808,7 +1808,11 @@ function ensureListener() {
       if (evt.stream === "lifecycle") {
         const phase = typeof evt.data?.phase === "string" ? evt.data.phase : undefined;
         const startedAt =
-          typeof evt.data?.startedAt === "number" ? evt.data.startedAt : current.startedAt;
+          typeof evt.data?.startedAt === "number"
+            ? evt.data.startedAt
+            : phase === "start"
+              ? now
+              : current.startedAt;
         const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : undefined;
         if (startedAt) {
           patch.startedAt = startedAt;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a malformed lifecycle start without a finite producer timestamp could leave an older task `startedAt` value in durable state. Downstream task duration could therefore describe a previous run, while a receipt-time fallback would hide the producer defect.

## Why This Change Was Made

Lifecycle producers own the true start instant. A shared validator now rejects `phase: "start"` unless `startedAt` is finite at both host and bundled-plugin admission; invalid direct events are dropped before sequencing and bundled-plugin callers receive an explicit `{ emitted: false }` result. Task projection independently accepts only finite timestamps, including `0`, and preserves prior finite state on malformed terminal data.

External plugins cannot emit the reserved lifecycle stream. Embedded, CLI, ACP, and bundled Codex producers were traced and already provide finite timestamps, so valid behavior and persisted schemas are unchanged.

## User Impact

Durable task timing now reflects the runtime producer's real start time instead of stale or fabricated state. Supported runtimes continue unchanged; malformed bundled-plugin starts fail explicitly.

## Evidence

- Focused Vitest: agent-events 36, bundled-plugin contract 10, gateway subscriptions 8, task registry 122 — 176 passed.
- Targeted oxfmt and oxlint — passed.
- Full branch autoreview — clean, confidence 0.93; rebase-resolution and shared-validator reviews clean at 0.99.
- Local changed gate passed format, boundaries, dependency guards, Plugin SDK baseline, and core/core-test/extension/extension-test typechecks. Its initial lint pass identified the agent-events line ceiling; extracting the shared validator fixed that exact finding and targeted lint passed.
- Blacksmith Testbox `tbx_01ky1t3smt79fbtmyp86x2mk0b` did not execute the command because delegated sync timed out: https://github.com/openclaw/openclaw/actions/runs/29811562814

Direct Codex contract check: sibling Codex `9970cd706fc4f25bbb97b42f4b68d993dabe91e2` captures item starts with `now_unix_timestamp_ms()` (`codex-rs/core/src/session/mod.rs:1999`, `codex-rs/core/src/turn_timing.rs:183`). OpenClaw's bundled Codex lifecycle uses its own finite `attemptStartedAt`, independent of optional upstream response metadata.

## Credit

Rebased and completed from the contribution by mikasa0818 (@mikasa0818). Contributor commits remain in the branch; maintainer resolution commits include `Co-authored-by: mikasa0818 <0668001030@xydigit.com>`.

AI-assisted: yes; the maintainer reviewed the full event admission, plugin boundary, task persistence, gateway fixture, and Codex source surfaces.
