### PR TITLE
fix(ci): sync Control UI raw-copy baseline

### DIFF
--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -1791,6 +1791,13 @@
       "kind": "html-attribute",
       "name": "aria-label",
       "path": "ui/src/pages/chat/components/chat-composer.ts",
+      "text": "BTW side question pending"
+    },
+    {
+      "count": 1,
+      "kind": "html-attribute",
+      "name": "aria-label",
+      "path": "ui/src/pages/chat/components/chat-composer.ts",
       "text": "BTW side result"
     },
     {
@@ -1813,6 +1820,13 @@
       "name": "aria-label",
       "path": "ui/src/pages/chat/components/chat-composer.ts",
       "text": "Compact recommended session context"
+    },
+    {
+      "count": 1,
+      "kind": "html-attribute",
+      "name": "aria-label",
+      "path": "ui/src/pages/chat/components/chat-composer.ts",
+      "text": "Dismiss BTW question"
     },
     {
       "count": 1,
@@ -1864,7 +1878,7 @@
       "text": "&times;"
     },
     {
-      "count": 1,
+      "count": 2,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/pages/chat/components/chat-composer.ts",
@@ -1953,6 +1967,13 @@
       "name": "text",
       "path": "ui/src/pages/chat/components/chat-composer.ts",
       "text": "Tab"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/chat/components/chat-composer.ts",
+      "text": "Thinking…"
     },
     {
       "count": 1,


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the Control UI i18n raw-copy check after the BTW composer added intentional labels/text without updating the tracked baseline. This blocks unrelated pull requests rebased after that merge.

## Why This Change Was Made

Regenerate only `ui/src/i18n/.i18n/raw-copy-baseline.json` with the repository-owned sync command. No runtime or translated copy changes.

## User Impact

None. Restores the shared CI contract for current `main` and newly rebased pull requests.

## Evidence

- Before: `node --import tsx scripts/control-ui-i18n.ts check` reports four BTW composer baseline deltas.
- After: the same command passes for all 20 locales.
- `git diff --check` passes.