### PR TITLE
fix: retry live Gateway readiness proof

### DIFF
--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -545,12 +545,7 @@ function defaultSleep(ms) {
   execFileSync("sleep", [String(ms / 1_000)]);
 }
 
-export function verifyGatewayReadiness(
-  runCommand,
-  checkout,
-  expectedSha,
-  sleep = defaultSleep,
-) {
+export function verifyGatewayReadiness(runCommand, checkout, expectedSha, sleep = defaultSleep) {
   let lastError;
   for (let attempt = 1; attempt <= GATEWAY_READINESS_ATTEMPTS; attempt += 1) {
     try {

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -35,6 +35,8 @@ import {
 const DEFAULT_CHECKOUT = "/Users/steipete/openclaw";
 const DEFAULT_EXPECTED_ORIGIN = "openclaw/openclaw";
 const FULL_SHA_RE = /^[0-9a-f]{40}$/u;
+const GATEWAY_READINESS_ATTEMPTS = 3;
+const GATEWAY_READINESS_RETRY_DELAY_MS = 5_000;
 const DEPENDENCY_INPUT_RE =
   /^(?:\.npmrc$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|patches\/)|(?:^|\/)package\.json$/u;
 
@@ -539,6 +541,31 @@ function verifyGateway(runCommand, checkout, expectedSha) {
   runCommand("pnpm", ["openclaw", "health", "--verbose", "--json"], checkout);
 }
 
+function defaultSleep(ms) {
+  execFileSync("sleep", [String(ms / 1_000)]);
+}
+
+export function verifyGatewayReadiness(
+  runCommand,
+  checkout,
+  expectedSha,
+  sleep = defaultSleep,
+) {
+  let lastError;
+  for (let attempt = 1; attempt <= GATEWAY_READINESS_ATTEMPTS; attempt += 1) {
+    try {
+      verifyGateway(runCommand, checkout, expectedSha);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < GATEWAY_READINESS_ATTEMPTS) {
+        sleep(GATEWAY_READINESS_RETRY_DELAY_MS);
+      }
+    }
+  }
+  throw lastError;
+}
+
 function summarizeGatewayLogEntry(entry) {
   return {
     time: entry.time,
@@ -651,10 +678,17 @@ function defaultAuditGatewayLogs(checkout, sinceMs) {
   return audit;
 }
 
-function verifyAndAuditGateway({ runCommand, auditGatewayLogs, checkout, expectedSha, sinceMs }) {
+function verifyAndAuditGateway({
+  runCommand,
+  auditGatewayLogs,
+  checkout,
+  expectedSha,
+  sinceMs,
+  sleep,
+}) {
   let verificationError;
   try {
-    verifyGateway(runCommand, checkout, expectedSha);
+    verifyGatewayReadiness(runCommand, checkout, expectedSha, sleep);
   } catch (error) {
     verificationError = error;
   }
@@ -730,6 +764,7 @@ export function maintainMain(options, dependencies = {}) {
     const runCommand = dependencies.runCommand ?? defaultRunCommand;
     const verifyMacTarget = dependencies.verifyMacTarget ?? defaultVerifyMacTarget;
     const auditGatewayLogs = dependencies.auditGatewayLogs ?? defaultAuditGatewayLogs;
+    const sleep = dependencies.sleep ?? defaultSleep;
     let gatewayLogAudit = null;
     let queuedMacState = null;
     if (actions.macAppRebuild) {
@@ -759,6 +794,7 @@ export function maintainMain(options, dependencies = {}) {
         checkout: update.checkout,
         expectedSha: update.afterSha,
         sinceMs: restartStartedAt,
+        sleep,
       });
     } else {
       try {
@@ -773,6 +809,7 @@ export function maintainMain(options, dependencies = {}) {
           checkout: update.checkout,
           expectedSha: update.afterSha,
           sinceMs: restartStartedAt,
+          sleep,
         });
       }
     }

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -23,6 +23,7 @@ import {
   maintainMain,
   originMatches,
   parseGatewayLogAudit,
+  verifyGatewayReadiness,
 } from "../../.agents/skills/openclaw-live-updater/scripts/update-main.mjs";
 import {
   BUILD_STAMP_FILE,
@@ -201,6 +202,35 @@ describe("openclaw live updater", () => {
       errors: [{ subsystem: "gateway", message: "startup failed" }],
       warnings: [{ subsystem: "gateway", message: "startup warning" }],
     });
+  });
+
+  test("retries bounded Gateway readiness after restart", () => {
+    const { mirror } = makeFixture();
+    writeBuild(mirror);
+    const calls: string[] = [];
+    const delays: number[] = [];
+    let statusAttempts = 0;
+
+    verifyGatewayReadiness(
+      (command: string, args: string[]) => {
+        const call = [command, ...args].join(" ");
+        calls.push(call);
+        if (call.includes("gateway status") && ++statusAttempts < 3) {
+          throw new Error("RPC warming up");
+        }
+      },
+      mirror,
+      git(mirror, "rev-parse", "HEAD"),
+      (ms: number) => delays.push(ms),
+    );
+
+    expect(delays).toEqual([5_000, 5_000]);
+    expect(calls).toEqual([
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw gateway status --deep --require-rpc --json",
+      "pnpm openclaw health --verbose --json",
+    ]);
   });
 
   test("accepts supported OpenClaw GitHub origins", () => {
@@ -576,10 +606,11 @@ describe("openclaw live updater", () => {
             auditCalls += 1;
             return { entries: 1, errorCount: 0, warningCount: 0, errors: [], warnings: [] };
           },
+          sleep() {},
         },
       ),
     ).toThrow("RPC unavailable");
-    expect(statusCalls).toBe(2);
+    expect(statusCalls).toBe(4);
     expect(auditCalls).toBe(1);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Closes #104365.

The live updater could report a successful exact-head Gateway restart as failed when its single deep RPC probe landed during startup warmup. The live service was healthy and the identical probe passed eight seconds later.

## Why This Change Was Made

Post-restart readiness now gets three bounded attempts with five seconds between failed probes. The retry is scoped to restart verification: no-op heartbeat probes remain immediate, exact-build assertions still run for every attempt, restart-window logs are still audited, and exhausted retries still fail closed.

## User Impact

Live Gateway updates tolerate normal startup warmup without false failure reports or unnecessary reruns. Persistent RPC failures remain visible after the bounded retry window.

## Evidence

- Live reproduction on clawmac at `8e2ddd60ad8865a2c27624eec05951a234bcdf76`: first 10-second RPC probe timed out while health was true; the same probe passed eight seconds later without another restart.
- Testbox focused run: 27/27 tests passed ([run](https://github.com/openclaw/openclaw/actions/runs/29148284101)).
- Testbox touched-surface gate: typecheck, lint, import-cycle and repository guards passed ([run](https://github.com/openclaw/openclaw/actions/runs/29148333870)).
- Autoreview: clean, no accepted/actionable findings; correctness 0.97.
