### PR TITLE
fix(clickclack): resolve tokens from runtime snapshot

### DIFF
--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -1,5 +1,9 @@
 // Clickclack tests cover accounts plugin behavior.
-import { describe, expect, it } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   listClickClackAccountIds,
   resolveClickClackAccount,
@@ -7,7 +11,68 @@ import {
 } from "./accounts.js";
 import type { CoreConfig } from "./types.js";
 
+afterEach(() => {
+  clearRuntimeConfigSnapshot();
+});
+
 describe("ClickClack account resolution", () => {
+  it("resolves a top-level SecretRef from the active runtime snapshot", () => {
+    const sourceCfg = {
+      channels: {
+        clickclack: {
+          baseUrl: "https://app.clickclack.chat",
+          token: { source: "exec", provider: "vault", id: "clickclack/token" },
+          workspace: "wsp_1",
+        },
+      },
+    } as unknown as CoreConfig;
+    const runtimeCfg = {
+      channels: {
+        clickclack: {
+          baseUrl: "https://app.clickclack.chat",
+          token: "ccb_runtime",
+          workspace: "wsp_1",
+        },
+      },
+    } as CoreConfig;
+    setRuntimeConfigSnapshot(runtimeCfg, sourceCfg);
+
+    const account = resolveClickClackAccount({ cfg: sourceCfg });
+
+    expect(account.configured).toBe(true);
+    expect(account.token).toBe("ccb_runtime");
+  });
+
+  it("does not substitute an unrelated runtime snapshot", () => {
+    const sourceCfg = {
+      channels: {
+        clickclack: {
+          baseUrl: "https://source.example",
+          token: "ccb_source",
+          workspace: "wsp_source",
+        },
+      },
+    } as CoreConfig;
+    setRuntimeConfigSnapshot(
+      {
+        channels: {
+          clickclack: {
+            baseUrl: "https://runtime.example",
+            token: "ccb_runtime",
+            workspace: "wsp_runtime",
+          },
+        },
+      } as CoreConfig,
+      { channels: { clickclack: { enabled: false } } } as CoreConfig,
+    );
+
+    const account = resolveClickClackAccount({ cfg: sourceCfg });
+
+    expect(account.baseUrl).toBe("https://source.example");
+    expect(account.token).toBe("ccb_source");
+    expect(account.workspace).toBe("wsp_source");
+  });
+
   it("preserves top-level default account when named accounts are configured", () => {
     const cfg = {
       channels: {

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -16,6 +16,7 @@ import {
   resolveSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { selectClickClackRuntimeConfig } from "./runtime-config.js";
 import type { ClickClackAccountConfig, CoreConfig, ResolvedClickClackAccount } from "./types.js";
 
 const DEFAULT_RECONNECT_MS = 1_500;
@@ -110,13 +111,14 @@ export function resolveClickClackAccount(params: {
   accountId?: string | null;
   env?: NodeJS.ProcessEnv;
 }): ResolvedClickClackAccount {
+  const cfg = selectClickClackRuntimeConfig(params.cfg);
   const accountId = normalizeAccountId(params.accountId);
-  const merged = resolveMergedClickClackAccountConfig(params.cfg, accountId);
-  const baseEnabled = params.cfg.channels?.clickclack?.enabled !== false;
+  const merged = resolveMergedClickClackAccountConfig(cfg, accountId);
+  const baseEnabled = cfg.channels?.clickclack?.enabled !== false;
   const enabled = baseEnabled && merged.enabled !== false;
   const baseUrl = merged.baseUrl?.trim().replace(/\/$/, "") ?? "";
   const token = resolveClickClackToken({
-    cfg: params.cfg,
+    cfg,
     value: merged.token,
     accountId,
     env: params.env,

--- a/extensions/clickclack/src/runtime-config.ts
+++ b/extensions/clickclack/src/runtime-config.ts
@@ -1,0 +1,15 @@
+/** Selects the active runtime config when the caller still holds the persisted source config. */
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import type { CoreConfig } from "./types.js";
+
+export function selectClickClackRuntimeConfig(inputConfig: CoreConfig): CoreConfig {
+  return (selectApplicableRuntimeConfig({
+    inputConfig,
+    runtimeConfig: getRuntimeConfigSnapshot(),
+    runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
+  }) ?? inputConfig) as CoreConfig;
+}


### PR DESCRIPTION
## Summary

- select ClickClack credentials from OpenClaw's active runtime config snapshot
- preserve caller-provided configs when they do not match the runtime snapshot source
- add regression coverage for exec-backed SecretRefs

## Root cause

ClickClack resolved accounts directly from the persisted source config. After OpenClaw successfully materialized an exec/file SecretRef into the in-memory runtime snapshot, the plugin still inspected the unresolved source object and classified the account as unconfigured.

## Impact

ClickClack channels can start with supported SecretRef-backed bot tokens instead of requiring plaintext or environment-token workarounds.

## Validation

- `./node_modules/.bin/vitest run --configLoader runner extensions/clickclack/src/accounts.test.ts`
- 9 tests passed
- `git diff --check`
