### PR TITLE
fix: cancel expired macOS node approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS node approval timeouts:** close an interactive execution-approval dialog when its node invoke expires so stale requests cannot block later commands. (#104282)
 - **iOS Share Extension drafts:** preserve legitimate shared text beginning with scaffold-like prefixes, remove only exact legacy scaffold lines, avoid treating scheme-like prose as a URL, and deduplicate host-mirrored content. (#103453) Thanks @lin-hongkuan.
 - **Telegram reasoning previews:** reposition split reasoning previews through deferred deletion so prior preview messages do not remain stale while preserving client scroll position. (#97828) Thanks @ly-wang19.
 - **Feishu native-card threading:** normalize whitespace reply targets once and reuse the shared reply mode for card and media parts so native-card topic replies stay in their thread. (#102804) Thanks @sunlit-deng.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS node approval timeouts:** close an interactive execution-approval dialog when its node invoke expires so stale requests cannot block later commands. (#104282)
 - **iOS Share Extension drafts:** preserve legitimate shared text beginning with scaffold-like prefixes, remove only exact legacy scaffold lines, avoid treating scheme-like prose as a URL, and deduplicate host-mirrored content. (#103453) Thanks @lin-hongkuan.
 - **Telegram reasoning previews:** reposition split reasoning previews through deferred deletion so prior preview messages do not remain stale while preserving client scroll position. (#97828) Thanks @ly-wang19.
 - **Feishu native-card threading:** normalize whitespace reply targets once and reuse the shared reply mode for card and media parts so native-card topic replies stay in their thread. (#102804) Thanks @sunlit-deng.

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
@@ -49,7 +49,13 @@ final class ExecApprovalsGatewayPrompter {
             // decision. If this Mac cannot present UI, leave the request
             // unresolved so the Gateway applies its current timeout fallback.
             guard self.shouldPresent(request: request) else { return }
-            guard let decision = ExecApprovalsPromptPresenter.prompt(request.request) else {
+            let nowMs = Int(Date().timeIntervalSince1970 * 1000)
+            let (remainingMs, overflow) = request.expiresAtMs.subtractingReportingOverflow(nowMs)
+            guard !overflow, remainingMs > 0 else { return }
+            guard let decision = await ExecApprovalsPromptPresenter.prompt(
+                request.request,
+                timeoutMs: remainingMs)
+            else {
                 return
             }
             try await GatewayConnection.shared.requestVoid(

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -5,6 +5,8 @@ import Foundation
 import OpenClawKit
 import OSLog
 
+private let execApprovalsSocketTimeoutMs = 15000
+
 struct ExecApprovalPromptRequest: Codable {
     var command: String
     var cwd: String?
@@ -363,7 +365,9 @@ final class ExecApprovalsPromptServer {
             return (approvals.socketPath, approvals.token)
         },
         onPrompt: @escaping @Sendable (ExecApprovalPromptRequest) async -> ExecApprovalDecision? = { request in
-            await ExecApprovalsPromptPresenter.prompt(request)
+            await ExecApprovalsPromptPresenter.prompt(
+                request,
+                timeoutMs: execApprovalsSocketTimeoutMs)
         })
     {
         self.retryDelay = retryDelay
@@ -583,8 +587,62 @@ final class ExecApprovalsPromptServer {
 }
 
 enum ExecApprovalsPromptPresenter {
+    private struct PendingPrompt {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
     @MainActor
-    static func prompt(_ request: ExecApprovalPromptRequest) -> ExecApprovalDecision? {
+    private static var activePrompt: (id: UUID, alert: NSAlert?, cancelled: Bool)?
+    @MainActor
+    private static var pendingPrompts: [PendingPrompt] = []
+
+    @MainActor
+    static func prompt(
+        _ request: ExecApprovalPromptRequest,
+        timeoutMs: Int? = nil) async -> ExecApprovalDecision?
+    {
+        if let timeoutMs, timeoutMs <= 0 { return nil }
+        let promptID = UUID()
+        let timeoutWorkItem = timeoutMs.map { _ in
+            DispatchWorkItem {
+                MainActor.assumeIsolated {
+                    self.cancelPrompt(id: promptID)
+                }
+            }
+        }
+        if let timeoutMs, let timeoutWorkItem {
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + .milliseconds(timeoutMs),
+                execute: timeoutWorkItem)
+        }
+        defer { timeoutWorkItem?.cancel() }
+        return await withTaskCancellationHandler {
+            guard !Task.isCancelled, await self.acquirePrompt(id: promptID) else { return nil }
+            guard !Task.isCancelled, self.activePrompt?.cancelled != true else {
+                self.releasePrompt(id: promptID)
+                return nil
+            }
+            let decision = self.runPrompt(request, id: promptID)
+            let cancelled = self.activePrompt?.id == promptID && self.activePrompt?.cancelled == true
+            self.releasePrompt(id: promptID)
+            return Task.isCancelled || cancelled ? nil : decision
+        } onCancel: {
+            // Caller deadlines cancel the prompt task. Abort the matching modal
+            // session so an expired approval cannot outlive or block later requests.
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    self.cancelPrompt(id: promptID)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private static func runPrompt(
+        _ request: ExecApprovalPromptRequest,
+        id: UUID) -> ExecApprovalDecision?
+    {
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -603,7 +661,49 @@ enum ExecApprovalsPromptPresenter {
             alert.buttons[denyIndex].hasDestructiveAction = true
         }
 
+        guard self.activePrompt?.id == id else { return nil }
+        self.activePrompt?.alert = alert
+        defer { self.activePrompt?.alert = nil }
         return self.decision(forModalResponse: alert.runModal(), decisions: decisions)
+    }
+
+    @MainActor
+    private static func acquirePrompt(id: UUID) async -> Bool {
+        // AppKit cannot cancel nested modal loops independently. Queue behind one
+        // active alert; caller cancellation and deadlines remove expired waiters.
+        if self.activePrompt == nil {
+            self.activePrompt = (id: id, alert: nil, cancelled: false)
+            return true
+        }
+        return await withCheckedContinuation { continuation in
+            self.pendingPrompts.append(PendingPrompt(id: id, continuation: continuation))
+        }
+    }
+
+    @MainActor
+    private static func releasePrompt(id: UUID) {
+        guard self.activePrompt?.id == id else { return }
+        self.activePrompt = nil
+        guard !self.pendingPrompts.isEmpty else { return }
+        let next = self.pendingPrompts.removeFirst()
+        self.activePrompt = (id: next.id, alert: nil, cancelled: false)
+        next.continuation.resume(returning: true)
+    }
+
+    @MainActor
+    private static func cancelPrompt(id: UUID) {
+        if self.activePrompt?.id == id {
+            self.activePrompt?.cancelled = true
+            guard let alert = self.activePrompt?.alert else { return }
+            if NSApp.modalWindow === alert.window {
+                NSApp.abortModal()
+            }
+            alert.window.close()
+            return
+        }
+        guard let index = self.pendingPrompts.firstIndex(where: { $0.id == id }) else { return }
+        let pending = self.pendingPrompts.remove(at: index)
+        pending.continuation.resume(returning: false)
     }
 
     static func decision(
@@ -751,6 +851,28 @@ enum ExecApprovalsPromptPresenter {
     }
 }
 
+#if DEBUG
+extension ExecApprovalsPromptPresenter {
+    @MainActor
+    static func reservePromptForTesting() -> UUID? {
+        guard self.activePrompt == nil else { return nil }
+        let id = UUID()
+        self.activePrompt = (id: id, alert: nil, cancelled: false)
+        return id
+    }
+
+    @MainActor
+    static func releasePromptForTesting(id: UUID) {
+        self.releasePrompt(id: id)
+    }
+
+    @MainActor
+    static var pendingPromptCountForTesting: Int {
+        self.pendingPrompts.count
+    }
+}
+#endif
+
 @MainActor
 private enum ExecHostExecutor {
     static func handle(_ request: ExecHostRequest) async -> ExecHostResponse {
@@ -786,7 +908,7 @@ private enum ExecHostExecutor {
         case .allow:
             break
         case .requiresPrompt:
-            guard let decision = ExecApprovalsPromptPresenter.prompt(
+            guard let decision = await ExecApprovalsPromptPresenter.prompt(
                 ExecApprovalPromptRequest(
                     command: context.displayCommand,
                     cwd: request.cwd,
@@ -798,7 +920,8 @@ private enum ExecHostExecutor {
                     sessionKey: request.sessionKey,
                     allowedDecisions: ExecApprovalPromptRequest.allowedDecisions(
                         forAsk: context.ask.rawValue,
-                        allowAlwaysEligible: context.canPersistAllowAlways)))
+                        allowAlwaysEligible: context.canPersistAllowAlways)),
+                timeoutMs: execApprovalsSocketTimeoutMs)
             else {
                 return self.errorResponse(
                     code: "UNAVAILABLE",
@@ -1380,7 +1503,7 @@ private final class ExecApprovalsSocketServer: @unchecked Sendable {
                 try self.sendApprovalResponse(handle: handle, id: UUID().uuidString, decision: .deny)
                 return
             }
-            try configureSocketTimeouts(fd, timeoutMs: 15000)
+            try configureSocketTimeouts(fd, timeoutMs: execApprovalsSocketTimeoutMs)
             guard let line = try readLineFromSocket(fd, maxBytes: 256_000),
                   let data = line.data(using: .utf8)
             else {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -1119,21 +1119,19 @@ extension MacNodeRuntime {
         }
 
         if requiresAsk, !approvedByAsk {
-            let promptDecision = await MainActor.run {
-                ExecApprovalsPromptPresenter.prompt(
-                    ExecApprovalPromptRequest(
-                        command: context.displayCommand,
-                        cwd: params.cwd,
-                        host: "node",
-                        security: context.security.rawValue,
-                        ask: context.ask.rawValue,
-                        agentId: context.agentId,
-                        resolvedPath: context.resolution?.resolvedPath,
-                        sessionKey: context.sessionKey,
-                        allowedDecisions: ExecApprovalPromptRequest.allowedDecisions(
-                            forAsk: context.ask.rawValue,
-                            allowAlwaysEligible: context.allowAlwaysEligible)))
-            }
+            let promptDecision = await ExecApprovalsPromptPresenter.prompt(
+                ExecApprovalPromptRequest(
+                    command: context.displayCommand,
+                    cwd: params.cwd,
+                    host: "node",
+                    security: context.security.rawValue,
+                    ask: context.ask.rawValue,
+                    agentId: context.agentId,
+                    resolvedPath: context.resolution?.resolvedPath,
+                    sessionKey: context.sessionKey,
+                    allowedDecisions: ExecApprovalPromptRequest.allowedDecisions(
+                        forAsk: context.ask.rawValue,
+                        allowAlwaysEligible: context.allowAlwaysEligible)))
             guard let decision = promptDecision else {
                 await self.emitExecEvent(
                     "exec.denied",

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
@@ -5,6 +5,18 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct ExecApprovalPromptLayoutTests {
+    @Test func `queued prompt expires without later presentation`() async throws {
+        let reservation = try #require(ExecApprovalsPromptPresenter.reservePromptForTesting())
+        defer { ExecApprovalsPromptPresenter.releasePromptForTesting(id: reservation) }
+
+        let decision = await ExecApprovalsPromptPresenter.prompt(
+            ExecApprovalPromptRequest(command: "/usr/bin/printf ok"),
+            timeoutMs: 1)
+
+        #expect(decision == nil)
+        #expect(ExecApprovalsPromptPresenter.pendingPromptCountForTesting == 0)
+    }
+
     @Test func `allowed decisions omit durable approval even when ask allows it`() {
         let decisions = ExecApprovalsPromptPresenter.allowedPromptDecisions(
             ExecApprovalPromptRequest(

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -11,6 +11,19 @@ extension NSLock {
     }
 }
 
+private final class InvokeCancellationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    func markCancelled() {
+        self.lock.withLock { self.cancelled = true }
+    }
+
+    func isCancelled() -> Bool {
+        self.lock.withLock { self.cancelled }
+    }
+}
+
 private final class DoubleCallbackPingWebSocketTask: WebSocketTasking, @unchecked Sendable {
     private let callbacks: [Error?]
 
@@ -2558,6 +2571,28 @@ struct GatewayNodeSessionTests {
         #expect(response.ok == false)
         #expect(response.error?.code == .unavailable)
         #expect(response.error?.message.contains("timed out") == true)
+    }
+
+    @Test
+    func `invoke timeout cancels the in-flight operation`() async {
+        let cancellation = InvokeCancellationFlag()
+        let response = await GatewayNodeSession.invokeWithTimeout(
+            request: BridgeInvokeRequest(id: "cancelled", command: "x", paramsJSON: nil),
+            timeoutMs: 10,
+            onInvoke: { request in
+                await withTaskCancellationHandler {
+                    try? await Task.sleep(for: .seconds(1))
+                    return BridgeInvokeResponse(id: request.id, ok: true, payloadJSON: nil, error: nil)
+                } onCancel: {
+                    cancellation.markCancelled()
+                }
+            })
+
+        for _ in 0..<50 where !cancellation.isCancelled() {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        #expect(response.ok == false)
+        #expect(cancellation.isCancelled())
     }
 
     @Test


### PR DESCRIPTION
Closes #104282

## What Problem This Solves

Fixes an issue where macOS node users could receive a Gateway timeout while the matching execution-approval dialog remained active and interfered with later node commands.

## Why This Change Was Made

Approval prompts now serialize through one AppKit modal owner. Node task cancellation, socket deadlines, and Gateway approval expiry remove queued requests or close the matching active modal; any decision produced after cancellation is discarded.

## User Impact

Expired node execution requests no longer leave stale approval dialogs behind. Concurrent valid approvals remain FIFO, while expired waiters are removed before they can be shown.

## Evidence

- `swift build --package-path apps/macos --target OpenClaw` on clawmac
- `swift test --package-path apps/macos --filter ExecApprovalPromptLayoutTests` — 13 passed
- `swift test --package-path apps/shared/OpenClawKit --filter "invoke timeout cancels the in-flight operation"` — 1 passed
- Blacksmith Testbox `pnpm check:changed` — passed (run 29145000229)
- Fresh Codex autoreview — no accepted/actionable findings
