### PR TITLE
fix(discord): exercise multipart proxy uploads on Node 24

### DIFF
--- a/extensions/discord/src/client.proxy.test.ts
+++ b/extensions/discord/src/client.proxy.test.ts
@@ -1,7 +1,8 @@
 // Discord tests cover client.proxy plugin behavior.
 import http from "node:http";
+import net from "node:net";
+import type { Duplex } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { fetch as undiciFetch } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDiscordRestClient } from "./client.js";
 import { createDiscordRequestClient } from "./proxy-request-client.js";
@@ -209,68 +210,129 @@ describe("createDiscordRestClient proxy support", () => {
   });
 
   it("serializes multipart media with undici-compatible FormData for proxy fetches", async () => {
-    const received = await new Promise<{
+    let resolveReceived!: (value: { contentType: string | undefined; body: string }) => void;
+    let rejectReceived!: (reason?: unknown) => void;
+    const receivedPromise = new Promise<{
       contentType: string | undefined;
       body: string;
     }>((resolve, reject) => {
-      const server = http.createServer((req, res) => {
-        const chunks: Buffer[] = [];
-        req.on("data", (chunk: Buffer) => chunks.push(chunk));
-        req.on("error", reject);
-        req.on("end", () => {
-          resolve({
-            contentType: req.headers["content-type"],
-            body: Buffer.concat(chunks).toString("utf8"),
-          });
-          res.setHeader("Content-Type", "application/json");
-          res.end(JSON.stringify({ id: "message-id", channel_id: "channel-id" }));
-          server.close();
+      resolveReceived = resolve;
+      rejectReceived = reject;
+    });
+    const target = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("error", rejectReceived);
+      req.on("end", () => {
+        resolveReceived({
+          contentType: req.headers["content-type"],
+          body: Buffer.concat(chunks).toString("utf8"),
         });
-      });
-      server.on("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        const address = server.address();
-        if (!address || typeof address === "string") {
-          reject(new Error("failed to bind test server"));
-          server.close();
-          return;
-        }
-        const rest = createDiscordRequestClient("test-token", {
-          baseUrl: `http://127.0.0.1:${address.port}`,
-          fetch: undiciFetch as unknown as typeof fetch,
-          queueRequests: false,
-        });
-        void rest
-          .post("/channels/123/messages", {
-            body: {
-              content: "with image",
-              files: [{ data: Buffer.from("png-data"), name: "image.png" }],
-            },
-          })
-          .catch((err: unknown) => {
-            reject(toLintErrorObject(err, "Non-Error rejection"));
-            server.close();
-          });
+        res.setHeader("Content-Type", "application/json");
+        res.setHeader("Connection", "close");
+        res.end(JSON.stringify({ id: "message-id", channel_id: "channel-id" }));
       });
     });
+    const proxy = http.createServer();
+    const tunnelSockets = new Set<Duplex>();
+    target.on("error", rejectReceived);
+    proxy.on("error", rejectReceived);
+    // Undici's ProxyAgent tunnels HTTP targets with CONNECT. Pipe the tunnel so
+    // this test exercises the production proxy fetch and its FormData rebuild.
+    proxy.on("connect", (req, clientSocket, head) => {
+      trackSocket(tunnelSockets, clientSocket);
+      if (!req.url) {
+        rejectReceived(new Error("proxy CONNECT request missing target"));
+        clientSocket.destroy();
+        return;
+      }
+      const targetUrl = new URL(`http://${req.url}`);
+      const targetSocket = net.connect(Number(targetUrl.port), targetUrl.hostname, () => {
+        clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        if (head.length > 0) {
+          targetSocket.write(head);
+        }
+        clientSocket.pipe(targetSocket);
+        targetSocket.pipe(clientSocket);
+      });
+      trackSocket(tunnelSockets, targetSocket);
+      targetSocket.on("error", rejectReceived);
+      clientSocket.on("error", rejectReceived);
+    });
 
-    expect(received.contentType).toMatch(/^multipart\/form-data; boundary=/);
-    expect(received.body).toContain('name="files[0]"; filename="image.png"');
-    expect(received.body).toContain('name="payload_json"');
-    expect(received.body).toContain('"attachments":[{"id":0,"filename":"image.png"}]');
+    try {
+      const targetPort = await listenOnLoopback(target, "target");
+      const proxyPort = await listenOnLoopback(proxy, "proxy");
+      const cfg = {
+        channels: {
+          discord: {
+            token: "Bot test-token",
+            proxy: `http://127.0.0.1:${proxyPort}`,
+          },
+        },
+      } as OpenClawConfig;
+      const proxyRest = createDiscordRestClient({ cfg }).rest as unknown as {
+        options?: { fetch?: typeof fetch };
+      };
+      const proxyFetch = proxyRest.options?.fetch;
+      if (!proxyFetch) {
+        throw new Error("expected Discord proxy fetch");
+      }
+      const rest = createDiscordRequestClient("test-token", {
+        baseUrl: `http://127.0.0.1:${targetPort}`,
+        fetch: proxyFetch,
+        queueRequests: false,
+      });
+      const [received] = await Promise.all([
+        receivedPromise,
+        rest.post("/channels/123/messages", {
+          body: {
+            content: "with image",
+            files: [{ data: Buffer.from("png-data"), name: "image.png" }],
+          },
+        }),
+      ]);
+
+      expect(received.contentType).toMatch(/^multipart\/form-data; boundary=/);
+      expect(received.body).toContain('name="files[0]"; filename="image.png"');
+      expect(received.body).toContain('name="payload_json"');
+      expect(received.body).toContain('"attachments":[{"id":0,"filename":"image.png"}]');
+    } finally {
+      for (const socket of tunnelSockets) {
+        socket.destroy();
+      }
+      await Promise.all([closeServer(target), closeServer(proxy)]);
+    }
   });
 });
 
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
+function trackSocket(sockets: Set<Duplex>, socket: Duplex): void {
+  sockets.add(socket);
+  socket.once("close", () => sockets.delete(socket));
+}
+
+async function listenOnLoopback(server: http.Server, label: string): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error(`failed to bind ${label} test server`);
   }
-  if (typeof value === "string") {
-    return new Error(value);
+  return address.port;
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  if (!server.listening) {
+    return;
   }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes a clean `origin/main` failure on Linux Node 24 where the Discord proxy multipart test received `text/plain;charset=UTF-8` instead of a multipart boundary.

## Why This Change Was Made

The failing harness passed Node's global `FormData` directly to the separately installed undici 8.5 fetch. Node 24 uses different FormData constructors there, so undici's brand check converts the body to text. Production already rebuilds cross-runtime FormData in `makeProxyFetch`; the test now uses a local CONNECT proxy and the actual Discord proxy fetch path instead of changing healthy runtime code.

## User Impact

No runtime behavior change. Discord multipart uploads through configured proxies now have Linux Node 24 regression coverage that matches the shipped request path.

## Evidence

- Before: Blacksmith Testbox `tbx_01kx8csj5gyrby7pawp9a71bt5`, Node `v24.13.0`, undici `8.5.0`: 1 failed / 9 passed; received `text/plain;charset=UTF-8`.
- After: same Testbox and focused file: 10 passed.
- `pnpm exec oxfmt --check extensions/discord/src/client.proxy.test.ts`
- `pnpm check:changed -- extensions/discord/src/client.proxy.test.ts` (extension test typecheck and lint clean)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean after addressing two actionable teardown/type findings)

AI-assisted: Codex implemented and reviewed this fix; no session transcript attached.
