### PR TITLE
Fix/OpenAI device code request timeout

### DIFF
--- a/extensions/openai/openai-chatgpt-device-code.test.ts
+++ b/extensions/openai/openai-chatgpt-device-code.test.ts
@@ -1,5 +1,7 @@
 // Openai tests cover openai chatgpt device code plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import { createServer } from "node:http";
+import type { Socket } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveCodexAccessTokenExpiry } from "./openai-chatgpt-auth-identity.js";
 import { loginOpenAICodexDeviceCode } from "./openai-chatgpt-device-code.js";
 
@@ -40,7 +42,9 @@ function cancelTrackedResponse(
   };
 }
 
-function fetchCall(fetchMock: ReturnType<typeof vi.fn<typeof fetch>>, index: number) {
+type FetchMock = ReturnType<typeof vi.fn<typeof fetch>>;
+
+function fetchCall(fetchMock: FetchMock, index: number) {
   const call = fetchMock.mock.calls[index];
   if (!call) {
     throw new Error(`expected fetch call ${index}`);
@@ -48,141 +52,265 @@ function fetchCall(fetchMock: ReturnType<typeof vi.fn<typeof fetch>>, index: num
   return call;
 }
 
+function hangingFetch(
+  _input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+): Promise<Response> {
+  return new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) {
+      reject(new Error("missing abort signal"));
+      return;
+    }
+
+    const abort = () => {
+      reject(
+        signal.reason instanceof Error ? signal.reason : new DOMException("aborted", "AbortError"),
+      );
+    };
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function createHangingFetch(): FetchMock {
+  return vi.fn(hangingFetch);
+}
+
+function stubDeviceCodeFetchTimeout(expectedTimeoutMs: number): void {
+  vi.spyOn(AbortSignal, "timeout").mockImplementation((actualTimeoutMs) => {
+    expect(actualTimeoutMs).toBe(expectedTimeoutMs);
+    const controller = new AbortController();
+    queueMicrotask(() => {
+      controller.abort(new DOMException("timed out", "TimeoutError"));
+    });
+    return controller.signal;
+  });
+}
+
+const originalAbortSignalTimeout = AbortSignal.timeout.bind(AbortSignal);
+
+function stubDeviceCodeFetchTimeoutAfterHeaders(expectedTimeoutMs: number): void {
+  vi.spyOn(AbortSignal, "timeout").mockImplementation((actualTimeoutMs) => {
+    expect(actualTimeoutMs).toBe(expectedTimeoutMs);
+    // Keep a short real timer so headers can return before the body stall
+    // aborts; keep enough slack for cold loopback under load.
+    return originalAbortSignalTimeout(120);
+  });
+}
+
+async function listenOnLoopback(server: ReturnType<typeof createServer>): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const onError = (err: Error) => reject(err);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function startPartialBodyStallServer(): Promise<{
+  origin: string;
+  getRequestCount: () => number;
+  close: () => Promise<void>;
+}> {
+  const sockets = new Set<Socket>();
+  let requestCount = 0;
+  // Send headers + a partial JSON prefix, then stall so body consumption must
+  // honor the same AbortSignal.timeout as the initial fetch.
+  const server = createServer((_req, res) => {
+    requestCount += 1;
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.write('{"partial":');
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+  const port = await listenOnLoopback(server);
+  return {
+    origin: `http://127.0.0.1:${port}`,
+    getRequestCount: () => requestCount,
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+function createLoopbackFetchRedirect(origin: string): FetchMock {
+  const realFetch = globalThis.fetch;
+  return vi.fn(async (_input, init) => realFetch(origin, init));
+}
+
 describe("loginOpenAICodexDeviceCode", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
   it("requests a device code, polls for authorization, and exchanges OAuth tokens", async () => {
     vi.useFakeTimers();
     vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
-    try {
-      const fetchMock = vi
-        .fn<typeof fetch>()
-        .mockResolvedValueOnce(
-          createJsonResponse({
-            device_auth_id: "device-auth-123",
-            user_code: "CODE-12345",
-            interval: "0",
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          authorization_code: "authorization-code-123",
+          code_challenge: "ignored",
+          code_verifier: "code-verifier-123",
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          access_token: createJwt({
+            exp: Math.floor(Date.now() / 1000) + 600,
+            "https://api.openai.com/auth": {
+              chatgpt_account_id: "acct_123",
+            },
+            "https://api.openai.com/profile": {
+              email: "codex@example.com",
+            },
           }),
-        )
-        .mockResolvedValueOnce(new Response(null, { status: 404 }))
-        .mockResolvedValueOnce(
-          createJsonResponse({
-            authorization_code: "authorization-code-123",
-            code_challenge: "ignored",
-            code_verifier: "code-verifier-123",
+          refresh_token: "refresh-token-123",
+          id_token: createJwt({
+            "https://api.openai.com/auth": {
+              chatgpt_account_id: "acct_123",
+            },
           }),
-        )
-        .mockResolvedValueOnce(
-          createJsonResponse({
-            access_token: createJwt({
-              exp: Math.floor(Date.now() / 1000) + 600,
-              "https://api.openai.com/auth": {
-                chatgpt_account_id: "acct_123",
-              },
-              "https://api.openai.com/profile": {
-                email: "codex@example.com",
-              },
-            }),
-            refresh_token: "refresh-token-123",
-            id_token: createJwt({
-              "https://api.openai.com/auth": {
-                chatgpt_account_id: "acct_123",
-              },
-            }),
-            expires_in: 600,
-          }),
-        );
-      const onVerification = vi.fn(async () => {});
-      const onProgress = vi.fn();
+          expires_in: 600,
+        }),
+      );
+    const onVerification = vi.fn(async () => {});
+    const onProgress = vi.fn();
 
-      const credentialsPromise = loginOpenAICodexDeviceCode({
-        fetchFn: fetchMock as typeof fetch,
-        onVerification,
-        onProgress,
-      });
-      await vi.advanceTimersByTimeAsync(0);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-      await vi.advanceTimersByTimeAsync(4_999);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-      await vi.advanceTimersByTimeAsync(1);
-      const credentials = await credentialsPromise;
+    const credentialsPromise = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock as typeof fetch,
+      onVerification,
+      onProgress,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    const credentials = await credentialsPromise;
 
-      const userCodeRequest = fetchCall(fetchMock, 0);
-      expect(userCodeRequest[0]).toBe("https://auth.openai.com/api/accounts/deviceauth/usercode");
-      expect(userCodeRequest[1]?.method).toBe("POST");
-      expect(userCodeRequest[1]?.headers).toEqual({
-        "Content-Type": "application/json",
-        originator: "openclaw",
-        version: "2026.3.22",
-        "User-Agent": "openclaw/2026.3.22",
-      });
+    const userCodeRequest = fetchCall(fetchMock, 0);
+    expect(userCodeRequest[0]).toBe("https://auth.openai.com/api/accounts/deviceauth/usercode");
+    expect(userCodeRequest[1]?.method).toBe("POST");
+    expect(userCodeRequest[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(userCodeRequest[1]?.headers).toEqual({
+      "Content-Type": "application/json",
+      originator: "openclaw",
+      version: "2026.3.22",
+      "User-Agent": "openclaw/2026.3.22",
+    });
 
-      const deviceTokenRequest = fetchCall(fetchMock, 1);
-      expect(deviceTokenRequest[0]).toBe("https://auth.openai.com/api/accounts/deviceauth/token");
-      expect(deviceTokenRequest[1]?.method).toBe("POST");
-      expect(deviceTokenRequest[1]?.headers).toEqual({
-        "Content-Type": "application/json",
-        originator: "openclaw",
-        version: "2026.3.22",
-        "User-Agent": "openclaw/2026.3.22",
-      });
+    const deviceTokenRequest = fetchCall(fetchMock, 1);
+    expect(deviceTokenRequest[0]).toBe("https://auth.openai.com/api/accounts/deviceauth/token");
+    expect(deviceTokenRequest[1]?.method).toBe("POST");
+    expect(deviceTokenRequest[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(deviceTokenRequest[1]?.headers).toEqual({
+      "Content-Type": "application/json",
+      originator: "openclaw",
+      version: "2026.3.22",
+      "User-Agent": "openclaw/2026.3.22",
+    });
 
-      const oauthTokenRequest = fetchCall(fetchMock, 3);
-      expect(oauthTokenRequest[0]).toBe("https://auth.openai.com/oauth/token");
-      expect(oauthTokenRequest[1]?.method).toBe("POST");
-      expect(oauthTokenRequest[1]?.headers).toEqual({
-        "Content-Type": "application/x-www-form-urlencoded",
-        originator: "openclaw",
-        version: "2026.3.22",
-        "User-Agent": "openclaw/2026.3.22",
-      });
-      expect(onVerification).toHaveBeenCalledWith({
-        verificationUrl: "https://auth.openai.com/codex/device",
-        userCode: "CODE-12345",
-        expiresInMs: 900_000,
-      });
-      expect(onProgress).toHaveBeenNthCalledWith(1, "Requesting device code…");
-      expect(onProgress).toHaveBeenNthCalledWith(2, "Waiting for device authorization…");
-      expect(onProgress).toHaveBeenNthCalledWith(3, "Exchanging device code…");
-      expect(typeof credentials.access).toBe("string");
-      expect(credentials.access.length).toBeGreaterThan(0);
-      expect(credentials.refresh).toBe("refresh-token-123");
-      expect(credentials).not.toHaveProperty("accountId");
-      expect(credentials.expires).toBeGreaterThan(Date.now());
-    } finally {
-      vi.useRealTimers();
-      vi.unstubAllEnvs();
-    }
+    const oauthTokenRequest = fetchCall(fetchMock, 3);
+    expect(oauthTokenRequest[0]).toBe("https://auth.openai.com/oauth/token");
+    expect(oauthTokenRequest[1]?.method).toBe("POST");
+    expect(oauthTokenRequest[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(oauthTokenRequest[1]?.headers).toEqual({
+      "Content-Type": "application/x-www-form-urlencoded",
+      originator: "openclaw",
+      version: "2026.3.22",
+      "User-Agent": "openclaw/2026.3.22",
+    });
+    expect(onVerification).toHaveBeenCalledWith({
+      verificationUrl: "https://auth.openai.com/codex/device",
+      userCode: "CODE-12345",
+      expiresInMs: 900_000,
+    });
+    expect(onProgress).toHaveBeenNthCalledWith(1, "Requesting device code…");
+    expect(onProgress).toHaveBeenNthCalledWith(2, "Waiting for device authorization…");
+    expect(onProgress).toHaveBeenNthCalledWith(3, "Exchanging device code…");
+    expect(typeof credentials.access).toBe("string");
+    expect(credentials.access.length).toBeGreaterThan(0);
+    expect(credentials.refresh).toBe("refresh-token-123");
+    expect(credentials).not.toHaveProperty("accountId");
+    expect(credentials.expires).toBeGreaterThan(Date.now());
   });
 
   it("aborts device-code polling without another request", async () => {
     vi.useFakeTimers();
     const controller = new AbortController();
-    try {
-      const fetchMock = vi
-        .fn<typeof fetch>()
-        .mockResolvedValueOnce(
-          createJsonResponse({
-            device_auth_id: "device-auth-123",
-            user_code: "CODE-12345",
-            interval: "5",
-          }),
-        )
-        .mockResolvedValueOnce(new Response(null, { status: 404 }));
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "5",
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
 
-      const login = loginOpenAICodexDeviceCode({
-        fetchFn: fetchMock,
-        onVerification: async () => {},
-        signal: controller.signal,
-      });
-      await vi.advanceTimersByTimeAsync(0);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+    const login = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock,
+      onVerification: async () => {},
+      signal: controller.signal,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
 
-      controller.abort(new Error("cancelled"));
-      await expect(login).rejects.toThrow("cancelled");
-      await vi.advanceTimersByTimeAsync(5_000);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-    } finally {
-      vi.useRealTimers();
-    }
+    controller.abort(new Error("cancelled"));
+    await expect(login).rejects.toThrow("cancelled");
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts an in-flight hung user-code request on caller cancel", async () => {
+    const controller = new AbortController();
+    const fetchMock = createHangingFetch();
+    // Keep operation timeout effectively disabled so only caller cancel fires.
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => new AbortController().signal);
+
+    const login = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock as typeof fetch,
+      onVerification: async () => {},
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchCall(fetchMock, 0)[1]?.signal).toBeInstanceOf(AbortSignal);
+
+    controller.abort(new Error("cancelled"));
+    await expect(login).rejects.toThrow("cancelled");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("treats JWT-derived expiry fallback as an absolute timestamp", async () => {
@@ -266,56 +394,52 @@ describe("loginOpenAICodexDeviceCode", () => {
 
   it("falls back when device-code intervals and token lifetimes overflow safe milliseconds", async () => {
     vi.useFakeTimers();
-    try {
-      const accessToken = createJwt({
-        exp: Math.floor(Date.now() / 1000) + 600,
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "acct_123",
-        },
-      });
-      const expectedExpiry = resolveCodexAccessTokenExpiry(accessToken);
-      const fetchMock = vi
-        .fn<typeof fetch>()
-        .mockResolvedValueOnce(
-          createJsonResponse({
-            device_auth_id: "device-auth-123",
-            user_code: "CODE-12345",
-            interval: Number.MAX_SAFE_INTEGER,
-          }),
-        )
-        .mockResolvedValueOnce(new Response(null, { status: 404 }))
-        .mockResolvedValueOnce(
-          createJsonResponse({
-            authorization_code: "authorization-code-123",
-            code_verifier: "code-verifier-123",
-          }),
-        )
-        .mockResolvedValueOnce(
-          createJsonResponse({
-            access_token: accessToken,
-            refresh_token: "refresh-token-123",
-            expires_in: Number.MAX_SAFE_INTEGER,
-          }),
-        );
+    const accessToken = createJwt({
+      exp: Math.floor(Date.now() / 1000) + 600,
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "acct_123",
+      },
+    });
+    const expectedExpiry = resolveCodexAccessTokenExpiry(accessToken);
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: Number.MAX_SAFE_INTEGER,
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          authorization_code: "authorization-code-123",
+          code_verifier: "code-verifier-123",
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          access_token: accessToken,
+          refresh_token: "refresh-token-123",
+          expires_in: Number.MAX_SAFE_INTEGER,
+        }),
+      );
 
-      const credentialsPromise = loginOpenAICodexDeviceCode({
-        fetchFn: fetchMock as typeof fetch,
-        onVerification: async () => {},
-      });
-      await vi.advanceTimersByTimeAsync(0);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-      await vi.advanceTimersByTimeAsync(4_999);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-      await vi.advanceTimersByTimeAsync(1);
-      const credentials = await credentialsPromise;
+    const credentialsPromise = loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock as typeof fetch,
+      onVerification: async () => {},
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    const credentials = await credentialsPromise;
 
-      if (expectedExpiry === undefined) {
-        throw new Error("expected device-code expiry to be calculated");
-      }
-      expect(credentials.expires).toBe(expectedExpiry);
-    } finally {
-      vi.useRealTimers();
+    if (expectedExpiry === undefined) {
+      throw new Error("expected device-code expiry to be calculated");
     }
+    expect(credentials.expires).toBe(expectedExpiry);
   });
 
   it("surfaces user-code request failures", async () => {
@@ -413,5 +537,280 @@ describe("loginOpenAICodexDeviceCode", () => {
     ).rejects.toThrow(
       "OpenAI device authorization failed: authorization_declined spoofed (Denied next line)",
     );
+  });
+
+  it("aborts hung user-code requests instead of waiting forever", async () => {
+    stubDeviceCodeFetchTimeout(30_000);
+    const fetchMock = createHangingFetch();
+
+    await expect(
+      loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock as typeof fetch,
+        onVerification: async () => {},
+      }),
+    ).rejects.toThrow("OpenAI device code user code request timed out after 30000ms");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchCall(fetchMock, 0)[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("retries device authorization polls after a per-request timeout", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        }),
+      )
+      .mockRejectedValueOnce(new DOMException("timed out", "TimeoutError"))
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          authorization_code: "authorization-code-123",
+          code_verifier: "code-verifier-123",
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          access_token: createJwt({
+            exp: Math.floor(Date.now() / 1000) + 600,
+          }),
+          refresh_token: "refresh-token-123",
+          expires_in: 600,
+        }),
+      );
+
+    const credentials = await loginOpenAICodexDeviceCode({
+      fetchFn: fetchMock as typeof fetch,
+      onVerification: async () => {},
+    });
+
+    expect(credentials.refresh).toBe("refresh-token-123");
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchCall(fetchMock, 1)[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(fetchCall(fetchMock, 2)[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("does not retry authorization polls after caller cancel", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        }),
+      )
+      .mockImplementationOnce(async (_input, init) => {
+        queueMicrotask(() => controller.abort(new Error("cancelled")));
+        return hangingFetch(_input, init);
+      });
+
+    await expect(
+      loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock as typeof fetch,
+        onVerification: async () => {},
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("cancelled");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts hung token exchange requests instead of waiting forever", async () => {
+    let timeoutCall = 0;
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((actualTimeoutMs) => {
+      timeoutCall += 1;
+      if (timeoutCall < 3) {
+        return originalAbortSignalTimeout(actualTimeoutMs);
+      }
+      expect(actualTimeoutMs).toBe(30_000);
+      const controller = new AbortController();
+      queueMicrotask(() => {
+        controller.abort(new DOMException("timed out", "TimeoutError"));
+      });
+      return controller.signal;
+    });
+
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          authorization_code: "authorization-code-123",
+          code_verifier: "code-verifier-123",
+        }),
+      )
+      .mockImplementationOnce(hangingFetch);
+
+    await expect(
+      loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock as typeof fetch,
+        onVerification: async () => {},
+      }),
+    ).rejects.toThrow("OpenAI device code token exchange timed out after 30000ms");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchCall(fetchMock, 2)[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("aborts when user-code headers arrive but the body never completes", async () => {
+    const server = await startPartialBodyStallServer();
+    stubDeviceCodeFetchTimeoutAfterHeaders(30_000);
+    const fetchMock = createLoopbackFetchRedirect(server.origin);
+
+    try {
+      await expect(
+        loginOpenAICodexDeviceCode({
+          fetchFn: fetchMock as typeof fetch,
+          onVerification: async () => {},
+        }),
+      ).rejects.toThrow("OpenAI device code user code request timed out after 30000ms");
+      expect(server.getRequestCount()).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchCall(fetchMock, 0)[1]?.signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("cancels a post-header body stall on caller abort without mapping to timeout", async () => {
+    const server = await startPartialBodyStallServer();
+    const controller = new AbortController();
+    // Keep operation timeout disabled so only caller cancel aborts the body.
+    vi.spyOn(AbortSignal, "timeout").mockImplementation(() => new AbortController().signal);
+    const fetchMock = createLoopbackFetchRedirect(server.origin);
+
+    try {
+      const login = loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock as typeof fetch,
+        onVerification: async () => {},
+        signal: controller.signal,
+      });
+      await Promise.resolve();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 30);
+      });
+      expect(server.getRequestCount()).toBe(1);
+      expect(fetchCall(fetchMock, 0)[1]?.signal).toBeInstanceOf(AbortSignal);
+
+      controller.abort(new Error("cancelled"));
+      await expect(login).rejects.toSatisfy((error: unknown) => {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toBe("cancelled");
+        expect((error as Error).message).not.toMatch(/timed out after/);
+        return true;
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("retries authorization polls after a post-header body stall", async () => {
+    const server = await startPartialBodyStallServer();
+    let timeoutCall = 0;
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((actualTimeoutMs) => {
+      timeoutCall += 1;
+      if (timeoutCall === 1) {
+        // user-code request: keep the configured deadline
+        return originalAbortSignalTimeout(actualTimeoutMs);
+      }
+      if (timeoutCall === 2) {
+        // first poll: short real timeout so the partial body aborts under the
+        // same operation signal after headers return
+        expect(actualTimeoutMs).toBe(30_000);
+        return originalAbortSignalTimeout(120);
+      }
+      return originalAbortSignalTimeout(actualTimeoutMs);
+    });
+
+    const realFetch = globalThis.fetch;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        }),
+      )
+      .mockImplementationOnce(async (_input, init) => realFetch(server.origin, init))
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          authorization_code: "authorization-code-123",
+          code_verifier: "code-verifier-123",
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          access_token: createJwt({
+            exp: Math.floor(Date.now() / 1000) + 600,
+          }),
+          refresh_token: "refresh-token-123",
+          expires_in: 600,
+        }),
+      );
+
+    try {
+      const credentials = await loginOpenAICodexDeviceCode({
+        fetchFn: fetchMock as typeof fetch,
+        onVerification: async () => {},
+      });
+      expect(credentials.refresh).toBe("refresh-token-123");
+      expect(server.getRequestCount()).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("aborts when token-exchange headers arrive but the body never completes", async () => {
+    const server = await startPartialBodyStallServer();
+    let timeoutCall = 0;
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((actualTimeoutMs) => {
+      timeoutCall += 1;
+      if (timeoutCall < 3) {
+        return originalAbortSignalTimeout(actualTimeoutMs);
+      }
+      expect(actualTimeoutMs).toBe(30_000);
+      return originalAbortSignalTimeout(120);
+    });
+
+    const realFetch = globalThis.fetch;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          device_auth_id: "device-auth-123",
+          user_code: "CODE-12345",
+          interval: "0",
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          authorization_code: "authorization-code-123",
+          code_verifier: "code-verifier-123",
+        }),
+      )
+      .mockImplementationOnce(async (_input, init) => realFetch(server.origin, init));
+
+    try {
+      await expect(
+        loginOpenAICodexDeviceCode({
+          fetchFn: fetchMock as typeof fetch,
+          onVerification: async () => {},
+        }),
+      ).rejects.toThrow("OpenAI device code token exchange timed out after 30000ms");
+      expect(server.getRequestCount()).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      await server.close();
+    }
   });
 });

--- a/extensions/openai/openai-chatgpt-device-code.ts
+++ b/extensions/openai/openai-chatgpt-device-code.ts
@@ -5,11 +5,13 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { resolveCodexAccessTokenExpiry } from "./openai-chatgpt-auth-identity.js";
+import { buildOAuthRequestSignal } from "./openai-chatgpt-oauth-abort.runtime.js";
 import { trimNonEmptyString } from "./openai-chatgpt-shared.js";
 
 const OPENAI_AUTH_BASE_URL = "https://auth.openai.com";
 const OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENAI_CODEX_DEVICE_CODE_TIMEOUT_MS = 15 * 60_000;
+const OPENAI_CODEX_DEVICE_CODE_REQUEST_TIMEOUT_MS = 30_000;
 const OPENAI_CODEX_DEVICE_CODE_DEFAULT_INTERVAL_MS = 5_000;
 const OPENAI_CODEX_DEVICE_CODE_MIN_INTERVAL_MS = 1_000;
 const OPENAI_CODEX_DEVICE_CALLBACK_URL = `${OPENAI_AUTH_BASE_URL}/deviceauth/callback`;
@@ -69,6 +71,11 @@ type DeviceCodeAuthorizationCode = {
   codeVerifier: string;
 };
 
+type DeviceCodeHttpResult = {
+  response: Response;
+  bodyText: string;
+};
+
 function parseJsonObject(text: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(text);
@@ -99,6 +106,87 @@ function sanitizeDeviceCodeErrorText(value: string): string {
 function resolveNextDeviceCodePollDelayMs(intervalMs: number, deadlineMs: number): number {
   const remainingMs = Math.max(0, deadlineMs - Date.now());
   return Math.min(Math.max(intervalMs, OPENAI_CODEX_DEVICE_CODE_MIN_INTERVAL_MS), remainingMs);
+}
+
+function resolveDeviceCodePollRequestTimeoutMs(deadlineMs: number): number {
+  return Math.min(
+    OPENAI_CODEX_DEVICE_CODE_REQUEST_TIMEOUT_MS,
+    Math.max(0, deadlineMs - Date.now()),
+  );
+}
+
+function isDeviceCodeOperationTimeoutError(error: unknown): boolean {
+  // AbortSignal.timeout uses TimeoutError; undici may surface the same abort as
+  // AbortError. Caller cancel is filtered separately before this check.
+  return error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError");
+}
+
+function formatDeviceCodeFetchTimeoutError(operation: string, timeoutMs: number): Error {
+  return new Error(`OpenAI device code ${operation} timed out after ${timeoutMs}ms`);
+}
+
+function rethrowIfDeviceCodeCallerAborted(signal: AbortSignal | undefined, error: unknown): void {
+  // Caller cancel must win over operation-timeout mapping so poll does not
+  // retry wizard/Ctrl-C aborts as if the remote endpoint stalled.
+  if (!signal?.aborted) {
+    return;
+  }
+  throw signal.reason instanceof Error ? signal.reason : error;
+}
+
+function rethrowIfRequestSignalAborted(signal: AbortSignal, error: unknown): void {
+  // Prefer the composed signal reason so TimeoutError stays distinguishable from
+  // caller cancel after undici collapses body aborts into AbortError.
+  if (!signal.aborted) {
+    return;
+  }
+  throw signal.reason instanceof Error ? signal.reason : error;
+}
+
+// One operation deadline for headers + bounded body read. Compose with the
+// optional caller AbortSignal so Ctrl-C / wizard cancel still abort in-flight
+// fetch and post-header body stalls without replacing that contract.
+async function runOpenAICodexDeviceCodeRequest(params: {
+  fetchFn: typeof fetch;
+  url: string;
+  init: Omit<RequestInit, "signal">;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<DeviceCodeHttpResult> {
+  const signal = buildOAuthRequestSignal({
+    signal: params.signal,
+    timeoutMs: params.timeoutMs,
+  });
+  try {
+    const response = await params.fetchFn(params.url, {
+      ...params.init,
+      signal,
+    });
+    const bodyText = await readOpenAICodexDeviceBody(response);
+    return { response, bodyText };
+  } catch (error) {
+    rethrowIfRequestSignalAborted(signal, error);
+    throw error;
+  }
+}
+
+async function fetchOpenAICodexDeviceCode(params: {
+  fetchFn: typeof fetch;
+  url: string;
+  init: Omit<RequestInit, "signal">;
+  timeoutMs: number;
+  timeoutOperation: string;
+  signal?: AbortSignal;
+}): Promise<DeviceCodeHttpResult> {
+  try {
+    return await runOpenAICodexDeviceCodeRequest(params);
+  } catch (error) {
+    rethrowIfDeviceCodeCallerAborted(params.signal, error);
+    if (isDeviceCodeOperationTimeoutError(error)) {
+      throw formatDeviceCodeFetchTimeoutError(params.timeoutOperation, params.timeoutMs);
+    }
+    throw error;
+  }
 }
 
 function formatDeviceCodeError(params: {
@@ -137,16 +225,21 @@ async function requestOpenAICodexDeviceCode(
   signal?: AbortSignal,
 ): Promise<RequestedDeviceCode> {
   signal?.throwIfAborted();
-  const response = await fetchFn(`${OPENAI_AUTH_BASE_URL}/api/accounts/deviceauth/usercode`, {
-    method: "POST",
-    headers: resolveOpenAICodexDeviceCodeHeaders("application/json"),
-    body: JSON.stringify({
-      client_id: OPENAI_CODEX_CLIENT_ID,
-    }),
+  const { response, bodyText } = await fetchOpenAICodexDeviceCode({
+    fetchFn,
+    url: `${OPENAI_AUTH_BASE_URL}/api/accounts/deviceauth/usercode`,
+    init: {
+      method: "POST",
+      headers: resolveOpenAICodexDeviceCodeHeaders("application/json"),
+      body: JSON.stringify({
+        client_id: OPENAI_CODEX_CLIENT_ID,
+      }),
+    },
+    timeoutMs: OPENAI_CODEX_DEVICE_CODE_REQUEST_TIMEOUT_MS,
+    timeoutOperation: "user code request",
     ...(signal ? { signal } : {}),
   });
 
-  const bodyText = await readOpenAICodexDeviceBody(response);
   if (!response.ok) {
     if (response.status === 404) {
       throw new Error(
@@ -190,17 +283,37 @@ async function pollOpenAICodexDeviceCode(params: {
 
   while (Date.now() < deadline) {
     params.signal?.throwIfAborted();
-    const response = await params.fetchFn(`${OPENAI_AUTH_BASE_URL}/api/accounts/deviceauth/token`, {
-      method: "POST",
-      headers: resolveOpenAICodexDeviceCodeHeaders("application/json"),
-      body: JSON.stringify({
-        device_auth_id: params.deviceAuthId,
-        user_code: params.userCode,
-      }),
-      ...(params.signal ? { signal: params.signal } : {}),
-    });
+    const requestTimeoutMs = resolveDeviceCodePollRequestTimeoutMs(deadline);
+    if (requestTimeoutMs <= 0) {
+      break;
+    }
 
-    const bodyText = await readOpenAICodexDeviceBody(response);
+    let response: Response;
+    let bodyText: string;
+    try {
+      ({ response, bodyText } = await runOpenAICodexDeviceCodeRequest({
+        fetchFn: params.fetchFn,
+        url: `${OPENAI_AUTH_BASE_URL}/api/accounts/deviceauth/token`,
+        init: {
+          method: "POST",
+          headers: resolveOpenAICodexDeviceCodeHeaders("application/json"),
+          body: JSON.stringify({
+            device_auth_id: params.deviceAuthId,
+            user_code: params.userCode,
+          }),
+        },
+        timeoutMs: requestTimeoutMs,
+        ...(params.signal ? { signal: params.signal } : {}),
+      }));
+    } catch (error) {
+      rethrowIfDeviceCodeCallerAborted(params.signal, error);
+      // Retry header or post-header body stalls until the 15-minute deadline.
+      if (isDeviceCodeOperationTimeoutError(error)) {
+        continue;
+      }
+      throw error;
+    }
+
     if (response.ok) {
       const body = parseJsonObject(bodyText) as DeviceCodeTokenPayload | null;
       const authorizationCode = trimNonEmptyString(body?.authorization_code);
@@ -241,20 +354,25 @@ async function exchangeOpenAICodexDeviceCode(params: {
   signal?: AbortSignal;
 }): Promise<OpenAICodexDeviceCodeCredentials> {
   params.signal?.throwIfAborted();
-  const response = await params.fetchFn(`${OPENAI_AUTH_BASE_URL}/oauth/token`, {
-    method: "POST",
-    headers: resolveOpenAICodexDeviceCodeHeaders("application/x-www-form-urlencoded"),
-    body: new URLSearchParams({
-      grant_type: "authorization_code",
-      code: params.authorizationCode,
-      redirect_uri: OPENAI_CODEX_DEVICE_CALLBACK_URL,
-      client_id: OPENAI_CODEX_CLIENT_ID,
-      code_verifier: params.codeVerifier,
-    }),
+  const { response, bodyText } = await fetchOpenAICodexDeviceCode({
+    fetchFn: params.fetchFn,
+    url: `${OPENAI_AUTH_BASE_URL}/oauth/token`,
+    init: {
+      method: "POST",
+      headers: resolveOpenAICodexDeviceCodeHeaders("application/x-www-form-urlencoded"),
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: params.authorizationCode,
+        redirect_uri: OPENAI_CODEX_DEVICE_CALLBACK_URL,
+        client_id: OPENAI_CODEX_CLIENT_ID,
+        code_verifier: params.codeVerifier,
+      }),
+    },
+    timeoutMs: OPENAI_CODEX_DEVICE_CODE_REQUEST_TIMEOUT_MS,
+    timeoutOperation: "token exchange",
     ...(params.signal ? { signal: params.signal } : {}),
   });
 
-  const bodyText = await readOpenAICodexDeviceBody(response);
   if (!response.ok) {
     throw new Error(
       formatDeviceCodeError({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running OpenAI Codex device-code login (`openclaw models auth login --provider openai --device-code`, or the equivalent configure/wizard auth choice) could hang forever when a single `auth.openai.com` HTTP request stopped responding.

Before this patch, the flow enforced a 15-minute poll-loop deadline around authorization waiting, and callers could cancel via `AbortSignal`, but the three HTTP calls for user-code request, authorization poll, and token exchange had no per-request operation deadline covering both headers and body reads. A stalled TCP/proxy/blackhole response, or a server that returned headers and then stalled the body, could leave the CLI spinner stuck.

## Why This Change Was Made

Treat each device-code HTTP call as one timed operation: headers fetch plus bounded body read under `buildOAuthRequestSignal` (caller `AbortSignal` composed with `AbortSignal.timeout`, 30s, aligned with the sibling ChatGPT browser OAuth token request timeout). Poll requests clamp that timeout to the remaining 15-minute authorization deadline and retry only on operation timeout (including post-header body stalls) until the overall deadline expires. Caller cancel (Ctrl-C / wizard abort) remains distinguishable and does not retry. User-code and token-exchange timeouts fail fast with a clear error.

Body/fetch aborts rethrow the composed signal reason so undici `AbortError` collapse does not erase `TimeoutError` vs caller cancel distinguishability.

Scope stays OpenAI Codex device-code login HTTP only; browser OAuth and other providers are unchanged.

## User Impact

**Before:** A hung device-code HTTP request (or a post-header body stall) could block `models auth login --device-code` indefinitely, even past the advertised 15-minute authorization window, while still depending on the overall poll deadline for happy-path waiting.

**After:** Each device-code request+body read aborts after 30 seconds (or sooner near the overall deadline). Poll timeouts retry within the 15-minute window; caller cancel aborts immediately without retry; user-code and token-exchange stalls surface an explicit timeout error instead of hanging forever.

## Evidence

- `extensions/openai/openai-chatgpt-device-code.ts` — `buildOAuthRequestSignal` composes caller cancel + 30s operation deadline across fetch + body read; poll retries only on operation timeout
- Regression: `extensions/openai/openai-chatgpt-device-code.test.ts`
  - hung user-code / token-exchange abort with timeout error
  - poll retries after `TimeoutError` and completes
  - caller cancel during hung fetch / poll wait / post-header body stall does not retry or map to timeout
  - real `node:http` partial-body stall coverage
  - success path asserts fetches carry an `AbortSignal`

### Unit regression

```bash
node scripts/run-vitest.mjs extensions/openai/openai-chatgpt-device-code.test.ts --reporter=verbose
```

```text
 ✓ aborts device-code polling without another request 3ms
 ✓ aborts an in-flight hung user-code request on caller cancel 1ms
 ✓ aborts hung user-code requests instead of waiting forever 0ms
 ✓ retries device authorization polls after a per-request timeout 0ms
 ✓ does not retry authorization polls after caller cancel 0ms
 ✓ aborts hung token exchange requests instead of waiting forever 0ms
 ✓ aborts when user-code headers arrive but the body never completes 130ms
 ✓ cancels a post-header body stall on caller abort without mapping to timeout 37ms
 ✓ retries authorization polls after a post-header body stall 123ms
 ✓ aborts when token-exchange headers arrive but the body never completes 124ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
 Duration  4.01s
[test] passed 1 Vitest shard in 14.04s
```

### Standalone runtime proof (outside Vitest)

```bash
node --import tsx /tmp/openclaw-openai-device-code-proof/standalone.mts
```

```text
standalone-proof: openai device-code operation timeout + caller cancel
{"proof":"standalone-production-login-user-code-partial-body-stall","path":"loginOpenAICodexDeviceCode → requestOpenAICodexDeviceCode → buildOAuthRequestSignal","result":{"ok":false,"error":{"name":"Error","message":"OpenAI device code user code request timed out after 30000ms"},"requests":1,"elapsedMs":81},"rejectedBeforeHangCap":true,"timedOutMessage":true}
{"proof":"standalone-production-login-caller-cancel-during-hung-fetch","path":"loginOpenAICodexDeviceCode({ signal }) → AbortSignal.any(caller, timeout)","result":{"ok":false,"error":{"name":"Error","message":"cancelled"},"requests":1,"elapsedMs":0},"cancelledNotTimedOut":true}
standalone-proof: done
```

## Real behavior proof

- **Behavior or issue addressed:** OpenAI Codex device-code login no longer leaves individual HTTP operations unbounded when the remote endpoint stops responding before headers return, or returns headers and then stalls the body; caller cancel remains distinct from operation timeout.
- **Canonical reachability path:** Operator runs device-code auth → `loginOpenAICodexDeviceCode` → `requestOpenAICodexDeviceCode` / `pollOpenAICodexDeviceCode` / `exchangeOpenAICodexDeviceCode` → `runOpenAICodexDeviceCodeRequest` → `buildOAuthRequestSignal` (`AbortSignal.any([caller, AbortSignal.timeout(...)])`) + `readOpenAICodexDeviceBody`.
- **Boundary crossed:** local-runtime; production `loginOpenAICodexDeviceCode` exercised via standalone `node --import tsx` (outside Vitest) against a real hung `node:http` loopback that sends headers then a partial JSON prefix and never finishes the body. Only `AbortSignal.timeout` duration is shortened for deterministic hang repro; production fetch+body composition, caller composition, and error/retry mapping stay unmocked.
- **Shared helper / provider constraint check:** Reuses `buildOAuthRequestSignal` from `openai-chatgpt-oauth-abort.runtime` (same helper as ChatGPT OAuth). 30s matches the existing OpenAI ChatGPT OAuth token request timeout. Preserves current-main caller `AbortSignal` cancellation from provider sign-in. Does not migrate this path onto `fetchWithSsrFGuard` in this change.
- **Real environment tested:** macOS, Node 22, product checkout on branch `fix/openai-device-code-request-timeout` rebased onto current `upstream/main`.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/openai/openai-chatgpt-device-code.test.ts --reporter=verbose
node --import tsx /tmp/openclaw-openai-device-code-proof/standalone.mts
```

- **Evidence after fix:**

```text
Unit:
 ✓ ... > aborts an in-flight hung user-code request on caller cancel
 ✓ ... > aborts hung user-code requests instead of waiting forever
 ✓ ... > retries device authorization polls after a per-request timeout
 ✓ ... > does not retry authorization polls after caller cancel
 ✓ ... > cancels a post-header body stall on caller abort without mapping to timeout
 ✓ ... > aborts when user-code headers arrive but the body never completes
 Test Files  1 passed (1)
      Tests  18 passed (18)

Standalone (outside Vitest):
{"proof":"standalone-production-login-user-code-partial-body-stall",...,"elapsedMs":81,"rejectedBeforeHangCap":true,"timedOutMessage":true}
{"proof":"standalone-production-login-caller-cancel-during-hung-fetch",...,"cancelledNotTimedOut":true}
standalone-proof: done
```

- **Observed result after fix:** Hung user-code/token-exchange reject with `OpenAI device code ... timed out after 30000ms` (~81ms wall with shortened timeout); caller cancel during hung fetch rejects with `cancelled` and does not map to timeout/retry; poll `TimeoutError` (including post-header body stall) retries and can still succeed within the overall deadline.
- **What was not tested:** Live `openclaw models auth login --provider openai --device-code` against a real stalled `auth.openai.com` endpoint.
- **Fix classification:** Root cause fix.

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
- [x] Single commit on `upstream/main`
