### PR TITLE
chore(skills): sync agent-transcript and crabbox

### DIFF
--- a/.agents/skills/agent-transcript/SKILL.md
+++ b/.agents/skills/agent-transcript/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-transcript
-description: "Add a redacted agent transcript section to GitHub PR or issue bodies during OpenClaw agent-created PR/issue workflows."
+description: "GitHub PR/issue agent transcripts: redact, preview, and insert safely."
 ---
 
 # Agent Transcript
@@ -72,10 +72,16 @@ Append/update a body file before `gh pr create --body-file` or connector PR crea
 3. If a high-confidence session is found, ask:
    `Include a redacted agent transcript? It helps reviewers and can make the PR easier to prioritize. I can open a local preview first.`
 4. If the user wants preview, run `preview`, open the HTML with `open`, and wait for confirmation.
-5. Before insertion, trim unrelated session turns from the generated section. Keep only turns that explain this PR/issue's goal, implementation choices, files, tests, proof, blockers, and final outcome.
-6. If the user approves, run `append-body`.
-7. Use the enriched body file for creation/update.
+5. Render to a temporary body, then trim the `## Agent Transcript` section before showing it to the user or inserting it publicly. Keep only turns that explain this PR/issue's goal, implementation choices, files, tests, proof, blockers, and final outcome.
+6. Inspect the trimmed transcript text. If it still includes unrelated earlier/later work, trim again before proceeding.
+7. If the user approves, append the reviewed transcript to the body used for creation/update.
 8. If no safe session is found, say nothing and continue without transcript. If the user declines, continue without transcript and do not add any transcript placeholder section.
+
+## Validate
+
+```bash
+node --test .agents/skills/agent-transcript/scripts/agent-transcript.test.mjs
+```
 
 ## Review Artifacts
 

--- a/.agents/skills/agent-transcript/scripts/agent-transcript
+++ b/.agents/skills/agent-transcript/scripts/agent-transcript
@@ -3,18 +3,21 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { spawn } from "node:child_process";
 
 const MARKER_START = "<!-- agent-transcript:start -->";
 const MARKER_END = "<!-- agent-transcript:end -->";
 const DEFAULT_MAX_CHARS = 50000;
 const DEFAULT_ENTRY_MAX_CHARS = 6000;
+const MAX_APP_SERVER_RESPONSE_BYTES = 20 * 1024 * 1024;
 
 function usage() {
   console.log(`Usage:
   agent-transcript find --query TEXT [--cwd PATH] [--since-days N] [--max-files N] [--root PATH...]
-  agent-transcript render --session FILE [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
-  agent-transcript preview --session FILE [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
-  agent-transcript append-body --body FILE --session FILE [--out FILE] [--max-chars N] [--entry-max-chars N]
+  agent-transcript render --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
+  agent-transcript render-thread --thread-id ID [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
+  agent-transcript preview --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N] [--title TEXT] [--url URL]
+  agent-transcript append-body --body FILE --session FILE [--app-server] [--thread-id ID] [--out FILE] [--max-chars N] [--entry-max-chars N]
   agent-transcript html --prs FILE [--out FILE] [--since-days N] [--min-score N] [--root PATH...] [--exclude-session FILE...]
 
 Local-only. No network calls.`);
@@ -47,8 +50,30 @@ function asArray(value) {
   return Array.isArray(value) ? value : [value];
 }
 
+function optionNumber(options, camelName, kebabName, fallback) {
+  const value = options[camelName] ?? options[kebabName] ?? fallback;
+  return Number(value);
+}
+
 function homePath(...parts) {
   return path.join(os.homedir(), ...parts);
+}
+
+function uniquePaths(paths) {
+  const seen = new Set();
+  const out = [];
+  for (const candidate of paths) {
+    const resolved = path.resolve(candidate);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    out.push(resolved);
+  }
+  return out;
+}
+
+function isPathInside(file, root) {
+  const relative = path.relative(path.resolve(root), path.resolve(file));
+  return relative === "" || (relative && !relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 function openClawSessionRoots() {
@@ -74,10 +99,18 @@ function openClawSessionRoots() {
   }
 }
 
+function claudeProjectRoots() {
+  const roots = [];
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+  if (configDir) roots.push(path.join(path.resolve(configDir), "projects"));
+  roots.push(homePath(".claude", "projects"));
+  return uniquePaths(roots);
+}
+
 function defaultRoots() {
   return [
     homePath(".codex", "sessions"),
-    homePath(".claude", "projects"),
+    ...claudeProjectRoots(),
     homePath(".pi", "agent", "sessions"),
     ...openClawSessionRoots(),
   ];
@@ -116,6 +149,12 @@ function readJsonl(file, maxLines = 12000) {
   return rows;
 }
 
+function sessionThreadId(file) {
+  const name = path.basename(String(file || ""));
+  const match = name.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\.jsonl)?$/i);
+  return match ? match[1] : null;
+}
+
 function stringContent(value) {
   if (value == null) return "";
   if (typeof value === "string") return value;
@@ -132,7 +171,7 @@ function stringContent(value) {
 
 function detectAgent(file, rows) {
   if (file.includes(`${path.sep}.codex${path.sep}`)) return "codex";
-  if (file.includes(`${path.sep}.claude${path.sep}`)) return "claude";
+  if (claudeProjectRoots().some((root) => isPathInside(file, root))) return "claude";
   if (file.includes(`${path.sep}.pi${path.sep}`)) return "pi";
   if (
     file.includes(`${path.sep}.openclaw${path.sep}`) ||
@@ -146,6 +185,9 @@ function detectAgent(file, rows) {
 }
 
 function eventText(row) {
+  if (row?.type === "compacted_replacement_item") {
+    return stringContent(row.payload?.content || row.payload?.summary || row.payload?.arguments || row.payload?.output);
+  }
   if (row?.type === "event_msg") {
     const payload = row.payload || {};
     return stringContent(payload.message || payload.text_elements || payload.content);
@@ -161,6 +203,16 @@ function eventText(row) {
 }
 
 function eventRole(row) {
+  if (row?.type === "compacted_replacement_item") {
+    const payload = row.payload || {};
+    if (payload.type === "function_call") return "tool";
+    if (payload.type === "function_call_output") return "tool_output";
+    if (payload.type === "reasoning" || payload.type === "compaction") return null;
+    if (payload.type === "web_search_call") return "web";
+    if (payload.role === "user") return "user";
+    if (payload.role === "assistant") return "assistant";
+    return null;
+  }
   if (row?.type === "event_msg") {
     const type = row.payload?.type;
     if (type === "user_message") return "user";
@@ -236,7 +288,7 @@ function normalizeEntry(role, text, stats, options = {}) {
   if (!t) return null;
   if (hasSetupBlob(t)) t = "[instructions recap omitted; policy/config text, not task dialogue]";
   if (unsafe(t).length) t = "[omitted: browser/session/auth internals; not useful for public PR transcript]";
-  const entryMaxChars = Number(options.entryMaxChars || options["entry-max-chars"] || DEFAULT_ENTRY_MAX_CHARS);
+  const entryMaxChars = optionNumber(options, "entryMaxChars", "entry-max-chars", DEFAULT_ENTRY_MAX_CHARS);
   if (t.length > entryMaxChars) {
     t = `${t.slice(0, entryMaxChars).trimEnd()}\n...[truncated ${t.length - entryMaxChars} chars]`;
   }
@@ -258,17 +310,10 @@ function coalesceEntries(entries) {
     const role = entryRole(entry);
     const body = entryBody(entry);
     const last = coalesced[coalesced.length - 1];
-    if (!last || !role || entryRole(last) !== role || role === "tool summary") {
-      coalesced.push(entry);
+    if (last && role && entryRole(last) === role && role !== "tool summary" && entryBody(last) === body) {
       continue;
     }
-    const lastBody = entryBody(last);
-    if (lastBody === body || lastBody.includes(body)) continue;
-    if (body.includes(lastBody)) {
-      coalesced[coalesced.length - 1] = `[${role}]\n${body}`;
-      continue;
-    }
-    coalesced[coalesced.length - 1] = `[${role}]\n${lastBody}\n\n${body}`;
+    coalesced.push(entry);
   }
   return coalesced;
 }
@@ -349,6 +394,19 @@ function recountEntries(stats, entries) {
   stats.assistant = entries.filter((entry) => entry.startsWith("[assistant]\n")).length;
 }
 
+function expandCompactedReplacementItems(row) {
+  if (row?.type !== "compacted") return [];
+  const replacementHistory = row.payload?.replacement_history;
+  if (!Array.isArray(replacementHistory)) return [];
+  return replacementHistory.map((item, index) => ({
+    type: "compacted_replacement_item",
+    payload: item,
+    timestamp: row.timestamp,
+    sourceLineType: row.type,
+    replacementIndex: index,
+  }));
+}
+
 function renderSession(file, options = {}) {
   const rows = readJsonl(file);
   const agent = detectAgent(file, rows);
@@ -370,7 +428,8 @@ function renderSession(file, options = {}) {
     const type = row?.type === "event_msg" ? row.payload?.type : null;
     return type === "user_message" || type === "agent_message";
   });
-  for (const row of rows) {
+  const renderRows = rows.flatMap((row) => [row, ...expandCompactedReplacementItems(row)]);
+  for (const row of renderRows) {
     const role = eventRole(row);
     if (!role) continue;
     if (hasEventDialogue && row.type === "response_item" && (role === "user" || role === "assistant")) {
@@ -408,7 +467,7 @@ function renderSession(file, options = {}) {
   }
   const renderedItems = coalesceEntries(items);
   recountEntries(stats, renderedItems);
-  const maxChars = Number(options.maxChars || DEFAULT_MAX_CHARS);
+  const maxChars = optionNumber(options, "maxChars", "max-chars", DEFAULT_MAX_CHARS);
   let joined = renderedItems.join("\n\n");
   if (joined.length > maxChars) joined = `${joined.slice(0, maxChars).trimEnd()}\n\n...[transcript truncated to ${maxChars} chars]`;
   const headerBits = [options.title, options.url].filter(Boolean).join(" | ");
@@ -433,6 +492,204 @@ ${joined}
 ${MARKER_END}
 `;
   return { file, agent, safe, unsafeAfter, stats, markdown };
+}
+
+function appServerThreadRead(threadId, rolloutPath) {
+  return new Promise((resolve, reject) => {
+    const codexBin = process.env.AGENT_TRANSCRIPT_CODEX_BIN || "codex";
+    const prefixArgs = process.env.AGENT_TRANSCRIPT_CODEX_PREFIX_ARGS
+      ? JSON.parse(process.env.AGENT_TRANSCRIPT_CODEX_PREFIX_ARGS)
+      : [];
+    const child = spawn(codexBin, [...prefixArgs, "app-server", "--listen", "stdio://"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let responseBytes = 0;
+    let settled = false;
+    let finishing = false;
+    const timer = setTimeout(() => {
+      finish(reject, new Error("thread read/resume timed out"));
+    }, 30000);
+    const finish = (fn, value) => {
+      if (settled || finishing) return;
+      finishing = true;
+      clearTimeout(timer);
+      const killTimer = setTimeout(() => child.kill("SIGKILL"), 2000);
+      child.once("close", () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(killTimer);
+        fn(value);
+      });
+      child.stdin.end();
+      child.kill("SIGTERM");
+    };
+    const send = (item) => child.stdin.write(`${JSON.stringify(item)}\n`);
+    let buffer = "";
+    child.stdout.on("data", (chunk) => {
+      responseBytes += chunk.length;
+      if (responseBytes > MAX_APP_SERVER_RESPONSE_BYTES) {
+        finish(reject, new Error(`app-server response exceeded ${MAX_APP_SERVER_RESPONSE_BYTES} bytes`));
+        return;
+      }
+      stdout += chunk;
+      buffer += chunk.toString();
+      let newline;
+      while ((newline = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (!line.trim()) continue;
+        let message;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (message.id === 1) {
+          send({ method: "initialized", params: {} });
+          send({
+            method: "thread/read",
+            id: 2,
+            params: {
+              threadId,
+              includeTurns: true,
+            },
+          });
+        }
+        if (message.id === 2) {
+          if (message.result?.thread) {
+            finish(resolve, message.result.thread);
+          } else if (message.error && /thread not loaded/i.test(String(message.error.message || ""))) {
+            send({
+              method: "thread/resume",
+              id: 3,
+              params: {
+                threadId,
+                ...(rolloutPath ? { path: path.resolve(rolloutPath) } : {}),
+              },
+            });
+          } else if (message.error) {
+            finish(reject, new Error(`thread/read failed: ${JSON.stringify(message.error)}`));
+          } else {
+            finish(reject, new Error("thread/read did not return a thread"));
+          }
+        }
+        if (message.id === 3) {
+          if (message.error) finish(reject, new Error(`thread/resume failed: ${JSON.stringify(message.error)}`));
+          else if (message.result?.thread) finish(resolve, message.result.thread);
+          else finish(reject, new Error("thread/resume did not return a thread"));
+        }
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      responseBytes += chunk.length;
+      if (responseBytes > MAX_APP_SERVER_RESPONSE_BYTES) {
+        finish(reject, new Error(`app-server output exceeded ${MAX_APP_SERVER_RESPONSE_BYTES} bytes`));
+        return;
+      }
+      stderr += chunk;
+    });
+    child.on("error", (error) => finish(reject, error));
+    child.on("exit", () => {
+      if (settled || finishing) return;
+      const detail = stderr.trim() || stdout.trim();
+      finish(reject, new Error(`app-server exited before thread read/resume response${detail ? `: ${detail}` : ""}`));
+    });
+    send({
+      method: "initialize",
+      id: 1,
+      params: {
+        clientInfo: {
+          name: "agent_transcript",
+          title: "Agent Transcript",
+          version: "0.0.0",
+        },
+        capabilities: {
+          experimentalApi: true,
+          optOutNotificationMethods: [],
+        },
+      },
+    });
+  });
+}
+
+function threadItemText(item) {
+  if (item?.type === "userMessage") return stringContent(item.content);
+  if (item?.type === "agentMessage") return stringContent(item.text);
+  return "";
+}
+
+function threadItemRole(item) {
+  if (item?.type === "userMessage") return "user";
+  if (item?.type === "agentMessage") return "assistant";
+  return null;
+}
+
+async function renderThread(threadId, options = {}) {
+  const thread = await appServerThreadRead(threadId, options.session);
+  const stats = {
+    agent: "codex",
+    entries: 0,
+    user: 0,
+    assistant: 0,
+    toolCalls: 0,
+    toolOutputsDropped: 0,
+    web: 0,
+    redactions: 0,
+    omittedUnsafe: 0,
+  };
+  const items = [];
+  for (const turn of thread.turns || []) {
+    for (const item of turn.items || []) {
+      const role = threadItemRole(item);
+      if (!role) continue;
+      const entry = normalizeEntry(role, threadItemText(item), stats, options);
+      if (!entry) continue;
+      if (entry.includes("[omitted: browser/session/auth internals")) stats.omittedUnsafe++;
+      items.push(entry);
+      stats.entries++;
+      if (role === "user") stats.user++;
+      if (role === "assistant") stats.assistant++;
+    }
+  }
+  const renderedItems = coalesceEntries(items);
+  recountEntries(stats, renderedItems);
+  const maxChars = optionNumber(options, "maxChars", "max-chars", DEFAULT_MAX_CHARS);
+  let joined = renderedItems.join("\n\n");
+  if (joined.length > maxChars) joined = `${joined.slice(0, maxChars).trimEnd()}\n\n...[transcript truncated to ${maxChars} chars]`;
+  const headerBits = [options.title, options.url].filter(Boolean).join(" | ");
+  const unsafeAfter = unsafe(joined);
+  const safe = unsafeAfter.length === 0;
+  const markdown = `${MARKER_START}
+## Agent Transcript
+
+<details>
+<summary>Redacted codex app-server transcript${headerBits ? `: ${redact(headerBits, stats)}` : ""}</summary>
+
+\`\`\`\`text
+source: codex app-server thread/read or thread/resume with turns
+thread: ${redact(threadId, stats)}
+redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
+omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
+stats: ${JSON.stringify(stats)}
+
+${joined}
+\`\`\`\`
+
+</details>
+${MARKER_END}
+`;
+  return { file: null, agent: "codex", safe, unsafeAfter, stats, markdown };
+}
+
+async function renderTranscript(options) {
+  if (options["app-server"] || options.appServer || options.threadId || options["thread-id"]) {
+    const threadId = options.threadId || options["thread-id"] || sessionThreadId(options.session);
+    if (!threadId) throw new Error("--thread-id is required when --app-server cannot infer it from --session");
+    return renderThread(threadId, options);
+  }
+  return renderSession(options.session, options);
 }
 
 function readBoundedText(file, maxBytes = 220000) {
@@ -588,7 +845,7 @@ function readPrs(file) {
   return Array.isArray(parsed) ? parsed : parsed.items || parsed.prs || [];
 }
 
-function main() {
+async function main() {
   const [command, ...rest] = process.argv.slice(2);
   const args = parseArgs(rest);
   if (!command || command === "--help" || command === "-h" || args.help) {
@@ -601,7 +858,15 @@ function main() {
   }
   if (command === "render") {
     if (!args.session) throw new Error("--session is required");
-    const rendered = renderSession(args.session, args);
+    const rendered = await renderTranscript(args);
+    if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
+    if (args.out) fs.writeFileSync(args.out, rendered.markdown);
+    else process.stdout.write(rendered.markdown);
+    return;
+  }
+  if (command === "render-thread") {
+    if (!args["thread-id"] && !args.threadId) throw new Error("--thread-id is required");
+    const rendered = await renderThread(args.threadId || args["thread-id"], args);
     if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
     if (args.out) fs.writeFileSync(args.out, rendered.markdown);
     else process.stdout.write(rendered.markdown);
@@ -609,7 +874,7 @@ function main() {
   }
   if (command === "preview") {
     if (!args.session) throw new Error("--session is required");
-    const rendered = renderSession(args.session, args);
+    const rendered = await renderTranscript(args);
     if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
     const output = singlePreviewDocument({
       title: args.title || "Agent Transcript Preview",
@@ -624,7 +889,7 @@ function main() {
   }
   if (command === "append-body") {
     if (!args.body || !args.session) throw new Error("--body and --session are required");
-    const rendered = renderSession(args.session, args);
+    const rendered = await renderTranscript(args);
     if (!rendered.safe) throw new Error(`unsafe transcript after redaction: ${rendered.unsafeAfter.join(", ")}`);
     const body = fs.readFileSync(args.body, "utf8");
     const next = replaceSection(body, rendered.markdown);
@@ -654,7 +919,7 @@ function main() {
         continue;
       }
       try {
-        const rendered = renderSession(candidate.file, { ...args, title: pr.title, url: pr.url });
+        const rendered = await renderTranscript({ ...args, session: candidate.file, title: pr.title, url: pr.url });
         records.push({
           ...pr,
           session: candidate.file,
@@ -676,7 +941,7 @@ function main() {
 }
 
 try {
-  main();
+  await main();
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);

--- a/.agents/skills/agent-transcript/scripts/agent-transcript.test.mjs
+++ b/.agents/skills/agent-transcript/scripts/agent-transcript.test.mjs
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const script = path.resolve(".agents/skills/agent-transcript/scripts/agent-transcript");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "agent-transcript-test-"));
+}
+
+function writeJsonl(file, rows) {
+  fs.writeFileSync(file, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+function run(args, options = {}) {
+  return execFileSync(process.execPath, [script, ...args], {
+    cwd: path.resolve("."),
+    encoding: "utf8",
+    ...options,
+  });
+}
+
+function writeFakeCodex(dir) {
+  const script = path.join(dir, "fake-codex.mjs");
+  fs.writeFileSync(
+    script,
+    `import readline from "node:readline";
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.id === 1) {
+    if (process.env.FAKE_CODEX_OVERSIZE === "stdout") {
+      process.stdout.write("x".repeat(21 * 1024 * 1024));
+      return;
+    }
+    if (process.env.FAKE_CODEX_OVERSIZE === "stderr") {
+      process.stderr.write("x".repeat(21 * 1024 * 1024));
+      return;
+    }
+    console.log(JSON.stringify({ id: 1, result: {} }));
+  } else if (message.id === 2) {
+    console.log(JSON.stringify({ id: 2, error: { code: -32600, message: "thread not loaded" } }));
+  } else if (message.id === 3) {
+    if (
+      message.params.path !== process.env.FAKE_EXPECTED_ROLLOUT_PATH ||
+      message.params.threadId !== "11111111-2222-4333-8444-555555555555"
+    ) {
+      console.log(JSON.stringify({ id: 3, error: { code: -32602, message: "missing resume path or thread id" } }));
+      return;
+    }
+    console.log(JSON.stringify({
+      id: 3,
+      result: {
+        thread: {
+          turns: [{ items: [
+            { type: "userMessage", content: [{ type: "text", text: "Scoped request." }] },
+            { type: "agentMessage", text: "Scoped response." }
+          ] }]
+        }
+      }
+    }));
+  }
+});
+`,
+  );
+  const posix = path.join(dir, "codex");
+  fs.writeFileSync(posix, `#!/bin/sh\nexec node "$(dirname "$0")/fake-codex.mjs" "$@"\n`);
+  fs.chmodSync(posix, 0o755);
+  fs.writeFileSync(path.join(dir, "codex.cmd"), `@node "%~dp0\\fake-codex.mjs" %*\r\n`);
+  return script;
+}
+
+test("render redacts common secrets and local identifiers", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Use /Users/ahmed/project, email person@example.com, and header Bearer abcdefghijklmnopqrstuvwxyz123456.",
+          },
+        ],
+      },
+    },
+    {
+      type: "response_item",
+      payload: { role: "assistant", content: [{ type: "text", text: "Done." }] },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /\[LOCAL_PATH\]/);
+  assert.match(output, /\[REDACTED_EMAIL\]/);
+  assert.match(output, /\[REDACTED_AUTH_HEADER\]/);
+  assert.doesNotMatch(output, /person@example\.com/);
+  assert.doesNotMatch(output, /abcdefghijklmnopqrstuvwxyz123456/);
+});
+
+test("render drops raw tool outputs but keeps a compact tool summary", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: { role: "user", content: [{ type: "text", text: "Run tests." }] },
+    },
+    {
+      type: "response_item",
+      payload: { type: "function_call", name: "exec_command", arguments: "npm test" },
+    },
+    {
+      type: "response_item",
+      payload: {
+        type: "function_call_output",
+        output: "raw output with sk-abcdefghijklmnopqrstuvwxyz123456",
+      },
+    },
+  ]);
+
+  const output = run(["render", "--session", session]);
+  assert.match(output, /tool summary/);
+  assert.match(output, /1 execute/);
+  assert.doesNotMatch(output, /raw output/);
+  assert.doesNotMatch(output, /sk-abcdefghijklmnopqrstuvwxyz123456/);
+});
+
+test("append-body replaces an existing transcript section", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "session.jsonl");
+  const body = path.join(dir, "body.md");
+  writeJsonl(session, [
+    {
+      type: "response_item",
+      payload: { role: "user", content: [{ type: "text", text: "New scoped work." }] },
+    },
+    {
+      type: "response_item",
+      payload: { role: "assistant", content: [{ type: "text", text: "Implemented." }] },
+    },
+  ]);
+  fs.writeFileSync(
+    body,
+    "# PR\n\n<!-- agent-transcript:start -->\nold transcript\n<!-- agent-transcript:end -->\n",
+  );
+
+  const output = run(["append-body", "--body", body, "--session", session]);
+  assert.match(output, /# PR/);
+  assert.match(output, /New scoped work/);
+  assert.doesNotMatch(output, /old transcript/);
+  assert.equal((output.match(/agent-transcript:start/g) || []).length, 1);
+});
+
+test("app-server rendering resumes a persisted thread when thread/read is not loaded", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "11111111-2222-4333-8444-555555555555.jsonl");
+  writeJsonl(session, []);
+  const fakeCodex = writeFakeCodex(dir);
+
+  const output = run(["render", "--session", session, "--app-server"], {
+    env: {
+      ...process.env,
+      AGENT_TRANSCRIPT_CODEX_BIN: process.execPath,
+      AGENT_TRANSCRIPT_CODEX_PREFIX_ARGS: JSON.stringify([fakeCodex]),
+      FAKE_EXPECTED_ROLLOUT_PATH: path.resolve(session),
+    },
+  });
+
+  assert.match(output, /codex app-server thread\/read or thread\/resume with turns/);
+  assert.match(output, /Scoped request\./);
+  assert.match(output, /Scoped response\./);
+});
+
+test("app-server rendering rejects oversized transport responses", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "11111111-2222-4333-8444-555555555555.jsonl");
+  writeJsonl(session, []);
+  const fakeCodex = writeFakeCodex(dir);
+
+  assert.throws(
+    () =>
+      run(["render", "--session", session, "--app-server"], {
+        env: {
+          ...process.env,
+          AGENT_TRANSCRIPT_CODEX_BIN: process.execPath,
+          AGENT_TRANSCRIPT_CODEX_PREFIX_ARGS: JSON.stringify([fakeCodex]),
+          FAKE_CODEX_OVERSIZE: "stdout",
+        },
+      }),
+    /app-server response exceeded 20971520 bytes/,
+  );
+});
+
+test("app-server rendering rejects oversized stderr", () => {
+  const dir = tempDir();
+  const session = path.join(dir, "11111111-2222-4333-8444-555555555555.jsonl");
+  writeJsonl(session, []);
+  const fakeCodex = writeFakeCodex(dir);
+
+  assert.throws(
+    () =>
+      run(["render", "--session", session, "--app-server"], {
+        env: {
+          ...process.env,
+          AGENT_TRANSCRIPT_CODEX_BIN: process.execPath,
+          AGENT_TRANSCRIPT_CODEX_PREFIX_ARGS: JSON.stringify([fakeCodex]),
+          FAKE_CODEX_OVERSIZE: "stderr",
+        },
+      }),
+    /app-server output exceeded 20971520 bytes/,
+  );
+});
+
+test("find scans CLAUDE_CONFIG_DIR projects and labels them as Claude", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  const projectDir = path.join(dir, "projects", "-tmp-agent-transcript");
+  fs.mkdirSync(projectDir, { recursive: true });
+  const session = path.join(projectDir, "11111111-2222-4333-8444-555555555555.jsonl");
+  writeJsonl(session, [
+    { type: "user", message: { role: "user", content: "claude-config-dir-marker" } },
+    { type: "assistant", message: { role: "assistant", content: "Done." } },
+  ]);
+
+  const output = run(
+    ["find", "--query", "claude-config-dir-marker", "--since-days", "1", "--max-files", "20"],
+    {
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        CLAUDE_CONFIG_DIR: `${dir}${path.sep}`,
+      },
+    },
+  );
+  const matches = JSON.parse(output);
+
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].file, session);
+  assert.equal(matches[0].agent, "claude");
+});
+
+test("find labels explicit roots under trailing-slash CLAUDE_CONFIG_DIR as Claude", () => {
+  const dir = tempDir();
+  const home = tempDir();
+  const projectRoot = path.join(dir, "projects");
+  const projectDir = path.join(projectRoot, "-tmp-agent-transcript");
+  fs.mkdirSync(projectDir, { recursive: true });
+  const session = path.join(projectDir, "22222222-3333-4444-8555-666666666666.jsonl");
+  writeJsonl(session, [
+    { type: "user", message: { role: "user", content: "claude-config-dir-explicit-root-marker" } },
+    { type: "assistant", message: { role: "assistant", content: "Done." } },
+  ]);
+
+  const output = run(
+    [
+      "find",
+      "--query",
+      "claude-config-dir-explicit-root-marker",
+      "--since-days",
+      "1",
+      "--max-files",
+      "20",
+      "--root",
+      projectRoot,
+    ],
+    {
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        CLAUDE_CONFIG_DIR: `${dir}${path.sep}`,
+      },
+    },
+  );
+  const matches = JSON.parse(output);
+
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].file, session);
+  assert.equal(matches[0].agent, "claude");
+});

--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: crabbox
 description: Use the Crabbox wrapper for OpenClaw remote validation across Linux, macOS, Windows, and WSL2, including delegated Blacksmith Testbox proof. Report the actual provider and id.
+metadata:
+  version: "2026-05-27"
 ---
 
 # Crabbox
@@ -381,6 +383,9 @@ Use these on debugging runs before inventing ad hoc logging:
   `coverage`, JUnit XML, and nearby logs. Treat as secret-bearing until reviewed.
 - `--keep-on-failure`: leave a failed one-shot lease alive for live debugging
   until idle/TTL expiry. Useful on direct providers and delegated one-shots.
+- `--results-auto`: after test commands, scan common JUnit XML filenames and
+  feed them into the failure digest. Use explicit `--junit <path>` for
+  nonstandard result paths or when auto discovery misses a framework.
 - `--timing-json`: final machine-readable timing. Add
   `echo CRABBOX_PHASE:install`, `CRABBOX_PHASE:test`, etc. in long shell
   commands; direct providers and Blacksmith Testbox both report them as
@@ -581,6 +586,8 @@ Useful WebVNC commands:
 ../crabbox/bin/crabbox desktop key --provider hetzner --id <cbx_id-or-slug> ctrl+l
 ../crabbox/bin/crabbox artifacts collect --id <cbx_id-or-slug> --all --output artifacts/<slug>
 ../crabbox/bin/crabbox artifacts publish --dir artifacts/<slug> --pr <number>
+../crabbox/bin/crabbox artifacts list <artifact-manifest.json-or-url>
+../crabbox/bin/crabbox artifacts pull <artifact-manifest.json-or-url> --output /tmp/<slug>-proof
 ```
 
 `desktop launch --webvnc --open` is usually the nicest one-shot: it starts the
@@ -589,6 +596,12 @@ WebVNC portal, and opens the portal. Keep browsers windowed for human QA; use
 `--fullscreen` only for capture/video workflows.
 For human handoff, include `--take-control` so the opened portal viewer gets
 keyboard/mouse control automatically instead of landing as an observer.
+
+Artifact publishing writes and uploads `artifact-manifest.json` by default. Use
+that URL for PR-ready proof handoff; `artifacts pull` verifies size and SHA256.
+Use `--skip-manifest` only for legacy markdown-only output.
+Never push screenshots, videos, or proof assets to the product repo or a temp
+artifact branch.
 
 Human handoff preflight:
 
@@ -813,8 +826,11 @@ Use `--market spot|on-demand` only on AWS warmup/one-shot runs.
   the hydration step.
 - Sync failed: rerun with `--debug`; check changed-file count and whether the
   checkout is dirty.
-- Command failed: rerun only the failing shard/file first. Do not rerun a full
-  suite until the focused failure is understood.
+- Command failed: read the failure digest before rerunning. Use `phase`, `area`,
+  `retryable`, `failed_phase`, `observed_phases`, shell-chain skip notes,
+  `test_results`, and `failed_test` lines to choose the smallest focused rerun.
+  Do not rerun a full suite until the failing shard/file or skipped `&&` segment
+  is understood.
 - Cleanup uncertain: `crabbox list --provider aws`; for explicit Blacksmith
   runs, use `blacksmith testbox list` and stop owned `tbx_...` leases you
   created.


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's zero-setup vendored copies of `agent-transcript` and `crabbox` have drifted from their canonical source in `openclaw/agent-skills`. A raw copy is not safe, however: OpenClaw uses the `.agents/skills` layout and carries stricter provider and source-trust policy for Crabbox.

## Summary

- bring the current canonical `agent-transcript` behavior and tests into OpenClaw
- adapt every transcript command/test path to OpenClaw's `.agents/skills` layout
- make app-server rendering resume a persisted rollout when a fresh app-server reports `thread not loaded`
- bring in compatible canonical Crabbox improvements for result discovery, artifact manifests, and failure triage
- preserve OpenClaw's existing trusted-versus-untrusted source classification, provider defaults, sync rules, and sanitized AWS procedure

Refs #104486.

## Scope

Canonical reference: `openclaw/agent-skills@fbc765e208061abafe8cefa31f99a179201ada67`.

This is an adapted downstream sync, not byte-identical vendoring. The explicit downstream differences are:

- `.agents/skills/...` paths in docs and tests
- `HOME` plus `USERPROFILE` isolation in the cross-platform tests
- `thread/read` to `thread/resume` fallback with an explicit rollout path for persisted Codex sessions
- manual semantic transcript trimming remains required before public insertion; the helper does not claim to automate relevance review
- Crabbox keeps current OpenClaw trust/provider/sync policy and adopts only non-conflicting canonical additions

This PR intentionally does not:

- touch `autoreview`, which was handled separately by #104343
- vendor `behavior-validator`, `handoff`, or `session-viewer`, which remain a maintainer product/ownership decision under #104486
- change which providers may execute untrusted contributor source

## Evidence

OpenClaw-checkout proof on Windows:

- `node --test .agents/skills/agent-transcript/scripts/agent-transcript.test.mjs`: 8 passed
- `node --check .agents/skills/agent-transcript/scripts/agent-transcript`: passed
- `node .agents/skills/agent-transcript/scripts/agent-transcript --help`: passed
- `oxfmt@0.58.0 --check` for the added test: passed
- `git diff --check`: passed

The test suite includes a fake app-server protocol proof that forces `thread/read` to return `thread not loaded`, then verifies that `thread/resume` uses the exact explicit rollout path and renders the persisted turns. Separate tests prove stdout and stderr above the shared 20 MiB transport ceiling are rejected before rendering, and process cleanup is shared by success, failure, and timeout paths.

Real Codex app-server smoke:

- resumed a local persisted session using the current `codex-cli 0.144.1` app-server
- produced a local-only redacted transcript with both section markers
- redaction stats: 1,000 replacements and 5 unsafe blocks omitted
- post-render scan found no raw auth header, private key, or OpenAI-style token pattern
- no transcript content was uploaded or added to this PR

Failed-first evidence:

- the canonical test initially failed from the OpenClaw checkout because it resolved `skills/...`; corrected to `.agents/skills/...`
- the Windows discovery test initially leaked the real user home into its fixture because only `HOME` was overridden; corrected by isolating both `HOME` and `USERPROFILE`
- direct `thread/read` initially returned `thread not loaded`; the current protocol-backed resume fallback is now both test-proven and runtime-smoked

Crabbox security review:

- untrusted contributor/fork code remains restricted to secretless fork CI or sanitized direct AWS Crabbox
- the documented AWS path still requires `--fresh-pr`, `--no-hydrate`, an empty instance profile, public networking, no Tailscale, exact-head verification, and the trusted bootstrap script
- the canonical local-container PR fallback, provider-default rewrites, and reusable `--no-sync` example were deliberately not imported because they conflict with OpenClaw's downstream security/runtime contract
