### PR TITLE
fix(browser): reject hex click coordinates in act route

### DIFF
--- a/extensions/browser/src/browser/routes/agent.act.normalize.ts
+++ b/extensions/browser/src/browser/routes/agent.act.normalize.ts
@@ -21,11 +21,12 @@ import {
   parseClickModifiers,
 } from "./agent.act.shared.js";
 import {
+  readRouteFiniteNumber,
   readRouteInteger,
   readRouteNonNegativeInteger,
   readRouteTimerTimeoutMs,
 } from "./route-numeric.js";
-import { toBoolean, toNumber, toStringArray, toStringOrEmpty } from "./utils.js";
+import { toBoolean, toStringArray, toStringOrEmpty } from "./utils.js";
 
 function normalizeActKind(raw: unknown): ActKind {
   const kind = toStringOrEmpty(raw);
@@ -104,6 +105,10 @@ function readActionTimeoutMs(body: Record<string, unknown>): number | undefined 
   return readRouteTimerTimeoutMs(body.timeoutMs);
 }
 
+function readClickCoordinate(body: Record<string, unknown>, key: "x" | "y"): number | undefined {
+  return readRouteFiniteNumber(body[key], key);
+}
+
 function readBoundedActionDurationMs(
   body: Record<string, unknown>,
   key: string,
@@ -174,8 +179,8 @@ export function normalizeActRequest(
       };
     }
     case "clickCoords": {
-      const x = toNumber(body.x);
-      const y = toNumber(body.y);
+      const x = readClickCoordinate(body, "x");
+      const y = readClickCoordinate(body, "y");
       if (x === undefined || y === undefined || x < 0 || y < 0) {
         throw new Error("clickCoords requires non-negative x and y");
       }

--- a/extensions/browser/src/browser/routes/agent.act.normalize.ts
+++ b/extensions/browser/src/browser/routes/agent.act.normalize.ts
@@ -105,10 +105,6 @@ function readActionTimeoutMs(body: Record<string, unknown>): number | undefined 
   return readRouteTimerTimeoutMs(body.timeoutMs);
 }
 
-function readClickCoordinate(body: Record<string, unknown>, key: "x" | "y"): number | undefined {
-  return readRouteFiniteNumber(body[key], key);
-}
-
 function readBoundedActionDurationMs(
   body: Record<string, unknown>,
   key: string,
@@ -179,8 +175,8 @@ export function normalizeActRequest(
       };
     }
     case "clickCoords": {
-      const x = readClickCoordinate(body, "x");
-      const y = readClickCoordinate(body, "y");
+      const x = readRouteFiniteNumber(body.x, "x");
+      const y = readRouteFiniteNumber(body.y, "y");
       if (x === undefined || y === undefined || x < 0 || y < 0) {
         throw new Error("clickCoords requires non-negative x and y");
       }

--- a/extensions/browser/src/browser/routes/utils.ts
+++ b/extensions/browser/src/browser/routes/utils.ts
@@ -70,19 +70,6 @@ export function toStringOrEmpty(value: unknown) {
   return "";
 }
 
-/** Coerce route numeric values from numbers or decimal strings. */
-export function toNumber(value: unknown) {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  const normalized = typeof value === "string" ? normalizeOptionalString(value) : undefined;
-  if (normalized) {
-    const parsed = Number(normalized);
-    return Number.isFinite(parsed) ? parsed : undefined;
-  }
-  return undefined;
-}
-
 /** Coerce route boolean values from booleans or common string forms. */
 export function toBoolean(value: unknown) {
   if (typeof value === "boolean") {

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -139,6 +139,28 @@ describe("browser control server", () => {
     slowTimeoutMs,
   );
 
+  it.each([
+    {
+      body: { kind: "clickCoords", x: "0x10", y: "20" },
+      message: "x must be a finite number",
+    },
+    {
+      body: { kind: "clickCoords", x: "20", y: "0x10" },
+      message: "y must be a finite number",
+    },
+  ])(
+    "returns ACT_INVALID_REQUEST for non-decimal coordinate clicks",
+    async ({ body, message }) => {
+      const base = await startServerAndBase();
+      const response = await postActAndReadError(base, body);
+
+      expect(response.status).toBe(400);
+      expect(response.body.code).toBe("ACT_INVALID_REQUEST");
+      expect(response.body.error).toContain(message);
+    },
+    slowTimeoutMs,
+  );
+
   it(
     "returns ACT_EXISTING_SESSION_UNSUPPORTED for unsupported existing-session actions",
     async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where direct Browser `/act` callers sending `clickCoords` could pass hexadecimal coordinate strings such as `"0x10"`, and the route would coerce them into unintended numeric positions instead of rejecting the invalid input.

## Why This Change Was Made

The Browser action route now uses the existing strict route finite-number parser for both `clickCoords.x` and `clickCoords.y`, matching the Browser CLI coordinate contract while preserving decimal coordinate strings such as `"42.5"`. The old permissive route-only numeric helper was removed so this boundary has one canonical parser.

## User Impact

Browser agents and direct Browser control callers get a clear invalid-request response for hex coordinate strings, instead of silently clicking a coerced coordinate.

## Evidence

- Claim proved: Browser `/act` rejects hex string coordinate values for both `clickCoords.x` and `clickCoords.y`, while decimal-string coordinates still perform a real coordinate click through the Browser control server.
- Current head: `acbb44838ae95a9d8fac96f99d5ecfd99c9d83a4`.
- Real Browser behavior proof: `node --import tsx --input-type=module -` started the branch's authenticated loopback Browser bridge with a temporary managed Chromium profile, then drove real HTTP `/start` and `/act` requests. The bearer token and ephemeral ports were redacted from the public transcript.

```json
{
  "head": "acbb44838ae95a9d8fac96f99d5ecfd99c9d83a4",
  "start": { "status": 200, "ok": true },
  "setup": {
    "status": 200,
    "ok": true,
    "result": { "left": 30, "top": 30, "width": 120, "height": 80 }
  },
  "decimalClick": { "status": 200, "ok": true, "url": "about:blank" },
  "clickedReadback": { "status": 200, "ok": true, "result": "1" },
  "hexX": {
    "status": 400,
    "code": "ACT_INVALID_REQUEST",
    "error": "x must be a finite number."
  },
  "hexY": {
    "status": 400,
    "code": "ACT_INVALID_REQUEST",
    "error": "y must be a finite number."
  }
}
```

- Focused regression: `node scripts/run-vitest.mjs extensions/browser/src/browser/server.agent-contract-core.test.ts -- --testNamePattern "coordinate|navigation \\+ common act"` passed with 1 file, 4 tests passed, and 21 skipped.
- Formatting: `node_modules\.bin\oxfmt.CMD --check --threads=1 extensions\browser\src\browser\routes\agent.act.normalize.ts extensions\browser\src\browser\routes\utils.ts extensions\browser\src\browser\server.agent-contract-core.test.ts` passed.
- Branch diff hygiene: `git diff --check upstream/main...HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main` passed with no accepted/actionable findings.
- Observed result: the real Browser control server accepted `x: "42.5", y: "64"`, clicked a live button inside the managed Chromium page, and read back click count `"1"`; the same real `/act` route rejected `x: "0x10"` and `y: "0x10"` with `ACT_INVALID_REQUEST` before dispatch.

AI-assisted: yes. I reviewed the Browser `/act` normalization path, the existing strict numeric route helper, the Browser CLI coordinate contract, open self PR occupancy, and the adjacent open Browser PR #104094, which covers a different existing-session target-refresh invariant.