### PR TITLE
fix(secrets): register secret targets for installed-origin plugins

### DIFF
--- a/src/secrets/target-registry-data.current-snapshot.test.ts
+++ b/src/secrets/target-registry-data.current-snapshot.test.ts
@@ -32,4 +32,39 @@ describe("getSecretTargetRegistry metadata reuse", () => {
       expect(call.allowWorkspaceScopedCurrent).not.toBe(true);
     }
   });
+
+  it("registers secret targets for installed-origin plugins (#104320)", async () => {
+    // Exa web providers moved from bundled origin to an installed package; the
+    // gateway known-target registry must keep covering their credential paths.
+    metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "exa",
+          origin: "global",
+          channels: [],
+          contracts: { webSearchProviders: ["exa"] },
+          configUiHints: { "webSearch.apiKey": { sensitive: true } },
+          configContracts: {
+            secretInputs: { paths: [{ path: "webSearch.apiKey" }] },
+          },
+        },
+        {
+          // Control: no web-provider contract / secretInputs → no fabricated target.
+          id: "noise-plugin",
+          origin: "global",
+          channels: [],
+          contracts: {},
+          configUiHints: {},
+        },
+      ],
+    } as never);
+    const { getSecretTargetRegistry } = await import("./target-registry-data.js");
+    const { isKnownSecretTargetId } = await import("./target-registry-query.js");
+
+    const ids = getSecretTargetRegistry().map((entry) => entry.id);
+
+    expect(ids).toContain("plugins.entries.exa.config.webSearch.apiKey");
+    expect(isKnownSecretTargetId("plugins.entries.exa.config.webSearch.apiKey")).toBe(true);
+    expect(ids.some((id) => id.includes("noise-plugin"))).toBe(false);
+  });
 });

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -49,11 +49,14 @@ function hasWebProviderContract(
   return (plugin.contracts?.[contract]?.length ?? 0) > 0;
 }
 
-function listBundledWebProviderSecretTargetRegistryEntries(
-  bundledPlugins: readonly PluginManifestRecord[],
+// Web-provider and config-contract secret targets come from every active plugin
+// manifest record (bundled, global/installed, workspace). Filtering by origin
+// would drop targets after a provider moves out of bundled origin (#104320).
+function listPluginWebProviderSecretTargetRegistryEntries(
+  plugins: readonly PluginManifestRecord[],
 ): SecretTargetRegistryEntry[] {
   const entries: SecretTargetRegistryEntry[] = [];
-  for (const record of bundledPlugins) {
+  for (const record of plugins) {
     for (const config of WEB_PROVIDER_SECRET_CONFIGS) {
       if (
         hasWebProviderContract(record, config.contract) &&
@@ -66,12 +69,12 @@ function listBundledWebProviderSecretTargetRegistryEntries(
   return entries.toSorted((left, right) => left.id.localeCompare(right.id));
 }
 
-function listBundledPluginConfigSecretTargetRegistryEntries(
-  bundledPlugins: readonly Pick<PluginManifestRecord, "id" | "configContracts">[],
+function listPluginConfigSecretTargetRegistryEntries(
+  plugins: readonly Pick<PluginManifestRecord, "id" | "configContracts">[],
 ): SecretTargetRegistryEntry[] {
   const entries: SecretTargetRegistryEntry[] = [];
   const seen = new Set<string>();
-  for (const record of bundledPlugins) {
+  for (const record of plugins) {
     const secretInputs = record.configContracts?.secretInputs?.paths ?? [];
     for (const secretInput of secretInputs) {
       const entry = createPluginOpenClawConfigSecretTargetEntry(record.id, secretInput.path);
@@ -505,13 +508,18 @@ function loadSecretTargetRegistryFromPluginMetadata(params: {
     env: params.env,
     ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
   }).plugins;
-  const bundledPlugins = plugins.filter((record) => record.origin === "bundled");
   const channelPlugins = plugins.filter((record) => record.channels.length > 0);
+  // Installed/workspace plugins own secret targets exactly like bundled ones
+  // (#104320: the Exa split moved web providers out of bundled origin and their
+  // targets vanished from the gateway's known-target registry). Entries stay
+  // manifest-scoped — web-provider contract + sensitive hint, or declared
+  // secretInput paths — so a non-bundled origin cannot widen target paths
+  // beyond its own declared contracts.
   return [
     ...CORE_SECRET_TARGET_REGISTRY,
-    ...listBundledWebProviderSecretTargetRegistryEntries(bundledPlugins),
-    ...listBundledPluginConfigSecretTargetRegistryEntries([
-      ...bundledPlugins,
+    ...listPluginWebProviderSecretTargetRegistryEntries(plugins),
+    ...listPluginConfigSecretTargetRegistryEntries([
+      ...plugins,
       ...listSourceBundledPluginConfigContractRecords(),
     ]),
     ...listChannelSecretTargetRegistryEntries(channelPlugins),


### PR DESCRIPTION
Fixes #104320

## What Problem This Solves

Fixes an issue where users with an **installed** (non-bundled) Exa web-search plugin and a SecretRef at `plugins.entries.exa.config.webSearch.apiKey` would fail `openclaw infer web search` / gateway `secrets.resolve` with `unknown target id`, even when the plugin was loaded/enabled and `secrets audit` reported full resolvability.

This is a regression of the #82621 / #82798 SecretRef command path after web providers moved into installed plugin packages.

## Why This Change Was Made

The gateway known-target registry only derived web-provider and plugin config-contract secret targets from **bundled-origin** plugin metadata. Installed/global/workspace plugins that declare the same contracts were filtered out, so CLI-discovered target IDs failed gateway validation.

This change builds those registry families from **every active plugin manifest record** (same pattern channel-contract entries already used), while keeping path ownership closed: targets are only created from a plugin’s own web-provider contract + sensitive config hint, or its declared `configContracts.secretInputs` paths. No hard-coded provider IDs and no weakened target validation.

Aligned with ClawSweeper’s best-solution guidance on #104320 and the concrete registry surface reviewed on competing open PR candidates.

## User Impact

Operators using installed web-search/web-fetch provider plugins (Exa is the shipped example) can resolve plugin-scoped SecretRef credentials through the gateway again for `infer web search` / related command paths, without the unknown-target rejection.

## Evidence

**Verification host:** local macOS (Crabbox bypass)

```text
# Focused primary proof
node scripts/run-vitest.mjs src/secrets/target-registry-data.current-snapshot.test.ts
# → 2 passed, including:
#   registers secret targets for installed-origin plugins (#104320)

node scripts/run-vitest.mjs src/secrets/target-registry-data.current-snapshot.test.ts src/secrets/target-registry.test.ts
# → 9 passed

pnpm check:changed
# → exit 0 (core + coreTests lanes; typecheck/lint/guards green)

pnpm test:changed
# → 1 failure unrelated to this surface:
#   src/cli/plugins-list-format.test.ts "sanitizes activation reasons in verbose output"
#   (FORCE_COLOR/ANSI path coloring: expects no \u001b[31m, but source path is colored red)
#   Reproduced with this patch reverted to origin/main files → same failure.
#   Touched-surface secrets tests: green.
```

## Real behavior proof

- **Behavior addressed:** Gateway process-stable secret target registry must recognize installed-origin plugin credential target IDs such as `plugins.entries.exa.config.webSearch.apiKey` so `secrets.resolve` / `infer web search` do not reject them as unknown.
- **Environment:** local macOS, openclaw checkout at branch `fix/104320-installed-plugin-secret-targets`, focused Vitest with mocked plugin metadata snapshot (`origin: "global"` Exa record).
- **Current-main contrast:** On main, `loadSecretTargetRegistryFromPluginMetadata` filtered `plugins` to `origin === "bundled"` before listing web-provider / config-contract secret targets. An installed-origin Exa metadata record therefore never contributed `plugins.entries.exa.config.webSearch.apiKey`, so `isKnownSecretTargetId(...)` stayed false for that id.
- **Exact steps or command run after this patch:**
  1. Mock `resolvePluginMetadataSnapshot` with Exa at `origin: "global"` (webSearchProviders + sensitive `webSearch.apiKey` hint + secretInputs), plus a control plugin with no contracts.
  2. `getSecretTargetRegistry()` then `isKnownSecretTargetId("plugins.entries.exa.config.webSearch.apiKey")`.
  3. Run: `node scripts/run-vitest.mjs src/secrets/target-registry-data.current-snapshot.test.ts`
- **Evidence after fix:** Test `registers secret targets for installed-origin plugins (#104320)` passes: registry ids contain the Exa target path; `isKnownSecretTargetId` returns true; control plugin does not invent targets.
- **Control check:** Only the installed Exa record with declared web-search contract/sensitive hint contributes the target; `noise-plugin` without contracts contributes none. Existing bundled-path cases in `target-registry.test.ts` still pass.
- **Observed result after fix:** Installed-origin Exa credential target is registered and known to the gateway target-id check.
- **What was not tested:** Live npm-installed Exa package + real Keychain SecretRef + live `openclaw infer web search` against a production Exa API key (issue labels are `source-repro` / `queueable-fix`, not `needs-live-repro`). No live paid API call.

## AI disclosure

This fix was authored with AI assistance (Grok auto pipeline). Human review of the registry ownership boundary and proof still applies.

Head: 6650ef7d0
