### PR TITLE
fix(release): restore trusted Telegram validation

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1777,7 +1777,7 @@ jobs:
                     control_pid="$!"
                     trap "kill ${control_pid} >/dev/null 2>&1 || true" EXIT
                     proc_marker_visible=false
-                    # The background child can still expose the shell's pre-exec environment.
+                    # The background child can still expose the shell pre-exec environment.
                     for _ in {1..100}; do
                       if tr "\0" "\n" <"/proc/${control_pid}/environ" 2>/dev/null |
                         grep -Fxq "OPENCLAW_QA_PROC_CONTROL=visible"; then

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -585,6 +585,23 @@ describe("release Telegram QA workflow", () => {
     expect(source).toContain('if [[ "${1:-}" == "--root-terminate-uid" ]]');
   });
 
+  it("keeps the generated SUT launcher valid bash", () => {
+    const createSutStep = workflowStep(
+      workflowJob("run_telegram"),
+      "Create isolated Telegram SUT identity and launcher",
+    );
+    const launcherSource = createSutStep.run?.match(
+      /<<'LAUNCHER'\n([\s\S]*?)\nLAUNCHER(?:\n|$)/u,
+    )?.[1];
+    expect(launcherSource).toBeTruthy();
+
+    const result = spawnSync("bash", ["-n"], {
+      encoding: "utf8",
+      input: launcherSource,
+    });
+    expect(result.status, result.stderr).toBe(0);
+  });
+
   it("arms the boundary preload only in the gateway main thread", () => {
     const createSutStep = workflowStep(
       workflowJob("run_telegram"),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the trusted Telegram release lane could not launch the isolated gateway after the proc-visibility hardening landed. The generated launcher terminated with an unmatched-quote parse error before writing its process identity, blocking beta release validation.

## Why This Change Was Made

Removes the apostrophe that escaped the launcher's nested single-quoted Bash program. Adds a regression test that extracts the complete generated launcher and checks it with `bash -n`, covering the actual artifact that failed in CI.

## User Impact

Release operators can run the trusted Telegram validation lane again. No product runtime behavior changes.

## Evidence

- Before: trusted Telegram child [29151532569](https://github.com/openclaw/openclaw/actions/runs/29151532569) failed at `launch-runtime` with `unexpected EOF while looking for matching` single quote.
- After: focused Testbox [29151977746](https://github.com/openclaw/openclaw/actions/runs/29151977746), 16/16 tests passed.
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings.

AI-assisted: yes. The generated change and regression test were reviewed and understood.
