### PR TITLE
fix(release): wait for Telegram proc visibility

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1777,15 +1777,15 @@ jobs:
                     control_pid="$!"
                     trap "kill ${control_pid} >/dev/null 2>&1 || true" EXIT
                     proc_marker_visible=false
-                    # The child PID exists before execve publishes command-scoped env.
+                    # The background child can still expose the shell's pre-exec environment.
                     for _ in {1..100}; do
-                      if tr "\0" "\n" <"/proc/${control_pid}/environ" |
+                      if tr "\0" "\n" <"/proc/${control_pid}/environ" 2>/dev/null |
                         grep -Fxq "OPENCLAW_QA_PROC_CONTROL=visible"; then
                         proc_marker_visible=true
                         break
                       fi
                       kill -0 "$control_pid" >/dev/null 2>&1 || break
-                      sleep 0.01
+                      sleep 0.05
                     done
                     [[ "$proc_marker_visible" == "true" ]]
                     # Reading the marker is the proof; the probe may exit before cleanup.

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -535,7 +535,11 @@ describe("release Telegram QA workflow", () => {
     expect(source).toContain("runtime_stage=verify-parent-proc-hidden");
     expect(source).toContain("runtime_stage=verify-proc-visibility");
     expect(source).toContain("for _ in {1..100}; do");
+    expect(source).toMatch(
+      /if tr "\\0" "\\n" <"\/proc\/\$\{control_pid\}\/environ" 2>\/dev\/null \|\n\s+grep -Fxq "OPENCLAW_QA_PROC_CONTROL=visible"; then/u,
+    );
     expect(source).toContain("proc_marker_visible=true\n                        break");
+    expect(source).toContain("sleep 0.05");
     expect(source).toContain('[[ "$proc_marker_visible" == "true" ]]');
     expect(source).toMatch(
       /kill "\$control_pid" >\/dev\/null 2>&1 \|\| true\n\s+wait "\$control_pid" \|\| true/u,


### PR DESCRIPTION
AI-assisted implementation; maintainer-reviewed and live-failure-verified.

## What Problem This Solves

Beta release Telegram validation can fail before its canary because `/proc/$pid/environ` is read while the probe child still exposes its pre-`exec` shell environment.

The race reproduced 44 times in 200 iterations on Blacksmith Testbox and caused Release Checks run 29149746290 plus child Telegram QA run 29149804635 to fail at `verify-proc-visibility`.

## Why This Change Was Made

The existing bounded readiness loop now tolerates a temporarily unreadable proc entry and allows up to five seconds for the command-scoped environment to become visible. It still fails closed if the child exits or the exact marker never appears.

This preserves the process-boundary proof instead of weakening or removing it.

## User Impact

Release validation no longer fails nondeterministically before Telegram canary execution when Linux schedules the background child between fork and exec.

## Evidence

- Before: 44/200 immediate proc-visibility misses on Blacksmith Testbox.
- After: 0/200 with the bounded readiness loop.
- Blacksmith Testbox `tbx_01kx8ee37gfm3hhf6xecdt7fmq`: focused workflow Vitest 15/15 passed.
- Same integrated head: Testbox `check:changed` passed.
- Fresh structured Codex autoreview: clean; no accepted or actionable findings.
