### PR TITLE
fix(ui): give workspace rail summary chips top padding

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -419,7 +419,9 @@
   flex-shrink: 0;
   flex-wrap: wrap;
   gap: 4px;
-  padding: 0 12px 8px;
+  /* Top padding keeps the count pills clear of the path row's divider line
+     (and of the header divider when no workspace root renders a path). */
+  padding: 8px 12px;
 }
 
 .chat-workspace-rail__summary span {


### PR DESCRIPTION
## What Problem This Solves

In the chat session workspace rail (Control UI), the summary count pills ("N changed / N read / N artifacts / N shown") render flush against the workspace-path row's divider line — `.chat-workspace-rail__summary` had `padding: 0 12px 8px`, so the pill borders touched the hairline above them. Reported from a live session screenshot: "padding here needs tweaking, line is too close to content".

## Why This Change Was Made

The summary row is the only rail row without top padding; every neighboring row (header, path, states, section titles) keeps clearance from its divider. Giving the chips symmetric 8px top/bottom padding restores the rhythm, and also covers the no-root case where the summary sits directly under the header divider.

## User Impact

The workspace rail's count pills no longer crowd the divider line under the workspace path; the panel header area reads cleanly. Pure presentation change, both right and bottom docks.

## Evidence

- CSS-only change in `ui/src/styles/chat/sidebar.css` (`.chat-workspace-rail__summary` `padding: 0 12px 8px` → `8px 12px`).
- Verified live in the mock dev harness (`pnpm dev:ui:mock`): measured `chip.top − path.bottom` went from `0px` to `8px`.
- Before: ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/workspace-rail-summary-padding-2026-07/workspace-rail-before.png)
- After: ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/workspace-rail-summary-padding-2026-07/workspace-rail-after.png)
