### PR TITLE
feat(memory): expose llama.cpp runtime diagnostics

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5602,6 +5602,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Configuration
   - H2: Native Runtime
+  - H2: Runtime diagnostics
   - H2: Troubleshooting
 
 ## plugins/logbook.md

--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -47,6 +47,11 @@ model. `local.modelCacheDir` overrides where downloaded models are cached
 (default: `~/.node-llama-cpp/models`), and `local.contextSize` accepts an
 integer or `"auto"`.
 
+When `local.contextSize` is numeric, the provider also gives that requirement
+to node-llama-cpp's automatic GPU-layer placement. This lets node-llama-cpp fit
+the model and embedding context together while retaining its memory-safety
+checks. With `"auto"`, node-llama-cpp keeps its normal automatic placement.
+
 ## Native Runtime
 
 Use Node 24 for the smoothest native install path. Source checkouts using
@@ -56,6 +61,18 @@ pnpm may need to approve and rebuild the native dependency:
 pnpm approve-builds
 pnpm rebuild node-llama-cpp
 ```
+
+## Runtime diagnostics
+
+Run `openclaw memory status --deep` after the provider has loaded to inspect
+the selected backend and build, device names, GPU offloaded layers, requested
+context size, and the last observed VRAM or unified-memory snapshot. The VRAM
+values include an observation timestamp because passive status reads do not
+reload the model or poll the device.
+
+The same last-known facts can appear in `openclaw doctor` when the running
+Gateway has already used the local provider. A normal status or doctor command
+does not load a model just to collect diagnostics.
 
 ## Troubleshooting
 

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -292,6 +292,8 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
     openclaw memory index --force --agent main
     ```
 
+    Numeric `local.contextSize` values also inform node-llama-cpp's automatic GPU-layer placement so model weights and the requested embedding context are fitted together. `openclaw memory status --deep` reports last-known llama.cpp backend, device, offload, requested-context, and timestamped memory facts after the runtime has loaded; passive status does not load a model.
+
     Set `provider: "local"` explicitly for local GGUF embeddings. `hf:` and HTTP(S) model references are supported for explicit local configs (via node-llama-cpp's model resolution), but they do not change the default provider.
 
   </Accordion>

--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const memoryHostEmbeddingMocks = vi.hoisted(() => ({
   createLocalEmbeddingProvider: vi.fn(),
 }));
+const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
   createLocalEmbeddingProvider: memoryHostEmbeddingMocks.createLocalEmbeddingProvider,
@@ -59,7 +60,13 @@ describe("llama.cpp provider plugin", () => {
 
   it("adapts the worker-backed local embedding provider", async () => {
     const close = vi.fn();
-    memoryHostEmbeddingMocks.createLocalEmbeddingProvider.mockResolvedValue({
+    const getRuntimeFacts = vi.fn(() => ({
+      engine: "llama.cpp" as const,
+      state: "ready" as const,
+      backend: "metal" as const,
+      buildType: "prebuilt" as const,
+    }));
+    const workerProvider = {
       id: "local",
       model: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
       maxInputTokens: 2048,
@@ -67,7 +74,11 @@ describe("llama.cpp provider plugin", () => {
       embedBatchInputs: vi.fn(async () => [[0.3, 0.4]]),
       embedBatch: vi.fn(async () => [[1, 0]]),
       close,
+    };
+    Object.defineProperty(workerProvider, LOCAL_EMBEDDING_RUNTIME_FACTS, {
+      value: getRuntimeFacts,
     });
+    memoryHostEmbeddingMocks.createLocalEmbeddingProvider.mockResolvedValue(workerProvider);
     const abortController = new AbortController();
 
     const result = await llamaCppEmbeddingProviderAdapter.create({
@@ -89,6 +100,20 @@ describe("llama.cpp provider plugin", () => {
 
     expect(provider.model).toBe(DEFAULT_LLAMA_CPP_EMBEDDING_MODEL);
     expect(provider.maxInputTokens).toBe(2048);
+    const adaptedGetRuntimeFacts = Reflect.get(provider, LOCAL_EMBEDDING_RUNTIME_FACTS);
+    if (typeof adaptedGetRuntimeFacts !== "function") {
+      throw new Error("expected llama.cpp runtime facts carrier");
+    }
+    expect(adaptedGetRuntimeFacts()).toEqual({
+      engine: "llama.cpp",
+      state: "ready",
+      backend: "metal",
+      buildType: "prebuilt",
+    });
+    expect(result.runtime?.cacheKeyData).toEqual({
+      provider: "local",
+      model: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
+    });
     expect(close).toHaveBeenCalledTimes(1);
     expect(memoryHostEmbeddingMocks.createLocalEmbeddingProvider).toHaveBeenCalledWith(
       {
@@ -104,9 +129,9 @@ describe("llama.cpp provider plugin", () => {
         nodeLlamaCppImportUrl: expect.stringContaining("node-llama-cpp"),
       },
     );
-    const workerProvider =
+    const createdWorkerProvider =
       await memoryHostEmbeddingMocks.createLocalEmbeddingProvider.mock.results[0].value;
-    expect(workerProvider.embedBatchInputs).toHaveBeenCalledWith([{ text: "doc" }], {
+    expect(createdWorkerProvider.embedBatchInputs).toHaveBeenCalledWith([{ text: "doc" }], {
       signal: abortController.signal,
     });
   });

--- a/extensions/llama-cpp/src/embedding-provider.ts
+++ b/extensions/llama-cpp/src/embedding-provider.ts
@@ -28,6 +28,7 @@ type LlamaCppEmbeddingProviderRuntimeOptions = {
 };
 
 const LLAMA_CPP_EMBEDDING_PROVIDER_ID = "local";
+const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
 export const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL =
   "hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf";
 const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_CACHE_FILE_NAME =
@@ -159,8 +160,18 @@ function resolveNodeLlamaCppImportUrl(): string {
   return pathToFileURL(requireFromPlugin.resolve("node-llama-cpp")).href;
 }
 
+function copyLocalRuntimeFacts(source: object, target: object): void {
+  const getRuntimeFacts = Reflect.get(source, LOCAL_EMBEDDING_RUNTIME_FACTS);
+  if (typeof getRuntimeFacts === "function") {
+    Object.defineProperty(target, LOCAL_EMBEDDING_RUNTIME_FACTS, {
+      enumerable: false,
+      value: getRuntimeFacts,
+    });
+  }
+}
+
 function adaptMemoryEmbeddingProvider(provider: MemoryEmbeddingProvider): EmbeddingProvider {
-  return {
+  const adapted: EmbeddingProvider = {
     id: LLAMA_CPP_EMBEDDING_PROVIDER_ID,
     model: provider.model,
     maxInputTokens: provider.maxInputTokens,
@@ -180,6 +191,8 @@ function adaptMemoryEmbeddingProvider(provider: MemoryEmbeddingProvider): Embedd
     },
     close: provider.close,
   };
+  copyLocalRuntimeFacts(provider, adapted);
+  return adapted;
 }
 
 export async function createLlamaCppMemoryEmbeddingProvider(
@@ -198,6 +211,9 @@ export async function createLlamaCppMemoryEmbeddingProvider(
   );
   const identifiedProvider =
     identity.model === provider.model ? provider : { ...provider, model: identity.model };
+  if (identifiedProvider !== provider) {
+    copyLocalRuntimeFacts(provider, identifiedProvider);
+  }
   return {
     provider: identifiedProvider,
     runtime: createLlamaCppEmbeddingProviderRuntime(identity),

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -74,6 +74,36 @@ type MemoryManagerPurpose = Parameters<typeof getMemorySearchManager>[0]["purpos
 
 type MemorySourceName = "memory" | "sessions";
 
+type LlamaCppRuntimeStatus = {
+  state?: string;
+  backend?: string;
+  buildType?: string;
+  deviceNames?: string[];
+  memory?: {
+    totalBytes: number;
+    usedBytes: number;
+    freeBytes: number;
+    unifiedBytes: number;
+    observedAtMs: number;
+  };
+  offload?: {
+    supported: boolean;
+    offloadedLayers?: number;
+    totalLayers?: number;
+  };
+  context?: {
+    requestedSize: number | "auto";
+  };
+  loadError?: string;
+};
+
+function readLlamaCppRuntimeStatus(
+  status: ReturnType<MemoryManager["status"]>,
+): LlamaCppRuntimeStatus | null {
+  const runtime = asRecord(asRecord(status.custom)?.llamaCppRuntime);
+  return runtime?.engine === "llama.cpp" ? (runtime as LlamaCppRuntimeStatus) : null;
+}
+
 function formatMemoryIndexIdentityWarning(
   status: ReturnType<MemoryManager["status"]>,
   agentId: string,
@@ -94,6 +124,20 @@ function formatMemoryIndexIdentityWarning(
     reason,
     fix: `Run: openclaw memory status --index --agent ${agentId}`,
   };
+}
+
+function formatRuntimeBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = units[0];
+  for (let index = 1; index < units.length && value >= 1024; index += 1) {
+    value /= 1024;
+    unit = units[index];
+  }
+  return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${unit}`;
 }
 
 type SourceScan = {
@@ -908,6 +952,43 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
       lines.push(`${label("Embeddings")} ${colorize(rich, stateColor, state)}`);
       if (embeddingProbe.error) {
         lines.push(`${label("Embeddings error")} ${warn(embeddingProbe.error)}`);
+      }
+    }
+    const llamaCppRuntime = opts.deep ? readLlamaCppRuntimeStatus(status) : null;
+    if (llamaCppRuntime) {
+      const runtime = llamaCppRuntime;
+      const backend = runtime.backend ?? "unknown";
+      const build = runtime.buildType ? ` (${runtime.buildType})` : "";
+      lines.push(`${label("llama.cpp")} ${info(backend)}${muted(build)}`);
+      if (runtime.deviceNames?.length) {
+        lines.push(`${label("Devices")} ${info(runtime.deviceNames.join(", "))}`);
+      }
+      if (runtime.memory) {
+        const unified =
+          runtime.memory.unifiedBytes > 0
+            ? ` · ${formatRuntimeBytes(runtime.memory.unifiedBytes)} unified`
+            : "";
+        lines.push(
+          `${label("VRAM snapshot")} ${info(`${formatRuntimeBytes(runtime.memory.usedBytes)} used · ${formatRuntimeBytes(runtime.memory.freeBytes)} free · ${formatRuntimeBytes(runtime.memory.totalBytes)} total${unified}`)} ${muted(`(${new Date(runtime.memory.observedAtMs).toISOString()})`)}`,
+        );
+      }
+      if (runtime.offload) {
+        const layers =
+          typeof runtime.offload.offloadedLayers === "number" &&
+          typeof runtime.offload.totalLayers === "number"
+            ? `${runtime.offload.offloadedLayers}/${runtime.offload.totalLayers} layers`
+            : runtime.offload.supported
+              ? "supported"
+              : "unsupported";
+        lines.push(`${label("GPU offload")} ${info(layers)}`);
+      }
+      if (runtime.context) {
+        lines.push(
+          `${label("Requested context")} ${info(`${runtime.context.requestedSize} tokens`)}`,
+        );
+      }
+      if (runtime.loadError) {
+        lines.push(`${label("llama.cpp error")} ${warn(runtime.loadError)}`);
       }
     }
     const identityWarning = formatMemoryIndexIdentityWarning(status, agentId);

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -472,6 +472,14 @@ describe("memory cli", () => {
           provider: "auto",
           requestedProvider: "auto",
           vector: { enabled: true },
+          custom: {
+            llamaCppRuntime: {
+              engine: "llama.cpp",
+              state: "ready",
+              backend: "metal",
+              buildType: "prebuilt",
+            },
+          },
         }),
       close,
     });
@@ -483,6 +491,7 @@ describe("memory cli", () => {
     expect(probeEmbeddingAvailability).not.toHaveBeenCalled();
     expectLogged(log, "Provider: auto");
     expectLogged(log, "Vector store: unknown");
+    expectNotLogged(log, "llama.cpp:");
     expect(close).toHaveBeenCalled();
   });
 
@@ -589,7 +598,35 @@ describe("memory cli", () => {
       probeVectorStoreAvailability,
       probeVectorAvailability,
       probeEmbeddingAvailability,
-      status: () => makeMemoryStatus({ files: 1, chunks: 1 }),
+      status: () =>
+        makeMemoryStatus({
+          files: 1,
+          chunks: 1,
+          custom: {
+            llamaCppRuntime: {
+              engine: "llama.cpp",
+              state: "ready",
+              backend: "metal",
+              buildType: "prebuilt",
+              deviceNames: ["Apple M4 Max"],
+              memory: {
+                totalBytes: 64 * 1024 ** 3,
+                usedBytes: 8 * 1024 ** 3,
+                freeBytes: 56 * 1024 ** 3,
+                unifiedBytes: 64 * 1024 ** 3,
+                observedAtMs: Date.parse("2026-07-10T12:00:00.000Z"),
+              },
+              offload: {
+                supported: true,
+                offloadedLayers: 20,
+                totalLayers: 24,
+              },
+              context: {
+                requestedSize: 4096,
+              },
+            },
+          },
+        }),
       close,
     });
 
@@ -600,6 +637,14 @@ describe("memory cli", () => {
     expect(probeVectorAvailability).toHaveBeenCalled();
     expect(probeEmbeddingAvailability).toHaveBeenCalled();
     expectLogged(log, "Embeddings: ready");
+    expectLogged(log, "llama.cpp: metal (prebuilt)");
+    expectLogged(log, "Devices: Apple M4 Max");
+    expectLogged(
+      log,
+      "VRAM snapshot: 8.0 GB used · 56 GB free · 64 GB total · 64 GB unified (2026-07-10T12:00:00.000Z)",
+    );
+    expectLogged(log, "GPU offload: 20/24 layers");
+    expectLogged(log, "Requested context: 4096 tokens");
     expect(close).toHaveBeenCalled();
   });
 

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -37,6 +37,7 @@ type CreateEmbeddingProviderOptions = MemoryEmbeddingProviderCreateOptions & {
 
 const DEFAULT_MEMORY_EMBEDDING_PROVIDER = "openai";
 const LOCAL_LLAMA_CPP_PROVIDER_ID = "local";
+const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
 
 function createMissingLlamaCppProviderError(): Error {
   return new Error(
@@ -52,7 +53,7 @@ function createMissingLlamaCppProviderError(): Error {
 function adaptGenericEmbeddingProvider(
   provider: GenericEmbeddingProvider,
 ): MemoryEmbeddingProvider {
-  return {
+  const adapted: MemoryEmbeddingProvider = {
     id: provider.id,
     model: provider.model,
     ...(typeof provider.maxInputTokens === "number"
@@ -75,6 +76,14 @@ function adaptGenericEmbeddingProvider(
       }),
     ...(provider.close ? { close: provider.close } : {}),
   };
+  const getRuntimeFacts = Reflect.get(provider, LOCAL_EMBEDDING_RUNTIME_FACTS);
+  if (typeof getRuntimeFacts === "function") {
+    Object.defineProperty(adapted, LOCAL_EMBEDDING_RUNTIME_FACTS, {
+      enumerable: false,
+      value: getRuntimeFacts,
+    });
+  }
+  return adapted;
 }
 
 function adaptGenericRuntime(

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2158,6 +2158,62 @@ describe("memory index", () => {
     }
   });
 
+  it("exposes already-created local runtime facts without probing embeddings", async () => {
+    const cfg = createCfg({});
+    const { getRequiredMemoryIndexManager } = await import("./test-manager-helpers.js");
+    const manager = await getRequiredMemoryIndexManager({
+      cfg,
+      agentId: "main",
+      purpose: "status",
+    });
+    try {
+      const getRuntimeFacts = vi.fn(() => ({
+        engine: "llama.cpp" as const,
+        state: "ready" as const,
+        backend: "cuda" as const,
+        buildType: "prebuilt" as const,
+        deviceNames: ["NVIDIA Test GPU"],
+        offload: {
+          supported: true,
+          offloadedLayers: 24,
+          totalLayers: 24,
+        },
+        context: {
+          requestedSize: 4096,
+        },
+      }));
+      const provider = {
+        id: "local",
+        model: "test-model.gguf",
+        embedQuery: vi.fn(async () => [1, 0, 0, 0]),
+        embedBatch: vi.fn(async (texts: string[]) => texts.map(() => [1, 0, 0, 0])),
+      };
+      Object.defineProperty(provider, Symbol.for("openclaw.localEmbeddingRuntimeFacts"), {
+        value: getRuntimeFacts,
+      });
+      const fields = manager as unknown as {
+        provider: typeof provider | null;
+      };
+      fields.provider = provider;
+
+      expect(manager.status().custom?.llamaCppRuntime).toMatchObject({
+        state: "ready",
+        backend: "cuda",
+        deviceNames: ["NVIDIA Test GPU"],
+        offload: {
+          offloadedLayers: 24,
+          totalLayers: 24,
+        },
+        context: {
+          requestedSize: 4096,
+        },
+      });
+      expect(getRuntimeFacts).toHaveBeenCalledTimes(1);
+    } finally {
+      await manager.close?.();
+    }
+  });
+
   it("keeps metadata after unchanged in-place force reindex", async () => {
     const cfg = createCfg({});
     const manager = await getFreshManager(cfg);

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -69,6 +69,17 @@ import {
   type MemoryReadonlyRecoveryState,
 } from "./manager-sync-control.js";
 import { applyTemporalDecayToHybridResults } from "./temporal-decay.js";
+
+const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
+
+function getLocalEmbeddingRuntimeFacts(provider: EmbeddingProvider | null): unknown {
+  if (!provider) {
+    return undefined;
+  }
+  const getRuntimeFacts = Reflect.get(provider, LOCAL_EMBEDDING_RUNTIME_FACTS);
+  return typeof getRuntimeFacts === "function" ? getRuntimeFacts() : undefined;
+}
+
 const SNIPPET_MAX_CHARS = 700;
 const VECTOR_TABLE = MEMORY_INDEX_VECTOR_TABLE;
 const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
@@ -1206,6 +1217,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         lastProvider: this.batchFailureLastProvider,
       },
       custom: {
+        llamaCppRuntime: getLocalEmbeddingRuntimeFacts(this.provider),
         searchMode: providerInfo.searchMode,
         providerState: this.providerLifecycle,
         providerUnavailableReason: this.providerUnavailableReason,

--- a/packages/memory-host-sdk/src/host/embeddings-worker-child.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker-child.ts
@@ -1,6 +1,7 @@
 // Memory Host SDK module implements embeddings worker child behavior.
 import { createLocalEmbeddingProviderInProcess } from "./embeddings.js";
 import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.types.js";
+import { getLocalEmbeddingRuntimeFacts } from "./local-embedding-runtime-facts.js";
 
 // Child process entrypoint for local embedding work.
 
@@ -87,17 +88,31 @@ async function handleRequest(request: LocalEmbeddingWorkerRequest): Promise<void
 
   const currentProvider = await getProvider(request.options);
   if (request.type === "initialize") {
-    send({ id: request.id, ok: true });
+    send({
+      id: request.id,
+      ok: true,
+      runtimeFacts: getLocalEmbeddingRuntimeFacts(currentProvider),
+    });
     return;
   }
   if (request.type === "embedQuery") {
     const value = await currentProvider.embedQuery(request.text);
-    send({ id: request.id, ok: true, value });
+    send({
+      id: request.id,
+      ok: true,
+      value,
+      runtimeFacts: getLocalEmbeddingRuntimeFacts(currentProvider),
+    });
     return;
   }
 
   const value = await currentProvider.embedBatch(request.texts);
-  send({ id: request.id, ok: true, value });
+  send({
+    id: request.id,
+    ok: true,
+    value,
+    runtimeFacts: getLocalEmbeddingRuntimeFacts(currentProvider),
+  });
 }
 
 // Requests are serialized so node-llama-cpp context state is not used concurrently.
@@ -107,7 +122,12 @@ process.on("message", (message) => {
     try {
       await handleRequest(request);
     } catch (err) {
-      send({ id: request.id, ok: false, error: serializeError(err) });
+      send({
+        id: request.id,
+        ok: false,
+        error: serializeError(err),
+        runtimeFacts: getLocalEmbeddingRuntimeFacts(provider),
+      });
     }
   });
 });

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -13,6 +13,10 @@ import type {
   EmbeddingProviderCallOptions,
   EmbeddingProviderOptions,
 } from "./embeddings.types.js";
+import {
+  attachLocalEmbeddingRuntimeFacts,
+  type LocalEmbeddingRuntimeFacts,
+} from "./local-embedding-runtime-facts.js";
 import { normalizeOptionalString } from "./string-utils.js";
 
 // Parent-side local embedding worker client for isolating node-llama-cpp state.
@@ -45,10 +49,12 @@ type LocalEmbeddingWorkerResponse =
       id: number;
       ok: true;
       value?: number[] | number[][];
+      runtimeFacts?: LocalEmbeddingRuntimeFacts;
     }
   | {
       id: number;
       ok: false;
+      runtimeFacts?: LocalEmbeddingRuntimeFacts;
       error:
         | string
         | {
@@ -174,6 +180,7 @@ class LocalEmbeddingWorkerClient {
   private child: ChildProcess | null = null;
   private nextRequestId = 1;
   private pending = new Map<number, PendingRequest>();
+  private lastRuntimeFacts: LocalEmbeddingRuntimeFacts | undefined;
 
   constructor(private readonly scriptPath: string) {}
 
@@ -200,6 +207,10 @@ class LocalEmbeddingWorkerClient {
   ): Promise<number[][]> {
     const result = await this.send({ type: "embedBatch", options, texts }, callOptions);
     return Array.isArray(result) ? (result as number[][]) : [];
+  }
+
+  getRuntimeFacts(): LocalEmbeddingRuntimeFacts | undefined {
+    return this.lastRuntimeFacts;
   }
 
   /** Ask the child to close gracefully, then force shutdown after a short grace period. */
@@ -311,6 +322,9 @@ class LocalEmbeddingWorkerClient {
     if (typeof response.id !== "number") {
       return;
     }
+    if (response.runtimeFacts) {
+      this.lastRuntimeFacts = response.runtimeFacts;
+    }
     const pending = this.pending.get(response.id);
     if (!pending) {
       return;
@@ -383,7 +397,7 @@ export async function createLocalEmbeddingWorkerProvider(
     }
   };
 
-  return {
+  const provider: EmbeddingProvider = {
     id: "local",
     model: modelPath,
     embedQuery: async (text, callOptions) => {
@@ -402,6 +416,8 @@ export async function createLocalEmbeddingWorkerProvider(
       await client.close();
     },
   };
+  attachLocalEmbeddingRuntimeFacts(provider, () => client.getRuntimeFacts());
+  return provider;
 }
 
 /** Convert abort reasons or arbitrary thrown values into lint-safe Error objects. */

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -3,10 +3,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { LOCAL_EMBEDDING_WORKER_ERROR_CODES } from "./embedding-worker-errors.js";
 import { createLocalEmbeddingWorkerProvider } from "./embeddings-worker.js";
 import { createLocalEmbeddingProviderInProcess, DEFAULT_LOCAL_MODEL } from "./embeddings.js";
 import { getLocalEmbeddingRuntimeFacts } from "./local-embedding-runtime-facts.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const nodeLlamaMock = vi.hoisted(() => ({
   importNodeLlamaCpp: vi.fn(),
@@ -693,7 +696,7 @@ process.on("message", (message) => {
   });
 
   it("retains worker runtime facts from failed embedding responses", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
+    const tempDir = tempDirs.make("openclaw-local-embedding-worker-");
     const workerScript = path.join(tempDir, "worker.cjs");
     await fs.writeFile(
       workerScript,

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -302,7 +302,37 @@ describe("local embedding provider", () => {
       backend: "metal",
       buildType: "prebuilt",
       deviceNames: ["Apple M4 Max"],
+      context: {
+        requestedSize: 4096,
+      },
       loadError: "GGUF load failed",
+    });
+  });
+
+  it("retains requested context when llama runtime initialization fails", async () => {
+    const runtime = mockLocalEmbeddingRuntime();
+    runtime.getLlama.mockRejectedValueOnce(new Error("No compatible llama.cpp backend"));
+    const provider = await createLocalEmbeddingProviderInProcess({
+      config: {} as never,
+      provider: "local",
+      model: "",
+      fallback: "none",
+      local: {
+        contextSize: 2048,
+      },
+    });
+
+    await expect(provider.embedQuery("runtime failure")).rejects.toThrow(
+      "No compatible llama.cpp backend",
+    );
+
+    expect(getLocalEmbeddingRuntimeFacts(provider)).toEqual({
+      engine: "llama.cpp",
+      state: "failed",
+      context: {
+        requestedSize: 2048,
+      },
+      loadError: "No compatible llama.cpp backend",
     });
   });
 

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LOCAL_EMBEDDING_WORKER_ERROR_CODES } from "./embedding-worker-errors.js";
 import { createLocalEmbeddingWorkerProvider } from "./embeddings-worker.js";
 import { createLocalEmbeddingProviderInProcess, DEFAULT_LOCAL_MODEL } from "./embeddings.js";
+import { getLocalEmbeddingRuntimeFacts } from "./local-embedding-runtime-facts.js";
 
 const nodeLlamaMock = vi.hoisted(() => ({
   importNodeLlamaCpp: vi.fn(),
@@ -43,11 +44,30 @@ function mockLocalEmbeddingRuntime(
   const disposeModel = vi.fn();
   const disposeLlama = vi.fn();
   const getEmbeddingFor = vi.fn().mockResolvedValue({ vector });
-  const createEmbeddingContext = vi
-    .fn()
-    .mockResolvedValue({ getEmbeddingFor, dispose: disposeContext });
-  const loadModel = vi.fn().mockResolvedValue({ createEmbeddingContext, dispose: disposeModel });
-  const getLlama = vi.fn(async () => ({ loadModel, dispose: disposeLlama }));
+  const createEmbeddingContext = vi.fn().mockResolvedValue({
+    getEmbeddingFor,
+    dispose: disposeContext,
+  });
+  const loadModel = vi.fn().mockResolvedValue({
+    createEmbeddingContext,
+    dispose: disposeModel,
+    fileInsights: { totalLayers: 24 },
+    gpuLayers: 20,
+  });
+  const getLlama = vi.fn(async () => ({
+    gpu: "metal",
+    buildType: "prebuilt",
+    supportsGpuOffloading: true,
+    getGpuDeviceNames: vi.fn(async () => ["Apple M4 Max"]),
+    getVramState: vi.fn(async () => ({
+      total: 64 * 1024 ** 3,
+      used: 8 * 1024 ** 3,
+      free: 56 * 1024 ** 3,
+      unifiedSize: 64 * 1024 ** 3,
+    })),
+    loadModel,
+    dispose: disposeLlama,
+  }));
   const resolveModelFile = vi.fn(async (modelPath: string) => `/resolved/${modelPath}`);
 
   nodeLlamaMock.importNodeLlamaCpp.mockResolvedValue({
@@ -148,6 +168,16 @@ describe("local embedding provider", () => {
     expect(runtime.createEmbeddingContext).toHaveBeenCalledWith(
       expect.objectContaining({ contextSize: 4096, createSignal: expect.any(AbortSignal) }),
     );
+    expect(runtime.loadModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gpuLayers: {
+          fitContext: {
+            contextSize: 4096,
+            embeddingContext: true,
+          },
+        },
+      }),
+    );
   });
 
   it("imports node-llama-cpp from an explicit module URL when provided", async () => {
@@ -184,6 +214,16 @@ describe("local embedding provider", () => {
     expect(runtime.createEmbeddingContext).toHaveBeenCalledWith(
       expect.objectContaining({ contextSize: 2048, createSignal: expect.any(AbortSignal) }),
     );
+    expect(runtime.loadModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gpuLayers: {
+          fitContext: {
+            contextSize: 2048,
+            embeddingContext: true,
+          },
+        },
+      }),
+    );
   });
 
   it('passes "auto" contextSize to createEmbeddingContext when explicitly set', async () => {
@@ -202,6 +242,68 @@ describe("local embedding provider", () => {
     expect(runtime.createEmbeddingContext).toHaveBeenCalledWith(
       expect.objectContaining({ contextSize: "auto", createSignal: expect.any(AbortSignal) }),
     );
+    expect(runtime.loadModel).toHaveBeenCalledWith(
+      expect.not.objectContaining({ gpuLayers: expect.anything() }),
+    );
+  });
+
+  it("reports selected backend, memory, offload, and effective context facts", async () => {
+    mockLocalEmbeddingRuntime();
+    const provider = await createLocalEmbeddingProviderInProcess({
+      config: {} as never,
+      provider: "local",
+      model: "",
+      fallback: "none",
+    });
+
+    expect(getLocalEmbeddingRuntimeFacts(provider)).toBeUndefined();
+    await provider.embedQuery("runtime facts");
+
+    expect(getLocalEmbeddingRuntimeFacts(provider)).toMatchObject({
+      engine: "llama.cpp",
+      state: "ready",
+      backend: "metal",
+      buildType: "prebuilt",
+      deviceNames: ["Apple M4 Max"],
+      memory: {
+        totalBytes: 64 * 1024 ** 3,
+        usedBytes: 8 * 1024 ** 3,
+        freeBytes: 56 * 1024 ** 3,
+        unifiedBytes: 64 * 1024 ** 3,
+        observedAtMs: expect.any(Number),
+      },
+      offload: {
+        supported: true,
+        offloadedLayers: 20,
+        totalLayers: 24,
+      },
+      context: {
+        requestedSize: 4096,
+      },
+      loadError: undefined,
+    });
+  });
+
+  it("retains reliable runtime facts when model loading fails", async () => {
+    const runtime = mockLocalEmbeddingRuntime();
+    runtime.loadModel.mockRejectedValueOnce(new Error("GGUF load failed"));
+    const provider = await createLocalEmbeddingProviderInProcess({
+      config: {} as never,
+      provider: "local",
+      model: "",
+      fallback: "none",
+    });
+
+    await expect(provider.embedQuery("runtime failure")).rejects.toThrow("GGUF load failed");
+
+    expect(getLocalEmbeddingRuntimeFacts(provider)).toMatchObject({
+      engine: "llama.cpp",
+      state: "failed",
+      backend: "metal",
+      buildType: "prebuilt",
+      deviceNames: ["Apple M4 Max"],
+      loadError: "GGUF load failed",
+    });
   });
 
   it("runs local batch embeddings sequentially", async () => {
@@ -214,8 +316,17 @@ describe("local embedding provider", () => {
     });
     nodeLlamaMock.importNodeLlamaCpp.mockResolvedValue({
       getLlama: vi.fn(async () => ({
+        gpu: false,
+        buildType: "prebuilt",
+        supportsGpuOffloading: false,
+        getGpuDeviceNames: vi.fn(async () => []),
+        getVramState: vi.fn(async () => ({ total: 0, used: 0, free: 0, unifiedSize: 0 })),
         loadModel: vi.fn(async () => ({
-          createEmbeddingContext: vi.fn(async () => ({ getEmbeddingFor })),
+          fileInsights: { totalLayers: 24 },
+          gpuLayers: 0,
+          createEmbeddingContext: vi.fn(async () => ({
+            getEmbeddingFor,
+          })),
         })),
       })),
       resolveModelFile: vi.fn(async () => "/resolved/model.gguf"),
@@ -363,7 +474,12 @@ describe("local embedding provider", () => {
     );
     nodeLlamaMock.importNodeLlamaCpp.mockResolvedValue({
       getLlama: async () => ({
-        loadModel: vi.fn(async () => ({ createEmbeddingContext, dispose: disposeModel })),
+        loadModel: vi.fn(async () => ({
+          createEmbeddingContext,
+          dispose: disposeModel,
+          fileInsights: { totalLayers: 24 },
+          gpuLayers: 0,
+        })),
         dispose: disposeLlama,
       }),
       resolveModelFile: vi.fn(async () => "/resolved/model.gguf"),
@@ -407,11 +523,31 @@ process.on("message", (message) => {
     return;
   }
   if (message.type === "embedQuery") {
-    process.send({ id: message.id, ok: true, value: [1, 0] });
+    process.send({
+      id: message.id,
+      ok: true,
+      value: [1, 0],
+      runtimeFacts: {
+        engine: "llama.cpp",
+        state: "ready",
+        backend: "cuda",
+        buildType: "prebuilt",
+      },
+    });
     return;
   }
   if (message.type === "embedBatch") {
-    process.send({ id: message.id, ok: true, value: message.texts.map(() => [0, 1]) });
+    process.send({
+      id: message.id,
+      ok: true,
+      value: message.texts.map(() => [0, 1]),
+      runtimeFacts: {
+        engine: "llama.cpp",
+        state: "ready",
+        backend: "cuda",
+        buildType: "prebuilt",
+      },
+    });
     return;
   }
   process.send({ id: message.id, ok: true });
@@ -438,6 +574,12 @@ process.on("message", (message) => {
       [0, 1],
       [0, 1],
     ]);
+    expect(getLocalEmbeddingRuntimeFacts(provider)).toEqual({
+      engine: "llama.cpp",
+      state: "ready",
+      backend: "cuda",
+      buildType: "prebuilt",
+    });
     await expect(provider.close?.()).resolves.toBeUndefined();
   });
 
@@ -518,6 +660,57 @@ process.on("message", (message) => {
     await expect(queuedEmbedResult).resolves.toMatchObject({
       code: LOCAL_EMBEDDING_WORKER_ERROR_CODES.exited,
     });
+  });
+
+  it("retains worker runtime facts from failed embedding responses", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
+    const workerScript = path.join(tempDir, "worker.cjs");
+    await fs.writeFile(
+      workerScript,
+      `
+process.on("message", (message) => {
+  if (message.type === "initialize" || message.type === "close") {
+    process.send({ id: message.id, ok: true });
+    return;
+  }
+  process.send({
+    id: message.id,
+    ok: false,
+    error: { message: "CUDA model load failed", code: "MODEL_LOAD_FAILED" },
+    runtimeFacts: {
+      engine: "llama.cpp",
+      state: "failed",
+      backend: "cuda",
+      buildType: "prebuilt",
+      deviceNames: ["NVIDIA Test GPU"],
+      loadError: "CUDA model load failed",
+    },
+  });
+});
+`,
+      "utf8",
+    );
+    const provider = await createLocalEmbeddingWorkerProvider(
+      {
+        config: {} as never,
+        provider: "local",
+        model: "",
+        fallback: "none",
+      },
+      { workerScriptPath: workerScript },
+    );
+
+    await expect(provider.embedQuery("hello")).rejects.toMatchObject({
+      message: "CUDA model load failed",
+      code: "MODEL_LOAD_FAILED",
+    });
+    expect(getLocalEmbeddingRuntimeFacts(provider)).toMatchObject({
+      state: "failed",
+      backend: "cuda",
+      deviceNames: ["NVIDIA Test GPU"],
+      loadError: "CUDA model load failed",
+    });
+    await provider.close?.();
   });
 
   it("does not pass inline-source or inspector exec args to the file-backed worker", async () => {

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -247,7 +247,7 @@ describe("local embedding provider", () => {
     );
   });
 
-  it("reports selected backend, memory, offload, and effective context facts", async () => {
+  it("reports selected backend, memory, offload, and requested context facts", async () => {
     mockLocalEmbeddingRuntime();
     const provider = await createLocalEmbeddingProviderInProcess({
       config: {} as never,

--- a/packages/memory-host-sdk/src/host/embeddings.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.ts
@@ -150,7 +150,10 @@ export async function createLocalEmbeddingProviderInProcess(
             logLevel: LlamaLogLevel.error,
           });
           llama = await disposeAndThrowIfClosed(nextLlama);
-          runtimeFacts = await readLlamaRuntimeFacts(llama);
+          runtimeFacts = {
+            ...(await readLlamaRuntimeFacts(llama)),
+            context: { requestedSize: contextSize },
+          };
         }
         if (!embeddingModel) {
           const resolved = await resolveModelFile(modelPath, {
@@ -211,6 +214,7 @@ export async function createLocalEmbeddingProviderInProcess(
           ...runtimeFacts,
           engine: "llama.cpp",
           state: "failed",
+          context: { requestedSize: contextSize },
           loadError: formatRuntimeLoadError(err),
         };
         initPromise = null;

--- a/packages/memory-host-sdk/src/host/embeddings.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.ts
@@ -3,6 +3,10 @@ import { sanitizeAndNormalizeEmbedding } from "./embedding-vectors.js";
 import { createLocalEmbeddingWorkerProvider } from "./embeddings-worker.js";
 import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.types.js";
 import {
+  attachLocalEmbeddingRuntimeFacts,
+  type LocalEmbeddingRuntimeFacts,
+} from "./local-embedding-runtime-facts.js";
+import {
   importNodeLlamaCpp,
   type Llama,
   type LlamaEmbeddingContext,
@@ -50,6 +54,40 @@ async function disposeResources(
   }
 }
 
+async function readLlamaRuntimeFacts(llama: Llama): Promise<LocalEmbeddingRuntimeFacts> {
+  const facts: LocalEmbeddingRuntimeFacts = {
+    engine: "llama.cpp",
+    state: "failed",
+    backend: llama.gpu || "cpu",
+    buildType: llama.buildType,
+    offload: {
+      supported: llama.supportsGpuOffloading,
+    },
+  };
+  try {
+    facts.deviceNames = await llama.getGpuDeviceNames();
+  } catch {
+    // Diagnostics must not prevent a model that otherwise works from loading.
+  }
+  try {
+    const memory = await llama.getVramState();
+    facts.memory = {
+      totalBytes: memory.total,
+      usedBytes: memory.used,
+      freeBytes: memory.free,
+      unifiedBytes: memory.unifiedSize,
+      observedAtMs: Date.now(),
+    };
+  } catch {
+    // Some backends cannot report memory state; keep the other runtime facts.
+  }
+  return facts;
+}
+
+function formatRuntimeLoadError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export async function createLocalEmbeddingProvider(
   options: EmbeddingProviderOptions,
   runtimeOptions?: LocalEmbeddingProviderRuntimeOptions,
@@ -78,6 +116,7 @@ export async function createLocalEmbeddingProviderInProcess(
   let initPromise: Promise<LlamaEmbeddingContext> | null = null;
   let initAbortController: AbortController | null = null;
   let closePromise: Promise<void> | null = null;
+  let runtimeFacts: LocalEmbeddingRuntimeFacts | undefined;
   let closed = false;
 
   const throwIfClosed = () => {
@@ -111,6 +150,7 @@ export async function createLocalEmbeddingProviderInProcess(
             logLevel: LlamaLogLevel.error,
           });
           llama = await disposeAndThrowIfClosed(nextLlama);
+          runtimeFacts = await readLlamaRuntimeFacts(llama);
         }
         if (!embeddingModel) {
           const resolved = await resolveModelFile(modelPath, {
@@ -121,8 +161,28 @@ export async function createLocalEmbeddingProviderInProcess(
           const nextModel = await llama.loadModel({
             modelPath: resolved,
             loadSignal: abortController.signal,
+            ...(typeof contextSize === "number"
+              ? {
+                  gpuLayers: {
+                    fitContext: {
+                      contextSize,
+                      embeddingContext: true,
+                    },
+                  },
+                }
+              : {}),
           });
           embeddingModel = await disposeAndThrowIfClosed(nextModel);
+          runtimeFacts = {
+            ...runtimeFacts,
+            engine: "llama.cpp",
+            state: "failed",
+            offload: {
+              supported: llama.supportsGpuOffloading,
+              offloadedLayers: embeddingModel.gpuLayers,
+              totalLayers: embeddingModel.fileInsights.totalLayers,
+            },
+          };
         }
         if (!embeddingContext) {
           const nextContext = await embeddingModel.createEmbeddingContext({
@@ -130,9 +190,29 @@ export async function createLocalEmbeddingProviderInProcess(
             createSignal: abortController.signal,
           });
           embeddingContext = await disposeAndThrowIfClosed(nextContext);
+          const refreshedRuntimeFacts = await readLlamaRuntimeFacts(llama);
+          runtimeFacts = {
+            ...runtimeFacts,
+            ...refreshedRuntimeFacts,
+            engine: "llama.cpp",
+            state: "ready",
+            offload: {
+              supported: llama.supportsGpuOffloading,
+              offloadedLayers: embeddingModel.gpuLayers,
+              totalLayers: embeddingModel.fileInsights.totalLayers,
+            },
+            context: { requestedSize: contextSize },
+            loadError: undefined,
+          };
         }
         return embeddingContext;
       } catch (err) {
+        runtimeFacts = {
+          ...runtimeFacts,
+          engine: "llama.cpp",
+          state: "failed",
+          loadError: formatRuntimeLoadError(err),
+        };
         initPromise = null;
         throw err;
       } finally {
@@ -149,7 +229,7 @@ export async function createLocalEmbeddingProviderInProcess(
   const normalize = (vector: ArrayLike<number>): number[] =>
     sanitizeAndNormalizeEmbedding(copyEmbeddingVector(vector, outputDimensionality));
 
-  return {
+  const provider: EmbeddingProvider = {
     id: "local",
     model: modelPath,
     embedQuery: async (text, optionsValue) => {
@@ -196,4 +276,6 @@ export async function createLocalEmbeddingProviderInProcess(
       return closePromise;
     },
   };
+  attachLocalEmbeddingRuntimeFacts(provider, () => runtimeFacts);
+  return provider;
 }

--- a/packages/memory-host-sdk/src/host/local-embedding-runtime-facts.ts
+++ b/packages/memory-host-sdk/src/host/local-embedding-runtime-facts.ts
@@ -1,0 +1,49 @@
+export type LocalEmbeddingRuntimeFacts = {
+  engine: "llama.cpp";
+  state: "ready" | "failed";
+  backend?: "metal" | "cuda" | "vulkan" | "cpu";
+  buildType?: "localBuild" | "prebuilt";
+  deviceNames?: string[];
+  memory?: {
+    totalBytes: number;
+    usedBytes: number;
+    freeBytes: number;
+    unifiedBytes: number;
+    observedAtMs: number;
+  };
+  offload?: {
+    supported: boolean;
+    offloadedLayers?: number;
+    totalLayers?: number;
+  };
+  context?: {
+    requestedSize: number | "auto";
+  };
+  loadError?: string;
+};
+
+const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
+
+export function attachLocalEmbeddingRuntimeFacts(
+  target: object,
+  getFacts: () => LocalEmbeddingRuntimeFacts | undefined,
+): void {
+  Object.defineProperty(target, LOCAL_EMBEDDING_RUNTIME_FACTS, {
+    configurable: false,
+    enumerable: false,
+    value: getFacts,
+    writable: false,
+  });
+}
+
+export function getLocalEmbeddingRuntimeFacts(
+  target: object | null | undefined,
+): LocalEmbeddingRuntimeFacts | undefined {
+  if (!target) {
+    return undefined;
+  }
+  const getFacts = Reflect.get(target, LOCAL_EMBEDDING_RUNTIME_FACTS);
+  return typeof getFacts === "function"
+    ? (getFacts as () => LocalEmbeddingRuntimeFacts | undefined)()
+    : undefined;
+}

--- a/packages/memory-host-sdk/src/host/node-llama.ts
+++ b/packages/memory-host-sdk/src/host/node-llama.ts
@@ -13,6 +13,10 @@ export type LlamaEmbeddingContext = {
 
 /** Loaded llama model capable of creating embedding contexts. */
 export type LlamaModel = {
+  fileInsights: {
+    totalLayers: number;
+  };
+  gpuLayers: number;
   createEmbeddingContext: (options?: {
     contextSize?: number | "auto";
     createSignal?: AbortSignal;
@@ -28,7 +32,32 @@ type ResolveModelFileOptions = {
 
 /** Root llama runtime object exposed by node-llama-cpp. */
 export type Llama = {
-  loadModel: (params: { modelPath: string; loadSignal?: AbortSignal }) => Promise<LlamaModel>;
+  gpu: "metal" | "cuda" | "vulkan" | false;
+  buildType: "localBuild" | "prebuilt";
+  supportsGpuOffloading: boolean;
+  getGpuDeviceNames: () => Promise<string[]>;
+  getVramState: () => Promise<{
+    total: number;
+    used: number;
+    free: number;
+    unifiedSize: number;
+  }>;
+  loadModel: (params: {
+    modelPath: string;
+    loadSignal?: AbortSignal;
+    gpuLayers?:
+      | "auto"
+      | "max"
+      | number
+      | {
+          min?: number;
+          max?: number;
+          fitContext?: {
+            contextSize?: number;
+            embeddingContext?: boolean;
+          };
+        };
+  }) => Promise<LlamaModel>;
   dispose?: () => Promise<void> | void;
 };
 

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -233,6 +233,28 @@ describe("probeGatewayMemoryStatus", () => {
     });
   });
 
+  it("carries last-known llama.cpp facts from the gateway", async () => {
+    callGateway.mockResolvedValue({
+      embedding: { ok: true },
+      embeddingRuntime: {
+        engine: "llama.cpp",
+        state: "ready",
+        backend: "metal",
+        buildType: "prebuilt",
+      },
+    });
+
+    await expect(probeGatewayMemoryStatus({ cfg })).resolves.toMatchObject({
+      checked: true,
+      ready: true,
+      runtimeFacts: {
+        state: "ready",
+        backend: "metal",
+        buildType: "prebuilt",
+      },
+    });
+  });
+
   it("treats outer gateway timeouts as inconclusive (skipped: false)", async () => {
     // A transport timeout must NOT be treated as a skipped probe. It is a real
     // diagnostic signal and the renderer should warn for key-optional providers.

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -9,7 +9,10 @@ import {
   isGatewayCredentialsRequiredError,
 } from "../gateway/call.js";
 import { isGatewaySecretRefUnavailableError } from "../gateway/credentials.js";
-import type { DoctorMemoryStatusPayload } from "../gateway/server-methods/doctor.js";
+import type {
+  DoctorMemoryEmbeddingRuntimePayload,
+  DoctorMemoryStatusPayload,
+} from "../gateway/server-methods/doctor.js";
 import { collectChannelStatusIssues } from "../infra/channels-status-issues.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -26,6 +29,7 @@ type GatewayMemoryProbe = {
   checked: boolean;
   ready: boolean;
   error?: string;
+  runtimeFacts?: DoctorMemoryEmbeddingRuntimePayload;
   /**
    * True when the probe was intentionally skipped by the gateway (probe: false
    * path). Distinct from checked: false caused by a network timeout or
@@ -170,6 +174,7 @@ export async function probeGatewayMemoryStatus(params: {
       checked: gatewayChecked,
       ready: payload.embedding.ok,
       error: payload.embedding.error,
+      ...(payload.embeddingRuntime ? { runtimeFacts: payload.embeddingRuntime } : {}),
       skipped: !gatewayChecked,
     };
   } catch (err) {

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -283,6 +283,13 @@ describe("noteMemorySearchHealth", () => {
           backend: "cuda",
           buildType: "prebuilt",
           deviceNames: ["NVIDIA Test GPU"],
+          memory: {
+            totalBytes: 24 * 1024 ** 3,
+            usedBytes: 8 * 1024 ** 3,
+            freeBytes: 16 * 1024 ** 3,
+            unifiedBytes: 0,
+            observedAtMs: Date.parse("2026-07-10T12:00:00.000Z"),
+          },
           offload: {
             supported: true,
             offloadedLayers: 24,
@@ -299,11 +306,50 @@ describe("noteMemorySearchHealth", () => {
       [
         "llama.cpp runtime: cuda, prebuilt",
         "Devices: NVIDIA Test GPU",
+        "VRAM snapshot: 8.0 GB used, 16 GB free, 24 GB total (2026-07-10T12:00:00.000Z)",
         "GPU offload: 24/24 layers",
         "Requested context: 4096 tokens",
       ].join("\n"),
       "Memory search",
     );
+  });
+
+  it("reports failed llama.cpp runtime facts alongside the readiness warning", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: {
+        checked: true,
+        ready: false,
+        error: "GGUF load failed",
+        runtimeFacts: {
+          engine: "llama.cpp",
+          state: "failed",
+          backend: "cpu",
+          buildType: "prebuilt",
+          offload: {
+            supported: false,
+          },
+          context: {
+            requestedSize: 512,
+          },
+          loadError: "GGUF load failed",
+        },
+      },
+    });
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = firstNoteMessage();
+    expect(message).toContain("llama.cpp runtime: cpu, prebuilt (failed)");
+    expect(message).toContain("GPU offload: unsupported");
+    expect(message).toContain("Requested context: 512 tokens");
+    expect(message).toContain("Load error: GGUF load failed");
+    expect(message).toContain("local embeddings are not confirmed ready");
+    expect(message).not.toContain("Gateway probe: GGUF load failed");
   });
 
   it("does not warn when local provider readiness probe was intentionally skipped", async () => {

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -266,6 +266,46 @@ describe("noteMemorySearchHealth", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
+  it("reports last-known llama.cpp runtime facts from the gateway", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: {
+        checked: true,
+        ready: true,
+        runtimeFacts: {
+          engine: "llama.cpp",
+          state: "ready",
+          backend: "cuda",
+          buildType: "prebuilt",
+          deviceNames: ["NVIDIA Test GPU"],
+          offload: {
+            supported: true,
+            offloadedLayers: 24,
+            totalLayers: 24,
+          },
+          context: {
+            requestedSize: 4096,
+          },
+        },
+      },
+    });
+
+    expect(note).toHaveBeenCalledWith(
+      [
+        "llama.cpp runtime: cuda, prebuilt",
+        "Devices: NVIDIA Test GPU",
+        "GPU offload: 24/24 layers",
+        "Requested context: 4096 tokens",
+      ].join("\n"),
+      "Memory search",
+    );
+  });
+
   it("does not warn when local provider readiness probe was intentionally skipped", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -3,6 +3,7 @@ import {
   findNormalizedProviderValue,
   normalizeProviderId,
 } from "@openclaw/model-catalog-core/provider-id";
+import { formatByteSize } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
 import {
@@ -64,17 +65,37 @@ type MemoryEmbeddingProviderDoctorMetadata = {
   autoSelectPriority?: number;
 };
 
+function formatRuntimeBytes(bytes: number): string {
+  return formatByteSize(bytes, {
+    style: "legacy-binary",
+    maxUnit: "tera",
+    separator: " ",
+    fractionDigits: (value, unit) => (unit === "byte" ? null : value >= 10 ? 0 : 1),
+  });
+}
+
 function formatLocalRuntimeDoctorNote(facts: DoctorMemoryEmbeddingRuntimePayload): string {
   const backend = facts.backend ?? "unknown";
   const build = facts.buildType ? `, ${facts.buildType}` : "";
   const devices = facts.deviceNames?.length ? `\nDevices: ${facts.deviceNames.join(", ")}` : "";
+  const memory = facts.memory
+    ? `\nVRAM snapshot: ${formatRuntimeBytes(facts.memory.usedBytes)} used, ${formatRuntimeBytes(facts.memory.freeBytes)} free, ${formatRuntimeBytes(facts.memory.totalBytes)} total${
+        facts.memory.unifiedBytes > 0
+          ? `, ${formatRuntimeBytes(facts.memory.unifiedBytes)} unified`
+          : ""
+      } (${new Date(facts.memory.observedAtMs).toISOString()})`
+    : "";
   const offload =
     typeof facts.offload?.offloadedLayers === "number" &&
     typeof facts.offload.totalLayers === "number"
       ? `\nGPU offload: ${facts.offload.offloadedLayers}/${facts.offload.totalLayers} layers`
-      : "";
+      : facts.offload
+        ? `\nGPU offload: ${facts.offload.supported ? "supported" : "unsupported"}`
+        : "";
   const context = facts.context ? `\nRequested context: ${facts.context.requestedSize} tokens` : "";
-  return `llama.cpp runtime: ${backend}${build}${devices}${offload}${context}`;
+  const loadError = facts.loadError ? `\nLoad error: ${facts.loadError}` : "";
+  const state = facts.state === "ready" ? "" : ` (${facts.state})`;
+  return `llama.cpp runtime: ${backend}${build}${state}${devices}${memory}${offload}${context}${loadError}`;
 }
 
 const BUNDLED_MEMORY_EMBEDDING_PROVIDER_DOCTOR_METADATA: MemoryEmbeddingProviderDoctorMetadata[] = [
@@ -529,10 +550,11 @@ export async function noteMemorySearchHealth(
 
   if (provider === "local") {
     const suggestedRemoteProvider = resolveSuggestedRemoteMemoryProvider();
-    if (opts?.gatewayMemoryProbe?.runtimeFacts?.state === "ready") {
-      noteFn(formatLocalRuntimeDoctorNote(opts.gatewayMemoryProbe.runtimeFacts), "Memory search");
-    }
+    const runtimeFacts = opts?.gatewayMemoryProbe?.runtimeFacts;
     if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
+      if (runtimeFacts) {
+        noteFn(formatLocalRuntimeDoctorNote(runtimeFacts), "Memory search");
+      }
       return;
     }
     const hasExplicitLocalModel = hasLocalEmbeddings(resolved.local);
@@ -542,12 +564,15 @@ export async function noteMemorySearchHealth(
       return;
     }
     const detail = opts?.gatewayMemoryProbe?.error?.trim();
+    const gatewayDetail = detail && detail !== runtimeFacts?.loadError ? detail : null;
     noteFn(
       [
+        runtimeFacts ? formatLocalRuntimeDoctorNote(runtimeFacts) : null,
+        runtimeFacts ? "" : null,
         hasExplicitLocalModel
           ? 'Memory search provider is set to "local" and a local model path is configured, but local embeddings are not confirmed ready.'
           : 'Memory search provider is set to "local", but local embeddings are not confirmed ready.',
-        detail ? `Gateway probe: ${detail}` : null,
+        gatewayDetail ? `Gateway probe: ${gatewayDetail}` : null,
         "",
         "Fix (pick one):",
         `- Install the llama.cpp provider plugin: ${formatCliCommand("openclaw plugins install @openclaw/llama-cpp-provider")}`,

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -23,6 +23,7 @@ import {
 } from "../agents/model-auth.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { DoctorMemoryEmbeddingRuntimePayload } from "../gateway/server-methods/doctor.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   checkQmdBinaryAvailability,
@@ -62,6 +63,19 @@ type MemoryEmbeddingProviderDoctorMetadata = {
   transport: "local" | "remote";
   autoSelectPriority?: number;
 };
+
+function formatLocalRuntimeDoctorNote(facts: DoctorMemoryEmbeddingRuntimePayload): string {
+  const backend = facts.backend ?? "unknown";
+  const build = facts.buildType ? `, ${facts.buildType}` : "";
+  const devices = facts.deviceNames?.length ? `\nDevices: ${facts.deviceNames.join(", ")}` : "";
+  const offload =
+    typeof facts.offload?.offloadedLayers === "number" &&
+    typeof facts.offload.totalLayers === "number"
+      ? `\nGPU offload: ${facts.offload.offloadedLayers}/${facts.offload.totalLayers} layers`
+      : "";
+  const context = facts.context ? `\nRequested context: ${facts.context.requestedSize} tokens` : "";
+  return `llama.cpp runtime: ${backend}${build}${devices}${offload}${context}`;
+}
 
 const BUNDLED_MEMORY_EMBEDDING_PROVIDER_DOCTOR_METADATA: MemoryEmbeddingProviderDoctorMetadata[] = [
   {
@@ -419,6 +433,7 @@ export async function noteMemorySearchHealth(
       ready: boolean;
       error?: string;
       skipped?: boolean;
+      runtimeFacts?: DoctorMemoryEmbeddingRuntimePayload;
     };
     noteFn?: typeof note;
     includeWorkspaceMemoryHealth?: boolean;
@@ -514,6 +529,9 @@ export async function noteMemorySearchHealth(
 
   if (provider === "local") {
     const suggestedRemoteProvider = resolveSuggestedRemoteMemoryProvider();
+    if (opts?.gatewayMemoryProbe?.runtimeFacts?.state === "ready") {
+      noteFn(formatLocalRuntimeDoctorNote(opts.gatewayMemoryProbe.runtimeFacts), "Memory search");
+    }
     if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
       return;
     }

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -322,6 +322,61 @@ describe("doctor.memory.status", () => {
     });
   });
 
+  it("returns llama.cpp runtime facts created by the deep embedding probe", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    let probed = false;
+    getMemorySearchManager.mockResolvedValue({
+      manager: {
+        status: () => ({
+          provider: "local",
+          ...(probed
+            ? {
+                custom: {
+                  llamaCppRuntime: {
+                    engine: "llama.cpp",
+                    state: "ready",
+                    backend: "cuda",
+                    buildType: "prebuilt",
+                    deviceNames: ["NVIDIA Test GPU"],
+                    offload: {
+                      supported: true,
+                      offloadedLayers: 24,
+                      totalLayers: 24,
+                    },
+                    context: {
+                      requestedSize: 4096,
+                    },
+                  },
+                },
+              }
+            : {}),
+        }),
+        probeEmbeddingAvailability: vi.fn(async () => {
+          probed = true;
+          return { ok: true };
+        }),
+        close,
+      },
+    });
+    const respond = vi.fn();
+
+    await invokeDoctorMemoryStatus(respond, { params: { probe: true } });
+
+    expect(respondPayload(respond).embeddingRuntime).toMatchObject({
+      state: "ready",
+      backend: "cuda",
+      deviceNames: ["NVIDIA Test GPU"],
+      offload: {
+        offloadedLayers: 24,
+        totalLayers: 24,
+      },
+      context: {
+        requestedSize: 4096,
+      },
+    });
+    expect(close).toHaveBeenCalled();
+  });
+
   it("does not live-probe embedding readiness by default", async () => {
     const close = vi.fn().mockResolvedValue(undefined);
     const probeEmbeddingAvailability = vi.fn().mockResolvedValue({ ok: true });

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -124,7 +124,32 @@ export type DoctorMemoryStatusPayload = {
     checkedAtMs?: number;
     cacheExpiresAtMs?: number;
   };
+  embeddingRuntime?: DoctorMemoryEmbeddingRuntimePayload;
   dreaming?: DoctorMemoryDreamingPayload;
+};
+
+export type DoctorMemoryEmbeddingRuntimePayload = {
+  engine: "llama.cpp";
+  state: "ready" | "failed";
+  backend?: "metal" | "cuda" | "vulkan" | "cpu";
+  buildType?: "localBuild" | "prebuilt";
+  deviceNames?: string[];
+  memory?: {
+    totalBytes: number;
+    usedBytes: number;
+    freeBytes: number;
+    unifiedBytes: number;
+    observedAtMs: number;
+  };
+  offload?: {
+    supported: boolean;
+    offloadedLayers?: number;
+    totalLayers?: number;
+  };
+  context?: {
+    requestedSize: number | "auto";
+  };
+  loadError?: string;
 };
 
 export type DoctorMemoryDreamDiaryPayload = {
@@ -727,11 +752,14 @@ export const doctorHandlers: GatewayRequestHandlers = {
     }
 
     try {
-      const status = manager.status();
+      let status = manager.status();
       const shouldProbe = shouldProbeMemoryEmbeddings(params);
       let embedding = shouldProbe
         ? await manager.probeEmbeddingAvailability()
         : (manager.getCachedEmbeddingAvailability?.() ?? SKIPPED_MEMORY_EMBEDDING_PROBE);
+      if (shouldProbe) {
+        status = manager.status();
+      }
       if (!embedding.ok && !embedding.error) {
         embedding = { ok: false, error: "memory embeddings unavailable" };
       }
@@ -774,6 +802,12 @@ export const doctorHandlers: GatewayRequestHandlers = {
         agentId,
         provider: status.provider,
         embedding,
+        embeddingRuntime: (() => {
+          const runtime = asOptionalRecord(asOptionalRecord(status.custom)?.llamaCppRuntime);
+          return runtime?.engine === "llama.cpp"
+            ? (runtime as DoctorMemoryEmbeddingRuntimePayload)
+            : undefined;
+        })(),
         dreaming: {
           ...dreamingConfig,
           ...storeStats,


### PR DESCRIPTION
Closes #104309

## What Problem This Solves

Local llama.cpp embeddings do not expose the runtime decisions needed to diagnose hardware acceleration. Operators cannot tell which backend/build was selected, which devices were found, how GPU layers were placed, what context requirement was used, or why model loading fell back or failed. Numeric embedding context requirements also were not supplied to node-llama-cpp's automatic GPU-layer placement contract.

Passive status must remain cheap and must not load a model solely to gather diagnostics.

## Why This Change Was Made

This carries llama-specific runtime facts through the existing facade and serialized worker result, then renders them only in the existing runtime result, deep status, and doctor paths. Numeric `contextSize` values feed node-llama-cpp 3.19.0's public `gpuLayers.fitContext` contract; `contextSize: "auto"` remains dependency-managed. Generic embedding provider/runtime and public plugin SDK contracts remain unchanged.

Alternatives rejected: global GPU/device config, reading the dependency-private `_llamaContext`, and multi-context pooling without benchmark proof.

## User Impact

Operators can verify CPU fallback or acceleration, inspect backend/build/device/offload decisions, see timestamped last-observed memory, and diagnose reliable load failures. Passive status still does not initialize the model.

## Evidence

- Personally inspected exact pinned `node-llama-cpp` 3.19.0 source and public types, including backend/device selection, VRAM state, GPU support, model loading, and `gpuLayers.fitContext`.
- Blacksmith Testbox focused facade, worker, protocol, fit-context, status, and doctor suites: 172 assertions passed on the final exact-base run.
- `OPENCLAW_TESTBOX=1 pnpm check:changed`: five selected lanes passed in 10m49s.
- Real Linux CPU runtime: backend `cpu`, build `prebuilt`, no devices, offload unsupported, 0/25 layers, requested context 512, dimensions 768.
- Real missing-model failure retained backend/build/requested-context facts and surfaced the exact load error.
- Two fresh autoreview passes found no accepted/actionable issues.
- The available Testbox exposed no GPU; accelerated placement is therefore dependency-contract and unit-test proven, not observed on GPU hardware.
- PR #104306 merged while this PR was in validation. This branch was rebased onto that merge, preserving the local-service changes and layering only llama-specific fact propagation on top; the seven commits remained patch-equivalent.
