### PR TITLE
chore(ui): remove dead .sidebar-new-session styles

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -941,59 +941,6 @@ html.openclaw-native-macos .shell-nav-expand {
   margin-top: 10px;
 }
 
-.sidebar-new-session {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 8px;
-  width: 100%;
-  min-height: 34px;
-  box-sizing: border-box;
-  padding: 0 9px;
-  border: none;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--accent);
-  font: inherit;
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1.2;
-  transition:
-    background var(--duration-fast) ease,
-    color var(--duration-fast) ease;
-}
-
-.sidebar-new-session:hover:not(:disabled) {
-  background: var(--accent-subtle);
-  color: var(--accent-hover);
-}
-
-.sidebar-new-session:disabled {
-  cursor: not-allowed;
-  opacity: 0.52;
-}
-
-.sidebar-new-session__icon,
-.sidebar-new-session__icon svg {
-  width: 15px;
-  height: 15px;
-}
-
-.sidebar-new-session__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: currentColor;
-}
-
-.sidebar-new-session__icon svg {
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.8px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
 /* min-height: 0 down this chain lets the recent list shrink and scroll instead
    of pushing the sidebar footer out of view. */
 .sidebar-recent-sessions {
@@ -2356,4 +2303,3 @@ openclaw-session-menu[popover] {
   color: var(--text-strong);
   font-style: italic;
 }
-


### PR DESCRIPTION
## What Problem This Solves

`ui/src/styles/layout.css` carried a 53-line `.sidebar-new-session` rule family (base, `:hover:not(:disabled)`, `:disabled`, `__icon`, `__icon svg`) with no remaining users. Dead selectors in the shared layout stylesheet mislead future sidebar work and pad the bundle.

## Why This Change Was Made

The last consumer was removed by the sessions-sidebar redesign (#103498), which switched the header button to the `sidebar-session-new` class; the old styles have been orphaned since. A repo-wide sweep (`ui/`, `apps/`, `docs/`, `src/`, all file types, plus a check for dynamically composed `sidebar-${...}` class names and e2e selectors) finds no references outside the CSS itself. Also drops one stray trailing blank line that made `oxfmt --check` fail on this file.

## User Impact

None visible; slightly smaller stylesheet. Pure deletion (−54 lines), no selectors that render anywhere are affected.

## Evidence

- `grep -rn "sidebar-new-session" ui apps docs src` → 0 matches after the change (7 CSS-only matches before).
- `oxfmt --check ui/src/styles/layout.css` passes after the change (failed before, due to the pre-existing trailing blank line).
- `git diff --check` clean; diff is deletions-only.
