### PR TITLE
fix(cron): preserve UTF-16 boundaries in exec tails

### DIFF
--- a/src/cron/run-diagnostics.test.ts
+++ b/src/cron/run-diagnostics.test.ts
@@ -192,6 +192,27 @@ describe("cron run diagnostics", () => {
     });
   });
 
+  it("keeps failed exec output tails valid at UTF-16 boundaries", () => {
+    const diagnostics = createCronRunDiagnosticsFromAgentResult(
+      {
+        payloads: [
+          {
+            toolName: "exec",
+            details: {
+              status: "completed",
+              exitCode: 2,
+              aggregated: `x😀${"y".repeat(1_999)}`,
+            },
+          },
+        ],
+      },
+      { nowMs: () => 123 },
+    );
+
+    expect(diagnostics?.summary).toBe("y".repeat(1_999));
+    expect(diagnostics?.entries[0]?.message).toBe(`${"y".repeat(999)}…`);
+  });
+
   it("does not capture harmless successful exec output", () => {
     const result = {
       payloads: [

--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -1,6 +1,6 @@
 /** Builds bounded, redacted diagnostics for cron run logs and UI surfaces. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isToolAllowedByPolicyName } from "../agents/tool-policy-match.js";
 import { normalizeToolName as normalizePolicyToolName } from "../agents/tool-policy.js";
 import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
@@ -87,7 +87,7 @@ function tailText(value: string, maxChars: number): string {
   }
   // Exec output often ends with the actionable failure; keep the tail when
   // bounding diagnostic text for run logs and control surfaces.
-  return value.slice(value.length - maxChars);
+  return sliceUtf16Safe(value, -maxChars);
 }
 
 function normalizeDiagnosticMessage(value: unknown): { message?: string; truncated?: boolean } {


### PR DESCRIPTION
## Summary

- preserve UTF-16 boundaries when retaining the tail of failed exec output
- add a regression test through `createCronRunDiagnosticsFromAgentResult`
- reuse the shared `sliceUtf16Safe` helper

## What Problem This Solves

Cron failed-exec diagnostics retain the final 2,000 UTF-16 code units because the actionable error is usually at the end. The previous tail slice could begin between an emoji's surrogate halves, leaving a lone low surrogate in the persisted diagnostic summary and message.

## User Impact

Long exec failures containing emoji or other astral characters at the truncation boundary can no longer produce malformed cron diagnostics in run logs and control surfaces.

## Origin / follow-up

- **Follows:** #103740, which made Codex diagnostic truncation UTF-16 safe.
- **Gap this fills:** cron diagnostics had already adopted safe prefix truncation, but the failed-exec tail helper still used raw `String.prototype.slice`.
- **Consistency:** this change reuses the same shared UTF-16-safe slicing utility used by other bounded text paths.

## Competition / linked PR analysis

A fresh competition scan of related open PR changed files and exact `tailText` references found no PR covering `src/cron/run-diagnostics.ts`. The author's open PRs also do not overlap this path.

## Merge risk

- **Why it matters / User impact:** malformed UTF-16 can be rendered as replacement characters or rejected by downstream serializers.
- **Risk labels considered:** availability.
- **Risk explanation:** the change can retain one fewer UTF-16 code unit when the old boundary landed inside a surrogate pair.
- **Why acceptable:** dropping the incomplete half preserves valid text and keeps the existing tail-first diagnostic policy.
- **Maintainer-ready confidence:** High; the production entry is directly reproducible and the patch uses an existing shared helper.
- **Patch quality notes:** focused two-file patch with no type escape, fallback, public contract change, or unrelated refactor.
- **Target test file:** `src/cron/run-diagnostics.test.ts`
- **Root cause:** the normalization invariant was violated because `tailText` used a raw UTF-16 code-unit slice whose start could land on a low surrogate.
- **Why this is root-cause fix:** the source boundary is corrected where the retained tail is created, before the malformed substring can enter normalization, the runtime diagnostics object, or persistence.
- **What did NOT change:** only surrogate-boundary handling changed; diagnostic limits, redaction, severity, entry ordering, fallback messages, schemas, and public APIs remain unchanged.
- **Architecture / source-of-truth check:** `tailText` in the canonical cron diagnostic construction path is the source of truth for failed-exec tail retention; no downstream renderer, storage schema, or delivery path was changed.
- **Scenario locked in:** a 2,002-code-unit failed exec output whose 2,000-unit tail starts inside an emoji.
- **Why this is the smallest reliable guardrail:** one shared-helper substitution plus one production-entry regression test.

## Real behavior proof

- **Behavior or issue addressed:** failed-exec tail truncation no longer emits a lone low surrogate.
- **Canonical reachability path:** input source `payloads[].details.aggregated` from the shipped exec tool result → ingestion/type checks in `createCronRunDiagnosticsFromAgentResult` and `createCronRunDiagnosticsFromExecDetails` → string normalization by `normalizeOptionalString` → runtime failed-exec message → `tailText` effect → normalized `CronRunDiagnostics` summary and entry.
- **Boundary crossed:** the production entry ingests the canonical exec-result payload and returns the runtime diagnostic object consumed by cron persistence and control surfaces; the proof terminates at that returned production object.
- **Shared helper / provider constraint check:** reused the repository's existing shared `sliceUtf16Safe` helper; provider-specific constraints are not applicable.
- **Real environment tested:** Linux worktree on Node 22 with the repository pnpm toolchain.
- **Exact steps or command run after this patch:** direct production-function execution with a 2,002-code-unit boundary fixture, plus `pnpm test src/cron/run-diagnostics.test.ts`.
- **Evidence after fix:**

```text
BEFORE: summary started with lone low surrogate U+DE00
AFTER:  summary length=1999, first code unit=0x79 ('y')
        entry length=1000, first code unit=0x79 ('y')
CONTROL: short ASCII failed-exec diagnostic remained unchanged
TESTS:   1 file passed, 14 tests passed
```

- **Observed result after fix:** both summary and entry begin on a complete character boundary while preserving the actionable tail.
- **What was not tested:** rendering and storage consumers were not exercised; this defect and proof terminate at the returned production diagnostic object.
- **Fix classification:** Root cause fix

## Review findings addressed

N/A — new focused follow-up with no existing review findings.

## Regression Test Plan

- run `pnpm test src/cron/run-diagnostics.test.ts`
- verify the surrogate-boundary failed-exec fixture remains valid
- verify short successful and failed exec controls remain unchanged

## Risk / Compatibility

No API or schema changes. At a split surrogate boundary, the retained tail can be one code unit shorter than before so the output remains valid UTF-16.

## What was not changed

No changes to cron scheduling, exec execution, diagnostic severity, redaction, storage schema, UI rendering, or delivery behavior.

## Root Cause

The tail helper bounded text with a raw UTF-16 code-unit slice. When its start index pointed at the low half of a surrogate pair, the returned string began with an unpaired surrogate.
