### PR TITLE
refactor(ui): style the new-session draft as the chat composer shell

### DIFF
--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -587,7 +587,9 @@ class NewSessionPage extends OpenClawLightDomElement {
   }
 
   private handleMessageKeydown(event: KeyboardEvent) {
-    if (event.key !== "Enter" || event.shiftKey || event.isComposing) {
+    // keyCode 229 mirrors the chat composer's IME guard: some browsers emit
+    // the candidate-confirm Enter with isComposing === false.
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing || event.keyCode === 229) {
       return;
     }
     // Honor the chat composer's send-shortcut setting so the draft picker

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -6,7 +6,9 @@ import { property, state } from "lit/decorators.js";
 import type { FsListDirResult } from "../../../../packages/gateway-protocol/src/index.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
+import { loadSettings } from "../../app/settings.ts";
 import { icons } from "../../components/icons.ts";
+import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
 import { searchForSession } from "../../lib/sessions/index.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
@@ -578,30 +580,55 @@ class NewSessionPage extends OpenClawLightDomElement {
               </div>`
             : nothing}
           ${this.error ? html`<div class="new-session-page__error">${this.error}</div>` : nothing}
-          <textarea
-            class="new-session-page__message"
-            rows="6"
-            placeholder=${t("newSession.messagePlaceholder")}
-            .value=${this.message}
-            @input=${(event: Event) => {
-              this.message = (event.target as HTMLTextAreaElement).value;
-            }}
-            @keydown=${(event: KeyboardEvent) => {
-              if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-                event.preventDefault();
-                void this.submit();
-              }
-            }}
-          ></textarea>
-          <div class="new-session-page__actions">
-            <button
-              type="button"
-              class="new-session-page__start"
-              ?disabled=${!this.canSubmit()}
-              @click=${() => void this.submit()}
-            >
-              ${this.submitting ? t("newSession.starting") : t("newSession.start")}
-            </button>
+          ${this.renderComposer()}
+        </div>
+      </div>
+    `;
+  }
+
+  private handleMessageKeydown(event: KeyboardEvent) {
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing) {
+      return;
+    }
+    // Honor the chat composer's send-shortcut setting so the draft picker
+    // sends exactly like an existing session's composer.
+    const requiresModifier = loadSettings().chatSendShortcut === "modifier-enter";
+    if (!requiresModifier || event.metaKey || event.ctrlKey) {
+      event.preventDefault();
+      void this.submit();
+    }
+  }
+
+  /** Draft message box styled as the chat composer shell so both pickers match. */
+  private renderComposer() {
+    const startLabel = this.submitting ? t("newSession.starting") : t("newSession.start");
+    return html`
+      <div class="agent-chat__input new-session-page__composer">
+        <div class="agent-chat__composer-input-row">
+          <div class="agent-chat__composer-combobox">
+            <textarea
+              class="new-session-page__message"
+              rows="4"
+              placeholder=${t("newSession.messagePlaceholder")}
+              .value=${this.message}
+              @input=${(event: Event) => {
+                this.message = (event.target as HTMLTextAreaElement).value;
+              }}
+              @keydown=${(event: KeyboardEvent) => this.handleMessageKeydown(event)}
+            ></textarea>
+          </div>
+          <div class="agent-chat__composer-actions">
+            <openclaw-tooltip content=${t("newSession.start")}>
+              <button
+                type="button"
+                class="chat-send-btn"
+                ?disabled=${!this.canSubmit()}
+                aria-label=${startLabel}
+                @click=${() => void this.submit()}
+              >
+                ${this.submitting ? icons.loader : icons.send}
+              </button>
+            </openclaw-tooltip>
           </div>
         </div>
       </div>

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -1,4 +1,6 @@
-/* Full-page new-session draft: target chips above a large composer. */
+/* Full-page new-session draft: target chips above the shared chat composer
+   shell (.agent-chat__input). Corner radii stay on the composer's radius
+   tokens so the draft picker matches the chat picker. */
 .new-session-page {
   display: flex;
   justify-content: center;
@@ -38,7 +40,7 @@
   gap: 6px;
   padding: 4px 10px;
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--bg-elevated) 70%, transparent);
   font-size: 12px;
   color: var(--text);
@@ -85,7 +87,7 @@
   width: 22px;
   height: 22px;
   border: 0;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--muted);
   cursor: pointer;
@@ -111,7 +113,7 @@
 .new-session-page__browser {
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   background: var(--panel);
 }
 
@@ -147,7 +149,7 @@
   gap: 8px;
   padding: 6px 8px;
   border: 0;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text);
   font-size: 13px;
@@ -181,30 +183,17 @@
   color: var(--danger);
 }
 
-.new-session-page__message {
-  width: 100%;
-  min-height: 140px;
-  padding: 12px 14px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: var(--bg);
-  color: var(--text);
-  font: inherit;
-  font-size: 13px;
-  resize: vertical;
+/* Larger draft box than the chat composer default; wins over the shared
+   .agent-chat__composer-combobox > textarea sizing by specificity. */
+.new-session-page__composer textarea.new-session-page__message {
+  min-height: 112px;
+  max-height: 40vh;
 }
 
-.new-session-page__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.new-session-page__start,
 .new-session-page__browser-use {
   padding: 6px 14px;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-md);
   background: var(--accent);
   color: var(--accent-contrast, #fff);
   font-size: 13px;
@@ -212,7 +201,6 @@
   cursor: pointer;
 }
 
-.new-session-page__start:disabled,
 .new-session-page__browser-use:disabled {
   opacity: 0.5;
   cursor: default;


### PR DESCRIPTION
Related: #104238

## What Problem This Solves

The full-page New session screen (added in #104238) introduced a bespoke message box and "Start session" button that looked different from the chat composer users already know: pill-shaped target chips, a 12px-radius textarea, and a 999px-radius accent button all on one page, none matching the chat picker's corner radius or layout.

## Why This Change Was Made

Instead of maintaining a second picker design, the draft page now reuses the chat composer's shell: the message box renders with the shared `agent-chat__input` / `agent-chat__composer-*` classes and the shared `chat-send-btn` send button, so it inherits the composer's card background, border, focus ring, and `--radius-md` corner radius. The target selectors (agent, exec node, folder, worktree) stay above the composer and now use the same radius tokens (`--radius-md` chips and browser panel, `--radius-sm` inner controls) instead of pills. The separate "Start session" button is replaced by the composer's send button, and Enter-to-send honors the same `chatSendShortcut` setting and IME guards (`isComposing`, `keyCode === 229`) as the chat composer.

## User Impact

The New session draft now looks and behaves like the chat composer with the target chips on top: one consistent corner radius across chips, folder browser, and message box, and the familiar send affordance inside the box. Draft semantics are unchanged (same `sessions.create` payload, same folder browser, same worktree gating).

## Evidence

After (mock-gateway harness, deterministic):

![New session draft using the chat composer shell](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-composer-shell/after.png)

- Verified interactively against `pnpm dev:ui:mock`: chips row above the composer, unified radii, send button enables with a draft, submit reaches `sessions.create`, error row renders above the composer and the draft is preserved on failure.
- `ui/src/e2e/new-session-page.e2e.test.ts` is unchanged and its selectors are preserved (`.new-session-page__message` on the textarea, "Start session" as the send button's accessible name); a Blacksmith Testbox run of the test is posted below before merge.
- `pnpm check:changed` passed on Blacksmith Testbox (Actions run 29151221109); a rerun covering the final head is posted below before merge.
- Codex autoreview (gpt-5.5): the initial pass flagged the missing IME `keyCode === 229` guard, fixed in the second commit; rerun clean.
