### PR TITLE
fix(telegram): prevent unlisted API calls from stalling delivery

### DIFF
--- a/extensions/telegram/src/bot.fetch-abort.test.ts
+++ b/extensions/telegram/src/bot.fetch-abort.test.ts
@@ -116,25 +116,28 @@ describe("createTelegramBot fetch abort", () => {
     vi.useRealTimers();
   });
 
-  it("uses the longer outbound text timeout for sendMessage", async () => {
-    vi.useFakeTimers();
-    const fetchSpy = vi.fn(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<AbortSignal>((resolve) => {
-          const signal = init?.signal as AbortSignal;
-          signal.addEventListener("abort", () => resolve(signal), { once: true });
-        }),
-    );
-    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy as unknown as typeof fetch);
+  it.each(["sendMessage", "answerCallbackQuery"])(
+    "uses the 60-second outbound guard for %s",
+    async (method) => {
+      vi.useFakeTimers();
+      const fetchSpy = vi.fn(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<AbortSignal>((resolve) => {
+            const signal = init?.signal as AbortSignal;
+            signal.addEventListener("abort", () => resolve(signal), { once: true });
+          }),
+      );
+      const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy as unknown as typeof fetch);
 
-    const observedSignalPromise = clientFetch("https://api.telegram.org/bot123456:ABC/sendMessage");
-    await vi.advanceTimersByTimeAsync(60_000);
-    const observedSignal = (await observedSignalPromise) as AbortSignal;
+      const observedSignalPromise = clientFetch(`https://api.telegram.org/bot123456:ABC/${method}`);
+      await vi.advanceTimersByTimeAsync(60_000);
+      const observedSignal = (await observedSignalPromise) as AbortSignal;
 
-    expect(observedSignal).toBeInstanceOf(AbortSignal);
-    expect(observedSignal.aborted).toBe(true);
-    vi.useRealTimers();
-  });
+      expect(observedSignal).toBeInstanceOf(AbortSignal);
+      expect(observedSignal.aborted).toBe(true);
+      vi.useRealTimers();
+    },
+  );
 
   it("lets configured timeoutSeconds extend outbound method guards", async () => {
     vi.useFakeTimers();

--- a/extensions/telegram/src/request-timeouts.test.ts
+++ b/extensions/telegram/src/request-timeouts.test.ts
@@ -49,8 +49,13 @@ describe("resolveTelegramRequestTimeoutMs", () => {
     expect(resolveTelegramRequestTimeoutMs("getme", 10)).toBe(15_000);
   });
 
-  it("does not assign hard timeouts to unrelated Telegram methods", () => {
-    expect(resolveTelegramRequestTimeoutMs("answercallbackquery")).toBeUndefined();
+  it("uses the outbound guard for unlisted Telegram methods", () => {
+    expect(resolveTelegramRequestTimeoutMs("answercallbackquery")).toBe(60_000);
+    expect(resolveTelegramRequestTimeoutMs("answercallbackquery", 10)).toBe(60_000);
+    expect(resolveTelegramRequestTimeoutMs("answercallbackquery", 90)).toBe(90_000);
+  });
+
+  it("does not assign a timeout when no Telegram method can be identified", () => {
     expect(resolveTelegramRequestTimeoutMs(null)).toBeUndefined();
   });
 });

--- a/extensions/telegram/src/request-timeouts.ts
+++ b/extensions/telegram/src/request-timeouts.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 
 export const TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS = 45_000;
-const TELEGRAM_OUTBOUND_TEXT_REQUEST_TIMEOUT_MS = 60_000;
+const TELEGRAM_DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 const TELEGRAM_DEFAULT_LONG_POLL_TIMEOUT_SECONDS = 30;
 const TELEGRAM_LONG_POLL_ABORT_MARGIN_SECONDS = 5;
 
@@ -24,10 +24,10 @@ const TELEGRAM_REQUEST_TIMEOUTS_MS = {
   pinchatmessage: 15_000,
   sendanimation: 30_000,
   sendaudio: 30_000,
-  sendchataction: TELEGRAM_OUTBOUND_TEXT_REQUEST_TIMEOUT_MS,
+  sendchataction: TELEGRAM_DEFAULT_REQUEST_TIMEOUT_MS,
   senddocument: 30_000,
-  sendmessage: TELEGRAM_OUTBOUND_TEXT_REQUEST_TIMEOUT_MS,
-  sendmessagedraft: TELEGRAM_OUTBOUND_TEXT_REQUEST_TIMEOUT_MS,
+  sendmessage: TELEGRAM_DEFAULT_REQUEST_TIMEOUT_MS,
+  sendmessagedraft: TELEGRAM_DEFAULT_REQUEST_TIMEOUT_MS,
   sendphoto: 30_000,
   sendvideo: 30_000,
   sendvoice: 30_000,
@@ -59,7 +59,7 @@ export function resolveTelegramRequestTimeoutMs(
   }
   const baseTimeoutMs =
     TELEGRAM_REQUEST_TIMEOUTS_MS[method as keyof typeof TELEGRAM_REQUEST_TIMEOUTS_MS] ??
-    TELEGRAM_OUTBOUND_TEXT_REQUEST_TIMEOUT_MS;
+    TELEGRAM_DEFAULT_REQUEST_TIMEOUT_MS;
   return Math.max(baseTimeoutMs, resolveConfiguredTelegramRequestTimeoutMs(timeoutSeconds) ?? 0);
 }
 

--- a/extensions/telegram/src/request-timeouts.ts
+++ b/extensions/telegram/src/request-timeouts.ts
@@ -54,11 +54,12 @@ export function resolveTelegramRequestTimeoutMs(
   if (!method) {
     return undefined;
   }
-  const baseTimeoutMs =
-    TELEGRAM_REQUEST_TIMEOUTS_MS[method as keyof typeof TELEGRAM_REQUEST_TIMEOUTS_MS];
-  if (baseTimeoutMs === undefined || method === "getupdates") {
-    return baseTimeoutMs;
+  if (method === "getupdates") {
+    return TELEGRAM_REQUEST_TIMEOUTS_MS.getupdates;
   }
+  const baseTimeoutMs =
+    TELEGRAM_REQUEST_TIMEOUTS_MS[method as keyof typeof TELEGRAM_REQUEST_TIMEOUTS_MS] ??
+    TELEGRAM_OUTBOUND_TEXT_REQUEST_TIMEOUT_MS;
   return Math.max(baseTimeoutMs, resolveConfiguredTelegramRequestTimeoutMs(timeoutSeconds) ?? 0);
 }
 


### PR DESCRIPTION
Closes #104524

AI-assisted: yes. I used an OpenAI coding agent, reviewed the resulting change, and understand the timeout behavior.

## What Problem This Solves

Fixes an issue where Telegram users could have all outbound replies for a session stall for roughly eight minutes when an API call used a method that was not explicitly listed in the client timeout table.

## Why This Change Was Made

Every identified Telegram API method except `getUpdates` now receives the existing 60-second outbound timeout as a default. Explicit method-specific guards remain unchanged, higher configured timeouts are still honored, and requests whose method cannot be identified remain untouched.

## User Impact

A newly introduced or otherwise unlisted Telegram API method can no longer silently fall back to grammY's approximately 500-second timeout and park the serialized delivery lane. Its client-side guard defaults to 60 seconds unless the operator configured a higher timeout.

## Evidence

- `pnpm exec vitest run extensions/telegram/src/request-timeouts.test.ts` — 1 file, 15 tests passed.
- `pnpm test:extension telegram` — 142 files, 2,666 tests passed.
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/request-timeouts.ts extensions/telegram/src/request-timeouts.test.ts` — 0 warnings, 0 errors.
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/request-timeouts.ts extensions/telegram/src/request-timeouts.test.ts` — formatting passed.
- `NODE_OPTIONS='--max-old-space-size=2300' node scripts/run-tsgo.mjs -p extensions/telegram/tsconfig.json --noEmit` — passed.
- `git diff --check` — passed.

No live Telegram probe was run because this checkout has no test-bot credentials. The linked issue includes the production incident evidence and reports the same fallback behavior running in production.

### Controlled runtime proof

A credential-free controlled Bot API endpoint exercised the real `createTelegramClientFetch` and `AbortController` path on this PR branch. All three requests ran concurrently against delayed local HTTP responses; no Telegram token or external API was used.

```text
controlled_endpoint=http://127.0.0.1:<redacted>/bot<redacted>/METHOD
unlisted-default: answerCallbackQuery, server delay 65000ms -> aborted after 60004ms: Telegram answercallbackquery timed out after 60000ms
unlisted-configured-override: answerCallbackQuery, configured timeout 70s, server delay 62000ms -> HTTP 200 after 62030ms
getUpdates-unchanged: getUpdates, configured timeout 70s, server delay 65000ms -> aborted after 45015ms: Telegram getupdates timed out after 45000ms
proof_result=PASS
```

This demonstrates the 60-second fallback through the actual fetch wrapper, the existing higher configured-timeout escape hatch, and the unchanged 45-second `getUpdates` guard.