### PR TITLE
fix(ui): delay scrolling truncated session titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI session title hover:** wait briefly before scrolling a truncated sidebar session name, and cancel the scroll when the pointer leaves during that grace period.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI session title hover:** wait briefly before scrolling a truncated sidebar session name, and cancel the scroll when the pointer leaves during that grace period.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2551,6 +2551,32 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       }));
       expect(layout.scrollWidth, JSON.stringify(layout)).toBeGreaterThan(layout.clientWidth);
 
+      await recentRow.dispatchEvent("mouseenter");
+      await page.waitForTimeout(250);
+      expect(await recentLabel.evaluate((label) => label.classList.value)).not.toContain(
+        "hover-marquee--scrolling",
+      );
+      await recentRow.dispatchEvent("mouseleave");
+      await page.waitForTimeout(300);
+      expect(await recentLabel.evaluate((label) => label.classList.value)).not.toContain(
+        "hover-marquee--scrolling",
+      );
+      await recentRow.dispatchEvent("mouseenter");
+      await expect
+        .poll(() => recentLabel.evaluate((label) => label.classList.value), { timeout: 1_500 })
+        .toContain("hover-marquee--scrolling");
+      await recentRow.dispatchEvent("mouseleave");
+      await expect
+        .poll(
+          () =>
+            recentLabel.evaluate((label) => ({
+              textIndent: getComputedStyle(label).textIndent,
+              textOverflow: getComputedStyle(label).textOverflow,
+            })),
+          { timeout: 1_500 },
+        )
+        .toEqual({ textIndent: "0px", textOverflow: "ellipsis" });
+
       await recentRow.locator("a.sidebar-recent-session__link").dispatchEvent("click", {
         button: 0,
       });

--- a/ui/src/lib/hover-marquee.test.ts
+++ b/ui/src/lib/hover-marquee.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startHoverMarquee, stopHoverMarquee } from "./hover-marquee.ts";
 
 function buildRow(params: { textWidth: number; labelWidth: number }) {
@@ -14,13 +14,32 @@ function buildRow(params: { textWidth: number; labelWidth: number }) {
 }
 
 describe("hover marquee", () => {
-  it("scrolls overflowing labels by the clipped distance and restores on leave", () => {
+  beforeEach(() => vi.useFakeTimers());
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.replaceChildren();
+  });
+
+  it("waits before scrolling overflowing labels by the clipped distance", () => {
     const { row, label } = buildRow({ textWidth: 320, labelWidth: 180 });
     startHoverMarquee(row);
-    expect(label.classList.contains("hover-marquee--scrolling")).toBe(true);
     expect(label.style.getPropertyValue("--hover-marquee-shift")).toBe("-140px");
     expect(label.style.getPropertyValue("--hover-marquee-duration")).toBe("1750ms");
+    vi.advanceTimersByTime(499);
+    expect(label.classList.contains("hover-marquee--scrolling")).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(label.classList.contains("hover-marquee--scrolling")).toBe(true);
     stopHoverMarquee(row);
+    expect(label.classList.contains("hover-marquee--scrolling")).toBe(false);
+  });
+
+  it("cancels the delayed scroll when hover ends early", () => {
+    const { row, label } = buildRow({ textWidth: 320, labelWidth: 180 });
+    startHoverMarquee(row);
+    vi.advanceTimersByTime(250);
+    stopHoverMarquee(row);
+    vi.advanceTimersByTime(250);
     expect(label.classList.contains("hover-marquee--scrolling")).toBe(false);
   });
 

--- a/ui/src/lib/hover-marquee.ts
+++ b/ui/src/lib/hover-marquee.ts
@@ -5,6 +5,8 @@
 // no ellipsis for atomic inline children, which would lose the resting "…".
 const MARQUEE_SPEED_PX_PER_SEC = 80;
 const MARQUEE_MIN_DURATION_MS = 300;
+const MARQUEE_HOVER_DELAY_MS = 500;
+const pendingMarquees = new WeakMap<HTMLElement, number>();
 
 function findMarqueeLabel(host: HTMLElement): HTMLElement | null {
   return host.classList.contains("hover-marquee")
@@ -12,11 +14,21 @@ function findMarqueeLabel(host: HTMLElement): HTMLElement | null {
     : host.querySelector<HTMLElement>(".hover-marquee");
 }
 
-export function startHoverMarquee(host: HTMLElement): void {
-  const label = findMarqueeLabel(host);
-  if (!label) {
+function clearPendingMarquee(label: HTMLElement): void {
+  const pending = pendingMarquees.get(label);
+  if (pending === undefined) {
     return;
   }
+  window.clearTimeout(pending);
+  pendingMarquees.delete(label);
+}
+
+export function startHoverMarquee(host: HTMLElement): void {
+  const label = findMarqueeLabel(host);
+  if (!label || label.classList.contains("hover-marquee--scrolling")) {
+    return;
+  }
+  clearPendingMarquee(label);
   // Measure at hover time: labels resize with the sidebar and with hover-only
   // row actions, so a cached width would drift. A negative mid-transition
   // indent (re-hover while snapping back) shrinks scrollWidth; add it back.
@@ -31,9 +43,21 @@ export function startHoverMarquee(host: HTMLElement): void {
   );
   label.style.setProperty("--hover-marquee-shift", `${-shift}px`);
   label.style.setProperty("--hover-marquee-duration", `${durationMs}ms`);
-  label.classList.add("hover-marquee--scrolling");
+  // Keep quick pointer passes quiet; leaving before the timer fires cancels it.
+  pendingMarquees.set(
+    label,
+    window.setTimeout(() => {
+      pendingMarquees.delete(label);
+      label.classList.add("hover-marquee--scrolling");
+    }, MARQUEE_HOVER_DELAY_MS),
+  );
 }
 
 export function stopHoverMarquee(host: HTMLElement): void {
-  findMarqueeLabel(host)?.classList.remove("hover-marquee--scrolling");
+  const label = findMarqueeLabel(host);
+  if (!label) {
+    return;
+  }
+  clearPendingMarquee(label);
+  label.classList.remove("hover-marquee--scrolling");
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where moving the pointer across sidebar sessions immediately started scrolling truncated session names, making the list feel restless during ordinary navigation.

## Why This Change Was Made

Adds a 500 ms grace period in the shared hover-marquee owner and cancels pending scrolling when the pointer leaves. The resting ellipsis remains intact during the delay; sustained hover keeps the existing distance- and speed-aware animation and reduced-motion behavior.

## User Impact

Brief pointer passes leave session titles stationary. Pausing on a truncated title still reveals its full text, and leaving before or after scrolling restores the ellipsis.

## Evidence

- Blacksmith Testbox through Crabbox: `tbx_01kx8apn5j1th9cmkac0a9b240`
- `pnpm test ui/src/lib/hover-marquee.test.ts` — 5/5 passed
- Mocked-Gateway Chromium scenario, `keeps long sidebar labels clipped after a session switch` — 1/1 passed
- `pnpm exec oxfmt --check` on all changed files — passed
- `pnpm check:changed` — passed, including core/test types and changed-file lint
- Structured autoreview (`gpt-5.5`, high) — clean; no accepted/actionable findings
- Browser behavior contract: 250 ms hover remains stationary; early leave cancels past the 500 ms threshold; sustained hover scrolls; leave restores the ellipsis

The behavior is temporal, so real Chromium assertions provide the useful proof; a static screenshot would not show the delay.
