### PR TITLE
fix(mac): silence exec approval lock warning

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -1175,7 +1175,7 @@ private final class ExecApprovalsSocketLifecycleLease: @unchecked Sendable {
     }
 
     private static func releaseProcessReservation(_ path: String) {
-        self.processLock.withLock {
+        _ = self.processLock.withLock {
             self.reservedPaths.remove(path)
         }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes repeated Swift compiler warnings during macOS app builds after releasing an exec-approval socket path reservation.

## Why This Change Was Made

Explicitly discards the `Set.remove` result returned through `withLock`, preserving the existing reservation cleanup while satisfying Swift's unused-result check.

## User Impact

No user-visible behavior change. macOS builds stay warning-clean for this path.

## Evidence

- Live signed macOS rebuild on main emitted `result of call to 'withLock' is unused` repeatedly at `ExecApprovalsSocket.swift:1178`.
- `git diff --check` passes.
- The pull request's macOS Swift CI build is the authoritative compiler proof.
