### PR TITLE
fix(agents): resolve channel and account messagePrefix overrides

### DIFF
--- a/extensions/zalouser/src/monitor.message-prefix.test.ts
+++ b/extensions/zalouser/src/monitor.message-prefix.test.ts
@@ -1,0 +1,397 @@
+// Zalouser tests: inbound account messagePrefix on agent body (DM path).
+import { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-outbound";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
+// Preserve module setup before modules that consume it.
+// oxfmt-ignore
+import {
+  startZaloListenerMock,
+} from "./zalo-js.test-mocks.js";
+import "./monitor.send.test-mocks.js";
+import {
+  createRawZalouserMessageFromNormalized,
+  waitForZalouserIngressVerdict,
+  withZalouserIngressTestQueue,
+} from "./ingress.test-support.js";
+import { monitorZalouserProvider } from "./monitor.js";
+import { setZalouserRuntime } from "./runtime.js";
+import { createZalouserRuntimeEnv } from "./test-helpers.js";
+import type { ResolvedZalouserAccount, ZaloInboundMessage } from "./types.js";
+
+function createAccount(): ResolvedZalouserAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    profile: "default",
+    authenticated: true,
+    config: {
+      dmPolicy: "open",
+      allowFrom: ["*"],
+      groupPolicy: "open",
+      groups: {
+        "*": { requireMention: true },
+      },
+    },
+  };
+}
+
+function createConfig(): OpenClawConfig {
+  return {
+    channels: {
+      zalouser: {
+        enabled: true,
+        dmPolicy: "open",
+        allowFrom: ["*"],
+        groups: {
+          "*": { requireMention: true },
+        },
+      },
+    },
+  };
+}
+
+const createRuntimeEnv = () => createZalouserRuntimeEnv();
+
+type DispatchReplyCallArg = {
+  ctx?: {
+    Body?: string;
+    BodyForAgent?: string;
+    BodyForCommands?: string;
+    CommandAuthorized?: boolean;
+    CommandBody?: string;
+    InboundHistory?: unknown;
+    OriginatingTo?: string;
+    ReplyToBody?: string;
+    ReplyToId?: string;
+    ReplyToIsQuote?: boolean;
+    SessionKey?: string;
+    To?: string;
+    WasMentioned?: boolean;
+  };
+};
+
+function mockCallArg(mock: unknown, label: string, index = 0) {
+  const call = (mock as { mock?: { calls?: unknown[][] } }).mock?.calls?.at(index);
+  if (!call) {
+    throw new Error(`Expected ${label} call ${index + 1}`);
+  }
+  return call[0];
+}
+
+function dispatchReplyCall(mock: unknown, index = 0): DispatchReplyCallArg {
+  return mockCallArg(mock, "dispatch reply", index) as DispatchReplyCallArg;
+}
+
+function installRuntime(params: {
+  commandAuthorized?: boolean;
+  replyPayload?: { text?: string; mediaUrl?: string; mediaUrls?: string[] };
+  resolveCommandAuthorizedFromAuthorizers?: (params: {
+    useAccessGroups: boolean;
+    authorizers: Array<{ configured: boolean; allowed: boolean }>;
+  }) => boolean;
+}) {
+  const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async ({ dispatcherOptions, ctx }) => {
+    await dispatcherOptions.typingCallbacks?.onReplyStart?.();
+    if (params.replyPayload) {
+      await dispatcherOptions.deliver(params.replyPayload);
+    }
+    return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 }, ctx };
+  });
+  const resolveCommandAuthorizedFromAuthorizers = vi.fn(
+    (input: {
+      useAccessGroups: boolean;
+      authorizers: Array<{ configured: boolean; allowed: boolean }>;
+    }) => {
+      if (params.resolveCommandAuthorizedFromAuthorizers) {
+        return params.resolveCommandAuthorizedFromAuthorizers(input);
+      }
+      return params.commandAuthorized ?? false;
+    },
+  );
+  const resolveAgentRoute = vi.fn(
+    (input: { dmScope?: string; peer?: { kind?: string; id?: string } }) => {
+      const peerKind = input.peer?.kind === "direct" ? "direct" : "group";
+      const peerId = input.peer?.id ?? "1";
+      return {
+        agentId: "main",
+        sessionKey:
+          peerKind === "direct" && input.dmScope === "main"
+            ? "agent:main:main"
+            : `agent:main:zalouser:${peerKind}:${peerId}`,
+        accountId: "default",
+        mainSessionKey: "agent:main:main",
+      };
+    },
+  );
+  const readAllowFromStore = vi.fn(async () => []);
+  type TurnPlan = Parameters<PluginRuntime["channel"]["inbound"]["dispatch"]>[0];
+  const recordInboundSession = vi.fn(async (_params: unknown) => {});
+  const dispatch = vi.fn(async (plan: TurnPlan) => {
+    const turn = {
+      ...plan,
+      agentId: plan.route.agentId,
+      routeSessionKey: plan.route.sessionKey,
+      storePath: "/tmp",
+      recordInboundSession,
+      dispatchReplyWithBufferedBlockDispatcher,
+    };
+    await turn.recordInboundSession({
+      storePath: turn.storePath,
+      sessionKey: turn.ctxPayload.SessionKey ?? turn.routeSessionKey,
+      ctx: turn.ctxPayload,
+      groupResolution: turn.record?.groupResolution,
+      createIfMissing: turn.record?.createIfMissing,
+      updateLastRoute: turn.record?.updateLastRoute,
+      onRecordError: turn.record?.onRecordError ?? (() => undefined),
+    });
+    const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
+      cfg: turn.cfg,
+      agentId: turn.agentId,
+      channel: "zalouser",
+      accountId: turn.accountId,
+      ...turn.replyPipeline,
+    });
+    const dispatchResult = await turn.dispatchReplyWithBufferedBlockDispatcher({
+      ctx: turn.ctxPayload,
+      cfg: turn.cfg,
+      dispatcherOptions: {
+        ...replyPipeline,
+        ...turn.dispatcherOptions,
+        deliver: async (...args: Parameters<typeof turn.delivery.deliver>) => {
+          const result = await turn.delivery.deliver(...args);
+          await turn.delivery.onDelivered?.(args[0], args[1], result);
+          return result;
+        },
+        onError: turn.delivery.onError,
+      },
+      replyOptions: {
+        onModelSelected,
+        ...turn.replyOptions,
+      },
+      replyResolver: turn.replyResolver,
+    });
+    return {
+      admission: { kind: "dispatch" as const },
+      dispatched: true,
+      ctxPayload: turn.ctxPayload,
+      routeSessionKey: turn.routeSessionKey,
+      dispatchResult,
+    };
+  });
+  const buildContext = vi.fn(
+    (paramsLocal: Parameters<PluginRuntime["channel"]["inbound"]["buildContext"]>[0]) =>
+      ({
+        Body: paramsLocal.message.body ?? paramsLocal.message.rawBody,
+        BodyForAgent: paramsLocal.message.bodyForAgent ?? paramsLocal.message.rawBody,
+        InboundHistory: paramsLocal.message.inboundHistory,
+        RawBody: paramsLocal.message.rawBody,
+        CommandBody: paramsLocal.message.commandBody ?? paramsLocal.message.rawBody,
+        BodyForCommands: paramsLocal.message.commandBody ?? paramsLocal.message.rawBody,
+        From: paramsLocal.from,
+        To: paramsLocal.reply.to,
+        SessionKey: paramsLocal.route.dispatchSessionKey ?? paramsLocal.route.routeSessionKey,
+        AccountId: paramsLocal.route.accountId ?? paramsLocal.accountId,
+        ChatType: paramsLocal.conversation.kind,
+        ConversationLabel: paramsLocal.conversation.label,
+        SenderName: paramsLocal.sender.name,
+        SenderId: paramsLocal.sender.id,
+        Provider: paramsLocal.provider ?? paramsLocal.channel,
+        Surface: paramsLocal.surface ?? paramsLocal.provider ?? paramsLocal.channel,
+        MessageSid: paramsLocal.messageId,
+        MessageSidFull: paramsLocal.messageIdFull,
+        OriginatingChannel: paramsLocal.channel,
+        OriginatingTo: paramsLocal.reply.originatingTo,
+        ...paramsLocal.extra,
+      }) as Awaited<ReturnType<PluginRuntime["channel"]["inbound"]["buildContext"]>>,
+  );
+  setZalouserRuntime({
+    logging: {
+      shouldLogVerbose: () => false,
+    },
+    channel: {
+      pairing: {
+        readAllowFromStore,
+        upsertPairingRequest: vi.fn(async () => ({ code: "PAIR", created: true })),
+        buildPairingReply: vi.fn(() => "pair"),
+      },
+      commands: {
+        shouldComputeCommandAuthorized: vi.fn((body: string) => body.trim().startsWith("/")),
+        resolveCommandAuthorizedFromAuthorizers,
+        isControlCommandMessage: vi.fn((body: string) => body.trim().startsWith("/")),
+        shouldHandleTextCommands: vi.fn(() => true),
+      },
+      mentions: {
+        buildMentionRegexes: vi.fn(() => []),
+        matchesMentionWithExplicit: vi.fn(
+          (input) => input.explicit?.isExplicitlyMentioned === true,
+        ),
+      },
+      groups: {
+        resolveRequireMention: vi.fn((input) => {
+          const cfg = input.cfg as OpenClawConfig;
+          const groupCfg = cfg.channels?.zalouser?.groups ?? {};
+          const typedGroupCfg = groupCfg as Record<string, { requireMention?: boolean }>;
+          const groupEntry = input.groupId ? typedGroupCfg[input.groupId] : undefined;
+          const defaultEntry = typedGroupCfg["*"];
+          if (typeof groupEntry?.requireMention === "boolean") {
+            return groupEntry.requireMention;
+          }
+          if (typeof defaultEntry?.requireMention === "boolean") {
+            return defaultEntry.requireMention;
+          }
+          return true;
+        }),
+      },
+      routing: {
+        resolveAgentRoute,
+      },
+      session: {
+        resolveStorePath: vi.fn(() => "/tmp"),
+        recordInboundSession,
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: vi.fn(() => undefined),
+        formatAgentEnvelope: vi.fn(({ body }) => body),
+        finalizeInboundContext: vi.fn((ctx) => ctx),
+        dispatchReplyWithBufferedBlockDispatcher,
+      },
+      inbound: {
+        dispatch,
+        buildContext:
+          buildContext as unknown as PluginRuntime["channel"]["inbound"]["buildContext"],
+      },
+      text: {
+        resolveMarkdownTableMode: vi.fn(() => "code"),
+        convertMarkdownTables: vi.fn((text: string) => text),
+        resolveChunkMode: vi.fn(() => "length"),
+        resolveTextChunkLimit: vi.fn(() => 1200),
+        chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+      },
+    },
+  } as unknown as PluginRuntime);
+
+  return {
+    dispatchReplyWithBufferedBlockDispatcher,
+    resolveAgentRoute,
+    resolveCommandAuthorizedFromAuthorizers,
+    readAllowFromStore,
+  };
+}
+
+async function processMessageThroughMonitor(params: {
+  message?: ZaloInboundMessage;
+  messages?: ZaloInboundMessage[];
+  account: ResolvedZalouserAccount;
+  config: OpenClawConfig;
+  runtime: ReturnType<typeof createZalouserRuntimeEnv>;
+  historyState?: { historyLimit?: number };
+  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+}): Promise<void> {
+  const messages = params.messages ?? (params.message ? [params.message] : []);
+  const account = params.historyState?.historyLimit
+    ? {
+        ...params.account,
+        config: { ...params.account.config, historyLimit: params.historyState.historyLimit },
+      }
+    : params.account;
+  await withZalouserIngressTestQueue(async (ingressQueue) => {
+    const abortController = new AbortController();
+    let resolveProcessed: (() => void) | undefined;
+    const processed = new Promise<void>((resolve) => {
+      resolveProcessed = resolve;
+    });
+    startZaloListenerMock.mockImplementationOnce(async (listenerParams) => {
+      for (const message of messages) {
+        await listenerParams.onMessage(createRawZalouserMessageFromNormalized(message));
+        if (!message.msgId) {
+          throw new Error("Zalouser monitor test message requires msgId");
+        }
+        await waitForZalouserIngressVerdict(ingressQueue, message.msgId, "completed");
+      }
+      resolveProcessed?.();
+      return { stop: vi.fn() };
+    });
+    const run = monitorZalouserProvider({
+      account,
+      config: params.config,
+      runtime: params.runtime,
+      abortSignal: abortController.signal,
+      statusSink: params.statusSink,
+      ingressQueue,
+    });
+    await processed;
+    abortController.abort();
+    await run;
+  });
+}
+
+function createDmMessage(overrides: Partial<ZaloInboundMessage> = {}): ZaloInboundMessage {
+  return {
+    threadId: "u-1",
+    isGroup: false,
+    senderId: "321",
+    senderName: "Bob",
+    groupName: undefined,
+    content: "hello",
+    timestampMs: Date.now(),
+    msgId: "dm-1",
+    raw: { source: "test" },
+    ...overrides,
+  };
+}
+
+describe("zalouser monitor messagePrefix", () => {
+  it("prefixes agent body with account messagePrefix on DM ingress", async () => {
+    const { dispatchReplyWithBufferedBlockDispatcher } = installRuntime({
+      commandAuthorized: false,
+    });
+    await processMessageThroughMonitor({
+      message: createDmMessage({ content: "hello", msgId: "dm-prefix-1" }),
+      account: {
+        ...createAccount(),
+        config: {
+          ...createAccount().config,
+          messagePrefix: "[acct]",
+          dmPolicy: "open",
+        },
+      },
+      config: {
+        ...createConfig(),
+        messages: { responsePrefix: "[global]" },
+      },
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    const call = dispatchReplyCall(dispatchReplyWithBufferedBlockDispatcher);
+    // Production monitor sets bodyForAgent to prefix + raw body.
+    expect(call?.ctx?.BodyForAgent).toBe("[acct] hello");
+    expect(call?.ctx?.Body ?? "").toContain("[acct] hello");
+  });
+
+  it("honors explicit empty account messagePrefix without inventing a prefix", async () => {
+    const { dispatchReplyWithBufferedBlockDispatcher } = installRuntime({
+      commandAuthorized: false,
+    });
+    await processMessageThroughMonitor({
+      message: createDmMessage({ content: "hello", msgId: "dm-prefix-empty" }),
+      account: {
+        ...createAccount(),
+        config: {
+          ...createAccount().config,
+          messagePrefix: "",
+          // Outbound-only; must not appear on inbound BodyForAgent.
+          responsePrefix: "[outbound]",
+          dmPolicy: "open",
+        },
+      },
+      config: createConfig(),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    const call = dispatchReplyCall(dispatchReplyWithBufferedBlockDispatcher);
+    expect(call?.ctx?.BodyForAgent).toBe("hello");
+    expect(call?.ctx?.BodyForAgent).not.toContain("[outbound]");
+  });
+});

--- a/extensions/zalouser/src/monitor.message-prefix.test.ts
+++ b/extensions/zalouser/src/monitor.message-prefix.test.ts
@@ -1,4 +1,5 @@
 // Zalouser tests: inbound account messagePrefix on agent body (DM path).
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-outbound";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
@@ -285,7 +286,7 @@ async function processMessageThroughMonitor(params: {
   config: OpenClawConfig;
   runtime: ReturnType<typeof createZalouserRuntimeEnv>;
   historyState?: { historyLimit?: number };
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
 }): Promise<void> {
   const messages = params.messages ?? (params.message ? [params.message] : []);
   const account = params.historyState?.historyLimit

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -550,11 +550,15 @@ async function processMessage(
 
   const fromLabel = isGroup ? groupName || `group:${chatId}` : senderName || `user:${senderId}`;
   const buildEnvelope = createChannelInboundEnvelopeBuilder({ cfg: config, route });
+  // Inbound agent body uses messagePrefix only. responsePrefix is outbound-only.
+  // Explicit empty string still wins via ?? so it does not fall through.
+  const messagePrefix = account.config.messagePrefix ?? "";
+  const bodyForPrefix = messagePrefix ? `${messagePrefix} ${rawBody}` : rawBody;
   const body = buildEnvelope({
     channel: "Zalo Personal",
     from: fromLabel,
     timestamp: message.timestampMs,
-    body: rawBody,
+    body: bodyForPrefix,
   });
   const combinedBody =
     isGroup && historyKey
@@ -618,7 +622,7 @@ async function processMessage(
     },
     message: {
       body: combinedBody,
-      bodyForAgent: rawBody,
+      bodyForAgent: bodyForPrefix,
       rawBody,
       commandBody,
       inboundHistory,


### PR DESCRIPTION
## What Problem This Solves

Operators can set a per-account inbound `messagePrefix` on Zalouser. Before this change, Zalouser never applied that field to the agent-facing inbound body (`bodyForAgent` stayed raw), so multi-account Zalo setups could not tag inbound agent text by account.

WhatsApp account precedence is already owned by the monitor config snapshot (`resolveWebMonitorConfigSnapshot` pins `channels.whatsapp.responsePrefix` to the selected account). Config consolidation in #111527 retired the old WhatsApp `messagePrefix` inputs. This replay does not retouch WhatsApp.

`responsePrefix` remains outbound-only on Zalouser. Inbound uses `messagePrefix` only.

## Evidence

Exact-head production contract on `cee5d4b575e` (macOS arm64, Node v26.5.1). Exercised the same prefix shaping Zalouser `monitor.ts` applies for `bodyForAgent`.

```console
$ node (production monitor.ts contract)

=== Zalouser production prefix shaping ===
{"messagePrefix":"[acct]","responsePrefix":"[outbound]","rawBody":"hello"}
  => {"bodyForAgent":"[acct] hello","rawBody":"hello","outboundOnly":"[outbound]"}
{"messagePrefix":"","responsePrefix":"[outbound]","rawBody":"hello"}
  => {"bodyForAgent":"hello","rawBody":"hello","outboundOnly":"[outbound]"}
{"messagePrefix":"[ch]","rawBody":"ping"}
  => {"bodyForAgent":"[ch] ping","rawBody":"ping"}

=== source lines (extensions/zalouser/src/monitor.ts) ===
const messagePrefix = account.config.messagePrefix ?? "";
const bodyForPrefix = messagePrefix ? `${messagePrefix} ${rawBody}` : rawBody;
bodyForAgent: bodyForPrefix,
```

Focused tests:

```console
$ node scripts/run-vitest.mjs extensions/zalouser/src/monitor.message-prefix.test.ts
 ✓ |extension-zalo| extensions/zalouser/src/monitor.message-prefix.test.ts (2 tests) 360ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

## Real behavior proof

- **Behavior or issue addressed:** Zalouser inbound `bodyForAgent` must honor account `messagePrefix` (not outbound `responsePrefix`). WhatsApp prefix ownership stays on the monitor snapshot after #111527.
- **Real environment tested:** macOS arm64, Node v26.5.1, OpenClaw worktree `/tmp/oc-104394-relit` at head `cee5d4b575e`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/oc-104394-relit
  node scripts/run-vitest.mjs extensions/zalouser/src/monitor.message-prefix.test.ts
  ```

- **Evidence after fix:** terminal output above. Account `messagePrefix` appears on agent body; outbound-only `responsePrefix` does not. Explicit empty `messagePrefix` keeps the raw body.
- **Observed result after fix:** Inbound agent text is tagged by account messagePrefix on the Zalouser production path. WhatsApp remains snapshot-owned and is not changed in this replay.
- **What was not tested:** Live Zalo cloud session with a real multi-account phone (no linked device in this environment). No ephemeral gateway harness run in this pass.

## Summary

- Zalouser: apply account `messagePrefix` to inbound agent body
- WhatsApp: already handled by config consolidation / monitor snapshot; not retouched

## Related

Refs Zalouser multi-account prefix configuration. Original issue #102937 was closed as completed for the WhatsApp/global `resolveMessagePrefix` surface after #111527. This remaining Zalouser inbound gap is still present on current main.
