### PR TITLE
perf(ci): fetch only source performance baseline

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -622,21 +622,23 @@ jobs:
           mkdir -p "$reports_root"
           git -C "$reports_root" init -b main
           git -C "$reports_root" remote add origin "https://github.com/openclaw/clawgrit-reports.git"
-          if ! git -C "$reports_root" fetch --depth=1 origin main; then
+          if ! git -C "$reports_root" fetch --filter=blob:none --depth=1 origin main; then
             echo "No previous source performance baseline could be fetched." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          git -C "$reports_root" checkout -B main FETCH_HEAD
           ref_slug="$(printf '%s' "${TESTED_REF}" | tr -c 'A-Za-z0-9._-' '-')"
-          pointer="${reports_root}/openclaw-performance/${ref_slug}/latest-mock-provider.json"
-          if [[ ! -f "$pointer" ]]; then
+          pointer="openclaw-performance/${ref_slug}/latest-mock-provider.json"
+          if ! git -C "$reports_root" cat-file -e "FETCH_HEAD:${pointer}"; then
             echo "No previous source performance baseline exists for ${TESTED_REF}." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          if ! latest_path="$(node -e "const fs=require('node:fs'); const data=JSON.parse(fs.readFileSync(process.argv[1],'utf8')); const value=String(data.path || ''); if (!/^openclaw-performance\\/[A-Za-z0-9._-]+\\/[0-9]+-[0-9]+\\/mock-provider$/u.test(value)) process.exit(1); process.stdout.write(value);" "$pointer")"; then
+          if ! latest_path="$(git -C "$reports_root" show "FETCH_HEAD:${pointer}" | node -e "const fs=require('node:fs'); const data=JSON.parse(fs.readFileSync(0,'utf8')); const value=String(data.path || ''); if (!/^openclaw-performance\\/[A-Za-z0-9._-]+\\/[0-9]+-[0-9]+\\/mock-provider$/u.test(value)) process.exit(1); process.stdout.write(value);")"; then
             echo "Previous source performance baseline pointer is invalid." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          git -C "$reports_root" sparse-checkout init --no-cone
+          printf '/%s/source/\n' "$latest_path" | git -C "$reports_root" sparse-checkout set --stdin
+          git -C "$reports_root" checkout --detach FETCH_HEAD
           baseline_source="${reports_root}/${latest_path}/source"
           if [[ -d "$baseline_source" ]]; then
             baseline_source="$(realpath "$baseline_source")"

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -153,9 +153,7 @@ describe("OpenClaw performance workflow", () => {
 
     expect(baseline.if).toBeUndefined();
     expect(baseline.env?.CLAWGRIT_REPORTS_TOKEN).toBeUndefined();
-    expect(run).toContain(
-      'remote add origin "https://github.com/openclaw/clawgrit-reports.git"',
-    );
+    expect(run).toContain('remote add origin "https://github.com/openclaw/clawgrit-reports.git"');
     expect(run).toContain("fetch --filter=blob:none --depth=1 origin main");
     expect(run).toContain('cat-file -e "FETCH_HEAD:${pointer}"');
     expect(run).toContain('show "FETCH_HEAD:${pointer}"');

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -146,15 +146,24 @@ describe("OpenClaw performance workflow", () => {
     );
   });
 
-  it("fetches the public clawgrit baseline without publisher credentials", () => {
+  it("sparse-fetches only the public source baseline without publisher credentials", () => {
     const workflowText = readFileSync(WORKFLOW, "utf8");
     const baseline = findStep("Fetch previous source performance baseline", "source_performance");
+    const run = baseline.run ?? "";
 
     expect(baseline.if).toBeUndefined();
     expect(baseline.env?.CLAWGRIT_REPORTS_TOKEN).toBeUndefined();
-    expect(baseline.run).toContain(
+    expect(run).toContain(
       'remote add origin "https://github.com/openclaw/clawgrit-reports.git"',
     );
+    expect(run).toContain("fetch --filter=blob:none --depth=1 origin main");
+    expect(run).toContain('cat-file -e "FETCH_HEAD:${pointer}"');
+    expect(run).toContain('show "FETCH_HEAD:${pointer}"');
+    expect(run).toContain("sparse-checkout init --no-cone");
+    expect(run).toContain("printf '/%s/source/\\n'");
+    expect(run).toContain("sparse-checkout set --stdin");
+    expect(run).toContain("checkout --detach FETCH_HEAD");
+    expect(run).not.toContain("checkout -B main FETCH_HEAD");
     expect(workflowText).not.toContain("https://x-access-token:");
   });
 


### PR DESCRIPTION
## What Problem This Solves

The source-performance job downloads the complete `openclaw/clawgrit-reports` history tree to read one 765 KB source baseline. In the latest profiled run, that baseline step alone took about 53 seconds.

Fixes #104375.

## Why This Change Was Made

The reports repository contains roughly 1.7 GB of reachable blobs, but this job needs only the branch pointer JSON and the immutable `source/` directory it references.

This change uses a blobless shallow fetch, reads and validates the pointer directly from `FETCH_HEAD`, then sparse-checks out only the referenced source directory. It preserves the existing public unauthenticated fetch and downstream baseline layout.

## User Impact

Scheduled and release-triggered performance workflows avoid about 50 seconds of unnecessary baseline transfer without changing measured probes or their comparison semantics.

No changelog entry: CI-only performance optimization.

## Evidence

- Blacksmith Testbox `tbx_01kx89e0e9rm887mh4gqpwwjth`: exact parsed YAML step completed in 1.327s and materialized 16 files / 765,489 bytes.
- `pnpm test:serial test/scripts/openclaw-performance-workflow.test.ts`: 27 tests passed.
- `pnpm check:workflows`: passed.
- `pnpm check:changed -- .github/workflows/openclaw-performance.yml test/scripts/openclaw-performance-workflow.test.ts`: passed.
- Autoreview: clean, no accepted/actionable findings; overall correctness `patch is correct` (0.84 confidence).