### PR TITLE
refactor(agents): converge CLI tool terminal reason onto run-termination

### DIFF
--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -40,6 +40,7 @@ import {
 } from "../cli-output.js";
 import { classifyFailoverReason } from "../embedded-agent-helpers.js";
 import { FailoverError, isTimeoutError, resolveFailoverStatus } from "../failover-error.js";
+import { resolveCliToolTerminalReason } from "../run-termination.js";
 import { prepareCliBundleMcpCaptureAttempt } from "./bundle-mcp.js";
 import { buildClaudeOwnerKey } from "./helpers.js";
 import { cliBackendLog, formatCliBackendOutputDigest } from "./log.js";
@@ -52,6 +53,8 @@ type ManagedRun = Awaited<ReturnType<ProcessSupervisor["spawn"]>>;
 type ClaudeLiveTurn = {
   backend: CliBackendConfig;
   diagnosticRefs: ClaudeLiveDiagnosticRefs;
+  /** Enclosing run abort signal; authoritative for tool terminal reason on turn failure. */
+  abortSignal?: AbortSignal;
   outputLimits: ClaudeLiveOutputLimits;
   startedAtMs: number;
   rawLines: string[];
@@ -670,11 +673,16 @@ function markClaudeLiveToolDenied(turn: ClaudeLiveTurn, tool: CliToolUseStartDel
 }
 
 function failActiveClaudeLiveTools(turn: ClaudeLiveTurn, error: unknown): void {
-  const timedOut =
-    isTimeoutError(error) || (error instanceof FailoverError && error.reason === "timeout");
-  const aborted = error instanceof Error && error.name === "AbortError";
-  const errorCategory = timedOut ? "timeout" : aborted ? "aborted" : "error";
-  const terminalReason = timedOut ? "timed_out" : aborted ? "cancelled" : "failed";
+  const terminalReason = resolveCliToolTerminalReason({
+    error,
+    abortSignal: turn.abortSignal,
+  });
+  const errorCategory =
+    terminalReason === "timed_out"
+      ? "timeout"
+      : terminalReason === "cancelled"
+        ? "aborted"
+        : "error";
   for (const activeTool of turn.activeTools.values()) {
     const event: Omit<DiagnosticToolExecutionErrorEvent, "seq" | "ts" | "type" | "errorCategory"> =
       {
@@ -1188,6 +1196,7 @@ function createTurn(params: {
       ...(params.context.params.sessionKey ? { sessionKey: params.context.params.sessionKey } : {}),
       ...(params.context.params.agentId ? { agentId: params.context.params.agentId } : {}),
     },
+    abortSignal: params.context.params.abortSignal,
     outputLimits: resolveCliStreamJsonOutputLimits(params.context.preparedBackend.backend),
     startedAtMs: Date.now(),
     rawLines: [],

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -69,7 +69,7 @@ import {
 } from "../embedded-agent-subscribe.tools.js";
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
-import { resolveAgentRunAbortLifecycleFields } from "../run-termination.js";
+import { resolveCliToolTerminalReason } from "../run-termination.js";
 import { prepareCliBundleMcpCaptureAttempt } from "./bundle-mcp.js";
 import {
   rotateClaudeLiveMcpCaptureKeyForContext,
@@ -845,15 +845,6 @@ export async function executePreparedCliRun(
             : {}),
         };
       };
-      const resolveToolTerminalReason = (error?: unknown) => {
-        const abortFields = resolveAgentRunAbortLifecycleFields(params.abortSignal);
-        if (abortFields.aborted) {
-          return abortFields.stopReason === "timeout" ? "timed_out" : "cancelled";
-        }
-        return error instanceof FailoverError && error.reason === "timeout"
-          ? "timed_out"
-          : "failed";
-      };
       let finalizeParsedTools = () => {};
       try {
         cliBackendLog.info(
@@ -1301,7 +1292,10 @@ export async function executePreparedCliRun(
               : undefined;
           const terminalReason =
             trustedTerminalReason ??
-            resolveToolTerminalReason(event.incomplete ? runError : undefined);
+            resolveCliToolTerminalReason({
+              error: event.incomplete ? runError : undefined,
+              abortSignal: params.abortSignal,
+            });
           // Incomplete client/MCP tools inherit the enclosing failed run even when
           // the loopback disconnect is ambiguous. Server-native tools do not.
           const useEnclosingTerminalReason =

--- a/src/agents/run-termination.test.ts
+++ b/src/agents/run-termination.test.ts
@@ -7,7 +7,103 @@ import {
   isAbortedAgentStopReason,
   resolveAgentRunAbortLifecycleFields,
   resolveAgentRunErrorLifecycleFields,
+  resolveCliToolTerminalReason,
 } from "./run-termination.js";
+
+describe("resolveCliToolTerminalReason", () => {
+  it.each([
+    {
+      name: "abort-timeout",
+      setup: () => {
+        const controller = new AbortController();
+        const timeout = new Error("timed out");
+        timeout.name = "TimeoutError";
+        controller.abort(timeout);
+        return { abortSignal: controller.signal, error: new Error("other") };
+      },
+      expected: "timed_out",
+    },
+    {
+      name: "abort-cancel",
+      setup: () => {
+        const controller = new AbortController();
+        controller.abort();
+        return { abortSignal: controller.signal, error: undefined };
+      },
+      expected: "cancelled",
+    },
+    {
+      name: "restart-abort reason",
+      setup: () => {
+        const controller = new AbortController();
+        controller.abort(createAgentRunRestartAbortError());
+        return { abortSignal: controller.signal, error: undefined };
+      },
+      expected: "cancelled",
+    },
+    {
+      name: "FailoverError timeout",
+      setup: () => ({
+        error: new FailoverError("CLI timed out", { reason: "timeout" }),
+      }),
+      expected: "timed_out",
+    },
+    {
+      name: "isTimeoutError error",
+      setup: () => {
+        const error = new Error("request timed out");
+        error.name = "TimeoutError";
+        return { error };
+      },
+      expected: "timed_out",
+    },
+    {
+      name: "AbortError",
+      setup: () => {
+        const error = new Error("CLI run aborted");
+        error.name = "AbortError";
+        return { error };
+      },
+      expected: "cancelled",
+    },
+    {
+      name: "plain Error",
+      setup: () => ({ error: new Error("tool failed") }),
+      expected: "failed",
+    },
+    {
+      name: "undefined error",
+      setup: () => ({ error: undefined }),
+      expected: "failed",
+    },
+    {
+      name: "timeout abort wins over generic AbortError",
+      setup: () => {
+        const controller = new AbortController();
+        const timeout = new Error("timed out");
+        timeout.name = "TimeoutError";
+        controller.abort(timeout);
+        const error = new Error("CLI run aborted");
+        error.name = "AbortError";
+        return { abortSignal: controller.signal, error };
+      },
+      expected: "timed_out",
+    },
+    {
+      name: "cancel abort wins over timeout-shaped error",
+      setup: () => {
+        const controller = new AbortController();
+        controller.abort();
+        const error = new Error("request timed out");
+        error.name = "TimeoutError";
+        return { abortSignal: controller.signal, error };
+      },
+      expected: "cancelled",
+    },
+  ] as const)("$name", ({ setup, expected }) => {
+    expect(resolveCliToolTerminalReason(setup())).toBe(expected);
+  });
+});
 
 describe("resolveAgentRunAbortLifecycleFields", () => {
   it("classifies generic cancellation as aborted", () => {

--- a/src/agents/run-termination.test.ts
+++ b/src/agents/run-termination.test.ts
@@ -100,6 +100,18 @@ describe("resolveCliToolTerminalReason", () => {
       },
       expected: "cancelled",
     },
+    {
+      name: "hostile name getter classifies failed instead of throwing",
+      setup: () => {
+        const error = Object.defineProperty(new Error("boom"), "name", {
+          get() {
+            throw new Error("hostile getter");
+          },
+        });
+        return { error };
+      },
+      expected: "failed",
+    },
   ] as const)("$name", ({ setup, expected }) => {
     expect(resolveCliToolTerminalReason(setup())).toBe(expected);
   });

--- a/src/agents/run-termination.ts
+++ b/src/agents/run-termination.ts
@@ -1,4 +1,4 @@
-import { isFailoverError } from "./failover-error.js";
+import { isFailoverError, isTimeoutError } from "./failover-error.js";
 import type { AgentRunTimeoutPhase } from "./run-timeout-attribution.js";
 
 /**
@@ -123,4 +123,27 @@ export function isAbortedAgentStopReason(
   value: unknown,
 ): value is typeof AGENT_RUN_ABORTED_STOP_REASON | typeof AGENT_RUN_RESTART_ABORT_STOP_REASON {
   return value === AGENT_RUN_ABORTED_STOP_REASON || value === AGENT_RUN_RESTART_ABORT_STOP_REASON;
+}
+
+/**
+ * CLI tool terminal reason for one-shot and live runners.
+ * Abort-signal lifecycle is authoritative so a timeout abort stays timed_out
+ * even when the delivered error is a generic AbortError.
+ */
+export function resolveCliToolTerminalReason(params: {
+  error?: unknown;
+  abortSignal?: AbortSignal;
+}): "timed_out" | "cancelled" | "failed" {
+  const abortFields = resolveAgentRunAbortLifecycleFields(params.abortSignal);
+  if (abortFields.aborted) {
+    return abortFields.stopReason === "timeout" ? "timed_out" : "cancelled";
+  }
+  const { error } = params;
+  if (isTimeoutError(error) || (isFailoverError(error) && error.reason === "timeout")) {
+    return "timed_out";
+  }
+  if (error instanceof Error && error.name === "AbortError") {
+    return "cancelled";
+  }
+  return "failed";
 }

--- a/src/agents/run-termination.ts
+++ b/src/agents/run-termination.ts
@@ -139,11 +139,16 @@ export function resolveCliToolTerminalReason(params: {
     return abortFields.stopReason === "timeout" ? "timed_out" : "cancelled";
   }
   const { error } = params;
-  if (isTimeoutError(error) || (isFailoverError(error) && error.reason === "timeout")) {
-    return "timed_out";
-  }
-  if (error instanceof Error && error.name === "AbortError") {
-    return "cancelled";
+  try {
+    if (isTimeoutError(error) || (isFailoverError(error) && error.reason === "timeout")) {
+      return "timed_out";
+    }
+    if (error instanceof Error && error.name === "AbortError") {
+      return "cancelled";
+    }
+  } catch {
+    // Run errors may expose hostile getters. Classification must not replace
+    // the original failure or suppress its terminal event.
   }
   return "failed";
 }


### PR DESCRIPTION
## What Problem This Solves

The one-shot and live CLI runners each derived the same terminal decision — `timed_out` / `cancelled` / `failed` for tools when a run ends — with different logic:

- `src/agents/cli-runner/execute.ts` (one-shot) read the abort signal's lifecycle fields, then only recognized `FailoverError` timeouts; a `TimeoutError`-shaped or `AbortError`-shaped run error without an aborted signal classified as `failed`.
- `src/agents/cli-runner/claude-live-session.ts` (live) only sniffed error shape (`isTimeoutError`, `FailoverError` timeout, `AbortError` name) and never consulted the abort signal.

Because the live path trusted the delivered error's name alone, a run timeout whose abort reason reached the turn as a generic `AbortError` (or a non-`Error` timeout reason, which `createAbortError` cannot preserve) was reported as `cancelled` instead of `timed_out`; conversely a user cancel racing a timeout-shaped provider error reported `timed_out` where the one-shot path reports `cancelled`. Same decision, two encodings, observable drift — seam 3 of #104219.

## Why This Change Was Made

Converge the derivation onto one owner, per the #104219 change shape. `resolveCliToolTerminalReason` lives in `src/agents/run-termination.ts` — the module that already owns abort→stop-reason semantics (`resolveAgentRunAbortLifecycleFields`) — and encodes one rule: abort-signal lifecycle fields are authoritative when the signal has aborted; error shape (`isTimeoutError`, `FailoverError` timeout, `AbortError` name) classifies otherwise. Both call-site derivations are deleted in the same change; the live turn now carries the run's real abort signal (`ClaudeLiveTurn.abortSignal`, threaded in `createTurn`).

`terminalReason` feeds diagnostic events only (`tool.execution.error` category/reason fields), so behavior changes are contained to diagnostics classification. The per-site `errorCategory` vocabularies (`timeout/aborted/error` vs `aborted/cli_tool_incomplete/cli_tool`) intentionally differ per event source and stay site-local.

## User Impact

Tool-failure diagnostics now classify consistently across CLI runner modes:

- Live runs that hit the run timeout report `timed_out` (previously `cancelled` when the abort reason arrived as a generic `AbortError` or a non-`Error` reason).
- A user cancel racing a timeout-shaped error consistently reports `cancelled` on both paths (signal wins).
- One-shot runs with a `TimeoutError`/`AbortError`-shaped run error and no aborted signal now report `timed_out`/`cancelled` instead of `failed`.

No control-flow, retry, or delivery behavior changes.

## Evidence

- Drift sites and trace: old derivations at `execute.ts` (`resolveToolTerminalReason`) and `claude-live-session.ts` (`failActiveClaudeLiveTools`); live abort delivery via `createAbortError(signal.reason)` loses timeout identity for generic/non-`Error` reasons.
- Tests: table-driven matrix for `resolveCliToolTerminalReason` in `src/agents/run-termination.test.ts` (11 cases), including both drift regressions: "timeout abort wins over generic AbortError" and "cancel abort wins over timeout-shaped error".
- Local: `pnpm tsgo:core`, `pnpm tsgo:test:src`, `pnpm check:import-cycles` all exit 0; focused vitest green (`run-termination`, cli-runner suites — 270+ tests).
- Remote (Blacksmith Testbox, leases `tbx_01kx80mneqrn7dyntk6cjptc4t`, `tbx_01kx837g6z39m9kjrfkr8mvsm8`), branch rebased on latest `main`: `pnpm check:changed` exit 0. `pnpm test:changed` hit two known-flaky failures under full parallel shard load (`model-fallback.probe.test.ts` async log-capture assertion; `Worker exited unexpectedly` on the gateway shard); both pass in isolation on the same lease and diff — probe test 20/20 twice, full gateway shard 402 files / 6454 tests green. Neither touches this diff's surface.
- `git diff --numstat`: +43/−17 prod, +96 tests. Net prod +26 buys the single owner: both call-site derivations deleted, one closed union exported.

### Real behavior proof (ephemeral runtime)

Real `executePreparedCliRun` flow — production executor, real process supervisor spawning a real child process, real `claude-stream-json` parser — with a stub CLI backend (one JSONL `mcp_tool_use` line, then silence; no network, no API keys, isolated `OPENCLAW_STATE_DIR`). Events observed on the trusted tool-execution bus (`onTrustedToolExecutionEvent`; the public `onDiagnosticEvent` filters trusted events). One-shot path exercised; the live session consumes the same shared helper.

Timeout run (no-output watchdog → `FailoverError reason:"timeout"`), redacted:

```json
{
  "type": "tool.execution.error",
  "runId": "run-proof-timeout",
  "toolName": "mcp__openclaw__cron",
  "toolOwner": "cli-runner",
  "toolCallId": "call-proof-timeout",
  "durationMs": 1509,
  "errorCategory": "cli_tool_incomplete",
  "terminalReason": "timed_out"
}
```

User-cancel run (`abortController.abort()` after `tool.execution.started` → `AbortError` with aborted signal), redacted:

```json
{
  "type": "tool.execution.error",
  "runId": "run-proof-cancel",
  "toolName": "mcp__openclaw__cron",
  "toolOwner": "cli-runner",
  "toolCallId": "call-proof-cancel",
  "durationMs": 137,
  "errorCategory": "aborted",
  "terminalReason": "cancelled"
}
```

**Claude-live path** (same harness family, routed through `shouldUseClaudeLiveSession`: backend id `claude-cli`, `liveSession: "claude-stdio"`; stub waits for the live turn's stdin input, emits a tool use, holds the session; log lines confirm `claude live session start/close reason=abort`). Both events emitted by `failActiveClaudeLiveTools` and carry `toolOwner: "claude-cli"`, exercising the newly threaded `ClaudeLiveTurn.abortSignal`:

Timeout abort — the exact drift case this PR fixes: signal aborted with a non-`Error` timeout reason (`{ name: "TimeoutError" }` → lifecycle `stopReason: "timeout"`), while `createAbortError` delivers a generic `AbortError("CLI run aborted")`. Pre-fix live classification (error shape only) would say `cancelled`; captured after-fix event:

```json
{
  "type": "tool.execution.error",
  "runId": "run-live-proof-timeout",
  "toolName": "mcp__openclaw__cron",
  "toolOwner": "claude-cli",
  "toolCallId": "call-live-timeout",
  "durationMs": 116,
  "errorCategory": "timeout",
  "terminalReason": "timed_out"
}
```

User cancel (plain `abort()` while the live tool is active):

```json
{
  "type": "tool.execution.error",
  "runId": "run-live-proof-cancel",
  "toolName": "mcp__openclaw__cron",
  "toolOwner": "claude-cli",
  "toolCallId": "call-live-cancel",
  "durationMs": 123,
  "errorCategory": "aborted",
  "terminalReason": "cancelled"
}
```

Branch rebased on current `main`; focused tests + `tsgo:core` green post-rebase.

Part of #104219 (seam 3: CLI-runner terminal reason derivation).
