### PR TITLE
fix(openai): guard Codex GPT-5.6 discovery boundary

### DIFF
--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -777,7 +777,7 @@ describe("buildOpenAIProvider", () => {
     }
   });
 
-  it("keeps successful sparse Codex catalog rows authoritative", async () => {
+  it("maps direct Codex catalog rows into OpenAI ChatGPT response models", async () => {
     const release = vi.fn(async () => undefined);
     const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async () => ({
       response: Response.json({
@@ -818,11 +818,7 @@ describe("buildOpenAIProvider", () => {
 
     expect(provider?.api).toBe("openai-chatgpt-responses");
     expect(provider?.auth).toBe("oauth");
-    const modelIds = provider?.models.map((model) => model.id);
-    expect(modelIds).toEqual(["gpt-5.4"]);
-    expect(modelIds).not.toEqual(
-      expect.arrayContaining(["gpt-5.6", "gpt-5.6-sol", "gpt-5.5", "gpt-5.3-codex-spark"]),
-    );
+    expect(provider?.models.map((model) => model.id)).toEqual(["gpt-5.4"]);
     expect(provider?.models[0]).toMatchObject({
       baseUrl: "https://chatgpt.com/backend-api/codex",
       input: ["text", "image"],

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -777,7 +777,7 @@ describe("buildOpenAIProvider", () => {
     }
   });
 
-  it("maps direct Codex catalog rows into OpenAI ChatGPT response models", async () => {
+  it("keeps successful sparse Codex catalog rows authoritative", async () => {
     const release = vi.fn(async () => undefined);
     const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async () => ({
       response: Response.json({
@@ -818,7 +818,11 @@ describe("buildOpenAIProvider", () => {
 
     expect(provider?.api).toBe("openai-chatgpt-responses");
     expect(provider?.auth).toBe("oauth");
-    expect(provider?.models.map((model) => model.id)).toEqual(["gpt-5.4"]);
+    const modelIds = provider?.models.map((model) => model.id);
+    expect(modelIds).toEqual(["gpt-5.4"]);
+    expect(modelIds).not.toEqual(
+      expect.arrayContaining(["gpt-5.6", "gpt-5.6-sol", "gpt-5.5", "gpt-5.3-codex-spark"]),
+    );
     expect(provider?.models[0]).toMatchObject({
       baseUrl: "https://chatgpt.com/backend-api/codex",
       input: ["text", "image"],
@@ -878,6 +882,16 @@ describe("buildOpenAIProvider", () => {
   it.each([
     ["fails", () => new Response("temporarily unavailable", { status: 503 })],
     ["returns no models", () => Response.json({ models: [] })],
+    [
+      "returns hidden-only models",
+      () =>
+        Response.json({
+          models: [
+            { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", visibility: "hide" },
+            { slug: "gpt-5.5", display_name: "GPT-5.5", show_in_picker: false },
+          ],
+        }),
+    ],
   ])("keeps static OpenAI OAuth rows when Codex catalog discovery %s", async (_label, response) => {
     const release = vi.fn(async () => undefined);
     const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async () => ({

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -488,9 +488,9 @@ async function buildOpenAICodexLiveProviderConfig(params: {
       .map(buildOpenAICodexModelFromLiveRow)
       .filter((model): model is ModelDefinitionConfig => Boolean(model));
     if (models.length > 0) {
-      // Successful Codex OAuth discovery is account-scoped and authoritative.
-      // Do not merge static OpenAI fallback rows here: omitted rows may be
-      // unavailable for the authenticated account and fail only at invocation.
+      // Successful Codex OAuth discovery is account-scoped and authoritative
+      // for the picker/list catalog. Do not merge static OpenAI fallback rows
+      // into a successful live catalog.
       return {
         baseUrl: OPENAI_CODEX_RESPONSES_BASE_URL,
         api: "openai-chatgpt-responses",

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -488,6 +488,9 @@ async function buildOpenAICodexLiveProviderConfig(params: {
       .map(buildOpenAICodexModelFromLiveRow)
       .filter((model): model is ModelDefinitionConfig => Boolean(model));
     if (models.length > 0) {
+      // Successful Codex OAuth discovery is account-scoped and authoritative.
+      // Do not merge static OpenAI fallback rows here: omitted rows may be
+      // unavailable for the authenticated account and fail only at invocation.
       return {
         baseUrl: OPENAI_CODEX_RESPONSES_BASE_URL,
         api: "openai-chatgpt-responses",


### PR DESCRIPTION
## DEV-20260711-001 / DEV-20260711-002 follow-up

### Bug fix: Guard OpenAI/Codex GPT-5.6 availability boundaries
- Keeps direct OpenAI API GPT-5.6 support intact.
- Keeps successful ChatGPT/Codex OAuth live discovery authoritative for the account-scoped picker/list catalog, so local static rows are not merged into a successful live catalog.
- Keeps bare `gpt-5.6` out of Codex OAuth fallback; OAuth fallback remains limited to supported Codex-family rows.
- Adds focused regression coverage for sparse visible discovery and hidden-only discovery fallback.
- Narrows the runtime comment to catalog authority only; it no longer claims omitted rows are invocation-ineligible.

## What Problem This Solves

PR #104185 attempted to restore GPT-5.6 availability, but its review found two provider-boundary regressions:

- bare `gpt-5.6` was added to the ChatGPT/Codex OAuth path;
- successful sparse Codex discovery was supplemented with local static fallback rows.

That can make OAuth users see picker entries that were not returned by the successful account-scoped Codex catalog. This PR preserves the intended boundary: direct OpenAI API model availability is separate from account-scoped ChatGPT/Codex OAuth discovery.

## Redacted Live Behavior Proof

### Live OAuth catalog proof
- Source: local OpenClaw setup with OpenAI ChatGPT/Codex OAuth profiles.
- Request: `GET https://chatgpt.com/backend-api/codex/models?client_version=<redacted>`.
- Redaction: bearer token redacted, ChatGPT account ID redacted; no account IDs, emails, tokens, private endpoints, IPs, or phone numbers included below.
- Result: HTTP `200`, response shape `{ models: [...] }`.
- Catalog shape observed twice: `rowCount=8`, `visibleUsableRowCount=7`, `hiddenOrPickerSuppressedRowCount=1`.
- Returned slugs: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, `codex-auto-review`.
- Visible/picker rows: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`.
- Hidden row: `codex-auto-review` with `visibility: "hide"`.
- Bare `gpt-5.6` was absent from the successful live OAuth catalog.

### Advertised-model invocation proof
- `openclaw infer model run --model openai/gpt-5.6-sol --prompt 'Return exactly: OPENCLAW-CODEX-GPT56-PROOF' --json`
  - Transport log: POST to public `https://chatgpt.com/backend-api/codex/responses`, status `200`; no tokens/account IDs printed.
  - JSON result: `ok: true`, provider `openai`, model `gpt-5.6-sol`, output text exactly `OPENCLAW-CODEX-GPT56-PROOF`.
- Additional advertised row sanity check:
  - `openclaw infer model run --model openai/gpt-5.4 --prompt 'Return exactly: OPENCLAW-CODEX-OAUTH-PROOF' --json`
  - POST to public `https://chatgpt.com/backend-api/codex/responses`, status `200`; output text exactly `OPENCLAW-CODEX-OAUTH-PROOF`.

### Limits of proof
- I did not find a safe way to force a real account-scoped catalog to return no usable visible rows; that fallback path remains covered by the deterministic regression test.
- The source comment is intentionally limited to picker/list catalog authority and does not assert that omitted rows are always unauthorized for invocation.

## Evidence

- Rejection analysis: #104185 ClawSweeper review asked to remove bare `gpt-5.6` from ChatGPT/Codex OAuth resolution and keep successful visible Codex discovery authoritative.
- Source evidence: this PR only changes `extensions/openai/openai-provider.ts` and `extensions/openai/openai-provider.test.ts`; it does not add bare `gpt-5.6` to `OPENAI_CODEX_GPT_56_MODEL_IDS` or static OAuth fallback.
- Behavior evidence: the focused regression test `keeps successful sparse Codex catalog rows authoritative` asserts a successful visible Codex response containing only `gpt-5.4` remains exactly `['gpt-5.4']` and does not append `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.5`, or `gpt-5.3-codex-spark`.
- Behavior evidence: hidden-only Codex discovery is covered as a fallback case, preserving the existing static OAuth fallback path only when there are no usable visible live rows.
- Live evidence: a real OAuth Codex catalog returned visible rows and one hidden row; OpenClaw should treat visible live rows as authoritative and filter the hidden row rather than supplementing with static rows.
- Invocation evidence: advertised live catalog model `gpt-5.6-sol` invoked successfully through OpenClaw's ChatGPT/Codex OAuth transport with redacted output.
- Comment refinement: commit `5937726d07` narrows the runtime comment to catalog authority and removes the stronger invocation-authorization rationale.

### Tests
- `git diff --check`: pass
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-provider-openai.config.ts extensions/openai/openai-provider.test.ts extensions/openai/openai-chatgpt-provider.test.ts --reporter=dot --no-color`: pass, 2 files / 63 tests
- QA gate (`qa-zig`): SPEC-PASS, QUALITY-PASS, secret-leakage assessment PASS
- GitHub checks for commit `5937726d07` passed, including QA Smoke CI, lint, type, package-boundary, dependency/security guards, changed-path scans, and Real behavior proof.

### Changed files
- `extensions/openai/openai-provider.ts`
- `extensions/openai/openai-provider.test.ts`

## User Impact

Direct OpenAI API users keep the existing GPT-5.6 model surface. ChatGPT/Codex OAuth users see the models returned by their successful account-scoped Codex picker/list catalog, avoiding local static rows that were not advertised by the live OAuth catalog.

## Notes

- No dependency, workflow, permission, or secret-handling changes.
- Does not merge or deploy.
- Follow-up/replacement path for #104185.
