### PR TITLE
fix(gateway): stop health monitor from undoing crash-loop give-up

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -6,11 +6,14 @@ import type { ChannelId } from "../channels/plugins/types.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
+import { resolveChannelHealthRecoveryOwnership } from "./channel-health-policy.js";
 import type { ChannelManager, ChannelRuntimeSnapshot } from "./server-channels.js";
 
 function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelManager {
-  return {
-    getRuntimeSnapshot: vi.fn(() => ({ channels: {}, channelAccounts: {} })),
+  const getRuntimeSnapshot =
+    overrides?.getRuntimeSnapshot ?? vi.fn(() => ({ channels: {}, channelAccounts: {} }));
+  const base: ChannelManager = {
+    getRuntimeSnapshot,
     startChannels: vi.fn(async () => {}),
     startChannel: vi.fn(async () => {}),
     stopChannel: vi.fn(async () => {}),
@@ -20,8 +23,24 @@ function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelM
     isHealthMonitorEnabled: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
     resetRestartAttempts: vi.fn(),
+    // Default ownership mirrors the live manager contract from the current snapshot.
+    resolveHealthRecoveryOwnership: vi.fn((channelId: ChannelId, accountId: string) => {
+      const snapshot = getRuntimeSnapshot();
+      const status = snapshot.channelAccounts[channelId]?.[accountId] ?? {};
+      return resolveChannelHealthRecoveryOwnership(status);
+    }),
     ...overrides,
   };
+  // If a test overrides getRuntimeSnapshot, re-bind ownership to that snapshot unless
+  // the test also supplies an explicit ownership implementation.
+  if (overrides?.getRuntimeSnapshot && !overrides.resolveHealthRecoveryOwnership) {
+    base.resolveHealthRecoveryOwnership = vi.fn((channelId: ChannelId, accountId: string) => {
+      const snapshot = base.getRuntimeSnapshot();
+      const status = snapshot.channelAccounts[channelId]?.[accountId] ?? {};
+      return resolveChannelHealthRecoveryOwnership(status);
+    });
+  }
+  return base;
 }
 
 function snapshotWith(
@@ -462,18 +481,37 @@ describe("channel-health-monitor", () => {
     monitor.stop();
   });
 
-  it("restarts a stopped channel that gave up (reconnectAttempts >= 10)", async () => {
+  it("does not clear attempts or revive a channel after manager give-up", async () => {
     const manager = createSnapshotManager({
       discord: {
         default: {
           ...managedStoppedAccount("Failed to resolve Discord application id"),
-          reconnectAttempts: 10,
+          restartPending: false,
+          reconnectAttempts: 11,
         },
       },
     });
     const monitor = await startAndRunCheck(manager);
-    expect(manager.resetRestartAttempts).toHaveBeenCalledWith("discord", "default");
-    expect(manager.startChannel).toHaveBeenCalledWith("discord", "default");
+    expect(manager.resolveHealthRecoveryOwnership).toHaveBeenCalledWith("discord", "default");
+    expect(manager.resetRestartAttempts).not.toHaveBeenCalled();
+    expect(manager.startChannel).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it("does not clear manager crash-loop progress during mid-backoff", async () => {
+    const manager = createSnapshotManager({
+      discord: {
+        default: {
+          ...managedStoppedAccount("start failed"),
+          restartPending: true,
+          reconnectAttempts: 3,
+        },
+      },
+    });
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.resolveHealthRecoveryOwnership).toHaveBeenCalledWith("discord", "default");
+    expect(manager.resetRestartAttempts).not.toHaveBeenCalled();
+    expect(manager.startChannel).not.toHaveBeenCalled();
     monitor.stop();
   });
 

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -10,7 +10,7 @@ import { resolveChannelHealthRecoveryOwnership } from "./channel-health-policy.j
 import type { ChannelManager, ChannelRuntimeSnapshot } from "./server-channels.js";
 
 function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelManager {
-  const getRuntimeSnapshot =
+  const getRuntimeSnapshot: ChannelManager["getRuntimeSnapshot"] =
     overrides?.getRuntimeSnapshot ?? vi.fn(() => ({ channels: {}, channelAccounts: {} }));
   const base: ChannelManager = {
     getRuntimeSnapshot,

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -161,11 +161,28 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             continue;
           }
 
+          // Manager owns crash-loop backoff and terminal give-up. Do not clear
+          // restartAttempts or startChannel for those states — that undoes give-up
+          // and resets the counter while a backoff task still owns the account.
+          const ownership = channelManager.resolveHealthRecoveryOwnership(
+            channelId as ChannelId,
+            accountId,
+          );
+          if (ownership.kind === "manager-owned") {
+            log.info?.(
+              `[${channelId}:${accountId}] health-monitor: skipping restart, manager owns recovery (${ownership.phase})`,
+            );
+            continue;
+          }
+
           const record = restartRecords.get(key) ?? {
             lastRestartAt: 0,
             restartsThisHour: [],
           };
 
+          // Timed-out recovery stop marks restartPending with reconnectAttempts=0;
+          // finish that recovery without waiting on this monitor's cooldown.
+          // Manager crash-loop backoff (attempts > 0) is filtered above as manager-owned.
           const continuingPendingRestart =
             status.running !== true &&
             status.restartPending === true &&

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -2,7 +2,11 @@
  * Channel health policy regression tests.
  */
 import { describe, expect, it } from "vitest";
-import { evaluateChannelHealth, resolveChannelRestartReason } from "./channel-health-policy.js";
+import {
+  evaluateChannelHealth,
+  resolveChannelHealthRecoveryOwnership,
+  resolveChannelRestartReason,
+} from "./channel-health-policy.js";
 
 function evaluateHealth(
   account: Record<string, unknown>,
@@ -228,5 +232,53 @@ describe("resolveChannelRestartReason", () => {
       { healthy: false, reason: "disconnected" },
     );
     expect(reason).toBe("disconnected");
+  });
+});
+
+describe("resolveChannelHealthRecoveryOwnership", () => {
+  it("treats mid-backoff (restartPending + positive attempts) as manager-owned", () => {
+    expect(
+      resolveChannelHealthRecoveryOwnership({
+        running: false,
+        restartPending: true,
+        reconnectAttempts: 3,
+      }),
+    ).toEqual({ kind: "manager-owned", phase: "active-backoff" });
+  });
+
+  it("treats terminal give-up as manager-owned", () => {
+    expect(
+      resolveChannelHealthRecoveryOwnership({
+        running: false,
+        restartPending: false,
+        reconnectAttempts: 11,
+      }),
+    ).toEqual({ kind: "manager-owned", phase: "gave-up" });
+    expect(
+      resolveChannelHealthRecoveryOwnership({
+        running: false,
+        reconnectAttempts: 10,
+      }),
+    ).toEqual({ kind: "manager-owned", phase: "gave-up" });
+  });
+
+  it("leaves timed-out recovery (restartPending, attempts=0) available for monitor", () => {
+    expect(
+      resolveChannelHealthRecoveryOwnership({
+        running: false,
+        restartPending: true,
+        reconnectAttempts: 0,
+      }),
+    ).toEqual({ kind: "available" });
+  });
+
+  it("leaves ordinary stopped accounts available for monitor revival", () => {
+    expect(
+      resolveChannelHealthRecoveryOwnership({
+        running: false,
+        restartPending: false,
+        reconnectAttempts: 0,
+      }),
+    ).toEqual({ kind: "available" });
   });
 });

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -45,8 +45,51 @@ export type ChannelHealthPolicy = {
 
 type ChannelRestartReason = "gave-up" | "stopped" | "stale-socket" | "stuck" | "disconnected";
 
+/** Must match manager crash-loop bound in `server-channels.ts` (`MAX_RESTART_ATTEMPTS`). */
+export const CHANNEL_MAX_RESTART_ATTEMPTS = 10;
+
+/**
+ * Who owns recovery for a stopped/unhealthy account snapshot.
+ * Manager backoff and terminal give-up are authoritative; the health monitor
+ * must not clear attempt accounting or revive those states.
+ */
+export type ChannelHealthRecoveryOwnership =
+  | { kind: "manager-owned"; phase: "active-backoff" | "gave-up" }
+  | { kind: "available" };
+
 function isManagedAccount(snapshot: ChannelHealthSnapshot): boolean {
   return snapshot.enabled !== false && snapshot.configured !== false;
+}
+
+/**
+ * Classify whether the channel manager already owns crash-loop recovery.
+ * Active backoff: mid-restart sleep with a positive attempt counter.
+ * Gave-up: terminal after exceeding CHANNEL_MAX_RESTART_ATTEMPTS.
+ * Available: monitor may stop/start and reset attempts (wedged/timed-out recovery).
+ */
+export function resolveChannelHealthRecoveryOwnership(
+  snapshot: Pick<ChannelHealthSnapshot, "running" | "restartPending" | "reconnectAttempts">,
+  opts?: { maxRestartAttempts?: number },
+): ChannelHealthRecoveryOwnership {
+  if (snapshot.running === true) {
+    return { kind: "available" };
+  }
+  const maxRestartAttempts = opts?.maxRestartAttempts ?? CHANNEL_MAX_RESTART_ATTEMPTS;
+  const attempts =
+    typeof snapshot.reconnectAttempts === "number" && Number.isFinite(snapshot.reconnectAttempts)
+      ? Math.max(0, Math.trunc(snapshot.reconnectAttempts))
+      : 0;
+  // Manager crash-loop backoff sets restartPending with attempt >= 1 while a
+  // task still owns the account; timed-out recovery uses reconnectAttempts=0.
+  if (snapshot.restartPending === true && attempts > 0) {
+    return { kind: "manager-owned", phase: "active-backoff" };
+  }
+  // Manager give-up clears restartPending and leaves reconnectAttempts above the
+  // bound (attempt becomes MAX+1). Policy logging also treats >= MAX as gave-up.
+  if (snapshot.restartPending !== true && attempts >= maxRestartAttempts) {
+    return { kind: "manager-owned", phase: "gave-up" };
+  }
+  return { kind: "available" };
 }
 
 const BUSY_ACTIVITY_STALE_THRESHOLD_MS = 25 * 60_000;

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -14,6 +14,7 @@ import { createRuntimeChannel } from "../plugins/runtime/runtime-channel.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import { createChannelManager, type ChannelManager } from "./server-channels.js";
 
 const hoisted = vi.hoisted(() => {
@@ -810,6 +811,127 @@ describe("server-channels auto restart", () => {
     );
 
     expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+  });
+
+  it("keeps timeout recovery available after prior crash-loop attempts", async () => {
+    let startCount = 0;
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      startCount += 1;
+      abortSignal.addEventListener("abort", () => {}, { once: true });
+      if (startCount === 1) {
+        throw new Error("initial start failed");
+      }
+      // Subsequent starts hang so a non-manual stop can time out while attempts remain.
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    await advanceTimersUntil(
+      () => startCount >= 2,
+      "expected crash-loop restart after first failure",
+      { stepMs: 10, maxMs: 500 },
+    );
+    await waitForMicrotaskCondition(() => {
+      const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+      return account?.running === true && (account.reconnectAttempts ?? 0) > 0;
+    }, "expected running channel with retained crash-loop attempts");
+
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.running).toBe(false);
+    expect(account?.restartPending).toBe(true);
+    expect(account?.reconnectAttempts).toBe(0);
+    expect(account?.lastError).toContain("channel stop timed out");
+    // Ownership must stay monitor-available even though the manager attempt map
+    // still holds the pre-timeout crash-loop count.
+    expect(manager.resolveHealthRecoveryOwnership("discord", DEFAULT_ACCOUNT_ID)).toEqual({
+      kind: "available",
+    });
+
+    // Two-phase timeout recovery: first start arms, second replaces the stuck task.
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await waitForMicrotaskCondition(
+      () => startAccount.mock.calls.length >= 3,
+      "expected timeout recovery to start a replacement channel task",
+    );
+    const recovered = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(recovered?.running).toBe(true);
+    expect(recovered?.restartPending).toBe(false);
+  });
+
+  it("composed manager+monitor: timeout recovery still restarts after prior crash-loop attempts", async () => {
+    // Health monitor uses setInterval; this suite's default fake timer set omits it.
+    vi.useRealTimers();
+    vi.useFakeTimers();
+    try {
+      let startCount = 0;
+      const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+        startCount += 1;
+        abortSignal.addEventListener("abort", () => {}, { once: true });
+        if (startCount === 1) {
+          throw new Error("initial start failed");
+        }
+        await new Promise<void>(() => {});
+      });
+      installTestRegistry(createTestPlugin({ startAccount }));
+      const manager = createManager();
+
+      await manager.startChannels();
+      await advanceTimersUntil(
+        () => startCount >= 2,
+        "expected crash-loop restart after first failure",
+        { stepMs: 10, maxMs: 500 },
+      );
+      await waitForMicrotaskCondition(() => {
+        const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+        return account?.running === true && (account.reconnectAttempts ?? 0) > 0;
+      }, "expected running channel with retained crash-loop attempts");
+
+      const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+        manual: false,
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await recoveryStopTask;
+
+      expect(manager.resolveHealthRecoveryOwnership("discord", DEFAULT_ACCOUNT_ID)).toEqual({
+        kind: "available",
+      });
+
+      const startsBeforeMonitor = startAccount.mock.calls.length;
+      const monitor = startChannelHealthMonitor({
+        channelManager: manager,
+        checkIntervalMs: 1_000,
+        startupGraceMs: 0,
+        cooldownCycles: 0,
+      });
+      // First monitor pass arms timed-out recovery; second pass replaces the task.
+      await vi.advanceTimersByTimeAsync(1_001);
+      await flushMicrotasks(40);
+      await vi.advanceTimersByTimeAsync(1_001);
+      await flushMicrotasks(40);
+      await waitForMicrotaskCondition(
+        () => startAccount.mock.calls.length > startsBeforeMonitor,
+        "expected health monitor to drive timeout recovery startChannel",
+      );
+      monitor.stop();
+
+      const recovered = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+      expect(recovered?.running).toBe(true);
+      expect(manager.resolveHealthRecoveryOwnership("discord", DEFAULT_ACCOUNT_ID)).toEqual({
+        kind: "available",
+      });
+    } finally {
+      vi.useRealTimers();
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    }
   });
 
   it("consumes startup failures during immediate recovery restart", async () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -26,8 +26,14 @@ import {
 import type { RuntimeEnv } from "../runtime.js";
 import { isAccountEnabled } from "../shared/account-enabled.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
+import {
+  CHANNEL_MAX_RESTART_ATTEMPTS,
+  resolveChannelHealthRecoveryOwnership,
+  type ChannelHealthRecoveryOwnership,
+} from "./channel-health-policy.js";
 import type { ChannelRuntimeSnapshot } from "./server-channel-runtime.types.js";
 export type { ChannelRuntimeSnapshot };
+export type { ChannelHealthRecoveryOwnership };
 
 const CHANNEL_RESTART_POLICY: BackoffPolicy = {
   initialMs: 5_000,
@@ -35,7 +41,7 @@ const CHANNEL_RESTART_POLICY: BackoffPolicy = {
   factor: 2,
   jitter: 0.1,
 };
-const MAX_RESTART_ATTEMPTS = 10;
+const MAX_RESTART_ATTEMPTS = CHANNEL_MAX_RESTART_ATTEMPTS;
 const CHANNEL_STABLE_RUN_MS = CHANNEL_RESTART_POLICY.maxMs;
 const CHANNEL_STOP_ABORT_TIMEOUT_MS = 5_000;
 const CHANNEL_STARTUP_CONCURRENCY = 4;
@@ -254,6 +260,14 @@ export type ChannelManager = {
   markChannelLoggedOut: (channelId: ChannelId, cleared: boolean, accountId?: string) => void;
   isManuallyStopped: (channelId: ChannelId, accountId: string) => boolean;
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
+  /**
+   * Manager-owned recovery contract for the health monitor.
+   * Active crash-loop backoff and terminal give-up must not be cleared or revived.
+   */
+  resolveHealthRecoveryOwnership: (
+    channelId: ChannelId,
+    accountId: string,
+  ) => ChannelHealthRecoveryOwnership;
   isHealthMonitorEnabled: (channelId: ChannelId, accountId: string) => boolean;
 };
 
@@ -1073,6 +1087,22 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     restartAttempts.delete(restartKey(channelId, accountId));
   };
 
+  const resolveHealthRecoveryOwnership = (
+    channelId: ChannelId,
+    accountId: string,
+  ): ChannelHealthRecoveryOwnership => {
+    const runtime = getRuntime(channelId, accountId);
+    const rKey = restartKey(channelId, accountId);
+    // Prefer manager-owned attempt counter when present so a stale snapshot
+    // cannot hide terminal give-up or mid-backoff ownership.
+    const attempts = restartAttempts.get(rKey) ?? runtime.reconnectAttempts;
+    return resolveChannelHealthRecoveryOwnership({
+      running: runtime.running,
+      restartPending: runtime.restartPending,
+      reconnectAttempts: attempts,
+    });
+  };
+
   return {
     getRuntimeSnapshot,
     startChannels,
@@ -1085,6 +1115,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     markChannelLoggedOut,
     isManuallyStopped: isManuallyStoppedFlag,
     resetRestartAttempts: resetRestartAttemptsForTest,
+    resolveHealthRecoveryOwnership,
     isHealthMonitorEnabled,
   };
 }

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -947,9 +947,15 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           log.warn?.(
             `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; continuing shutdown`,
           );
+          // Timed-out recovery is monitor-owned: keep restartPending and publish
+          // reconnectAttempts=0 so the health-monitor "continue pending recovery"
+          // path matches the ownership query (recoveryStopTimedOut override).
+          // Do not leave a prior crash-loop count on the snapshot or ownership
+          // will look like active-backoff and the monitor will skip startChannel.
           const stoppedPatch = {
             restartPending: !manual,
             lastError: `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms`,
+            ...(!manual ? { reconnectAttempts: 0 } : {}),
           };
           if (manual) {
             setRuntime(channelId, id, {
@@ -1093,6 +1099,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   ): ChannelHealthRecoveryOwnership => {
     const runtime = getRuntime(channelId, accountId);
     const rKey = restartKey(channelId, accountId);
+    // Monitor-owned stop-timeout recovery must win over retained crash-loop
+    // attempt counters. A prior restartAttempts/reconnectAttempts value with
+    // restartPending would otherwise classify as active-backoff and the monitor
+    // would skip the follow-up startChannel that replaces the timed-out task.
+    if (recoveryStopTimedOut.has(rKey)) {
+      return { kind: "available" };
+    }
     // Prefer manager-owned attempt counter when present so a stale snapshot
     // cannot hide terminal give-up or mid-backoff ownership.
     const attempts = restartAttempts.get(rKey) ?? runtime.reconnectAttempts;

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -38,6 +38,7 @@ function createManager(snapshot: ChannelRuntimeSnapshot): ChannelManager {
     isHealthMonitorEnabled: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
     resetRestartAttempts: vi.fn(),
+    resolveHealthRecoveryOwnership: vi.fn(() => ({ kind: "available" as const })),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the gateway channel health monitor could erase a channel manager's crash-loop restart progress and revive accounts after the manager had already given up. Operators configuring permanent give-up after repeated channel start failures would see the account keep restarting instead of staying stopped.

Closes #104458

## Why This Change Was Made

The manager already owns crash-loop accounting (backoff and terminal give-up). This change makes that ownership an explicit closed contract (`resolveHealthRecoveryOwnership` / `resolveChannelHealthRecoveryOwnership`) and teaches the health monitor to skip stop/start/reset when the manager already owns recovery. Timed-out recovery (restartPending with zero attempts) remains monitor-available so wedged-task recovery is preserved.

## User Impact

Failing channel accounts that hit the manager's restart budget stay given-up instead of being silently revived. Mid-backoff accounts keep their consecutive-attempt counter, so give-up remains a stable terminal state under the default health monitor.

## Evidence

Verification host: local macOS (Crabbox bypass)

Focused tests (pass):
```text
node scripts/run-vitest.mjs src/gateway/channel-health-monitor.test.ts \
  src/gateway/channel-health-policy.test.ts src/gateway/server/readiness.test.ts
# Test Files  12 passed (12)  Tests  316 passed (316)

node scripts/run-vitest.mjs src/gateway/server-channels.test.ts
# Test Files  2 passed (2)  Tests  96 passed (96)
```

Static closeout (after `pnpm check:changed` stuck on local install thrash):
```text
git diff --check origin/main...HEAD  # exit 0
node scripts/run-oxlint.mjs src/gateway/channel-health-monitor.ts \
  src/gateway/channel-health-policy.ts src/gateway/server-channels.ts
# Found 0 warnings and 0 errors.
```

## Real behavior proof

- Behavior addressed: Health monitor must not clear manager `restartAttempts` during mid-backoff, and must not `startChannel` after manager give-up. **Also:** after a prior crash-loop attempt, a recovery stop timeout must remain monitor-owned so the follow-up `startChannel` can replace the timed-out task (CS P1).
- Environment: local macOS openclaw checkout; focused Vitest via `node scripts/run-vitest.mjs`.
- Current-main contrast: On main, monitor only treated `restartPending && reconnectAttempts===0` as continuing recovery, so mid-backoff (`reconnectAttempts>0`) and gave-up (`reconnectAttempts>=10`, not pending) still called `resetRestartAttempts` + `startChannel`. Existing test even expected give-up revival. PR head also misclassified stop-timeout recovery as manager `active-backoff` when the attempt map still held a prior count.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/gateway/channel-health-monitor.test.ts -t "does not clear attempts or revive a channel after manager give-up"`
  2. `node scripts/run-vitest.mjs src/gateway/channel-health-monitor.test.ts -t "does not clear manager crash-loop progress during mid-backoff"`
  3. `node scripts/run-vitest.mjs src/gateway/channel-health-policy.test.ts -t "resolveChannelHealthRecoveryOwnership"`
  4. `node scripts/run-vitest.mjs src/gateway/server-channels.test.ts -t "keeps timeout recovery available after prior crash-loop attempts"`
  5. `node scripts/run-vitest.mjs src/gateway/server-channels.test.ts -t "composed manager+monitor: timeout recovery still restarts after prior crash-loop attempts"`
  6. Full focused suite: `node scripts/run-vitest.mjs src/gateway/server-channels.test.ts src/gateway/channel-health-monitor.test.ts src/gateway/channel-health-policy.test.ts src/gateway/server/readiness.test.ts`
- Evidence after fix (deterministic manager+monitor lifecycle):
  ```text
  # Timeout-recovery ownership + composed monitor restart (after CS P1 fix)
  node scripts/run-vitest.mjs src/gateway/server-channels.test.ts \
    -t "keeps timeout recovery available|composed manager"
  # Test Files  1 passed (1)
  # Tests  2 passed | 48 skipped (50)

  # Full focused surface
  node scripts/run-vitest.mjs src/gateway/server-channels.test.ts \
    src/gateway/channel-health-monitor.test.ts \
    src/gateway/channel-health-policy.test.ts \
    src/gateway/server/readiness.test.ts
  # Test Files  14 passed (14)
  # Tests  416 passed (416)
  ```
  Lifecycle sequence covered by the new composed case:
  1. First start fails → manager crash-loop attempt counter becomes > 0
  2. Second start hangs while running with retained reconnectAttempts
  3. Non-manual stop times out → `recoveryStopTimedOut` + `restartPending`, snapshot `reconnectAttempts=0`
  4. `resolveHealthRecoveryOwnership` returns `{ kind: "available" }` (not `active-backoff`)
  5. Health monitor arms recovery then starts a replacement task; channel returns to `running: true`
- Control check: Sibling monitor cases still restart stuck/disconnected/ordinary-stopped accounts; give-up and mid-backoff still skip `resetRestartAttempts`/`startChannel`; continuing pending recovery with `reconnectAttempts=0` still bypasses cooldown.
- Observed result after fix: Manager-owned recovery phases are skipped by the monitor; attempt counter and terminal give-up are preserved; timed-out stop recovery after prior attempts is still monitor-owned and restarts.
- What was not tested: Multi-hour simulated default-timing harness from the issue report; live provider channel crash loops.
## AI disclosure

This PR was authored with AI assistance (Grok / fix-openclaw-issue auto pipeline). Human review of the ownership contract and proof remains welcome.

