### PR TITLE
fix(agents): keep failover detail truncation UTF-16 safe

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.test.ts
+++ b/src/agents/embedded-agent-helpers/errors.test.ts
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assistant-error-format.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
-import { formatAssistantErrorText, isLikelyContextOverflowError } from "./errors.js";
+import {
+  extractFailoverSignalDetails,
+  formatAssistantErrorText,
+  isLikelyContextOverflowError,
+} from "./errors.js";
 
 const { toolPolicyAuditInfo } = vi.hoisted(() => ({
   toolPolicyAuditInfo: vi.fn(),
@@ -95,6 +99,34 @@ describe("formatAssistantErrorText streaming JSON parse classification", () => {
         sandboxMode: "non-main",
       },
     );
+  });
+});
+
+describe("extractFailoverSignalDetails", () => {
+  it("truncates long detail strings without splitting UTF-16 surrogate pairs", () => {
+    // Regression test for UTF-16 safe truncation. The failover classifier
+    // receives arbitrary provider error text that may contain emoji or other
+    // non-BMP characters; truncating at a fixed code-unit boundary can leave
+    // an unpaired surrogate and corrupt downstream string handling.
+    const emoji = "🎉"; // U+1F389, a UTF-16 surrogate pair (2 code units)
+    const message = "a".repeat(999) + emoji + "!";
+    expect(message).toHaveLength(1002);
+
+    const details = extractFailoverSignalDetails(new Error(message));
+    expect(details).toBeDefined();
+    expect(details).toHaveLength(1);
+
+    const detail = details![0];
+
+    // Raw .slice(0, 1000) would cut the surrogate pair, producing a lone high
+    // surrogate (0xD83C) at the end.
+    const rawSlice = message.slice(0, 1000);
+    expect(rawSlice).toHaveLength(1000);
+    expect(rawSlice.charCodeAt(rawSlice.length - 1)).toBe(0xd83c);
+
+    // truncateUtf16Safe backs up to the last complete code point.
+    expect(detail).toHaveLength(999);
+    expect(detail).toBe("a".repeat(999));
   });
 });
 

--- a/src/agents/embedded-agent-helpers/errors.test.ts
+++ b/src/agents/embedded-agent-helpers/errors.test.ts
@@ -103,30 +103,21 @@ describe("formatAssistantErrorText streaming JSON parse classification", () => {
 });
 
 describe("extractFailoverSignalDetails", () => {
-  it("truncates long detail strings without splitting UTF-16 surrogate pairs", () => {
-    // Regression test for UTF-16 safe truncation. The failover classifier
-    // receives arbitrary provider error text that may contain emoji or other
-    // non-BMP characters; truncating at a fixed code-unit boundary can leave
-    // an unpaired surrogate and corrupt downstream string handling.
-    const emoji = "🎉"; // U+1F389, a UTF-16 surrogate pair (2 code units)
-    const message = "a".repeat(999) + emoji + "!";
-    expect(message).toHaveLength(1002);
+  it.each([
+    {
+      name: "backs off before a split surrogate pair",
+      input: `${"a".repeat(999)}🎉!`,
+      expected: "a".repeat(999),
+    },
+    {
+      name: "keeps the full ASCII budget",
+      input: "a".repeat(1001),
+      expected: "a".repeat(1000),
+    },
+  ])("$name in nested provider details", ({ input, expected }) => {
+    const details = extractFailoverSignalDetails({ error: { body: { detail: input } } });
 
-    const details = extractFailoverSignalDetails(new Error(message));
-    expect(details).toBeDefined();
-    expect(details).toHaveLength(1);
-
-    const detail = details![0];
-
-    // Raw .slice(0, 1000) would cut the surrogate pair, producing a lone high
-    // surrogate (0xD83C) at the end.
-    const rawSlice = message.slice(0, 1000);
-    expect(rawSlice).toHaveLength(1000);
-    expect(rawSlice.charCodeAt(rawSlice.length - 1)).toBe(0xd83c);
-
-    // truncateUtf16Safe backs up to the last complete code point.
-    expect(detail).toHaveLength(999);
-    expect(detail).toBe("a".repeat(999));
+    expect(details).toEqual([expected]);
   });
 });
 

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -308,7 +308,7 @@ function normalizeFailoverDetailString(value: string | undefined): string | unde
     return undefined;
   }
   return trimmed.length > MAX_FAILOVER_DETAIL_CHARS
-    ? trimmed.slice(0, MAX_FAILOVER_DETAIL_CHARS)
+    ? truncateUtf16Safe(trimmed, MAX_FAILOVER_DETAIL_CHARS)
     : trimmed;
 }
 


### PR DESCRIPTION
## What Problem This Solves
`normalizeFailoverDetailString` in `src/agents/embedded-agent-helpers/errors.ts` truncates provider error detail strings for failover classification using raw `.slice(0, MAX_FAILOVER_DETAIL_CHARS)`. When the boundary falls inside a UTF-16 surrogate pair (e.g., emoji), this leaves an unpaired surrogate in the classifier input.

## Why This Change Was Made
The repo already has `truncateUtf16Safe` from `@openclaw/normalization-core/utf16-slice` imported in this file, and the ongoing UTF-16 safe-truncation campaign has fixed the same pattern in chat tool titles (#104464), OpenRouter fusion prompt fragments (#104433), and gateway hook console values. This change applies the same helper to the failover detail path so classification strings stay well-formed.

## User Impact
Failover classification inputs containing non-BMP characters are now truncated at complete code points instead of surrogate-pair boundaries, preventing downstream string handling issues.

## Evidence
- Added a regression test in `src/agents/embedded-agent-helpers/errors.test.ts` that constructs a 1002-code-unit message ending with a surrogate pair, proves raw `.slice(0, 1000)` would produce a lone high surrogate, and asserts `extractFailoverSignalDetails` returns a 999-char well-truncated string.
- Local verification on head `f08e9613f4`:
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/errors.test.ts` → 6 passed
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit` → 0 errors
  - `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-helpers/errors.test.ts` → exit code 0

## Real behavior proof
I ran a standalone script against the actual `src/agents/embedded-agent-helpers/errors.ts` exports on this PR's head (`f08e9613f4`). It constructs a provider-style error whose detail is 999 ASCII characters followed by the surrogate-pair emoji 🎉 (U+1F389), crosses the 1,000-unit cap, and shows:

```
input length: 1002

--- current-main raw .slice(0, 1000) ---
length: 1000
last char code unit: d83c
ends with lone high surrogate: true

--- after PR: extractFailoverSignalDetails ---
details returned: 1
normalized length: 999
normalized last char code unit: 61
normalized well-formed (no lone high surrogate): true

--- classifyFailoverSignal on normalized signal (status 429) ---
classification: { kind: 'reason', reason: 'rate_limit' }
```

The raw slice leaves a lone high surrogate (`0xD83C`), while `extractFailoverSignalDetails` returns a 999-character well-formed detail, and `classifyFailoverSignal` still selects the expected `rate_limit` fallback reason from the normalized signal.
