### PR TITLE
fix(agents): keep exec finalization suspension-safe

### DIFF
--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -82,6 +82,8 @@ export interface ProcessSession {
   exitReason?: TerminationReason;
   noOutputTimedOut?: boolean;
   exited: boolean;
+  /** Process exit observed; backend cleanup still owns the terminal transition. */
+  finalizing?: boolean;
   truncated: boolean;
   backgrounded: boolean;
   /** PTY cursor key mode: unknown until a PTY reports smkx/rmkx. */

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -3,8 +3,10 @@
  * Covers target resolution, cursor mode tracking, exit outcome classification,
  * system events, and process lifecycle behavior.
  */
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunExit } from "../process/supervisor/types.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS } from "../utils/timer-delay.js";
+import type { BashSandboxConfig } from "./bash-tools.shared.js";
 
 const requestHeartbeatMock = vi.hoisted(() => vi.fn());
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
@@ -27,15 +29,21 @@ vi.mock("../process/supervisor/index.js", () => ({
 }));
 
 let markBackgrounded: typeof import("./bash-process-registry.js").markBackgrounded;
+let getActiveBackgroundExecSessionCount: typeof import("./bash-process-registry.js").getActiveBackgroundExecSessionCount;
+let resetProcessRegistryForTests: typeof import("./bash-process-registry.js").resetProcessRegistryForTests;
 let buildExecExitOutcome: typeof import("./bash-tools.exec-runtime.js").buildExecExitOutcome;
 let detectCursorKeyMode: typeof import("./bash-tools.exec-runtime.js").detectCursorKeyMode;
 let formatExecFailureReason: typeof import("./bash-tools.exec-runtime.js").formatExecFailureReason;
 let renderExecUpdateText: typeof import("./bash-tools.exec-runtime.js").renderExecUpdateText;
 let resolveExecTarget: typeof import("./bash-tools.exec-runtime.js").resolveExecTarget;
 let runExecProcess: typeof import("./bash-tools.exec-runtime.js").runExecProcess;
+let prepareGatewaySuspend: typeof import("../infra/gateway-suspend-coordinator.js").prepareGatewaySuspend;
+let resetGatewaySuspendCoordinatorForTest: typeof import("../infra/gateway-suspend-coordinator.js").resetGatewaySuspendCoordinatorForTest;
+let resumeGatewaySuspend: typeof import("../infra/gateway-suspend-coordinator.js").resumeGatewaySuspend;
 
 beforeAll(async () => {
-  ({ markBackgrounded } = await import("./bash-process-registry.js"));
+  ({ getActiveBackgroundExecSessionCount, markBackgrounded, resetProcessRegistryForTests } =
+    await import("./bash-process-registry.js"));
   ({
     buildExecExitOutcome,
     detectCursorKeyMode,
@@ -44,13 +52,40 @@ beforeAll(async () => {
     resolveExecTarget,
     runExecProcess,
   } = await import("./bash-tools.exec-runtime.js"));
+  ({ prepareGatewaySuspend, resetGatewaySuspendCoordinatorForTest, resumeGatewaySuspend } =
+    await import("../infra/gateway-suspend-coordinator.js"));
 });
 
 beforeEach(() => {
+  resetGatewaySuspendCoordinatorForTest();
+  resetProcessRegistryForTests();
   requestHeartbeatMock.mockClear();
   enqueueSystemEventMock.mockClear();
   supervisorMock.spawn.mockReset();
 });
+
+afterEach(() => {
+  resetGatewaySuspendCoordinatorForTest();
+  resetProcessRegistryForTests();
+});
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function prepareSuspension(requestId: string) {
+  return prepareGatewaySuspend({
+    requestId,
+    pauseScheduling: vi.fn(),
+    resumeScheduling: vi.fn(),
+  });
+}
 
 function expectExecTarget(
   actual: ReturnType<typeof resolveExecTarget>,
@@ -501,6 +536,130 @@ describe("exec notifyOnExit suppression", () => {
     expect(message).not.toContain("�");
     expect(message).toContain(tailHead);
   });
+});
+
+describe("sandbox exec finalization suspension", () => {
+  it.each([
+    {
+      scenario: "successful cleanup",
+      finalizeRejects: false,
+      processTimesOut: false,
+      expectedStatus: "completed" as const,
+      expectedFailureKind: undefined,
+    },
+    {
+      scenario: "failed cleanup",
+      finalizeRejects: true,
+      processTimesOut: false,
+      expectedStatus: "failed" as const,
+      expectedFailureKind: "runtime-error" as const,
+    },
+    {
+      scenario: "failed cleanup after a process timeout",
+      finalizeRejects: true,
+      processTimesOut: true,
+      expectedStatus: "failed" as const,
+      expectedFailureKind: "overall-timeout" as const,
+    },
+  ])(
+    "keeps suspension busy until asynchronous finalization settles after $scenario",
+    async ({ finalizeRejects, processTimesOut, expectedFailureKind, expectedStatus }) => {
+      const exit = createDeferred<RunExit>();
+      const finalization = createDeferred<void>();
+      const finalizeExec = vi.fn<NonNullable<BashSandboxConfig["finalizeExec"]>>(
+        async () => await finalization.promise,
+      );
+      supervisorMock.spawn.mockImplementationOnce(
+        async (input: { onStdout?: (chunk: string) => void }) => {
+          input.onStdout?.("sandbox output\n");
+          return {
+            runId: "sandbox-run",
+            startedAtMs: Date.now(),
+            pid: 123,
+            wait: async () => await exit.promise,
+            cancel: vi.fn(),
+          };
+        },
+      );
+
+      const run = await runExecProcess({
+        command: "sandbox-command",
+        workdir: "/tmp",
+        env: {},
+        sandbox: {
+          containerName: "sandbox",
+          workspaceDir: "/workspace",
+          containerWorkdir: "/workspace",
+          buildExecSpec: async () => ({
+            argv: ["sandbox-command"],
+            env: {},
+            stdinMode: "pipe-closed",
+            finalizeToken: "sandbox-token",
+          }),
+          finalizeExec,
+        },
+        usePty: false,
+        warnings: [],
+        maxOutput: 1000,
+        pendingMaxOutput: 1000,
+        notifyOnExit: true,
+        sessionKey: "agent:main:main",
+        timeoutSec: null,
+      });
+      markBackgrounded(run.session);
+      expect(getActiveBackgroundExecSessionCount()).toBe(1);
+
+      exit.resolve({
+        reason: processTimesOut ? "overall-timeout" : "exit",
+        exitCode: processTimesOut ? null : 0,
+        exitSignal: processTimesOut ? "SIGKILL" : null,
+        durationMs: 1,
+        stdout: "",
+        stderr: "",
+        timedOut: processTimesOut,
+        noOutputTimedOut: false,
+      });
+      await vi.waitFor(() => expect(finalizeExec).toHaveBeenCalledOnce());
+      expect(run.session.finalizing).toBe(true);
+
+      const busy = prepareSuspension(`before-finalize-${expectedFailureKind ?? "success"}`);
+      expect(busy.status).toBe("busy");
+      if (busy.status === "busy") {
+        expect(busy.blockers).toContainEqual(
+          expect.objectContaining({ kind: "background-exec", count: 1 }),
+        );
+      }
+      expect(getActiveBackgroundExecSessionCount()).toBe(1);
+
+      if (finalizeRejects) {
+        finalization.reject(new Error("sandbox finalize failed"));
+      } else {
+        finalization.resolve();
+      }
+      const outcome = await run.promise;
+
+      expect(outcome.status).toBe(expectedStatus);
+      if (outcome.status === "failed") {
+        expect(outcome.failureKind).toBe(expectedFailureKind);
+        expect(outcome.reason).toContain(
+          expectedFailureKind === "runtime-error" ? "sandbox finalize failed" : "timed out",
+        );
+      }
+      expect(finalizeExec).toHaveBeenCalledOnce();
+      expect(getActiveBackgroundExecSessionCount()).toBe(0);
+      expect(run.session.finalizing).toBe(false);
+      expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+      expect(requireSystemEventCall()[0]).toContain(
+        expectedStatus === "failed" ? "Exec failed" : "Exec completed",
+      );
+
+      const ready = prepareSuspension(`after-finalize-${expectedFailureKind ?? "success"}`);
+      expect(ready.status).toBe("ready");
+      if (ready.status === "ready") {
+        expect(resumeGatewaySuspend(ready.suspensionId)).toMatchObject({ ok: true });
+      }
+    },
+  );
 });
 
 describe("formatExecFailureReason", () => {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -734,6 +734,45 @@ export async function runExecProcess(opts: {
       token: sandboxFinalizeToken,
     });
   };
+  const finalizeAndSettleSession = async (
+    outcome: ExecProcessOutcome,
+  ): Promise<ExecProcessOutcome> => {
+    let finalOutcome = outcome;
+    session.finalizing = true;
+    try {
+      await finalizeSandboxExec({
+        status: outcome.status,
+        exitCode: outcome.exitCode,
+        timedOut: outcome.timedOut,
+      });
+    } catch (error) {
+      if (outcome.status === "completed") {
+        finalOutcome = buildExecRuntimeErrorOutcome({
+          error,
+          aggregated: session.aggregated.trim(),
+          durationMs: Date.now() - startedAt,
+        });
+      } else {
+        logWarn(`exec: sandbox finalize after process failure failed (${String(error)}).`);
+      }
+    } finally {
+      // Finalization can release remote process/session resources. Keep the
+      // background-work blocker until that owner transition has settled.
+      session.finalizing = false;
+      if (!session.exited) {
+        markExited(
+          session,
+          finalOutcome.exitCode,
+          finalOutcome.exitSignal,
+          finalOutcome.status,
+          finalOutcome.exitReason,
+          finalOutcome.noOutputTimedOut,
+        );
+        maybeNotifyOnExit(session, finalOutcome.status);
+      }
+    }
+    return finalOutcome;
+  };
 
   const spawnSpec:
     | {
@@ -943,49 +982,32 @@ export async function runExecProcess(opts: {
         timeoutSec: opts.timeoutSec,
       });
 
-      markExited(
-        session,
-        exit.exitCode,
-        exit.exitSignal,
-        outcome.status,
-        exit.reason,
-        exit.noOutputTimedOut,
-      );
-      maybeNotifyOnExit(session, outcome.status);
-      if (!session.child && session.stdin) {
-        session.stdin.destroyed = true;
-      }
-      await finalizeSandboxExec({
-        status: outcome.status,
-        exitCode: exit.exitCode ?? null,
-        timedOut: exit.timedOut,
-      });
+      const finalOutcome = await finalizeAndSettleSession(outcome);
       emitExecProcessCompleted({
         command: opts.command,
         mode: usingPty ? "pty" : "child",
-        outcome,
+        outcome: finalOutcome,
         sessionKey: opts.sessionKey,
         target: diagnosticTarget,
       });
-      return outcome;
+      return finalOutcome;
     })
-    .catch((err: unknown): ExecProcessOutcome => {
+    .catch(async (err: unknown): Promise<ExecProcessOutcome> => {
       updatesDisabled = true;
-      markExited(session, null, null, "failed");
-      maybeNotifyOnExit(session, "failed");
       const outcome = buildExecRuntimeErrorOutcome({
         error: err,
         aggregated: session.aggregated.trim(),
         durationMs: Date.now() - startedAt,
       });
+      const finalOutcome = await finalizeAndSettleSession(outcome);
       emitExecProcessCompleted({
         command: opts.command,
         mode: usingPty ? "pty" : "child",
-        outcome,
+        outcome: finalOutcome,
         sessionKey: opts.sessionKey,
         target: diagnosticTarget,
       });
-      return outcome;
+      return finalOutcome;
     });
 
   return {

--- a/src/agents/bash-tools.process.supervisor.test.ts
+++ b/src/agents/bash-tools.process.supervisor.test.ts
@@ -26,8 +26,10 @@ vi.mock("../process/kill-tree.js", () => ({
 }));
 
 let addSession: typeof import("./bash-process-registry.js").addSession;
+let getActiveBackgroundExecSessionCount: typeof import("./bash-process-registry.js").getActiveBackgroundExecSessionCount;
 let getFinishedSession: typeof import("./bash-process-registry.js").getFinishedSession;
 let getSession: typeof import("./bash-process-registry.js").getSession;
+let markBackgrounded: typeof import("./bash-process-registry.js").markBackgrounded;
 let resetProcessRegistryForTests: typeof import("./bash-process-registry.js").resetProcessRegistryForTests;
 let createProcessSessionFixture: typeof import("./bash-process-registry.test-helpers.js").createProcessSessionFixture;
 let createProcessTool: typeof import("./bash-tools.process.js").createProcessTool;
@@ -76,8 +78,14 @@ function expectTextContent(value: unknown, text: string) {
 
 describe("process tool supervisor cancellation", () => {
   beforeAll(async () => {
-    ({ addSession, getFinishedSession, getSession, resetProcessRegistryForTests } =
-      await import("./bash-process-registry.js"));
+    ({
+      addSession,
+      getActiveBackgroundExecSessionCount,
+      getFinishedSession,
+      getSession,
+      markBackgrounded,
+      resetProcessRegistryForTests,
+    } = await import("./bash-process-registry.js"));
     ({ createProcessSessionFixture } = await import("./bash-process-registry.test-helpers.js"));
     ({ createProcessTool } = await import("./bash-tools.process.js"));
   });
@@ -146,6 +154,29 @@ describe("process tool supervisor cancellation", () => {
     expectFinishedSessionState("sess-fallback", { status: "failed", exitSignal: "SIGKILL" });
     expectTextContent(result.content[0], "Killed session sess-fallback.");
   });
+
+  it.each(["kill", "remove"] as const)(
+    "refuses %s while sandbox finalization owns the terminal transition",
+    async (action) => {
+      supervisorMock.getRecord.mockReturnValue({ runId: "sess-finalizing", state: "exited" });
+      const session = createBackgroundSession("sess-finalizing", 4242);
+      session.finalizing = true;
+      addSession(session);
+      markBackgrounded(session);
+      const processTool = createProcessTool();
+
+      const result = await processTool.execute("toolcall", {
+        action,
+        sessionId: "sess-finalizing",
+      });
+
+      expect(supervisorMock.cancel).not.toHaveBeenCalled();
+      expect(killProcessTreeMock).not.toHaveBeenCalled();
+      expectSessionState("sess-finalizing", { exited: false });
+      expect(getActiveBackgroundExecSessionCount()).toBe(1);
+      expectTextContent(result.content[0], "Session sess-finalizing is finalizing.");
+    },
+  );
 
   it("fails remove when no supervisor record and no pid is available", async () => {
     supervisorMock.getRecord.mockReturnValue(undefined);

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -357,6 +357,12 @@ export function createProcessTool(
             result: failedResult(`Session ${params.sessionId} is not backgrounded.`),
           };
         }
+        if (scopedSession.finalizing) {
+          return {
+            ok: false as const,
+            result: failedResult(`Session ${params.sessionId} is finalizing.`),
+          };
+        }
         const stdin = resolveSessionStdin(scopedSession);
         if (!isWritableStdin(stdin)) {
           return {
@@ -657,6 +663,9 @@ export function createProcessTool(
           if (!scopedSession.backgrounded) {
             return failText(`Session ${params.sessionId} is not backgrounded.`);
           }
+          if (scopedSession.finalizing) {
+            return failText(`Session ${params.sessionId} is finalizing.`);
+          }
           const canceled = cancelManagedSession(scopedSession.id);
           if (!canceled) {
             const terminated = terminateSessionFallback(scopedSession);
@@ -706,6 +715,9 @@ export function createProcessTool(
 
         case "remove": {
           if (scopedSession) {
+            if (scopedSession.finalizing) {
+              return failText(`Session ${params.sessionId} is finalizing.`);
+            }
             const canceled = cancelManagedSession(scopedSession.id);
             if (canceled) {
               // Keep remove semantics deterministic: drop from process registry now.


### PR DESCRIPTION
Fixes #104382

AI-assisted implementation; maintainer-reviewed and source-verified.

## What Problem This Solves

Fixes a race where a background sandbox exec cleared Gateway lifecycle admission as soon as its process exited, before asynchronous sandbox cleanup settled. A host could report prepare readiness and suspend while cleanup still owned resources.

## Why This Change Was Made

The active background blocker now survives through sandbox finalization resolve or reject. Terminal state and notification happen once after both process and cleanup outcomes are known.

When cleanup fails after an otherwise successful process, the session reports a runtime error. When the process already failed, timed out, or was signaled, that primary outcome remains authoritative and the cleanup failure is logged rather than overwriting it.

## User Impact

Scale-to-zero and restart preparation now wait for real background exec finalization, and session status cannot become controllable or terminal before cleanup has actually settled.

## Evidence

- Blacksmith Testbox `tbx_01kx8d092tdjqd2jj0805fjy81`: 47 focused tests passed.
- Same exact head: Testbox `check:changed` passed.
- Regressions cover held finalization, cleanup rejection after success, cleanup rejection after primary failure, and one terminal notification.
- Structured Codex autoreview found two ordering defects during implementation; both were fixed. Fresh integrated-head review clean.
