### PR TITLE
fix(gateway): preserve channel restart ownership

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -22,6 +22,7 @@ function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelM
     markChannelLoggedOut: vi.fn(),
     isHealthMonitorEnabled: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
+    getRestartState: vi.fn(() => "idle" as const),
     resetRestartAttempts: vi.fn(),
     ...overrides,
   };
@@ -484,15 +485,18 @@ describe("channel-health-monitor", () => {
     monitor.stop();
   });
 
-  it("restarts a stopped channel that gave up (reconnectAttempts >= 10)", async () => {
-    const manager = createSnapshotManager({
-      discord: {
-        default: {
-          ...managedStoppedAccount("Failed to resolve Discord application id"),
-          reconnectAttempts: 10,
+  it("uses the health monitor's bounded recovery policy after manager give-up", async () => {
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: {
+            ...managedStoppedAccount("Failed to resolve Discord application id"),
+            reconnectAttempts: 11,
+          },
         },
       },
-    });
+      { getRestartState: vi.fn(() => "gave-up" as const) },
+    );
     const monitor = await startAndRunCheck(manager);
     expect(manager.resetRestartAttempts).toHaveBeenCalledWith("discord", "default");
     expect(manager.startChannel).toHaveBeenCalledWith("discord", "default");

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -149,6 +149,10 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             );
             continue;
           }
+          const restartState = channelManager.getRestartState(channelId as ChannelId, accountId);
+          if (restartState === "backoff") {
+            continue;
+          }
 
           const record = restartRecords.get(key) ?? {
             lastRestartAt: 0,
@@ -156,9 +160,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           };
 
           const continuingPendingRestart =
-            status.running !== true &&
-            status.restartPending === true &&
-            (status.reconnectAttempts ?? 0) === 0;
+            status.running !== true && status.restartPending === true && restartState === "idle";
 
           // A timed-out recovery stop uses the first start request to mark
           // restartPending; the next monitor pass must finish that same recovery

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -19,6 +19,7 @@ import {
   listActiveDegradedSecretOwners,
   setActiveDegradedSecretOwners,
 } from "../secrets/runtime-degraded-state.js";
+import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import { createChannelManager, type ChannelManager } from "./server-channels.js";
 
 const hoisted = vi.hoisted(() => {
@@ -332,6 +333,83 @@ describe("server-channels auto restart", () => {
     expect(signals[1]?.aborted).toBe(false);
   });
 
+  it("allows one bounded health-monitor revival after manager give-up", async () => {
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"],
+    });
+    const startAccount = vi.fn(async () => {});
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    await advanceTimersUntil(
+      () => startAccount.mock.calls.length >= 11,
+      "expected crash-loop restarts to reach the maximum attempt cap",
+      { stepMs: 10, maxMs: 500 },
+    );
+    await vi.advanceTimersByTimeAsync(200);
+    await flushMicrotasks();
+
+    const monitor = startChannelHealthMonitor({
+      channelManager: manager,
+      checkIntervalMs: 5,
+      timing: { monitorStartupGraceMs: 0 },
+      cooldownCycles: 0,
+      maxRestartsPerHour: 1,
+    });
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    expect(startAccount).toHaveBeenCalledTimes(22);
+    expect(
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID],
+    ).toMatchObject({
+      running: false,
+      restartPending: false,
+      reconnectAttempts: 11,
+    });
+    monitor.stop();
+  });
+
+  it("preserves manager retry progress while a crash-loop backoff is active", async () => {
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"],
+    });
+    const attemptsAtStart: number[] = [];
+    const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+      attemptsAtStart.push(ctx.getStatus().reconnectAttempts ?? 0);
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+    const monitor = startChannelHealthMonitor({
+      channelManager: manager,
+      checkIntervalMs: 5,
+      timing: { monitorStartupGraceMs: 0 },
+      cooldownCycles: 0,
+    });
+
+    await manager.startChannels();
+    await advanceTimersUntil(
+      () => startAccount.mock.calls.length >= 6,
+      "expected crash-loop retries while the health monitor is active",
+      { stepMs: 5, maxMs: 200 },
+    );
+    monitor.stop();
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    expect(startAccount).toHaveBeenCalledTimes(11);
+    expect(attemptsAtStart).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID],
+    ).toMatchObject({
+      running: false,
+      restartPending: false,
+      reconnectAttempts: 11,
+    });
+    monitor.stop();
+  });
+
   it.each(["resolve", "reject"] as const)(
     "resets the restart counter after a stable run that ends with %s",
     async (outcome) => {
@@ -625,6 +703,79 @@ describe("server-channels auto restart", () => {
 
     expect(startAccount).toHaveBeenCalledTimes(2);
     expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+  });
+
+  it("lets the health monitor finish timed-out reload recovery after prior crashes", async () => {
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"],
+    });
+    let startCount = 0;
+    const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+      startCount += 1;
+      if (startCount <= 2) {
+        throw new Error(`crash ${startCount}`);
+      }
+      ctx.setStatus({
+        accountId: DEFAULT_ACCOUNT_ID,
+        connected: false,
+        lastStartAt: Date.now() - 60_000,
+      });
+      ctx.abortSignal.addEventListener("abort", () => {}, { once: true });
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    await advanceTimersUntil(
+      () => startAccount.mock.calls.length === 3,
+      "expected prior crash attempts before the hanging task",
+      { stepMs: 10, maxMs: 100 },
+    );
+    expect(
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID],
+    ).toMatchObject({
+      running: true,
+      restartPending: false,
+      reconnectAttempts: 2,
+    });
+
+    const monitor = startChannelHealthMonitor({
+      channelManager: manager,
+      checkIntervalMs: 10_000,
+      timing: { monitorStartupGraceMs: 0, channelConnectGraceMs: 0 },
+    });
+    await advanceTimersUntil(
+      () =>
+        manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]
+          ?.restartPending === true,
+      "expected the first monitor pass to time out and request recovery",
+      { stepMs: 100, maxMs: 16_000 },
+    );
+
+    expect(
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID],
+    ).toMatchObject({
+      running: false,
+      restartPending: true,
+      reconnectAttempts: 2,
+    });
+    expect(manager.getRestartState("discord", DEFAULT_ACCOUNT_ID)).toBe("idle");
+    expect(startAccount).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushMicrotasks();
+    monitor.stop();
+
+    expect(startAccount).toHaveBeenCalledTimes(4);
+    expect(
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID],
+    ).toMatchObject({
+      running: true,
+      restartPending: false,
+      reconnectAttempts: 0,
+      lastError: null,
+    });
   });
 
   it("does not restart when a timed-out recovery stop settles as terminal", async () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -261,6 +261,7 @@ export type ChannelManager = {
   isAmbientAutostartSuppressed: (channelId: string) => boolean;
   markChannelLoggedOut: (channelId: ChannelId, cleared: boolean, accountId?: string) => void;
   isManuallyStopped: (channelId: ChannelId, accountId: string) => boolean;
+  getRestartState: (channelId: ChannelId, accountId: string) => "idle" | "backoff" | "gave-up";
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
   isHealthMonitorEnabled: (channelId: ChannelId, accountId: string) => boolean;
 };
@@ -1122,6 +1123,25 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     return manuallyStopped.has(restartKey(channelId, accountId));
   };
 
+  const getRestartState = (
+    channelId: ChannelId,
+    accountId: string,
+  ): "idle" | "backoff" | "gave-up" => {
+    const rKey = restartKey(channelId, accountId);
+    // Timed-out stop recovery owns this lifecycle; retained crash attempts must
+    // not prevent the health monitor from issuing the second recovery start.
+    if (recoveryStopTimedOut.has(rKey)) {
+      return "idle";
+    }
+    const attempts = restarts.get(rKey)?.attempts ?? 0;
+    if (attempts > MAX_RESTARTS) {
+      return "gave-up";
+    }
+    return attempts > 0 && getRuntime(channelId, accountId).restartPending === true
+      ? "backoff"
+      : "idle";
+  };
+
   const resetRestartAttemptsForTest = (channelId: ChannelId, accountId: string): void => {
     restarts.delete(restartKey(channelId, accountId));
   };
@@ -1142,6 +1162,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       ambientAutostartSuppressedChannelIds.has(channelId),
     markChannelLoggedOut,
     isManuallyStopped: isManuallyStoppedFlag,
+    getRestartState,
     resetRestartAttempts: resetRestartAttemptsForTest,
     isHealthMonitorEnabled,
   };

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -40,6 +40,7 @@ function createManager(snapshot: ChannelRuntimeSnapshot): ChannelManager {
     markChannelLoggedOut: vi.fn(),
     isHealthMonitorEnabled: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
+    getRestartState: vi.fn(() => "idle" as const),
     resetRestartAttempts: vi.fn(),
   };
 }


### PR DESCRIPTION
## Summary

- keep `ChannelManager` authoritative while crash-loop backoff is active
- expose a closed restart state (`idle | backoff | gave-up`) to the health monitor
- prevent health-monitor sweeps from clearing active manager retry progress
- preserve the existing bounded post-give-up health-monitor revival policy
- preserve monitor-owned recovery for genuinely idle, unhealthy, and timed-out recovery paths

Fixes #104458

## What Problem This Solves

The channel manager owns crash-loop attempts and backs off between retries. The health monitor separately evaluates stopped accounts and calls `resetRestartAttempts()` before recovery.

During an active manager backoff, a health sweep could therefore:

1. clear the manager's private attempt count,
2. call `startChannel()`, which no-ops because the manager task still exists,
3. let the manager resume with its retry progress erased.

That composition prevents the manager from reaching its retry cap and can keep a persistently failing account in an unbounded restart loop.

The monitor cannot safely infer manager ownership from snapshot fields such as `running`, `restartPending`, and `reconnectAttempts`, because timed-out monitor recovery also uses `restartPending`. This patch puts the ownership decision at the manager boundary that owns the private attempt map.

## Implementation

`ChannelManager.getRestartState()` returns:

- `idle`: no active manager backoff; the health monitor may own recovery
- `backoff`: manager retry progress is active and must not be reset
- `gave-up`: the manager exhausted its retry budget

The health monitor skips only `backoff`. A `gave-up` account continues through the monitor's existing cooldown and `maxRestartsPerHour` budget, preserving the established bounded revival contract. Timed-out stop recovery takes precedence over retained crash-attempt state and reports `idle`, allowing the monitor to issue the second start required to replace the stale task.

## Evidence

### RED: current-main behavior before the fix

The manager-plus-monitor integration regression uses the real `createChannelManager`, real `startChannelHealthMonitor`, production retry limit, and deterministic fake time.

Before the fix, the monitor cleared active manager progress and the failing account reached 16 starts instead of terminating its first manager cycle at 11.

```console
active-backoff regression:
  expected first manager cycle: 11 starts
  received:                     16 starts
```

### GREEN: exact-head behavior after the fix

With the monitor active through the first six attempts, the manager now observes the complete monotonic sequence:

```text
reconnectAttempts at each start: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
first manager cycle:             11 starts
```

The monitor is then stopped in that test so the first cycle can be asserted independently from the separate post-give-up policy.

A second real manager-plus-monitor integration test configures `maxRestartsPerHour: 1` and proves the existing bounded revival contract remains intact:

```text
initial manager cycle: 11 starts
one monitor revival:   11 starts
total:                 22 starts
further revival:       blocked by monitor hourly budget
```

A composed timeout regression proves the hot-reload sequence with retained retry history:

```text
prior crash attempts:            2
third provider task:             running, then ignores abort
non-manual stop:                 times out
first reload-style start:        arms timed-out recovery
restart state after first start: idle (monitor-owned)
next monitor sweep:              replaces stale task
replacement reconnectAttempts:   0
```

Focused validation:

```console
$ pnpm test \
  src/gateway/channel-health-monitor.test.ts \
  src/gateway/channel-health-policy.test.ts \
  src/gateway/server-channels.test.ts \
  src/gateway/server/readiness.test.ts

Test Files  14 passed (14)
Tests       398 passed (398)
```

### Changed-file gate

```console
$ OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 \
  pnpm check:changed -- \
  src/gateway/channel-health-monitor.ts \
  src/gateway/channel-health-monitor.test.ts \
  src/gateway/server-channels.ts \
  src/gateway/server-channels.test.ts \
  src/gateway/server/readiness.test.ts

exit 0
```

This includes production and test typechecks, changed-file lint, dependency/package guards, database-first guards, and runtime import-cycle checks.

## Review feedback addressed

The reviews identified two distinct ownership boundaries: manager give-up must preserve bounded monitor revival, and timed-out stop recovery must remain monitor-owned even when prior crash attempts are retained. The revised patch now:

- protects only active manager backoff,
- preserves post-give-up bounded revival,
- restores the focused monitor contract test,
- adds cross-module proof that the revival remains capped,
- gives timed-out recovery precedence over attempt-based backoff classification,
- adds the composed prior-crashes → reload timeout → monitor replacement regression.

## Compatibility and risk

- no configuration changes
- no protocol changes
- no provider/channel-specific behavior
- existing bounded post-give-up revival is preserved
- ordinary idle unhealthy accounts remain restartable
- manual and terminal-disconnect guards are unchanged
- timed-out recovery remains monitor-owned
- stable runs still reset crash-loop attempts through the existing manager path
