### PR TITLE
fix(secrets): register secret targets for installed-origin plugins

### DIFF
--- a/src/secrets/target-registry-data.current-snapshot.test.ts
+++ b/src/secrets/target-registry-data.current-snapshot.test.ts
@@ -32,4 +32,29 @@ describe("getSecretTargetRegistry metadata reuse", () => {
       expect(call.allowWorkspaceScopedCurrent).not.toBe(true);
     }
   });
+  it("registers secret targets for installed-origin plugins (#104320)", async () => {
+    // The Exa web providers moved from bundled origin to an installed plugin
+    // package; the gateway's known-target registry must keep covering them.
+    metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "exa",
+          origin: "global",
+          channels: [],
+          contracts: { webSearchProviders: ["exa"] },
+          configUiHints: { "webSearch.apiKey": { sensitive: true } },
+          configContracts: {
+            secretInputs: { paths: [{ path: "webSearch.apiKey" }] },
+          },
+        },
+      ],
+    } as never);
+    const { getSecretTargetRegistry } = await import("./target-registry-data.js");
+    const { isKnownSecretTargetId } = await import("./target-registry-query.js");
+
+    const ids = getSecretTargetRegistry().map((entry) => entry.id);
+
+    expect(ids).toContain("plugins.entries.exa.config.webSearch.apiKey");
+    expect(isKnownSecretTargetId("plugins.entries.exa.config.webSearch.apiKey")).toBe(true);
+  });
 });

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -49,11 +49,11 @@ function hasWebProviderContract(
   return (plugin.contracts?.[contract]?.length ?? 0) > 0;
 }
 
-function listBundledWebProviderSecretTargetRegistryEntries(
-  bundledPlugins: readonly PluginManifestRecord[],
+function listPluginWebProviderSecretTargetRegistryEntries(
+  plugins: readonly PluginManifestRecord[],
 ): SecretTargetRegistryEntry[] {
   const entries: SecretTargetRegistryEntry[] = [];
-  for (const record of bundledPlugins) {
+  for (const record of plugins) {
     for (const config of WEB_PROVIDER_SECRET_CONFIGS) {
       if (
         hasWebProviderContract(record, config.contract) &&
@@ -66,12 +66,12 @@ function listBundledWebProviderSecretTargetRegistryEntries(
   return entries.toSorted((left, right) => left.id.localeCompare(right.id));
 }
 
-function listBundledPluginConfigSecretTargetRegistryEntries(
-  bundledPlugins: readonly Pick<PluginManifestRecord, "id" | "configContracts">[],
+function listPluginConfigSecretTargetRegistryEntries(
+  plugins: readonly Pick<PluginManifestRecord, "id" | "configContracts">[],
 ): SecretTargetRegistryEntry[] {
   const entries: SecretTargetRegistryEntry[] = [];
   const seen = new Set<string>();
-  for (const record of bundledPlugins) {
+  for (const record of plugins) {
     const secretInputs = record.configContracts?.secretInputs?.paths ?? [];
     for (const secretInput of secretInputs) {
       const entry = createPluginOpenClawConfigSecretTargetEntry(record.id, secretInput.path);
@@ -471,13 +471,18 @@ function loadSecretTargetRegistryFromPluginMetadata(params: {
     env: params.env,
     ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
   }).plugins;
-  const bundledPlugins = plugins.filter((record) => record.origin === "bundled");
   const channelPlugins = plugins.filter((record) => record.channels.length > 0);
+  // Installed/workspace plugins own secret targets exactly like bundled ones
+  // (#104320: the Exa split moved web providers out of bundled origin and their
+  // targets vanished from the gateway's known-target registry). Entries stay
+  // manifest-scoped — web-provider contract + sensitive hint, or declared
+  // secretInput paths — so a non-bundled origin cannot widen target paths
+  // beyond its own declared contracts.
   return [
     ...CORE_SECRET_TARGET_REGISTRY,
-    ...listBundledWebProviderSecretTargetRegistryEntries(bundledPlugins),
-    ...listBundledPluginConfigSecretTargetRegistryEntries([
-      ...bundledPlugins,
+    ...listPluginWebProviderSecretTargetRegistryEntries(plugins),
+    ...listPluginConfigSecretTargetRegistryEntries([
+      ...plugins,
       ...listSourceBundledPluginConfigContractRecords(),
     ]),
     ...listChannelSecretTargetRegistryEntries(channelPlugins),


### PR DESCRIPTION
## What Problem This Solves

#104320 (P1, regression of #82621/#82798): the secret target registry built its plugin-derived entries from **bundled-origin records only** (`target-registry-data.ts` filtered `record.origin === "bundled"`). When the Exa web providers moved out of bundled origin into an installed plugin package, their config targets (`plugins.entries.exa.config.webSearch.apiKey`) vanished from the gateway's known-target registry — `secrets.resolve` rejects the CLI-discovered target with `unknown target id`, and `infer web search` fails on an unresolved SecretRef before provider I/O, even though the plugin is loaded, enabled, and `secrets audit` reports full resolvability.

## Why This Change Was Made

Per the triage's best-solution shape ("build the known-target registry from active installed-plugin manifest metadata, while preserving plugin enablement, manifest-first laziness, strict allowed-path scoping, and provider-specific ownership"):

- Web-provider and config-contract secret target entries now come from **every active plugin manifest record**, exactly as channel-contract entries already did (they never filtered by origin — the bundled-only filter on the other two families was the inconsistency).
- Scoping is unchanged and stays manifest-owned: an entry is only created for a plugin that declares the web-provider contract **and** marks the config path sensitive in its own manifest hints, or declares the path in `configContracts.secretInputs`. A non-bundled origin cannot widen target paths beyond its own declared contracts, and no plugin runtime is loaded (metadata snapshot only — laziness preserved).
- No hard-coded provider ids, no validation weakening: `isKnownSecretTargetId` remains a closed registry; the registry just covers what's actually installed.

## User Impact

Users of installed (non-bundled) provider plugins with SecretRef-backed credentials — the Exa split being the shipped example — get working `infer web search`/`web fetch` credential resolution again instead of a hard `INVALID_REQUEST` from the gateway.

## Evidence

**Executed real-handler before/after** (the issue's exact `secrets.resolve` params driven through the real `createSecretsHandlers` handler, with an installed-origin Exa manifest record in the metadata snapshot):

| | result |
|---|---|
| current `main` | `ok: false` — `INVALID_REQUEST: invalid secrets.resolve params: unknown target id "plugins.entries.exa.config.webSearch.apiKey"` (byte-identical to the issue's report) |
| this PR | `ok: true` — validation passes, resolution proceeds |

**Regression test** (`target-registry-data.current-snapshot.test.ts`): an installed-origin (`origin: "global"`) record with the web-search contract + sensitive hint + declared secretInput produces the registry entry and `isKnownSecretTargetId` accepts it. **Fails on prior head** with `expected [ 'auth-profiles.api_key.key', …(37) ] to include 'plugins.entries.exa.config.webSearch.apiKey'`.

**Validation:** full `src/secrets` suite **553/553**; `tsgo:core` 0; oxlint/oxfmt clean.

Fixes #104320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJogTw4aGDiacwqju1uod6
