### PR TITLE
fix(commitments): isolate extraction batches by agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Commitment extraction agent isolation:** partition background extraction batches by agent so prompts, provider credentials, extractor sessions, and terminal-failure cooldowns never cross agent boundaries.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Commitment extraction agent isolation:** partition background extraction batches by agent so prompts, provider credentials, extractor sessions, and terminal-failure cooldowns never cross agent boundaries.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.
 - **OpenAI Realtime client-secret deadlines:** bound voice and transcription secret acquisition to 30 seconds through the guarded fetch boundary while preserving authentication and bounded response parsing. (#102860) Thanks @Alix-007.

--- a/src/commitments/runtime.test.ts
+++ b/src/commitments/runtime.test.ts
@@ -190,6 +190,43 @@ describe("commitment extraction runtime", () => {
     expect(store.commitments[0]).not.toHaveProperty("sourceAssistantText");
   });
 
+  it("partitions extraction batches by agent", async () => {
+    const cfg = await createConfig();
+    const extractBatch = vi.fn(async (_params: { items: CommitmentExtractionItem[] }) => ({
+      candidates: [],
+    }));
+    configureCommitmentExtractionRuntime({
+      forceInTests: true,
+      extractBatch,
+      setTimer: () => ({ unref() {} }) as ReturnType<typeof setTimeout>,
+      clearTimer: () => undefined,
+    });
+
+    for (const [index, agentId] of ["alpha", "beta", "alpha", "beta"].entries()) {
+      expect(
+        enqueueCommitmentExtraction({
+          cfg,
+          nowMs: nowMs + index,
+          agentId,
+          sessionKey: `agent:${agentId}:telegram:user-1`,
+          channel: "telegram",
+          sourceMessageId: `m${index}`,
+          userText: `Commitment candidate ${index}`,
+          assistantText: "I will follow up.",
+        }),
+      ).toBe(true);
+    }
+
+    await expect(drainCommitmentExtractionQueue()).resolves.toBe(4);
+    expect(extractBatch).toHaveBeenCalledTimes(2);
+    expect(
+      extractBatch.mock.calls.map(([params]) => params.items.map((item) => item.agentId)),
+    ).toEqual([
+      ["alpha", "alpha"],
+      ["beta", "beta"],
+    ]);
+  });
+
   it("uses the configured agent model for the hidden extractor run", async () => {
     const cfg = await createConfig();
     cfg.agents = {
@@ -566,6 +603,58 @@ describe("commitment extraction runtime", () => {
     // the dropped batch.
     await expect(drainCommitmentExtractionQueue()).resolves.toBe(0);
     expect(extractBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps other agents queued after a terminal extraction failure", async () => {
+    const cfg = await createConfig();
+    const scheduled: Array<() => void> = [];
+    const extractBatch = vi.fn(async ({ items }: { items: CommitmentExtractionItem[] }) => {
+      if (items[0]?.agentId === "alpha") {
+        throw new Error('No API key found for provider "openai".');
+      }
+      return { candidates: [] };
+    });
+    configureCommitmentExtractionRuntime({
+      forceInTests: true,
+      extractBatch,
+      setTimer: (callback) => {
+        scheduled.push(callback);
+        return { unref() {} } as ReturnType<typeof setTimeout>;
+      },
+      clearTimer: () => undefined,
+    });
+
+    for (const agentId of ["alpha", "beta"]) {
+      expect(
+        enqueueCommitmentExtraction({
+          cfg,
+          nowMs,
+          agentId,
+          sessionKey: `agent:${agentId}:telegram:user-1`,
+          channel: "telegram",
+          userText: "I have an interview tomorrow.",
+          assistantText: "Good luck.",
+        }),
+      ).toBe(true);
+    }
+
+    expect(scheduled).toHaveLength(1);
+    scheduled[0]?.();
+    await vi.waitFor(() => {
+      expect(extractBatch).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(scheduled).toHaveLength(2);
+    });
+
+    scheduled[1]?.();
+    await vi.waitFor(() => {
+      expect(extractBatch).toHaveBeenCalledTimes(2);
+    });
+    expect(extractBatch.mock.calls.map(([params]) => params.items[0]?.agentId)).toEqual([
+      "alpha",
+      "beta",
+    ]);
   });
 
   it("schedules a retry when a non-terminal failure leaves the queue full", async () => {

--- a/src/commitments/runtime.ts
+++ b/src/commitments/runtime.ts
@@ -78,9 +78,8 @@ function clearTimer(handle: TimerHandle): void {
 }
 
 // Single-slot debounce: schedule one drain unless one is already pending. Shared
-// by enqueue (new work), the overflow branch, and the drain's non-terminal
-// failure path (so a batch restored after a timer-fired failure still gets
-// retried even when no later enqueue arrives).
+// by enqueue (new work), the overflow branch, and drain failure paths so queued
+// work still progresses after a timer-fired extraction failure.
 function scheduleDrainSoon(debounceMs: number): void {
   if (timer) {
     return;
@@ -294,6 +293,24 @@ async function hydrateBatch(
   );
 }
 
+function takeAgentBatch(
+  agentId: string,
+  maxItems: number,
+): Array<Omit<CommitmentExtractionItem, "existingPending"> & { cfg?: OpenClawConfig }> {
+  const batch = [];
+  for (let index = 0; index < queue.length && batch.length < maxItems;) {
+    if (queue[index]?.agentId !== agentId) {
+      index += 1;
+      continue;
+    }
+    const [item] = queue.splice(index, 1);
+    if (item) {
+      batch.push(item);
+    }
+  }
+  return batch;
+}
+
 /** Drains queued extraction work in batches and returns processed item count. */
 export async function drainCommitmentExtractionQueue(): Promise<number> {
   if (draining) {
@@ -303,9 +320,15 @@ export async function drainCommitmentExtractionQueue(): Promise<number> {
   try {
     let processed = 0;
     while (queue.length > 0) {
-      const firstCfg = queue[0]?.cfg;
+      const first = queue[0];
+      if (!first) {
+        break;
+      }
+      const firstCfg = first.cfg;
       const resolved = resolveCommitmentsConfig(firstCfg);
-      const batch = queue.splice(0, resolved.extraction.batchMaxItems);
+      // Extraction inherits the first item's model, credentials, workspace, and
+      // session file. Keep every prompt and failure policy scoped to that agent.
+      const batch = takeAgentBatch(first.agentId, resolved.extraction.batchMaxItems);
       const items = await hydrateBatch(batch);
       const extractor = runtime.extractBatch ?? defaultExtractBatch;
       let result: CommitmentExtractionBatchResult;
@@ -319,6 +342,9 @@ export async function drainCommitmentExtractionQueue(): Promise<number> {
             Date.now(),
             items[0]?.nowMs ?? Date.now(),
           );
+          if (queue.length > 0) {
+            scheduleDrainSoon(resolved.extraction.debounceMs);
+          }
         } else {
           // Non-terminal failure (e.g. transient model/network error): the batch
           // was already spliced out, so restore it to the front in original order.


### PR DESCRIPTION
Closes #104425

## What Problem This Solves

Fixes an issue where operators using commitment extraction with multiple agents could have one agent's conversation included in an extraction prompt executed and persisted under another agent's identity when turns completed in the same debounce window.

## Why This Change Was Made

The background drain now selects up to the configured batch limit from the first queued agent only, preserving other agents' queue order. Terminal model or authentication failures remain scoped to the failing agent and re-arm the drain when unaffected agents still have queued work.

## User Impact

Commitment extraction prompts, provider credentials, workspaces, extractor session files, and terminal-failure cooldowns no longer cross agent boundaries. Commitments remain opt-in.

## Evidence

- Blacksmith Testbox through Crabbox `tbx_01kx8dd1pzazvc53t9d73rwgwx`: `corepack pnpm test src/commitments/runtime.test.ts` — 14/14 passed.
- Same Testbox: `corepack pnpm check:changed` — passed core and core-test typechecks, changed-file lint, import-cycle, database-first, and guard checks.
- Same Testbox: targeted `oxfmt --check` — passed.
- Structured Codex autoreview (`gpt-5.5`, high): first pass found the timer re-arm gap; fixed and re-proven. Final pass: no accepted/actionable findings.
- Regression coverage asserts interleaved agents produce homogeneous batches and a timer-fired terminal failure for one agent still drains the other agent.

AI-assisted: yes. The implementation and proof were inspected and understood by the maintainer agent.

