### PR TITLE
feat(ui): redesign queued-message list as compact composer-width rows

### DIFF
--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -952,78 +952,80 @@ export function renderChatQueue(props: ChatQueueProps) {
   }
   return html`
     <div class="chat-queue" role="status" aria-live="polite">
-      <div class="chat-queue__title">Queued (${visibleQueue.length})</div>
-      <div class="chat-queue__list">
-        ${visibleQueue.map((item) => {
-          const stateLabel = sendStateLabel(item);
-          return html`
-            <div
-              class="chat-queue__item ${item.kind === "steered" ? "chat-queue__item--steered" : ""}"
-            >
-              <div class="chat-queue__main">
-                ${item.kind === "steered"
-                  ? html`<span class="chat-queue__badge">Steered</span>`
-                  : nothing}
-                ${stateLabel ? html`<span class="chat-queue__badge">${stateLabel}</span>` : nothing}
-                <div class="chat-queue__text">
-                  ${item.text ||
-                  (item.attachments?.length ? `Image (${item.attachments.length})` : "")}
-                </div>
-                ${item.sendError
-                  ? html`<div class="chat-queue__error">${item.sendError}</div>`
-                  : nothing}
-              </div>
-              <div class="chat-queue__actions">
-                ${(item.sendState === "failed" || item.sendState === "unconfirmed") &&
-                props.onQueueRetry
-                  ? html`
-                      <button
-                        class="btn chat-queue__retry"
-                        type="button"
-                        aria-label=${t("chat.queue.retryQueuedMessage")}
-                        @click=${() => props.onQueueRetry?.(item.id)}
-                      >
-                        ${icons.refresh}
-                        <span>${t("chat.queue.retry")}</span>
-                      </button>
-                    `
-                  : nothing}
-                ${props.canAbort &&
-                props.onQueueSteer &&
-                item.kind !== "steered" &&
-                (item.sendState === undefined || item.sendState === "waiting-idle") &&
-                !item.localCommandName
-                  ? html`
-                      <button
-                        class="btn chat-queue__steer"
-                        type="button"
-                        aria-label="Steer queued message"
-                        @click=${() => props.onQueueSteer?.(item.id)}
-                      >
-                        ${icons.cornerDownRight}
-                        <span>Steer</span>
-                      </button>
-                    `
-                  : nothing}
-                ${item.sendState === "executing-command" || item.sendState === "steering"
-                  ? nothing
-                  : html`
-                      <openclaw-tooltip content="Remove queued message">
-                        <button
-                          class="btn chat-queue__remove"
-                          type="button"
-                          aria-label="Remove queued message"
-                          @click=${() => props.onQueueRemove(item.id)}
-                        >
-                          ${icons.x}
-                        </button>
-                      </openclaw-tooltip>
-                    `}
-              </div>
-            </div>
-          `;
-        })}
-      </div>
+      ${visibleQueue.map((item) => renderChatQueueItem(item, props))}
+    </div>
+  `;
+}
+
+function renderChatQueueItem(item: ChatQueueItem, props: ChatQueueProps) {
+  const stateLabel = sendStateLabel(item);
+  const steered = item.kind === "steered";
+  const failed = item.sendState === "failed" || item.sendState === "unconfirmed";
+  const busy = item.sendState === "executing-command" || item.sendState === "steering";
+  const canSteer =
+    Boolean(props.canAbort && props.onQueueSteer) &&
+    !steered &&
+    (item.sendState === undefined || item.sendState === "waiting-idle") &&
+    !item.localCommandName;
+  const text = item.text || (item.attachments?.length ? `Image (${item.attachments.length})` : "");
+  const itemClass = `chat-queue__item${steered ? " chat-queue__item--steered" : ""}${
+    failed ? " chat-queue__item--failed" : ""
+  }`;
+  // Row order keeps the actions on the first flex line; the error wraps below
+  // them via flex-basis so failed rows grow by one line instead of a card.
+  return html`
+    <div class=${itemClass}>
+      <span class="chat-queue__icon" aria-hidden="true">
+        ${failed ? icons.alertTriangle : icons.clock}
+      </span>
+      ${steered
+        ? html`<span class="chat-queue__badge chat-queue__badge--steered">Steered</span>`
+        : nothing}
+      ${stateLabel ? html`<span class="chat-queue__badge">${stateLabel}</span>` : nothing}
+      <span class="chat-queue__text" title=${text}>${text}</span>
+      <span class="chat-queue__actions">
+        ${failed && props.onQueueRetry
+          ? html`
+              <button
+                class="chat-queue__retry"
+                type="button"
+                aria-label=${t("chat.queue.retryQueuedMessage")}
+                @click=${() => props.onQueueRetry?.(item.id)}
+              >
+                ${icons.refresh}
+                <span>${t("chat.queue.retry")}</span>
+              </button>
+            `
+          : nothing}
+        ${canSteer
+          ? html`
+              <button
+                class="chat-queue__steer"
+                type="button"
+                aria-label="Steer queued message"
+                @click=${() => props.onQueueSteer?.(item.id)}
+              >
+                ${icons.cornerDownRight}
+                <span>Steer</span>
+              </button>
+            `
+          : nothing}
+        ${busy
+          ? nothing
+          : html`
+              <openclaw-tooltip content="Remove queued message">
+                <button
+                  class="chat-queue__remove"
+                  type="button"
+                  aria-label="Remove queued message"
+                  @click=${() => props.onQueueRemove(item.id)}
+                >
+                  ${icons.x}
+                </button>
+              </openclaw-tooltip>
+            `}
+      </span>
+      ${item.sendError ? html`<span class="chat-queue__error">${item.sendError}</span>` : nothing}
     </div>
   `;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2918,62 +2918,6 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   }
 }
 
-.chat-queue__item--steered {
-  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
-}
-
-.chat-queue__main {
-  min-width: 0;
-}
-
-.chat-queue__actions {
-  display: flex;
-  align-items: flex-start;
-  gap: 6px;
-}
-
-.chat-queue__steer,
-.chat-queue__retry {
-  align-self: start;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  color: var(--accent);
-  font-size: 12px;
-  line-height: 1;
-}
-
-.chat-queue__steer svg,
-.chat-queue__retry svg {
-  width: 13px;
-  height: 13px;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.chat-queue__steer:hover:not(:disabled),
-.chat-queue__retry:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-}
-
-.chat-queue__badge {
-  display: inline-flex;
-  width: fit-content;
-  margin-bottom: 6px;
-  flex-shrink: 0;
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  color: var(--accent);
-  font-size: 0.68rem;
-  font-weight: 600;
-  line-height: 1.2;
-}
-
 .slash-menu {
   position: absolute;
   bottom: 100%;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3484,63 +3484,171 @@ td.data-table-key-col {
   flex: 1;
 }
 
-/* Chat queue */
+/* Chat queue: compact pending rows aligned with the composer shell width. */
 .chat-queue {
-  margin-top: 12px;
-  padding: 12px;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: var(--card);
-  display: grid;
-  gap: 8px;
-}
-
-.chat-queue__title {
-  font-family: var(--mono);
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--muted);
-}
-
-.chat-queue__list {
-  display: grid;
-  gap: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: calc(100% - 36px);
+  max-width: 48rem;
+  margin: 8px auto 0;
 }
 
 .chat-queue__item {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
-  gap: 12px;
-  padding: 10px 12px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px 8px;
+  min-height: 30px;
+  padding: 3px 5px 3px 10px;
   border-radius: var(--radius-md);
-  border: 1px dashed var(--border-strong);
-  background: var(--secondary);
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  color: var(--muted);
+}
+
+.chat-queue__item--steered {
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+}
+
+.chat-queue__item--failed {
+  background: color-mix(in srgb, var(--danger) 8%, transparent);
+}
+
+.chat-queue__icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--muted);
+}
+
+.chat-queue__icon svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.75px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chat-queue__item--failed .chat-queue__icon {
+  color: var(--danger);
+}
+
+.chat-queue__badge {
+  flex-shrink: 0;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--fg) 12%, transparent);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.chat-queue__badge--steered {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+}
+
+.chat-queue__item--failed .chat-queue__badge {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger);
 }
 
 .chat-queue__text {
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--chat-text);
   font-size: 13px;
-  line-height: 1.45;
-  white-space: pre-wrap;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
+  line-height: 1.4;
 }
 
+/* Wraps onto its own flex line below the row (see renderChatQueueItem). */
 .chat-queue__error {
-  margin-top: 4px;
+  flex-basis: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 0 3px 22px;
   color: var(--danger);
-  font-size: 12px;
+  font-size: 11.5px;
   line-height: 1.35;
 }
 
-.chat-queue__remove {
-  align-self: start;
-  padding: 4px 10px;
-  font-size: 12px;
+.chat-queue__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.chat-queue__steer,
+.chat-queue__retry {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--accent);
+  font-size: 11.5px;
+  font-weight: 600;
   line-height: 1;
+  cursor: pointer;
+}
+
+.chat-queue__steer svg,
+.chat-queue__retry svg {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.75px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chat-queue__steer:hover:not(:disabled),
+.chat-queue__retry:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.chat-queue__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.chat-queue__remove:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+
+.chat-queue__remove svg {
+  width: 13px;
+  height: 13px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 /* Chat lines */


### PR DESCRIPTION
## What Problem This Solves

Fixes #104444.

When a message is queued in the Control UI (gateway offline, agent busy, or a failed send), the composer area grows a large "Queued (N)" card: mono header, a full-width dashed box per message, badges stacked above the text, and oversized buttons. A single one-word queued message eats ~160px of vertical space and renders wider than the composer itself, dominating the chat viewport for what is transient bookkeeping.

## Why This Change Was Made

Queued messages should read as a slim status line above the composer, not primary content. This redesigns the queue as compact, composer-width rows:

- One single-line row per queued message: state icon (clock, or alert triangle for failures), a small state pill ("Waiting for reconnect", "Failed", "Steered", ...), one-line truncated text (full text via `title`), and inline ghost actions (Steer / Retry / Remove).
- The "Queued (N)" header, the card wrapper, and the dashed per-item boxes are gone; the row stack aligns with the composer shell width (`calc(100% - 36px)`, max 48rem) instead of spanning the full pane.
- Failed rows tint red and grow by exactly one line for the error message instead of a multi-line card.
- All queue CSS now lives in one `components.css` section; the scattered rules in `chat/layout.css` were deleted. The buttons no longer piggyback on the global `.btn` chrome.

Behavior (queue semantics, action visibility rules, aria/live-region, retry/steer/remove callbacks) is unchanged; test hooks (`.chat-queue`, `__badge`, `__error`, `__retry`, `__steer`, `__remove`, state-label texts) are preserved.

## User Impact

Queued/failed messages now take a fraction of the previous space and visually attach to the composer. Before/after with the same states:

| | Before | After |
|---|---|---|
| Waiting for reconnect | ![before-reconnect](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/queued-message-redesign/before-reconnect-light.png) | ![after-reconnect](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/queued-message-redesign/after-reconnect-light.png) |
| Failed send | ![before-failed](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/queued-message-redesign/before-failed-light.png) | ![after-failed](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/queued-message-redesign/after-failed-light.png) |

Dark mode:

![after-dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/queued-message-redesign/after-reconnect-dark.png)

## Evidence

- Screenshots above are deterministic captures from the mock-gateway Playwright harness (`installMockGateway` + `startControlUiE2eServer`), light and dark color schemes, driving the real offline-queue and rejected-send flows.
- `ui/src/e2e/chat-flow.e2e.test.ts` (queue flows: offline reconnect queue, rejected pre-ACK send, ACK-lost retry, applying-chat-settings queue) run locally against this branch.
- `pnpm test ui/src/pages/chat/chat-view.test.ts` (chat queue render contract: Steer visibility, failed retry/remove affordances, running-command row) — run IDs in PR comments/CI.
- `pnpm check:changed` (format/lint/type lanes) on the changed files.
