### PR TITLE
fix(gateway): track cron settlement recovery during suspend

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -3979,8 +3979,10 @@ describe("gateway agent handler", () => {
 
   it("stops continuation release recovery after gateway generation rotation", async () => {
     vi.useFakeTimers();
+    resetGatewayWorkAdmission();
     try {
       const { sessionKey, store } = setupCronContinuationReleaseFixture();
+      const context = makeContext();
       let releaseAttempts = 0;
       mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
         if (store[sessionKey].cronRunContinuation?.phase === "continuing") {
@@ -4001,11 +4003,20 @@ describe("gateway agent handler", () => {
         {
           reqId: "cron-media-release-rotates",
           client: cronContinuationGatewayClient(),
+          context,
           flushDispatch: false,
         },
       );
       await vi.advanceTimersByTimeAsync(10);
       expect(releaseAttempts).toBe(3);
+      const busyPrepare = await invokeGatewaySuspendPrepare(context, "cron-media-release-rotating");
+      expect(busyPrepare).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          status: "busy",
+          blockers: expect.arrayContaining([expect.objectContaining({ kind: "root-request" })]),
+        }),
+      );
 
       mocks.lifecycleGeneration = "post-restart-generation";
       await vi.advanceTimersByTimeAsync(250);
@@ -4015,7 +4026,21 @@ describe("gateway agent handler", () => {
         phase: "continuing",
         ownerRunId: "cron-media-release-rotates",
       });
+      const readyPrepare = await invokeGatewaySuspendPrepare(
+        context,
+        "cron-media-release-rotation-complete",
+      );
+      const readyPayload = readyPrepare.mock.calls.at(-1)?.[1] as
+        | { status?: string; suspensionId?: string }
+        | undefined;
+      expect(readyPayload).toMatchObject({ status: "ready" });
+      expect(resumeGatewaySuspend(readyPayload?.suspensionId ?? "missing")).toMatchObject({
+        ok: true,
+        status: "running",
+      });
     } finally {
+      resetGatewaySuspendCoordinatorForTest();
+      resetGatewayWorkAdmission();
       vi.useRealTimers();
     }
   });

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -28,6 +28,11 @@ import {
   type DiagnosticEventPayload,
 } from "../../infra/diagnostic-events.js";
 import {
+  resetGatewaySuspendCoordinatorForTest,
+  resumeGatewaySuspend,
+} from "../../infra/gateway-suspend-coordinator.js";
+import { resetGatewayWorkAdmission } from "../../process/gateway-work-admission.js";
+import {
   interruptSessionWorkAdmissions,
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
@@ -49,6 +54,7 @@ import { setGatewayDedupeEntry } from "./agent-job.js";
 import { agentHandlers } from "./agent.js";
 import { chatHandlers } from "./chat.js";
 import { expectSubagentFollowupReactivation } from "./subagent-followup.test-helpers.js";
+import { suspendHandlers } from "./suspend.js";
 import type { GatewayRequestContext } from "./types.js";
 
 const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
@@ -223,6 +229,7 @@ vi.mock("../../infra/agent-events.js", () => ({
   clearAgentRunContext: mocks.clearAgentRunContext,
   emitAgentEvent: mocks.emitAgentEvent,
   getAgentEventLifecycleGeneration: () => mocks.lifecycleGeneration,
+  getAgentRunContext: vi.fn(() => undefined),
   registerAgentRunContext: mocks.registerAgentRunContext,
   onAgentEvent: vi.fn(),
 }));
@@ -612,6 +619,26 @@ function setupCronContinuationReleaseFixture() {
     sessionKey,
     store: { [sessionKey]: structuredClone(entry) } as Record<string, SessionEntry>,
   };
+}
+
+async function invokeGatewaySuspendPrepare(context: GatewayRequestContext, requestId: string) {
+  const respond = vi.fn();
+  await suspendHandlers["gateway.suspend.prepare"]({
+    params: { requestId },
+    respond: respond as never,
+    context: {
+      ...context,
+      cron: {
+        pauseScheduling: vi.fn(),
+        resumeScheduling: vi.fn(),
+        getSuspensionBlockerCount: () => 0,
+      },
+    } as unknown as GatewayRequestContext,
+    req: { type: "req", id: requestId, method: "gateway.suspend.prepare" },
+    client: null,
+    isWebchatConnect: () => false,
+  });
+  return respond;
 }
 
 // Operator-write client that is NOT the in-process backend ACP spawn caller:
@@ -3784,6 +3811,7 @@ describe("gateway agent handler", () => {
 
   it("recovers a continuation release after reporting a durable write failure", async () => {
     vi.useFakeTimers();
+    resetGatewayWorkAdmission();
     try {
       mocks.agentCommand.mockClear();
       const { sessionKey, store } = setupCronContinuationReleaseFixture();
@@ -3828,6 +3856,15 @@ describe("gateway agent handler", () => {
         expect.objectContaining({ code: ErrorCodes.UNAVAILABLE }),
         expect.objectContaining({ runId: "cron-media-release-fails" }),
       );
+      const busyPrepare = await invokeGatewaySuspendPrepare(context, "cron-media-release-backoff");
+      expect(busyPrepare).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          status: "busy",
+          reason: "active-work",
+          blockers: expect.arrayContaining([expect.objectContaining({ kind: "root-request" })]),
+        }),
+      );
 
       await vi.advanceTimersByTimeAsync(250);
 
@@ -3836,6 +3873,18 @@ describe("gateway agent handler", () => {
         lifecycleRevision: "revision-1",
         phase: "ready",
         basePersisted: true,
+      });
+      const readyPrepare = await invokeGatewaySuspendPrepare(
+        context,
+        "cron-media-release-recovered",
+      );
+      const readyPayload = readyPrepare.mock.calls.at(-1)?.[1] as
+        | { status?: string; suspensionId?: string }
+        | undefined;
+      expect(readyPayload).toMatchObject({ status: "ready" });
+      expect(resumeGatewaySuspend(readyPayload?.suspensionId ?? "missing")).toMatchObject({
+        ok: true,
+        status: "running",
       });
       const retryRespond = await invokeAgent(request, {
         reqId: "cron-media-release-retry",
@@ -3850,6 +3899,80 @@ describe("gateway agent handler", () => {
       );
       expect(mocks.agentCommand).toHaveBeenCalledOnce();
     } finally {
+      resetGatewaySuspendCoordinatorForTest();
+      resetGatewayWorkAdmission();
+      vi.useRealTimers();
+    }
+  });
+
+  it("releases suspension admission after continuation recovery exhausts", async () => {
+    vi.useFakeTimers();
+    resetGatewayWorkAdmission();
+    try {
+      const { sessionKey, store } = setupCronContinuationReleaseFixture();
+      const context = makeContext();
+      let releaseAttempts = 0;
+      mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+        if (store[sessionKey].cronRunContinuation?.phase === "continuing") {
+          releaseAttempts += 1;
+          throw new Error("disk unavailable");
+        }
+        return await updater(store);
+      });
+      mocks.agentCommand.mockResolvedValue({ payloads: [{ text: "continued" }], meta: {} });
+
+      await invokeAgent(
+        {
+          message: "media completion",
+          sessionKey,
+          internalEvents: [cronMediaCompletionEvent()],
+          idempotencyKey: "cron-media-release-exhausts",
+        },
+        {
+          reqId: "cron-media-release-exhausts",
+          client: cronContinuationGatewayClient(),
+          context,
+          flushDispatch: false,
+        },
+      );
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(releaseAttempts).toBe(3);
+      const busyPrepare = await invokeGatewaySuspendPrepare(
+        context,
+        "cron-media-release-exhaustion-backoff",
+      );
+      expect(busyPrepare).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          status: "busy",
+          blockers: expect.arrayContaining([expect.objectContaining({ kind: "root-request" })]),
+        }),
+      );
+
+      for (const delayMs of [250, 1_000, 4_000, 15_000]) {
+        await vi.advanceTimersByTimeAsync(delayMs);
+      }
+
+      expect(releaseAttempts).toBe(15);
+      expect(context.logGateway.warn).toHaveBeenCalledWith(
+        "cron continuation release recovery exhausted for cron-media-release-exhausts",
+      );
+      const readyPrepare = await invokeGatewaySuspendPrepare(
+        context,
+        "cron-media-release-exhausted",
+      );
+      const readyPayload = readyPrepare.mock.calls.at(-1)?.[1] as
+        | { status?: string; suspensionId?: string }
+        | undefined;
+      expect(readyPayload).toMatchObject({ status: "ready" });
+      expect(resumeGatewaySuspend(readyPayload?.suspensionId ?? "missing")).toMatchObject({
+        ok: true,
+        status: "running",
+      });
+    } finally {
+      resetGatewaySuspendCoordinatorForTest();
+      resetGatewayWorkAdmission();
       vi.useRealTimers();
     }
   });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -116,7 +116,10 @@ import {
 } from "../../infra/voicewake-routing.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { PluginHookSessionEndReason } from "../../plugins/hook-types.js";
-import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
+import {
+  retainGatewayRootWorkAdmissionContinuation,
+  runWithGatewayIndependentRootWorkContinuation,
+} from "../../process/gateway-work-admission.js";
 import {
   classifySessionKeyShape,
   isAcpSessionKey,
@@ -1962,9 +1965,9 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
       cronContinuationReleaseRecoveryScheduled = true;
       const ownerLifecycleGeneration = lifecycleGeneration;
-      // Keep the failed settlement recoverable without retaining the process or
-      // transferring claim ownership beyond this request's gateway generation.
-      void (async () => {
+      // Settlement retries can still persist session and dedupe state. Reserve a
+      // detached root now so suspension cannot snapshot between retry attempts.
+      void runWithGatewayIndependentRootWorkContinuation(async () => {
         for (const delayMs of CRON_CONTINUATION_RELEASE_RECOVERY_DELAYS_MS) {
           await waitForCronContinuationReleaseRecovery(delayMs);
           if (
@@ -1985,7 +1988,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           }
         }
         context.logGateway.warn(`cron continuation release recovery exhausted for ${runId}`);
-      })();
+      });
     };
     const releaseCronContinuationClaimWithRecovery = async (
       outcome?: { terminalOutcome: AgentRunTerminalOutcome },


### PR DESCRIPTION
Fixes #104371

AI-assisted implementation; maintainer-reviewed and source-verified.

## What Problem This Solves

Fixes a lifecycle race where a delayed cron-continuation recovery retry could outlive the Gateway root that scheduled it. A scale-to-zero host could observe prepare readiness and suspend before the recovery attempt settled.

## Why This Change Was Made

The detached recovery lifecycle now owns independent Gateway root admission. Prepare remains busy while recovery is pending and the admission is released exactly once when recovery succeeds, exhausts retries, or is retired by lifecycle rotation.

This keeps continuation recovery at the existing Gateway owner boundary without adding a second scheduler or host-specific readiness policy.

## User Impact

Agent-requested cron continuations remain protected across suspend and restart preparation when their first scheduling attempt fails transiently.

## Evidence

- Regression holds the delayed recovery attempt and verifies prepare remains busy until it settles.
- Regression covers lifecycle rotation and retry exhaustion release paths.
- Blacksmith Testbox `tbx_01kx8b4kajgm704bts0f35241q`: 460 focused Gateway tests passed.
- Same exact head: Testbox `check:changed` passed.
- Fresh structured Codex autoreview: clean; no accepted or actionable findings.
