### PR TITLE
fix(ui): hide group submenu separator when New group is the only entry

### DIFF
--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -174,6 +174,33 @@ describe("session menu", () => {
     expect(menuItemLabels(menu)).not.toContain("Remove from group");
   });
 
+  it("omits the submenu separator when New group is the only entry", async () => {
+    const menu = await mountMenu({ groups: [] });
+
+    menuItem(menu, "Move to group").click();
+    await menu.updateComplete;
+
+    const submenu = menu.querySelector<HTMLElement>(".session-menu__submenu");
+    if (!submenu) {
+      throw new Error("Expected group submenu");
+    }
+    expect(menuItemLabels(submenu)).toEqual(["New group…"]);
+    expect(submenu.querySelector('[role="separator"]')).toBeNull();
+  });
+
+  it("keeps the submenu separator when groups exist", async () => {
+    const menu = await mountMenu({ groups: ["Research"] });
+
+    menuItem(menu, "Move to group").click();
+    await menu.updateComplete;
+
+    const submenu = menu.querySelector<HTMLElement>(".session-menu__submenu");
+    if (!submenu) {
+      throw new Error("Expected group submenu");
+    }
+    expect(submenu.querySelector('[role="separator"]')).not.toBeNull();
+  });
+
   it("numbers group submenu entries and dispatches them from digit keys", async () => {
     const onAction = vi.fn<(action: SessionMenuAction) => void>();
     const menu = await mountMenu({

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -268,7 +268,9 @@ class SessionMenu extends OpenClawLightDomElement {
               category: null,
             })
           : nothing}
-        <div class="session-menu__separator" role="separator"></div>
+        ${this.groups.length > 0 || session.category
+          ? html`<div class="session-menu__separator" role="separator"></div>`
+          : nothing}
         ${entry(t("sessionsView.newGroup"), false, { kind: "new-group" })}
       </div>
     `;


### PR DESCRIPTION
## What Problem This Solves

When a session has no groups yet, the "Move to group" submenu renders a stray separator line above "New group…" — a divider with nothing above it (only entry in the submenu).

## Why This Change Was Made

The separator before "New group…" in the session context menu's group submenu was rendered unconditionally. It only makes sense when there is content above it (existing groups or "Remove from group").

## User Impact

The group submenu no longer shows a dangling separator when "New group…" is the only entry. No change when groups exist or the session is already grouped.

## Evidence

- `ui/src/components/session-menu.ts`: separator now renders only when `groups.length > 0 || session.category`.
- Regression tests added in `ui/src/components/session-menu.test.ts`: separator absent with no groups/category, present when groups exist.
- `pnpm test ui/src/components/session-menu.test.ts`: 17/17 passed.
- `oxfmt --check` + `scripts/run-oxlint.mjs` clean on both files.
