### PR TITLE
fix(ui): sidebar session list collapses into overlapping rows in short windows

### DIFF
--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -1084,6 +1084,80 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     }
   });
 
+  it("scrolls long session lists in short windows instead of squeezing sections", async () => {
+    const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
+    const rows = [
+      ...Array.from({ length: 8 }, (_, index) =>
+        sessionRow(`agent:main:work-${index}`, `Work session ${index}`, baseTime - index * 60_000, {
+          worktree: { branch: `openclaw/wt-${index}`, repoRoot: "/Users/dev/Projects/clawdbot" },
+        }),
+      ),
+      ...Array.from({ length: 30 }, (_, index) =>
+        sessionRow(`agent:main:chat-${index}`, `Chat ${index}`, baseTime - (index + 10) * 60_000),
+      ),
+    ];
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 620, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse(rows),
+      },
+      sessionKey: "agent:main:main",
+    });
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await expect
+        .poll(() => page.locator(".sidebar-recent-session").count(), { timeout: 15_000 })
+        .toBeGreaterThanOrEqual(rows.length);
+      await captureUiProof(page, "short-window-session-sections.png");
+
+      // Sections must stack below each other, not paint over the rows above.
+      const overlaps = await page.evaluate(() => {
+        const rects = [
+          ...document.querySelectorAll(".sidebar-recent-session, .sidebar-recent-sessions__head"),
+        ]
+          .map((element) => {
+            const rect = element.getBoundingClientRect();
+            return { top: rect.top, bottom: rect.bottom };
+          })
+          .filter((rect) => rect.bottom > rect.top)
+          .toSorted((a, b) => a.top - b.top);
+        let bad = 0;
+        for (let index = 1; index < rects.length; index += 1) {
+          if (rects[index].top < rects[index - 1].bottom - 2) {
+            bad += 1;
+          }
+        }
+        return bad;
+      });
+      expect(overlaps).toBe(0);
+
+      // The squeeze regression compressed sections into the viewport with no
+      // overflow; a healthy list is taller than its container and scrolls.
+      const scroll = await page.evaluate(() => {
+        const list = document.querySelector(".sidebar-recent-sessions");
+        if (!list) {
+          return null;
+        }
+        list.scrollTop = list.scrollHeight;
+        return {
+          clientHeight: list.clientHeight,
+          scrollHeight: list.scrollHeight,
+          scrollTop: list.scrollTop,
+        };
+      });
+      expect(scroll).not.toBeNull();
+      expect(scroll?.scrollHeight ?? 0).toBeGreaterThan(scroll?.clientHeight ?? 0);
+      expect(scroll?.scrollTop ?? 0).toBeGreaterThan(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps sidebar session controls reachable on touch pointers", async () => {
     const context = await browser.newContext({
       hasTouch: true,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -695,6 +695,9 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 }
 
 .sidebar {
+  /* Sticky headers inside the sidebar reuse --sidebar-bg so scrolled rows
+     never shine through with a mismatched tone. */
+  --sidebar-bg: color-mix(in srgb, var(--bg) 96%, var(--bg-elevated) 4%);
   position: relative;
   display: flex;
   flex-direction: column;
@@ -702,11 +705,11 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   min-height: 0;
   min-width: 0;
   overflow: hidden;
-  background: color-mix(in srgb, var(--bg) 96%, var(--bg-elevated) 4%);
+  background: var(--sidebar-bg);
 }
 
 :root[data-theme-mode="light"] .sidebar {
-  background: color-mix(in srgb, var(--panel) 98%, white 2%);
+  --sidebar-bg: color-mix(in srgb, var(--panel) 98%, white 2%);
 }
 
 .sidebar-shell {
@@ -990,6 +993,13 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   cursor: default;
 }
 
+/* The scroller's children must not flex-shrink: shrink squeezes each section
+   to its min-height while the fixed-height rows inside overflow and paint
+   over the following section. Fixed sizing makes the list scroll instead. */
+.sidebar-recent-sessions > * {
+  flex: 0 0 auto;
+}
+
 .sidebar-recent-sessions__group {
   display: flex;
   flex-direction: column;
@@ -1039,7 +1049,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   position: sticky;
   top: 0;
   z-index: 2;
-  background: var(--bg);
+  background: var(--sidebar-bg);
 }
 
 .sidebar-recent-sessions__head .sidebar-recent-sessions__label-text {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the sidebar session list would look garbled when the window is short or the list is long: session group headers (channel groups, Work, Chats, custom groups) and rows painted on top of each other instead of scrolling. With an expanded More section plus a few dozen sessions, rows from one section overlapped the next section's header and rows, making the sidebar unreadable and sessions unreachable.

## Why This Change Was Made

`.sidebar-recent-sessions` is a flex-column scroll container, but its children (session sections, agent sections, the draft row) kept their default `flex-shrink: 1`. Sections carry an explicit `min-height: 28px` (empty-group drop targets), so under vertical space pressure flexbox compressed every section down toward that minimum instead of letting the container overflow and scroll. The fixed-height rows inside each squeezed section then overflowed and painted over the following section.

The fix pins the scroller's children to `flex: 0 0 auto` so the list overflows and scrolls like it should. While in there, the sticky "Sessions" header now reuses the sidebar's actual background via a shared `--sidebar-bg` custom property (it previously used plain `var(--bg)`, which subtly mismatched the sidebar's color-mix tone when rows scrolled underneath, especially in light mode).

## User Impact

Session sidebars with many sessions or short windows now scroll cleanly instead of collapsing into overlapping rows. No behavior change when everything fits.

Before / after (1280×620, Work + Chats sections):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-short-window-squeeze-2026-07/before-fix.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-short-window-squeeze-2026-07/after-fix.png) |

## Evidence

- New e2e regression test `scrolls long session lists in short windows instead of squeezing sections` in `ui/src/e2e/session-management.e2e.test.ts`: renders 38 sessions (Work + Chats sections) at a 620px-tall viewport, asserts zero overlapping row/header rects and that `.sidebar-recent-sessions` actually overflows and scrolls.
- The test fails on the previous CSS (overlap assertion trips) and passes with this change.
- Full `ui/src/e2e/session-management.e2e.test.ts` (11 tests), `sidebar-customization.e2e.test.ts`, and `sidebar-dev-branch.e2e.test.ts` pass with this change.
- Live mock-gateway harness measurement at 1280×620 with two sections: previous CSS produces 97 overlapping row/header rects with the list compressed to fit; with this change 0 overlaps and the list reports `scrollHeight` ≫ `clientHeight`.
- `pnpm check:changed` green (delegated Testbox run, exit 0).
