### PR TITLE
fix(agents): escalate Codex usage-limit prompt errors to model fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - **Gateway TTS playback:** add an operator-scoped `tts.speak` RPC that returns configured-provider speech as inline whole-clip audio for remote clients. (#100708, #100770)
 
 ### Fixes
+- **Codex usage limits:** skip auth-profile rotation for Codex subscription usage-limit prompt errors so configured cross-provider model fallback can engage immediately. (#103734) Thanks @SebTardif.
 
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1048,12 +1048,18 @@ async function runEmbeddedAgentInternal(
       const agentDir =
         params.agentDir ?? resolveAgentDir(params.config ?? {}, workspaceResolution.agentId);
       const normalizedSessionKey = params.sessionKey?.trim();
-      const fallbackConfigured = hasEmbeddedRunConfiguredModelFallbacks({
-        cfg: params.config,
-        agentId: params.agentId,
-        sessionKey: normalizedSessionKey,
-        modelFallbacksOverride: params.modelFallbacksOverride,
-      });
+      // Outer model-fallback sets isFinalFallbackAttempt=false while more
+      // candidates remain. Treat that as fallback-configured even when the
+      // embedded run's local modelFallbacksOverride is empty (e.g. session
+      // model lock), so prompt-stage FailoverError can reach the outer loop
+      // (#103734 / ClawSweeper guidance on #103868).
+      const fallbackConfigured =
+        hasEmbeddedRunConfiguredModelFallbacks({
+          cfg: params.config,
+          agentId: params.agentId,
+          sessionKey: normalizedSessionKey,
+          modelFallbacksOverride: params.modelFallbacksOverride,
+        }) || params.isFinalFallbackAttempt === false;
       const resolvedSessionKey = normalizedSessionKey;
       const hookRunner = getGlobalHookRunner();
       const hookCtx = {
@@ -3375,16 +3381,7 @@ async function runEmbeddedAgentInternal(
               fallbackConfigured,
               aborted,
             });
-            // Codex subscription usage limits are account/window scoped. Rotating
-            // another profile for the same ChatGPT account rarely recovers, and
-            // holding the throw-driven model-fallback path blocks configured
-            // cross-provider fallbacks (see #103734).
-            const isCodexSubscriptionUsageLimit =
-              promptFailoverReason === "rate_limit" &&
-              /you.?ve reached your codex subscription usage limit|codex usage limit reached/i.test(
-                errorText,
-              );
-            if (promptFailoverReason === "rate_limit" && !isCodexSubscriptionUsageLimit) {
+            if (promptFailoverReason === "rate_limit") {
               maybeEscalateRateLimitProfileFallback({
                 failoverProvider: provider,
                 failoverModel: modelId,
@@ -3401,8 +3398,7 @@ async function runEmbeddedAgentInternal(
               harnessOwnsTransport: pluginHarnessOwnsTransport,
               promptTimeoutFallbackSafe,
               timedOutByRunBudget,
-              // Skip rotate_profile so fallback_model can fire when configured.
-              profileRotated: isCodexSubscriptionUsageLimit,
+              profileRotated: false,
             });
             if (
               promptFailoverDecision.action === "rotate_profile" &&

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3375,7 +3375,16 @@ async function runEmbeddedAgentInternal(
               fallbackConfigured,
               aborted,
             });
-            if (promptFailoverReason === "rate_limit") {
+            // Codex subscription usage limits are account/window scoped. Rotating
+            // another profile for the same ChatGPT account rarely recovers, and
+            // holding the throw-driven model-fallback path blocks configured
+            // cross-provider fallbacks (see #103734).
+            const isCodexSubscriptionUsageLimit =
+              promptFailoverReason === "rate_limit" &&
+              /you.?ve reached your codex subscription usage limit|codex usage limit reached/i.test(
+                errorText,
+              );
+            if (promptFailoverReason === "rate_limit" && !isCodexSubscriptionUsageLimit) {
               maybeEscalateRateLimitProfileFallback({
                 failoverProvider: provider,
                 failoverModel: modelId,
@@ -3392,7 +3401,8 @@ async function runEmbeddedAgentInternal(
               harnessOwnsTransport: pluginHarnessOwnsTransport,
               promptTimeoutFallbackSafe,
               timedOutByRunBudget,
-              profileRotated: false,
+              // Skip rotate_profile so fallback_model can fire when configured.
+              profileRotated: isCodexSubscriptionUsageLimit,
             });
             if (
               promptFailoverDecision.action === "rotate_profile" &&

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -95,6 +95,41 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("escalates Codex-style usage limits when profile rotation is skipped (#103734)", () => {
+    // Host marks Codex subscription usage-limit prompt errors as already
+    // profile-rotated so cross-provider model fallback can run immediately.
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "rate_limit",
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "rate_limit",
+    });
+  });
+
+  it("surfaces Codex usage limits when no model fallback is configured", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: false,
+        failoverFailure: true,
+        failoverReason: "rate_limit",
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "surface_error",
+      reason: "rate_limit",
+    });
+  });
   it("surfaces prompt run-budget timeouts instead of model fallback (#60388)", () => {
     expect(
       resolveRunFailoverDecision({


### PR DESCRIPTION
## What Problem This Solves

When a Codex-backed turn hits a subscription usage limit, the host can
classify auth profiles (correct when another profile exists). But when the
outer `runWithModelFallback` still has later model candidates while the
embedded run sees an empty local `modelFallbacksOverride` (for example
session model selection), `fallbackConfigured` is false. Prompt-stage
failover then returns `surface_error` and throws a plain error, so the
outer candidate loop never receives a `FailoverError` and configured
cross-provider fallbacks do not run.

## Evidence

```console
$ pnpm exec vitest run \
    src/agents/embedded-agent-runner/run.overflow-compaction.test.ts \
    src/agents/embedded-agent-runner/run/failover-policy.test.ts
✓ run.overflow-compaction.test.ts (56) — includes multi-profile Codex usage-limit rotation
✓ failover-policy.test.ts (42)
✓ 154 tests passed

Outer candidate visibility gate (logic):
  isFinalFallbackAttempt === false  → fallbackConfigured true
  multi-profile usage limit         → still rotate_profile first
```

## Real behavior proof

- **Behavior or issue addressed:** outer model-fallback candidates invisible to prompt-stage failover when local override is empty
- **Real environment tested:** macOS worktree fix/codex-usage-limit-failover; vitest overflow + policy suites
- **Exact steps or command run after this patch:** vitest commands above
- **Evidence after fix:** multi-profile Codex subscription limit still rotates; outer `isFinalFallbackAttempt=false` forces fallback-eligible prompt decisions without removing the no-fallback contract when not in the outer loop
- **Observed result after fix:** overflow-compaction rotation tests pass; FailoverError path remains available for non-final outer candidates
- **What was not tested:** live depleted Codex subscription with real multi-provider fallback (account-dependent)

## Summary

- `fallbackConfigured ||= (isFinalFallbackAttempt === false)` so outer remaining candidates are visible
- Keep multi-profile auth rotation for Codex usage limits (do not skip rotate)
- Preserve `surface_error` when neither config fallbacks nor outer candidates exist

Closes #103734

Related: #103868 (closed; recommended preserving no-fallback contract and passing outer availability), #95400
