### PR TITLE
fix: bind macOS node allowlist commands safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Mac node exec allowlists:** use a non-login shell transport for macOS node commands so exact executable approvals can bind safely instead of failing every agent `node_exec` request as an allowlist miss. (#104330)
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.
 - **Gateway client watchdog:** keep transport-stall detection active for unbounded and mixed pending requests so dead sockets reject pending requests, reconnect, and never replay rejected requests. (#103407) Thanks @NianJiuZst.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Mac node exec allowlists:** use a non-login shell transport for macOS node commands so exact executable approvals can bind safely instead of failing every agent `node_exec` request as an allowlist miss. (#104330)
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.
 - **Gateway client watchdog:** keep transport-stall detection active for unbounded and mixed pending requests so dead sockets reject pending requests, reconnect, and never replay rejected requests. (#103407) Thanks @NianJiuZst.

--- a/src/infra/node-shell.test.ts
+++ b/src/infra/node-shell.test.ts
@@ -27,8 +27,13 @@ describe("buildNodeShellCommand", () => {
     ]);
   });
 
-  it("uses /bin/sh for non-windows and missing platform values", () => {
-    expect(buildNodeShellCommand("echo hi", "darwin")).toEqual(["/bin/sh", "-lc", "echo hi"]);
+  it("uses bindable non-login sh for macOS nodes", () => {
+    expect(buildNodeShellCommand("echo hi", "darwin")).toEqual(["/bin/sh", "-c", "echo hi"]);
+    expect(buildNodeShellCommand("echo hi", "macOS")).toEqual(["/bin/sh", "-c", "echo hi"]);
+    expect(buildNodeShellCommand("echo hi", "macOS 26.5.2")).toEqual(["/bin/sh", "-c", "echo hi"]);
+  });
+
+  it("retains login sh for other posix and missing platform values", () => {
     expect(buildNodeShellCommand("echo hi", "linux")).toEqual(["/bin/sh", "-lc", "echo hi"]);
     expect(buildNodeShellCommand("echo hi")).toEqual(["/bin/sh", "-lc", "echo hi"]);
     expect(buildNodeShellCommand("echo hi", null)).toEqual(["/bin/sh", "-lc", "echo hi"]);

--- a/src/infra/node-shell.ts
+++ b/src/infra/node-shell.ts
@@ -9,5 +9,10 @@ export function buildNodeShellCommand(command: string, platform?: string | null)
   if (normalized.startsWith("win")) {
     return ["cmd.exe", "/d", "/s", "/c", command];
   }
+  if (normalized === "darwin" || normalized.startsWith("macos")) {
+    // The Mac node binds static allowlisted commands through non-login sh.
+    // A login shell can execute unapproved startup files before the payload.
+    return ["/bin/sh", "-c", command];
+  }
   return ["/bin/sh", "-lc", command];
 }


### PR DESCRIPTION
## What Problem This Solves

Mac App nodes using `security=allowlist` reject exact executable approvals from the agent's standard `node_exec` path. The caller wraps macOS commands in a login shell, while the Mac host correctly refuses to reuse approval through login startup files.

Fixes #104330.

## Why This Change Was Made

Use the Mac host's existing safe binding contract: `/bin/sh -c` for a static macOS payload. The Mac App can then resolve and bind the exact approved executable before execution. Windows remains on `cmd.exe`; Linux and unknown POSIX nodes retain `/bin/sh -lc` to avoid expanding this compatibility change beyond the proven regression.

The platform match covers both Node's `darwin` identifier and the Mac App's versioned `macOS 26.5.2`-style metadata.

## User Impact

- Before: an exact `/bin/hostname` Mac-node approval still returned `SYSTEM_RUN_DENIED: allowlist miss`.
- After: the standard agent node-exec command binds to and runs the approved executable.
- Login startup files remain outside reusable authorization.

## Evidence

- Blacksmith Testbox `tbx_01kx86ejmwtkvgcj5b3zf4qp0a`: `corepack pnpm test src/infra/node-shell.test.ts` — 3 passed.
- Blacksmith Testbox `tbx_01kx86hredg07pjg317k793t2n`: touched-file `check:changed` — passed.
- Fresh autoreview: clean, no accepted/actionable findings, confidence 0.97.
- Live Gateway + Mac App proof on the same `megaclaw` allowlist policy:
  - `/bin/sh -lc /bin/hostname` with raw command `/bin/hostname` — denied as allowlist miss.
  - `/bin/sh -c /bin/hostname` with the same raw command — exit 0, stdout `megaclaw`.

## Changes

- `src/infra/node-shell.ts`: select non-login shell transport for `darwin` and versioned `macOS` node metadata.
- `src/infra/node-shell.test.ts`: cover real Mac App metadata and preserve other-platform behavior.
