### PR TITLE
fix(mcp): map disabled flag to enabled in config normalization

### DIFF
--- a/src/config/mcp-config-normalize.ts
+++ b/src/config/mcp-config-normalize.ts
@@ -69,6 +69,10 @@ export function canonicalizeConfiguredMcpServer(
     next.clientKey = next.client_key;
     delete next.client_key;
   }
+  if (typeof next.disabled === "boolean" && typeof next.enabled !== "boolean") {
+    next.enabled = !next.disabled;
+    delete next.disabled;
+  }
   return next;
 }
 
@@ -80,6 +84,13 @@ export function normalizeConfiguredMcpServers(value: unknown): ConfigMcpServers 
   return Object.fromEntries(
     Object.entries(value)
       .filter(([, server]) => isRecord(server))
-      .map(([name, server]) => [name, { ...(server as Record<string, unknown>) }]),
+      .map(([name, server]) => {
+        const next = { ...(server as Record<string, unknown>) };
+        if (typeof next.disabled === "boolean" && typeof next.enabled !== "boolean") {
+          next.enabled = !next.disabled;
+          delete next.disabled;
+        }
+        return [name, next];
+      }),
   );
 }


### PR DESCRIPTION
### What Problem This Solves
Resolves #103954

When an MCP server entry in `openclaw.json` has `disabled: true`, the gateway silently ignores it and spawns the processes anyway. This PR fixes the bug by mapping `disabled` to `enabled` during MCP config normalization, ensuring disabled servers remain unspawned.

### Evidence
- **Tests**: Local Vitest passed for `bundle-mcp-config.ts`.
- **Proof**: Manually added `disabled` flag mapping in `mcp-config-normalize.ts` prior to validation.