### PR TITLE
fix(telegram): mark durable webhook acceptance

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -718,7 +718,9 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     The local listener binds to `127.0.0.1:8787` by default. For public ingress, put a reverse proxy in front of the local port, or set `webhookHost: "0.0.0.0"` intentionally.
 
-    Webhook mode validates request guards, the Telegram secret token, and the JSON body before returning `200`. OpenClaw then processes the update asynchronously through the same per-chat/per-topic bot lanes used by long polling, so slow agent turns do not hold Telegram's delivery ACK.
+    Webhook mode validates request guards, the Telegram secret token, and the JSON body, then commits the update to its durable ingress queue before returning an empty `200`. Successful durable adoption includes `x-openclaw-delivery-accepted: durable`; health, routing, authentication, validation, and storage-error responses omit this header. Reverse proxies and host controllers can require the header to distinguish OpenClaw adoption from a generic empty `200` without inferring acceptance from response timing.
+
+    OpenClaw then processes the update asynchronously through the same per-chat/per-topic bot lanes used by long polling, so slow agent turns do not hold Telegram's delivery ACK.
 
   </Accordion>
 

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -556,6 +556,10 @@ describe("startTelegramWebhook", () => {
         expect(botParams.telegramTransport).toBeDefined();
         const health = await fetch(`http://127.0.0.1:${port}/healthz`);
         expect(health.status).toBe(200);
+        expect(health.headers.get("x-openclaw-delivery-accepted")).toBeNull();
+        const notFound = await fetch(`http://127.0.0.1:${port}/not-the-webhook`);
+        expect(notFound.status).toBe(404);
+        expect(notFound.headers.get("x-openclaw-delivery-accepted")).toBeNull();
         expect(initSpy).toHaveBeenCalledTimes(1);
         expect(setWebhookSpy).toHaveBeenCalled();
         expectMockMessageContains(runtimeLog, "webhook local listener on http://127.0.0.1:");
@@ -854,12 +858,74 @@ describe("startTelegramWebhook", () => {
         });
 
         expect(response.status).toBe(200);
+        expect(response.headers.get("x-openclaw-delivery-accepted")).toBe("durable");
         expect(await response.text()).toBe("");
         await vi.waitFor(() => expect(workStarted).toBe(true));
         expect(workFinished).toBe(false);
 
         finishWork?.();
         await vi.waitFor(() => expect(workFinished).toBe(true));
+      },
+    );
+  });
+
+  it("marks delivery accepted only after the durable enqueue commits", async () => {
+    let releaseEnqueue: (() => void) | undefined;
+    let markEnqueueStarted: (() => void) | undefined;
+    const enqueueGate = new Promise<void>((resolve) => {
+      releaseEnqueue = resolve;
+    });
+    const enqueueStarted = new Promise<void>((resolve) => {
+      markEnqueueStarted = resolve;
+    });
+    setTelegramRuntime({
+      state: {
+        resolveStateDir: () => webhookStateDir ?? os.tmpdir(),
+        openChannelIngressQueue: (
+          options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
+        ) => {
+          const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
+          return {
+            ...queue,
+            enqueue: async (...args: Parameters<typeof queue.enqueue>) => {
+              markEnqueueStarted?.();
+              await enqueueGate;
+              return await queue.enqueue(...args);
+            },
+          };
+        },
+      },
+    } as TelegramRuntime);
+
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        let responseSettled = false;
+        const responseTask = postWebhookJson({
+          url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+          payload: JSON.stringify({ update_id: 4, message: { text: "commit gate" } }),
+          secret: TELEGRAM_SECRET,
+        }).then((response) => {
+          responseSettled = true;
+          return response;
+        });
+
+        try {
+          await enqueueStarted;
+          await yieldWebhookTask();
+          expect(responseSettled).toBe(false);
+
+          releaseEnqueue?.();
+          const response = await responseTask;
+          expect(response.status).toBe(200);
+          expect(response.headers.get("x-openclaw-delivery-accepted")).toBe("durable");
+          expect(await response.text()).toBe("");
+        } finally {
+          releaseEnqueue?.();
+        }
       },
     );
   });
@@ -1286,6 +1352,7 @@ describe("startTelegramWebhook", () => {
         });
 
         expect(response.status).toBe(500);
+        expect(response.headers.get("x-openclaw-delivery-accepted")).toBeNull();
         expect(handleUpdateSpy).not.toHaveBeenCalled();
       },
     );
@@ -1332,11 +1399,13 @@ describe("startTelegramWebhook", () => {
 
           if (response.status === 429) {
             saw429 = true;
+            expect(response.headers.get("x-openclaw-delivery-accepted")).toBeNull();
             expect(await response.text()).toBe("Too Many Requests");
             break;
           }
 
           expect(response.status).toBe(401);
+          expect(response.headers.get("x-openclaw-delivery-accepted")).toBeNull();
           expect(await response.text()).toBe("unauthorized");
         }
 
@@ -1348,6 +1417,7 @@ describe("startTelegramWebhook", () => {
           secret: TELEGRAM_SECRET,
         });
         expect(validResponse.status).toBe(200);
+        expect(validResponse.headers.get("x-openclaw-delivery-accepted")).toBe("durable");
         expect(await validResponse.text()).toBe("");
         await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(1));
       },

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -72,6 +72,8 @@ import { createTelegramWebhookStatusPublisher } from "./webhook-status.js";
 
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+const TELEGRAM_WEBHOOK_ACCEPTED_HEADER = "x-openclaw-delivery-accepted";
+const TELEGRAM_WEBHOOK_ACCEPTED_VALUE = "durable";
 const TELEGRAM_WEBHOOK_SPOOLED_DRAIN_INTERVAL_MS = 500;
 const TELEGRAM_WEBHOOK_SPOOLED_CLAIM_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const TELEGRAM_WEBHOOK_SPOOLED_HANDLER_TIMEOUT_MS = 25 * 60_000;
@@ -948,6 +950,7 @@ export async function startTelegramWebhook(opts: {
       });
       // Enqueue duplicate detection makes Telegram webhook retries idempotent:
       // re-posted update_ids map to the same spool row and still ack fast.
+      res.setHeader(TELEGRAM_WEBHOOK_ACCEPTED_HEADER, TELEGRAM_WEBHOOK_ACCEPTED_VALUE);
       respondText(200);
       status.noteWebhookUpdateReceived();
       requestWebhookSpoolDrain();


### PR DESCRIPTION
Fixes #104372

AI-assisted implementation; maintainer-reviewed and source-verified.

## What Problem This Solves

Telegram webhook ingress already durably enqueues authenticated updates before returning success, but its HTTP response did not let a host controller distinguish that durable boundary from unrelated successful routes.

## Why This Change Was Made

Successful durable enqueue responses and durable duplicates now include `x-openclaw-delivery-accepted: durable`. The marker is emitted only after the SQLite enqueue resolves; health, route misses, authentication and rate-limit failures, and enqueue failures omit it.

The body remains empty and the status remains `2xx`, preserving Telegram's existing retry contract.

## User Impact

External ingress controllers can record exact durable Telegram acceptance without inferring it from HTTP status alone or overstating health-route success as delivery proof.

## Evidence

- Blacksmith Testbox `tbx_01kx8c1h08zwpgbf6tf8x7f2pv`: 35 webhook tests passed.
- Same exact head: Testbox `check:changed` passed.
- Source-blind full-Gateway HTTP validation passed acceptance, duplicate, health, route miss, wrong-secret, and invalid-update cases.
- Fresh structured Codex autoreview: clean; no accepted or actionable findings.
- Remaining live proof gap: real reverse-proxy header preservation requires approved Telegram test infrastructure.
