### PR TITLE
fix(ui): sidebar build chip collides with the connection status dot

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1781,8 +1781,9 @@ openclaw-session-menu[popover] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  /* 28px keeps the fixed-width footer row from ellipsizing "commit · age". */
+  width: 28px;
+  height: 28px;
   flex: 0 0 auto;
   border: none;
   border-radius: var(--radius-md);
@@ -1835,6 +1836,13 @@ openclaw-session-menu[popover] {
   height: 8px;
   border-radius: var(--radius-full);
   flex-shrink: 0;
+}
+
+/* The online/offline glow spreads 4px beyond the dot; the footer bar's 2px gap
+   alone lets it collide with the build text. 6px + gap matches the 8px dot
+   spacing in the settings sidebar footer. */
+.sidebar-footer-bar .sidebar-status__dot {
+  margin-right: 6px;
 }
 
 .sidebar-status__dot.sidebar-connection-status--online {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the sidebar footer's build chip (`commit · age`, e.g. `8917dac · 2m`) rendered nearly touching the connection status dot. The dot's online/offline glow ring spreads 4px beyond the dot while the footer bar only has a 2px flex gap, so the glow visually collided with the build text.

## Why This Change Was Made

The footer bar is a fully packed fixed-width row (258px sidebar), so simply adding margin next to the dot pushed the build text into its ellipsis and truncated the age (`0123456 · 2…`). The fix pairs the new spacing with a small reclaim on the icon side:

- `ui/src/styles/layout.css`: footer-scoped `margin-right: 6px` on `.sidebar-status__dot` (6px + 2px gap = 8px total, matching the settings sidebar footer's dot spacing).
- `.sidebar-footer-icon` hit-boxes go 30px → 28px, which still leaves 6px padding around the 16px glyphs and sits closer to the adjacent 26px theme toggle. This keeps `commit · age` fully visible.

## User Impact

The build chip in the sidebar footer is readable with clear separation from the status dot, and the full `commit · age` text still fits without ellipsizing. Footer icon buttons are 2px smaller; their glyphs are unchanged.

## Evidence

Verified in the mock Control UI harness (`pnpm dev:ui:mock`, 1280px desktop viewport), measuring `.sidebar-footer-build` via DOM:

- Before: dot-to-text gap 2px (glow overlapping text); chip clientWidth 79px for worst-case text `0123456 · 22h` (75px) — barely fit.
- Naive margin-only fix: clientWidth 71px → truncated.
- After this change: dot-to-text gap 8px, chip scrollWidth == clientWidth == 75px, `truncated: false`, screenshot-verified full `0123456 · 22h` rendering with right-aligned footer icons intact.
- `git diff --check` clean; autoreview (Codex, gpt-5.5) clean: "No actionable defects found in the scoped CSS change."

No other stylesheet overrides `.sidebar-footer-icon` / `.sidebar-status__dot` sizing (grepped `ui/src/styles/*.css`).
