### PR TITLE
fix(agents): preserve Anthropic Retry-After for auto-retry backoff

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -319,6 +319,14 @@ export interface AssistantMessage {
   errorCode?: string;
   errorType?: string;
   errorBody?: string;
+  /** HTTP status from the failed provider response when the transport preserved it. */
+  httpStatus?: number;
+  /**
+   * Server-requested cooldown in seconds (Retry-After) when the transport preserved it.
+   * Callers should treat this as a lower bound for same-model retry delay and still apply
+   * operator max-delay caps.
+   */
+  retryAfterSeconds?: number;
   timestamp: number; // Unix timestamp in milliseconds
 }
 

--- a/src/agents/anthropic-transport-stream.retry-after.real.test.ts
+++ b/src/agents/anthropic-transport-stream.retry-after.real.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Real local-stub proof for Anthropic 429 Retry-After preservation.
+ * Uses a loopback HTTP server and the production transport stream function
+ * (including buildGuardedModelFetch); only the provider endpoint is stubbed.
+ */
+import http from "node:http";
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { afterEach, describe, expect, it } from "vitest";
+import { createAnthropicMessagesTransportStreamFn } from "./anthropic-transport-stream.js";
+
+type AnthropicMessagesModel = Model<"anthropic-messages">;
+
+function waitForServerListening(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Expected loopback server to listen on a TCP port"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+describe("anthropic transport Retry-After real stub", () => {
+  let server: http.Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await closeServer(server);
+      server = undefined;
+    }
+  });
+
+  it("preserves HTTP status and Retry-After through the production stream path", async () => {
+    let requestCount = 0;
+    server = http.createServer((request, response) => {
+      requestCount += 1;
+      // Drain the body so the client is not left hanging on a half-open socket.
+      request.resume();
+      response.writeHead(429, {
+        "content-type": "application/json",
+        "retry-after": "30",
+      });
+      response.end(
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "rate_limit_error",
+            message: "Number of request tokens has exceeded your per-minute rate limit.",
+          },
+        }),
+      );
+    });
+    const port = await waitForServerListening(server);
+    const model = {
+      id: "claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      baseUrl: `http://127.0.0.1:${port}`,
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 1024,
+    } satisfies AnthropicMessagesModel;
+
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "hello" }],
+        } as never,
+        { apiKey: "sk-ant-test-key" } as never,
+      ),
+    );
+    const result = await stream.result();
+
+    expect(requestCount).toBe(1);
+    expect(result.stopReason).toBe("error");
+    expect(result.httpStatus).toBe(429);
+    expect(result.retryAfterSeconds).toBe(30);
+    expect(result.errorMessage ?? "").toContain("rate_limit_error");
+  });
+});

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -12,9 +12,13 @@ const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
   guardedFetchMock: vi.fn(),
 }));
 
-vi.mock("./provider-transport-fetch.js", () => ({
-  buildGuardedModelFetch: buildGuardedModelFetchMock,
-}));
+vi.mock("./provider-transport-fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./provider-transport-fetch.js")>();
+  return {
+    ...actual,
+    buildGuardedModelFetch: buildGuardedModelFetchMock,
+  };
+});
 
 let createAnthropicMessagesTransportStreamFn: typeof import("./anthropic-transport-stream.js").createAnthropicMessagesTransportStreamFn;
 
@@ -873,6 +877,34 @@ describe("anthropic transport stream", () => {
     expect(headers.get("api-key")).toBeNull();
     expect(headers.get("x-api-key")).toBeNull();
     expect(headers.get("X-Provider")).toBe("foundry");
+  });
+
+  it("projects HTTP status and Retry-After from Anthropic error responses", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "rate_limit_error",
+            message: "Number of request tokens has exceeded your per-minute rate limit.",
+          },
+        }),
+        { status: 429, headers: { "retry-after": "30" } },
+      ),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.httpStatus).toBe(429);
+    expect(result.retryAfterSeconds).toBe(30);
+    expect(result.errorBody).toContain("rate_limit_error");
   });
 
   it("bounds streamed Anthropic error responses without content-length", async () => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -72,7 +72,7 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dyn
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { unwrapModelHeaderSentinelsForProviderEgress } from "./provider-secret-egress.js";
-import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
+import { buildGuardedModelFetch, parseRetryAfterSeconds } from "./provider-transport-fetch.js";
 import type { StreamFn } from "./runtime/index.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
@@ -837,9 +837,7 @@ function createAnthropicMessagesClient(params: {
         });
         if (!response.ok) {
           const detail = await readAnthropicMessagesErrorBodySnippet(response);
-          throw new Error(
-            detail || `Anthropic Messages request failed with HTTP ${response.status}`,
-          );
+          throw createAnthropicMessagesHttpError(response, detail);
         }
         if (!response.body) {
           return;
@@ -848,6 +846,32 @@ function createAnthropicMessagesClient(params: {
       },
     },
   };
+}
+
+/**
+ * Preserve HTTP status and Retry-After on the thrown error so shared transport
+ * projection can attach them to AssistantMessage for same-model retry backoff.
+ * Without this, only the error text survives and AgentSession uses fixed exponential delays.
+ */
+function createAnthropicMessagesHttpError(response: Response, detail: string): Error {
+  const error = new Error(
+    detail || `Anthropic Messages request failed with HTTP ${response.status}`,
+  ) as Error & {
+    status?: number;
+    httpStatus?: number;
+    retryAfterSeconds?: number;
+    errorBody?: string;
+  };
+  error.status = response.status;
+  error.httpStatus = response.status;
+  if (detail) {
+    error.errorBody = detail;
+  }
+  const retryAfterSeconds = parseRetryAfterSeconds(response.headers);
+  if (retryAfterSeconds !== undefined && Number.isFinite(retryAfterSeconds)) {
+    error.retryAfterSeconds = retryAfterSeconds;
+  }
+  return error;
 }
 
 async function readAnthropicMessagesErrorBodySnippet(response: Response): Promise<string> {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -51,6 +51,7 @@ import {
   retireSessionMcpRuntime,
   retireSessionMcpRuntimeForSessionKey,
 } from "../agent-bundle-mcp-tools.js";
+import { createPreparedEmbeddedAgentSettingsManager } from "../agent-project-settings.js";
 import {
   resolveAgentDir,
   resolveSessionAgentIds,
@@ -1696,6 +1697,13 @@ async function runEmbeddedAgentInternal(
       let compactionContinuationRetryAttempts = 0;
       let beforeAgentFinalizeRevisionAttempts = 0;
       let sameModelIdleTimeoutRetries = 0;
+      // Resolve once per outer run so embedded same-model rate-limit retry honors
+      // the same provider maxRetryDelayMs contract as AgentSession auto-retry.
+      const providerMaxRetryDelayMs = createPreparedEmbeddedAgentSettingsManager({
+        cwd: params.cwd ?? resolvedWorkspace,
+        agentDir,
+        cfg: params.config,
+      }).getProviderRetrySettings().maxRetryDelayMs;
       // Cost-runaway breaker for #76293. State lives at the run-loop level
       // on purpose so it survives across attempt boundaries and across
       // profile/auth retries within this embedded run (a wrapper-local
@@ -3662,6 +3670,7 @@ async function runEmbeddedAgentInternal(
               canRestartForLiveSwitch &&
               sameModelIdleTimeoutRetries < MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES,
             allowSameModelRateLimitRetry: rateLimitProfileRotations < rateLimitProfileRotationLimit,
+            maxRetryDelayMs: providerMaxRetryDelayMs,
             assistantProfileFailureReason,
             lastProfileId,
             modelId,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3531,7 +3531,10 @@ async function runEmbeddedAgentInternal(
               providerStarted: assistantProviderStarted,
               transientRateLimit:
                 assistantProfileFailoverReason === "rate_limit" &&
-                isShortWindowRateLimitMessage(attemptAssistant?.errorMessage),
+                isShortWindowRateLimitMessage(attemptAssistant?.errorMessage, {
+                  httpStatus: attemptAssistant?.httpStatus,
+                  retryAfterSeconds: attemptAssistant?.retryAfterSeconds,
+                }),
             },
           );
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -391,6 +391,39 @@ describe("handleAssistantFailover", () => {
       expect(advanceAuthProfile).not.toHaveBeenCalled();
     });
 
+    it("prefers transport-preserved Retry-After over error text for same-model retry", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          lastAssistant: {
+            // Body lacks Retry-After text; structured transport fields are authoritative.
+            errorMessage:
+              '{"type":"error","error":{"type":"rate_limit_error","message":"Number of request tokens has exceeded your per-minute rate limit."}}',
+            httpStatus: 429,
+            retryAfterSeconds: 30,
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBe("same_model_rate_limit");
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledWith({ retryAfterSeconds: 30 });
+      expect(maybeEscalateRateLimitProfileFallback).not.toHaveBeenCalled();
+    });
+
     it("allows RESOURCE_EXHAUSTED messages with short-window 429 hints", async () => {
       const maybeRetrySameModelRateLimit = vi.fn(async () => true);
       const maybeEscalateRateLimitProfileFallback = vi.fn();

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -424,6 +424,73 @@ describe("handleAssistantFailover", () => {
       expect(maybeEscalateRateLimitProfileFallback).not.toHaveBeenCalled();
     });
 
+    it("declines same-model retry when structured Retry-After exceeds positive maxRetryDelayMs", async () => {
+      // CS P1: AgentSession declines over-cap Retry-After; outer failover must not
+      // re-authorize a silent same-model wait just because the value is ≤ 60s.
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          maxRetryDelayMs: 10_000,
+          lastAssistant: {
+            errorMessage: "rate_limit_error",
+            httpStatus: 429,
+            retryAfterSeconds: 30,
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBeUndefined();
+      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeEscalateRateLimitProfileFallback).toHaveBeenCalledTimes(1);
+      expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows same-model retry when maxRetryDelayMs is 0 (unlimited) for structured Retry-After", async () => {
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          maxRetryDelayMs: 0,
+          lastAssistant: {
+            errorMessage: "rate_limit_error",
+            httpStatus: 429,
+            retryAfterSeconds: 30,
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBe("same_model_rate_limit");
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledWith({ retryAfterSeconds: 30 });
+      expect(maybeEscalateRateLimitProfileFallback).not.toHaveBeenCalled();
+    });
+
     it("allows RESOURCE_EXHAUSTED messages with short-window 429 hints", async () => {
       const maybeRetrySameModelRateLimit = vi.fn(async () => true);
       const maybeEscalateRateLimitProfileFallback = vi.fn();

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -84,9 +84,35 @@ function parseRetryAfterSeconds(message: string): number | null {
 
 function resolveShortWindowRateLimitRetry(
   message: string | undefined,
+  structured?: { httpStatus?: number; retryAfterSeconds?: number },
 ): ShortWindowRateLimitRetry | null {
+  const structuredRetryAfter =
+    structured?.retryAfterSeconds !== undefined &&
+    Number.isFinite(structured.retryAfterSeconds) &&
+    structured.retryAfterSeconds >= 0
+      ? structured.retryAfterSeconds
+      : null;
+  // Prefer transport-preserved Retry-After when present; text parsing is fallback.
+  if (
+    structuredRetryAfter !== null &&
+    structuredRetryAfter <= MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS
+  ) {
+    return { retryAfterSeconds: structuredRetryAfter };
+  }
+  if (
+    structuredRetryAfter !== null &&
+    structuredRetryAfter > MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS
+  ) {
+    return null;
+  }
+
   const raw = message?.trim();
   if (!raw) {
+    // Bare HTTP 429 with no text can still be a short-window throttle when the
+    // transport attached status without a Retry-After header.
+    if (structured?.httpStatus === 429) {
+      return {};
+    }
     return null;
   }
   const retryAfterSeconds = parseRetryAfterSeconds(raw);
@@ -107,15 +133,19 @@ function resolveShortWindowRateLimitRetry(
   // present; hard daily/usage/subscription limits are filtered above.
   // Some gateways strip throttle details and Retry-After. Preserve the
   // long-window exclusions above before treating a bare 429 as transient.
-  const statusPrefixed429 = extractLeadingHttpStatus(raw)?.code === 429;
+  const statusPrefixed429 =
+    extractLeadingHttpStatus(raw)?.code === 429 || structured?.httpStatus === 429;
   if (!SHORT_WINDOW_RATE_LIMIT_RE.test(raw) && !shortRetryAfter && !statusPrefixed429) {
     return null;
   }
   return retryAfterSeconds !== null ? { retryAfterSeconds } : {};
 }
 
-export function isShortWindowRateLimitMessage(message: string | undefined): boolean {
-  return resolveShortWindowRateLimitRetry(message) !== null;
+export function isShortWindowRateLimitMessage(
+  message: string | undefined,
+  structured?: { httpStatus?: number; retryAfterSeconds?: number },
+): boolean {
+  return resolveShortWindowRateLimitRetry(message, structured) !== null;
 }
 
 /**
@@ -255,7 +285,13 @@ export async function handleAssistantFailover(params: {
       // Minute-scale RPM windows can clear without spending a profile rotation
       // or model fallback. Keep the retry bounded; once exhausted, continue
       // through the existing rate-limit escalation path.
-      const shortWindowRetry = resolveShortWindowRateLimitRetry(params.lastAssistant?.errorMessage);
+      const shortWindowRetry = resolveShortWindowRateLimitRetry(
+        params.lastAssistant?.errorMessage,
+        {
+          httpStatus: params.lastAssistant?.httpStatus,
+          retryAfterSeconds: params.lastAssistant?.retryAfterSeconds,
+        },
+      );
       if (
         params.allowSameModelRateLimitRetry &&
         shortWindowRetry &&

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -4,6 +4,7 @@
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { AssistantMessage } from "../../../llm/types.js";
+import { resolveAutoRetryDelayMs } from "../../../llm/utils/retry.js";
 import { extractLeadingHttpStatus } from "../../../shared/assistant-error-format.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import {
@@ -167,6 +168,13 @@ export async function handleAssistantFailover(params: {
   timedOutByRunBudget: boolean;
   allowSameModelIdleTimeoutRetry: boolean;
   allowSameModelRateLimitRetry: boolean;
+  /**
+   * Provider retry max for structured/server Retry-After cooldowns.
+   * Matches SettingsManager.getProviderRetrySettings().maxRetryDelayMs (default 60000).
+   * Positive: decline same-model short-window retry when Retry-After exceeds the max.
+   * Zero: cap disabled (unlimited) for this check.
+   */
+  maxRetryDelayMs?: number;
   assistantProfileFailureReason: AuthProfileFailureReason | null;
   lastProfileId?: string;
   modelId: string;
@@ -292,9 +300,25 @@ export async function handleAssistantFailover(params: {
           retryAfterSeconds: params.lastAssistant?.retryAfterSeconds,
         },
       );
+      // Same maxRetryDelayMs contract as AgentSession auto-retry: a positive
+      // cap must not be bypassed by this outer same-model short-window branch.
+      const maxRetryDelayMs =
+        params.maxRetryDelayMs === undefined || !Number.isFinite(params.maxRetryDelayMs)
+          ? 60_000
+          : Math.max(0, params.maxRetryDelayMs);
+      const retryAfterWithinCap =
+        shortWindowRetry?.retryAfterSeconds === undefined
+          ? true
+          : resolveAutoRetryDelayMs({
+              attempt: 1,
+              baseDelayMs: 0,
+              retryAfterSeconds: shortWindowRetry.retryAfterSeconds,
+              maxRetryDelayMs,
+            }).action === "delay";
       if (
         params.allowSameModelRateLimitRetry &&
         shortWindowRetry &&
+        retryAfterWithinCap &&
         (await params.maybeRetrySameModelRateLimit(shortWindowRetry))
       ) {
         return sameModelRateLimitRetry();

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -452,7 +452,8 @@ async function requestBodyHasStreamTrue(
   }
 }
 
-function parseRetryAfterSeconds(headers: Headers): number | undefined {
+/** Parse Retry-After / Retry-After-Ms response headers into a non-negative seconds value. */
+export function parseRetryAfterSeconds(headers: Headers): number | undefined {
   const retryAfterMs = headers.get("retry-after-ms");
   if (retryAfterMs) {
     const trimmedRetryAfterMs = retryAfterMs.trim();

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -33,7 +33,7 @@ import type {
   Model,
   TextContent,
 } from "../../llm/types.js";
-import { isRetryableAssistantError } from "../../llm/utils/retry.js";
+import { isRetryableAssistantError, resolveAutoRetryDelayMs } from "../../llm/utils/retry.js";
 import { attachRuntimeUserTurnTranscriptContext } from "../../sessions/user-turn-transcript-runtime-context.js";
 import type {
   PersistedUserTurnMessage,
@@ -2672,7 +2672,13 @@ export class AgentSession {
       return false;
     }
 
-    const delayMs = settings.baseDelayMs * 2 ** (this.retryCount - 1);
+    const providerRetry = this.settingsManager.getProviderRetrySettings();
+    const delayMs = resolveAutoRetryDelayMs({
+      attempt: this.retryCount,
+      baseDelayMs: settings.baseDelayMs,
+      retryAfterSeconds: message.retryAfterSeconds,
+      maxRetryDelayMs: providerRetry.maxRetryDelayMs,
+    });
 
     this.emit({
       type: "auto_retry_start",

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -2673,12 +2673,19 @@ export class AgentSession {
     }
 
     const providerRetry = this.settingsManager.getProviderRetrySettings();
-    const delayMs = resolveAutoRetryDelayMs({
+    const delayDecision = resolveAutoRetryDelayMs({
       attempt: this.retryCount,
       baseDelayMs: settings.baseDelayMs,
       retryAfterSeconds: message.retryAfterSeconds,
       maxRetryDelayMs: providerRetry.maxRetryDelayMs,
     });
+    // Over-cap Retry-After: decline silent auto-retry so higher-level handling can
+    // surface the full cooldown (maxRetryDelayMs contract).
+    if (delayDecision.action === "no_auto_retry") {
+      this.retryCount--;
+      return false;
+    }
+    const delayMs = delayDecision.delayMs;
 
     this.emit({
       type: "auto_retry_start",

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -30,6 +30,8 @@ type TransportOutputShape = {
   errorCode?: string;
   errorType?: string;
   errorBody?: string;
+  httpStatus?: number;
+  retryAfterSeconds?: number;
 };
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
@@ -149,7 +151,24 @@ type TransportErrorDetails = {
   errorCode?: string;
   errorType?: string;
   errorBody?: string;
+  httpStatus?: number;
+  retryAfterSeconds?: number;
 };
+
+function readFiniteNumberProperty(value: unknown, key: string): number | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const raw = (value as Record<string, unknown>)[key];
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return raw;
+  }
+  if (typeof raw === "string" && raw.trim() !== "") {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
 
 function readStringLikeProperty(value: unknown, key: string): string | undefined {
   if (!value || typeof value !== "object") {
@@ -229,11 +248,27 @@ function extractTransportErrorDetails(error: unknown): TransportErrorDetails {
     normalizeTransportErrorBody(readStringLikeProperty(errorObject, "body")) ??
     normalizeTransportErrorBody(readObjectProperty(errorObject, "body")) ??
     normalizeTransportErrorBody(nestedError);
+  // Prefer explicit transport fields; fall back to common HTTP status aliases.
+  const httpStatusRaw =
+    readFiniteNumberProperty(errorObject, "httpStatus") ??
+    readFiniteNumberProperty(errorObject, "status") ??
+    readFiniteNumberProperty(errorObject, "statusCode");
+  const httpStatus =
+    httpStatusRaw !== undefined && httpStatusRaw >= 100 && httpStatusRaw <= 599
+      ? Math.trunc(httpStatusRaw)
+      : undefined;
+  const retryAfterSecondsRaw = readFiniteNumberProperty(errorObject, "retryAfterSeconds");
+  const retryAfterSeconds =
+    retryAfterSecondsRaw !== undefined && retryAfterSecondsRaw >= 0
+      ? retryAfterSecondsRaw
+      : undefined;
 
   return {
     ...(errorCode ? { errorCode } : {}),
     ...(errorType ? { errorType } : {}),
     ...(errorBody ? { errorBody } : {}),
+    ...(httpStatus !== undefined ? { httpStatus } : {}),
+    ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
   };
 }
 

--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AssistantMessage } from "../types.js";
-import { isRetryableAssistantError } from "./retry.js";
+import { isRetryableAssistantError, resolveAutoRetryDelayMs } from "./retry.js";
 
 function errorMessage(message: string): AssistantMessage {
   return {
@@ -53,5 +53,51 @@ describe("isRetryableAssistantError", () => {
         ),
       ),
     ).toBe(true);
+  });
+});
+
+describe("resolveAutoRetryDelayMs", () => {
+  it("uses Retry-After as a lower bound when it exceeds exponential backoff", () => {
+    expect(
+      resolveAutoRetryDelayMs({
+        attempt: 1,
+        baseDelayMs: 2000,
+        retryAfterSeconds: 30,
+        maxRetryDelayMs: 60_000,
+      }),
+    ).toBe(30_000);
+  });
+
+  it("keeps exponential backoff when Retry-After is shorter", () => {
+    expect(
+      resolveAutoRetryDelayMs({
+        attempt: 3,
+        baseDelayMs: 2000,
+        retryAfterSeconds: 1,
+        maxRetryDelayMs: 60_000,
+      }),
+    ).toBe(8000);
+  });
+
+  it("caps Retry-After at the configured provider max delay", () => {
+    expect(
+      resolveAutoRetryDelayMs({
+        attempt: 1,
+        baseDelayMs: 2000,
+        retryAfterSeconds: 3600,
+        maxRetryDelayMs: 60_000,
+      }),
+    ).toBe(60_000);
+  });
+
+  it("honors cooldowns above 60s when the operator raises maxRetryDelayMs", () => {
+    expect(
+      resolveAutoRetryDelayMs({
+        attempt: 1,
+        baseDelayMs: 2000,
+        retryAfterSeconds: 90,
+        maxRetryDelayMs: 120_000,
+      }),
+    ).toBe(90_000);
   });
 });

--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -65,7 +65,7 @@ describe("resolveAutoRetryDelayMs", () => {
         retryAfterSeconds: 30,
         maxRetryDelayMs: 60_000,
       }),
-    ).toBe(30_000);
+    ).toEqual({ action: "delay", delayMs: 30_000 });
   });
 
   it("keeps exponential backoff when Retry-After is shorter", () => {
@@ -76,10 +76,10 @@ describe("resolveAutoRetryDelayMs", () => {
         retryAfterSeconds: 1,
         maxRetryDelayMs: 60_000,
       }),
-    ).toBe(8000);
+    ).toEqual({ action: "delay", delayMs: 8000 });
   });
 
-  it("caps Retry-After at the configured provider max delay", () => {
+  it("declines auto-retry when Retry-After exceeds a positive max", () => {
     expect(
       resolveAutoRetryDelayMs({
         attempt: 1,
@@ -87,10 +87,15 @@ describe("resolveAutoRetryDelayMs", () => {
         retryAfterSeconds: 3600,
         maxRetryDelayMs: 60_000,
       }),
-    ).toBe(60_000);
+    ).toEqual({
+      action: "no_auto_retry",
+      reason: "retry_after_exceeds_max",
+      retryAfterMs: 3_600_000,
+      maxRetryDelayMs: 60_000,
+    });
   });
 
-  it("honors cooldowns above 60s when the operator raises maxRetryDelayMs", () => {
+  it("honors cooldowns within a raised positive max", () => {
     expect(
       resolveAutoRetryDelayMs({
         attempt: 1,
@@ -98,6 +103,27 @@ describe("resolveAutoRetryDelayMs", () => {
         retryAfterSeconds: 90,
         maxRetryDelayMs: 120_000,
       }),
-    ).toBe(90_000);
+    ).toEqual({ action: "delay", delayMs: 90_000 });
+  });
+
+  it("treats maxRetryDelayMs 0 as unlimited and honors full Retry-After", () => {
+    expect(
+      resolveAutoRetryDelayMs({
+        attempt: 1,
+        baseDelayMs: 2000,
+        retryAfterSeconds: 3600,
+        maxRetryDelayMs: 0,
+      }),
+    ).toEqual({ action: "delay", delayMs: 3_600_000 });
+  });
+
+  it("uses exponential only when Retry-After is absent", () => {
+    expect(
+      resolveAutoRetryDelayMs({
+        attempt: 2,
+        baseDelayMs: 2000,
+        maxRetryDelayMs: 60_000,
+      }),
+    ).toEqual({ action: "delay", delayMs: 4000 });
   });
 });

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -1,5 +1,33 @@
 import type { AssistantMessage } from "../types.js";
 
+/**
+ * Resolve auto-retry sleep using exponential backoff as the floor and a validated
+ * server Retry-After as a lower bound, capped by the operator max delay.
+ */
+export function resolveAutoRetryDelayMs(params: {
+  attempt: number;
+  baseDelayMs: number;
+  retryAfterSeconds?: number;
+  maxRetryDelayMs: number;
+}): number {
+  const attempt = Math.max(1, Math.trunc(params.attempt));
+  const baseDelayMs = Math.max(0, params.baseDelayMs);
+  const exponentialDelayMs = baseDelayMs * 2 ** (attempt - 1);
+  const maxRetryDelayMs = Math.max(0, params.maxRetryDelayMs);
+  const retryAfterSeconds = params.retryAfterSeconds;
+  if (
+    retryAfterSeconds === undefined ||
+    !Number.isFinite(retryAfterSeconds) ||
+    retryAfterSeconds < 0
+  ) {
+    return exponentialDelayMs;
+  }
+  // Cap server cooldown at the configured provider max so extreme Retry-After values
+  // cannot stall a session indefinitely; values within the cap are honored in full.
+  const retryAfterDelayMs = Math.min(maxRetryDelayMs, Math.ceil(retryAfterSeconds * 1000));
+  return Math.max(exponentialDelayMs, retryAfterDelayMs);
+}
+
 function buildProviderErrorPattern(patterns: readonly string[]): RegExp {
   return new RegExp(patterns.join("|"), "i");
 }

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -1,31 +1,63 @@
 import type { AssistantMessage } from "../types.js";
 
 /**
- * Resolve auto-retry sleep using exponential backoff as the floor and a validated
- * server Retry-After as a lower bound, capped by the operator max delay.
+ * Decision for AgentSession auto-retry sleep.
+ *
+ * Contract (matches `maxRetryDelayMs` on StreamOptions / provider retry settings):
+ * - positive max: honor full server Retry-After when it is ≤ max; decline auto-retry
+ *   when the server asks for longer so higher-level handling can surface the wait
+ * - zero max: cap disabled — honor the full server Retry-After (and exponential floor)
+ * - no/invalid Retry-After: exponential backoff only
+ */
+export type AutoRetryDelayDecision =
+  | { action: "delay"; delayMs: number }
+  | {
+      action: "no_auto_retry";
+      reason: "retry_after_exceeds_max";
+      retryAfterMs: number;
+      maxRetryDelayMs: number;
+    };
+
+/**
+ * Resolve AgentSession auto-retry sleep from exponential backoff + server Retry-After.
+ * Returns `no_auto_retry` when a positive max is set and the server cooldown exceeds it.
  */
 export function resolveAutoRetryDelayMs(params: {
   attempt: number;
   baseDelayMs: number;
   retryAfterSeconds?: number;
   maxRetryDelayMs: number;
-}): number {
+}): AutoRetryDelayDecision {
   const attempt = Math.max(1, Math.trunc(params.attempt));
   const baseDelayMs = Math.max(0, params.baseDelayMs);
   const exponentialDelayMs = baseDelayMs * 2 ** (attempt - 1);
-  const maxRetryDelayMs = Math.max(0, params.maxRetryDelayMs);
+  // 0 means "unlimited" (cap disabled). Do not Math.max(0, …) away the zero signal.
+  const maxRetryDelayMs = Number.isFinite(params.maxRetryDelayMs)
+    ? Math.max(0, params.maxRetryDelayMs)
+    : 0;
   const retryAfterSeconds = params.retryAfterSeconds;
   if (
     retryAfterSeconds === undefined ||
     !Number.isFinite(retryAfterSeconds) ||
     retryAfterSeconds < 0
   ) {
-    return exponentialDelayMs;
+    return { action: "delay", delayMs: exponentialDelayMs };
   }
-  // Cap server cooldown at the configured provider max so extreme Retry-After values
-  // cannot stall a session indefinitely; values within the cap are honored in full.
-  const retryAfterDelayMs = Math.min(maxRetryDelayMs, Math.ceil(retryAfterSeconds * 1000));
-  return Math.max(exponentialDelayMs, retryAfterDelayMs);
+  const retryAfterDelayMs = Math.ceil(retryAfterSeconds * 1000);
+  // Positive max: over-cap cooldowns must not auto-retry early.
+  if (maxRetryDelayMs > 0 && retryAfterDelayMs > maxRetryDelayMs) {
+    return {
+      action: "no_auto_retry",
+      reason: "retry_after_exceeds_max",
+      retryAfterMs: retryAfterDelayMs,
+      maxRetryDelayMs,
+    };
+  }
+  // Within cap (or unlimited when max is 0): honor full Retry-After as a floor.
+  return {
+    action: "delay",
+    delayMs: Math.max(exponentialDelayMs, retryAfterDelayMs),
+  };
 }
 
 function buildProviderErrorPattern(patterns: readonly string[]): RegExp {


### PR DESCRIPTION
## What Problem This Solves

Fixes #103849.

Anthropic Messages transport dropped HTTP status and `Retry-After` on error responses, so auto-retry backoff ignored the server cooldown and could retry too aggressively after 429s. After metadata was restored, AgentSession honored `maxRetryDelayMs` but embedded same-model failover still authorized short-window retries that could bypass a positive provider cap.

## Why This Change Was Made

1. Preserve structured error metadata (`httpStatus`, `retryAfterSeconds`) through the Anthropic transport stream path into shared retry/session delay handling.
2. Restore the documented `maxRetryDelayMs` contract in AgentSession — when the server cooldown exceeds a **positive** max, decline auto-retry; when max is **0**, treat the cap as disabled and honor the full cooldown.
3. **ClawSweeper P1:** thread the same provider `maxRetryDelayMs` into embedded `handleAssistantFailover` so outer same-model short-window retries cannot bypass the configured cap.

## User Impact

When Anthropic returns 429 with `Retry-After`, OpenClaw can honor the server cooldown. Positive provider caps now apply at both AgentSession and embedded same-model failover layers; long cooldowns above the configured max no longer schedule shortened silent same-model retries at either layer.

## Evidence

### Verification (narrow)

Host: local macOS.

| Check | Result |
|---|---|
| `node scripts/run-vitest.mjs src/llm/utils/retry.test.ts` | **12/12 pass** |
| `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/assistant-failover.test.ts` | **35/35 pass** (includes over-cap decline + max 0 unlimited) |
| Prior: anthropic transport + real loopback stub suites | green on prior commits |

Commit: `713fa8a75db13a66075ea62c2a2bd311222974b5`

### Real behavior proof

- **Behavior addressed:** (1) Anthropic 429 status + Retry-After reach retry policy; (2) AgentSession auto-retry declines when Retry-After exceeds positive `maxRetryDelayMs`; (3) `maxRetryDelayMs: 0` honors full cooldown; (4) **embedded failover declines same-model retry for the same over-cap structured Retry-After and escalates instead**.
- **Environment:** local macOS; pure production decision helpers + focused Vitest handoff coverage (no live Anthropic account turn).
- **Current-main contrast:** main drops Retry-After on Anthropic non-OK; prior PR head enforced the cap only in AgentSession while outer failover still authorized ≤60s same-model waits.
- **Exact steps after patch:**
  1. `resolveAutoRetryDelayMs({ retryAfterSeconds: 30, maxRetryDelayMs: 10000, ... })` → `no_auto_retry`
  2. `resolveAutoRetryDelayMs({ retryAfterSeconds: 30, maxRetryDelayMs: 0, ... })` → delay 30000ms
  3. `handleAssistantFailover` with structured `retryAfterSeconds: 30` + `maxRetryDelayMs: 10000` → **no** `same_model_rate_limit`; escalates (profile/fallback path)
  4. same structured inputs with `maxRetryDelayMs: 0` → `same_model_rate_limit` allowed
- **Redacted runtime output (local):**
  ```text
  === Real behavior proof (redacted, local macOS) ===
  path: AgentSession delay policy + embedded failover unit handoff

  [AgentSession] maxRetryDelayMs=10000 retryAfterSeconds=30
  {"action":"no_auto_retry","reason":"retry_after_exceeds_max","retryAfterMs":30000,"maxRetryDelayMs":10000}
  [AgentSession] maxRetryDelayMs=0 retryAfterSeconds=30
  {"action":"delay","delayMs":30000}
  [AgentSession] maxRetryDelayMs=10000 retryAfterSeconds=5
  {"action":"delay","delayMs":5000}

  handoff expectation for outer failover with same inputs:
  - over-cap (30s > 10s max): no same_model_rate_limit; escalate/fallback
  - unlimited (max 0): same_model_rate_limit allowed
  - within-cap (5s <= 10s): same_model_rate_limit allowed

  focused Vitest: declines same-model retry when structured Retry-After exceeds positive maxRetryDelayMs PASS
  focused Vitest: allows same-model retry when maxRetryDelayMs is 0 (unlimited) PASS
  suite: assistant-failover.test.ts 35/35 PASS
  ```
- **Control check:** both layers share `resolveAutoRetryDelayMs` for the over-cap decision; outer path reuses provider settings via `createPreparedEmbeddedAgentSettingsManager(...).getProviderRetrySettings().maxRetryDelayMs`.
- **Observed result after fix:** over-cap cooldowns no longer schedule shortened silent same-model retries at AgentSession or embedded failover.
- **What was not tested:** live `api.anthropic.com` account turn; full `pnpm check:changed` fan-out.

## AI disclosure

Authored/assisted with AI (Grok). Addressed ClawSweeper P1 outer-cap bypass + proof handoff; rebased earlier on main.