### PR TITLE
fix(whatsapp): keep pre-connect recovery replayable

### DIFF
--- a/extensions/whatsapp/src/send.delivery-recovery.test.ts
+++ b/extensions/whatsapp/src/send.delivery-recovery.test.ts
@@ -1,0 +1,126 @@
+// Whatsapp tests cover the durable outbound handoff across startup recovery.
+import {
+  createEmptyPluginRegistry,
+  createOutboundTestPlugin,
+  createTestRegistry,
+  deliverOutboundPayloads,
+  releasePinnedPluginChannelRegistry,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { withStateDirEnv } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { whatsappChannelOutbound } from "./channel-outbound.js";
+import {
+  getRegisteredWhatsAppConnectionController,
+  registerWhatsAppConnectionController,
+  unregisterWhatsAppConnectionController,
+} from "./connection-controller-registry.js";
+import { createAcceptedWhatsAppSendResult } from "./inbound/send-result.test-helper.js";
+import type { ActiveWebListener } from "./inbound/types.js";
+
+const cfg = { channels: { whatsapp: {} } } as OpenClawConfig;
+const accountId = "default";
+
+function clearDefaultController(): void {
+  const controller = getRegisteredWhatsAppConnectionController(accountId);
+  if (controller) {
+    unregisterWhatsAppConnectionController(accountId, controller);
+  }
+}
+
+async function drainDefaultWhatsAppDeliveries(stateDir: string) {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  await drainPendingDeliveries({
+    drainKey: `whatsapp:${accountId}`,
+    logLabel: "WhatsApp reconnect drain",
+    cfg,
+    log,
+    stateDir,
+    selectEntry: (entry) => ({
+      match:
+        entry.channel === "whatsapp" && ((entry.accountId ?? "").trim() || accountId) === accountId,
+      bypassBackoff:
+        typeof entry.lastError === "string" &&
+        entry.lastError.includes("No active WhatsApp Web listener"),
+    }),
+  });
+  return log;
+}
+
+describe("WhatsApp delivery recovery", () => {
+  beforeEach(() => {
+    clearDefaultController();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "whatsapp",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "whatsapp",
+            outbound: whatsappChannelOutbound,
+          }),
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    clearDefaultController();
+    releasePinnedPluginChannelRegistry();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("keeps pre-connect recovery replayable, then sends exactly once after connect", async () => {
+    await withStateDirEnv("openclaw-whatsapp-delivery-recovery-", async ({ stateDir }) => {
+      const initialError = await deliverOutboundPayloads({
+        cfg,
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: "queued before listener startup" }],
+        queuePolicy: "required",
+      }).catch((err: unknown) => err);
+      expect(initialError).toMatchObject({
+        cause: expect.any(PlatformMessageNotDispatchedError),
+      });
+
+      const preConnectLog = await drainDefaultWhatsAppDeliveries(stateDir);
+      expect(preConnectLog.warn).toHaveBeenCalledWith(
+        expect.stringContaining("No active WhatsApp Web listener"),
+      );
+
+      const sendMessage = vi.fn(async () =>
+        createAcceptedWhatsAppSendResult("text", "recovered-message"),
+      );
+      const listener: ActiveWebListener = {
+        sendComposingTo: vi.fn(async () => {}),
+        sendMessage,
+        sendPoll: vi.fn(async () => createAcceptedWhatsAppSendResult("poll", "poll")),
+        sendReaction: vi.fn(async () => createAcceptedWhatsAppSendResult("reaction", "reaction")),
+      };
+      const controller = {
+        getActiveListener: () => listener,
+        getCurrentSock: () => null,
+        getSelfIdentity: () => null,
+      };
+      registerWhatsAppConnectionController(accountId, controller);
+
+      await drainDefaultWhatsAppDeliveries(stateDir);
+      await drainDefaultWhatsAppDeliveries(stateDir);
+
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(sendMessage).toHaveBeenCalledWith(
+        "+1555",
+        "queued before listener startup",
+        undefined,
+        undefined,
+      );
+    });
+  });
+});

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -4,6 +4,7 @@ import fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { redactIdentifier } from "openclaw/plugin-sdk/logging-core";
 import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS } from "openclaw/plugin-sdk/media-runtime";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -326,27 +327,19 @@ describe("web outbound", () => {
 
   it("throws a helpful error when no active listener exists", async () => {
     hoisted.controllerListeners.clear();
-    await expect(
-      sendMessageWhatsApp("+1555", "hi", {
-        verbose: false,
-        cfg: WHATSAPP_TEST_CFG,
-        accountId: "work",
-      }),
-    ).rejects.toThrow(/No active WhatsApp Web listener/);
-    await expect(
-      sendMessageWhatsApp("+1555", "hi", {
-        verbose: false,
-        cfg: WHATSAPP_TEST_CFG,
-        accountId: "work",
-      }),
-    ).rejects.toThrow(/channels login/);
-    await expect(
-      sendMessageWhatsApp("+1555", "hi", {
-        verbose: false,
-        cfg: WHATSAPP_TEST_CFG,
-        accountId: "work",
-      }),
-    ).rejects.toThrow(/account: work/);
+    const error = await sendMessageWhatsApp("+1555", "hi", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      accountId: "work",
+    }).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(error).toMatchObject({
+      code: "OPENCLAW_PLATFORM_MESSAGE_NOT_DISPATCHED",
+      message: expect.stringMatching(
+        /No active WhatsApp Web listener.*channels login.*account work/,
+      ),
+    });
   });
 
   it("maps audio to PTT with opus mime when ogg", async () => {

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -2,6 +2,7 @@
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { generateSecureUuid } from "openclaw/plugin-sdk/core";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { redactIdentifier } from "openclaw/plugin-sdk/logging-core";
 import {
   convertMarkdownTables,
@@ -97,9 +98,10 @@ function requireOutboundActiveWebListener(params: { cfg: OpenClawConfig; account
   const listener =
     getRegisteredWhatsAppConnectionController(resolvedAccountId)?.getActiveListener() ?? null;
   if (!listener) {
-    throw new Error(
+    const cause = new Error(
       `No active WhatsApp Web listener (account: ${resolvedAccountId}). Start the gateway, then link WhatsApp with: ${formatCliCommand(`openclaw channels login --channel whatsapp --account ${resolvedAccountId}`)}.`,
     );
+    throw new PlatformMessageNotDispatchedError(cause.message, { cause });
   }
   return { accountId: resolvedAccountId, listener };
 }


### PR DESCRIPTION
Fixes #91212

AI-assisted implementation; maintainer-reviewed and source-verified.

## What Problem This Solves

Fixes a startup recovery path where WhatsApp could classify a missing outbound listener as an attempted send. Durable recovery then preserved false send evidence instead of safely retrying after the listener connected.

## Why This Change Was Made

The WhatsApp adapter now uses the existing public SDK `PlatformMessageNotDispatchedError` for its pre-send listener gate. That lets the shared durable recovery path clear false attempt evidence while keeping the pending intent for the existing reconnect drain.

The fix stays at the transport owner boundary and reuses the generic durable marker instead of adding delay heuristics or a WhatsApp-specific retry queue.

## User Impact

Messages queued before the WhatsApp listener is ready can recover after connect without being lost or sent twice.

## Evidence

- Real-adapter regression: enqueue before listener, pre-connect drain fails safely, listener connects, two subsequent drains produce exactly one recipient send.
- Blacksmith Testbox `pearl-hermit` (`tbx_01kx8fss8mm2ef6888c3qjen9f`) focused proof: 36 tests passed.
- Testbox `check:changed` passed.
- Full Testbox build passed.
- Structured Codex autoreview: clean; no accepted or actionable findings.
- Remaining live proof gap: no credentialed WhatsApp restart roundtrip was run.
