### PR TITLE
fix(utils): use UTF-16 safe truncation for long URL timeout logs

### DIFF
--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -191,6 +191,28 @@ describe("buildTimeoutAbortSignal", () => {
     expect(JSON.stringify(record)).not.toContain(SYNTHETIC_TELEGRAM_BOT_TOKEN);
   });
 
+  it("does not split surrogate pairs at the fallback timeout URL boundary", async () => {
+    const visiblePrefix = "x".repeat(499);
+    const record = await captureTimeoutLogUrl(`${visiblePrefix}🚀tail`);
+    const expectedUrl = `${visiblePrefix}...`;
+
+    expect(record.url).toBe(expectedUrl);
+    expect(record.consoleMessage).toBe(
+      `fetch timeout after 25ms (elapsed 25ms) operation=unit-test url=${expectedUrl}`,
+    );
+  });
+
+  it("keeps the full ASCII budget in fallback timeout URL logs", async () => {
+    const visiblePrefix = "x".repeat(500);
+    const record = await captureTimeoutLogUrl(`${visiblePrefix}tail`);
+    const expectedUrl = `${visiblePrefix}...`;
+
+    expect(record.url).toBe(expectedUrl);
+    expect(record.consoleMessage).toBe(
+      `fetch timeout after 25ms (elapsed 25ms) operation=unit-test url=${expectedUrl}`,
+    );
+  });
+
   it.each([
     ["https://example.com/bot/settings?safe=1", "https://example.com/bot/settings"],
     ["https://example.com/bots/chat?safe=1", "https://example.com/bots/chat"],

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -1,5 +1,6 @@
 // Fetch timeout helpers wrap fetch calls with timeout and abort behavior.
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveSafeTimeoutDelayMs } from "./timer-delay.js";
 
@@ -41,7 +42,9 @@ function sanitizeTimeoutLogUrl(rawUrl: string | undefined): string | undefined {
     parsed.search = "";
     parsed.hash = "";
     const value = redactSensitiveUrlLikeString(parsed.toString());
-    return value.length > LOG_URL_MAX_CHARS ? `${value.slice(0, LOG_URL_MAX_CHARS)}...` : value;
+    return value.length > LOG_URL_MAX_CHARS
+      ? `${truncateUtf16Safe(value, LOG_URL_MAX_CHARS)}...`
+      : value;
   } catch {
     const withoutQueryOrHash = trimmed.split(URL_SECRET_SUFFIX_PATTERN, 1)[0] ?? "";
     const cleaned = redactSensitiveUrlLikeString(
@@ -55,7 +58,7 @@ function sanitizeTimeoutLogUrl(rawUrl: string | undefined): string | undefined {
       return undefined;
     }
     return cleaned.length > LOG_URL_MAX_CHARS
-      ? `${cleaned.slice(0, LOG_URL_MAX_CHARS)}...`
+      ? `${truncateUtf16Safe(cleaned, LOG_URL_MAX_CHARS)}...`
       : cleaned;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

`sanitizeTimeoutLogUrl` in `src/utils/fetch-timeout.ts` truncates long URLs with `String.prototype.slice(0, LOG_URL_MAX_CHARS)`, which can split surrogate pairs in URLs containing emoji or other multi-byte characters, producing replacement characters (`�`) in timeout log output.

## Why This Change Was Made

Replaces two `value.slice(0, LOG_URL_MAX_CHARS)` calls with `truncateUtf16Safe()` from `@openclaw/normalization-core/utf16-slice`, matching the pattern established by 10+ merged UTF-16 safety PRs across the codebase.

## User Impact

- Long URLs containing emoji/Unicode in timeout logs are now truncated without corrupting surrogate pairs
- No change to truncation behavior for ASCII URLs
- Same `LOG_URL_MAX_CHARS = 500` limit preserved

## Evidence

```
$ npx vitest run src/utils/fetch-timeout.test.ts --reporter=verbose

 ✓  utils  src/utils/fetch-timeout.test.ts > buildTimeoutAbortSignal > logs when its own timeout aborts the signal
 ✓  utils  src/utils/fetch-timeout.test.ts > buildTimeoutAbortSignal > keeps timeout aborts visible to OpenAI SSE streams
 ✓  utils  src/utils/fetch-timeout.test.ts > buildTimeoutAbortSignal > annotates timeout logs when the timer fires late
 ... (22/22 passed)

 Test Files  1 passed (1)
      Tests  22 passed (22)
```