### PR TITLE
fix: paired Mac Codex sessions finish loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex fleet session catalogs:** allow cold large-session scans on paired Mac nodes to finish before the Gateway reports the host unavailable.
 - **iOS Share Extension drafts:** preserve legitimate shared text beginning with scaffold-like prefixes, remove only exact legacy scaffold lines, avoid treating scheme-like prose as a URL, and deduplicate host-mirrored content. (#103453) Thanks @lin-hongkuan.
 - **Telegram reasoning previews:** reposition split reasoning previews through deferred deletion so prior preview messages do not remain stale while preserving client scroll position. (#97828) Thanks @ly-wang19.
 - **Feishu native-card threading:** normalize whitespace reply targets once and reuse the shared reply mode for card and media parts so native-card topic replies stay in their thread. (#102804) Thanks @sunlit-deng.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Codex fleet session catalogs:** allow cold large-session scans on paired Mac nodes to finish before the Gateway reports the host unavailable.
 - **iOS Share Extension drafts:** preserve legitimate shared text beginning with scaffold-like prefixes, remove only exact legacy scaffold lines, avoid treating scheme-like prose as a URL, and deduplicate host-mirrored content. (#103453) Thanks @lin-hongkuan.
 - **Telegram reasoning previews:** reposition split reasoning previews through deferred deletion so prior preview messages do not remain stale while preserving client scroll position. (#97828) Thanks @ly-wang19.
 - **Feishu native-card threading:** normalize whitespace reply targets once and reuse the shared reply mode for card and media parts so native-card topic replies stay in their thread. (#102804) Thanks @sunlit-deng.

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalog.swift
@@ -131,6 +131,7 @@ enum MacNodeCodexThreadCatalog {
     static let defaultUserMacOSBetaAppExecutable = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Applications/Codex Beta.app/Contents/Resources/codex")
         .path
+    static let defaultTimeoutSeconds: Double = 24
     private static let maxSessionIdLength = 256
     private static let maxSessionNameLength = 500
     private static let maxCwdLength = 4096
@@ -208,7 +209,7 @@ enum MacNodeCodexThreadCatalog {
         arguments: [String]? = nil,
         cwd: URL? = nil,
         clearEnv: [String] = [],
-        timeoutSeconds: Double = 12,
+        timeoutSeconds: Double = MacNodeCodexThreadCatalog.defaultTimeoutSeconds,
         maxLineBytes: Int = 5 * 1024 * 1024) async throws -> String
     {
         let params = try self.decodeParams(paramsJSON)
@@ -226,7 +227,7 @@ enum MacNodeCodexThreadCatalog {
     private static func list(
         params: ListParams,
         invocation: ResolvedInvocation,
-        timeoutSeconds: Double = 12,
+        timeoutSeconds: Double = MacNodeCodexThreadCatalog.defaultTimeoutSeconds,
         maxLineBytes: Int = 5 * 1024 * 1024) async throws -> String
     {
         guard params.searchTerm != nil else {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -940,6 +940,10 @@ struct MacNodeCodexThreadCatalogTests {
         #expect((decoded["sessions"] as? [Any])?.count == 50)
     }
 
+    @Test func `default deadline allows cold large catalog scans`() {
+        #expect(MacNodeCodexThreadCatalog.defaultTimeoutSeconds == 24)
+    }
+
     @Test func `rejects unknown and out of range params before launch`() async {
         let cases = [
             (#"{"extra":true}"#, "unknown Codex session catalog parameter: extra"),

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -752,6 +752,7 @@ describe("Codex supervision catalog", () => {
         nodeId: "devbox",
         command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
         params: expect.not.objectContaining({ archived: expect.anything() }),
+        timeoutMs: 28_000,
       }),
     );
     expect(JSON.stringify(result)).not.toContain("private");

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -74,7 +74,10 @@ export const CODEX_SESSION_ARCHIVE_METHOD = "codex.sessions.archive";
 const CODEX_APP_SERVER_THREADS_CAPABILITY = "codex-app-server-threads";
 const DEFAULT_PAGE_LIMIT = 50;
 export const CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT = 100;
-const NODE_INVOKE_TIMEOUT_MS = 20_000;
+// A node may need a cold Codex state scan before returning a large catalog page.
+// Keep this above the Mac node's native 24-second deadline so its result wins,
+// while remaining below the shared CLI client's 30-second outer deadline.
+const NODE_INVOKE_TIMEOUT_MS = 28_000;
 const MAX_SEARCH_LENGTH = 500;
 const MAX_CURSOR_LENGTH = 4096;
 const MAX_CURSOR_COUNT = 100;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Codex Sessions across paired Macs could see a healthy Mac reported as unavailable when its large native Codex history needed more than 12 seconds for a cold catalog scan.

## Why This Change Was Made

The Mac node now allows 24 seconds for the native App Server scan, while the Gateway node invocation allows 28 seconds. This preserves transport headroom and remains below the CLI client's 30-second outer deadline, so slow hosts remain isolated without turning the whole fleet request into a failure.

## User Impact

Large non-archived Codex catalogs on paired Macs can finish loading in Codex Sessions instead of intermittently showing `NODE_INVOKE_FAILED`.

## Evidence

- Testbox: `pnpm test extensions/codex/src/session-catalog.test.ts` — 69 passed.
- Testbox: `pnpm check:changed` — passed all selected typecheck, lint, macOS packaging, daemon, boundary, tooling, and guard lanes.
- clawmac macOS proof: `swift test --filter MacNodeCodexThreadCatalogTests` — 25 passed.
- Structured autoreview after the final timeout ordering — clean, no actionable findings.
- Live before-fix reproduction: a 40-session MacBook catalog timed out through the paired-node command while a 10-session request succeeded.
