### PR TITLE
fix(discord): single-source thread-binding default placement and guard artifact parity

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -83,6 +83,7 @@ import { discordSetupAdapter } from "./setup-adapter.js";
 import { createDiscordPluginBase, discordConfigAdapter } from "./shared.js";
 import { collectDiscordStatusIssues } from "./status-issues.js";
 import { parseDiscordTarget } from "./target-parsing.js";
+import { defaultTopLevelPlacement } from "./thread-binding-api.js";
 
 const DISCORD_ACCOUNT_STARTUP_STAGGER_MS = 10_000;
 const discordMessageAdapter = createChannelMessageAdapterFromOutbound({
@@ -479,7 +480,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
       },
       conversationBindings: {
         supportsCurrentConversationBinding: true,
-        defaultTopLevelPlacement: "child",
+        defaultTopLevelPlacement,
         createManager: async ({ cfg, accountId }) =>
           (await loadDiscordThreadBindingsManagerModule()).createThreadBindingManager({
             cfg,

--- a/extensions/discord/src/thread-binding-api.ts
+++ b/extensions/discord/src/thread-binding-api.ts
@@ -1,0 +1,4 @@
+// Discord API module exposes the plugin public contract.
+// Single source for the top-level artifact and the runtime plugin so the
+// fast-path placement hint cannot drift from conversationBindings.
+export const defaultTopLevelPlacement = "child" as const;

--- a/extensions/discord/thread-binding-api.ts
+++ b/extensions/discord/thread-binding-api.ts
@@ -1,2 +1,2 @@
 // Discord API module exposes the plugin public contract.
-export const defaultTopLevelPlacement = "child" as const;
+export { defaultTopLevelPlacement } from "./src/thread-binding-api.js";

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -79,7 +79,10 @@ import {
 } from "./setup-contract.js";
 import { createMatrixSetupWizardProxy, matrixSetupAdapter } from "./setup-core.js";
 import { runMatrixStartupMaintenance } from "./startup-maintenance.js";
-import { resolveMatrixInboundConversation } from "./thread-binding-api.js";
+import {
+  defaultTopLevelPlacement,
+  resolveMatrixInboundConversation,
+} from "./thread-binding-api.js";
 import type { CoreConfig } from "./types.js";
 // Mutex for serializing account startup (workaround for concurrent dynamic import race condition)
 let matrixStartupLock: Promise<void> = Promise.resolve();
@@ -454,7 +457,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
       },
       conversationBindings: {
         supportsCurrentConversationBinding: true,
-        defaultTopLevelPlacement: "child",
+        defaultTopLevelPlacement,
         setIdleTimeoutBySessionKey: ({ targetSessionKey, accountId, idleTimeoutMs }) =>
           setMatrixThreadBindingIdleTimeoutBySessionKey({
             targetSessionKey,

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -2384,6 +2384,7 @@ const CHANNEL_CONTRACT_CONFIG_PATTERNS = new Map([
       "src/channels/plugins/contracts/plugins-core.resolve-config-writes.contract.test.ts",
       "src/channels/plugins/contracts/registry.contract.test.ts",
       "src/channels/plugins/contracts/session-binding.registry-backed.contract.test.ts",
+      "src/channels/plugins/contracts/thread-binding-artifact.contract.test.ts",
       "src/channels/plugins/contracts/*-shard-d.contract.test.ts",
       "src/channels/plugins/contracts/*-shard-h.contract.test.ts",
     ],

--- a/src/channels/plugins/contracts/test-helpers/bundled-channel-plugin-loader.ts
+++ b/src/channels/plugins/contracts/test-helpers/bundled-channel-plugin-loader.ts
@@ -294,3 +294,27 @@ export async function getBundledChannelDirectoryPluginAsync(
   channelDirectoryPluginPromiseCache.set(id, loading);
   return (await loading) ?? undefined;
 }
+
+type ChannelThreadBindingArtifactModule = { defaultTopLevelPlacement?: unknown };
+
+function isMissingBundledThreadBindingArtifact(error: unknown, id: ChannelId): boolean {
+  return (
+    error instanceof Error &&
+    error.message === `Unable to resolve bundled plugin public surface ${id}/thread-binding-api.js`
+  );
+}
+
+/** Returns a bundled channel's thread-binding artifact, or null when it ships none. */
+export async function getBundledChannelThreadBindingArtifactAsync(
+  id: ChannelId,
+): Promise<ChannelThreadBindingArtifactModule | null> {
+  return await loadBundledPluginPublicSurface<ChannelThreadBindingArtifactModule>({
+    pluginId: id,
+    artifactBasename: "thread-binding-api.js",
+  }).catch((error: unknown) => {
+    if (isMissingBundledThreadBindingArtifact(error, id)) {
+      return null;
+    }
+    throw error;
+  });
+}

--- a/src/channels/plugins/contracts/thread-binding-artifact.contract.test.ts
+++ b/src/channels/plugins/contracts/thread-binding-artifact.contract.test.ts
@@ -1,0 +1,65 @@
+// Thread-binding artifact parity contract for bundled channel plugins.
+//
+// Core resolves default thread placement from lightweight `thread-binding-api`
+// artifacts before full plugin loading (src/channels/plugins/thread-binding-api.ts).
+// This suite pins artifact exports to the runtime plugin's conversationBindings
+// so the fast path cannot drift from loaded-plugin behavior.
+import { beforeAll, describe, expect, it } from "vitest";
+import { loadBundledPluginPublicSurface } from "../../../test-utils/bundled-plugin-public-surface.js";
+import {
+  getBundledChannelPluginAsync,
+  listBundledChannelPluginIds,
+} from "./test-helpers/bundled-channel-plugin-loader.js";
+
+// Bundled channels expected to ship a top-level thread-binding artifact.
+const THREAD_BINDING_ARTIFACT_PLUGIN_IDS = ["discord", "matrix"] as const;
+
+const MISSING_PUBLIC_SURFACE_PREFIX = "Unable to resolve bundled plugin public surface ";
+
+type ThreadBindingArtifactModule = { defaultTopLevelPlacement?: unknown };
+
+async function loadThreadBindingArtifact(
+  pluginId: string,
+): Promise<ThreadBindingArtifactModule | null> {
+  try {
+    return await loadBundledPluginPublicSurface<ThreadBindingArtifactModule>({
+      pluginId,
+      artifactBasename: "thread-binding-api.js",
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith(MISSING_PUBLIC_SURFACE_PREFIX)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+describe("bundled channel thread-binding artifact parity", () => {
+  const artifactPlacements = new Map<string, unknown>();
+
+  beforeAll(async () => {
+    for (const id of listBundledChannelPluginIds()) {
+      const artifact = await loadThreadBindingArtifact(id);
+      if (artifact) {
+        artifactPlacements.set(id, artifact.defaultTopLevelPlacement);
+      }
+    }
+  });
+
+  it("keeps the artifact table in sync with bundled channels that ship one", () => {
+    expect([...artifactPlacements.keys()].toSorted()).toEqual([
+      ...THREAD_BINDING_ARTIFACT_PLUGIN_IDS,
+    ]);
+  });
+
+  it.each(THREAD_BINDING_ARTIFACT_PLUGIN_IDS)(
+    "keeps the %s artifact placement equal to the runtime plugin default",
+    async (id) => {
+      const artifactPlacement = artifactPlacements.get(id);
+      expect(["current", "child"]).toContain(artifactPlacement);
+
+      const plugin = await getBundledChannelPluginAsync(id);
+      expect(plugin?.conversationBindings?.defaultTopLevelPlacement).toBe(artifactPlacement);
+    },
+  );
+});

--- a/src/channels/plugins/contracts/thread-binding-artifact.contract.test.ts
+++ b/src/channels/plugins/contracts/thread-binding-artifact.contract.test.ts
@@ -5,41 +5,21 @@
 // This suite pins artifact exports to the runtime plugin's conversationBindings
 // so the fast path cannot drift from loaded-plugin behavior.
 import { beforeAll, describe, expect, it } from "vitest";
-import { loadBundledPluginPublicSurface } from "../../../test-utils/bundled-plugin-public-surface.js";
 import {
   getBundledChannelPluginAsync,
+  getBundledChannelThreadBindingArtifactAsync,
   listBundledChannelPluginIds,
 } from "./test-helpers/bundled-channel-plugin-loader.js";
 
 // Bundled channels expected to ship a top-level thread-binding artifact.
 const THREAD_BINDING_ARTIFACT_PLUGIN_IDS = ["discord", "matrix"] as const;
 
-const MISSING_PUBLIC_SURFACE_PREFIX = "Unable to resolve bundled plugin public surface ";
-
-type ThreadBindingArtifactModule = { defaultTopLevelPlacement?: unknown };
-
-async function loadThreadBindingArtifact(
-  pluginId: string,
-): Promise<ThreadBindingArtifactModule | null> {
-  try {
-    return await loadBundledPluginPublicSurface<ThreadBindingArtifactModule>({
-      pluginId,
-      artifactBasename: "thread-binding-api.js",
-    });
-  } catch (error) {
-    if (error instanceof Error && error.message.startsWith(MISSING_PUBLIC_SURFACE_PREFIX)) {
-      return null;
-    }
-    throw error;
-  }
-}
-
 describe("bundled channel thread-binding artifact parity", () => {
   const artifactPlacements = new Map<string, unknown>();
 
   beforeAll(async () => {
     for (const id of listBundledChannelPluginIds()) {
-      const artifact = await loadThreadBindingArtifact(id);
+      const artifact = await getBundledChannelThreadBindingArtifactAsync(id);
       if (artifact) {
         artifactPlacements.set(id, artifact.defaultTopLevelPlacement);
       }

--- a/src/channels/plugins/thread-binding-api.test.ts
+++ b/src/channels/plugins/thread-binding-api.test.ts
@@ -68,10 +68,12 @@ describe("bundled channel thread binding fast path", () => {
   });
 
   it("treats missing artifacts as absent hints", () => {
-    expect(resolveBundledChannelThreadBindingDefaultPlacement("discord")).toBeUndefined();
+    // "absent" is a synthetic channel; real bundled artifacts are covered by
+    // the thread-binding artifact parity contract test.
+    expect(resolveBundledChannelThreadBindingDefaultPlacement("absent")).toBeUndefined();
     expect(
       resolveBundledChannelThreadBindingInboundConversation({
-        channelId: "discord",
+        channelId: "absent",
         to: "channel:general",
         isGroup: true,
       }),

--- a/test/vitest/vitest.contracts-shared.ts
+++ b/test/vitest/vitest.contracts-shared.ts
@@ -36,6 +36,7 @@ export const channelSessionContractPatterns = [
   "src/channels/plugins/contracts/plugins-core.resolve-config-writes.contract.test.ts",
   "src/channels/plugins/contracts/registry.contract.test.ts",
   "src/channels/plugins/contracts/session-binding.registry-backed.contract.test.ts",
+  "src/channels/plugins/contracts/thread-binding-artifact.contract.test.ts",
   "src/channels/plugins/contracts/*-shard-d.contract.test.ts",
   "src/channels/plugins/contracts/*-shard-h.contract.test.ts",
 ];


### PR DESCRIPTION
Related: #104318

## What Problem This Solves

Fixes a dual-surface drift hazard where Discord's lightweight `thread-binding-api.ts` artifact hardcoded `defaultTopLevelPlacement = "child"` inline while `src/channel.ts` independently hardcoded the same literal — two hand-maintained copies with nothing keeping them in sync. Matrix's channel.ts carried the same inline-literal hazard. Core genuinely consumes these artifacts on startup-safe paths (thread-bindings-policy, conversation-resolution), so drift would silently change pre-runtime placement behavior.

## Why This Change Was Made

Single source of truth per channel (`src/thread-binding-api.ts` constant re-exported by the root artifact, consumed by the plugin object), matching the pattern matrix's artifact already used, plus a table-driven parity contract test that discovers every bundled channel shipping a thread-binding artifact and asserts artifact export === the real plugin's `conversationBindings.defaultTopLevelPlacement`. Contract test lanes enumerate files explicitly, so the new test is registered in the contracts lane configs.

## User Impact

No behavior change today; prevents a class of silent placement drift between fast-path and runtime behavior.

## Evidence

- Parity contract suite (discord+matrix rows) 9/9 on Testbox `tbx_01kx86hrxwddz38dczac6hq4pq`; matrix thread-binding + discord channel tests 37/37 on `tbx_01kx867d8v3gg6bvg8xh7aq99z`; vitest-projects-config 16/16 on `tbx_01kx86rb47zbtt0gfd0ncbm3kc`; oxfmt clean on `tbx_01kx86xq9bxzwhd009m366dyt2`.
- Autoreview (codex gpt-5.6-sol, xhigh): clean, no findings.
- The old core test's `resolveBundledChannelThreadBindingDefaultPlacement("discord") → undefined` was a mock-fixture artifact, not vestigiality — fixture renamed; core loader genuinely consumes discord's artifact.
