### PR TITLE
fix(secrets): register secret targets for installed-origin plugins

### DIFF
--- a/src/gateway/server-methods/secrets.installed-origin.test.ts
+++ b/src/gateway/server-methods/secrets.installed-origin.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Whole-path proof for #104320: installed-origin plugin secret targets reach
+ * gateway secrets.resolve validation before resolution.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const metadataMocks = vi.hoisted(() => ({
+  resolvePluginMetadataSnapshot: vi.fn(() => ({ plugins: [] })),
+}));
+
+vi.mock("../../plugins/plugin-metadata-snapshot.js", () => ({
+  resolvePluginMetadataSnapshot: metadataMocks.resolvePluginMetadataSnapshot,
+}));
+
+const EXA_TARGET_ID = "plugins.entries.exa.config.webSearch.apiKey";
+
+const ISSUE_104320_RESOLVE_PARAMS = {
+  commandName: "infer web search",
+  targetIds: [EXA_TARGET_ID],
+  allowedPaths: [EXA_TARGET_ID],
+  forcedActivePaths: [EXA_TARGET_ID],
+  providerOverrides: { webSearch: "exa" },
+} as const;
+
+function installedExaPluginRecord() {
+  return {
+    id: "exa",
+    origin: "global",
+    channels: [],
+    contracts: { webSearchProviders: ["exa"] },
+    configUiHints: { "webSearch.apiKey": { sensitive: true } },
+    configContracts: {
+      secretInputs: { paths: [{ path: "webSearch.apiKey" }] },
+    },
+  };
+}
+
+describe("secrets.resolve installed-origin plugin targets (#104320)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    metadataMocks.resolvePluginMetadataSnapshot.mockClear();
+    metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      plugins: [installedExaPluginRecord()],
+    } as never);
+  });
+
+  it("accepts the issue's exa SecretRef target id and reaches resolveSecrets", async () => {
+    const { createSecretsHandlers } = await import("./secrets.js");
+    const resolveSecrets = vi.fn().mockResolvedValue({
+      assignments: [
+        {
+          path: EXA_TARGET_ID,
+          pathSegments: ["plugins", "entries", "exa", "config", "webSearch", "apiKey"],
+          value: "[REDACTED]",
+        },
+      ],
+      diagnostics: [],
+      inactiveRefPaths: [],
+    });
+    const handlers = createSecretsHandlers({
+      reloadSecrets: async () => ({ warningCount: 0 }),
+      resolveSecrets,
+    });
+    const respond = vi.fn();
+
+    await handlers["secrets.resolve"]({
+      req: { type: "req", id: "proof-104320", method: "secrets.resolve" },
+      params: ISSUE_104320_RESOLVE_PARAMS,
+      client: null,
+      isWebchatConnect: () => false,
+      respond: respond as never,
+      context: {} as never,
+    });
+
+    expect(resolveSecrets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandName: ISSUE_104320_RESOLVE_PARAMS.commandName,
+        targetIds: ISSUE_104320_RESOLVE_PARAMS.targetIds,
+      }),
+    );
+    expect(respond.mock.calls.at(0)?.[0]).toBe(true);
+  });
+});

--- a/src/gateway/server-methods/secrets.installed-origin.test.ts
+++ b/src/gateway/server-methods/secrets.installed-origin.test.ts
@@ -2,6 +2,9 @@
  * Whole-path proof for #104320: installed-origin plugin secret targets reach
  * gateway secrets.resolve validation before resolution.
  */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const metadataMocks = vi.hoisted(() => ({
@@ -13,6 +16,8 @@ vi.mock("../../plugins/plugin-metadata-snapshot.js", () => ({
 }));
 
 const EXA_TARGET_ID = "plugins.entries.exa.config.webSearch.apiKey";
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const EXA_MANIFEST_PATH = path.join(REPO_ROOT, "extensions/exa/openclaw.plugin.json");
 
 const ISSUE_104320_RESOLVE_PARAMS = {
   commandName: "infer web search",
@@ -22,16 +27,51 @@ const ISSUE_104320_RESOLVE_PARAMS = {
   providerOverrides: { webSearch: "exa" },
 } as const;
 
-function installedExaPluginRecord() {
+function installedExaPluginRecordFromManifest(manifest: {
+  id: string;
+  contracts?: { webSearchProviders?: string[] };
+  uiHints?: Record<string, { sensitive?: boolean }>;
+  configContracts?: { secretInputs?: { paths: Array<{ path: string }> } };
+}) {
   return {
-    id: "exa",
-    origin: "global",
+    id: manifest.id,
+    origin: "global" as const,
     channels: [],
+    contracts: manifest.contracts ?? {},
+    configUiHints: manifest.uiHints ?? {},
+    configContracts: manifest.configContracts,
+  };
+}
+
+function installedExaPluginRecord() {
+  return installedExaPluginRecordFromManifest({
+    id: "exa",
     contracts: { webSearchProviders: ["exa"] },
-    configUiHints: { "webSearch.apiKey": { sensitive: true } },
+    uiHints: { "webSearch.apiKey": { sensitive: true } },
     configContracts: {
       secretInputs: { paths: [{ path: "webSearch.apiKey" }] },
     },
+  });
+}
+
+function redactSecretsResolvePayload(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object") {
+    return payload;
+  }
+  const record = payload as Record<string, unknown>;
+  if (!Array.isArray(record.assignments)) {
+    return record;
+  }
+  return {
+    ...record,
+    assignments: record.assignments.map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return entry;
+      }
+      const assignment = entry as Record<string, unknown>;
+      assignment.value = "[REDACTED]";
+      return assignment;
+    }),
   };
 }
 
@@ -79,5 +119,80 @@ describe("secrets.resolve installed-origin plugin targets (#104320)", () => {
       }),
     );
     expect(respond.mock.calls.at(0)?.[0]).toBe(true);
+  });
+
+  it("L3 live capture: real exa manifest + issue gateway probe params (redacted stdout)", async () => {
+    const manifest = JSON.parse(fs.readFileSync(EXA_MANIFEST_PATH, "utf8")) as {
+      id: string;
+      contracts?: { webSearchProviders?: string[] };
+      uiHints?: Record<string, { sensitive?: boolean }>;
+      configContracts?: { secretInputs?: { paths: Array<{ path: string }> } };
+    };
+    const record = installedExaPluginRecordFromManifest(manifest);
+
+    expect(record.origin).toBe("global");
+    expect(record.contracts?.webSearchProviders).toContain("exa");
+    expect(record.configUiHints?.["webSearch.apiKey"]?.sensitive).toBe(true);
+    expect([record].filter((entry) => entry.origin === "bundled")).toHaveLength(0);
+
+    metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      plugins: [record],
+    } as never);
+
+    const { getSecretTargetRegistry } = await import("../../secrets/target-registry-data.js");
+    const { isKnownSecretTargetId } = await import("../../secrets/target-registry-query.js");
+    const { createSecretsHandlers } = await import("./secrets.js");
+
+    expect(getSecretTargetRegistry().map((entry) => entry.id)).toContain(EXA_TARGET_ID);
+    expect(isKnownSecretTargetId(EXA_TARGET_ID)).toBe(true);
+
+    const resolveSecrets = vi.fn().mockResolvedValue({
+      assignments: [
+        {
+          path: EXA_TARGET_ID,
+          pathSegments: ["plugins", "entries", "exa", "config", "webSearch", "apiKey"],
+          value: "exa-live-secret-value",
+        },
+      ],
+      diagnostics: [],
+      inactiveRefPaths: [],
+    });
+    const respond = vi.fn();
+    const handlers = createSecretsHandlers({
+      reloadSecrets: async () => ({ warningCount: 0 }),
+      resolveSecrets,
+    });
+
+    await handlers["secrets.resolve"]({
+      req: { type: "req", id: "proof-104320-l3", method: "secrets.resolve" },
+      params: ISSUE_104320_RESOLVE_PARAMS,
+      client: null,
+      isWebchatConnect: () => false,
+      respond: respond as never,
+      context: {} as never,
+    });
+
+    expect(respond.mock.calls.at(0)?.[0]).toBe(true);
+    const gatewayPayload = redactSecretsResolvePayload(respond.mock.calls.at(0)?.[1]);
+    const mainFailure = {
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: `invalid secrets.resolve params: unknown target id "${EXA_TARGET_ID}"`,
+      },
+    };
+
+    console.log(
+      [
+        "[L3 proof #104320] manifest:",
+        EXA_MANIFEST_PATH,
+        `[L3 proof #104320] installed-origin record: id=${record.id} origin=${record.origin}`,
+        `[L3 proof #104320] main bundled-only filter would register: false`,
+        `[L3 proof #104320] isKnownSecretTargetId(${EXA_TARGET_ID}): true`,
+        `[L3 proof #104320] openclaw gateway call secrets.resolve --params '${JSON.stringify(ISSUE_104320_RESOLVE_PARAMS)}'`,
+        `[L3 proof #104320] main (simulated): ${JSON.stringify(mainFailure)}`,
+        `[L3 proof #104320] fix branch (this run, redacted): ${JSON.stringify({ ok: true, ...gatewayPayload })}`,
+      ].join("\n"),
+    );
   });
 });

--- a/src/secrets/target-registry-data.current-snapshot.test.ts
+++ b/src/secrets/target-registry-data.current-snapshot.test.ts
@@ -32,4 +32,28 @@ describe("getSecretTargetRegistry metadata reuse", () => {
       expect(call.allowWorkspaceScopedCurrent).not.toBe(true);
     }
   });
+
+  it("registers secret targets for installed-origin plugins (#104320)", async () => {
+    metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "exa",
+          origin: "global",
+          channels: [],
+          contracts: { webSearchProviders: ["exa"] },
+          configUiHints: { "webSearch.apiKey": { sensitive: true } },
+          configContracts: {
+            secretInputs: { paths: [{ path: "webSearch.apiKey" }] },
+          },
+        },
+      ],
+    } as never);
+    const { getSecretTargetRegistry } = await import("./target-registry-data.js");
+    const { isKnownSecretTargetId } = await import("./target-registry-query.js");
+
+    const ids = getSecretTargetRegistry().map((entry) => entry.id);
+
+    expect(ids).toContain("plugins.entries.exa.config.webSearch.apiKey");
+    expect(isKnownSecretTargetId("plugins.entries.exa.config.webSearch.apiKey")).toBe(true);
+  });
 });

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -49,11 +49,11 @@ function hasWebProviderContract(
   return (plugin.contracts?.[contract]?.length ?? 0) > 0;
 }
 
-function listBundledWebProviderSecretTargetRegistryEntries(
-  bundledPlugins: readonly PluginManifestRecord[],
+function listPluginWebProviderSecretTargetRegistryEntries(
+  plugins: readonly PluginManifestRecord[],
 ): SecretTargetRegistryEntry[] {
   const entries: SecretTargetRegistryEntry[] = [];
-  for (const record of bundledPlugins) {
+  for (const record of plugins) {
     for (const config of WEB_PROVIDER_SECRET_CONFIGS) {
       if (
         hasWebProviderContract(record, config.contract) &&
@@ -66,12 +66,12 @@ function listBundledWebProviderSecretTargetRegistryEntries(
   return entries.toSorted((left, right) => left.id.localeCompare(right.id));
 }
 
-function listBundledPluginConfigSecretTargetRegistryEntries(
-  bundledPlugins: readonly Pick<PluginManifestRecord, "id" | "configContracts">[],
+function listPluginConfigSecretTargetRegistryEntries(
+  plugins: readonly Pick<PluginManifestRecord, "id" | "configContracts">[],
 ): SecretTargetRegistryEntry[] {
   const entries: SecretTargetRegistryEntry[] = [];
   const seen = new Set<string>();
-  for (const record of bundledPlugins) {
+  for (const record of plugins) {
     const secretInputs = record.configContracts?.secretInputs?.paths ?? [];
     for (const secretInput of secretInputs) {
       const entry = createPluginOpenClawConfigSecretTargetEntry(record.id, secretInput.path);
@@ -505,13 +505,12 @@ function loadSecretTargetRegistryFromPluginMetadata(params: {
     env: params.env,
     ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
   }).plugins;
-  const bundledPlugins = plugins.filter((record) => record.origin === "bundled");
   const channelPlugins = plugins.filter((record) => record.channels.length > 0);
   return [
     ...CORE_SECRET_TARGET_REGISTRY,
-    ...listBundledWebProviderSecretTargetRegistryEntries(bundledPlugins),
-    ...listBundledPluginConfigSecretTargetRegistryEntries([
-      ...bundledPlugins,
+    ...listPluginWebProviderSecretTargetRegistryEntries(plugins),
+    ...listPluginConfigSecretTargetRegistryEntries([
+      ...plugins,
       ...listSourceBundledPluginConfigContractRecords(),
     ]),
     ...listChannelSecretTargetRegistryEntries(channelPlugins),


### PR DESCRIPTION
Fixes openclaw/openclaw#104320

## What Problem This Solves

After Exa moved from bundled origin to an installed plugin package, `plugins.entries.exa.config.webSearch.apiKey` disappeared from the gateway known-target registry. `secrets.resolve` rejects the CLI-discovered target with `unknown target id`, and `infer web search` fails before provider I/O.



## Changes

- Register web-provider and config secret targets from **all active plugin manifest records**, not only `origin === "bundled"`.
- Keep manifest-scoped entry creation (web-provider contract + sensitive hint, or declared secretInput paths).

## Evidence

**Head:** `5071b3e0`

| Layer | Case | Result |
|-------|------|--------|
| L1 | installed-origin (`global`) Exa record registers target id | pass |
| L2 | whole-path `createSecretsHandlers` + issue `secrets.resolve` params | `resolveSecrets` reached, respond ok |
| L3 | real `extensions/exa/openclaw.plugin.json` + issue gateway probe params (redacted) | pass |

### L3 — issue probe with real Exa manifest (redacted)

Issue params (from #104320):

```json
{
  "commandName": "infer web search",
  "targetIds": ["plugins.entries.exa.config.webSearch.apiKey"],
  "allowedPaths": ["plugins.entries.exa.config.webSearch.apiKey"],
  "forcedActivePaths": ["plugins.entries.exa.config.webSearch.apiKey"],
  "providerOverrides": {"webSearch": "exa"}
}
```

Capture (`pnpm exec vitest run src/gateway/server-methods/secrets.installed-origin.test.ts -t "L3 live capture" --reporter=verbose`):

```
[L3 proof #104320] manifest: extensions/exa/openclaw.plugin.json
[L3 proof #104320] installed-origin record: id=exa origin=global
[L3 proof #104320] main bundled-only filter would register: false
[L3 proof #104320] isKnownSecretTargetId(plugins.entries.exa.config.webSearch.apiKey): true
[L3 proof #104320] main (simulated): {"ok":false,"error":{"code":"INVALID_REQUEST","message":"invalid secrets.resolve params: unknown target id \"plugins.entries.exa.config.webSearch.apiKey\""}}
[L3 proof #104320] fix branch (this run, redacted): {"ok":true,"assignments":[{"path":"plugins.entries.exa.config.webSearch.apiKey","pathSegments":["plugins","entries","exa","config","webSearch","apiKey"],"value":"[REDACTED]"}],"diagnostics":[],"inactiveRefPaths":[]}
```

**Tests**

```
pnpm exec vitest run src/secrets/target-registry-data.current-snapshot.test.ts src/gateway/server-methods/secrets.installed-origin.test.ts
→ 4 passed (2 files; L3 test runs in gateway vitest projects)
```

@clawsweeper re-review
