### PR TITLE
fix(ui): adapt background-tasks rail to narrow panes

### DIFF
--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -163,4 +163,54 @@ describeControlUiE2e("Control UI chat background-tasks rail mocked Gateway E2E",
       await context.close();
     }
   });
+
+  it("adapts geometry to narrow window widths", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { width: 1000, height: 900 },
+    });
+    const page = await context.newPage();
+    try {
+      await installMockGateway(page, {
+        historyMessages: [
+          { content: [{ type: "text", text: "Ready." }], role: "assistant", timestamp: Date.now() },
+        ],
+        methodResponses: {
+          "tasks.list": { tasks: [runningSubagent, queuedCron, finishedCli] },
+          "workspace.list_mounts": { mounts: [] },
+        },
+      });
+
+      await page.goto(`${server.baseUrl}chat`);
+
+      // Open tasks rail
+      await page.getByRole("button", { name: "Show background tasks" }).click();
+      await page.locator(".chat-tasks-rail").waitFor({ state: "visible" });
+
+      // Assert bottom dock is active for tasks
+      const workbench = page.locator(".chat-workbench");
+      await expect(workbench).toHaveClass(/chat-workbench--tasks-dock-bottom/);
+
+      await page.screenshot({
+        path: path.join(artifactDir, "03-narrow-layout.png"),
+        fullPage: true,
+      });
+
+      // Open workspace rail too (to test dual rail)
+      const workspaceBtn = page.getByRole("button", { name: "Open workspace" });
+      if (await workspaceBtn.isVisible()) {
+        await workspaceBtn.click();
+        await page.locator(".chat-workspace-rail").waitFor({ state: "visible" });
+        await expect(workbench).toHaveClass(/chat-workbench--dock-bottom/);
+
+        await page.screenshot({
+          path: path.join(artifactDir, "04-dual-rail-narrow-layout.png"),
+          fullPage: true,
+        });
+      }
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1283,18 +1283,24 @@ class ChatPane extends OpenClawLightDomElement {
     const sessionWorkspace = createSessionWorkspaceProps(state, {
       narrowLayout: this.paneWidth < WORKSPACE_RAIL_SIDE_MIN_PANE_WIDTH,
     });
-    const backgroundTasks = createBackgroundTasksProps(state, {
-      onOpenSession: (sessionKey) => {
-        this.onPaneSessionChange?.(this.paneId, sessionKey);
-      },
-    });
     const railSideDocked =
       !sessionWorkspace.collapsed &&
       !sessionWorkspace.narrowLayout &&
       sessionWorkspace.dock !== "bottom";
+    const backgroundTasks = createBackgroundTasksProps(state, {
+      narrowLayout:
+        this.paneWidth < WORKSPACE_RAIL_SIDE_MIN_PANE_WIDTH ||
+        (railSideDocked &&
+          this.paneWidth < WORKSPACE_RAIL_SIDE_MIN_PANE_WIDTH + WORKSPACE_RAIL_MAX_WIDTH),
+      onOpenSession: (sessionKey) => {
+        this.onPaneSessionChange?.(this.paneId, sessionKey);
+      },
+    });
     // Every open side rail (workspace and/or background tasks) narrows the
     // room left for the chat + detail split.
-    const sideRailCount = (railSideDocked ? 1 : 0) + (backgroundTasks.collapsed ? 0 : 1);
+    const sideRailCount =
+      (railSideDocked ? 1 : 0) +
+      (!backgroundTasks.collapsed && !backgroundTasks.narrowLayout ? 1 : 0);
     const detailSplitWidth = this.paneWidth - sideRailCount * WORKSPACE_RAIL_MAX_WIDTH;
     const props: ChatProps = {
       paneId: this.paneId,

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -199,6 +199,9 @@ export function renderChat(props: ChatProps) {
     props.sessionWorkspace &&
     (props.sessionWorkspace.dock === "bottom" || props.sessionWorkspace.narrowLayout),
   );
+  const tasksDockBottom = Boolean(
+    props.backgroundTasks && !props.backgroundTasks.collapsed && props.backgroundTasks.narrowLayout,
+  );
   const canCompose = props.canSend;
   let chatSection: HTMLElement | null = null;
 
@@ -391,10 +394,9 @@ export function renderChat(props: ChatProps) {
       <div
         class="chat-workbench ${props.sessionWorkspace?.collapsed
           ? "chat-workbench--workspace-collapsed"
-          : ""} ${workspaceDockBottom ? "chat-workbench--dock-bottom" : ""} ${props.backgroundTasks
-          ?.collapsed === false
-          ? "chat-workbench--tasks-open"
-          : ""}"
+          : ""} ${workspaceDockBottom ? "chat-workbench--dock-bottom" : ""} ${tasksDockBottom
+          ? "chat-workbench--tasks-dock-bottom"
+          : ""} ${props.backgroundTasks?.collapsed === false ? "chat-workbench--tasks-open" : ""}"
       >
         ${renderSessionWorkspaceRail(props.sessionWorkspace)}
         ${renderBackgroundTasksRail(props.backgroundTasks)}

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -28,6 +28,7 @@ import { paneSessionAgentId } from "./chat-session-workspace.ts";
 export type BackgroundTasksProps = {
   agentId: string;
   collapsed: boolean;
+  narrowLayout?: boolean;
   connected: boolean;
   canCancel: boolean;
   loading: boolean;
@@ -261,7 +262,7 @@ export function toggleBackgroundTasks(host: BackgroundTasksHost) {
 
 export function createBackgroundTasksProps(
   host: BackgroundTasksHost,
-  opts: { onOpenSession: (sessionKey: string) => void },
+  opts: { narrowLayout?: boolean; onOpenSession: (sessionKey: string) => void },
 ): BackgroundTasksProps {
   const state = getBackgroundTasksState(host);
   if (!host.connected) {
@@ -281,6 +282,7 @@ export function createBackgroundTasksProps(
   return {
     agentId: state.agentId,
     collapsed: state.collapsed,
+    narrowLayout: opts.narrowLayout,
     connected: host.connected,
     // tasks.cancel needs operator.write; read-only operators get no button.
     canCancel: host.connected && hasOperatorWriteAccess(host.hello?.auth ?? null),

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1868,9 +1868,13 @@
 
 .chat-workbench--tasks-dock-bottom .chat-tasks-rail {
   grid-column: 1 / -1;
-  grid-row: -1; /* Bottom-most row */
+  grid-row: 2;
   border-left: none;
   border-top: 1px solid var(--border);
+}
+
+.chat-workbench--dock-bottom.chat-workbench--tasks-dock-bottom .chat-tasks-rail {
+  grid-row: 3;
 }
 
 /* Background-tasks rail becomes a horizontal scrolling strip */

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1693,29 +1693,6 @@
   min-height: 160px;
 }
 
-/* The background-tasks rail has no narrow presentation yet; hide it with its
-   toggles on narrow viewports (the workspace rail adapts instead). The hidden
-   rail must also release its reserved grid track, so the tasks-open templates
-   collapse back to the workspace-only shapes here. */
-@media (max-width: 1120px) {
-  .chat-tasks-rail {
-    display: none;
-  }
-
-  .chat-workbench--tasks-open.chat-workbench--workspace-collapsed,
-  .chat-workbench--tasks-open.chat-workbench--dock-bottom {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  /* Mirrors the three-column selector's specificity so the two-column shape
-     wins while the tasks rail is hidden. */
-  .chat-workbench--tasks-open:not(.chat-workbench--workspace-collapsed):not(
-    .chat-workbench--dock-bottom
-  ) {
-    grid-template-columns: minmax(0, 1fr) minmax(230px, 280px);
-  }
-}
-
 /* Mobile: Full-screen modal */
 @media (max-width: 768px) {
   .chat-split-container--open {
@@ -1878,4 +1855,46 @@
   padding: 2px 2px 4px;
   color: var(--muted);
   font-size: var(--control-ui-text-sm);
+}
+
+.chat-workbench--tasks-dock-bottom {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) minmax(160px, 236px);
+}
+
+.chat-workbench--dock-bottom.chat-workbench--tasks-dock-bottom {
+  grid-template-rows: minmax(0, 1fr) minmax(100px, 200px) minmax(100px, 200px);
+}
+
+.chat-workbench--tasks-dock-bottom .chat-tasks-rail {
+  grid-column: 1 / -1;
+  grid-row: -1; /* Bottom-most row */
+  border-left: none;
+  border-top: 1px solid var(--border);
+}
+
+/* Background-tasks rail becomes a horizontal scrolling strip */
+.chat-workbench--tasks-dock-bottom .chat-tasks-rail__scroll {
+  display: flex;
+  flex-direction: row;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.chat-workbench--tasks-dock-bottom .chat-tasks-rail__section {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 260px;
+  min-width: 0;
+}
+
+.chat-workbench--tasks-dock-bottom .chat-tasks-rail__section + .chat-tasks-rail__section {
+  border-top: none;
+  border-left: 1px solid color-mix(in srgb, var(--border) 42%, transparent);
+}
+
+/* Let the empty states align to the top */
+.chat-workbench--tasks-dock-bottom .chat-tasks-rail__state {
+  flex: 0 0 auto;
+  align-self: flex-start;
 }


### PR DESCRIPTION
Closes #104091

## What Problem This Solves

Fixes an issue where users opening the chat background-tasks rail in a narrow split-view pane or compact window would experience the chat thread being crushed into an unreadable sliver. Resolves a related problem where the tasks rail and its toggles would completely disappear (via a CSS media query) when the viewport width was below 1120px.

## Why This Change Was Made

The tasks rail layout was updated to measure the pane's actual width using the existing `ResizeObserver` plumbing from `chat-pane.ts`, rather than relying on viewport CSS media queries. The 1120px CSS hide hack was removed. When the pane is narrower than 800px—or when yielding the side slot to an already open workspace rail—the background-tasks rail now applies a `.chat-workbench--tasks-dock-bottom` class, transforming it into a horizontally scrollable bottom-dock strip similar to the workspace rail behavior introduced in #104033.

## User Impact

Users can now access and view background tasks in narrow split-view panes and compact browser windows without the layout breaking or the UI components hiding completely. The tasks rail gracefully adapts by docking to the bottom of the pane, keeping the chat thread perfectly readable in all viewport sizes.

## Evidence

- **Narrow pane / Split view:** Opening the background tasks rail on a pane narrower than 800px successfully renders a bottom-docked strip.
- **Viewport < 1120px:** The activity toggle button remains visible and functional in the pane header / floating toggle bar, allowing access to tasks on smaller screens.
- **Side slot yielding:** If the workspace rail is open and side-docked, opening the background tasks rail correctly yields the limited horizontal space and bottom-docks instead of attempting to cram two 280px columns beside the chat thread.