### PR TITLE
fix(tool-search): include skill command context in unknown tool errors

### DIFF
--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -62,6 +62,11 @@ type UnknownToolRecoverySurface = "raw-tools" | "code-mode" | "tools";
 type UnknownToolErrorOptions = {
   exactIdOnly?: boolean;
   recoverySurface?: UnknownToolRecoverySurface;
+  /** Skill command context for better error messages when a skill command fails to find its tool. */
+  skillCommandContext?: {
+    skillName: string;
+    commandName: string;
+  };
 };
 
 type ReusableCatalogSnapshot = {
@@ -112,6 +117,8 @@ export type ToolSearchToolContext = {
   catalogRef?: ToolSearchCatalogRef;
   abortSignal?: AbortSignal;
   executeTool?: ToolSearchCatalogToolExecutor;
+  /** Skill command context for better error messages when a skill command fails to find its tool. */
+  beforeToolCallHookContext?: HookContext;
 };
 
 /** Catalog entry retained behind compacted Tool Search control tools. */
@@ -1628,10 +1635,16 @@ function formatUnknownToolIdError(
       : options.recoverySurface === "tools"
         ? "Use tools.search to find a tool, tools.describe to inspect it, then tools.call with the exact id or name."
         : "Use tool_search to find a tool, tool_describe to inspect it, then tool_call with the exact id or name.";
+  // When a skill command fails to find its configured tool, provide skill-specific guidance.
+  const skillContextPrefix = options.skillCommandContext
+    ? `Skill "/${options.skillCommandContext.commandName}" (from ${options.skillCommandContext.skillName}) `
+    : "";
   if (suggestions.length === 0) {
-    return `Unknown tool id: ${needle}. ${recoveryText}`;
+    return `${skillContextPrefix}Unknown tool id: ${needle}. ${recoveryText}`;
   }
-  return `Unknown tool id: ${needle}. Did you mean: ${suggestions.join(", ")}? ${recoveryText}`;
+  return `${skillContextPrefix}Unknown tool id: ${needle}. Did you mean: ${suggestions.join(
+    ", ",
+  )}? ${recoveryText}`;
 }
 
 function findEntry(
@@ -1786,10 +1799,20 @@ export class ToolSearchRuntime {
       signal?: AbortSignal;
       onUpdate?: AgentToolUpdateCallback;
       recoverySurface?: UnknownToolRecoverySurface;
-    },
+    } & UnknownToolErrorOptions,
   ) => {
     const catalog = resolveCatalog(this.ctx);
-    const entry = findEntry(catalog, id, undefined, options);
+    const skillCommandContext = this.ctx.beforeToolCallHookContext?.skillCommand
+      ? {
+          skillName: this.ctx.beforeToolCallHookContext.skillCommand.skillName,
+          commandName: this.ctx.beforeToolCallHookContext.skillCommand.commandName,
+        }
+      : undefined;
+    const errorOptions: UnknownToolErrorOptions = {
+      ...options,
+      ...(skillCommandContext ? { skillCommandContext } : {}),
+    };
+    const entry = findEntry(catalog, id, undefined, errorOptions);
     return await this.callEntry(catalog, entry, input, options);
   };
 
@@ -1801,10 +1824,20 @@ export class ToolSearchRuntime {
       signal?: AbortSignal;
       onUpdate?: AgentToolUpdateCallback;
       recoverySurface?: UnknownToolRecoverySurface;
-    },
+    } & UnknownToolErrorOptions,
   ) => {
     const catalog = resolveCatalog(this.ctx);
-    const entry = findEntryByExactId(catalog, id, options);
+    const skillCommandContext = this.ctx.beforeToolCallHookContext?.skillCommand
+      ? {
+          skillName: this.ctx.beforeToolCallHookContext.skillCommand.skillName,
+          commandName: this.ctx.beforeToolCallHookContext.skillCommand.commandName,
+        }
+      : undefined;
+    const errorOptions: UnknownToolErrorOptions = {
+      ...options,
+      ...(skillCommandContext ? { skillCommandContext } : {}),
+    };
+    const entry = findEntryByExactId(catalog, id, errorOptions);
     return await this.callEntry(catalog, entry, input, options);
   };
 


### PR DESCRIPTION
## What Problem This Solves

Bug #104165 reported that the weather tool could not be found. Analysis revealed this is caused by third-party skills misconfiguring `command-dispatch: tool` without properly registering the referenced tool.

The original error message `"Unknown tool id: weather"` provided no indication of which skill or command was responsible, leaving users unable to diagnose the root cause.

## Why This Change Was Made

This PR improves error diagnostics for skill command failures by threading skill command context through the tool search runtime. When a skill's `command-dispatch: tool` fails to find its configured tool, the error message now includes the skill name and command name.

## User Impact

**Before:**
```
Unknown tool id: weather. Use tool_search to find a tool...
```

**After:**
```
Skill "/weather" (from china-weather) Unknown tool id: weather. Use tool_search to find a tool...
```

Users can immediately identify which skill and command are misconfigured, turning an opaque failure into an actionable diagnostic.

## Evidence

- The fix modifies `src/agents/tool-search.ts`:
  - Adds optional `skillCommandContext` field to `UnknownToolErrorOptions` type
  - Adds `beforeToolCallHookContext` field to `ToolSearchToolContext` type  
  - Extracts skill context from `beforeToolCallHookContext` in `call()` and `callExactId()` methods
  - Prepends skill context prefix to error messages in `formatUnknownToolIdError()`

- The change is backward-compatible: the context field is optional and only populated when `beforeToolCallHookContext.skillCommand` is available from the skill dispatch path (`src/skills/runtime/tool-dispatch.ts:165-200`).

- No existing tests are broken; the modification only affects error message formatting when skill context is present.