### PR TITLE
fix(codex): bound app-server binding fingerprints

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -182,7 +182,7 @@ two-party event loops that do not go through the shared inbound reply runner.
     );
     ```
 
-    Prefer `getSessionEntry(...)`, `listSessionEntries(...)`, `patchSessionEntry(...)`, or `upsertSessionEntry(...)` for session workflows. These helpers address sessions by agent/session identity so plugins do not depend on the legacy `sessions.json` storage shape. Use `preserveActivity: true` for metadata-only patches that should not refresh session activity, and `replaceEntry: true` only when the callback returns a complete entry and deleted fields must stay deleted.
+    Prefer `getSessionEntry(...)`, `listSessionEntries(...)`, `patchSessionEntry(...)`, or `upsertSessionEntry(...)` for session workflows. These helpers address sessions by agent/session identity so plugins do not depend on the legacy `sessions.json` storage shape. Use `preserveActivity: true` for metadata-only patches that should not refresh session activity, and `replaceEntry: true` only when the callback returns a complete entry and deleted fields must stay deleted. Doctor and migration paths can combine `fallbackEntry`, `skipMaintenance`, and `requireWriteSuccess` for one atomic canonical-store repair.
 
     `createSessionEntry(...)` creates a new canonical session row and transcript. Its trusted `initialEntry` surface is deliberately narrow: a non-empty `agentHarnessId`, optional `modelSelectionLocked: true`, and optional `pluginExtensions`. The injected runtime accepts only harness ids owned by the calling plugin through `registerAgentHarness(...)`; this is an ownership invariant, not a sandbox between in-process plugins. It rejects an existing row; `label` and `spawnedCwd` are separate creation fields rather than trusted-entry patches.
 

--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -353,6 +353,156 @@ describe("codex doctor contract", () => {
     await fs.rm(fixture.stateDir, { recursive: true, force: true });
   });
 
+  it("normalizes a partial raw conversation import before copying the session row", async () => {
+    const threadId = "thread-partial-import";
+    const sessionId = "partial-import";
+    const sessionKey = "agent:main:partial-import";
+    const emptyConversation: StoredCodexAppServerBinding = {
+      version: 1,
+      state: "active",
+      binding: {
+        threadId,
+        cwd: "",
+        dynamicToolsFingerprint: "",
+      },
+    };
+    const rawFingerprint = "x".repeat(
+      65_535 - Buffer.byteLength(JSON.stringify(emptyConversation)),
+    );
+    const rawConversation: StoredCodexAppServerBinding = {
+      ...emptyConversation,
+      binding: {
+        ...emptyConversation.binding,
+        dynamicToolsFingerprint: rawFingerprint,
+      },
+    };
+    const rawSession = { ...rawConversation, sessionId };
+    expect(Buffer.byteLength(JSON.stringify(rawConversation))).toBe(65_535);
+    expect(Buffer.byteLength(JSON.stringify(rawSession))).toBeGreaterThan(65_536);
+
+    const fixture = await createBindingMigrationFixture({
+      name: sessionId,
+      sessionIndex: {
+        [sessionKey]: {
+          sessionId,
+          sessionFile: `${sessionId}.jsonl`,
+        },
+      },
+      threadId,
+      binding: { dynamicToolsFingerprint: rawFingerprint },
+    });
+    const conversationKey = bindingStoreKey({
+      kind: "conversation",
+      bindingId: legacyCodexConversationBindingId(fixture.transcriptPath),
+    });
+    const sessionBindingKey = bindingStoreKey({
+      kind: "session",
+      agentId: "main",
+      sessionId,
+      sessionKey,
+    });
+    const store = openBindingStore(fixture.env);
+    await store.register(conversationKey, rawConversation);
+
+    await expect(fixture.migration.migrateLegacyState(fixture.params)).resolves.toEqual({
+      changes: [
+        "Migrated 1 Codex app-server binding sidecar(s) to plugin state and archived the legacy sources",
+      ],
+      warnings: [],
+    });
+
+    const expectedFingerprint = hashCodexAppServerBindingFingerprint(rawFingerprint);
+    await expect(store.lookup(conversationKey)).resolves.toMatchObject({
+      state: "active",
+      binding: { dynamicToolsFingerprint: expectedFingerprint },
+    });
+    await expect(store.lookup(sessionBindingKey)).resolves.toMatchObject({
+      state: "active",
+      sessionId,
+      binding: { dynamicToolsFingerprint: expectedFingerprint },
+    });
+    await expect(fs.access(fixture.sidecarPath)).rejects.toThrow();
+    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
+    await expect(fixture.migration.migrateLegacyState(fixture.params)).resolves.toEqual({
+      changes: [],
+      warnings: [],
+    });
+
+    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+  });
+
+  it("normalizes retained raw conversation and session rows before comparison", async () => {
+    const threadId = "thread-retained-import";
+    const sessionId = "retained-import";
+    const sessionKey = "agent:main:retained-import";
+    const rawFingerprint = "x".repeat(60_000);
+    const rawConversation: StoredCodexAppServerBinding = {
+      version: 1,
+      state: "active",
+      binding: {
+        threadId,
+        cwd: "",
+        dynamicToolsFingerprint: rawFingerprint,
+      },
+    };
+    const rawSession: StoredCodexAppServerBinding = {
+      ...rawConversation,
+      sessionId,
+    };
+    expect(Buffer.byteLength(JSON.stringify(rawSession))).toBeLessThan(65_536);
+
+    const fixture = await createBindingMigrationFixture({
+      name: sessionId,
+      sessionIndex: {
+        [sessionKey]: {
+          sessionId,
+          sessionFile: `${sessionId}.jsonl`,
+        },
+      },
+      threadId,
+      binding: { dynamicToolsFingerprint: rawFingerprint },
+    });
+    const conversationKey = bindingStoreKey({
+      kind: "conversation",
+      bindingId: legacyCodexConversationBindingId(fixture.transcriptPath),
+    });
+    const sessionBindingKey = bindingStoreKey({
+      kind: "session",
+      agentId: "main",
+      sessionId,
+      sessionKey,
+    });
+    const store = openBindingStore(fixture.env);
+    await store.register(conversationKey, rawConversation);
+    await store.register(sessionBindingKey, rawSession);
+
+    await expect(fixture.migration.migrateLegacyState(fixture.params)).resolves.toEqual({
+      changes: [
+        "Migrated 1 Codex app-server binding sidecar(s) to plugin state and archived the legacy sources",
+      ],
+      warnings: [],
+    });
+
+    const expectedFingerprint = hashCodexAppServerBindingFingerprint(rawFingerprint);
+    await expect(store.lookup(conversationKey)).resolves.toMatchObject({
+      state: "active",
+      binding: { dynamicToolsFingerprint: expectedFingerprint },
+    });
+    await expect(store.lookup(sessionBindingKey)).resolves.toMatchObject({
+      state: "active",
+      sessionId,
+      binding: { dynamicToolsFingerprint: expectedFingerprint },
+    });
+    await expect(fs.access(fixture.sidecarPath)).rejects.toThrow();
+    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
+    await expect(fixture.migration.migrateLegacyState(fixture.params)).resolves.toEqual({
+      changes: [],
+      warnings: [],
+    });
+
+    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+  });
+
   it("matches an owner through the contained fallback for a stale session file locator", async () => {
     const sessionKey = "agent:main:stale-locator";
     const fixture = await createBindingMigrationFixture({

--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -21,6 +21,7 @@ import {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   CODEX_APP_SERVER_BINDING_NAMESPACE,
   createStoredCodexAppServerBinding,
+  hashCodexAppServerBindingFingerprint,
   type StoredCodexAppServerBinding,
 } from "./src/app-server/session-binding.js";
 import { legacyCodexConversationBindingId } from "./src/conversation-binding-data.js";
@@ -279,6 +280,74 @@ describe("codex doctor contract", () => {
       fs.readFile(path.join(fixture.sessionsDir, "sessions.json"), "utf8").then(JSON.parse),
     ).resolves.toMatchObject({
       "agent:main:session-1": { sessionId: "session-current", agentHarnessId: "codex" },
+    });
+
+    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+  });
+
+  it("bounds oversized legacy fingerprints before plugin-state import", async () => {
+    const rawDynamicToolsFingerprint = JSON.stringify([
+      { name: "legacy_large_tool", inputSchema: { description: "dynamic-marker".repeat(8_000) } },
+    ]);
+    const rawUserMcpServersFingerprint = JSON.stringify({
+      mcp_servers: {
+        legacy: {
+          command: "node",
+          args: ["user-mcp-marker".repeat(8_000)],
+          http_headers: { authorization: "Bearer legacy-secret" },
+        },
+      },
+    });
+    const sessionKey = "agent:main:oversized";
+    const fixture = await createBindingMigrationFixture({
+      name: "oversized",
+      sessionIndex: {
+        [sessionKey]: {
+          sessionId: "oversized",
+          sessionFile: "oversized.jsonl",
+        },
+      },
+      threadId: "thread-oversized",
+      binding: {
+        dynamicToolsFingerprint: rawDynamicToolsFingerprint,
+        userMcpServersFingerprint: rawUserMcpServersFingerprint,
+      },
+    });
+    expect((await fs.stat(fixture.sidecarPath)).size).toBeGreaterThan(65_536);
+
+    await expect(fixture.migration.migrateLegacyState(fixture.params)).resolves.toEqual({
+      changes: [
+        "Migrated 1 Codex app-server binding sidecar(s) to plugin state and archived the legacy sources",
+      ],
+      warnings: [],
+    });
+
+    const stored = await openBindingStore(fixture.env).lookup(
+      bindingStoreKey({
+        kind: "session",
+        agentId: "main",
+        sessionId: "oversized",
+        sessionKey,
+      }),
+    );
+    expect(stored).toMatchObject({
+      state: "active",
+      binding: {
+        dynamicToolsFingerprint: hashCodexAppServerBindingFingerprint(rawDynamicToolsFingerprint),
+        userMcpServersFingerprint: hashCodexAppServerBindingFingerprint(
+          rawUserMcpServersFingerprint,
+        ),
+      },
+    });
+    expect(Buffer.byteLength(JSON.stringify(stored))).toBeLessThan(65_536);
+    expect(JSON.stringify(stored)).not.toContain("dynamic-marker");
+    expect(JSON.stringify(stored)).not.toContain("user-mcp-marker");
+    expect(JSON.stringify(stored)).not.toContain("legacy-secret");
+    await expect(fs.access(fixture.sidecarPath)).rejects.toThrow();
+    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
+    await expect(fixture.migration.migrateLegacyState(fixture.params)).resolves.toEqual({
+      changes: [],
+      warnings: [],
     });
 
     await fs.rm(fixture.stateDir, { recursive: true, force: true });

--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -10,6 +10,7 @@ import type {
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
 } from "openclaw/plugin-sdk/runtime-doctor";
+import { getSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   legacyConfigRules,
@@ -67,6 +68,7 @@ async function createBindingMigrationFixture(options: {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-"));
   const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
   const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+  const storePath = path.join(sessionsDir, "sessions.json");
   const transcriptPath = path.join(sessionsDir, `${options.name}.jsonl`);
   const sidecarPath = `${transcriptPath}.codex-app-server.json`;
   await fs.mkdir(sessionsDir, { recursive: true });
@@ -76,11 +78,7 @@ async function createBindingMigrationFixture(options: {
     "utf8",
   );
   if (options.sessionIndex !== undefined) {
-    await fs.writeFile(
-      path.join(sessionsDir, "sessions.json"),
-      JSON.stringify(options.sessionIndex),
-      "utf8",
-    );
+    await fs.writeFile(storePath, JSON.stringify(options.sessionIndex), "utf8");
   }
   await fs.writeFile(
     sidecarPath,
@@ -115,6 +113,7 @@ async function createBindingMigrationFixture(options: {
     sessionsDir,
     sidecarPath,
     stateDir,
+    storePath,
     transcriptPath,
   };
 }
@@ -276,11 +275,20 @@ describe("codex doctor contract", () => {
       ),
     ).resolves.toMatchObject({ state: "active", binding: { threadId: "thread-1" } });
     await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
-    await expect(
-      fs.readFile(path.join(fixture.sessionsDir, "sessions.json"), "utf8").then(JSON.parse),
-    ).resolves.toMatchObject({
-      "agent:main:session-1": { sessionId: "session-current", agentHarnessId: "codex" },
+    expect(
+      getSessionEntry({
+        agentId: "main",
+        env: fixture.env,
+        sessionKey: "agent:main:session-1",
+        storePath: fixture.storePath,
+      }),
+    ).toMatchObject({
+      sessionId: "session-current",
+      agentHarnessId: "codex",
     });
+    await expect(
+      fs.readFile(fixture.storePath, "utf8").then(JSON.parse),
+    ).resolves.not.toHaveProperty("agent:main:session-1.agentHarnessId");
 
     await fs.rm(fixture.stateDir, { recursive: true, force: true });
   });
@@ -503,7 +511,7 @@ describe("codex doctor contract", () => {
     await fs.rm(fixture.stateDir, { recursive: true, force: true });
   });
 
-  it("matches an owner through the contained fallback for a stale session file locator", async () => {
+  it("rejects an explicit session file locator outside the session directory", async () => {
     const sessionKey = "agent:main:stale-locator";
     const fixture = await createBindingMigrationFixture({
       name: "stale-locator",
@@ -518,21 +526,20 @@ describe("codex doctor contract", () => {
 
     const result = await fixture.migration.migrateLegacyState(fixture.params);
 
-    expect(result.warnings).toEqual([]);
-    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
-    await expect(
-      fs.readFile(path.join(fixture.sessionsDir, "sessions.json"), "utf8").then(JSON.parse),
-    ).resolves.toMatchObject({ [sessionKey]: { agentHarnessId: "codex" } });
-    await expect(
-      openBindingStore(fixture.env).lookup(
-        bindingStoreKey({
-          kind: "session",
-          agentId: "main",
-          sessionId: "stale-locator",
-          sessionKey,
-        }),
-      ),
-    ).resolves.toMatchObject({ state: "active", binding: { threadId: "thread-stale-locator" } });
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("invalid locator");
+    await expect(fs.access(fixture.sidecarPath)).resolves.toBeUndefined();
+    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).rejects.toThrow();
+    expect(
+      getSessionEntry({
+        agentId: "main",
+        env: fixture.env,
+        sessionKey,
+        storePath: fixture.storePath,
+      }),
+    ).toBeUndefined();
+    await expect(openBindingStore(fixture.env).entries()).resolves.toEqual([]);
 
     await fs.rm(fixture.stateDir, { recursive: true, force: true });
   });
@@ -575,9 +582,15 @@ describe("codex doctor contract", () => {
     const targetIndex = JSON.parse(
       await fs.readFile(path.join(fixture.sessionsDir, "sessions.json"), "utf8"),
     ) as Record<string, Record<string, unknown>>;
-    expect(configuredIndex["agent:main:aliased-store"]).toMatchObject({
-      agentHarnessId: "codex",
-    });
+    expect(
+      getSessionEntry({
+        agentId: "main",
+        env: fixture.env,
+        sessionKey: "agent:main:aliased-store",
+        storePath: storeAlias,
+      }),
+    ).toMatchObject({ agentHarnessId: "codex" });
+    expect(configuredIndex["agent:main:aliased-store"]).not.toHaveProperty("agentHarnessId");
     expect(targetIndex["agent:main:aliased-store"]).not.toHaveProperty("agentHarnessId");
 
     await fs.rm(fixture.stateDir, { recursive: true, force: true });
@@ -620,9 +633,17 @@ describe("codex doctor contract", () => {
 
     expect(result.warnings).toEqual([]);
     await expect(fs.access(`${configuredSidecar}.migrated`)).resolves.toBeUndefined();
-    await expect(fs.readFile(configuredStore, "utf8").then(JSON.parse)).resolves.toMatchObject({
-      [sessionKey]: { agentHarnessId: "codex" },
-    });
+    expect(
+      getSessionEntry({
+        agentId: "main",
+        env: fixture.env,
+        sessionKey,
+        storePath: configuredStore,
+      }),
+    ).toMatchObject({ agentHarnessId: "codex" });
+    await expect(fs.readFile(configuredStore, "utf8").then(JSON.parse)).resolves.not.toHaveProperty(
+      `${sessionKey}.agentHarnessId`,
+    );
 
     await fs.rm(fixture.stateDir, { recursive: true, force: true });
   });
@@ -667,16 +688,17 @@ describe("codex doctor contract", () => {
           return;
         }
         rebound = true;
-        await fs.writeFile(
-          path.join(fixture.sessionsDir, "sessions.json"),
-          JSON.stringify({
-            [sessionKey]: {
-              sessionId: "session-current",
-              sessionFile: "replacement.jsonl",
-              lifecycleRevision: "rev-2",
-            },
-          }),
-        );
+        await upsertSessionEntry({
+          agentId: "main",
+          env: fixture.env,
+          sessionKey,
+          storePath: fixture.storePath,
+          entry: {
+            sessionId: "session-current",
+            lifecycleRevision: "rev-2",
+            updatedAt: Date.now(),
+          },
+        });
       });
 
       const result = await fixture.migration.migrateLegacyState({ ...fixture.params, context });
@@ -689,6 +711,14 @@ describe("codex doctor contract", () => {
       await expect(
         fs.readFile(path.join(fixture.sessionsDir, "sessions.json"), "utf8").then(JSON.parse),
       ).resolves.not.toHaveProperty(`${sessionKey}.agentHarnessId`);
+      expect(
+        getSessionEntry({
+          agentId: "main",
+          env: fixture.env,
+          sessionKey,
+          storePath: fixture.storePath,
+        }),
+      ).toMatchObject({ lifecycleRevision: "rev-2" });
       await expect(store.lookup(sessionBindingKey)).resolves.toMatchObject({
         version: 1,
         state: "cleared",
@@ -699,6 +729,61 @@ describe("codex doctor contract", () => {
       await fs.rm(fixture.stateDir, { recursive: true, force: true });
     },
   );
+
+  it("retires an imported row when its locator escapes during owner revalidation", async () => {
+    const sessionKey = "agent:main:locator-race";
+    const fixture = await createBindingMigrationFixture({
+      name: "locator-race",
+      sessionIndex: {
+        [sessionKey]: {
+          sessionId: "locator-race",
+          sessionFile: "locator-race.jsonl",
+        },
+      },
+      threadId: "thread-locator-race",
+    });
+    let rebound = false;
+    const context = createDoctorContext(fixture.env, async () => {
+      if (rebound) {
+        return;
+      }
+      rebound = true;
+      await fs.writeFile(
+        fixture.storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "locator-race",
+            sessionFile: "../outside.jsonl",
+          },
+        }),
+      );
+    });
+
+    const result = await fixture.migration.migrateLegacyState({ ...fixture.params, context });
+
+    expect(result.warnings).toEqual([
+      expect.stringContaining("session owner changed before Codex ownership could be recorded"),
+    ]);
+    await expect(fs.access(fixture.sidecarPath)).resolves.toBeUndefined();
+    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).rejects.toThrow();
+    await expect(
+      openBindingStore(fixture.env).lookup(
+        bindingStoreKey({
+          kind: "session",
+          agentId: "main",
+          sessionId: "locator-race",
+          sessionKey,
+        }),
+      ),
+    ).resolves.toMatchObject({
+      version: 1,
+      state: "cleared",
+      sessionId: "locator-race",
+      retired: true,
+    });
+
+    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+  });
 
   it("does not resurrect a retired session generation from its legacy sidecar", async () => {
     const sessionKey = "agent:main:retired";
@@ -964,12 +1049,15 @@ describe("codex doctor contract", () => {
       JSON.stringify({ schemaVersion: 2, threadId: "thread-escaped" }),
       "utf8",
     );
+    await fs.symlink(outsideDir, path.join(outerDir, "escaped"));
     await fs.writeFile(
       externalStore,
       JSON.stringify({
         "agent:main:foreign": {
           sessionId: "foreign",
-          sessionFile: path.join(outsideDir, "foreign.jsonl"),
+          // The transcript is missing, but the sidecar exists through an
+          // escaping symlink. Containment must resolve the existing ancestor.
+          sessionFile: "escaped/foreign.jsonl",
         },
       }),
       "utf8",

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -13,6 +13,7 @@ import {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   createCodexAppServerBindingStore,
   createStoredCodexAppServerBinding,
+  hashCodexAppServerBindingFingerprint,
   readCodexAppServerThreadBinding,
   type StoredCodexAppServerBinding,
 } from "./session-binding.js";
@@ -379,6 +380,39 @@ describe("Codex app-server binding store", () => {
       pluginAppPolicyContext,
     });
     expect(imported?.binding.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
+  });
+
+  it("normalizes legacy fingerprints without rehashing canonical values", () => {
+    const rawDynamicToolsFingerprint = JSON.stringify([{ name: "legacy_tool" }]);
+    const rawUserMcpServersFingerprint = JSON.stringify({
+      mcp_servers: { legacy: { command: "node" } },
+    });
+    const imported = createStoredCodexAppServerBinding({
+      schemaVersion: 2,
+      threadId: "thread-legacy-fingerprints",
+      cwd: "/repo",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      dynamicToolsFingerprint: rawDynamicToolsFingerprint,
+      userMcpServersFingerprint: rawUserMcpServersFingerprint,
+    });
+    expect(imported?.binding).toMatchObject({
+      dynamicToolsFingerprint: hashCodexAppServerBindingFingerprint(rawDynamicToolsFingerprint),
+      userMcpServersFingerprint: hashCodexAppServerBindingFingerprint(rawUserMcpServersFingerprint),
+    });
+
+    const existingHash = `sha256:${"a".repeat(64)}`;
+    const canonical = createStoredCodexAppServerBinding({
+      schemaVersion: 2,
+      threadId: "thread-canonical-fingerprints",
+      cwd: "/repo",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      dynamicToolsFingerprint: "[]",
+      userMcpServersFingerprint: existingHash,
+    });
+    expect(canonical?.binding).toMatchObject({
+      dynamicToolsFingerprint: "[]",
+      userMcpServersFingerprint: existingHash,
+    });
   });
 
   it("canonicalizes undefined fields before writing to JSON-only plugin state", async () => {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -24,6 +24,7 @@ import type { CodexServiceTier } from "./protocol.js";
 const CODEX_APP_SERVER_NATIVE_AUTH_PROVIDER = "openai";
 const PUBLIC_OPENAI_MODEL_PROVIDER = "openai";
 const BINDING_LEASE_RETRY_INTERVAL_MS = 1_000;
+const BOUNDED_BINDING_FINGERPRINT_PATTERN = /^sha256:[a-f0-9]{64}$/i;
 
 export {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
@@ -381,6 +382,42 @@ const storedBindingSchema = z.discriminatedUnion("state", [
 // id fences delayed lifecycle cleanup so an old generation cannot clear its successor.
 export type StoredCodexAppServerBinding = z.infer<typeof storedBindingSchema>;
 
+export function hashCodexAppServerBindingFingerprint(canonical: string): string {
+  return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
+}
+
+function normalizeLegacyBindingFingerprint(value: unknown): unknown {
+  if (
+    typeof value !== "string" ||
+    value === "" ||
+    value === "[]" ||
+    BOUNDED_BINDING_FINGERPRINT_PATTERN.test(value)
+  ) {
+    return value;
+  }
+  return hashCodexAppServerBindingFingerprint(value);
+}
+
+function normalizeLegacyBindingFingerprints(
+  record: Record<string, unknown>,
+): Record<string, unknown> {
+  // Shipped sidecars can contain unbounded canonical JSON fingerprints. Bound
+  // them at the legacy encoder so plugin-state registration cannot reject the row.
+  let normalized = record;
+  for (const key of ["dynamicToolsFingerprint", "userMcpServersFingerprint"] as const) {
+    const value = record[key];
+    const next = normalizeLegacyBindingFingerprint(value);
+    if (next === value) {
+      continue;
+    }
+    if (normalized === record) {
+      normalized = { ...record };
+    }
+    normalized[key] = next;
+  }
+  return normalized;
+}
+
 /** Encodes a migrated sidecar binding as one canonical plugin-state row. */
 export function createStoredCodexAppServerBinding(
   value: unknown,
@@ -389,10 +426,11 @@ export function createStoredCodexAppServerBinding(
     lookup?: Omit<CodexAppServerAuthProfileLookup, "authProfileId">;
   } = {},
 ): Extract<StoredCodexAppServerBinding, { state: "active" }> | undefined {
-  const record = asRecord(value);
-  if (!record) {
+  const rawRecord = asRecord(value);
+  if (!rawRecord) {
     return undefined;
   }
+  const record = normalizeLegacyBindingFingerprints(rawRecord);
   if (record.schemaVersion !== 1 && record.schemaVersion !== 2) {
     return undefined;
   }

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -418,6 +418,21 @@ function normalizeLegacyBindingFingerprints(
   return normalized;
 }
 
+export function normalizeStoredCodexAppServerBindingFingerprints(
+  value: unknown,
+): StoredCodexAppServerBinding | undefined {
+  const stored = readStoredCodexAppServerBinding(value);
+  if (!stored || stored.state !== "active") {
+    return stored;
+  }
+  const binding = normalizeLegacyBindingFingerprints(
+    stored.binding as unknown as Record<string, unknown>,
+  );
+  return binding === stored.binding
+    ? stored
+    : readStoredCodexAppServerBinding({ ...stored, binding });
+}
+
 /** Encodes a migrated sidecar binding as one canonical plugin-state row. */
 export function createStoredCodexAppServerBinding(
   value: unknown,

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -1923,6 +1923,54 @@ describe("Codex app-server thread lifecycle bindings", () => {
     ]);
   });
 
+  it("stores large dynamic tool fingerprints as bounded hashes", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-large-tools");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const largeDynamicTools = [
+      {
+        type: "namespace",
+        name: "openclaw",
+        description: "",
+        tools: Array.from({ length: 200 }, (_, index) => ({
+          ...createNamedDynamicTool(`tool_${index}`),
+          inputSchema: {
+            type: "object",
+            properties: Object.fromEntries(
+              Array.from({ length: 20 }, (__, propertyIndex) => [
+                `property_${propertyIndex}`,
+                {
+                  type: "string",
+                  description: "x".repeat(200),
+                },
+              ]),
+            ),
+            additionalProperties: false,
+          },
+        })),
+      },
+    ] satisfies Parameters<typeof startOrResumeThread>[0]["dynamicTools"];
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: largeDynamicTools,
+      appServer: createThreadLifecycleAppServerOptions(),
+    });
+
+    const binding = await readCodexAppServerBinding(sessionFile);
+    expect(binding?.dynamicToolsFingerprint).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(binding?.dynamicToolsFingerprint).toHaveLength(71);
+    expect(binding?.dynamicToolsFingerprint).not.toContain("tool_199");
+  });
+
   it("keeps plugin app bindings across transient native-tool-disabled turns", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -450,7 +450,7 @@ export async function startOrResumeThread(params: {
       () => legacyFingerprintDynamicTools(params.dynamicTools),
     );
     const dynamicToolsFingerprint = lifecycleTiming.measureSync("dynamic-tools-fingerprint", () =>
-      hashDynamicToolFingerprint(legacyDynamicToolsFingerprint),
+      hashCanonicalFingerprint(legacyDynamicToolsFingerprint),
     );
     const dynamicToolsContainDeferred = flattenCodexDynamicToolFunctions(params.dynamicTools).some(
       (tool) => tool.deferLoading === true,
@@ -2867,7 +2867,7 @@ export function areCodexDynamicToolFingerprintsCompatible(params: {
 }
 
 function fingerprintDynamicTools(dynamicTools: CodexDynamicToolSpec[]): string {
-  return hashDynamicToolFingerprint(legacyFingerprintDynamicTools(dynamicTools));
+  return hashCanonicalFingerprint(legacyFingerprintDynamicTools(dynamicTools));
 }
 
 function legacyFingerprintDynamicTools(dynamicTools: CodexDynamicToolSpec[]): string {
@@ -2876,7 +2876,7 @@ function legacyFingerprintDynamicTools(dynamicTools: CodexDynamicToolSpec[]): st
   );
 }
 
-function hashDynamicToolFingerprint(canonical: string): string {
+function hashCanonicalFingerprint(canonical: string): string {
   return "sha256:" + crypto.createHash("sha256").update(canonical).digest("hex");
 }
 
@@ -2884,7 +2884,9 @@ function fingerprintUserMcpServersConfigPatch(
   configPatch: JsonObject | undefined,
 ): string | undefined {
   return configPatch
-    ? JSON.stringify(stabilizeJsonValue(redactUserMcpServersFingerprintSecrets(configPatch)))
+    ? hashCanonicalFingerprint(
+        JSON.stringify(stabilizeJsonValue(redactUserMcpServersFingerprintSecrets(configPatch))),
+      )
     : undefined;
 }
 
@@ -2978,7 +2980,7 @@ function readActiveCodexTurnIds(thread: unknown): string[] {
 }
 
 const LEGACY_EMPTY_DYNAMIC_TOOLS_FINGERPRINT = legacyFingerprintDynamicTools([]);
-const EMPTY_DYNAMIC_TOOLS_FINGERPRINT = hashDynamicToolFingerprint(
+const EMPTY_DYNAMIC_TOOLS_FINGERPRINT = hashCanonicalFingerprint(
   LEGACY_EMPTY_DYNAMIC_TOOLS_FINGERPRINT,
 );
 

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -76,6 +76,7 @@ import {
 } from "./protocol.js";
 import {
   assertCodexBindingMayBeReplaced,
+  hashCodexAppServerBindingFingerprint,
   isCodexAppServerNativeAuthProfile,
   normalizeCodexAppServerBindingModelProvider,
   reclaimCurrentCodexSessionGeneration,
@@ -2867,7 +2868,7 @@ export function areCodexDynamicToolFingerprintsCompatible(params: {
 }
 
 function fingerprintDynamicTools(dynamicTools: CodexDynamicToolSpec[]): string {
-  return hashCanonicalFingerprint(legacyFingerprintDynamicTools(dynamicTools));
+  return hashCodexAppServerBindingFingerprint(legacyFingerprintDynamicTools(dynamicTools));
 }
 
 function legacyFingerprintDynamicTools(dynamicTools: CodexDynamicToolSpec[]): string {
@@ -2876,15 +2877,11 @@ function legacyFingerprintDynamicTools(dynamicTools: CodexDynamicToolSpec[]): st
   );
 }
 
-function hashCanonicalFingerprint(canonical: string): string {
-  return "sha256:" + crypto.createHash("sha256").update(canonical).digest("hex");
-}
-
 function fingerprintUserMcpServersConfigPatch(
   configPatch: JsonObject | undefined,
 ): string | undefined {
   return configPatch
-    ? hashCanonicalFingerprint(
+    ? hashCodexAppServerBindingFingerprint(
         JSON.stringify(stabilizeJsonValue(redactUserMcpServersFingerprintSecrets(configPatch))),
       )
     : undefined;
@@ -2980,7 +2977,7 @@ function readActiveCodexTurnIds(thread: unknown): string[] {
 }
 
 const LEGACY_EMPTY_DYNAMIC_TOOLS_FINGERPRINT = legacyFingerprintDynamicTools([]);
-const EMPTY_DYNAMIC_TOOLS_FINGERPRINT = hashCanonicalFingerprint(
+const EMPTY_DYNAMIC_TOOLS_FINGERPRINT = hashCodexAppServerBindingFingerprint(
   LEGACY_EMPTY_DYNAMIC_TOOLS_FINGERPRINT,
 );
 

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -451,7 +451,7 @@ export async function startOrResumeThread(params: {
       () => legacyFingerprintDynamicTools(params.dynamicTools),
     );
     const dynamicToolsFingerprint = lifecycleTiming.measureSync("dynamic-tools-fingerprint", () =>
-      hashCanonicalFingerprint(legacyDynamicToolsFingerprint),
+      hashCodexAppServerBindingFingerprint(legacyDynamicToolsFingerprint),
     );
     const dynamicToolsContainDeferred = flattenCodexDynamicToolFunctions(params.dynamicTools).some(
       (tool) => tool.deferLoading === true,

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -152,6 +152,48 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     });
   });
 
+  it("stores large user MCP server fingerprints as bounded hashes", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    registerCodexTestSessionIdentity(sessionFile, "session-1", "agent:main:session-1");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir, {
+        mcp: {
+          servers: Object.fromEntries(
+            Array.from({ length: 120 }, (_, index) => [
+              `server_${index}`,
+              {
+                transport: "stdio",
+                command: "node",
+                args: [
+                  `/opt/openclaw/mcp/server-${index}/dist/index.js`,
+                  "--description",
+                  "x".repeat(400),
+                ],
+              },
+            ]),
+          ),
+        },
+      } as unknown as EmbeddedRunAttemptParams["config"]),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+    });
+
+    const binding = await readCodexAppServerBinding(sessionFile);
+    expect(binding?.userMcpServersFingerprint).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(binding?.userMcpServersFingerprint?.length).toBe(71);
+    expect(binding?.userMcpServersFingerprint).not.toContain("server_119");
+  });
+
   it("projects only Codex user MCP servers scoped to the current agent", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
@@ -523,7 +565,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
       appServer: createAppServerOptions(),
     });
     const firstBinding = await readCodexAppServerBinding(sessionFile);
-    expect(firstBinding?.userMcpServersFingerprint).toContain("<redacted:sha256:");
+    expect(firstBinding?.userMcpServersFingerprint).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(firstBinding?.userMcpServersFingerprint).not.toContain("access-token-one");
 
     request.mockClear();
@@ -544,7 +586,7 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
       "Bearer access-token-two",
     );
     const secondBinding = await readCodexAppServerBinding(sessionFile);
-    expect(secondBinding?.userMcpServersFingerprint).toContain("<redacted:sha256:");
+    expect(secondBinding?.userMcpServersFingerprint).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(secondBinding?.userMcpServersFingerprint).not.toContain("access-token-two");
     expect(secondBinding?.userMcpServersFingerprint).not.toBe(
       firstBinding?.userMcpServersFingerprint,

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -415,7 +415,12 @@ async function migrateSource(
       ]);
       const raw = JSON.parse(contents) as Record<string, unknown>;
       const [
-        { bindingStoreKey, createStoredCodexAppServerBinding, readStoredCodexAppServerBinding },
+        {
+          bindingStoreKey,
+          createStoredCodexAppServerBinding,
+          normalizeStoredCodexAppServerBindingFingerprints,
+          readStoredCodexAppServerBinding,
+        },
         { legacyCodexConversationBindingId },
       ] = await Promise.all([
         import("../app-server/session-binding.js"),
@@ -458,17 +463,53 @@ async function migrateSource(
           bindingId: legacyCodexConversationBindingId(sessionFile),
         }),
       );
+      const normalizeStoredRow = async (
+        key: string,
+        current: MigratedBindingRow,
+      ): Promise<{ value?: MigratedBindingRow; warning?: string }> => {
+        const parsed = readStoredCodexAppServerBinding(current);
+        if (!parsed) {
+          return { warning: `canonical plugin state is invalid at ${key}` };
+        }
+        const normalized = normalizeStoredCodexAppServerBindingFingerprints(parsed);
+        if (!normalized) {
+          return { warning: `canonical plugin state is invalid at ${key}` };
+        }
+        if (isDeepStrictEqual(parsed, normalized)) {
+          return { value: parsed };
+        }
+        if (parsed.lease && parsed.lease.expiresAt > Date.now()) {
+          return { warning: `canonical plugin state is leased at ${key}` };
+        }
+        const update = store.update;
+        if (!update) {
+          return { warning: `canonical plugin state could not be normalized at ${key}` };
+        }
+        await update(key, (candidate) => {
+          const candidateParsed = readStoredCodexAppServerBinding(candidate);
+          if (!candidateParsed || !isDeepStrictEqual(candidateParsed, parsed)) {
+            return undefined;
+          }
+          return normalized;
+        });
+        const persisted = readStoredCodexAppServerBinding(await store.lookup(key));
+        if (!persisted || !isDeepStrictEqual(persisted, normalized)) {
+          return { warning: `canonical plugin state changed at ${key}` };
+        }
+        importedKeys++;
+        return { value: normalized };
+      };
       let currentConversation: MigratedBindingRow | undefined;
       for (const key of conversationKeys) {
         const current = await store.lookup(key);
         if (current === undefined) {
           continue;
         }
-        const parsed = readStoredCodexAppServerBinding(current);
-        if (!parsed) {
-          return retain(`canonical plugin state is invalid at ${key}`);
+        const result = await normalizeStoredRow(key, current);
+        if (result.warning || !result.value) {
+          return retain(result.warning ?? `canonical plugin state is invalid at ${key}`);
         }
-        currentConversation ??= parsed;
+        currentConversation ??= result.value;
       }
       const stored = currentConversation ?? baseStored;
       const sessionKey = owner
@@ -500,7 +541,14 @@ async function migrateSource(
       };
       for (const entry of entries) {
         const current = await store.lookup(entry.key);
-        if (current !== undefined && !hasExpected(current, entry.value)) {
+        if (current === undefined) {
+          continue;
+        }
+        const result = await normalizeStoredRow(entry.key, current);
+        if (result.warning || !result.value) {
+          return retain(result.warning ?? `canonical plugin state is invalid at ${entry.key}`);
+        }
+        if (!hasExpected(result.value, entry.value)) {
           return retain(`canonical plugin state changed at ${entry.key}`);
         }
       }

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -9,10 +9,7 @@ import {
 import { withFileLock, type FileLockOptions } from "openclaw/plugin-sdk/file-lock";
 import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
-import {
-  resolveStorePath,
-  updateSessionStoreEntry,
-} from "openclaw/plugin-sdk/session-store-runtime";
+import { patchSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   CODEX_APP_SERVER_BINDING_NAMESPACE,
@@ -50,6 +47,7 @@ type LegacyBindingOwner = {
   transcriptPath: string;
   lifecycleRevision?: string;
   agentHarnessId?: string;
+  updatedAt?: number;
 };
 
 type LegacySessionIndexEntry = {
@@ -57,6 +55,7 @@ type LegacySessionIndexEntry = {
   sessionFile?: string;
   lifecycleRevision?: string;
   agentHarnessId?: string;
+  updatedAt?: number;
 };
 
 type BindingOwnerCollection = {
@@ -209,7 +208,7 @@ async function readLegacySessionIndex(
     const lifecycleRevision = value.lifecycleRevision;
     const agentHarnessId = value.agentHarnessId;
     if (
-      !sessionId ||
+      !isSafeLegacySessionId(value.sessionId) ||
       (sessionFile !== undefined && typeof sessionFile !== "string") ||
       (lifecycleRevision !== undefined && typeof lifecycleRevision !== "string") ||
       (agentHarnessId !== undefined && typeof agentHarnessId !== "string")
@@ -223,6 +222,11 @@ async function readLegacySessionIndex(
         ...(typeof sessionFile === "string" ? { sessionFile } : {}),
         ...(typeof lifecycleRevision === "string" ? { lifecycleRevision } : {}),
         ...(typeof agentHarnessId === "string" ? { agentHarnessId } : {}),
+        ...(typeof value.updatedAt === "number" &&
+        Number.isFinite(value.updatedAt) &&
+        value.updatedAt >= 0
+          ? { updatedAt: value.updatedAt }
+          : {}),
       },
     });
   }
@@ -242,11 +246,16 @@ async function* iterateIndexedSidecars(surface: SessionSurface): AsyncGenerator<
       if (sessionFile.startsWith("sqlite:")) {
         continue;
       }
-      const transcriptPath = resolveLegacySessionFileLocator(
-        path.dirname(storePath),
-        entry,
-        entry.sessionId,
-      );
+      let transcriptPath: string;
+      try {
+        transcriptPath = await resolveLegacySessionFileLocator(
+          path.dirname(storePath),
+          entry,
+          entry.sessionId,
+        );
+      } catch {
+        continue;
+      }
       const sidecarPath = `${transcriptPath}${LEGACY_BINDING_SUFFIX}`;
       if (await isRegularFile(sidecarPath)) {
         yield sidecarPath;
@@ -314,7 +323,7 @@ async function collectBindingOwners(
       let legacyTranscriptPath: string;
       let canonicalLegacyTranscriptPath: string;
       try {
-        legacyTranscriptPath = resolveLegacySessionFileLocator(sessionsDir, entry, sessionId);
+        legacyTranscriptPath = await resolveLegacySessionFileLocator(sessionsDir, entry, sessionId);
         canonicalLegacyTranscriptPath = await canonicalizePath(legacyTranscriptPath);
       } catch {
         failures.push(`session index ${storePath} has an invalid locator for ${sessionKey}`);
@@ -331,6 +340,7 @@ async function collectBindingOwners(
         transcriptPath: legacyTranscriptPath,
         ...(entry.lifecycleRevision ? { lifecycleRevision: entry.lifecycleRevision } : {}),
         ...(entry.agentHarnessId?.trim() ? { agentHarnessId: entry.agentHarnessId.trim() } : {}),
+        ...(entry.updatedAt !== undefined ? { updatedAt: entry.updatedAt } : {}),
       };
       const candidates =
         owners.get(canonicalLegacyTranscriptPath) ?? new Map<string, LegacyBindingOwner>();
@@ -355,13 +365,26 @@ async function collectBindingOwners(
 
 // Doctor-only locator for retired file-backed session indexes. Active runtime
 // never resolves these paths; migration needs them only to find old sidecars.
-function resolveLegacySessionFileLocator(
+async function resolveLegacySessionFileLocator(
   sessionsDir: string,
   entry: { sessionFile?: string },
   sessionId: string,
-): string {
+): Promise<string> {
+  const base = path.resolve(sessionsDir);
+  const fallback = path.join(base, `${sessionId}.jsonl`);
   const sessionFile = entry.sessionFile?.trim();
-  return path.resolve(sessionsDir, sessionFile || `${sessionId}.jsonl`);
+  if (!sessionFile) {
+    return fallback;
+  }
+  const candidate = path.resolve(base, sessionFile);
+  const [canonicalBase, canonicalCandidate] = await Promise.all([
+    canonicalizePathForContainment(base),
+    canonicalizePathForContainment(candidate),
+  ]);
+  if (!isPathWithin(canonicalBase, canonicalCandidate)) {
+    throw new Error("legacy session file locator escapes its session directory");
+  }
+  return candidate;
 }
 
 function resolveLegacyBindingOwnerAgentId(params: {
@@ -561,7 +584,7 @@ async function migrateSource(
         }
       }
       if (owner) {
-        const ownershipWarning = await recordSessionOwner(owner);
+        const ownershipWarning = await recordSessionOwner(owner, params.env);
         if (ownershipWarning) {
           if (sessionEntry?.value.state === "active") {
             const update = store.update;
@@ -613,13 +636,59 @@ async function migrateSource(
   }
 }
 
-async function recordSessionOwner(owner: LegacyBindingOwner): Promise<string | undefined> {
+async function recordSessionOwner(
+  owner: LegacyBindingOwner,
+  env: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  const currentIndex = await readLegacySessionIndex(owner.storePath);
+  if ("failure" in currentIndex) {
+    return "its legacy session owner could not be revalidated";
+  }
+  const currentOwner = currentIndex.entries.find(
+    ({ sessionKey }) => sessionKey === owner.sessionKey,
+  );
+  if (!currentOwner || currentOwner.entry.sessionId !== owner.sessionId) {
+    return "its session owner changed before Codex ownership could be recorded";
+  }
+  let currentTranscriptPath: string;
+  try {
+    currentTranscriptPath = await resolveLegacySessionFileLocator(
+      path.dirname(owner.storePath),
+      currentOwner.entry,
+      currentOwner.entry.sessionId,
+    );
+  } catch {
+    return "its session owner changed before Codex ownership could be recorded";
+  }
+  if (
+    (await canonicalizePath(currentTranscriptPath)) !==
+      (await canonicalizePath(owner.transcriptPath)) ||
+    currentOwner.entry.lifecycleRevision !== owner.lifecycleRevision
+  ) {
+    return "its session owner changed before Codex ownership could be recorded";
+  }
+  const legacyHarnessId = currentOwner.entry.agentHarnessId?.trim();
+  if (currentOwner.entry.agentHarnessId !== undefined && !legacyHarnessId) {
+    return "its session owner changed before Codex ownership could be recorded";
+  }
+  if (legacyHarnessId && legacyHarnessId !== CODEX_AGENT_HARNESS_ID) {
+    return `its session is owned by agent harness ${legacyHarnessId}`;
+  }
+
   let observedForeignHarness: string | undefined;
-  const updated = await updateSessionStoreEntry({
+  const updated = await patchSessionEntry({
+    agentId: owner.agentId,
+    env,
+    fallbackEntry: {
+      sessionId: owner.sessionId,
+      updatedAt: currentOwner.entry.updatedAt ?? owner.updatedAt ?? 0,
+      ...(owner.lifecycleRevision ? { lifecycleRevision: owner.lifecycleRevision } : {}),
+    },
+    preserveActivity: true,
+    requireWriteSuccess: true,
+    skipMaintenance: true,
     storePath: owner.storePath,
     sessionKey: owner.sessionKey,
-    skipMaintenance: true,
-    requireWriteSuccess: true,
     update: (entry) => {
       if (
         entry.sessionId.trim() !== owner.sessionId ||
@@ -629,7 +698,7 @@ async function recordSessionOwner(owner: LegacyBindingOwner): Promise<string | u
       }
       const harnessId =
         typeof entry.agentHarnessId === "string" ? entry.agentHarnessId.trim() : undefined;
-      if (entry.agentHarnessId !== undefined && harnessId === undefined) {
+      if (entry.agentHarnessId !== undefined && !harnessId) {
         return null;
       }
       if (harnessId && harnessId !== CODEX_AGENT_HARNESS_ID) {
@@ -683,6 +752,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function isSafeLegacySessionId(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const trimmed = value.trim();
+  return (
+    trimmed.length > 0 && trimmed.length <= 255 && /^[A-Za-z0-9][A-Za-z0-9._:@-]*$/.test(trimmed)
+  );
+}
+
 function isPathWithin(root: string, candidate: string): boolean {
   const relative = path.relative(root, candidate);
   // Bare ".." (candidate is root's parent) must stay outside; treating it as
@@ -698,6 +777,25 @@ async function canonicalizePath(filePath: string): Promise<string> {
     return await fs.realpath(filePath);
   } catch {
     return path.resolve(filePath);
+  }
+}
+
+async function canonicalizePathForContainment(filePath: string): Promise<string> {
+  const resolved = path.resolve(filePath);
+  const suffix: string[] = [];
+  let probe = resolved;
+  while (true) {
+    try {
+      const realProbe = await fs.realpath(probe);
+      return suffix.length === 0 ? realProbe : path.join(realProbe, ...suffix.toReversed());
+    } catch {
+      const parent = path.dirname(probe);
+      if (parent === probe) {
+        return resolved;
+      }
+      suffix.push(path.basename(probe));
+      probe = parent;
+    }
   }
 }
 

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -155,6 +155,46 @@ describe("runDoctorSessionSqlite", () => {
     expect(message?.message?.content).toEqual([{ type: "text", text: "legacy string" }]);
   });
 
+  it("preserves a same-generation canonical harness owner during legacy import", async () => {
+    const store = createLegacyStore({
+      entryOverrides: { lifecycleRevision: "rev-1" },
+    });
+    await upsertSqliteSessionEntry(
+      {
+        agentId: "main",
+        env: store.env,
+        sessionKey: "agent:main:main",
+        storePath: store.storePath,
+      },
+      {
+        agentHarnessId: "codex",
+        lifecycleRevision: "rev-1",
+        sessionId: "session-1",
+        updatedAt: 3000,
+      },
+    );
+
+    const report = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+
+    expect(report.totals).toMatchObject({ importedEntries: 1, issues: 0 });
+    expect(
+      loadExactSqliteSessionEntry({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        storePath: store.storePath,
+      })?.entry,
+    ).toMatchObject({
+      agentHarnessId: "codex",
+      lifecycleRevision: "rev-1",
+      sessionId: "session-1",
+      sessionFile: expect.stringMatching(/^sqlite:/),
+    });
+  });
+
   it("imports and validates legacy sessions idempotently", async () => {
     const store = createLegacyStore();
 

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1629,8 +1629,18 @@ export async function importSqliteSessionRows(
   return await runExclusiveSqliteSessionWrite(resolved, async () => {
     let transcriptEvents = 0;
     runOpenClawAgentWriteTransaction((database) => {
+      const currentEntry = readSessionEntryRow(database, resolved.sessionKey)?.entry;
+      const preservedHarnessId =
+        params.entry.agentHarnessId === undefined &&
+        currentEntry?.sessionId === params.entry.sessionId &&
+        currentEntry.lifecycleRevision === params.entry.lifecycleRevision
+          ? currentEntry.agentHarnessId?.trim()
+          : undefined;
+      // Plugin doctor migrations can claim a legacy session before the full
+      // session import runs. Preserve that same-generation canonical owner.
       const importedEntry = {
         ...params.entry,
+        ...(preservedHarnessId ? { agentHarnessId: preservedHarnessId } : {}),
         sessionFile: formatSqliteSessionMarkerForScope({
           ...resolved,
           sessionId: params.entry.sessionId,

--- a/src/plugin-sdk/session-store-runtime.test.ts
+++ b/src/plugin-sdk/session-store-runtime.test.ts
@@ -170,6 +170,41 @@ describe("session-store-runtime compatibility surface", () => {
     expect(getSessionEntry({ sessionKey: staleSessionKey, storePath })).toBeUndefined();
   });
 
+  it("forwards maintenance suppression through entry patches", async () => {
+    const staleSessionKey = "agent:main:stale";
+    const activeSessionKey = "agent:main:active";
+    const now = Date.now();
+    await seedSessionEntry(staleSessionKey, {
+      sessionId: "session-stale",
+      updatedAt: now - 8 * DAY_MS,
+    });
+    await seedSessionEntry(activeSessionKey, {
+      sessionId: "session-active",
+      updatedAt: now,
+    });
+
+    await patchSessionEntry({
+      sessionKey: activeSessionKey,
+      storePath,
+      maintenanceConfig: {
+        mode: "enforce",
+        pruneAfterMs: 7 * DAY_MS,
+        modelRunPruneAfterMs: DAY_MS,
+        maxEntries: 1,
+        resetArchiveRetentionMs: 7 * DAY_MS,
+        maxDiskBytes: null,
+        highWaterBytes: null,
+      },
+      requireWriteSuccess: true,
+      skipMaintenance: true,
+      update: () => ({ model: "gpt-5.5" }),
+    });
+
+    expect(getSessionEntry({ sessionKey: staleSessionKey, storePath })).toMatchObject({
+      sessionId: "session-stale",
+    });
+  });
+
   it("accepts pre-model-run maintenance configs through entry patches", async () => {
     const staleModelRunKey = "agent:main:explicit:model-run-123e4567-e89b-12d3-a456-426614174000";
     const activeSessionKey = "agent:main:active";

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -61,7 +61,9 @@ type PatchSessionEntryParams = SessionStoreReadParams & {
   fallbackEntry?: SessionEntry;
   maintenanceConfig?: ResolvedSessionMaintenanceConfigInput;
   preserveActivity?: boolean;
+  requireWriteSuccess?: boolean;
   replaceEntry?: boolean;
+  skipMaintenance?: boolean;
   update: SessionStoreEntryPatch;
 };
 
@@ -180,7 +182,9 @@ export async function patchSessionEntry(
         ? normalizeResolvedMaintenanceConfigInput(params.maintenanceConfig)
         : undefined,
     preserveActivity: params.preserveActivity,
+    requireWriteSuccess: params.requireWriteSuccess,
     replaceEntry: params.replaceEntry,
+    skipMaintenance: params.skipMaintenance,
   });
 }
 


### PR DESCRIPTION
Closes #104503

AI-assisted.

## What Problem This Solves

Fixes an issue where users running Codex app-server backed agents could see agent runs fail before a response when their active OpenClaw tool or user MCP surface was large enough to make Codex thread-binding fingerprints exceed the plugin-state per-value limit.

## Why This Change Was Made

Codex thread bindings only need stable change detectors for dynamic tools and user MCP config, not the full serialized fingerprint payload. This change stores non-empty dynamic-tool and user-MCP fingerprints as bounded `sha256:<64 hex>` strings while preserving the existing `[]` empty-tool fingerprint used by transient no-tool maintenance turns.

## User Impact

Plugin-heavy installs can keep using Codex-backed agents without tripping `PLUGIN_STATE_LIMIT_EXCEEDED` while writing the app-server thread binding. User MCP bearer values remain absent from the persisted binding, and large tool/MCP surfaces no longer inflate that binding.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.binding.test.ts extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts`
- Result: 2 files passed, 62 tests passed.
- Live beta.5 observation before this source fix: a plugin-heavy install with 238 enabled tool contracts and 6 configured MCP servers failed Codex agent smoke with `PLUGIN_STATE_LIMIT_EXCEEDED`.
- Local hotfix using the same bounded-fingerprint shape allowed the same `openclaw agent --agent main ... Reply with exactly: SMOKE_OK` smoke to complete successfully.
