### PR TITLE
fix(node-pairing): require operator.admin to approve browser.proxy nodes

### DIFF
--- a/src/infra/node-pairing-authz.test.ts
+++ b/src/infra/node-pairing-authz.test.ts
@@ -10,6 +10,13 @@ describe("resolveNodePairApprovalScopes", () => {
     ]);
   });
 
+  it("requires operator.admin for browser.proxy commands", () => {
+    expect(resolveNodePairApprovalScopes(["browser.proxy"])).toEqual([
+      "operator.pairing",
+      "operator.admin",
+    ]);
+  });
+
   it("requires operator.write for non-exec commands", () => {
     expect(resolveNodePairApprovalScopes(["canvas.present"])).toEqual([
       "operator.pairing",

--- a/src/infra/node-pairing-authz.ts
+++ b/src/infra/node-pairing-authz.ts
@@ -1,5 +1,5 @@
 // Maps node pairing command declarations to required operator scopes.
-import { NODE_SYSTEM_RUN_COMMANDS } from "./node-commands.js";
+import { NODE_BROWSER_PROXY_COMMAND, NODE_SYSTEM_RUN_COMMANDS } from "./node-commands.js";
 
 /** Operator scopes required to approve a pending node pairing surface. */
 export type NodeApprovalScope = "operator.pairing" | "operator.write" | "operator.admin";
@@ -8,13 +8,15 @@ const OPERATOR_PAIRING_SCOPE: NodeApprovalScope = "operator.pairing";
 const OPERATOR_WRITE_SCOPE: NodeApprovalScope = "operator.write";
 const OPERATOR_ADMIN_SCOPE: NodeApprovalScope = "operator.admin";
 
+const ADMIN_APPROVAL_COMMANDS = [...NODE_SYSTEM_RUN_COMMANDS, NODE_BROWSER_PROXY_COMMAND];
+
 /** Map declared node commands to the least operator scopes needed for approval. */
 export function resolveNodePairApprovalScopes(commands: unknown): NodeApprovalScope[] {
   const normalized = Array.isArray(commands)
     ? commands.filter((command): command is string => typeof command === "string")
     : [];
   if (
-    normalized.some((command) => NODE_SYSTEM_RUN_COMMANDS.some((allowed) => allowed === command))
+    normalized.some((command) => ADMIN_APPROVAL_COMMANDS.some((allowed) => allowed === command))
   ) {
     return [OPERATOR_PAIRING_SCOPE, OPERATOR_ADMIN_SCOPE];
   }


### PR DESCRIPTION
## What Problem This Solves

Approving a node whose pairing surface advertises the `browser.proxy` capability only requires
`operator.write`, even though directly invoking `browser.proxy` requires `operator.admin`. A
lower-privileged `operator.write` operator can therefore approve (trust) a `browser.proxy`-capable
node. Because the bundled browser tool auto-routes its traffic to a trusted paired node, that
write-scoped approval is the one-time trust decision that lets a node become the target for
admin-level browser traffic (page content, cookies, credentials).

Root cause: `resolveNodePairApprovalScopes` bumps the required approval scope to `operator.admin`
only when a declared command is in `NODE_SYSTEM_RUN_COMMANDS`. `browser.proxy`
(`NODE_BROWSER_PROXY_COMMAND`) is not in that set, so a `browser.proxy` surface falls into the
generic branch and returns `[operator.pairing, operator.write]`.

`src/infra/node-pairing-authz.ts` (before):

```ts
import { NODE_SYSTEM_RUN_COMMANDS } from "./node-commands.js";
...
if (
  normalized.some((command) => NODE_SYSTEM_RUN_COMMANDS.some((allowed) => allowed === command))
) {
  return [OPERATOR_PAIRING_SCOPE, OPERATOR_ADMIN_SCOPE];
}
```

The invoke path already gates `browser.proxy` at `operator.admin`
(`src/gateway/server-methods/nodes.ts`):

```ts
if (command === "browser.proxy" && !clientHasOperatorAdminScope(client)) {
  respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, `missing scope: ${BROWSER_PROXY_REQUIRED_SCOPE}`));
  return;
}
```

PR #85916 added that invoke-time admin gate but never updated the sibling approval-scope
resolver, leaving the two gates inconsistent.

## Why This Change Was Made

Add `browser.proxy` to the command set that triggers the `operator.admin` approval bump, so
approval is at least as strict as invocation.

`src/infra/node-pairing-authz.ts` (after):

```ts
import { NODE_BROWSER_PROXY_COMMAND, NODE_SYSTEM_RUN_COMMANDS } from "./node-commands.js";
...
const ADMIN_APPROVAL_COMMANDS = [...NODE_SYSTEM_RUN_COMMANDS, NODE_BROWSER_PROXY_COMMAND];
...
if (
  normalized.some((command) => ADMIN_APPROVAL_COMMANDS.some((allowed) => allowed === command))
) {
  return [OPERATOR_PAIRING_SCOPE, OPERATOR_ADMIN_SCOPE];
}
```

Both constants already live in `src/infra/node-commands.ts` and are reused, not re-declared.

`resolveNodePairApprovalScopes` is the single owner of the approval-scope mapping; both callers
(`approveNodePairing` in `src/infra/node-pairing.ts` and `node.pair.approve` in
`src/gateway/server-methods/nodes.ts`) route their scope check through it, so one change covers
every approval path. The only command gated at `operator.admin` on the invoke side is
`browser.proxy`; `system.run.*` was already covered, so after this change the approval-scope
admin set is at least as strict as the invoke-time admin gate for every command.

Note on the internal browser dispatch: the gateway `browser.request` method
(`extensions/browser/src/gateway/browser-request.ts`) is registered with `scope: operator.admin`
(`extensions/browser/src/browser-gateway-contract.ts`) and that scope is enforced at
`authorizeGatewayMethod` before the handler runs, so its direct `nodeRegistry.invoke` call is
not an authorization bypass and is intentionally out of scope here. This change only corrects the
approval-scope asymmetry.

## User Impact

A non-admin `operator.write` operator can no longer approve a node advertising `browser.proxy`;
that approval now requires `operator.admin`, matching the scope already required to invoke
`browser.proxy`. Existing admin approvals and all non-browser, non-exec surface approvals are
unaffected.

## Evidence

- `node scripts/run-vitest.mjs src/infra/node-pairing-authz.test.ts` - 5 passed. The new
  assertion fails on pristine main (returns `[operator.pairing, operator.write]`) and passes
  with the patch.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` on both changed files - clean.
- `run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` - clean.

### Real behavior proof
Behavior addressed: an operator.write (non-admin) operator can approve a node advertising the browser.proxy capability, whereas invoking browser.proxy requires operator.admin; the fix makes approval require operator.admin too.
Real environment tested: drove the real approveNodePairing reducer through its on-disk paired-device store in a fresh temp base directory on pristine main e681646834 and on the patched tree; the real requestDevicePairing, approveDevicePairing, requestNodePairing, approveNodePairing, and resolveMissingRequestedScope all ran against the real store, with nothing stubbed (the store was seeded through the real pairing request/approve functions).
Exact steps or command run after this patch: seed a paired node device, request a node surface declaring commands ["browser.proxy"], then call approveNodePairing(requestId, { callerScopes: ["operator.pairing", "operator.write"] }, baseDir) and record the returned outcome.
Evidence after fix:
```
# BEFORE (pristine main e681646834)
caller scopes: [operator.pairing, operator.write]
surface commands: [browser.proxy]
approveNodePairing -> APPROVED nodeId=node-1 commands=["browser.proxy"]
# AFTER (this patch, identical inputs)
caller scopes: [operator.pairing, operator.write]
surface commands: [browser.proxy]
approveNodePairing -> FORBIDDEN missingScope=operator.admin
```
Observed result after fix: the same write-scoped approval that previously trusted the browser.proxy node is now refused with missingScope operator.admin, matching the invoke-time gate.
What was not tested: no live gateway RPC round trip or real remote node; the full build was not run.
