### PR TITLE
fix(middleware): count UTF-8 bytes in middleware details budget

### DIFF
--- a/src/agents/harness/tool-result-middleware.test.ts
+++ b/src/agents/harness/tool-result-middleware.test.ts
@@ -634,4 +634,35 @@ describe("createAgentToolResultMiddlewareRunner", () => {
     expect(result.content).toEqual([{ type: "text", text: "compacted" }]);
     expect(result.details).toEqual({ compacted: true, runtime: "codex", harness: "codex" });
   });
+
+  it("counts multi-byte UTF-8 characters towards the details byte budget", async () => {
+    // Each CJK character is 1 UTF-16 code unit but 3 UTF-8 bytes.
+    // A details payload of 40_000 CJK chars is 40_000 .length units
+    // but 120_000 UTF-8 bytes — exceeding the 100_000 byte budget.
+    // The byte counter must use Buffer.byteLength, not string.length,
+    // to reject oversized non-ASCII payloads.
+    const cjkChar = "中"; // 中 — 3 UTF-8 bytes
+    const payload = cjkChar.repeat(40_000);
+    // 40_000 UTF-16 units < 100_000, but 120_000 UTF-8 bytes > 100_000
+    expect(payload.length).toBe(40_000);
+    expect(Buffer.byteLength(payload, "utf8")).toBe(120_000);
+
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "codex" }, [
+      () => ({
+        result: {
+          content: [{ type: "text", text: "compacted" }],
+          details: { payload },
+        },
+      }),
+    ]);
+
+    const result = await runner.applyToolResultMiddleware({
+      toolCallId: "call-1",
+      toolName: "exec",
+      args: {},
+      result: { content: [{ type: "text", text: "raw" }], details: {} },
+    });
+
+    expect(result.details).toEqual({ status: "error", middlewareError: true });
+  });
 });

--- a/src/agents/harness/tool-result-middleware.ts
+++ b/src/agents/harness/tool-result-middleware.ts
@@ -69,7 +69,7 @@ function isValidMiddlewareDetails(
     return false;
   }
   if (typeof value === "string") {
-    state.bytes += value.length;
+    state.bytes += Buffer.byteLength(value, "utf8");
     return state.bytes <= MAX_MIDDLEWARE_DETAILS_BYTES;
   }
   if (typeof value === "number" || typeof value === "boolean") {
@@ -97,7 +97,7 @@ function isValidMiddlewareDetails(
   }
   for (const [key, entry] of Object.entries(value)) {
     state.keys += 1;
-    state.bytes += key.length;
+    state.bytes += Buffer.byteLength(key, "utf8");
     if (state.keys > MAX_MIDDLEWARE_DETAILS_KEYS || state.bytes > MAX_MIDDLEWARE_DETAILS_BYTES) {
       return false;
     }


### PR DESCRIPTION
## What Problem This Solves

`isValidMiddlewareDetails` tracks a byte budget (`MAX_MIDDLEWARE_DETAILS_BYTES = 100_000`) but uses `string.length` (UTF-16 code units) instead of actual UTF-8 byte count. Multi-byte characters — CJK, emoji, accented text — are undercounted: a 40,000-character CJK string has `.length = 40_000` (passes the 100KB limit) but `Buffer.byteLength = 120_000` (should be rejected).

## Why This Change Was Made

The byte budget exists to prevent middleware results from creating unbounded transcript growth. Using the wrong length metric silently allows oversized non-ASCII payloads through the budget check.

## User Impact

Middleware details containing internationalized tool output (error messages, file names, API responses) now correctly respect the 100KB byte budget. No change for ASCII-only payloads — `.length` and `Buffer.byteLength` produce identical results.

## Evidence

- Test added: 40,000 CJK chars pass `.length` check (40K < 100K) but are rejected by `Buffer.byteLength` (120K > 100K)
- Existing tests continue to pass — ASCII-based limits are unchanged