### PR TITLE
fix(secrets): include installed plugins in web-provider secret target registry

### DIFF
--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -509,7 +509,9 @@ function loadSecretTargetRegistryFromPluginMetadata(params: {
   const channelPlugins = plugins.filter((record) => record.channels.length > 0);
   return [
     ...CORE_SECRET_TARGET_REGISTRY,
-    ...listBundledWebProviderSecretTargetRegistryEntries(bundledPlugins),
+    // All plugins (bundled + installed) contribute web-provider secret targets
+    // so the gateway recognizes their target IDs in `secrets.resolve` (#104320).
+    ...listBundledWebProviderSecretTargetRegistryEntries(plugins),
     ...listBundledPluginConfigSecretTargetRegistryEntries([
       ...bundledPlugins,
       ...listSourceBundledPluginConfigContractRecords(),


### PR DESCRIPTION
## What Problem This Solves

When web search providers were split into installed plugin packages (e.g. Exa), the gateway's `secrets.resolve` handler started rejecting their credential target IDs as unknown (#104320). Running `openclaw infer web search --provider exa` fails with `UnresolvedSecretInputError` because `isKnownSecretTargetId` returns false for `plugins.entries.exa.config.webSearch.apiKey`.

## Why This Change Was Made

The root cause is in `loadSecretTargetRegistryFromPluginMetadata` (`src/secrets/target-registry-data.ts:508`). It filters `plugins` to `bundledPlugins` (origin === "bundled") before passing them to `listBundledWebProviderSecretTargetRegistryEntries`. When the Exa plugin was moved from bundled to installed, its origin changed and its credential target was no longer registered.

The CLI discovers the target ID dynamically from the provider's `credentialPath` property, but the gateway's `isKnownSecretTargetId` check only knows about targets in the static registry — causing a mismatch.

Fix: pass the full plugin list to `listBundledWebProviderSecretTargetRegistryEntries` instead of only bundled plugins. This ensures installed plugins' web-provider credential paths are registered in the secret target registry and recognized by `secrets.resolve`.

## User Impact

Users with installed web search plugins (e.g. Exa) will be able to use `openclaw infer web search --provider exa` without `UnresolvedSecretInputError`. No impact on bundled plugin behavior.

## Evidence

- All 552 secrets tests pass (`pnpm test src/secrets/`)
- Type check passes (`pnpm tsgo`)
- The change is a single-line parameter swap with a comment explaining the rationale

Fixes #104320

🤖 Generated with [Claude Code](https://claude.com/claude-code)