### PR TITLE
improve(control-ui): move dev branch badge to its own footer strip

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1941,6 +1941,14 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               .soundsEnabled=${this.lobsterPetSounds}
               .gatewayVersion=${this.gatewayVersion}
             ></openclaw-lobster-pet>
+            ${this.devGitBranch
+              ? html`<div class="sidebar-footer-branch" title=${this.devGitBranch}>
+                  <span class="sidebar-footer-branch__icon" aria-hidden="true"
+                    >${icons.gitBranch}</span
+                  >
+                  <span class="sidebar-footer-branch__name">${this.devGitBranch}</span>
+                </div>`
+              : nothing}
             <div class="sidebar-footer-bar">
               <openclaw-tooltip .content=${gatewayStatusTooltip}>
                 <span
@@ -1952,11 +1960,6 @@ class AppSidebar extends OpenClawLightDomContentsElement {
                   aria-label=${gatewayStatus}
                 ></span>
               </openclaw-tooltip>
-              ${this.devGitBranch
-                ? html`<span class="sidebar-footer-branch" title=${this.devGitBranch}
-                    >${this.devGitBranch}</span
-                  >`
-                : nothing}
               <span class="sidebar-footer-bar__spacer"></span>
               <openclaw-tooltip .content=${settingsTooltip}>
                 <a

--- a/ui/src/e2e/sidebar-dev-branch.e2e.test.ts
+++ b/ui/src/e2e/sidebar-dev-branch.e2e.test.ts
@@ -52,7 +52,9 @@ describeControlUiE2e("Control UI sidebar dev branch badge E2E", () => {
 
       const badge = page.locator(".sidebar-footer-branch");
       await badge.waitFor();
-      await expect.poll(() => badge.textContent()).toBe(DEV_BRANCH);
+      await expect
+        .poll(() => badge.locator(".sidebar-footer-branch__name").textContent())
+        .toBe(DEV_BRANCH);
       await expect.poll(() => badge.getAttribute("title")).toBe(DEV_BRANCH);
 
       const colors = await badge.evaluate((element) => {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1735,18 +1735,43 @@ openclaw-session-menu[popover] {
   flex: 1 1 auto;
 }
 
-/* Dev-checkout branch badge: only rendered when the gateway runs from a git
-   checkout off main, so operators notice non-release gateway code at a glance. */
+/* Dev-checkout branch strip: only rendered when the gateway runs from a git
+   checkout off main. Sits on its own row above the icon bar so the full branch
+   name stays readable without crowding the footer controls. */
 .sidebar-footer-branch {
-  flex: 0 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   min-width: 0;
-  margin-left: 6px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  margin: 0 10px 2px;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
   font-size: 11px;
   font-family: var(--font-mono);
   color: var(--danger);
+}
+
+.sidebar-footer-branch__icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.sidebar-footer-branch__icon svg {
+  width: 12px;
+  height: 12px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.7px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.sidebar-footer-branch__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Footer icons mix in-app anchors, buttons, and one external docs link: the


### PR DESCRIPTION
Related: #104262

## What Problem This Solves

The dev-branch badge added in #104262 rendered inline in the sidebar footer icon row, which made the row crowded: connection dot, truncated red branch name, and four icon buttons all competed for one 34px strip, and long `claude/…` branch names truncated to noise.

## Why This Change Was Made

The branch indicator moves to its own slim tinted strip directly above the footer icon row, with a git-branch icon and the full branch name (ellipsis only when the sidebar is very narrow, full name in the tooltip). The icon row returns to exactly its pre-#104262 layout. Rendering is still gated on `devGitBranch` from the bootstrap config, so release installs and mainline checkouts get no extra row.

## User Impact

On dev gateways the full branch name is now readable at a glance instead of truncated, and the footer controls are uncluttered. Release installs are unchanged.

## Evidence

Footer with the new strip (from the e2e screenshot artifact):

![sidebar footer with dev branch strip above the icon row](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-dev-branch/footer-dev-branch-strip.png)

- `ui/src/e2e/sidebar-dev-branch.e2e.test.ts` updated for the new structure (name span, strip container title/color): 2 tests green on Testbox with Playwright chromium.
- `oxfmt --check` green on the changed files (Testbox).
- Autoreview (codex, gpt-5.5): clean, no actionable findings.
