### PR TITLE
fix(android): refresh notification access on resume

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -3475,7 +3475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 773,
+      "line": 774,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -3483,7 +3483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 773,
+      "line": 774,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -3491,7 +3491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 806,
+      "line": 819,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
@@ -3499,7 +3499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 806,
+      "line": 819,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -3507,7 +3507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 810,
+      "line": 823,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -3515,7 +3515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 810,
+      "line": 823,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -3523,7 +3523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 822,
+      "line": 835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -3531,7 +3531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 822,
+      "line": 835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -3539,7 +3539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 827,
+      "line": 840,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -3547,7 +3547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 827,
+      "line": 840,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -3555,7 +3555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 837,
+      "line": 849,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -3563,7 +3563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 886,
+      "line": 898,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -3571,7 +3571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 893,
+      "line": 905,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -3579,7 +3579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 893,
+      "line": 905,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -3587,7 +3587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 898,
+      "line": 910,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -3595,7 +3595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 901,
+      "line": 913,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -3603,7 +3603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 902,
+      "line": 914,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
@@ -3611,7 +3611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 909,
+      "line": 921,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -3619,7 +3619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 920,
+      "line": 932,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -3627,7 +3627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1159,
+      "line": 1171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
@@ -3635,7 +3635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1159,
+      "line": 1171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -3643,7 +3643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1168,
+      "line": 1180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -3651,7 +3651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1168,
+      "line": 1180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -3659,7 +3659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1178,
+      "line": 1190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -3667,7 +3667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1178,
+      "line": 1190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -3675,7 +3675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1189,
+      "line": 1201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -3683,7 +3683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1197,
+      "line": 1209,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
@@ -3691,7 +3691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1222,
+      "line": 1234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
@@ -3699,7 +3699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1224,
+      "line": 1236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw only checks location when your paired Gateway requests it. ",
       "surface": "android",
@@ -3707,7 +3707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1237,
+      "line": 1249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -3715,7 +3715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1242,
+      "line": 1254,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
@@ -3723,7 +3723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1290,
+      "line": 1302,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -3731,7 +3731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1305,
+      "line": 1317,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -3739,7 +3739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1321,
+      "line": 1333,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget gateway?",
       "surface": "android",
@@ -3747,7 +3747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1334,
+      "line": 1346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -3755,7 +3755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1340,
+      "line": 1352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -3763,7 +3763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1344,
+      "line": 1356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -3771,7 +3771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1344,
+      "line": 1356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -3779,7 +3779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1345,
+      "line": 1357,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -3787,7 +3787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1345,
+      "line": 1357,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -3795,7 +3795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1355,
+      "line": 1367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -3803,7 +3803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1356,
+      "line": 1368,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -3811,7 +3811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1360,
+      "line": 1372,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateways",
       "surface": "android",
@@ -3819,7 +3819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1362,
+      "line": 1374,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No paired gateways.",
       "surface": "android",
@@ -3827,7 +3827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1382,
+      "line": 1394,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget",
       "surface": "android",
@@ -3835,7 +3835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1404,
+      "line": 1416,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway setup",
       "surface": "android",
@@ -3843,7 +3843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1406,
+      "line": 1418,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan or paste a setup code to add another gateway.",
       "surface": "android",
@@ -3851,7 +3851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1413,
+      "line": 1425,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add gateway",
       "surface": "android",
@@ -3859,7 +3859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1414,
+      "line": 1426,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
@@ -3867,7 +3867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1418,
+      "line": 1430,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -3875,7 +3875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1427,
+      "line": 1439,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
@@ -3883,7 +3883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1428,
+      "line": 1440,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -3891,7 +3891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1430,
+      "line": 1442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -3899,7 +3899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1431,
+      "line": 1443,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -3907,7 +3907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1433,
+      "line": 1445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection security",
       "surface": "android",
@@ -3915,7 +3915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1437,
+      "line": 1449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -3923,7 +3923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1437,
+      "line": 1449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -3931,7 +3931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1454,
+      "line": 1466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -3939,7 +3939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1455,
+      "line": 1467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -3947,7 +3947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1457,
+      "line": 1469,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -3955,7 +3955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1462,
+      "line": 1474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -3963,7 +3963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1479,
+      "line": 1491,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -3971,7 +3971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1505,
+      "line": 1517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -3979,7 +3979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1505,
+      "line": 1517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme and translated Android text.",
       "surface": "android",
@@ -3987,7 +3987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1517,
+      "line": 1529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -3995,7 +3995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1527,
+      "line": 1539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App language",
       "surface": "android",
@@ -4003,7 +4003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1529,
+      "line": 1541,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Changes Android text that OpenClaw has translated. Screens with English-only copy stay unchanged.",
       "surface": "android",
@@ -4011,7 +4011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1566,
+      "line": 1578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected",
       "surface": "android",
@@ -4019,7 +4019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1612,
+      "line": 1624,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -4027,7 +4027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1642,
+      "line": 1654,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -4035,7 +4035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1642,
+      "line": 1654,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -4043,7 +4043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1660,
+      "line": 1672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -4051,7 +4051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1662,
+      "line": 1674,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -4059,7 +4059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1665,
+      "line": 1677,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -4067,7 +4067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1676,
+      "line": 1688,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
@@ -4075,7 +4075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1693,
+      "line": 1705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -4083,7 +4083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1695,
+      "line": 1707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -4091,7 +4091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1696,
+      "line": 1708,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
@@ -4099,7 +4099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1755,
+      "line": 1767,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -4107,7 +4107,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1756,
+      "line": 1768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -4115,7 +4115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1765,
+      "line": 1777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -4123,7 +4123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1791,
+      "line": 1803,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -4131,7 +4131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1826,
+      "line": 1838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -4139,7 +4139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1859,
+      "line": 1871,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -4147,7 +4147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1933,
+      "line": 1945,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -4155,7 +4155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1942,
+      "line": 1954,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -4163,7 +4163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1942,
+      "line": 1954,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowing",
       "surface": "android",
@@ -4171,7 +4171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1950,
+      "line": 1962,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -4179,7 +4179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1950,
+      "line": 1962,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving",
       "surface": "android",
@@ -4187,7 +4187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1958,
+      "line": 1970,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -4195,7 +4195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1958,
+      "line": 1970,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Denying",
       "surface": "android",
@@ -4203,7 +4203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1983,
+      "line": 1995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -4211,7 +4211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2011,
+      "line": 2023,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -4219,7 +4219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2066,
+      "line": 2078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -4227,7 +4227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2080,
+      "line": 2092,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -4235,7 +4235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2080,
+      "line": 2092,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -4243,7 +4243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2098,
+      "line": 2110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -4251,7 +4251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2101,
+      "line": 2113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -4259,7 +4259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2140,
+      "line": 2152,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -4267,7 +4267,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 2155,
+      "line": 2167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -4275,7 +4275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2193,
+      "line": 2205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -4283,7 +4283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2195,
+      "line": 2207,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -4291,7 +4291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2251,
+      "line": 2263,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -4299,7 +4299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2254,
+      "line": 2266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -4307,7 +4307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2254,
+      "line": 2266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -4315,7 +4315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2282,
+      "line": 2294,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -4323,7 +4323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2289,
+      "line": 2301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -4331,7 +4331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2320,
+      "line": 2332,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -4339,7 +4339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2341,
+      "line": 2353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -4347,7 +4347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2342,
+      "line": 2354,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -4355,7 +4355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2343,
+      "line": 2355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -4363,7 +4363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2344,
+      "line": 2356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -763,6 +763,7 @@ private fun NotificationSettingsScreen(
   onBack: () -> Unit,
 ) {
   val context = LocalContext.current
+  val lifecycleOwner = LocalLifecycleOwner.current
   val enabled by viewModel.notificationForwardingEnabled.collectAsState()
   val mode by viewModel.notificationForwardingMode.collectAsState()
   val packages by viewModel.notificationForwardingPackages.collectAsState()
@@ -785,6 +786,18 @@ private fun NotificationSettingsScreen(
       )
     }
   var listenerEnabled by remember { mutableStateOf(DeviceNotificationListenerService.isAccessEnabled(context)) }
+
+  DisposableEffect(lifecycleOwner, context) {
+    val observer =
+      LifecycleEventObserver { _, event ->
+        if (event == Lifecycle.Event.ON_RESUME) {
+          listenerEnabled = DeviceNotificationListenerService.isAccessEnabled(context)
+        }
+      }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+  }
+
   val notificationPermissionLauncher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
       viewModel.setNotificationForwardingEnabled(granted)
@@ -827,7 +840,6 @@ private fun NotificationSettingsScreen(
         text = if (listenerEnabled) "Check Access" else "Open System Access",
         onClick = {
           openNotificationListenerSettings(context)
-          listenerEnabled = DeviceNotificationListenerService.isAccessEnabled(context)
         },
         modifier = Modifier.weight(1f),
       )


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

Android's Notification settings can keep showing notification-listener access as `Setup` after the user grants access in system settings and returns to OpenClaw. The screen checked the permission immediately after launching Android settings, before the user could change it.

## Why This Change Was Made

Observe the screen lifecycle and re-read `DeviceNotificationListenerService.isAccessEnabled()` on `ON_RESUME`. This removes the premature check after launching system settings and follows the lifecycle-refresh pattern already used by Android onboarding.

## User Impact

The Access status and action update immediately after returning to OpenClaw. Users no longer need to leave and reopen the Notification settings screen to see that access was granted.

## Evidence

Android emulator behavior was verified with exact base and patched APKs against a fresh, isolated, paired OpenClaw gateway. The online gate showed the gateway online, one node online, and no pending device or node approvals.

Before (left) — the base APK remains on `Setup`; after (right) — the patched APK refreshes to `Granted` on resume:

<p>
  <img width="260" src="https://github.com/user-attachments/assets/83f7e5b3-1786-4c83-96cd-076d1d6b5018" alt="Before: notification access remains Setup after returning from Android system settings" />
  <img width="260" src="https://github.com/user-attachments/assets/8c12db90-4c31-4b25-a6bf-d2c2ff7e9896" alt="After: notification access refreshes to Granted after returning from Android system settings" />
</p>

Checks:

- `pnpm native:i18n:check`
- `pnpm android:i18n:check`
- `node scripts/ensure-cli-startup-build.mjs`
- Gradle `:app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.SettingsScreensTest`
- `pnpm android:assemble`
