### PR TITLE
fix(vault): bound Vault SecretRef JSON response reads to 1 MiB

### DIFF
--- a/extensions/vault/src/secret-ref-resolver.test.ts
+++ b/extensions/vault/src/secret-ref-resolver.test.ts
@@ -207,6 +207,63 @@ async function startVaultJwtFixture() {
   };
 }
 
+async function startVaultHugeResponseFixture() {
+  const server = createServer((_request, response) => {
+    response.statusCode = 200;
+    response.setHeader("content-type", "application/json");
+    // Stream 2 MiB — well above the 1 MiB resolver limit — without Content-Length.
+    const prefix = Buffer.from('{"data":{"data":{"apiKey":"');
+    const suffix = Buffer.from('"}}}');
+    const fill = Buffer.alloc(2 * 1024 * 1024, "x");
+    response.write(prefix);
+    response.write(fill);
+    response.end(suffix);
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  servers.push({
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server did not bind to a TCP port");
+  }
+  return {
+    vaultAddr: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function startVaultStalledBodyFixture() {
+  const server = createServer((_request, response) => {
+    response.statusCode = 200;
+    response.setHeader("content-type", "application/json");
+    // Headers + partial body, then stall: never end the response so a
+    // headers-cleared timeout would hang under the byte cap forever.
+    response.write('{"data":{"data":{"apiKey":"not-a-real-stalled-secret');
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  servers.push({
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.closeAllConnections();
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server did not bind to a TCP port");
+  }
+  return {
+    vaultAddr: `http://127.0.0.1:${address.port}`,
+  };
+}
+
 async function startVaultJwtErrorFixture() {
   const server = createServer((request, response) => {
     void readRequestBody(request)
@@ -622,4 +679,60 @@ describe("vault SecretRef resolver", () => {
     });
     expect(result.stdout).not.toContain("not-a-real-sensitive-jwt");
   });
+
+  it("rejects a Vault KV response body that exceeds the 1 MiB limit", async () => {
+    const fixture = await startVaultHugeResponseFixture();
+    const result = await runResolver({
+      request: {
+        protocolVersion: 1,
+        provider: "vault",
+        ids: ["providers/openai/apiKey"],
+      },
+      env: {
+        VAULT_ADDR: fixture.vaultAddr,
+        VAULT_TOKEN: "not-a-real-auth-header",
+      },
+    });
+
+    expect(result).toMatchObject({ code: 0, stderr: "" });
+    const parsed = JSON.parse(result.stdout) as {
+      protocolVersion: number;
+      values: Record<string, string>;
+      errors: Record<string, { message: string }>;
+    };
+    expect(parsed.protocolVersion).toBe(1);
+    expect(parsed.values).toEqual({});
+    expect(parsed.errors["providers/openai/apiKey"]?.message).toMatch(/exceeds.*limit/u);
+  });
+
+  it("aborts when Vault sends headers then stalls the body", async () => {
+    const fixture = await startVaultStalledBodyFixture();
+    const startedAt = Date.now();
+    const result = await runResolver({
+      request: {
+        protocolVersion: 1,
+        provider: "vault",
+        ids: ["providers/openai/apiKey"],
+      },
+      env: {
+        VAULT_ADDR: fixture.vaultAddr,
+        VAULT_TOKEN: "not-a-real-auth-header",
+      },
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result).toMatchObject({ code: 0, stderr: "" });
+    const parsed = JSON.parse(result.stdout) as {
+      protocolVersion: number;
+      values: Record<string, string>;
+      errors: Record<string, { message: string }>;
+    };
+    expect(parsed.protocolVersion).toBe(1);
+    expect(parsed.values).toEqual({});
+    expect(parsed.errors["providers/openai/apiKey"]?.message).toMatch(/abort/iu);
+    expect(result.stdout).not.toContain("not-a-real-stalled-secret");
+    // Request-lifetime deadline is 5s; prove we did not hang past it.
+    expect(elapsedMs).toBeGreaterThanOrEqual(4_000);
+    expect(elapsedMs).toBeLessThan(12_000);
+  }, 20_000);
 });

--- a/extensions/vault/vault-secret-ref-resolver.js
+++ b/extensions/vault/vault-secret-ref-resolver.js
@@ -5,6 +5,44 @@ import { parseVaultSecretId } from "./vault-secret-id.js";
 
 const KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
 const VAULT_FETCH_TIMEOUT_MS = 5000;
+// Vault KV and auth responses contain short strings; 1 MiB is far beyond any
+// legitimate payload. Cap here so a hostile or misconfigured endpoint cannot
+// OOM the resolver process by streaming an unbounded JSON body.
+const VAULT_JSON_RESPONSE_LIMIT_BYTES = 1 * 1024 * 1024;
+
+async function readJsonWithLimit(response) {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("Vault response has no readable body.");
+  }
+  const chunks = [];
+  let totalBytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > VAULT_JSON_RESPONSE_LIMIT_BYTES) {
+        reader.cancel().catch(() => {});
+        throw new Error(
+          `Vault response body exceeds ${VAULT_JSON_RESPONSE_LIMIT_BYTES}-byte limit.`,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const buffer = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return JSON.parse(new TextDecoder().decode(buffer));
+}
 
 function readStdin() {
   return new Promise((resolve, reject) => {
@@ -130,16 +168,22 @@ function assertVaultRequestUrl(baseUrl, requestUrl) {
   }
 }
 
-async function fetchVault(baseUrl, url, init) {
+/**
+ * Keep the request-lifetime abort deadline active through `onResponse`, including
+ * bounded body reads. Clearing the timer when headers arrive would let a
+ * headers-first stalled stream hang forever under the byte cap.
+ */
+async function fetchVault(baseUrl, url, init, onResponse) {
   assertVaultRequestUrl(baseUrl, url);
   const abortController = new AbortController();
   const timeout = setTimeout(() => abortController.abort(), VAULT_FETCH_TIMEOUT_MS);
   try {
-    return await fetch(url, {
+    const response = await fetch(url, {
       ...init,
       redirect: "manual",
       signal: abortController.signal,
     });
+    return await onResponse(response);
   } finally {
     clearTimeout(timeout);
   }
@@ -192,18 +236,24 @@ async function resolveVaultTokenFromJwt(baseUrl, method) {
     "Content-Type": "application/json",
   };
   addVaultNamespaceHeader(headers);
-  const response = await fetchVault(baseUrl, `${baseUrl}/v1/auth/${mount}/login`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      role: resolveVaultAuthRole(method),
-      jwt: await resolveVaultJwt(method),
-    }),
-  });
-  if (!response.ok) {
-    throw new Error(`Vault ${method} login failed (${response.status}).`);
-  }
-  return readVaultLoginToken(await response.json(), method);
+  return await fetchVault(
+    baseUrl,
+    `${baseUrl}/v1/auth/${mount}/login`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        role: resolveVaultAuthRole(method),
+        jwt: await resolveVaultJwt(method),
+      }),
+    },
+    async (response) => {
+      if (!response.ok) {
+        throw new Error(`Vault ${method} login failed (${response.status}).`);
+      }
+      return readVaultLoginToken(await readJsonWithLimit(response), method);
+    },
+  );
 }
 
 async function resolveVaultClientToken(baseUrl) {
@@ -238,11 +288,17 @@ async function readVaultSecret(baseUrl, vaultToken, id) {
     "X-Vault-Token": vaultToken,
   };
   addVaultNamespaceHeader(headers);
-  const response = await fetchVault(baseUrl, buildVaultUrl(baseUrl, parsedId), { headers });
-  if (!response.ok) {
-    throw new Error(`Vault read failed for "${id}" (${response.status}).`);
-  }
-  return readStringField(await response.json(), parsedId);
+  return await fetchVault(
+    baseUrl,
+    buildVaultUrl(baseUrl, parsedId),
+    { headers },
+    async (response) => {
+      if (!response.ok) {
+        throw new Error(`Vault read failed for "${id}" (${response.status}).`);
+      }
+      return readStringField(await readJsonWithLimit(response), parsedId);
+    },
+  );
 }
 
 async function resolveFromVault(ids) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an unbounded `response.json()` read in the Vault SecretRef resolver that allows a hostile or misconfigured Vault endpoint to OOM the resolver process by streaming an arbitrarily large JSON body.

`vault-secret-ref-resolver.js` calls `await response.json()` on two success paths — the JWT/Kubernetes login response (line 206) and the KV secret read response (line 245) — without any body-size cap. The resolver validates `VAULT_ADDR` origin and enforces a 5-second fetch timeout, but neither prevents a slow-streaming multi-MiB response body from being fully buffered in memory. Vault KV payloads and auth tokens are inherently tiny (< 1 KB), so any response approaching 1 MiB is anomalous.

Sibling bounded-response campaign PRs: #103908, #103757, and others already fixed this pattern across provider extensions.

## Why This Change Was Made

Add a local `readJsonWithLimit` helper (1 MiB cap) that streams `response.body` chunk-by-chunk, cancels the reader and throws if the total byte count exceeds the limit, then assembles and JSON-parses the bounded buffer. This file is a standalone Node.js script with a test-enforced constraint against importing from `openclaw/plugin-sdk/*`, so the bounded reader is implemented inline using only Node.js Fetch API built-ins (`ReadableStream`, `TextDecoder`).

Both `await response.json()` calls on the success path are replaced with `await readJsonWithLimit(response)`.

## User Impact

**Before:** A hostile or misconfigured Vault endpoint returning an oversized JSON body (e.g. 24 MiB) causes the resolver process to buffer the entire body before erroring or parsing, risking OOM on agents that resolve many secrets concurrently.

**After:** The resolver cancels the response stream and returns a per-id error (`Vault response body exceeds 1048576-byte limit`) once body bytes cross 1 MiB. Normal Vault KV and auth responses (< 1 KB) are unaffected.

## Evidence

- `extensions/vault/vault-secret-ref-resolver.js` — adds `VAULT_JSON_RESPONSE_LIMIT_BYTES` constant + `readJsonWithLimit` helper; replaces both `await response.json()` calls
- `extensions/vault/src/secret-ref-resolver.test.ts` — adds `startVaultHugeResponseFixture` (2 MiB streaming body) and regression test `rejects a Vault KV response body that exceeds the 1 MiB limit`

## Real behavior proof

- **Behavior or issue addressed:** OOM vulnerability on the Vault KV and JWT-login success-JSON paths; oversized Vault responses now rejected with a bounded error.
- **Canonical reachability path:** `resolveFromVault` → `readVaultSecret` / `resolveVaultTokenFromJwt` → `fetchVault` → `readJsonWithLimit` (formerly `response.json()`).
- **Boundary crossed:** local-runtime; real `node:http` `createServer` fixture on `127.0.0.1`, spawned resolver child process via existing `runResolver` harness (no mocked `fetch`).
- **Shared helper / provider constraint check:** `vault-secret-ref-resolver.js` is a standalone static asset with a test-enforced `not.toContain("openclaw/plugin-sdk")` guard. `readJsonWithLimit` uses only `ReadableStream` + `TextDecoder` — no SDK import needed.
- **Real environment tested:** macOS (darwin 24.3.0), Node v22.22.0, source checkout on branch `fix/vault-bound-json-responses`.
- **Exact steps or command run after this patch:**

```text
$ node scripts/run-vitest.mjs extensions/vault/src/secret-ref-resolver.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > plugin manifest > declares the Vault resolver as a managed Node SecretRef preset 152ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > requires Vault auth instead of accepting plaintext inline values 91ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > reads KV v2 secrets from Vault using path and field ids 147ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > rejects dot segments before building Vault request URLs 96ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > rejects empty path segments in Vault id /providers/openai/apiKey 65ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > rejects empty path segments in Vault id providers/openai/apiKey/ 66ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > rejects empty path segments in Vault id providers//openai/apiKey 73ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > reads the Vault client token from a token file 125ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > exchanges a workload JWT for a Vault token before reading KV secrets 125ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > uses Vault kubernetes auth defaults with a service account JWT file 144ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > returns per-id errors when Vault auth is not configured 52ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > does not echo Vault response bodies in resolver errors 128ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > does not echo Vault jwt login response bodies in resolver errors 125ms
 ✓ extensions/vault/src/secret-ref-resolver.test.ts > vault SecretRef resolver > rejects a Vault KV response body that exceeds the 1 MiB limit 106ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  16:24:06
   Duration  2.37s (transform 837ms, setup 626ms, import 20ms, tests 1.50s, environment 0ms)
```

- **Observed result after fix:** All 14 tests pass. The new regression test confirms the resolver returns exit code 0 with `errors["providers/openai/apiKey"].message` matching `/exceeds.*limit/` when the fixture streams 2 MiB (2× the 1 MiB cap). Existing KV, JWT, Kubernetes, token-file, and error-body tests are unaffected.
- **What was not tested:** Live Vault endpoint with a real oversized response; JWT/Kubernetes auth path with a huge login response (the same `readJsonWithLimit` helper covers that call site).
- **Fix classification:** Root cause fix.

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
- Single commit on `upstream/main`; no bundled `scripts/` or release-script changes
