### PR TITLE
fix(config): reject unsupported MCP disabled config

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -110,6 +110,26 @@ describe("legacy MCP server config migrate", () => {
       "Removed mcp.servers.example.disabled true because enabled is already set to true.",
     ]);
   });
+
+  it("migrates node-host MCP server disabled flags", () => {
+    const res = migrateLegacyConfigForTest({
+      nodeHost: {
+        mcp: {
+          servers: {
+            example: { command: "example-mcp", disabled: true },
+          },
+        },
+      },
+    });
+
+    expect(res.config?.nodeHost?.mcp?.servers?.example).toEqual({
+      command: "example-mcp",
+      enabled: false,
+    });
+    expect(res.changes).toEqual([
+      "Moved nodeHost.mcp.servers.example.disabled true → enabled false.",
+    ]);
+  });
 });
 
 describe("legacy memory search config migrate", () => {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -72,6 +72,46 @@ describe("compatibility binding repair migrate", () => {
   });
 });
 
+describe("legacy MCP server config migrate", () => {
+  it("moves disabled to the inverse canonical enabled value", () => {
+    const res = migrateLegacyConfigForTest({
+      mcp: {
+        servers: {
+          disabled: { command: "example-mcp", disabled: true },
+          enabled: { command: "example-mcp", disabled: false },
+        },
+      },
+    });
+
+    expect(res.config?.mcp?.servers).toEqual({
+      disabled: { command: "example-mcp", enabled: false },
+      enabled: { command: "example-mcp", enabled: true },
+    });
+    expect(res.changes).toEqual([
+      "Moved mcp.servers.disabled.disabled true → enabled false.",
+      "Moved mcp.servers.enabled.disabled false → enabled true.",
+    ]);
+  });
+
+  it("keeps explicit enabled when removing disabled", () => {
+    const res = migrateLegacyConfigForTest({
+      mcp: {
+        servers: {
+          example: { command: "example-mcp", disabled: true, enabled: true },
+        },
+      },
+    });
+
+    expect(res.config?.mcp?.servers?.example).toEqual({
+      command: "example-mcp",
+      enabled: true,
+    });
+    expect(res.changes).toEqual([
+      "Removed mcp.servers.example.disabled true because enabled is already set to true.",
+    ]);
+  });
+});
+
 describe("legacy memory search config migrate", () => {
   it("removes sidecar memory search index paths", () => {
     const res = migrateLegacyConfigForTest({

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -73,46 +73,40 @@ describe("compatibility binding repair migrate", () => {
 });
 
 describe("legacy MCP server config migrate", () => {
-  it("moves disabled to the inverse canonical enabled value", () => {
-    const res = migrateLegacyConfigForTest({
+  it("moves disabled to enabled, preserves canonical values, and is idempotent", () => {
+    const raw = {
       mcp: {
         servers: {
           disabled: { command: "example-mcp", disabled: true },
           enabled: { command: "example-mcp", disabled: false },
+          canonical: { command: "example-mcp", disabled: true, enabled: true },
         },
       },
-    });
+    };
+
+    expect(findLegacyConfigIssues(raw)).toEqual([
+      expect.objectContaining({
+        path: "mcp.servers",
+        message: expect.stringContaining('unsupported "disabled" key'),
+      }),
+    ]);
+    const res = migrateLegacyConfigForTest(raw);
 
     expect(res.config?.mcp?.servers).toEqual({
       disabled: { command: "example-mcp", enabled: false },
       enabled: { command: "example-mcp", enabled: true },
+      canonical: { command: "example-mcp", enabled: true },
     });
     expect(res.changes).toEqual([
       "Moved mcp.servers.disabled.disabled true → enabled false.",
       "Moved mcp.servers.enabled.disabled false → enabled true.",
+      "Removed mcp.servers.canonical.disabled true because enabled is already set to true.",
     ]);
-  });
-
-  it("keeps explicit enabled when removing disabled", () => {
-    const res = migrateLegacyConfigForTest({
-      mcp: {
-        servers: {
-          example: { command: "example-mcp", disabled: true, enabled: true },
-        },
-      },
-    });
-
-    expect(res.config?.mcp?.servers?.example).toEqual({
-      command: "example-mcp",
-      enabled: true,
-    });
-    expect(res.changes).toEqual([
-      "Removed mcp.servers.example.disabled true because enabled is already set to true.",
-    ]);
+    expect(migrateLegacyConfigForTest(res.config)).toEqual({ config: null, changes: [] });
   });
 
   it("migrates node-host MCP server disabled flags", () => {
-    const res = migrateLegacyConfigForTest({
+    const raw = {
       nodeHost: {
         mcp: {
           servers: {
@@ -120,7 +114,15 @@ describe("legacy MCP server config migrate", () => {
           },
         },
       },
-    });
+    };
+
+    expect(findLegacyConfigIssues(raw)).toEqual([
+      expect.objectContaining({
+        path: "nodeHost.mcp.servers",
+        message: expect.stringContaining('unsupported "disabled" key'),
+      }),
+    ]);
+    const res = migrateLegacyConfigForTest(raw);
 
     expect(res.config?.nodeHost?.mcp?.servers?.example).toEqual({
       command: "example-mcp",

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
@@ -28,36 +28,58 @@ const MCP_SERVER_DISABLED_RULE: LegacyConfigRule = {
     Object.values(value).some((server) => isRecord(server) && typeof server.disabled === "boolean"),
 };
 
+const NODE_HOST_MCP_SERVER_DISABLED_RULE: LegacyConfigRule = {
+  path: ["nodeHost", "mcp", "servers"],
+  message:
+    'nodeHost.mcp.servers uses the unsupported "disabled" key; use "enabled: false" instead. Run "openclaw doctor --fix" to migrate it.',
+  match: (value) =>
+    isRecord(value) &&
+    Object.values(value).some((server) => isRecord(server) && typeof server.disabled === "boolean"),
+};
+
+function migrateMcpServerDisabledFlags(
+  servers: Record<string, unknown> | undefined,
+  pathPrefix: string,
+  changes: string[],
+): void {
+  if (!servers) {
+    return;
+  }
+
+  for (const [serverName, rawServer] of Object.entries(servers)) {
+    if (!isRecord(rawServer) || typeof rawServer.disabled !== "boolean") {
+      continue;
+    }
+    const disabled = rawServer.disabled;
+    if (typeof rawServer.enabled !== "boolean") {
+      rawServer.enabled = !disabled;
+      changes.push(
+        `Moved ${pathPrefix}.${serverName}.disabled ${disabled} → enabled ${!disabled}.`,
+      );
+    } else {
+      changes.push(
+        `Removed ${pathPrefix}.${serverName}.disabled ${disabled} because enabled is already set to ${rawServer.enabled}.`,
+      );
+    }
+    delete rawServer.disabled;
+  }
+}
+
 /** Legacy config migration specs for MCP server config compatibility. */
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP: LegacyConfigMigrationSpec[] = [
   defineLegacyConfigMigration({
     id: "mcp.servers.disabled->enabled",
     describe: "Move unsupported MCP disabled flags to canonical enabled flags",
-    legacyRules: [MCP_SERVER_DISABLED_RULE],
+    legacyRules: [MCP_SERVER_DISABLED_RULE, NODE_HOST_MCP_SERVER_DISABLED_RULE],
     apply: (raw, changes) => {
       const mcp = isRecord(raw.mcp) ? raw.mcp : undefined;
       const servers = isRecord(mcp?.servers) ? mcp?.servers : undefined;
-      if (!servers) {
-        return;
-      }
+      migrateMcpServerDisabledFlags(servers, "mcp.servers", changes);
 
-      for (const [serverName, rawServer] of Object.entries(servers)) {
-        if (!isRecord(rawServer) || typeof rawServer.disabled !== "boolean") {
-          continue;
-        }
-        const disabled = rawServer.disabled;
-        if (typeof rawServer.enabled !== "boolean") {
-          rawServer.enabled = !disabled;
-          changes.push(
-            `Moved mcp.servers.${serverName}.disabled ${disabled} → enabled ${!disabled}.`,
-          );
-        } else {
-          changes.push(
-            `Removed mcp.servers.${serverName}.disabled ${disabled} because enabled is already set to ${rawServer.enabled}.`,
-          );
-        }
-        delete rawServer.disabled;
-      }
+      const nodeHost = isRecord(raw.nodeHost) ? raw.nodeHost : undefined;
+      const nodeHostMcp = isRecord(nodeHost?.mcp) ? nodeHost.mcp : undefined;
+      const nodeHostServers = isRecord(nodeHostMcp?.servers) ? nodeHostMcp.servers : undefined;
+      migrateMcpServerDisabledFlags(nodeHostServers, "nodeHost.mcp.servers", changes);
     },
   }),
   defineLegacyConfigMigration({

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
@@ -19,8 +19,47 @@ const MCP_SERVER_TYPE_RULE: LegacyConfigRule = {
     Object.values(value).some((server) => isRecord(server) && isKnownCliMcpTypeAlias(server.type)),
 };
 
+const MCP_SERVER_DISABLED_RULE: LegacyConfigRule = {
+  path: ["mcp", "servers"],
+  message:
+    'mcp.servers uses the unsupported "disabled" key; use "enabled: false" instead. Run "openclaw doctor --fix" to migrate it.',
+  match: (value) =>
+    isRecord(value) &&
+    Object.values(value).some((server) => isRecord(server) && typeof server.disabled === "boolean"),
+};
+
 /** Legacy config migration specs for MCP server config compatibility. */
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "mcp.servers.disabled->enabled",
+    describe: "Move unsupported MCP disabled flags to canonical enabled flags",
+    legacyRules: [MCP_SERVER_DISABLED_RULE],
+    apply: (raw, changes) => {
+      const mcp = isRecord(raw.mcp) ? raw.mcp : undefined;
+      const servers = isRecord(mcp?.servers) ? mcp?.servers : undefined;
+      if (!servers) {
+        return;
+      }
+
+      for (const [serverName, rawServer] of Object.entries(servers)) {
+        if (!isRecord(rawServer) || typeof rawServer.disabled !== "boolean") {
+          continue;
+        }
+        const disabled = rawServer.disabled;
+        if (typeof rawServer.enabled !== "boolean") {
+          rawServer.enabled = !disabled;
+          changes.push(
+            `Moved mcp.servers.${serverName}.disabled ${disabled} → enabled ${!disabled}.`,
+          );
+        } else {
+          changes.push(
+            `Removed mcp.servers.${serverName}.disabled ${disabled} because enabled is already set to ${rawServer.enabled}.`,
+          );
+        }
+        delete rawServer.disabled;
+      }
+    },
+  }),
   defineLegacyConfigMigration({
     id: "mcp.servers.type->transport",
     describe: "Move CLI-native MCP server type aliases to OpenClaw transport",

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.mcp.ts
@@ -1,4 +1,4 @@
-// Legacy MCP runtime config migrations for CLI-native transport aliases.
+// Legacy MCP runtime config migrations.
 import {
   defineLegacyConfigMigration,
   type LegacyConfigMigrationSpec,
@@ -19,30 +19,25 @@ const MCP_SERVER_TYPE_RULE: LegacyConfigRule = {
     Object.values(value).some((server) => isRecord(server) && isKnownCliMcpTypeAlias(server.type)),
 };
 
-const MCP_SERVER_DISABLED_RULE: LegacyConfigRule = {
-  path: ["mcp", "servers"],
+const MCP_SERVER_DISABLED_RULES: LegacyConfigRule[] = [
+  ["mcp", "servers"],
+  ["nodeHost", "mcp", "servers"],
+].map((path) => ({
+  path,
   message:
-    'mcp.servers uses the unsupported "disabled" key; use "enabled: false" instead. Run "openclaw doctor --fix" to migrate it.',
+    `${path.join(".")} entries use the unsupported "disabled" key; use "enabled" with the inverse boolean value. ` +
+    'Run "openclaw doctor --fix" to migrate it.',
   match: (value) =>
     isRecord(value) &&
     Object.values(value).some((server) => isRecord(server) && typeof server.disabled === "boolean"),
-};
-
-const NODE_HOST_MCP_SERVER_DISABLED_RULE: LegacyConfigRule = {
-  path: ["nodeHost", "mcp", "servers"],
-  message:
-    'nodeHost.mcp.servers uses the unsupported "disabled" key; use "enabled: false" instead. Run "openclaw doctor --fix" to migrate it.',
-  match: (value) =>
-    isRecord(value) &&
-    Object.values(value).some((server) => isRecord(server) && typeof server.disabled === "boolean"),
-};
+}));
 
 function migrateMcpServerDisabledFlags(
-  servers: Record<string, unknown> | undefined,
+  servers: unknown,
   pathPrefix: string,
   changes: string[],
 ): void {
-  if (!servers) {
+  if (!isRecord(servers)) {
     return;
   }
 
@@ -68,26 +63,17 @@ function migrateMcpServerDisabledFlags(
 /** Legacy config migration specs for MCP server config compatibility. */
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP: LegacyConfigMigrationSpec[] = [
   defineLegacyConfigMigration({
-    id: "mcp.servers.disabled->enabled",
-    describe: "Move unsupported MCP disabled flags to canonical enabled flags",
-    legacyRules: [MCP_SERVER_DISABLED_RULE, NODE_HOST_MCP_SERVER_DISABLED_RULE],
+    id: "mcp.servers.canonicalize",
+    describe: "Normalize legacy MCP server config",
+    legacyRules: [...MCP_SERVER_DISABLED_RULES, MCP_SERVER_TYPE_RULE],
     apply: (raw, changes) => {
       const mcp = isRecord(raw.mcp) ? raw.mcp : undefined;
-      const servers = isRecord(mcp?.servers) ? mcp?.servers : undefined;
-      migrateMcpServerDisabledFlags(servers, "mcp.servers", changes);
+      migrateMcpServerDisabledFlags(mcp?.servers, "mcp.servers", changes);
 
       const nodeHost = isRecord(raw.nodeHost) ? raw.nodeHost : undefined;
       const nodeHostMcp = isRecord(nodeHost?.mcp) ? nodeHost.mcp : undefined;
-      const nodeHostServers = isRecord(nodeHostMcp?.servers) ? nodeHostMcp.servers : undefined;
-      migrateMcpServerDisabledFlags(nodeHostServers, "nodeHost.mcp.servers", changes);
-    },
-  }),
-  defineLegacyConfigMigration({
-    id: "mcp.servers.type->transport",
-    describe: "Move CLI-native MCP server type aliases to OpenClaw transport",
-    legacyRules: [MCP_SERVER_TYPE_RULE],
-    apply: (raw, changes) => {
-      const mcp = isRecord(raw.mcp) ? raw.mcp : undefined;
+      migrateMcpServerDisabledFlags(nodeHostMcp?.servers, "nodeHost.mcp.servers", changes);
+
       const servers = isRecord(mcp?.servers) ? mcp?.servers : undefined;
       if (!servers) {
         return;

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -78,6 +78,29 @@ describe("boolean config validation", () => {
       }),
     );
   });
+
+  it('rejects node-host MCP server "disabled" with the canonical replacement', () => {
+    const result = validateConfigObjectRaw({
+      nodeHost: {
+        mcp: {
+          servers: {
+            example: { command: "example-mcp", disabled: true },
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected disabled node-host MCP server config to fail validation");
+    }
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        path: "nodeHost.mcp.servers.example.disabled",
+        message: expect.stringContaining('use "enabled: false" instead'),
+      }),
+    );
+  });
 });
 
 describe("agent timeoutSeconds config", () => {

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -57,6 +57,27 @@ describe("boolean config validation", () => {
     const result = OpenClawSchema.safeParse(config);
     expect(result.success).toBe(false);
   });
+
+  it('rejects MCP server "disabled" with the canonical replacement', () => {
+    const result = validateConfigObjectRaw({
+      mcp: {
+        servers: {
+          example: { command: "example-mcp", disabled: true },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected disabled MCP server config to fail validation");
+    }
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        path: "mcp.servers.example.disabled",
+        message: expect.stringContaining('use "enabled: false" instead'),
+      }),
+    );
+  });
 });
 
 describe("agent timeoutSeconds config", () => {

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -58,49 +58,29 @@ describe("boolean config validation", () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects MCP server "disabled" with the canonical replacement', () => {
-    const result = validateConfigObjectRaw({
-      mcp: {
-        servers: {
-          example: { command: "example-mcp", disabled: true },
-        },
-      },
-    });
+  it.each([
+    ["root", true, "mcp.servers.example.disabled", "enabled: false"],
+    ["root", false, "mcp.servers.example.disabled", "enabled: true"],
+    ["node-host", true, "nodeHost.mcp.servers.example.disabled", "enabled: false"],
+  ])(
+    'rejects %s MCP server "disabled: %s" with the inverse canonical value',
+    (scope, disabled, path, replacement) => {
+      const server = { command: "example-mcp", disabled };
+      const config =
+        scope === "root"
+          ? { mcp: { servers: { example: server } } }
+          : { nodeHost: { mcp: { servers: { example: server } } } };
+      const result = validateConfigObjectRaw(config);
 
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      throw new Error("expected disabled MCP server config to fail validation");
-    }
-    expect(result.issues).toContainEqual(
-      expect.objectContaining({
-        path: "mcp.servers.example.disabled",
-        message: expect.stringContaining('use "enabled: false" instead'),
-      }),
-    );
-  });
-
-  it('rejects node-host MCP server "disabled" with the canonical replacement', () => {
-    const result = validateConfigObjectRaw({
-      nodeHost: {
-        mcp: {
-          servers: {
-            example: { command: "example-mcp", disabled: true },
-          },
-        },
-      },
-    });
-
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      throw new Error("expected disabled node-host MCP server config to fail validation");
-    }
-    expect(result.issues).toContainEqual(
-      expect.objectContaining({
-        path: "nodeHost.mcp.servers.example.disabled",
-        message: expect.stringContaining('use "enabled: false" instead'),
-      }),
-    );
-  });
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        throw new Error("expected disabled MCP server config to fail validation");
+      }
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({ path, message: expect.stringContaining(replacement) }),
+      );
+    },
+  );
 });
 
 describe("agent timeoutSeconds config", () => {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -413,6 +413,14 @@ const McpServerSchema = z
       .optional(),
   })
   .superRefine((data, ctx) => {
+    if (Object.hasOwn(data, "disabled")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'unsupported key "disabled"; use "enabled: false" instead, then run "openclaw doctor --fix" to migrate existing config',
+        path: ["disabled"],
+      });
+    }
     // transport "stdio" requires a non-empty command — URL-only servers must use "sse" or "streamable-http"
     if (
       data.transport === "stdio" &&

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -414,10 +414,14 @@ const McpServerSchema = z
   })
   .superRefine((data, ctx) => {
     if (Object.hasOwn(data, "disabled")) {
+      const disabled = Reflect.get(data, "disabled") as unknown;
+      const replacement =
+        typeof disabled === "boolean"
+          ? `"enabled: ${!disabled}" instead, then run "openclaw doctor --fix" to migrate existing config`
+          : 'the canonical "enabled" boolean instead';
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message:
-          'unsupported key "disabled"; use "enabled: false" instead, then run "openclaw doctor --fix" to migrate existing config',
+        message: `unsupported key "disabled"; use ${replacement}`,
         path: ["disabled"],
       });
     }


### PR DESCRIPTION
Closes #103954

## What Problem This Solves

Fixes an issue where operators configured an MCP server with `disabled: true` and OpenClaw silently started the server because only `enabled: false` controls MCP activation.

## Why This Change Was Made

The change migrates the unsupported inverse flag to the canonical enablement setting through `openclaw doctor --fix`, while configuration validation now reports the incorrect key with an actionable replacement. Runtime behavior continues to read only the canonical setting.

## User Impact

Operators receive a clear configuration error instead of unexpectedly spawning an MCP server. Existing boolean `disabled` entries can be repaired automatically with `openclaw doctor --fix`.

## Evidence

### Real isolated CLI proof

Executed from PR head `f53982039f67` with Node `v24.14.0`, using isolated `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` values and no real credentials. The configured stdio command was `/usr/bin/touch $MARKER`, so any process start would leave an observable marker.

Before repair, `openclaw config validate --json` exited 1 and reported:

```json
{
  "valid": false,
  "issues": [
    {
      "path": "mcp.servers.proof-disabled.disabled",
      "message": "unsupported key \"disabled\"; use \"enabled: false\" instead, then run \"openclaw doctor --fix\" to migrate existing config"
    }
  ]
}
```

`openclaw doctor --fix --non-interactive` exited 0 and printed:

```text
Legacy config keys detected
- mcp.servers uses the unsupported "disabled" key; use "enabled: false" instead.

Doctor changes
Moved mcp.servers.proof-disabled.disabled true → enabled false.

Updated config: $CONFIG
Doctor complete.
```

The rewritten entry contained the canonical field and no `disabled` key:

```json
{
  "enabled": false,
  "command": "/usr/bin/touch",
  "args": ["$MARKER"],
  "transport": "stdio"
}
```

After repair, `openclaw config validate --json` exited 0 with `{"valid":true,"warnings":[]}`.

For the post-repair process-start check, the marker was removed and the actual MCP runtime probe was run:

```console
$ openclaw mcp probe --json
{
  "servers": {},
  "tools": [],
  "diagnostics": []
}
$ test -e "$MARKER" && echo present || echo absent
absent
```

A named probe also rejected the server before launch: `MCP server "proof-disabled" is disabled ... Run openclaw mcp configure proof-disabled --enable before probing it.`

### Contract and automated validation

- OpenClaw filters `mcp.servers` entries with `enabled: false` before session MCP runtime materialization (`src/agents/bundle-mcp-config.ts`).
- Direct upstream Codex source inspection at [`5c19155cbd93`](https://github.com/openai/codex/commit/5c19155cbd93bfa099016e7487259f61669823ff) confirmed that `enabled` defaults to true, `false` means skip initialization, and the connection manager filters disabled servers before spawning them (`codex-rs/config/src/mcp_types.rs`, `codex-rs/codex-mcp/src/connection_manager.rs`).
- Focused config and doctor tests passed: 237 assertions across the relevant test shards.
- Core TypeScript check passed with `pnpm tsgo:core`.
- Regression coverage verifies both inverse-value migration and preservation of an explicitly configured `enabled` value.

## AI-assisted contribution

Implemented with Codex; targeted tests, core typechecking, direct upstream contract inspection, and isolated real CLI proof were completed before submission.
