### PR TITLE
fix: isolate Gateway from live builds

### DIFF
--- a/.agents/skills/openclaw-live-updater/SKILL.md
+++ b/.agents/skills/openclaw-live-updater/SKILL.md
@@ -30,9 +30,9 @@ Keep `/Users/steipete/openclaw` a read-only-to-the-agent deployment mirror: clea
    - Every successful update sets `actions.gatewayBuild` and rebuilds exact new `main` before any restart.
    - Missing, invalid, or stale build output also forces a build, even when Git did not move.
    - A dependency-input change, absent `node_modules`, or missing/invalid build provenance first runs `pnpm install --frozen-lockfile`.
-   - `pnpm build` must leave both canonical stamp heads and `dist/build-info.json.commit` equal to post-update `afterSha`; any missing/mismatched stamp or required artifact blocks restart.
+   - Stop the managed Gateway immediately before `pnpm build`; never mutate the live `dist` tree while an old Gateway can dynamically import from it. `pnpm build` must leave both canonical stamp heads and `dist/build-info.json.commit` equal to post-update `afterSha`; any missing/mismatched stamp or required artifact blocks restart.
    - Only after exact-SHA build proof may it restart the managed Gateway and require `gateway status --deep --require-rpc --json` plus `health --verbose --json`.
-   - After every managed restart, query Gateway logs through RPC, restrict the audit to entries emitted since that restart began, report warning summaries, and fail the pass on any error/fatal entry. Never accept supervisor or RPC health without this restart-window log audit.
+   - After every managed restart, query Gateway logs through RPC, restrict the audit to entries emitted since that restart began, report warning summaries, and fail the pass on any error/fatal entry. If RPC verification or log retrieval fails, still inspect the local structured log for that restart window. Never accept supervisor or RPC health without this restart-window log audit.
 
    Treat supervisor state alone as insufficient. If build or proof fails, leave the new mirror head intact and retry the stale/missing build on the next heartbeat; never run the old `dist` against new source.
 

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -554,11 +554,30 @@ export function parseGatewayLogAudit(output, sinceMs) {
     .filter(Boolean)
     .flatMap((line) => {
       try {
-        const entry = JSON.parse(line);
-        const timestamp = Date.parse(entry.time ?? "");
-        return entry.type === "log" && Number.isFinite(timestamp) && timestamp >= sinceMs
-          ? [entry]
-          : [];
+        const raw = JSON.parse(line);
+        const rawLevel = raw.type === "log" ? raw.level : raw._meta?.logLevelName;
+        const level = String(rawLevel ?? "").toLowerCase();
+        const time = raw.time ?? raw._meta?.date;
+        const timestamp = Date.parse(time ?? "");
+        if (!level || !Number.isFinite(timestamp) || timestamp < sinceMs) {
+          return [];
+        }
+        let subsystem = raw.subsystem ?? null;
+        if (!subsystem && typeof raw["0"] === "string") {
+          try {
+            subsystem = JSON.parse(raw["0"]).subsystem ?? null;
+          } catch {
+            subsystem = null;
+          }
+        }
+        return [
+          {
+            time,
+            level,
+            subsystem,
+            message: raw.message ?? raw["1"] ?? raw["0"] ?? "",
+          },
+        ];
       } catch {
         return [];
       }
@@ -576,28 +595,72 @@ export function parseGatewayLogAudit(output, sinceMs) {
   };
 }
 
+function localDateKey(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function readFallbackGatewayLogs(sinceMs) {
+  const dates = new Set([localDateKey(new Date(sinceMs)), localDateKey(new Date())]);
+  const directories = new Set(["/tmp/openclaw", path.join(tmpdir(), "openclaw")]);
+  const contents = [];
+  for (const directory of directories) {
+    for (const date of dates) {
+      const logPath = path.join(directory, `openclaw-${date}.log`);
+      if (existsSync(logPath)) {
+        contents.push(readFileSync(logPath, "utf8"));
+      }
+    }
+  }
+  return contents.join("\n");
+}
+
 function defaultAuditGatewayLogs(checkout, sinceMs) {
-  const output = execFileSync(
-    process.execPath,
-    [
-      "openclaw.mjs",
-      "logs",
-      "--json",
-      "--limit",
-      "1000",
-      "--max-bytes",
-      "1000000",
-      "--timeout",
-      "10000",
-    ],
-    { cwd: checkout, encoding: "utf8", maxBuffer: 4 * 1024 * 1024 },
-  );
+  let output;
+  try {
+    output = execFileSync(
+      process.execPath,
+      [
+        "openclaw.mjs",
+        "logs",
+        "--json",
+        "--limit",
+        "1000",
+        "--max-bytes",
+        "1000000",
+        "--timeout",
+        "10000",
+      ],
+      { cwd: checkout, encoding: "utf8", maxBuffer: 4 * 1024 * 1024 },
+    );
+  } catch (error) {
+    output = readFallbackGatewayLogs(sinceMs);
+    if (!output) {
+      throw error;
+    }
+  }
   const audit = parseGatewayLogAudit(output, sinceMs);
   if (audit.errorCount > 0) {
     throw new UpdateInvariantError(
       "gateway_restart_log_errors",
       `Gateway emitted ${audit.errorCount} error/fatal log entries after restart: ${JSON.stringify(audit.errors.slice(0, 5))}`,
     );
+  }
+  return audit;
+}
+
+function verifyAndAuditGateway({ runCommand, auditGatewayLogs, checkout, expectedSha, sinceMs }) {
+  let verificationError;
+  try {
+    verifyGateway(runCommand, checkout, expectedSha);
+  } catch (error) {
+    verificationError = error;
+  }
+  const audit = auditGatewayLogs(checkout, sinceMs);
+  if (verificationError) {
+    throw verificationError;
   }
   return audit;
 }
@@ -684,11 +747,17 @@ export function maintainMain(options, dependencies = {}) {
       runCommand("pnpm", ["install", "--frozen-lockfile"], update.checkout);
     }
     if (actions.gatewayBuild) {
+      runCommand("pnpm", ["openclaw", "gateway", "stop"], update.checkout);
       runCommand("pnpm", ["build"], update.checkout);
       assertExactBuild(update.checkout, update.afterSha);
       const restartStartedAt = restartGateway(runCommand, update.checkout, update.afterSha);
-      verifyGateway(runCommand, update.checkout, update.afterSha);
-      gatewayLogAudit = auditGatewayLogs(update.checkout, restartStartedAt);
+      gatewayLogAudit = verifyAndAuditGateway({
+        runCommand,
+        auditGatewayLogs,
+        checkout: update.checkout,
+        expectedSha: update.afterSha,
+        sinceMs: restartStartedAt,
+      });
     } else {
       try {
         verifyGateway(runCommand, update.checkout, update.afterSha);
@@ -696,8 +765,13 @@ export function maintainMain(options, dependencies = {}) {
         actions.gatewayRestart = true;
         actions.gatewaySelfHeal = true;
         const restartStartedAt = restartGateway(runCommand, update.checkout, update.afterSha);
-        verifyGateway(runCommand, update.checkout, update.afterSha);
-        gatewayLogAudit = auditGatewayLogs(update.checkout, restartStartedAt);
+        gatewayLogAudit = verifyAndAuditGateway({
+          runCommand,
+          auditGatewayLogs,
+          checkout: update.checkout,
+          expectedSha: update.afterSha,
+          sinceMs: restartStartedAt,
+        });
       }
     }
     if (actions.macAppRebuild) {

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -176,6 +176,33 @@ describe("openclaw live updater", () => {
     });
   });
 
+  test("audits raw file logs when RPC log retrieval is unavailable", () => {
+    const output = [
+      {
+        "0": '{"subsystem":"gateway"}',
+        "1": "startup warning",
+        time: "2026-07-11T08:00:03.000Z",
+        _meta: { date: "2026-07-11T08:00:03.000Z", logLevelName: "WARN" },
+      },
+      {
+        "0": '{"subsystem":"gateway"}',
+        "1": "startup failed",
+        time: "2026-07-11T08:00:04.000Z",
+        _meta: { date: "2026-07-11T08:00:04.000Z", logLevelName: "ERROR" },
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join("\n");
+
+    expect(parseGatewayLogAudit(output, Date.parse("2026-07-11T08:00:02.000Z"))).toMatchObject({
+      entries: 2,
+      errorCount: 1,
+      warningCount: 1,
+      errors: [{ subsystem: "gateway", message: "startup failed" }],
+      warnings: [{ subsystem: "gateway", message: "startup warning" }],
+    });
+  });
+
   test("accepts supported OpenClaw GitHub origins", () => {
     expect(originMatches("https://github.com/openclaw/openclaw.git")).toBe(true);
     expect(originMatches("git@github.com:openclaw/openclaw.git")).toBe(true);
@@ -344,6 +371,7 @@ describe("openclaw live updater", () => {
     });
     expect(commands.calls).toEqual([
       "pnpm install --frozen-lockfile",
+      "pnpm openclaw gateway stop",
       "pnpm build",
       "pnpm openclaw gateway restart",
       "pnpm openclaw gateway status --deep --require-rpc --json",
@@ -390,6 +418,7 @@ describe("openclaw live updater", () => {
     expect(output.actions.dependencyInstall).toBe(true);
     expect(commands.calls).toEqual([
       "pnpm install --frozen-lockfile",
+      "pnpm openclaw gateway stop",
       "pnpm build",
       "pnpm openclaw gateway restart",
       "pnpm openclaw gateway status --deep --require-rpc --json",
@@ -518,7 +547,40 @@ describe("openclaw live updater", () => {
         },
       ),
     ).toThrow(/build output does not match/u);
-    expect(calls).toEqual(["pnpm install --frozen-lockfile", "pnpm build"]);
+    expect(calls).toEqual([
+      "pnpm install --frozen-lockfile",
+      "pnpm openclaw gateway stop",
+      "pnpm build",
+    ]);
+  });
+
+  test("audits restart-window logs even when deep Gateway verification fails", () => {
+    const { root, mirror } = makeFixture();
+    mkdirSync(path.join(mirror, "node_modules"));
+    writeBuild(mirror);
+    let auditCalls = 0;
+    let statusCalls = 0;
+
+    expect(() =>
+      maintainMain(
+        { checkout: mirror, remote: "origin", lockPath: path.join(root, "maintenance.lock") },
+        {
+          fetchMain: fetchFixtureMain,
+          runCommand(command: string, args: string[]) {
+            if (command === "pnpm" && args.slice(0, 3).join(" ") === "openclaw gateway status") {
+              statusCalls += 1;
+              throw new Error("RPC unavailable");
+            }
+          },
+          auditGatewayLogs() {
+            auditCalls += 1;
+            return { entries: 1, errorCount: 0, warningCount: 0, errors: [], warnings: [] };
+          },
+        },
+      ),
+    ).toThrow("RPC unavailable");
+    expect(statusCalls).toBe(2);
+    expect(auditCalls).toBe(1);
   });
 
   test("retains failed exact-bundle Mac proof for the next heartbeat", () => {


### PR DESCRIPTION
## Summary

- stop the managed Gateway before a live checkout build mutates `dist`
- audit restart-window logs even when deep RPC verification fails
- fall back to the local structured log when RPC log retrieval is unavailable

## Proof

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/openclaw-live-updater.test.ts` (26 passed)
- updater skill frontmatter YAML parse
- autoreview clean
