### PR TITLE
refactor(agents): converge run staleness policy onto diagnostic activity owner

### DIFF
--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -16,10 +16,10 @@ import {
   waitForReplyRunEndBySessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
 import {
-  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
+  resolveRunStaleThresholdMs,
 } from "../../logging/diagnostic-run-activity.js";
 import {
   diagnosticLogger as diag,
@@ -94,10 +94,6 @@ type PreparedEmbeddedAgentQueueMessage =
       kind: "embedded_run";
       handle: EmbeddedAgentQueueHandle;
     };
-
-// Paired with REPLY_RUN_STALE_TAKEOVER_MS in the reply registry; src/agents
-// keeps its own constant to avoid importing auto-reply policy into this owner.
-const EMBEDDED_STEER_STALE_CAPTURE_MS = 10 * 60_000;
 
 function createQueueFailureOutcome(
   sessionId: string,
@@ -490,16 +486,9 @@ function prepareEmbeddedAgentQueueMessage(
     return { kind: "complete", outcome: createQueueFailureOutcome(sessionId, "not_streaming") };
   }
   const activity = getDiagnosticSessionActivitySnapshot({ sessionId });
-  // Quiet tool phases stay steerable until the blocked-tool floor: refusing at
-  // the shorter window would push the message into admission takeover of a run
-  // the diagnostic layer still considers healthy.
-  const steerStaleCaptureMs =
-    activity.activeWorkKind === "tool_call"
-      ? Math.max(EMBEDDED_STEER_STALE_CAPTURE_MS, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)
-      : EMBEDDED_STEER_STALE_CAPTURE_MS;
   if (
     typeof activity.lastProgressAgeMs === "number" &&
-    activity.lastProgressAgeMs > steerStaleCaptureMs
+    activity.lastProgressAgeMs > resolveRunStaleThresholdMs(activity)
   ) {
     diag.debug(`queue message failed: sessionId=${sessionId} reason=stale_run`);
     return { kind: "complete", outcome: createQueueFailureOutcome(sessionId, "stale_run") };

--- a/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { RUN_STALE_TAKEOVER_MS } from "../../logging/diagnostic-run-activity.js";
 import type { ReplyPayload } from "../types.js";
 import {
   createDispatcher,
@@ -9,7 +10,6 @@ import {
   resetPluginTtsAndThreadMocks,
   runtimePluginMocks,
 } from "./dispatch-from-config.shared.test-harness.js";
-import { REPLY_RUN_STALE_TAKEOVER_MS } from "./reply-run-registry.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
@@ -117,7 +117,7 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
     activeOperation.setPhase("running");
     const replyResolver = vi.fn(async () => ({ text: "telegram reply" }) satisfies ReplyPayload);
     const dispatchParams = createVisibleDispatchParams(replyResolver);
-    vi.setSystemTime(startedAt + REPLY_RUN_STALE_TAKEOVER_MS + 1);
+    vi.setSystemTime(startedAt + RUN_STALE_TAKEOVER_MS + 1);
 
     const result = await dispatchReplyFromConfig(dispatchParams);
 

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -4,6 +4,7 @@ import { createAgentRunRestartAbortError } from "../../agents/run-termination.js
 import {
   getDiagnosticSessionActivitySnapshot,
   resetDiagnosticRunActivityForTest,
+  RUN_STALE_TAKEOVER_MS,
 } from "../../logging/diagnostic-run-activity.js";
 import { diagnosticLogger } from "../../logging/diagnostic-runtime.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
@@ -18,7 +19,6 @@ import {
   isReplyRunAbortableForSignal,
   queueReplyRunMessage,
   REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
-  REPLY_RUN_STALE_TAKEOVER_MS,
   REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS,
   replyRunRegistry,
   runAfterReplyOperationClear,
@@ -901,7 +901,7 @@ describe("reply run registry", () => {
       });
       operation.setPhase("running");
 
-      vi.advanceTimersByTime(REPLY_RUN_STALE_TAKEOVER_MS + 1);
+      vi.advanceTimersByTime(RUN_STALE_TAKEOVER_MS + 1);
 
       expect(queueReplyRunMessage("session-running", "stale")).toBe(false);
       expect(queueMessage).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -6,10 +6,10 @@ import {
 } from "../../agents/run-termination.js";
 import { createAbortError } from "../../infra/abort-signal.js";
 import {
-  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
+  resolveRunStaleThresholdMs,
 } from "../../logging/diagnostic-run-activity.js";
 import { diagnosticLogger as diag } from "../../logging/diagnostic-runtime.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
@@ -218,9 +218,6 @@ export const REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS = 15_000;
 // Terminal results must release the lane even if the owner never resumes.
 // Without this, abort/failure can leave the session wedged until process restart.
 export const REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS = 60_000;
-// Visible human turns may reclaim only runs with no real progress for this window.
-// Timers and user-message injection never refresh activity; agent events do.
-export const REPLY_RUN_STALE_TAKEOVER_MS = 10 * 60_000;
 
 export type ReplyOperationStaleReason = "terminal_unreleased" | "no_activity" | "stuck_recovery";
 
@@ -886,25 +883,16 @@ export function expireStaleReplyRunBySessionId(
   return operation ? expireStaleReplyOperation(operation, reason) : false;
 }
 
-/**
- * Effective staleness window for an operation. Quiet-but-alive tool phases get
- * the diagnostic blocked-tool floor: a human message must not reclaim a healthy
- * long tool that stuck recovery itself would not touch yet.
- */
-export function resolveReplyRunStaleThresholdMs(operation: ReplyOperation): number {
+// lastActivityAtMs is refreshed by agent events only; timers and user-message
+// injection never refresh it, so quiet runs age toward reclaim.
+export function isReplyRunEvidenceStale(operation: ReplyOperation): boolean {
   const activity = getDiagnosticSessionActivitySnapshot({
     sessionId: operation.sessionId,
     sessionKey: operation.key,
   });
-  return activity.activeWorkKind === "tool_call"
-    ? Math.max(REPLY_RUN_STALE_TAKEOVER_MS, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)
-    : REPLY_RUN_STALE_TAKEOVER_MS;
-}
-
-export function isReplyRunEvidenceStale(operation: ReplyOperation): boolean {
   return (
     !operation.result &&
-    Date.now() - operation.lastActivityAtMs > resolveReplyRunStaleThresholdMs(operation)
+    Date.now() - operation.lastActivityAtMs > resolveRunStaleThresholdMs(activity)
   );
 }
 

--- a/src/auto-reply/reply/reply-turn-admission.test.ts
+++ b/src/auto-reply/reply/reply-turn-admission.test.ts
@@ -6,6 +6,7 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import {
   markDiagnosticToolStartedForTest,
   resetDiagnosticRunActivityForTest,
+  RUN_STALE_TAKEOVER_MS,
 } from "../../logging/diagnostic-run-activity.js";
 import {
   interruptSessionWorkAdmissions,
@@ -14,7 +15,6 @@ import {
 import {
   createReplyOperation,
   REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
-  REPLY_RUN_STALE_TAKEOVER_MS,
   REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS,
   replyRunRegistry,
   runAfterReplyOperationClear,
@@ -947,7 +947,7 @@ describe("reply turn admission", () => {
         isStreaming: () => true,
       });
       active.setPhase("running");
-      vi.setSystemTime(startedAt + REPLY_RUN_STALE_TAKEOVER_MS + 1);
+      vi.setSystemTime(startedAt + RUN_STALE_TAKEOVER_MS + 1);
 
       const result = await admitReplyTurn({
         sessionKey: "agent:main:telegram:topic:stale-visible",
@@ -1084,7 +1084,7 @@ describe("reply turn admission", () => {
           isStreaming: () => true,
         });
         active.setPhase("running");
-        vi.setSystemTime(startedAt + REPLY_RUN_STALE_TAKEOVER_MS + 1);
+        vi.setSystemTime(startedAt + RUN_STALE_TAKEOVER_MS + 1);
 
         const admission = admitReplyTurn({
           sessionKey: `agent:main:telegram:topic:stale-${kind}`,

--- a/src/auto-reply/reply/reply-turn-admission.ts
+++ b/src/auto-reply/reply/reply-turn-admission.ts
@@ -3,6 +3,10 @@ import { resolveSessionWorkStartError } from "../../config/sessions/lifecycle.js
 import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import {
+  getDiagnosticSessionActivitySnapshot,
+  resolveRunStaleThresholdMs,
+} from "../../logging/diagnostic-run-activity.js";
+import {
   beginSessionWorkAdmission,
   type SessionWorkAdmissionLease,
 } from "../../sessions/session-lifecycle-admission.js";
@@ -12,7 +16,6 @@ import {
   isReplyRunEvidenceStale,
   REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
   REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS,
-  resolveReplyRunStaleThresholdMs,
   replyRunRegistry,
   ReplyRunAlreadyActiveError,
   ReplyRunFollowupAdmissionBlockedError,
@@ -78,9 +81,13 @@ function resolveVisibleActiveWaitMs(operation: ReplyOperation | undefined): numb
     return REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS;
   }
   const ageMs = Date.now() - operation.lastActivityAtMs;
+  const activity = getDiagnosticSessionActivitySnapshot({
+    sessionId: operation.sessionId,
+    sessionKey: operation.key,
+  });
   const remainingMs = operation.result
     ? REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS - ageMs
-    : resolveReplyRunStaleThresholdMs(operation) - ageMs;
+    : resolveRunStaleThresholdMs(activity) - ageMs;
   return Math.min(REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS, Math.max(1, remainingMs));
 }
 

--- a/src/logging/diagnostic-run-activity.test.ts
+++ b/src/logging/diagnostic-run-activity.test.ts
@@ -1,0 +1,34 @@
+// Unit tests for shared run-staleness threshold policy.
+import { describe, expect, it } from "vitest";
+import {
+  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+  resolveRunStaleThresholdMs,
+  RUN_STALE_TAKEOVER_MS,
+} from "./diagnostic-run-activity.js";
+
+describe("resolveRunStaleThresholdMs", () => {
+  it.each([
+    {
+      name: "default window when no active work",
+      activity: {},
+      expected: RUN_STALE_TAKEOVER_MS,
+    },
+    {
+      name: "default window for model_call",
+      activity: { activeWorkKind: "model_call" as const },
+      expected: RUN_STALE_TAKEOVER_MS,
+    },
+    {
+      name: "default window for embedded_run",
+      activity: { activeWorkKind: "embedded_run" as const },
+      expected: RUN_STALE_TAKEOVER_MS,
+    },
+    {
+      name: "blocked-tool floor for tool_call",
+      activity: { activeWorkKind: "tool_call" as const },
+      expected: Math.max(RUN_STALE_TAKEOVER_MS, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS),
+    },
+  ])("$name", ({ activity, expected }) => {
+    expect(resolveRunStaleThresholdMs(activity)).toBe(expected);
+  });
+});

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -61,6 +61,9 @@ type DiagnosticRunProgressActivityEvent = Pick<
 // steer gates): lowering it reopens #88870, removing it reopens #96168.
 export const BLOCKED_TOOL_CALL_ABORT_FLOOR_MS = 15 * 60_000;
 
+// Default quiet-run reclaim window for steer/takeover. Evidence clocks stay local.
+export const RUN_STALE_TAKEOVER_MS = 10 * 60_000;
+
 export type DiagnosticSessionActivitySnapshot = {
   activeWorkKind?: DiagnosticSessionActiveWorkKind;
   hasActiveEmbeddedRun?: boolean;
@@ -70,6 +73,16 @@ export type DiagnosticSessionActivitySnapshot = {
   lastProgressAgeMs?: number;
   lastProgressReason?: string;
 };
+
+// Quiet-but-alive tool phases get the blocked-tool floor so a human message
+// cannot reclaim a healthy long tool that stuck recovery would not touch yet.
+export function resolveRunStaleThresholdMs(
+  activity: Pick<DiagnosticSessionActivitySnapshot, "activeWorkKind">,
+): number {
+  return activity.activeWorkKind === "tool_call"
+    ? Math.max(RUN_STALE_TAKEOVER_MS, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)
+    : RUN_STALE_TAKEOVER_MS;
+}
 
 const activityByRef = new Map<string, SessionActivity>();
 const activityByRunId = new Map<string, SessionActivity>();


### PR DESCRIPTION
## What Problem This Solves

The run-staleness takeover window was hand-copied between the two run registries:

- `src/auto-reply/reply/reply-run-registry.ts` — `REPLY_RUN_STALE_TAKEOVER_MS = 10 * 60_000` plus `resolveReplyRunStaleThresholdMs` deriving the quiet-tool blocked-floor threshold.
- `src/agents/embedded-agent-runner/runs.ts` — `EMBEDDED_STEER_STALE_CAPTURE_MS = 10 * 60_000`, whose own comment admitted it was "Paired with REPLY_RUN_STALE_TAKEOVER_MS … keeps its own constant to avoid importing auto-reply policy", with the identical `Math.max(…, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)` derivation inlined.

Changing one constant (or one derivation) silently diverges steer/takeover behavior between the reply and embedded backends. Seam 4 of #104219.

## Why This Change Was Made

Both registries already import `BLOCKED_TOOL_CALL_ABORT_FLOOR_MS` and `getDiagnosticSessionActivitySnapshot` from `src/logging/diagnostic-run-activity.ts` — the module that owns run-activity/staleness facts. Moving the policy there dissolves the layering objection that motivated the hand-copied pair: one `RUN_STALE_TAKEOVER_MS` constant and one `resolveRunStaleThresholdMs(activity)` resolver (quiet `tool_call` phases get the blocked-tool floor; everything else the 10-minute window).

Deleted in the same change: both local constants, the inlined derivation in `runs.ts`, and the exported `resolveReplyRunStaleThresholdMs` (its two prod callers — `isReplyRunEvidenceStale` and `reply-turn-admission.ts`'s `resolveVisibleActiveWaitMs` — consume the shared resolver directly; no pass-through wrapper kept). Staleness *evidence* clocks stay local to each registry; only the *threshold* policy converged.

Sibling sweep: no other copy of this stale-takeover threshold decision exists; remaining 10-minute constants in the tree (task-queue audit, heartbeat, delivery backoff, etc.) are unrelated policies and untouched.

## User Impact

None — zero behavior change. Both constants were already equal and both sites already applied the same floor rule, so every threshold is byte-identical before and after. This removes the drift hazard, not current behavior.

## Evidence

- Shared owner: `src/logging/diagnostic-run-activity.ts` (constant + resolver beside the floor constant whose comment carries the #88870/#96168 contract).
- Tests: new table-driven unit coverage for `resolveRunStaleThresholdMs` (default vs `tool_call` floor); all existing evidence-path tests kept (steer refusal on stale runs, quiet-tool floor steer, admission reclaim/defer) — they prove each registry still wires the shared threshold into its own clock. No tests deleted.
- `git diff --numstat`: net prod **−4 LOC** (pure dedup); +38 test lines.
- Local: `pnpm tsgo:core`, `pnpm tsgo:test:src`, `pnpm check:import-cycles`, focused vitest (5 suites, 118+ tests), oxfmt — all green.
- Remote (Blacksmith Testbox, lease `tbx_01kx8h219vz27w4g1wm5q88x30`): `pnpm check:changed` exit 0 and `pnpm test:changed` exit 0 (all shards passed).

### Real behavior proof (ephemeral gateway, real clocks)

Live gateway run (built worktree, mock Telegram Bot API + mock OpenAI provider on loopback, throwaway `OPENCLAW_STATE_DIR`, `messages.queue.mode: "steer"`, debug logging; no prod constants touched — only watchdog/timeout config raised so the product windows are reachable). Two concurrent sessions, probed at the same wall-clock offset **T+10.5 min**:

Scenario A — quiet run, **no tool** (mock model holds the stream silently). Probe hits the embedded steer gate and is refused stale under the default 10-minute window:

```text
19:08:32.451 [diagnostic] run active check: sessionId=5b8aeb1a-… active=true
19:08:32.453 [diagnostic] queue message failed: sessionId=5b8aeb1a-… reason=stale_run
```

Scenario B — quiet run **with an active `exec` tool** (`sleep 1200`). Same offset: **no** `stale_run`; the steer is accepted because the quiet-tool phase is protected by the 15-minute blocked-tool floor:

```text
19:08:32.296 [diagnostic] message queued: sessionId=889a1b60-… queueDepth=2 sessionState=processing
19:10:09.730 [diagnostic] message queued: sessionId=889a1b60-… source=embedded-agent-runner queueDepth=3
```

Same quiet duration, opposite outcomes — the A/B contrast demonstrates both boundaries of the now-shared `resolveRunStaleThresholdMs` (`runs.ts` steer gate consumer) on real clocks (~12 min wall).

**Reply-admission consumer** (`isReplyRunEvidenceStale` → `expireStaleReplyOperation`): deliberately attempted live under `followup` and `interrupt` queue modes as well — that expire path is not reachable from real Telegram gateway mid-run messages in any queue mode; `retainLifecycleAdmissionOnActive`, gateway queue resolution, and queue policy intercept before `admitReplyTurn`'s expire catch. It stays covered by the existing direct unit test ("lets visible turns reclaim a stale active operation"), and consumes the identical shared threshold. No log lines were fabricated to claim otherwise.

CI note: the earlier `checks-node-compact-small-whole-2` failure on the pre-rebase head was the shard-packing issue fixed on main by `test(ci): lock balanced whole shard packing`; after rebasing onto current main, all checks are green.

Part of #104219 (seam 4: run-registry staleness policy).
