### PR TITLE
fix(msteams): detect provider-prefixed target ids

### DIFF
--- a/extensions/msteams/src/resolve-allowlist.test.ts
+++ b/extensions/msteams/src/resolve-allowlist.test.ts
@@ -500,12 +500,27 @@ describe("looksLikeMSTeamsTargetId", () => {
     expect(looksLikeMSTeamsTargetId("user:40a1a0ed-4ff2-4164-a219-55518990c197")).toBe(true);
   });
 
-  it.each(["", "   ", "user:John Smith", "Product Team/Roadmap", "Engineering", "hello"])(
-    "rejects non-id inputs (%s)",
-    (raw) => {
-      expect(looksLikeMSTeamsTargetId(raw)).toBe(false);
-    },
-  );
+  it.each([
+    "teams:user:40a1a0ed-4ff2-4164-a219-55518990c197",
+    "msteams:user:40a1a0ed-4ff2-4164-a219-55518990c197",
+    "teams:conversation:19:abc@thread.tacv2",
+    "msteams:conversation:19:abc@thread.tacv2",
+  ])("accepts provider-prefixed explicit target ids (%s)", (raw) => {
+    expect(looksLikeMSTeamsTargetId(raw)).toBe(true);
+  });
+
+  it.each([
+    "",
+    "   ",
+    "user:John Smith",
+    "teams:user:John Smith",
+    "msteams:user:John Smith",
+    "Product Team/Roadmap",
+    "Engineering",
+    "hello",
+  ])("rejects non-id inputs (%s)", (raw) => {
+    expect(looksLikeMSTeamsTargetId(raw)).toBe(false);
+  });
 
   it("normalizes leading/trailing whitespace before classifying", () => {
     expect(looksLikeMSTeamsTargetId("  19:abc@thread.tacv2  ")).toBe(true);

--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -183,7 +183,7 @@ export function looksLikeMSTeamsConversationId(raw: string): boolean {
  * can forward verbatim to the channel adapter.
  */
 export function looksLikeMSTeamsTargetId(raw: string): boolean {
-  const trimmed = raw.trim();
+  const trimmed = stripProviderPrefix(raw).trim();
   if (looksLikeMSTeamsConversationId(trimmed)) {
     return true;
   }


### PR DESCRIPTION
﻿Fixes #104381

## What Problem This Solves

Fixes an issue where provider-prefixed Microsoft Teams explicit targets could be classified differently from the same target after MSTeams normalization.

`looksLikeMSTeamsTargetId()` already recognized `user:<aad-guid>` and `conversation:<id>` as explicit Microsoft Teams targets, and the surrounding MSTeams target helpers already strip local `teams:` / `msteams:` prefixes before parsing targets. However, this detector only trimmed the raw input, so `teams:user:<aad-guid>`, `msteams:user:<aad-guid>`, and provider-prefixed conversation targets were not classified like their normalized forms.

## Why This Change Was Made

This keeps the MSTeams explicit-target detector aligned with the rest of the MSTeams target parsing surface by stripping the local provider prefix before applying the existing ID checks.

The change is intentionally narrow: provider-prefixed AAD user IDs and conversation IDs are classified like their unprefixed forms, while display-name targets such as `teams:user:Alice Example` still return `false` so directory lookup behavior is preserved.

## User Impact

Users and operators can use provider-prefixed MSTeams explicit targets consistently in paths that rely on the shared target-ID detector. For example, `teams:user:<aad-guid>` now follows the same explicit-ID classification as `user:<aad-guid>`, and `teams:conversation:19:...@thread.tacv2` follows the same classification as `conversation:19:...@thread.tacv2`.

## Evidence

- Added focused regression coverage showing `teams:user:<aad-guid>`, `msteams:user:<aad-guid>`, `teams:conversation:19:abc@thread.tacv2`, and `msteams:conversation:19:abc@thread.tacv2` are recognized as explicit IDs by `looksLikeMSTeamsTargetId()`.
- Added negative coverage showing `teams:user:John Smith` and `msteams:user:John Smith` still do not pass the id-like detector, preserving the existing directory/display-name path.
- Source-backed user-entry call chain checked on the current branch:

```text
gateway send request
  -> src/gateway/server-methods/send.ts: maybeResolveIdLikeTarget(...)
  -> src/infra/outbound/target-id-resolution.ts: maybeResolvePluginMessagingTarget(...)
  -> src/infra/outbound/target-normalization.ts: looksLikeTargetId(...)
  -> extensions/msteams/src/channel.ts: msteamsPlugin.messaging.targetResolver.looksLikeId
  -> extensions/msteams/src/resolve-allowlist.ts: looksLikeMSTeamsTargetId(...)
```

- `extensions/msteams/src/channel.ts` wires the real MSTeams plugin with `targetPrefixes: ["msteams", "teams"]`, `normalizeTarget: normalizeMSTeamsMessagingTarget`, and `targetResolver.looksLikeId: (raw) => looksLikeMSTeamsTargetId(raw)`, so this helper is the provider-owned classifier used by the user-facing send target path.
- `node scripts/run-vitest.mjs run extensions/msteams/src/resolve-allowlist.test.ts` passes with 43 tests after rebasing onto current `main`.
- `git diff --check -- extensions/msteams/src/resolve-allowlist.ts extensions/msteams/src/resolve-allowlist.test.ts` passes.

Live-proof note: I checked this workstation for a runnable MSTeams live setup before updating the PR evidence. There are no `MSTEAMS` / `MS_TEAMS` / `TEAMS` / `OPENCLAW` environment keys and no MSTeams channel credentials or targets under the local `.openclaw` config scan, so I cannot honestly attach a redacted real Microsoft Teams send log from this machine. I am not treating the source-backed call chain above as live-send proof.

Adjacent `extensions/msteams/src/channel.directory.test.ts` and `extensions/msteams/src/channel.test.ts` were also considered, but this checkout is missing generated/workspace gateway-protocol package metadata/subpath exports, so those suites fail before running tests and are not treated as evidence for this PR.
