### PR TITLE
fix(attempt-execution): use truncateUtf16Safe for summary text truncation

### DIFF
--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -5,6 +5,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import readline from "node:readline";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   isSilentReplyPrefixText,
   isSilentReplyText,
@@ -402,7 +403,7 @@ export function formatClaudeCliFallbackPrelude(
       // Truncate the summary at a word boundary if it's huge; clearly mark
       // the truncation so the fallback model treats the prelude as a hint,
       // not exhaustive state.
-      const slice = seed.summaryText.slice(0, Math.max(0, remaining - 64));
+      const slice = truncateUtf16Safe(seed.summaryText, Math.max(0, remaining - 64));
       const lastBreak = slice.lastIndexOf(" ");
       const trimmed = lastBreak > 0 ? slice.slice(0, lastBreak).trimEnd() : slice.trimEnd();
       sections.push(`\nSummary of earlier conversation (truncated):\n${trimmed} …`);

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -201,7 +201,7 @@ describe("formatClaudeCliFallbackPrelude", () => {
   });
 
   it.each([
-    ["a surrogate boundary", `${"x".repeat(21)}😀tail`, "x".repeat(21)],
+    ["a surrogate boundary", `${"x".repeat(21)}😀${"y".repeat(100)}`, "x".repeat(21)],
     ["the ASCII budget", "x".repeat(100), "x".repeat(22)],
   ])("preserves %s when truncating an oversized summary", (_label, summaryText, expected) => {
     const out = formatClaudeCliFallbackPrelude(

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -200,6 +200,18 @@ describe("formatClaudeCliFallbackPrelude", () => {
     expect(out).toMatch(/…$/);
   });
 
+  it.each([
+    ["a surrogate boundary", `${"x".repeat(21)}😀tail`, "x".repeat(21)],
+    ["the ASCII budget", "x".repeat(100), "x".repeat(22)],
+  ])("preserves %s when truncating an oversized summary", (_label, summaryText, expected) => {
+    const out = formatClaudeCliFallbackPrelude(
+      { summaryText, recentTurns: [] },
+      { charBudget: 128 },
+    );
+
+    expect(out).toContain(`Summary of earlier conversation (truncated):\n${expected} …`);
+  });
+
   it("drops oldest turns first when the budget cannot fit all of them", () => {
     const turns = Array.from({ length: 10 }, (_, i) => ({
       role: "user" as const,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Claude CLI fallback prelude text truncated from a long conversation summary could produce a dangling UTF-16 surrogate when a snapshot limit landed between the two code units of an emoji. The malformed text then flows into the fallback model's prelude instead of ending at the last complete character.

## Why This Change Was Made

The `seed.summaryText.slice(0, targetLength)` call in the summary truncation path operates on raw UTF-16 code units and can split surrogate pairs. OpenClaw's canonical `truncateUtf16Safe` helper handles this correctly by checking the boundary code units and retreating past any partial surrogate pair.

## User Impact

Claude CLI fallback prelude text remains valid Unicode at its character budget limit. User messages containing emoji or other supplementary-plane characters in the conversation history no longer produce a broken boundary character in the fallback prompt.

## Evidence

### Live verification

Reproduced with the real `truncateUtf16Safe` helper, simulating the exact code path from `attempt-execution.helpers.ts`:

Constructed summary text of 3063 ASCII characters + 🎉 (U+1F389, surrogate pair), total 3065 UTF-16 code units. `remaining=3128`, `target=3128-64=3064` — the truncation point lands exactly between the surrogate pair (index 3063 = 0xd83c high surrogate, index 3064 = 0xdf89 low surrogate).

#### Before (`summaryText.slice(0, 3064)`)

```text
TRUNCATED_LENGTH=3064
LAST_CODE_UNIT=0xd83c
LONE_HIGH_SURROGATE=true
BOUNDARY_SUFFIX_JSON="\ud83c"
JSON_ROUND_TRIP_STABLE=true
```

#### After (`truncateUtf16Safe(summaryText, 3064)`)

```text
TRUNCATED_LENGTH=3063
LAST_CODE_UNIT=0x61
LONE_SURROGATE=false
BOUNDARY_SUFFIX_JSON="a"
JSON_ROUND_TRIP_STABLE=true
EMOJI_DROPPED=true
```

**Verdict**: Before leaves a dangling high surrogate 0xd83c. After safely retreats to the last complete character (0x61 = `"a"`), the emoji is fully dropped instead of half-emitted. JSON round-trip stable. PASS.