### PR TITLE
fix(maint): reuse recent same-PR hosted gates

### DIFF
--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -19,7 +19,7 @@ const ARTIFACT_FALLBACK_REQUIRED_WORKFLOWS = [
 ];
 const WORKFLOW_RUNS_PAGE_SIZE = 100;
 const MAX_WORKFLOW_RUN_SEARCH_RESULTS = 1_000;
-export const HOSTED_GATE_MAX_AGE_HOURS = 24;
+export const HOSTED_GATE_MAX_AGE_HOURS = 12;
 const HOSTED_GATE_MAX_AGE_MS = HOSTED_GATE_MAX_AGE_HOURS * 60 * 60 * 1_000;
 const HOSTED_GATE_CLOCK_SKEW_MS = 5 * 60 * 1_000;
 
@@ -231,6 +231,7 @@ export function workflowRunPageCount(totalCount) {
 
 export function collectHostedGateEvidence({
   sha,
+  pr,
   recentSha,
   workflowRuns,
   changelogOnly = false,
@@ -309,19 +310,43 @@ export function collectHostedGateEvidence({
       );
       return latestManual && latestManual.conclusion !== "success";
     });
-    if (!recentSha || currentHeadHasTerminalNonSuccess) {
+    if (currentHeadHasTerminalNonSuccess) {
       throw exactError;
     }
-    // Only prepare-sync-head supplies recentSha, after its controlled rebase preserved the PR patch.
-    // Arbitrary branch history is never eligible, so new untested pushes cannot borrow old green runs.
     const targetScheduledWorkflows = new Set(
       SCHEDULED_HOSTED_WORKFLOWS.filter(
         (workflowName) =>
           matchingAuthoritativeRuns(workflowRuns, workflowName, sha, false).length > 0,
       ),
     );
-    evidenceSha = recentSha;
-    selected = collectForSha(recentSha, true, targetScheduledWorkflows);
+    const fallbackShas = [
+      recentSha,
+      ...workflowRuns
+        .filter(
+          (run) =>
+            run?.event === "pull_request" &&
+            run?.head_sha !== sha &&
+            run?.pull_requests?.some((pullRequest) => pullRequest?.number === pr) &&
+            isRecentRun(run, nowMs),
+        )
+        .toSorted((left, right) =>
+          String(right.updated_at ?? "").localeCompare(String(left.updated_at ?? "")),
+        )
+        .map((run) => run.head_sha),
+    ].filter(Boolean);
+    let fallbackError;
+    for (const fallbackSha of new Set(fallbackShas)) {
+      try {
+        selected = collectForSha(fallbackSha, true, targetScheduledWorkflows);
+        evidenceSha = fallbackSha;
+        break;
+      } catch (error) {
+        fallbackError ??= error;
+      }
+    }
+    if (!selected) {
+      throw fallbackError ?? exactError;
+    }
   }
 
   const evidence = {
@@ -348,12 +373,18 @@ export function collectHostedGateEvidence({
   return evidence;
 }
 
-export function workflowRunQueryPaths(repo, { sha, recentSha }, page = 1) {
+export function workflowRunQueryPaths(repo, { sha, recentSha, headBranch }, page = 1) {
   const pageSuffix = `per_page=${WORKFLOW_RUNS_PAGE_SIZE}&page=${page}`;
   const shas = [...new Set([sha, recentSha].filter(Boolean))];
-  return shas.map(
+  const queries = shas.map(
     (headSha) => `repos/${repo}/actions/runs?head_sha=${encodeURIComponent(headSha)}&${pageSuffix}`,
   );
+  if (headBranch) {
+    queries.push(
+      `repos/${repo}/actions/runs?branch=${encodeURIComponent(headBranch)}&event=pull_request&${pageSuffix}`,
+    );
+  }
+  return queries;
 }
 
 function loadWorkflowRunsForQuery(queryForPage) {
@@ -374,8 +405,8 @@ function loadWorkflowRunsForQuery(queryForPage) {
   return workflowRuns;
 }
 
-function loadWorkflowRuns(repo, sha, recentSha) {
-  const queries = workflowRunQueryPaths(repo, { sha, recentSha });
+function loadWorkflowRuns(repo, sha, recentSha, headBranch) {
+  const queries = workflowRunQueryPaths(repo, { sha, recentSha, headBranch });
   const withPage = (query, page) => query.replace(/page=1$/u, `page=${page}`);
   const workflowRuns = queries.flatMap((query) =>
     loadWorkflowRunsForQuery((page) => withPage(query, page)),
@@ -385,10 +416,15 @@ function loadWorkflowRuns(repo, sha, recentSha) {
 
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
+  const headBranch = execPlainGh(["api", `repos/${args.repo}/pulls/${args.pr}`, "--jq", ".head.ref"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
   const evidence = collectHostedGateEvidence({
     sha: args.sha,
+    pr: args.pr,
     recentSha: args.recentSha,
-    workflowRuns: loadWorkflowRuns(args.repo, args.sha, args.recentSha),
+    workflowRuns: loadWorkflowRuns(args.repo, args.sha, args.recentSha, headBranch),
     changelogOnly: args.changelogOnly,
   });
   const evidenceHeadSha = evidence.evidenceHeadSha ?? args.sha;
@@ -398,7 +434,7 @@ export function main(argv = process.argv.slice(2)) {
     repo: args.repo,
     pullRequestNumber: args.pr,
     selection: {
-      mode: evidenceHeadSha === args.sha ? "exact-head" : "recent-rebase-head",
+      mode: evidenceHeadSha === args.sha ? "exact-head" : "recent-pr-head",
       maxAgeHours: HOSTED_GATE_MAX_AGE_HOURS,
     },
     ...evidence,

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -416,10 +416,13 @@ function loadWorkflowRuns(repo, sha, recentSha, headBranch) {
 
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
-  const headBranch = execPlainGh(["api", `repos/${args.repo}/pulls/${args.pr}`, "--jq", ".head.ref"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  }).trim();
+  const headBranch = execPlainGh(
+    ["api", `repos/${args.repo}/pulls/${args.pr}`, "--jq", ".head.ref"],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  ).trim();
   const evidence = collectHostedGateEvidence({
     sha: args.sha,
     pr: args.pr,

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -43,7 +43,7 @@ function successfulRun(name: string, id: number, updatedAt: string) {
 }
 
 function collectHostedGateEvidence(options: Parameters<typeof collectHostedGateEvidenceRaw>[0]) {
-  return collectHostedGateEvidenceRaw({ nowMs, ...options });
+  return collectHostedGateEvidenceRaw({ nowMs, pr, ...options });
 }
 
 describe("verify-pr-hosted-gates", () => {
@@ -127,6 +127,30 @@ describe("verify-pr-hosted-gates", () => {
     });
   });
 
+  it("accepts recent green evidence from an earlier head of the same PR", () => {
+    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
+    const evidence = collectHostedGateEvidence({
+      sha,
+      workflowRuns: [
+        {
+          ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
+          head_sha: previousSha,
+        },
+        {
+          ...successfulRun("CI", 2, "2026-06-17T10:54:00Z"),
+          status: "in_progress",
+          conclusion: null,
+        },
+      ],
+    });
+
+    expect(evidence).toEqual({
+      headSha: sha,
+      evidenceHeadSha: previousSha,
+      workflows: [expect.objectContaining({ name: "CI", id: 1, headSha: previousSha })],
+    });
+  });
+
   it("requires recent evidence for scheduled gates observed on the target head", () => {
     const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     const targetArmRun = {
@@ -190,6 +214,27 @@ describe("verify-pr-hosted-gates", () => {
       ).toThrow(`Missing successful CI workflow for ${sha}`);
     },
   );
+
+  it("does not reuse green evidence from another PR", () => {
+    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        workflowRuns: [
+          {
+            ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
+            head_sha: previousSha,
+            pull_requests: [{ number: pr + 1 }],
+          },
+          {
+            ...successfulRun("CI", 2, "2026-06-17T10:54:00Z"),
+            status: "in_progress",
+            conclusion: null,
+          },
+        ],
+      }),
+    ).toThrow(`Missing successful CI workflow for ${sha}`);
+  });
 
   it("requires the complete recent gate cohort from the recorded head", () => {
     const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
@@ -292,6 +337,7 @@ describe("verify-pr-hosted-gates", () => {
     const recentUnrelatedRun = {
       ...successfulRun("CI", 4, "2026-06-17T10:50:00Z"),
       head_sha: unrelatedSha,
+      pull_requests: [{ number: pr + 1 }],
     };
     expect(() =>
       collectHostedGateEvidence({
@@ -649,7 +695,20 @@ describe("verify-pr-hosted-gates", () => {
       `repos/openclaw/openclaw/actions/runs?head_sha=${sha}&per_page=100&page=1`,
       `repos/openclaw/openclaw/actions/runs?head_sha=${previousSha}&per_page=100&page=1`,
     ]);
-    expect(HOSTED_GATE_MAX_AGE_HOURS).toBe(24);
+    expect(HOSTED_GATE_MAX_AGE_HOURS).toBe(12);
+  });
+
+  it("queries recent pull-request runs for the head branch", () => {
+    expect(
+      workflowRunQueryPaths("openclaw/openclaw", {
+        sha,
+        recentSha: "",
+        headBranch: "codex/relax hosted gates",
+      }),
+    ).toEqual([
+      `repos/openclaw/openclaw/actions/runs?head_sha=${sha}&per_page=100&page=1`,
+      "repos/openclaw/openclaw/actions/runs?branch=codex%2Frelax%20hosted%20gates&event=pull_request&per_page=100&page=1",
+    ]);
   });
 
   it("bounds workflow-run pagination to GitHub's search result limit", () => {


### PR DESCRIPTION
## What Problem This Solves

The landing wrapper only reused recent hosted-gate evidence after its own controlled rebase. Ordinary follow-up pushes therefore waited for an entirely new gate cohort even when the same PR had just completed one.

## Why This Change Was Made

Allow a coherent successful gate cohort from an earlier head of the same PR to satisfy hosted-gate verification for up to 12 hours. Exact-head evidence remains preferred, evidence never crosses PRs or mixes heads, and any terminal failure on the current head still blocks landing.

This generalizes the rebase-only exception introduced in #100663 while shortening its window from 24 hours to 12.

## User Impact

Maintainers can land small follow-up pushes without routinely waiting for duplicate hosted gates. A currently failing head cannot borrow an older green result.

## Evidence

- `corepack pnpm test test/scripts/verify-pr-hosted-gates.test.ts` — 33 passed on Blacksmith Testbox lease `tbx_01kx87w86s0pcv5d0697975m6q`
- `node_modules/.bin/oxfmt --check scripts/verify-pr-hosted-gates.mjs test/scripts/verify-pr-hosted-gates.test.ts`
- `git diff --check`
- Fresh autoreview: clean; deliberate pending-current-head reuse tradeoff noted
