### PR TITLE
fix(chat): tool titles corrupt boundary emoji in long inputs

### DIFF
--- a/src/gateway/chat-tool-titles.test.ts
+++ b/src/gateway/chat-tool-titles.test.ts
@@ -133,6 +133,25 @@ describe("generateToolCallTitles", () => {
     expect(content).not.toContain(token.slice(0, 12));
   });
 
+  it("keeps bounded tool input valid before utility-model prompt construction", async () => {
+    mockPreparedModel();
+    mockCompletionTitles({ "0": "Inspected boundary input" });
+
+    await generateToolCallTitles({
+      cfg: {} satisfies OpenClawConfig,
+      agentId: AGENT_ID,
+      items: [{ id: "item-1", name: "bash", input: `${"a".repeat(1_999)}😀tail` }],
+    });
+
+    const call = completeWithPreparedSimpleCompletionModel.mock.calls[0]?.[0] as {
+      context: { messages: Array<{ content: string }> };
+    };
+    const promptPayload = JSON.parse(call.context.messages[0]?.content ?? "{}") as {
+      items?: Array<{ input?: string }>;
+    };
+    expect(promptPayload.items?.[0]?.input).toBe("a".repeat(1_999));
+  });
+
   it("serves repeated items from the SQLite cache without a second completion", async () => {
     mockPreparedModel();
     mockCompletionTitles({ "0": "Checked repo status" });

--- a/src/gateway/chat-tool-titles.ts
+++ b/src/gateway/chat-tool-titles.ts
@@ -74,7 +74,7 @@ function normalizeItems(items: readonly ToolTitleRequestItem[]): ToolTitleReques
     // secret egress path. Redaction runs on the full schema-bounded input and
     // only then truncates — slicing first could bisect a secret so its
     // fragment no longer matches any redaction pattern.
-    const input = redactToolPayloadText(item.input).slice(0, TOOL_TITLE_INPUT_MAX_CHARS);
+    const input = truncateUtf16Safe(redactToolPayloadText(item.input), TOOL_TITLE_INPUT_MAX_CHARS);
     if (!id || !name || !input.trim() || seen.has(id)) {
       continue;
     }

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -14,6 +14,21 @@ const LONG_GENERIC_ARGS = {
   description: "The websocket reconnect loop spins when the auth token expires mid-session.",
 };
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    const previous = value.charCodeAt(index - 1);
+    const next = value.charCodeAt(index + 1);
+    if (unit >= 0xd800 && unit <= 0xdbff && !(next >= 0xdc00 && next <= 0xdfff)) {
+      return true;
+    }
+    if (unit >= 0xdc00 && unit <= 0xdfff && !(previous >= 0xd800 && previous <= 0xdbff)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("resolveToolTitleRequest", () => {
   afterEach(() => {
     resetToolTitlesForTest();
@@ -51,6 +66,27 @@ describe("resolveToolTitleRequest", () => {
     const second = resolveToolTitleRequest("bash", { command: "pnpm install --frozen" });
 
     expect(first?.key).toBe(second?.key);
+  });
+
+  it("keeps every bounded tool-title input on a valid UTF-16 boundary", () => {
+    const command = resolveToolTitleRequest("bash", {
+      command: `${"a".repeat(1_999)}😀tail`,
+    });
+    const stringArgs = resolveToolTitleRequest(
+      "mcp__linear__create_issue",
+      `${"a".repeat(1_999)}😀tail`,
+    );
+    const jsonPrefix = '{"value":"';
+    const objectArgs = resolveToolTitleRequest("mcp__linear__create_issue", {
+      value: `${"a".repeat(1_999 - jsonPrefix.length)}😀tail`,
+    });
+
+    expect(command?.input).toBe("a".repeat(1_999));
+    expect(stringArgs?.input).toBe("a".repeat(1_999));
+    expect(objectArgs?.input).toBe(`${jsonPrefix}${"a".repeat(1_999 - jsonPrefix.length)}`);
+    expect(
+      [command, stringArgs, objectArgs].some((request) => hasLoneSurrogate(request?.input ?? "")),
+    ).toBe(false);
   });
 });
 

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -60,7 +60,7 @@ describe("resolveToolTitleRequest", () => {
       "serialized object args",
       "mcp__linear__create_issue",
       { value: `${"a".repeat(1_989)}😀tail` },
-      `${'{"value":"'}${"a".repeat(1_989)}`,
+      '{"value":"' + "a".repeat(1_989),
     ],
   ])("keeps bounded %s on a valid UTF-16 boundary", (_label, name, args, expected) => {
     expect(resolveToolTitleRequest(name, args)?.input).toBe(expected);

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -14,21 +14,6 @@ const LONG_GENERIC_ARGS = {
   description: "The websocket reconnect loop spins when the auth token expires mid-session.",
 };
 
-function hasLoneSurrogate(value: string): boolean {
-  for (let index = 0; index < value.length; index += 1) {
-    const unit = value.charCodeAt(index);
-    const previous = value.charCodeAt(index - 1);
-    const next = value.charCodeAt(index + 1);
-    if (unit >= 0xd800 && unit <= 0xdbff && !(next >= 0xdc00 && next <= 0xdfff)) {
-      return true;
-    }
-    if (unit >= 0xdc00 && unit <= 0xdfff && !(previous >= 0xd800 && previous <= 0xdbff)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 describe("resolveToolTitleRequest", () => {
   afterEach(() => {
     resetToolTitlesForTest();
@@ -68,25 +53,17 @@ describe("resolveToolTitleRequest", () => {
     expect(first?.key).toBe(second?.key);
   });
 
-  it("keeps every bounded tool-title input on a valid UTF-16 boundary", () => {
-    const command = resolveToolTitleRequest("bash", {
-      command: `${"a".repeat(1_999)}😀tail`,
-    });
-    const stringArgs = resolveToolTitleRequest(
+  it.each([
+    ["command", "bash", { command: `${"a".repeat(1_999)}😀tail` }, "a".repeat(1_999)],
+    ["string args", "mcp__linear__create_issue", `${"a".repeat(1_999)}😀tail`, "a".repeat(1_999)],
+    [
+      "serialized object args",
       "mcp__linear__create_issue",
-      `${"a".repeat(1_999)}😀tail`,
-    );
-    const jsonPrefix = '{"value":"';
-    const objectArgs = resolveToolTitleRequest("mcp__linear__create_issue", {
-      value: `${"a".repeat(1_999 - jsonPrefix.length)}😀tail`,
-    });
-
-    expect(command?.input).toBe("a".repeat(1_999));
-    expect(stringArgs?.input).toBe("a".repeat(1_999));
-    expect(objectArgs?.input).toBe(`${jsonPrefix}${"a".repeat(1_999 - jsonPrefix.length)}`);
-    expect(
-      [command, stringArgs, objectArgs].some((request) => hasLoneSurrogate(request?.input ?? "")),
-    ).toBe(false);
+      { value: `${"a".repeat(1_989)}😀tail` },
+      `${'{"value":"'}${"a".repeat(1_989)}`,
+    ],
+  ])("keeps bounded %s on a valid UTF-16 boundary", (_label, name, args, expected) => {
+    expect(resolveToolTitleRequest(name, args)?.input).toBe(expected);
   });
 });
 

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -8,6 +8,7 @@
  * labels.
  */
 
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { resolveToolCallKind, unwrapShellWrapperCommand } from "../../lib/chat/tool-call-view.ts";
 
@@ -68,11 +69,11 @@ function serializeArgs(args: unknown): string | null {
     return null;
   }
   if (typeof args === "string") {
-    return args.slice(0, MAX_TITLE_INPUT_CHARS);
+    return truncateUtf16Safe(args, MAX_TITLE_INPUT_CHARS);
   }
   try {
     const encoded = JSON.stringify(args);
-    return typeof encoded === "string" ? encoded.slice(0, MAX_TITLE_INPUT_CHARS) : null;
+    return typeof encoded === "string" ? truncateUtf16Safe(encoded, MAX_TITLE_INPUT_CHARS) : null;
   } catch {
     return null;
   }
@@ -98,7 +99,7 @@ export function resolveToolTitleRequest(
     if (command.length < MIN_COMMAND_CHARS_FOR_TITLE) {
       return null;
     }
-    const input = command.slice(0, MAX_TITLE_INPUT_CHARS);
+    const input = truncateUtf16Safe(command, MAX_TITLE_INPUT_CHARS);
     return { key: digest("command", input), input };
   }
   if (kind !== "generic") {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users viewing a long command or generic tool call in Control UI could send corrupted text to the AI tool-title generator when an emoji crossed the existing 2,000-unit input limit.

## Why This Change Was Made

Control UI now applies OpenClaw's canonical UTF-16-safe truncation to command text, raw string args, and serialized object args before hashing and scheduling `chat.toolTitles`. The Gateway independently applies the same boundary after full-input secret redaction, protecting other RPC clients before cache keys and utility-model prompts are built.

The security order remains unchanged: Gateway redacts the complete schema-bounded input first, then truncates. Existing 2,000-unit budgets, protocol limits, debounce/batching, cache scope, utility routing, and title output behavior remain unchanged. A fresh open-PR scan found no PR covering this UI-to-Gateway tool-title path.

## User Impact

Model-generated purpose titles for long tool calls no longer receive a broken replacement glyph at an emoji boundary. Complete text within the current budget, secret redaction, cached titles, deterministic fallback labels, and all opt-in behavior stay the same.

## Evidence

- Before the fix, both owners failed at the exact boundary:

  ```text
  Control UI: 1 failed | 16 passed (17)
  Gateway:    4 failed | 44 passed (48)
  Received suffix: ...�
  Boundary code unit: U+D83D
  ```

- After the fix, a real isolated OpenClaw Gateway ran with tool titles enabled and a deterministic local utility-model endpoint. The proof sent one unsafe direct Gateway request and one separate request through the production Control UI debounce path:

  ```text
  gatewayReady: true
  directGatewayRequestCompleted: true
  productionUiDebounceCompleted: true
  uiRequestInputUtf16Units: 1999
  uiRequestLoneSurrogate: false
  directUtilityPromptInputUtf16Units: 1999
  directUtilityPromptLoneSurrogate: false
  uiUtilityPromptInputUtf16Units: 1999
  uiUtilityPromptLoneSurrogate: false
  directSafePrefixPreserved: true
  uiSafePrefixPreserved: true
  renderedTitle: Checked UI boundary
  providerRequestCount: 2
  ```

  This exercises Control UI request eligibility and debounce, the real `chat.toolTitles` RPC handler, Gateway redaction/normalization/cache routing, utility-model HTTP requests, and the rendered title lookup.

- Full affected test files:

  ```text
  Control UI: 1 file passed, 17 tests passed
  Gateway:    4 files passed, 48 tests passed
  ```

- `pnpm ui:build` passed with 1,097 modules transformed.
- Targeted formatting passed for all four changed files.
- Changed-surface checks passed, including core/core-test type checks, lint, dependency guards, database-first guard, runtime sidecar checks, and zero runtime import cycles.
