### PR TITLE
fix(brave): use own-property checks for credential field lookups

### DIFF
--- a/extensions/brave/src/web-search-shared.own-entries.test.ts
+++ b/extensions/brave/src/web-search-shared.own-entries.test.ts
@@ -1,0 +1,169 @@
+// Brave credential own-property checks: Object.hasOwn() vs `in`
+// These tests verify that inherited prototype properties on the legacy
+// tools.web.search config object are not mistaken for explicit user credentials,
+// and that the primary credential reader also rejects proto-inherited entries.
+import { describe, expect, it } from "vitest";
+import { buildBraveWebSearchProviderBase } from "../web-search-shared.js";
+
+describe("brave credential own-property checks", () => {
+  const base = buildBraveWebSearchProviderBase();
+  const credentialReader = base.getConfiguredCredentialValue!;
+  const fallbackReader = base.getConfiguredCredentialFallback!;
+
+  describe("primary credential reader (plugin config first)", () => {
+    it("ignores proto-inherited apiKey via plugin config", () => {
+      const pluginEntry = Object.create({ webSearch: { apiKey: "proto-plugin-key" } });
+      pluginEntry.config = { unrelated: "value" };
+      const cfg = { plugins: { entries: { brave: pluginEntry } } };
+
+      const result = credentialReader(cfg);
+      expect(result).toBeUndefined();
+    });
+
+    it("reads own plugin config apiKey", () => {
+      const cfg = {
+        plugins: {
+          entries: {
+            brave: {
+              config: {
+                webSearch: { apiKey: "own-plugin-key" },
+              },
+            },
+          },
+        },
+      };
+
+      expect(credentialReader(cfg)).toBe("own-plugin-key");
+    });
+
+    it("falls through to legacy search when no plugin config", () => {
+      const search = Object.create({ apiKey: "proto-legacy-key" });
+      const cfg = { tools: { web: { search } } };
+
+      // Proto-inherited legacy key must be rejected even in fallback
+      expect(credentialReader(cfg)).toBeUndefined();
+    });
+
+    it("reads own legacy apiKey when no plugin config", () => {
+      const cfg = { tools: { web: { search: { apiKey: "own-legacy-key" } } } };
+      expect(credentialReader(cfg)).toBe("own-legacy-key");
+    });
+  });
+
+  describe("legacy fallback credential reader", () => {
+    it("ignores proto-inherited apiKey from tools.web.search", () => {
+      const search = Object.create({ apiKey: "proto-search-key" });
+      search.irrelevantOwnField = "yes";
+
+      const result = fallbackReader({
+        tools: { web: { search } },
+      });
+
+      // Object.hasOwn(search, "apiKey") returns false → inherited value rejected
+      expect(result).toBeUndefined();
+    });
+
+    it("reads own apiKey from tools.web.search", () => {
+      const result = fallbackReader({
+        tools: {
+          web: {
+            search: { apiKey: "own-search-key" },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        path: "tools.web.search.apiKey",
+        value: "own-search-key",
+      });
+    });
+
+    it("returns undefined when tools.web.search has no apiKey", () => {
+      const result = fallbackReader({
+        tools: {
+          web: {
+            search: { someOtherKey: "irrelevant" },
+          },
+        },
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when tools.web.search is missing entirely", () => {
+      const result = fallbackReader({ tools: { web: {} } });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("canonical plugin config inheritance", () => {
+    // The canonical Brave credential path is:
+    //   plugins.entries.brave.config.webSearch.apiKey (primary)
+    //   tools.web.search.apiKey (legacy fallback)
+    // Object.hasOwn() protects against proto-inherited apiKey at the final
+    // extraction level in both paths.
+
+    it("rejects proto-inherited apiKey on plugin webSearch object", () => {
+      // apiKey is on the webSearch object's prototype; the primary reader
+      // uses Object.hasOwn(pluginConfig, "apiKey") to reject it.
+      const webSearch = Object.create({ apiKey: "proto-api-key" });
+      const cfg = { plugins: { entries: { brave: { config: { webSearch } } } } };
+      expect(credentialReader(cfg)).toBeUndefined();
+    });
+
+    it("reads own apiKey from plugin webSearch object (backward compat)", () => {
+      const cfg = {
+        plugins: {
+          entries: {
+            brave: {
+              config: {
+                webSearch: { apiKey: "canonical-plugin-key" },
+              },
+            },
+          },
+        },
+      };
+      expect(credentialReader(cfg)).toBe("canonical-plugin-key");
+    });
+
+    it("plugin config takes precedence over legacy with own values", () => {
+      const cfg = {
+        plugins: {
+          entries: {
+            brave: {
+              config: {
+                webSearch: { apiKey: "plugin-precedence-key" },
+              },
+            },
+          },
+        },
+        tools: {
+          web: {
+            search: { apiKey: "legacy-key" },
+          },
+        },
+      };
+      expect(credentialReader(cfg)).toBe("plugin-precedence-key");
+    });
+
+    it("falls through to legacy with own apiKey when plugin config has no apiKey", () => {
+      const cfg = {
+        plugins: {
+          entries: {
+            brave: {
+              config: {
+                webSearch: { unrelatedOption: "value" },
+              },
+            },
+          },
+        },
+        tools: {
+          web: {
+            search: { apiKey: "fallback-legacy-key" },
+          },
+        },
+      };
+      expect(credentialReader(cfg)).toBe("fallback-legacy-key");
+    });
+  });
+});

--- a/extensions/brave/web-search-shared.ts
+++ b/extensions/brave/web-search-shared.ts
@@ -21,7 +21,7 @@ function resolveLegacyTopLevelBraveCredential(
   const tools = isRecord(config.tools) ? config.tools : undefined;
   const web = isRecord(tools?.web) ? tools.web : undefined;
   const search = isRecord(web?.search) ? web.search : undefined;
-  if (!search || !("apiKey" in search)) {
+  if (!search || !Object.hasOwn(search, "apiKey")) {
     return undefined;
   }
   return { path: "tools.web.search.apiKey", value: search.apiKey };
@@ -40,10 +40,11 @@ function resolveBraveWebSearchPluginConfig(config: unknown): Record<string, unkn
 
 /** Resolve Brave credentials from current plugin config or legacy fallback. */
 function resolveConfiguredBraveCredential(config: unknown): unknown {
-  return (
-    resolveBraveWebSearchPluginConfig(config)?.apiKey ??
-    resolveLegacyTopLevelBraveCredential(config)?.value
-  );
+  const pluginConfig = resolveBraveWebSearchPluginConfig(config);
+  if (pluginConfig && Object.hasOwn(pluginConfig, "apiKey")) {
+    return pluginConfig.apiKey;
+  }
+  return resolveLegacyTopLevelBraveCredential(config)?.value;
 }
 
 /** Build the common Brave provider metadata without the runtime tool executor. */


### PR DESCRIPTION
### What Problem This Solves

Brave config credential lookup paths use `"<key>" in <configObj>` to check whether a credential field is present. The `in` operator traverses the prototype chain, so an inherited property (e.g. via `Object.create({apiKey: "malicious"})`) could be mistaken for an explicit user credential entry.

This is the **pre-Zod validation boundary** — the raw POJO config object from `JSON.parse()` before schema validation. These `in` checks operate on the raw object where prototype-chain properties from a crafted `__proto__` survive until the `Object.hasOwn()` gate.

### Why This Change Was Made

Use `Object.hasOwn()` which only checks own properties — inherited prototype properties are ignored. Config objects are plain POJOs from JSON, so `Object.hasOwn()` behaves identically for all legitimate config shapes while closing the prototype-chain attack surface.

### User Impact

No user-visible change for normal config. Prototype-chain inherited properties are no longer treated as user credential entries across Brave credential lookup paths.

### Evidence

**Unit tests**:
- `node scripts/run-vitest.mjs extensions/brave/src/web-search-shared.own-entries.test.ts` — 12 tests passed

**Runtime proof** (imported real `buildBraveWebSearchProviderBase` module, tested both credential paths):

```
-- 1/5.  Core semantic proof --
  'apiKey' in Object.create({ apiKey: "inherited" }):    true
  Object.hasOwn(Object.create({ apiKey: "inherited" })): false
  -> Object.hasOwn() rejects proto, accepts own

-- 2/5.  Loading real Brave web-search-shared module --
  Module loaded successfully

-- 3/5.  Plugin config credential lookup --
  getConfiguredCredentialValue(proto):       undefined
  -> Proto-inherited plugin apiKey REJECTED

-- 4/5.  Own plugin config credential lookup --
  getConfiguredCredentialValue(own):         own-plugin-key
  -> Own plugin apiKey ACCEPTED

-- 5/5.  Legacy search credential fallback --
  getConfiguredCredentialFallback(proto):    undefined
  -> Proto-inherited legacy apiKey REJECTED
  getConfiguredCredentialFallback(own):      {"path":"tools.web.search.apiKey","value":"own-legacy-key"}
  -> Own legacy apiKey ACCEPTED

-- CONTRACT VERIFICATION --
  in operator:         ALL proto fields detected -> WOULD OVERRIDE
  Object.hasOwn():     ALL proto fields ignored -> SAFE
  Own properties:      both paths accept -> BACKWARD COMPAT
```
