### PR TITLE
fix(codex): allow slower Mac session catalogs

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalog.swift
@@ -131,7 +131,7 @@ enum MacNodeCodexThreadCatalog {
     static let defaultUserMacOSBetaAppExecutable = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Applications/Codex Beta.app/Contents/Resources/codex")
         .path
-    static let defaultTimeoutSeconds: Double = 24
+    static let defaultTimeoutSeconds: Double = 60
     private static let maxSessionIdLength = 256
     private static let maxSessionNameLength = 500
     private static let maxCwdLength = 4096

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -941,7 +941,7 @@ struct MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `default deadline allows cold large catalog scans`() {
-        #expect(MacNodeCodexThreadCatalog.defaultTimeoutSeconds == 24)
+        #expect(MacNodeCodexThreadCatalog.defaultTimeoutSeconds == 60)
     }
 
     @Test func `rejects unknown and out of range params before launch`() async {

--- a/docs/plugins/codex-supervision.md
+++ b/docs/plugins/codex-supervision.md
@@ -153,7 +153,8 @@ openclaw codex archive <thread-id> --confirm-no-other-runner [--json] [--url <ur
 - `--json` prints the structured Gateway response.
 
 All three commands inherit `--url`, `--token`, and `--timeout <ms>` from the
-Gateway client; the default timeout is 30,000 ms. They also expose the shared
+Gateway client. Session listing defaults to 75,000 ms so cold paired-node
+catalogs can complete; continue and archive default to 30,000 ms. They also expose the shared
 `--expect-final` switch, which does not change these unary supervision RPCs.
 Each command requires the `operator.write` Gateway scope.
 Standard `-h, --help` output is available on each subcommand.

--- a/docs/specs/codex-supervision.md
+++ b/docs/specs/codex-supervision.md
@@ -146,7 +146,8 @@ openclaw codex archive <thread-id> --confirm-no-other-runner [--json] [gateway-o
 ```
 
 `[gateway-options]` is `--url <url>`, `--token <token>`, `--timeout <ms>`, and
-the inherited `--expect-final` switch. The timeout defaults to 30,000 ms;
+the inherited `--expect-final` switch. Session listing defaults to 75,000 ms;
+continue and archive default to 30,000 ms;
 `--expect-final` has no additional effect for these unary RPCs. Session search
 is title-only and case-insensitive; each response scans a bounded native page
 chain, and `--cursor` continues older results. The limit defaults to 50 per host

--- a/extensions/codex/README.md
+++ b/extensions/codex/README.md
@@ -20,7 +20,7 @@ openclaw codex continue <thread-id> [--json] [--url <url>] [--token <token>] [--
 openclaw codex archive <thread-id> --confirm-no-other-runner [--json] [--url <url>] [--token <token>] [--timeout <ms>] [--expect-final]
 ```
 
-The catalog never includes archived threads and has no archived or include-archived option. `--limit` defaults to 50 sessions per host, `--cursor` requires `--host`, and the Gateway timeout defaults to 30,000 ms. All three commands require `operator.write`. Paired-node rows are list-only; continue and archive operate only on the Gateway-local host, and archive requires the no-other-runner confirmation.
+The catalog never includes archived threads and has no archived or include-archived option. `--limit` defaults to 50 sessions per host, `--cursor` requires `--host`, and the sessions Gateway timeout defaults to 75,000 ms so cold paired-node catalogs can complete. Continue and archive retain the shared 30,000 ms default. All three commands require `operator.write`. Paired-node rows are list-only; continue and archive operate only on the Gateway-local host, and archive requires the no-other-runner confirmation.
 
 A supervised OpenClaw Chat cannot be deleted while its model-selection lock protects the native binding. Before native archive, OpenClaw checks the exact target and every non-archived spawned descendant reported by Codex; any active OpenClaw binding blocks the operation. Descendant pagination errors, cycles, and safety-limit exhaustion also fail closed. Codex still does not expose a conditional archive operation or cross-process runner lease, so the confirmation covers unknown native clients and the race between the status read and archive request.
 

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -752,7 +752,7 @@ describe("Codex supervision catalog", () => {
         nodeId: "devbox",
         command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
         params: expect.not.objectContaining({ archived: expect.anything() }),
-        timeoutMs: 28_000,
+        timeoutMs: 65_000,
       }),
     );
     expect(JSON.stringify(result)).not.toContain("private");

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -75,9 +75,9 @@ const CODEX_APP_SERVER_THREADS_CAPABILITY = "codex-app-server-threads";
 const DEFAULT_PAGE_LIMIT = 50;
 export const CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT = 100;
 // A node may need a cold Codex state scan before returning a large catalog page.
-// Keep this above the Mac node's native 24-second deadline so its result wins,
-// while remaining below the shared CLI client's 30-second outer deadline.
-const NODE_INVOKE_TIMEOUT_MS = 28_000;
+// Keep this above the Mac node's native 60-second deadline so its specific
+// timeout wins instead of the less useful generic node.invoke timeout.
+const NODE_INVOKE_TIMEOUT_MS = 65_000;
 const MAX_SEARCH_LENGTH = 500;
 const MAX_CURSOR_LENGTH = 4096;
 const MAX_CURSOR_COUNT = 100;

--- a/extensions/codex/src/session-cli.test.ts
+++ b/extensions/codex/src/session-cli.test.ts
@@ -135,6 +135,12 @@ describe("registerCodexSessionCli", () => {
         await program.parseAsync(["codex", "sessions"], { from: "user" });
       });
 
+      expect(gatewayRuntime.callGatewayFromCli).toHaveBeenCalledWith(
+        "codex.sessions.list",
+        { timeout: "75000", json: false },
+        {},
+        { mode: "cli", scopes: ["operator.write"] },
+      );
       expect(output).toContain("MacBook Pro (gateway · gateway:local) — connected — 1 session");
       expect(output).toContain("00000000-0000-4000-8000-000000000002");
       expect(output).toContain("Build Codex fleet sessions");
@@ -147,6 +153,14 @@ describe("registerCodexSessionCli", () => {
       );
       expect(output).toContain("Dev Box (node · node:devbox · devbox) — offline — 0 sessions");
       expect(output).toContain("Error [NODE_OFFLINE]: Paired node is offline");
+    });
+
+    it("declares the extended federated catalog timeout in help", () => {
+      const program = createProgram();
+      const codex = program.commands.find((command) => command.name() === "codex");
+      const sessions = codex?.commands.find((command) => command.name() === "sessions");
+
+      expect(sessions?.helpInformation()).toContain('(default: "75000")');
     });
 
     it("neutralizes terminal controls in human-readable host and session metadata", async () => {

--- a/extensions/codex/src/session-cli.ts
+++ b/extensions/codex/src/session-cli.ts
@@ -38,6 +38,8 @@ type CodexArchiveCliOptions = CodexGatewayOptions & {
   confirmNoOtherRunner?: boolean;
 };
 
+const CODEX_SESSION_CATALOG_CLI_TIMEOUT_MS = 75_000;
+
 function writeLine(value = ""): void {
   process.stdout.write(`${value}\n`);
 }
@@ -293,6 +295,7 @@ export function registerCodexSessionCli(program: Command): void {
       .option("--limit <count>", "Maximum sessions returned per host")
       .option("--cursor <cursor>", "Continue one host page (requires --host)")
       .option("--json", "Print the structured catalog response", false),
+    { timeoutMs: CODEX_SESSION_CATALOG_CLI_TIMEOUT_MS },
   ).action(async (options: CodexSessionsCliOptions) => {
     await listCodexSessions(options);
   });

--- a/src/cli/gateway-rpc.ts
+++ b/src/cli/gateway-rpc.ts
@@ -21,11 +21,11 @@ async function loadGatewayRpcRuntime(): Promise<GatewayRpcRuntimeModule> {
   return gatewayRpcRuntimeLoader.load();
 }
 
-export function addGatewayClientOptions(cmd: Command) {
+export function addGatewayClientOptions(cmd: Command, defaults?: { timeoutMs?: number }) {
   return cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
     .option("--token <token>", "Gateway token (if required)")
-    .option("--timeout <ms>", "Timeout in ms", "30000")
+    .option("--timeout <ms>", "Timeout in ms", String(defaults?.timeoutMs ?? 30_000))
     .option("--expect-final", "Wait for final response (agent)", false);
 }
 


### PR DESCRIPTION
## What Problem This Solves

The first cold-catalog timeout fix in #104299 still timed out on a real MacBook with a large Codex history. A direct limit-40 node invocation failed after 33.97 seconds because the Mac node deadline remained 24 seconds.

## Why This Change Was Made

Align the three nested deadlines with observed cold-scan behavior:

- 60 seconds for the native macOS Codex catalog process
- 65 seconds for the Gateway node invocation
- 75 seconds for the `openclaw codex sessions` CLI request

The shared Gateway CLI helper now accepts an additive per-command timeout default, so continue/archive retain their existing 30-second default. Help text, plugin docs, and the supervision spec all describe the same values.

## User Impact

Large non-archived Codex session catalogs can finish loading from paired Mac nodes instead of surfacing `NODE_INVOKE_FAILED`. Explicit `--timeout` overrides remain unchanged.

## Evidence

- Before: direct MacBook limit-40 invocation failed with `Codex app-server thread list timed out` after 33.97 seconds.
- Testbox focused tests: 88 passed (`session-catalog.test.ts`, `session-cli.test.ts`).
- Testbox changed-surface gate: passed core/plugin typechecks, core/plugin lint, packaging/daemon/tooling tests, and repository guards.
- Autoreview: clean after aligning runtime, help, and docs defaults.
- Testbox runs: https://github.com/openclaw/openclaw/actions/runs/29146453698 and https://github.com/openclaw/openclaw/actions/runs/29146617032

Follow-up to #104299.
