### PR TITLE
fix: send managed Codex app-server version

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -1,7 +1,7 @@
 // Codex tests cover client plugin behavior.
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { embeddedAgentLog, OPENCLAW_VERSION } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   testing,
@@ -13,6 +13,7 @@ import {
 } from "./client.js";
 import { resetSharedCodexAppServerClientForTests } from "./shared-client.js";
 import { createClientHarness } from "./test-support.js";
+import { MANAGED_CODEX_APP_SERVER_PACKAGE_VERSION } from "./version.js";
 
 describe("CodexAppServerClient", () => {
   const clients: CodexAppServerClient[] = [];
@@ -227,7 +228,7 @@ describe("CodexAppServerClient", () => {
     expect(harness.writes).toHaveLength(1);
   });
 
-  it("initializes with the required client version", async () => {
+  it("initializes with the managed Codex compatibility version", async () => {
     const { harness, initializing, outbound } = startInitialize();
     harness.send({
       id: outbound.id,
@@ -242,7 +243,7 @@ describe("CodexAppServerClient", () => {
         clientInfo: {
           name: "openclaw",
           title: "OpenClaw",
-          version: OPENCLAW_VERSION,
+          version: MANAGED_CODEX_APP_SERVER_PACKAGE_VERSION,
         },
         capabilities: {
           experimentalApi: true,
@@ -250,6 +251,10 @@ describe("CodexAppServerClient", () => {
       },
     });
     expect(outbound.params?.clientInfo?.version).not.toBe("");
+    expect(harness.client.getRuntimeIdentity()).toMatchObject({
+      serverVersion: "0.143.0",
+      userAgent: "openclaw/0.143.0 (macOS; test)",
+    });
     expect(JSON.parse(harness.writes[1] ?? "{}")).toEqual({ method: "initialized" });
   });
 

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -4,7 +4,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
-import { embeddedAgentLog, OPENCLAW_VERSION } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveCodexAppServerRuntimeOptions, type CodexAppServerStartOptions } from "./config.js";
 import {
@@ -27,7 +27,10 @@ import {
   closeCodexAppServerTransportAndWait,
   type CodexAppServerTransport,
 } from "./transport.js";
-import { MIN_CODEX_APP_SERVER_VERSION } from "./version.js";
+import {
+  MANAGED_CODEX_APP_SERVER_PACKAGE_VERSION,
+  MIN_CODEX_APP_SERVER_VERSION,
+} from "./version.js";
 
 /** Minimum supported Codex app-server version exported for callers/tests. */
 export { MIN_CODEX_APP_SERVER_VERSION } from "./version.js";
@@ -297,7 +300,7 @@ export class CodexAppServerClient {
       clientInfo: {
         name: "openclaw",
         title: "OpenClaw",
-        version: OPENCLAW_VERSION,
+        version: MANAGED_CODEX_APP_SERVER_PACKAGE_VERSION,
       },
       capabilities: {
         experimentalApi: true,

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -51,8 +51,8 @@ export type RpcMessage = RpcRequest | RpcResponse;
 export type CodexInitializeParams = {
   clientInfo: {
     name: string;
-    title?: string;
-    version?: string;
+    title?: string | null;
+    version: string;
   };
   capabilities?: JsonObject;
 };


### PR DESCRIPTION
Closes #103884

Task: req-20260711-openclaw-gpt56-pr

## What Problem This Solves

Fixes an issue where users running GPT-5.6 Sol through the OpenClaw Codex runtime could receive Codex's "requires a newer version" error even though OpenClaw manages a newer Codex app-server package.

## Why This Change Was Made

The Codex app-server initialize contract uses `clientInfo.name` and `clientInfo.version` to record the client identity and version. OpenClaw now keeps the client name/title as `openclaw`/`OpenClaw`, but sends the managed Codex app-server package version as `clientInfo.version`; no OpenClaw product version or unknown protocol field is sent or added to runtime identity/fingerprints.

## User Impact

OpenClaw's Codex runtime now advertises the managed Codex compatibility version during initialize, so model gates that depend on the Codex client/app-server version see the correct managed version instead of the OpenClaw product version.

## Evidence

- `git diff --check` -> exit 0.
- `npm exec --yes pnpm@11.2.2 -- test extensions/codex/src/app-server/client.test.ts` -> 1 file passed, 32 tests passed.
- `npm exec --yes pnpm@11.2.2 -- test extensions/codex/src/app-server/managed-binary.test.ts` -> 1 file passed, 12 tests passed.
- Dependency contract checked in sibling Codex source:
  - `codex-rs/app-server-protocol/src/protocol/v1.rs:27-41` defines `InitializeParams.client_info` with `ClientInfo { name, title, version }` and required `version`.
  - `codex-rs/app-server/src/request_processors/initialize_processor.rs:77-99` reads `name`, `title`, and `version`, stores `client_version`, and builds the user-agent suffix from `{name}; {version}`.
  - `codex-rs/app-server-client/src/lib.rs:344-365` and `codex-rs/app-server-client/src/remote.rs:94-113` build initialize params from caller-supplied client name/version without extra fields.
- Testbox/Crabbox was unavailable in this checkout (`crabbox`/`blacksmith` not on PATH; `node scripts/crabbox-wrapper.mjs --help` reported the selected binary failed sanity checks), so the focused tests were run as the local fallback after installing pinned dependencies with `npm exec --yes pnpm@11.2.2 -- install --frozen-lockfile`.

## Post-main-update evidence

Updated after rebasing this PR onto current `origin/main` (`30cc87a8`).

- New PR head: `2c261511`.
- `git diff --check origin/main..HEAD` -> exit 0.
- `node scripts/test-projects.mjs extensions/codex/src/app-server/client.test.ts extensions/codex/src/app-server/managed-binary.test.ts` -> 2 files passed, 46 tests passed.
- Redacted live managed-path proof was added in https://github.com/openclaw/openclaw/pull/104344#issuecomment-4950053552, showing default managed OpenClaw Codex path succeeding on `gpt-5.6-sol` with this patch.

## Maintainer decision still needed

The remaining policy question is tracked in https://github.com/openclaw/openclaw/pull/104344#issuecomment-4950055177: whether OpenClaw's Codex initialize identity should advertise the managed Codex compatibility version for desktop/custom app-server commands as well, or derive identity by command source.
