### PR TITLE
ci(release): preserve Telegram launcher stage

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1156,7 +1156,7 @@ jobs:
           #!/bin/bash
           set -Eeuo pipefail
           launcher_stage=entry
-          trap 'exit_status=$?; trap - ERR; printf "Telegram SUT launcher failed: stage=%s line=%s status=%s\n" "$launcher_stage" "$LINENO" "$exit_status" >&2; exit "$exit_status"' ERR
+          trap 'exit_status=$?; trap - ERR; if [[ -n "${launcher_stage_file:-}" && -r "$launcher_stage_file" ]]; then launcher_stage="$(<"$launcher_stage_file")"; fi; printf "Telegram SUT launcher failed: stage=%s line=%s status=%s\n" "$launcher_stage" "$LINENO" "$exit_status" >&2; exit "$exit_status"' ERR
 
           transport_keys=(
             HOME
@@ -1658,14 +1658,24 @@ jobs:
           export command_sha256 expected_env_keys_b64 sandbox_payload_b64
 
           launcher_stage=enter-mount-namespace
+          launcher_stage_file="${RUNTIME_ROOT}/launcher-stage-${BASHPID}"
+          printf '%s\n' "$launcher_stage" >"$launcher_stage_file"
+          chmod 0600 "$launcher_stage_file"
+          trap 'rm -f "$launcher_stage_file"' EXIT
+          export launcher_stage_file
           /usr/bin/unshare \
             --mount \
             --fork \
             --propagation private \
             /bin/bash -ceu '
-              launcher_stage=mask-host-paths
+              set_launcher_stage() {
+                launcher_stage="$1"
+                printf "%s\n" "$launcher_stage" >"$launcher_stage_file"
+              }
+              set_launcher_stage mask-host-paths
               trap "exit_status=\$?; trap - ERR; printf \"Telegram SUT launcher failed: stage=%s line=%s status=%s\\n\" \"\$launcher_stage\" \"\$LINENO\" \"\$exit_status\" >&2; exit \"\$exit_status\"" ERR
               for masked_path in "$RUNNER_HOME" /tmp /var/tmp /dev/shm; do
+                set_launcher_stage "mask-host-path:${masked_path}"
                 [[ -d "$masked_path" ]]
                 mount \
                   -t tmpfs \
@@ -1673,10 +1683,10 @@ jobs:
                   openclaw-telegram-mask \
                   "$masked_path"
               done
-              launcher_stage=mount-proc
+              set_launcher_stage mount-proc
               mount -t proc proc /proc -o nosuid,nodev,noexec,hidepid=2
               if [[ "$boundary_mode" == "true" ]]; then
-                launcher_stage=write-identity
+                set_launcher_stage write-identity
                 pid="$$"
                 proc_stat="$(cat "/proc/${pid}/stat")"
                 proc_tail="${proc_stat##*) }"
@@ -1708,6 +1718,8 @@ jobs:
                 exec 3>"$sandbox_file"
               fi
 
+              set_launcher_stage launch-runtime
+              unset launcher_stage_file
               exec /usr/bin/prlimit \
                 --core=0:0 \
                 --nproc=256:256 \

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -522,12 +522,18 @@ describe("release Telegram QA workflow", () => {
     expect(source).toContain("Telegram SUT launcher failed: stage=%s line=%s status=%s");
     expect(source).toContain("launcher_stage=root-run-setup");
     expect(source).toContain("launcher_stage=enter-mount-namespace");
-    expect(source).toContain("launcher_stage=mask-host-paths");
-    expect(source).toContain("launcher_stage=mount-proc");
-    expect(source).toContain("launcher_stage=write-identity");
+    expect(source).toContain("set_launcher_stage mask-host-paths");
+    expect(source).toContain('launcher_stage_file="${RUNTIME_ROOT}/launcher-stage-${BASHPID}"');
+    expect(source).toContain('set_launcher_stage "mask-host-path:${masked_path}"');
+    expect(source).toContain("set_launcher_stage mount-proc");
+    expect(source).toContain("set_launcher_stage write-identity");
+    expect(source).toContain("set_launcher_stage launch-runtime");
+    expect(source).toMatch(/set_launcher_stage launch-runtime\n\s+unset launcher_stage_file/u);
     expect(source).toContain('TMPDIR="${SUT_RUNTIME_ROOT}/tmp"');
     expect(source).toContain('"$RUNTIME_ROOT"/tmp/openclaw-qa-suite-*');
-    expect(source).toMatch(/launcher_stage=enter-mount-namespace\n\s+\/usr\/bin\/unshare/u);
+    expect(source.indexOf("launcher_stage=enter-mount-namespace")).toBeLessThan(
+      source.indexOf("/usr/bin/unshare"),
+    );
     expect(source).not.toContain("exec /usr/bin/unshare");
     expect(source).not.toContain("set -x");
     expect(source).toContain('source_node_bin="$(realpath -e "$(command -v node)")"');
@@ -608,6 +614,29 @@ describe("release Telegram QA workflow", () => {
     expect(result.status).toBe(23);
     expect(result.stderr).toMatch(
       /Telegram SUT launcher failed: stage=enter-mount-namespace line=[0-9]+ status=23/u,
+    );
+  });
+
+  it("reports the persisted inner launcher stage when namespace supervision fails", () => {
+    const source = readFileSync(WORKFLOW_PATH, "utf8");
+    const trapLine = source.match(/^\s+(trap 'exit_status=.*' ERR)$/mu)?.[1];
+    expect(trapLine).toBeTruthy();
+
+    const workdir = tempDirs.make("openclaw-telegram-launcher-stage-");
+    const stagePath = join(workdir, "stage");
+    writeFileSync(stagePath, "mount-proc\n");
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `set -Eeuo pipefail\nlauncher_stage=enter-mount-namespace\nlauncher_stage_file=${JSON.stringify(stagePath)}\n${trapLine}\nbash -c 'exit 23'`,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(23);
+    expect(result.stderr).toMatch(
+      /Telegram SUT launcher failed: stage=mount-proc line=[0-9]+ status=23/u,
     );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The exact-merge Telegram release canary now fails quickly, but the launcher reports every nested mount-namespace failure as `enter-mount-namespace`. That hides whether the failing operation is path masking, `/proc` mounting, identity handoff, or runtime launch and blocks a bounded release fix.

## Why This Change Was Made

Persist the current nested launcher stage in a root-owned runtime file. The supervising shell reads that marker only when reporting failure, removes it on exit, and unsets the path before entering the strict unprivileged runtime environment. Isolation remains fail closed; there is no fallback or bypass.

## User Impact

Release Telegram QA failures identify the exact sandbox stage instead of producing an ambiguous outer `unshare` attribution. This shortens diagnosis without changing product runtime behavior.

## Evidence

- Blacksmith Testbox `tbx_01kx88dz3yddw57gkx7zvgmmzq`: focused workflow test, 14/14 passed.
- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- `git diff --check`
- Fresh autoreview: no accepted/actionable findings.

Context: follow-up to #104324 and exact-merge run 29147392152.
