### PR TITLE
fix(nodes): reject malformed media payloads when base64 is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
-- **Node media base64 validation:** reject malformed camera snaps, camera clips, and screen recordings before decoding or writing files while preserving valid whitespace and unpadded payloads. (#104414) Thanks @qingminglong.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.
 - **Gateway client watchdog:** keep transport-stall detection active for unbounded and mixed pending requests so dead sockets reject pending requests, reconnect, and never replay rejected requests. (#103407) Thanks @NianJiuZst.
 - **iOS Share Extension drafts:** preserve legitimate shared text beginning with scaffold-like prefixes, remove only exact legacy scaffold lines, avoid treating scheme-like prose as a URL, and deduplicate host-mirrored content. (#103453) Thanks @lin-hongkuan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
+- **Node media base64 validation:** reject malformed camera snaps, camera clips, and screen recordings before decoding or writing files while preserving valid whitespace and unpadded payloads. (#104414) Thanks @qingminglong.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.
 - **Gateway client watchdog:** keep transport-stall detection active for unbounded and mixed pending requests so dead sockets reject pending requests, reconnect, and never replay rejected requests. (#103407) Thanks @NianJiuZst.
 - **iOS Share Extension drafts:** preserve legitimate shared text beginning with scaffold-like prefixes, remove only exact legacy scaffold lines, avoid treating scheme-like prose as a URL, and deduplicate host-mirrored content. (#103453) Thanks @lin-hongkuan.

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -223,10 +223,10 @@ describe("nodes camera helpers", () => {
     ).rejects.toThrow(/node remoteip/i);
   });
 
-  it("writes base64 to file", async () => {
+  it("normalizes valid base64 before writing", async () => {
     await withCameraTempDir(async (dir) => {
       const out = path.join(dir, "x.bin");
-      await writeBase64ToFile(out, "aGk=");
+      await writeBase64ToFile(out, " aGk\n");
       await expect(readFileUtf8AndCleanup(out)).resolves.toBe("hi");
     });
   });

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -247,6 +247,20 @@ describe("nodes camera helpers", () => {
     });
   });
 
+  it("rejects malformed base64 payloads before writing", async () => {
+    await withCameraTempDir(async (dir) => {
+      const out = path.join(dir, "x.bin");
+      await expect(writeBase64ToFile(out, "not-base64!")).rejects.toThrow(/invalid base64/i);
+      await expectPathMissing(out);
+      await expect(writeScreenRecordToFile(out, "not-base64!")).rejects.toThrow(/invalid base64/i);
+      await expectPathMissing(out);
+      await expect(writeScreenSnapshotToFile(out, "not-base64!")).rejects.toThrow(
+        /invalid base64/i,
+      );
+      await expectPathMissing(out);
+    });
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -247,11 +247,13 @@ describe("nodes camera helpers", () => {
     });
   });
 
-  it("rejects malformed base64 payloads before writing", async () => {
+  it("rejects empty and malformed base64 payloads before writing", async () => {
     await withCameraTempDir(async (dir) => {
       const out = path.join(dir, "x.bin");
-      await expect(writeBase64ToFile(out, "not-base64!")).rejects.toThrow(/invalid base64/i);
-      await expectPathMissing(out);
+      for (const base64 of ["", " \n", "a", "a===", "not-base64!"]) {
+        await expect(writeBase64ToFile(out, base64)).rejects.toThrow(/invalid base64/i);
+        await expectPathMissing(out);
+      }
       await expect(writeScreenRecordToFile(out, "not-base64!")).rejects.toThrow(/invalid base64/i);
       await expectPathMissing(out);
       await expect(writeScreenSnapshotToFile(out, "not-base64!")).rejects.toThrow(

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -1,6 +1,7 @@
-// Camera payload validation and artifact writers for node media commands.
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+// Camera payload validation and artifact writers for node media commands.
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import { toErrorObject } from "../infra/errors.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
@@ -215,10 +216,14 @@ export async function writeBase64ToFile(
   opts: { maxBytes?: number } = {},
 ) {
   const maxBytes = opts.maxBytes ?? MAX_CAMERA_BASE64_BYTES;
-  if (estimateDecodedBase64Bytes(base64) > maxBytes) {
+  const canonicalBase64 = canonicalizeBase64(base64);
+  if (!canonicalBase64) {
+    throw new Error("writeBase64ToFile: invalid base64 payload");
+  }
+  if (estimateDecodedBase64Bytes(canonicalBase64) > maxBytes) {
     throw new Error(`writeBase64ToFile: decoded payload exceeds max ${maxBytes}`);
   }
-  const buf = Buffer.from(base64, "base64");
+  const buf = Buffer.from(canonicalBase64, "base64");
   if (buf.length > maxBytes) {
     throw new Error(`writeBase64ToFile: decoded ${buf.length} bytes, exceeds max ${maxBytes}`);
   }

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -1,7 +1,7 @@
+// Camera payload validation and artifact writers for node media commands.
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-// Camera payload validation and artifact writers for node media commands.
-import { canonicalizeBase64 } from "@openclaw/media-core/base64";
+import { canonicalizeBase64, estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { toErrorObject } from "../infra/errors.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
@@ -203,12 +203,6 @@ export async function writeUrlToFile(
   return { path: filePath, bytes };
 }
 
-function estimateDecodedBase64Bytes(base64: string): number {
-  const normalized = base64.replace(/\s+/g, "");
-  const padding = normalized.endsWith("==") ? 2 : normalized.endsWith("=") ? 1 : 0;
-  return Math.floor((normalized.length * 3) / 4) - padding;
-}
-
 /** Decode a base64 media payload to disk with preflight and post-decode size checks. */
 export async function writeBase64ToFile(
   filePath: string,
@@ -216,7 +210,7 @@ export async function writeBase64ToFile(
   opts: { maxBytes?: number } = {},
 ) {
   const maxBytes = opts.maxBytes ?? MAX_CAMERA_BASE64_BYTES;
-  if (estimateDecodedBase64Bytes(base64) > maxBytes) {
+  if (estimateBase64DecodedBytes(base64) > maxBytes) {
     throw new Error(`writeBase64ToFile: decoded payload exceeds max ${maxBytes}`);
   }
   const canonicalBase64 = canonicalizeBase64(base64);

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -216,12 +216,12 @@ export async function writeBase64ToFile(
   opts: { maxBytes?: number } = {},
 ) {
   const maxBytes = opts.maxBytes ?? MAX_CAMERA_BASE64_BYTES;
+  if (estimateDecodedBase64Bytes(base64) > maxBytes) {
+    throw new Error(`writeBase64ToFile: decoded payload exceeds max ${maxBytes}`);
+  }
   const canonicalBase64 = canonicalizeBase64(base64);
   if (!canonicalBase64) {
     throw new Error("writeBase64ToFile: invalid base64 payload");
-  }
-  if (estimateDecodedBase64Bytes(canonicalBase64) > maxBytes) {
-    throw new Error(`writeBase64ToFile: decoded payload exceeds max ${maxBytes}`);
   }
   const buf = Buffer.from(canonicalBase64, "base64");
   if (buf.length > maxBytes) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where node camera and screen media commands could write a corrupt local artifact when a node returned malformed base64 media data.

## Why This Change Was Made

The shared node media base64 writer now keeps the existing allocation-light size preflight, then validates and canonicalizes the payload with the existing `@openclaw/media-core/base64` contract before decoding. Camera payload writes and the screen record/snapshot writers all pass through this owner-local boundary, so the malformed-payload rule is enforced once for the full small cluster.

## User Impact

Users and agents now get a clear invalid-base64 error instead of a silently written corrupt media file when a node returns malformed inline camera or screen media. Oversized valid payloads still hit the existing size guard before decode.

## Evidence

- Claim proved: malformed node-returned base64 media payloads are rejected before file write for the shared camera writer and the screen record/snapshot wrappers.
- Current-head runtime proof at `e67680b8e1f69012b78ba88237be2610f34ef09f`: `node --import tsx --input-type=module -` imported the production node media writers and drove a node-returned `payload.base64=not-base64!` through the camera snap writer, screen record writer, and screen snapshot writer. Each path returned `writeBase64ToFile: invalid base64 payload`, and each target reported `output_exists=false`.
- Focused regression proof at `e67680b8e1f69012b78ba88237be2610f34ef09f`: `node scripts/run-vitest.mjs src/cli/nodes-camera.test.ts` passed with 1 file and 29 tests.
- PR diff hygiene: `git diff --check upstream/main...HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main` passed with no accepted/actionable findings.
- Observed result: invalid node media base64 now fails before `fs.writeFile` for camera, screen record, and screen snapshot outputs, leaving no local artifact behind.

AI-assisted: yes. I reviewed the node media writer, camera and screen caller paths, the shared media-core base64 helper, and focused regression coverage.