### PR TITLE
refactor(channels): adopt core retryAsync for feishu and matrix retry loops

### DIFF
--- a/extensions/feishu/src/comment-shared.ts
+++ b/extensions/feishu/src/comment-shared.ts
@@ -1,4 +1,5 @@
 // Feishu plugin module implements comment shared behavior.
+import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 import {
   isRecord as sharedIsRecord,
   normalizeOptionalString,
@@ -142,56 +143,39 @@ export async function requestFeishuApi<T>(
   options: {
     includeConfigParams?: boolean;
     includeNestedErrorLogId?: boolean;
-    /** Base delay per retry attempt in ms; multiplied by attempt index. @internal */
+    /** Base retry delay in ms; doubles on the second retry. @internal */
     retryDelayMs?: number;
   } = {},
 ): Promise<T> {
-  const retryDelayMs = options.retryDelayMs ?? FEISHU_SEND_RETRY_BASE_MS;
-  let lastFulfilledRateLimit: { response: unknown; code: number } | undefined;
-  for (let attempt = 0; attempt <= FEISHU_SEND_MAX_RETRIES; attempt++) {
-    if (attempt > 0) {
-      // Linear backoff: delay grows with each attempt to give the rate-limit window time to reset.
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, attempt * retryDelayMs);
-      });
-    }
-    try {
-      const result = await request();
-      // Feishu SDK may fulfill with a rate-limit body (e.g. { code: 11232, ... })
-      // instead of throwing. Classify before returning so retry covers both shapes.
-      const fulfilledRateLimit = getFeishuSendRateLimitCodeFromResponse(result);
-      if (fulfilledRateLimit !== undefined) {
-        // Capture for the synthetic-error path below; on a non-final attempt
-        // continue retrying, on the final attempt fall through so the loop
-        // exits and the wrapped exhaustion error is thrown.
-        lastFulfilledRateLimit = { response: result, code: fulfilledRateLimit };
-        if (attempt < FEISHU_SEND_MAX_RETRIES) {
-          continue;
+  try {
+    return await retryAsync(
+      async () => {
+        const result = await request();
+        // Feishu SDK may fulfill with a rate-limit body (e.g. { code: 11232, ... })
+        // instead of throwing. Rethrow it in the AxiosError response shape so
+        // getFeishuSendRateLimitCode classifies it retryable and exhaustion
+        // wraps it exactly like an SDK throw.
+        const fulfilledRateLimit = getFeishuSendRateLimitCodeFromResponse(result);
+        if (fulfilledRateLimit !== undefined) {
+          throw Object.assign(
+            new Error(`Request fulfilled with rate-limit code ${fulfilledRateLimit}`),
+            { response: { status: 200, data: result } },
+          );
         }
-        break;
-      }
-      return result;
-    } catch (error) {
-      const isRetryable =
-        attempt < FEISHU_SEND_MAX_RETRIES && getFeishuSendRateLimitCode(error) !== undefined;
-      if (!isRetryable) {
-        throw createFeishuApiError(error, errorPrefix, options);
-      }
-      // Rate-limit on a non-final attempt — loop continues to next retry.
-    }
-  }
-  // Exhausted retries while the SDK kept fulfilling rate-limit bodies. Surface
-  // the last response as an error so callers see the same wrapped shape they
-  // would have seen if the SDK had thrown.
-  if (lastFulfilledRateLimit) {
-    const synthetic = Object.assign(
-      new Error(`Request fulfilled with rate-limit code ${lastFulfilledRateLimit.code}`),
-      { response: { status: 200, data: lastFulfilledRateLimit.response } },
+        return result;
+      },
+      {
+        attempts: FEISHU_SEND_MAX_RETRIES + 1,
+        // With a 2-retry budget the core exponential schedule (1x, 2x base)
+        // matches the previous linear attempt*base backoff exactly; revisit
+        // the delay curve if FEISHU_SEND_MAX_RETRIES grows.
+        minDelayMs: options.retryDelayMs ?? FEISHU_SEND_RETRY_BASE_MS,
+        shouldRetry: (error) => getFeishuSendRateLimitCode(error) !== undefined,
+      },
     );
-    throw createFeishuApiError(synthetic, errorPrefix, options);
+  } catch (error) {
+    throw createFeishuApiError(error, errorPrefix, options);
   }
-  // Unreachable: every iteration either returns or throws. Required for TypeScript exhaustiveness.
-  throw createFeishuApiError(new Error("unreachable"), errorPrefix, options);
 }
 
 type ParsedCommentDocumentRef = {

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -1,5 +1,4 @@
 // Matrix plugin module implements approval handler behavior.
-import { setTimeout as sleep } from "node:timers/promises";
 import type {
   ChannelApprovalCapabilityHandlerContext,
   PendingApprovalView,
@@ -21,6 +20,7 @@ import {
   listMessageReceiptPlatformIds,
   resolveMessageReceiptPrimaryId,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeUniqueStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildMatrixApprovalReactionHint,
@@ -184,19 +184,15 @@ async function retryMatrixApprovalDelivery<T>(
   operation: () => Promise<T>,
   params: { shouldRetry?: (error: unknown) => boolean } = {},
 ): Promise<T> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= MATRIX_APPROVAL_DELIVERY_ATTEMPTS; attempt += 1) {
-    try {
-      return await operation();
-    } catch (error) {
-      lastError = error;
-      if (attempt === MATRIX_APPROVAL_DELIVERY_ATTEMPTS || params.shouldRetry?.(error) === false) {
-        break;
-      }
-      await sleep(MATRIX_APPROVAL_DELIVERY_RETRY_DELAY_MS * attempt);
-    }
-  }
-  throw lastError;
+  // With a 3-attempt budget the core exponential schedule (250ms, 500ms)
+  // matches the previous linear attempt*250ms backoff exactly; revisit the
+  // delay curve if MATRIX_APPROVAL_DELIVERY_ATTEMPTS grows.
+  return await retryAsync(operation, {
+    attempts: MATRIX_APPROVAL_DELIVERY_ATTEMPTS,
+    minDelayMs: MATRIX_APPROVAL_DELIVERY_RETRY_DELAY_MS,
+    // Deliveries default to retryable; callers opt out per error class.
+    shouldRetry: (error) => params.shouldRetry?.(error) !== false,
+  });
 }
 
 async function prepareTarget(


### PR DESCRIPTION
Related: #104318

## What Problem This Solves

Channels hand-roll retry/backoff loops instead of using the core retry engine, so retryability decisions and delay math drift per channel. This sweep migrates the two sites whose semantics map cleanly and documents exactly why the remaining three do not (that record feeds the ChannelAdapter v2 delivery design).

## Why This Change Was Made

feishu's `requestFeishuApi` (comment send path) and matrix's `retryMatrixApprovalDelivery` now run on core `retryAsync`, keeping each channel's classification exactly (feishu re-throws fulfilled rate-limit bodies in the synthetic AxiosError shape its predicate expects; matrix keeps its caller opt-out predicate and size-limit fallback). Backoff-curve equivalence at the fixed attempt budgets is pinned in comments. Skipped with recorded gaps: mattermost (full-jitter schedule test-asserted, inexpressible in core retryAsync — needs a jitter-mode knob), imessage watch-subscribe (abort-aware sleep + teardown between attempts), feishu comment monitor (result-predicate poll, not error retry).

## User Impact

No behavior change; retry cadence equivalence documented at the changed sites.

## Evidence

- Blacksmith Testbox `tbx_01kx8ds5kpydq7q42mw3xc1a52`: feishu/imessage/mattermost/matrix suites green + full `pnpm check:changed`; existing retry contract tests (feishu send.retry, matrix approval) hold unchanged.
- Autoreview (codex gpt-5.6-sol, xhigh): clean on first pass.
- `git diff --numstat`: net −20 prod LOC.
