### PR TITLE
improve(ci): shorten Kova runtime packaging

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -171,6 +171,7 @@ jobs:
       MATRIX_REPEAT: ${{ matrix.repeat }}
       MATRIX_DEEP_PROFILE: ${{ matrix.deep_profile }}
       MATRIX_LIVE: ${{ matrix.live }}
+      OPENCLAW_OCM_RUNTIME_BUILD_PROFILE: ${{ (inputs.profile || 'diagnostic') == 'diagnostic' && 'sourcePerformance' || '' }}
     steps:
       - name: Decide lane
         id: lane

--- a/scripts/ocm-npm-workspace-deps.mjs
+++ b/scripts/ocm-npm-workspace-deps.mjs
@@ -9,6 +9,9 @@ import { pathToFileURL } from "node:url";
 const WORKSPACE_DIRS_ENV = "OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS";
 const REAL_NPM_ENV = "OPENCLAW_OCM_REAL_NPM_BIN";
 const ALLOW_UNRELEASED_CHANGELOG_ENV = "OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG";
+const RUNTIME_BUILD_PROFILE_ENV = "OPENCLAW_OCM_RUNTIME_BUILD_PROFILE";
+const supportedRuntimeBuildProfiles = new Set(["sourcePerformance"]);
+const fullGitCommitPattern = /^[0-9a-f]{40}$/iu;
 
 export function parseWorkspaceDependencyDirs(
   raw = process.env[WORKSPACE_DIRS_ENV],
@@ -75,6 +78,48 @@ export function resolveNpmEnvironment(args, env = process.env) {
   };
 }
 
+export function resolveRuntimePackPlan(args, env = process.env) {
+  if (args[0] !== "pack") {
+    return null;
+  }
+  const profile = env[RUNTIME_BUILD_PROFILE_ENV]?.trim();
+  if (!profile) {
+    return null;
+  }
+  if (!supportedRuntimeBuildProfiles.has(profile)) {
+    throw new Error(`invalid ${RUNTIME_BUILD_PROFILE_ENV}: ${profile}`);
+  }
+  return {
+    profile,
+    packArgs: args.includes("--ignore-scripts") ? args : [...args, "--ignore-scripts"],
+  };
+}
+
+export function resolveRuntimePackEnvironment(
+  env = process.env,
+  now = () => new Date(),
+  readGitCommit = () => {
+    const result = spawnSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return result.status === 0 ? result.stdout.trim() : null;
+  },
+) {
+  const explicitTimestamp = env.OPENCLAW_BUILD_TIMESTAMP?.trim();
+  const explicitCommit = env.GIT_COMMIT?.trim() || env.GIT_SHA?.trim();
+  const checkedOutCommit = explicitCommit ? null : readGitCommit()?.trim();
+  const commit = explicitCommit || checkedOutCommit || env.GITHUB_SHA?.trim();
+  if (commit && !fullGitCommitPattern.test(commit)) {
+    throw new Error("runtime pack commit must be a full 40-character hexadecimal SHA");
+  }
+  return {
+    ...env,
+    OPENCLAW_BUILD_TIMESTAMP: explicitTimestamp || now().toISOString(),
+    ...(commit ? { GIT_COMMIT: commit.toLowerCase() } : {}),
+  };
+}
+
 function runTar(args) {
   const result = spawnSync("tar", args, {
     env: process.env,
@@ -86,6 +131,59 @@ function runTar(args) {
   if (result.status !== 0) {
     throw new Error(`tar failed with status ${result.status ?? 1}`);
   }
+}
+
+function runChecked(command, args, options = {}) {
+  const result = runNpm(command, args, options);
+  if (result.status !== 0) {
+    throw new Error(`${command} failed with status ${result.status ?? 1}`);
+  }
+}
+
+function supportsPreparedRuntimePack(env) {
+  const script = `
+    const mod = await import("./scripts/openclaw-prepack.ts");
+    process.exit(typeof mod.preparePrepackArtifacts === "function" ? 0 : 1);
+  `;
+  const result = runNpm(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", script],
+    {
+      env,
+      stdio: "ignore",
+    },
+  );
+  return result.status === 0;
+}
+
+function prepareRuntimePack(profile, env) {
+  runChecked(process.execPath, ["scripts/build-all.mjs", profile], {
+    env,
+    stdio: "inherit",
+  });
+  runChecked(process.execPath, ["scripts/ui.js", "build"], {
+    env,
+    stdio: "inherit",
+  });
+  const script = `
+    const mod = await import("./scripts/openclaw-prepack.ts");
+    await mod.preparePrepackArtifacts();
+  `;
+  runChecked(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script], {
+    env,
+    stdio: "inherit",
+  });
+}
+
+function restoreRuntimePack(env) {
+  const script = `
+    const mod = await import("./scripts/package-changelog.mjs");
+    await mod.restorePackageChangelog();
+  `;
+  runChecked(process.execPath, ["--input-type=module", "--eval", script], {
+    env,
+    stdio: "inherit",
+  });
 }
 
 function packWorkspaceDependencies(npm, workspaceDirs, outputDir) {
@@ -171,10 +269,27 @@ function main() {
   const args = process.argv.slice(2);
   const npm = process.env[REAL_NPM_ENV]?.trim() || "npm";
   const workspaceDirs = parseWorkspaceDependencyDirs();
+  const npmEnv = resolveNpmEnvironment(args);
+  const runtimePackPlan = resolveRuntimePackPlan(args);
+  const runtimePackEnv = runtimePackPlan ? resolveRuntimePackEnvironment(npmEnv) : null;
+  if (runtimePackPlan && runtimePackEnv && supportsPreparedRuntimePack(runtimePackEnv)) {
+    // This adapter-only archive is installed into OCM and never published.
+    // Standard npm pack still runs the full package build.
+    try {
+      prepareRuntimePack(runtimePackPlan.profile, runtimePackEnv);
+      const result = runNpm(npm, runtimePackPlan.packArgs, {
+        env: runtimePackEnv,
+        stdio: "inherit",
+      });
+      return result.status ?? 1;
+    } finally {
+      restoreRuntimePack(runtimePackEnv);
+    }
+  }
   const plan = resolveWorkspaceInstallPlan(args, workspaceDirs);
   if (!plan) {
     const result = runNpm(npm, args, {
-      env: resolveNpmEnvironment(args),
+      env: npmEnv,
       stdio: "inherit",
     });
     return result.status ?? 1;

--- a/scripts/openclaw-prepack.ts
+++ b/scripts/openclaw-prepack.ts
@@ -216,16 +216,20 @@ async function writeDistInventory(): Promise<void> {
   await writePackageDistInventory(process.cwd());
 }
 
-async function main(): Promise<void> {
-  const buildEnv = resolvePrepackBuildEnvironment();
-  runPnpm(["build"], buildEnv);
-  runPnpm(["ui:build"], buildEnv);
+export async function preparePrepackArtifacts(env: NodeJS.ProcessEnv = process.env): Promise<void> {
   ensurePreparedArtifacts();
   await writeDistInventory();
   runBuildSmoke();
   await preparePackageChangelog(process.cwd(), {
-    allowUnreleased: resolvePrepackAllowUnreleasedChangelog(),
+    allowUnreleased: resolvePrepackAllowUnreleasedChangelog(env),
   });
+}
+
+async function main(): Promise<void> {
+  const buildEnv = resolvePrepackBuildEnvironment();
+  runPnpm(["build"], buildEnv);
+  runPnpm(["ui:build"], buildEnv);
+  await preparePrepackArtifacts(buildEnv);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/test/scripts/ocm-npm-workspace-deps.test.ts
+++ b/test/scripts/ocm-npm-workspace-deps.test.ts
@@ -8,6 +8,8 @@ import {
   buildInstallManifest,
   parseWorkspaceDependencyDirs,
   resolveNpmEnvironment,
+  resolveRuntimePackEnvironment,
+  resolveRuntimePackPlan,
   resolveWorkspaceInstallPlan,
   rewriteWorkspaceDependencyVersions,
 } from "../../scripts/ocm-npm-workspace-deps.mjs";
@@ -24,6 +26,58 @@ describe("OCM npm workspace dependency adapter", () => {
       KEEP: "value",
       OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG: "1",
     });
+  });
+
+  it("uses a prepared runtime-only pack for the diagnostic build profile", () => {
+    expect(
+      resolveRuntimePackPlan(["pack", "--pack-destination", "/tmp/out"], {
+        OPENCLAW_OCM_RUNTIME_BUILD_PROFILE: "sourcePerformance",
+      }),
+    ).toEqual({
+      profile: "sourcePerformance",
+      packArgs: ["pack", "--pack-destination", "/tmp/out", "--ignore-scripts"],
+    });
+  });
+
+  it("keeps normal package builds on the full prepack path", () => {
+    expect(resolveRuntimePackPlan(["pack"], {})).toBeNull();
+    expect(
+      resolveRuntimePackPlan(["install"], {
+        OPENCLAW_OCM_RUNTIME_BUILD_PROFILE: "sourcePerformance",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects unsupported runtime build profiles", () => {
+    expect(() =>
+      resolveRuntimePackPlan(["pack"], {
+        OPENCLAW_OCM_RUNTIME_BUILD_PROFILE: "qaRuntime",
+      }),
+    ).toThrow("invalid OPENCLAW_OCM_RUNTIME_BUILD_PROFILE: qaRuntime");
+  });
+
+  it("pins one timestamp and commit across the prepared runtime pack", () => {
+    const env = resolveRuntimePackEnvironment(
+      { KEEP: "value" },
+      () => new Date("2026-07-11T12:34:56.000Z"),
+      () => "ABCDEF0123456789ABCDEF0123456789ABCDEF01",
+    );
+
+    expect(env).toMatchObject({
+      KEEP: "value",
+      GIT_COMMIT: "abcdef0123456789abcdef0123456789abcdef01",
+      OPENCLAW_BUILD_TIMESTAMP: "2026-07-11T12:34:56.000Z",
+    });
+  });
+
+  it("rejects ambiguous runtime pack commits", () => {
+    expect(() =>
+      resolveRuntimePackEnvironment(
+        { GITHUB_SHA: "abc123" },
+        () => new Date("2026-07-11T12:34:56.000Z"),
+        () => null,
+      ),
+    ).toThrow("runtime pack commit must be a full 40-character hexadecimal SHA");
   });
 
   it("resolves workspace package directories", () => {

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -776,8 +776,12 @@ esac
   });
 
   it("installs local workspace packages beside the OCM root tarball", () => {
+    const workflow = readWorkflow();
     const configure = findStep("Configure OCM local workspace dependencies");
 
+    expect(workflow.jobs?.kova?.env?.OPENCLAW_OCM_RUNTIME_BUILD_PROFILE).toBe(
+      "${{ (inputs.profile || 'diagnostic') == 'diagnostic' && 'sourcePerformance' || '' }}",
+    );
     expect(configure.run).toContain(
       'npm_wrapper="$PERFORMANCE_HELPER_DIR/scripts/ocm-npm-workspace-deps.mjs"',
     );


### PR DESCRIPTION
Closes #104435

## What Problem This Solves

Resolves a release-validation bottleneck where Kova spent about 168 seconds rebuilding a full publish package before diagnostic scenarios could start.

## Why This Change Was Made

The OpenClaw-specific OCM npm adapter now creates a runtime-only diagnostic archive from the focused `sourcePerformance` build, while ordinary `npm pack` and release publication keep the full prepack path. The adapter pins one commit/timestamp across the build, restores changelog state explicitly, and falls back to the full package path for older target refs.

## User Impact

Maintainers get materially faster Kova release diagnostics without weakening published package checks or changing normal package behavior.

## Evidence

- Before: current Kova target setup measured 168.287 seconds, dominated by the full OpenClaw prepack build.
- After: the real adapter archive completed in 25.39 seconds on Testbox `tbx_01kx8ese40e8y1dwpnvywj7t7a` (about 143 seconds saved).
- Exact adapter install succeeded and launched `OpenClaw 2026.7.2`; required runtime and Control UI artifacts were present.
- Changelog hash was unchanged after the script-skipping archive path, with no backup artifact left behind.
- `pnpm test:serial test/openclaw-prepack.test.ts test/scripts/ocm-npm-workspace-deps.test.ts test/scripts/openclaw-performance-workflow.test.ts`: 50 tests passed.
- `pnpm check:changed`: passed scripts/tooling lanes on the same Testbox.
- Fresh autoreview: no accepted/actionable findings.
