### PR TITLE
fix(outbound): preserve inline formatting on attributed b/i/s tags

### DIFF
--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -42,6 +42,16 @@ describe("sanitizeForPlainText", () => {
     expect(sanitizeForPlainText("<code>foo()</code>")).toBe("`foo()`");
   });
 
+  it("preserves inline formatting when opening tags carry attributes", () => {
+    expect(sanitizeForPlainText('<b class="x">bold</b>')).toBe("*bold*");
+    expect(sanitizeForPlainText('<strong style="font-weight:bold">bold</strong>')).toBe("*bold*");
+    expect(sanitizeForPlainText('<i id="y">italic</i>')).toBe("_italic_");
+    expect(sanitizeForPlainText('<em data-lang="en">italic</em>')).toBe("_italic_");
+    expect(sanitizeForPlainText('<s class="del">deleted</s>')).toBe("~deleted~");
+    expect(sanitizeForPlainText('<strike style="text-decoration">old</strike>')).toBe("~old~");
+    expect(sanitizeForPlainText('<del data-revision="3">removed</del>')).toBe("~removed~");
+  });
+
   // --- block elements -----------------------------------------------------
 
   it("converts <p> and <div> to newlines", () => {

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -34,11 +34,11 @@ export function sanitizeForPlainText(text: string): string {
     // Block elements → newlines
     .replace(/<\/?(p|div)>/gi, "\n")
     // Bold → WhatsApp/Signal bold
-    .replace(/<(b|strong)>(.*?)<\/\1>/gi, "*$2*")
+    .replace(/<(b|strong)(?:\s[^>]*)?>(.*?)<\/\1>/gi, "*$2*")
     // Italic → WhatsApp/Signal italic
-    .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
+    .replace(/<(i|em)(?:\s[^>]*)?>(.*?)<\/\1>/gi, "_$2_")
     // Strikethrough → WhatsApp/Signal strikethrough
-    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, "~$2~")
+    .replace(/<(s|strike|del)(?:\s[^>]*)?>(.*?)<\/\1>/gi, "~$2~")
     // Inline code
     .replace(/<code>(.*?)<\/code>/gi, "`$1`")
     // Headings → bold text with newline


### PR DESCRIPTION
## What Problem This Solves

`sanitizeForPlainText` in `src/infra/outbound/sanitize-text.ts` converts inline HTML tags to channel-friendly lightweight markup. The current regexes for `<b>`/`<strong>`, `<i>`/`<em>`, and `<s>`/`<strike>`/`<del>` only match bare opening tags, so model output such as `<b class="x">bold</b>` falls through to the generic tag stripper and arrives as plain text instead of `*bold*`.

This is a sibling gap to #104118, which fixes the same issue for `<code>` tags with attributes.

## Why This Change Was Made

Updated the inline-formatting regexes to accept optional attributes on the opening tag (`/<(b|strong)(?:\s[^>]*)?>(.*?)<\/\1>/gi`, and likewise for `i/em` and `s/strike/del`), matching the existing pattern used for `<h[1-6][^>]*>` and `<li[^>]*>` and the `<code>` fix in #104118. Added focused regression tests covering `class`, `style`, `id`, and data attributes.

## User Impact

Users on channels that rely on `sanitizeForPlainText` (Telegram, iMessage, IRC, Google Chat, WhatsApp, etc.) will now see bold, italic, and strikethrough formatting preserved when models emit attributed inline tags, instead of silently stripped tags.

## Evidence

- Added a regression test in `src/infra/outbound/sanitize-text.test.ts` that asserts attributed `<b>`, `<strong>`, `<i>`, `<em>`, `<s>`, `<strike>`, and `<del>` tags are converted to `*`, `_`, and `~` wrapping respectively.
- Local verification on head `095541f6e5`:
  - `node scripts/run-vitest.mjs src/infra/outbound/sanitize-text.test.ts` → 29 passed
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit` → 0 errors
  - `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/outbound/sanitize-text.ts src/infra/outbound/sanitize-text.test.ts` → exit code 0

## Real behavior proof

I ran a standalone script against the actual `sanitizeForPlainText` export on this PR's head (`095541f6e5`). It imports the current implementation and compares it with the old regex set (without the `(?:\s[^>]*)?` allowance) on attributed inline tags:

```
=== outbound inline-tag attribute handling ===

bold
  input:  <b class="x">bold</b>
  before: bold
  after:  *bold*

strong
  input:  <strong style="font-weight:bold">bold</strong>
  before: bold
  after:  *bold*

italic
  input:  <i id="y">italic</i>
  before: italic
  after:  _italic_

emphasis
  input:  <em data-lang="en">italic</em>
  before: italic
  after:  _italic_

strikethrough-s
  input:  <s class="del">deleted</s>
  before: deleted
  after:  ~deleted~

strikethrough-strike
  input:  <strike style="text-decoration">old</strike>
  before: old
  after:  ~old~

strikethrough-del
  input:  <del data-revision="3">removed</del>
  before: removed
  after:  ~removed~

=== mixed content ===
input:  Hello <b class="x">world</b> and <i id="y">nice</i> <s class="del">day</s>
before: Hello world and nice day
after:  Hello *world* and _nice_ ~day~
```

Before the fix, attributed inline tags were stripped to plain text; after the fix, they are converted to the expected WhatsApp/Signal-style `*bold*`, `_italic_`, and `~strikethrough~` markers.
