### PR TITLE
improve(ci): let Kova own diagnostic build profiles

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -50,7 +50,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 790f0b28229cb60a60c289ef8c250d76c639f48f
+        default: 8c778e7412a887ee22f54b613b29c17e274068bd
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -153,7 +153,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '790f0b28229cb60a60c289ef8c250d76c639f48f' }}
+      KOVA_REF: ${{ inputs.kova_ref || '8c778e7412a887ee22f54b613b29c17e274068bd' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}
@@ -171,7 +171,6 @@ jobs:
       MATRIX_REPEAT: ${{ matrix.repeat }}
       MATRIX_DEEP_PROFILE: ${{ matrix.deep_profile }}
       MATRIX_LIVE: ${{ matrix.live }}
-      OPENCLAW_OCM_RUNTIME_BUILD_PROFILE: ${{ (inputs.profile || 'diagnostic') == 'diagnostic' && 'sourcePerformance' || '' }}
     steps:
       - name: Decide lane
         id: lane

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -50,7 +50,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 8c778e7412a887ee22f54b613b29c17e274068bd
+        default: 5425ee9e6c59cc18c1fd52a65df09fbc758381a7
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -153,7 +153,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '8c778e7412a887ee22f54b613b29c17e274068bd' }}
+      KOVA_REF: ${{ inputs.kova_ref || '5425ee9e6c59cc18c1fd52a65df09fbc758381a7' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -82,7 +82,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "790f0b28229cb60a60c289ef8c250d76c639f48f";
+    const kovaRef = "8c778e7412a887ee22f54b613b29c17e274068bd";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
 
@@ -779,9 +779,7 @@ esac
     const workflow = readWorkflow();
     const configure = findStep("Configure OCM local workspace dependencies");
 
-    expect(workflow.jobs?.kova?.env?.OPENCLAW_OCM_RUNTIME_BUILD_PROFILE).toBe(
-      "${{ (inputs.profile || 'diagnostic') == 'diagnostic' && 'sourcePerformance' || '' }}",
-    );
+    expect(workflow.jobs?.kova?.env).not.toHaveProperty("OPENCLAW_OCM_RUNTIME_BUILD_PROFILE");
     expect(configure.run).toContain(
       'npm_wrapper="$PERFORMANCE_HELPER_DIR/scripts/ocm-npm-workspace-deps.mjs"',
     );

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -82,7 +82,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "8c778e7412a887ee22f54b613b29c17e274068bd";
+    const kovaRef = "5425ee9e6c59cc18c1fd52a65df09fbc758381a7";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
 


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's performance workflow duplicated Kova's diagnostic build-profile policy. That split ownership made Kova upgrades require coordinated workflow edits and allowed a green workflow to publish false `FAIL` records from Kova's old cross-surface span contract.

## Why This Change Was Made

Kova now owns both pieces of policy:

- `sourcePerformance` selection for the diagnostic profile
- per-surface diagnostic span requirements

This workflow only pins the reviewed Kova commit and forwards the requested profile.

## User Impact

Release performance validation has one policy owner. OpenClaw no longer overrides Kova's runtime build profile, and the pinned Kova version no longer hard-fails scenarios for spans owned by unrelated surfaces.

## Evidence

- Kova build-profile ownership: https://github.com/openclaw/Kova/pull/29
- Kova diagnostic span ownership: https://github.com/openclaw/Kova/pull/31
- pinned Kova commit: `5425ee9e6c59cc18c1fd52a65df09fbc758381a7`
- Blacksmith Testbox `tbx_01kx8h5yqkjnvf105k33bsmtsb`: focused workflow test `28/28`
- same Testbox: path-scoped `pnpm check:changed` passed
- Codex autoreview: clean
