### PR TITLE
fix(release): wait for Telegram proc marker

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1776,8 +1776,18 @@ jobs:
                     OPENCLAW_QA_PROC_CONTROL=visible sleep 30 &
                     control_pid="$!"
                     trap "kill ${control_pid} >/dev/null 2>&1 || true" EXIT
-                    tr "\0" "\n" <"/proc/${control_pid}/environ" |
-                      grep -Fxq "OPENCLAW_QA_PROC_CONTROL=visible"
+                    proc_marker_visible=false
+                    # The child PID exists before execve publishes command-scoped env.
+                    for _ in {1..100}; do
+                      if tr "\0" "\n" <"/proc/${control_pid}/environ" |
+                        grep -Fxq "OPENCLAW_QA_PROC_CONTROL=visible"; then
+                        proc_marker_visible=true
+                        break
+                      fi
+                      kill -0 "$control_pid" >/dev/null 2>&1 || break
+                      sleep 0.01
+                    done
+                    [[ "$proc_marker_visible" == "true" ]]
                     # Reading the marker is the proof; the probe may exit before cleanup.
                     kill "$control_pid" >/dev/null 2>&1 || true
                     wait "$control_pid" || true

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -534,6 +534,9 @@ describe("release Telegram QA workflow", () => {
     expect(source).toContain("runtime_stage=verify-runtime-privileges");
     expect(source).toContain("runtime_stage=verify-parent-proc-hidden");
     expect(source).toContain("runtime_stage=verify-proc-visibility");
+    expect(source).toContain("for _ in {1..100}; do");
+    expect(source).toContain("proc_marker_visible=true\n                        break");
+    expect(source).toContain('[[ "$proc_marker_visible" == "true" ]]');
     expect(source).toMatch(
       /kill "\$control_pid" >\/dev\/null 2>&1 \|\| true\n\s+wait "\$control_pid" \|\| true/u,
     );


### PR DESCRIPTION
## What Problem This Solves

Telegram QA starts a marker-bearing child and immediately reads `/proc/<pid>/environ`. The PID exists before the child completes `execve`, so the one-shot read can observe the pre-exec environment and fail the visibility proof nondeterministically.

## Why This Change Was Made

Poll for the marker for at most one second while the child remains alive, then keep the final marker assertion strict. Cleanup remains idempotent and the child is still reaped.

## User Impact

The exact-merge Telegram release canary no longer fails because it read `/proc` during the fork-to-exec race. A missing marker still fails closed.

## Evidence

- Exact failure: run 29149804635, `verify-proc-visibility`; trusted workflow `591bb49d` already included idempotent cleanup, proving the remaining failure was the marker pipeline.
- Blacksmith Testbox `tbx_01kx8d4mwek7baq0hvrske74v6`: focused workflow test, 15/15 passed.
- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- `git diff --check`
- Fresh autoreview: no accepted/actionable findings.

Context: follows #104324, #104356, #104387, and #104400.
