### PR TITLE
feat(macos): navigate dashboard history with Command brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **macOS dashboard navigation:** use ⌘[ and ⌘] to move backward and forward in the focused dashboard browser.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)
 - **Meta provider:** add bundled `muse-spark-1.1` model support with Responses API streaming, tool calls, encrypted reasoning replay, onboarding, and standalone npm/ClawHub distribution. (#102873) Thanks @HamidShojanazeri.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **macOS dashboard navigation:** use ⌘[ and ⌘] to move backward and forward in the focused dashboard browser.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)
 - **Meta provider:** add bundled `muse-spark-1.1` model support with Responses API streaming, tool calls, encrypted reasoning replay, onboarding, and standalone npm/ClawHub distribution. (#102873) Thanks @HamidShojanazeri.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -18322,8 +18322,24 @@
       "id": "native.apple.185a1b27c9859cc0"
     },
     {
+      "kind": "ui-call",
+      "line": 114,
+      "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
+      "source": "Back",
+      "surface": "apple",
+      "id": "native.apple.f6048387f9b99c8e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 119,
+      "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
+      "source": "Forward",
+      "surface": "apple",
+      "id": "native.apple.c19b0989064c0020"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 126,
+      "line": 137,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -18331,7 +18347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 126,
+      "line": 137,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw - Voice Wake live meter active",
       "surface": "apple",
@@ -18339,7 +18355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 327,
+      "line": 338,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -18347,7 +18363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 327,
+      "line": 338,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -162,6 +162,16 @@ final class DashboardManager {
         self.controller?.closeDashboard()
     }
 
+    func navigateBack() {
+        guard self.controller?.window?.isKeyWindow == true else { return }
+        self.controller?.navigateBack()
+    }
+
+    func navigateForward() {
+        guard self.controller?.window?.isKeyWindow == true else { return }
+        self.controller?.navigateForward()
+    }
+
     private static func websocketURLString(for dashboardURL: URL) -> String {
         guard var components = URLComponents(url: dashboardURL, resolvingAgainstBaseURL: false) else {
             return dashboardURL.absoluteString

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -544,11 +544,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     @objc private func navigateBack(_: Any?) {
-        self.navigateBack()
+        self.webView.goBack()
     }
 
     @objc private func navigateForward(_: Any?) {
-        self.navigateForward()
+        self.webView.goForward()
     }
 
     private var activeNavigationWebView: WKWebView {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -535,12 +535,30 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         return button
     }
 
+    func navigateBack() {
+        self.activeNavigationWebView.goBack()
+    }
+
+    func navigateForward() {
+        self.activeNavigationWebView.goForward()
+    }
+
     @objc private func navigateBack(_: Any?) {
-        self.webView.goBack()
+        self.navigateBack()
     }
 
     @objc private func navigateForward(_: Any?) {
-        self.webView.goForward()
+        self.navigateForward()
+    }
+
+    private var activeNavigationWebView: WKWebView {
+        guard let linkWebView = self.linkBrowser.activeWebView,
+              let firstResponder = self.window?.firstResponder as? NSView,
+              firstResponder === linkWebView || firstResponder.isDescendant(of: linkWebView)
+        else {
+            return self.webView
+        }
+        return linkWebView
     }
 
     private static func makeWindow(contentView: NSView) -> NSWindow {
@@ -1033,6 +1051,19 @@ extension DashboardWindowController {
 
     var _testAllowsBackForwardGestures: Bool {
         self.webView.allowsBackForwardNavigationGestures
+    }
+
+    var _testNavigationWebViewIdentity: ObjectIdentifier {
+        ObjectIdentifier(self.activeNavigationWebView)
+    }
+
+    var _testDashboardWebViewIdentity: ObjectIdentifier {
+        ObjectIdentifier(self.webView)
+    }
+
+    func _testFocusLinkBrowser() -> Bool {
+        guard let webView = self.linkBrowser.activeWebView else { return false }
+        return self.window?.makeFirstResponder(webView) == true
     }
 }
 #endif

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -110,6 +110,17 @@ struct OpenClawApp: App {
                 .keyboardShortcut(",", modifiers: .command)
             }
             SidebarCommands()
+            CommandMenu("Navigate") {
+                Button("Back") {
+                    DashboardManager.shared.navigateBack()
+                }
+                .keyboardShortcut("[", modifiers: .command)
+
+                Button("Forward") {
+                    DashboardManager.shared.navigateForward()
+                }
+                .keyboardShortcut("]", modifiers: .command)
+            }
         }
         .onChange(of: self.isMenuPresented) { _, _ in
             self.updateStatusHighlight()

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -42,6 +42,19 @@ struct DashboardWindowSmokeTests {
             buttonNumber: 1))
     }
 
+    @Test func `dashboard navigation shortcuts target the focused browser`() throws {
+        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let controller = DashboardWindowController(
+            url: dashboard,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+        #expect(controller._testNavigationWebViewIdentity == controller._testDashboardWebViewIdentity)
+
+        controller._testOpenLinkBrowser(try #require(URL(string: "https://docs.openclaw.ai/")))
+        let linkWebView = try #require(controller._testLinkBrowserWebViewIdentity)
+        #expect(controller._testFocusLinkBrowser())
+        #expect(controller._testNavigationWebViewIdentity == linkWebView)
+    }
+
     @Test func `dashboard parses only bounded native link requests`() throws {
         let request = DashboardWindowController.linkRequest(from: [
             "type": "open-link",


### PR DESCRIPTION
## What Problem This Solves

The macOS dashboard exposes navigation history through title-bar controls and trackpad gestures, but keyboard users cannot use the standard Command-[ and Command-] shortcuts to move backward and forward.

## Why This Change Was Made

Adds app-level Navigate commands for the standard shortcuts and routes them through the existing dashboard history implementation. Navigation follows the focused embedded browser: the main Control UI by default, or the link sidebar when it owns focus.

## User Impact

macOS users can navigate dashboard history with Command-[ and Command-], including while browsing links in the focused sidebar browser.

## Evidence

- `swift test --package-path apps/macos --filter DashboardWindowSmokeTests` on personal macOS remote: 25 tests passed, including the new focused-browser routing regression test.
- `scripts/format-swift.sh macos`: clean (0 files require formatting).
- `pnpm native:i18n:sync`: generated native inventory committed; exact-head CI verifies it.
- `git diff --check`: clean.
- `.agents/skills/autoreview/scripts/autoreview --mode local --model gpt-5.5 --thinking high`: clean, no accepted/actionable findings.
- Proof gap: no separate signed-app black-box key-event session; focused macOS integration coverage verifies target selection and history dispatch.
