### PR TITLE
chore: update Peekaboo to 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **macOS Peekaboo:** update the embedded Peekaboo automation and bridge dependency to 3.9.0.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)
 - **Meta provider:** add bundled `muse-spark-1.1` model support with Responses API streaming, tool calls, encrypted reasoning replay, onboarding, and standalone npm/ClawHub distribution. (#102873) Thanks @HamidShojanazeri.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **macOS Peekaboo:** update the embedded Peekaboo automation and bridge dependency to 3.9.0.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)
 - **Meta provider:** add bundled `muse-spark-1.1` model support with Responses API streaming, tool calls, encrypted reasoning replay, onboarding, and standalone npm/ClawHub distribution. (#102873) Thanks @HamidShojanazeri.

--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/Peekaboo.git",
       "state" : {
-        "revision" : "1fa8eead7eeac3ff618a3111fc333ae78db043d2",
-        "version" : "3.5.2"
+        "revision" : "e3a2b3793fe4c4a6b4ccbc3069ccd9816516edb7",
+        "version" : "3.9.0"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.4.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
-        .package(url: "https://github.com/steipete/Peekaboo.git", exact: "3.5.2"),
+        .package(url: "https://github.com/steipete/Peekaboo.git", exact: "3.9.0"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),

--- a/apps/macos/Sources/OpenClaw/PeekabooBridgeHostCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/PeekabooBridgeHostCoordinator.swift
@@ -56,7 +56,8 @@ final class PeekabooBridgeHostCoordinator {
     private func startIfNeeded() async {
         guard self.host == nil else { return }
 
-        var allowlistedTeamIDs: Set = ["Y5PE65HELJ"]
+        // Peekaboo owns release-signer migrations; hosts must accept its current compatibility set.
+        var allowlistedTeamIDs = PeekabooBridgeConstants.trustedReleaseTeamIDs
         if let teamID = Self.currentTeamID() {
             allowlistedTeamIDs.insert(teamID)
         }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

OpenClaw's macOS app still embeds Peekaboo 3.5.2, so its in-process automation and bridge host miss the fixes and improvements released through Peekaboo 3.9.0.

## Why This Change Was Made

Update the exact SwiftPM dependency and resolved commit to the latest verified release, `v3.9.0` (`e3a2b3793fe4c4a6b4ccbc3069ccd9816516edb7`). The bridge host now seeds its caller allowlist from Peekaboo's dependency-owned trusted release TeamID set, preserving compatibility across Peekaboo's signing migration while still accepting the current OpenClaw app signer.

## User Impact

The macOS app will ship Peekaboo 3.9.0's current automation and bridge behavior instead of the older 3.5.2 implementation, and bridge clients signed by either supported Peekaboo release identity remain authorized.

## Evidence

- Upstream release: https://github.com/openclaw/Peekaboo/releases/tag/v3.9.0
- Confirmed the SwiftPM tag resolves to `e3a2b3793fe4c4a6b4ccbc3069ccd9816516edb7` and inspected the 3.9.0 package products plus OpenClaw-used bridge, server, host, automation-service, and release-signer trust contracts.
- Blacksmith Testbox through Crabbox `tbx_01kx8b6t17z5xjn764r8yc9yqf`: `corepack pnpm check:changed` passed the dependency pin guard and 174 routed macOS/package tests (37 skipped platform-specific cases).
- `git diff --check`
- Autoreview identified the stale local TeamID override; after adopting `PeekabooBridgeConstants.trustedReleaseTeamIDs`, the focused rerun and final autoreview are clean with no accepted/actionable findings (`codex`, `gpt-5.5`, high reasoning).
- Native Swift build, tests, and SwiftLint are delegated to the PR's macOS CI lane.
