### PR TITLE
fix(workboard): scope default positions by board

### DIFF
--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1976,6 +1976,8 @@ describe("WorkboardStore", () => {
 
     expect(repeatedOps.id).toBe(ops.id);
     expect(product.id).not.toBe(ops.id);
+    expect(ops.position).toBe(1000);
+    expect(product.position).toBe(1000);
     await expect(store.list({ boardId: "ops" })).resolves.toHaveLength(1);
     await expect(store.listBoards()).resolves.toMatchObject({
       boards: expect.arrayContaining([
@@ -1989,13 +1991,24 @@ describe("WorkboardStore", () => {
       byStatus: { todo: 1 },
     });
     const prototypeAgentId = ["__", "proto__"].join("");
-    await store.create({
+    const secondProduct = await store.create({
       title: "Prototype safe",
       boardId: "product",
       agentId: prototypeAgentId,
     });
+    expect(secondProduct.position).toBe(2000);
     const stats = await store.stats({ boardId: "product" });
     expect(stats.byAgent[prototypeAgentId]).toBe(1);
+    const metadataBoardFirst = await store.create({
+      title: "Metadata board first",
+      metadata: { automation: { boardId: "metadata-board" } },
+    });
+    const metadataBoardSecond = await store.create({
+      title: "Metadata board second",
+      metadata: { automation: { boardId: "metadata-board" } },
+    });
+    expect(metadataBoardFirst.position).toBe(1000);
+    expect(metadataBoardSecond.position).toBe(2000);
   });
 
   it("rejects completed manifests for cards not created from the parent", async () => {

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -2561,12 +2561,6 @@ export class WorkboardStore {
       automation,
     );
     const normalizedPosition = normalizePosition(input.position, Number.NaN);
-    const position = Number.isFinite(normalizedPosition)
-      ? normalizedPosition
-      : Math.max(
-          0,
-          ...cards.filter((card) => card.status === status).map((card) => card.position),
-        ) + POSITION_STEP;
     const notes = normalizeNotes(input.notes);
     const agentId = normalizeOptionalString(input.agentId);
     const sessionKey = normalizeOptionalString(input.sessionKey);
@@ -2601,6 +2595,15 @@ export class WorkboardStore {
     const syncedMetadata = trimMetadataToBudget(
       syncExecutionAttemptMetadata(metadata, execution, now),
     );
+    const boardId = syncedMetadata.automation?.boardId ?? "default";
+    const position = Number.isFinite(normalizedPosition)
+      ? normalizedPosition
+      : Math.max(
+          0,
+          ...cards
+            .filter((card) => card.status === status && cardBoardId(card) === boardId)
+            .map((card) => card.position),
+        ) + POSITION_STEP;
     let card: WorkboardCard = {
       id: randomUUID(),
       title: normalizeTitle(input.title),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating Workboard cards on separate boards could see the default card order on one board offset by cards that only exist on another board.

## Why This Change Was Made

Workboard create now allocates implicit card positions inside the final normalized board scope and status, including board ids supplied through either top-level create fields or metadata automation. Explicit positions, status ordering, idempotent create behavior, and board stats remain unchanged.

## User Impact

Workboard boards keep independent default card ordering, so the first todo card on each board starts at the expected position and later cards advance within that board only.

## Evidence

- Claim proved: default Workboard create positions are scoped by board for both top-level `boardId` and `metadata.automation.boardId` inputs.
- Current head: `6e7feec9444ed0deace2f508dbf2aa1dc1df1c57`.
- Real Workboard runtime proof: `node --import tsx --input-type=module -` with a repo-local transcript importing `createWorkboardTools`, `workboard_create`, `WorkboardStore.create`, and `createWorkboardSqliteStores`, then closing/reopening SQLite and reading back through `WorkboardStore.list`.

```json
{
  "head": "6e7feec9444ed0deace2f508dbf2aa1dc1df1c57",
  "proofPath": [
    "createWorkboardTools",
    "workboard_create",
    "WorkboardStore.create",
    "createWorkboardSqliteStores",
    "close/reopen SQLite",
    "WorkboardStore.list"
  ],
  "observed": {
    "toolCreates": [
      { "boardId": "ops", "title": "ops first", "status": "todo", "position": 1000 },
      { "boardId": "product", "title": "product first", "status": "todo", "position": 1000 },
      { "boardId": "product", "title": "product second", "status": "todo", "position": 2000 }
    ],
    "storeMetadataCreates": [
      { "boardId": "metadata-board", "title": "metadata first", "status": "todo", "position": 1000 },
      { "boardId": "metadata-board", "title": "metadata second", "status": "todo", "position": 2000 }
    ],
    "persistedAfterReopen": [
      { "boardId": "metadata-board", "title": "metadata first", "status": "todo", "position": 1000 },
      { "boardId": "metadata-board", "title": "metadata second", "status": "todo", "position": 2000 },
      { "boardId": "ops", "title": "ops first", "status": "todo", "position": 1000 },
      { "boardId": "product", "title": "product first", "status": "todo", "position": 1000 },
      { "boardId": "product", "title": "product second", "status": "todo", "position": 2000 }
    ]
  },
  "assertions": {
    "opsFirstStartsAt1000": true,
    "productFirstStartsAt1000": true,
    "productSecondAdvancesTo2000": true,
    "metadataFirstStartsAt1000": true,
    "metadataSecondAdvancesTo2000": true,
    "persistedAfterReopen": true
  },
  "ok": true
}
```

- Focused regression: `node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts -- --testNamePattern "scopes idempotent creates and stats by board"` passed with 1 test and 78 skipped on this head.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode local` passed with no accepted/actionable findings.