### PR TITLE
test(ci): match legacy planner import adapter

### DIFF
--- a/test/scripts/plugin-contract-test-plan.test.ts
+++ b/test/scripts/plugin-contract-test-plan.test.ts
@@ -16,7 +16,7 @@ describe("scripts/lib/plugin-contract-test-plan.mjs", () => {
     const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
 
     expect(workflow).toContain(
-      'await import(\n            "./scripts/lib/plugin-contract-test-plan.mjs"',
+      'const pluginContractPlan = await importTargetPlan(\n            "./scripts/lib/plugin-contract-test-plan.mjs",',
     );
     expect(workflow).toContain("checks-fast-contracts-plugins-legacy");
     expect(workflow).not.toContain(


### PR DESCRIPTION
## What Problem This Solves

Main CI fails deterministically in `test/scripts/plugin-contract-test-plan.test.ts` after #103975 replaced a direct dynamic import with the legacy-target `importTargetPlan` adapter but left the guard expecting the old source text.

The same failure appears in current-main CI run 29153352591 and an unrelated PR run, blocking otherwise healthy landings.

## Why This Change Was Made

Update the existing source guard to assert the adapter call introduced by #103975, including the planner module path. The surrounding assertions still verify the legacy shard fallback and reject the recursive fallback shape.

## User Impact

No runtime behavior changes. Main CI again validates the intended legacy-target planner import path instead of failing on stale expected text.

## Evidence

- Current-main CI reproduces one failure in `test/scripts/plugin-contract-test-plan.test.ts`: expected the removed direct `await import` call.
- `.github/workflows/ci.yml` now intentionally calls `importTargetPlan("./scripts/lib/plugin-contract-test-plan.mjs")`.
- Patch applies cleanly to current `main`; `git diff --check` passes.
- Exact-head hosted CI passed 45 jobs with 11 scoped skips and zero failures: https://github.com/openclaw/openclaw/actions/runs/29153829600
