### PR TITLE
fix(telegram): use IR chunker for outbound text to prevent mid-word splits

### DIFF
--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -10,7 +10,6 @@ import {
   attachChannelToResult,
   createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
-import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import {
   resolveSendableOutboundReplyParts,
   sendPayloadMediaSequenceOrFallback,
@@ -20,7 +19,7 @@ import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
-import { splitTelegramHtmlChunks } from "./format.js";
+import { markdownToTelegramChunks, splitTelegramHtmlChunks } from "./format.js";
 import {
   canonicalizeTelegramPresentationPayload,
   resolveTelegramInteractiveTextFallback,
@@ -55,9 +54,14 @@ function chunkTelegramOutboundText(
   limit: number,
   ctx?: { formatting?: OutboundDeliveryFormattingOptions },
 ): string[] {
-  return ctx?.formatting?.parseMode === "HTML"
-    ? splitTelegramHtmlChunks(text, limit)
-    : chunkMarkdownTextWithMode(text, limit, ctx?.formatting?.chunkMode ?? "length");
+  if (ctx?.formatting?.parseMode === "HTML") {
+    return splitTelegramHtmlChunks(text, limit);
+  }
+  // Use the IR chunker so split points account for HTML rendering length.
+  // Return markdown text (not HTML) so downstream renderers stay consistent.
+  return markdownToTelegramChunks(text, limit, {
+    tableMode: ctx?.formatting?.tableMode,
+  }).map((chunk) => chunk.text);
 }
 
 async function resolveTelegramSendContext(params: {


### PR DESCRIPTION
## What Problem This Solves

The Telegram outbound adapter chunked raw markdown at the 4000-char limit (Layer 1), then the transport re-chunked the rendered HTML at 4000 HTML units (Layer 2). Because HTML rendering inflates length (bold tags, autolinked URLs, entity escapes), a Layer-1 chunk packed close to 4000 raw chars could exceed 4000 after rendering, causing Layer 2 to hard-split mid-word with no word-boundary awareness (#104377).

This bypassed the existing IR chunk-before-render pipeline (`chunkMarkdownIR` / `renderMarkdownIRChunksWithinLimit`) that was designed to prevent exactly this class of bug.

## Why This Change Was Made

Replace `chunkMarkdownTextWithMode` (raw-text chunking) with `markdownToTelegramChunks` (IR-aware chunking) in the Telegram outbound adapter's chunker function. The IR chunker:

1. Parses markdown to an IR
2. Finds split points that keep the rendered HTML within the limit
3. Returns both the markdown source and rendered HTML for each chunk

We return only the markdown `text` from each chunk (not the HTML) so downstream renderers in `buildChunkedTextPlan` remain consistent — they still render markdown to HTML themselves. The key difference is that the split points are now chosen based on rendered length, not raw markdown length, so Layer 2 re-chunking becomes a no-op for correctly-sized chunks.

## User Impact

Long cron announce posts and other lengthy Telegram messages will no longer be split mid-word. Split boundaries will respect word/paragraph edges and account for HTML rendering inflation.

No change to messages that already fit within a single chunk.

## Evidence

- 50 Telegram chunk tests pass (`pnpm test extensions/telegram -- -t chunk`)
- 873 outbound tests pass (`pnpm test src/infra/outbound`)
- Type check passes (`pnpm tsgo`)
- The `markdownToTelegramChunks` function already existed in `format.ts` — we just wire it into the outbound adapter where it belongs

Fixes #104377

🤖 Generated with [Claude Code](https://claude.com/claude-code)