### PR TITLE
fix(doctor): restore local audio information

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1667,21 +1667,6 @@ describe("doctor health contributions", () => {
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
   });
 
-  it("keeps local audio inventory in the lint flow", async () => {
-    const contribution = requireDoctorContribution("doctor:local-audio-acceleration");
-    const contributionChecks = await resolveDoctorContributionHealthChecks();
-
-    expect(contribution.healthCheckIds).toEqual(["core/doctor/local-audio-acceleration"]);
-    expect(
-      contributionChecks.find((check) => check.id === "core/doctor/local-audio-acceleration"),
-    ).toBeDefined();
-
-    await contribution.run({} as DoctorContributionRunContext);
-
-    expect(mocks.getHealthCheck).not.toHaveBeenCalled();
-    expect(mocks.note).not.toHaveBeenCalled();
-  });
-
   it("keeps systemd linger opt-in and reports disabled linger when selected", async () => {
     const contributionChecks = await resolveDoctorContributionHealthChecks();
     const systemdLingerCheck = contributionChecks.find(

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1509,6 +1509,10 @@ async function runProviderCatalogProjectionHealth(ctx: DoctorHealthFlowContext):
   await runCoreHealthFindingNote(ctx, "core/doctor/provider-catalog-projection");
 }
 
+async function runLocalAudioAccelerationHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  await runCoreHealthFindingNote(ctx, "core/doctor/local-audio-acceleration");
+}
+
 async function runRuntimeToolSchemasHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   await runCoreHealthFindingNote(ctx, "core/doctor/runtime-tool-schemas");
 }
@@ -2037,9 +2041,7 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:local-audio-acceleration",
       label: "Local audio acceleration",
       healthCheckIds: ["core/doctor/local-audio-acceleration"],
-      // This informational inventory is rendered through `doctor --lint`.
-      // Keep the normal doctor flow quiet instead of presenting healthy local STT as a warning.
-      run: async () => {},
+      run: runLocalAudioAccelerationHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:runtime-tool-schemas",


### PR DESCRIPTION
## What Problem This Solves

Two concurrent merges left current main internally inconsistent. #104045 made the shared doctor bridge severity-aware and added a test requiring local-audio `info` findings to render as `Doctor information` without failing health. #104237 then merged its earlier no-op runner over that newer behavior, so the test now fails and ordinary doctor silently drops the informational inventory.

## Why This Change Was Made

Restore the local-audio contribution runner through the now severity-aware `runCoreHealthFindingNote` path and remove the superseded no-op boundary test. The existing #104045 regression test remains the canonical contract: informational findings render, `healthOk` stays true, and no warning is emitted.

The resulting two file blobs exactly match the reviewed severity-aware implementation from main immediately before #104237.

## User Impact

`openclaw doctor` reports available local STT selection under `Doctor information` without treating it as unhealthy. The documented `doctor --lint --only core/doctor/local-audio-acceleration --severity-min info` path remains available.

## Evidence

- AWS Crabbox `run_d287bef2516e`: 2 files / 113 focused doctor tests passed on current main plus this repair.
- [PR #104207 failing job](https://github.com/openclaw/openclaw/actions/runs/29144430184/job/86523433454) pinpoints the current-main contradiction in `reports local audio acceleration as information without failing doctor health`.
- Canonical `oxfmt --check` on both changed TypeScript files: passed.
- `git diff --check`: passed.
- Fresh autoreview: no actionable findings; patch correct at 0.86 confidence.

Related: #104045, #104237, #104207
