### PR TITLE
fix: startup migrations block on recoverable legacy state

### DIFF
--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -577,6 +577,30 @@ describe("codex doctor contract", () => {
     },
   );
 
+  it("ignores metadata-only session rows when proving zero ownership", async () => {
+    const fixture = await createBindingMigrationFixture({
+      name: "orphan-metadata-row",
+      sessionIndex: {
+        "agent:main:metadata-only": {
+          label: "Waiting for first turn",
+          updatedAt: 1,
+        },
+      },
+      threadId: "thread-orphan",
+    });
+
+    await expect(fixture.migration.migrateLegacyState(fixture.params)).resolves.toEqual({
+      changes: [
+        "Migrated 1 Codex app-server binding sidecar(s) to plugin state and archived the legacy sources",
+      ],
+      warnings: [],
+    });
+    await expect(fs.access(fixture.sidecarPath)).rejects.toThrow();
+    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
+
+    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+  });
+
   it("retains a zero-owner sidecar when canonical plugin state is malformed", async () => {
     const fixture = await createBindingMigrationFixture({
       name: "orphan-invalid-state",

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -210,6 +210,11 @@ async function readLegacySessionIndex(
     if (!isRecord(value)) {
       return { failure: `session index ${storePath} has invalid entries` };
     }
+    // Metadata-only rows have no transcript identity and therefore cannot own
+    // a binding sidecar. Runtime normalization preserves this shipped shape.
+    if (value.sessionId === undefined) {
+      continue;
+    }
     const rawSessionId = typeof value.sessionId === "string" ? value.sessionId.trim() : "";
     const sessionId = normalizedByKey.get(sessionKey)?.sessionId?.trim() ?? "";
     const sessionFile = value.sessionFile;

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -1200,7 +1200,7 @@ describe("memory-core doctor dreaming migration", () => {
     expect(retryEntriesAfter).toEqual(retryEntriesBefore);
   });
 
-  it("leaves the legacy memory sidecar in place when canonical rows conflict", async () => {
+  it("keeps canonical rows and archives a conflicting derived legacy index", async () => {
     const stateDir = path.join(rootDir, "state");
     const legacyPath = path.join(stateDir, "memory", "main.sqlite");
     const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
@@ -1209,22 +1209,21 @@ describe("memory-core doctor dreaming migration", () => {
 
     const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
 
-    expect(result.warnings).toEqual([
-      expect.stringContaining(
-        "Skipped Memory Core legacy memory index import for agent main because legacy rows could not be imported: Error: legacy memory files rows conflict",
-      ),
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Resolved Memory Core legacy memory index conflict for agent main by keeping canonical per-agent SQLite rows",
+      expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
     ]);
-    expect(result.changes).toEqual([]);
     expect(readMemoryRows(agentPath)).toEqual({
       sources: [{ path: "MEMORY.md", source: "memory", hash: "canonical-file-hash" }],
       chunks: [{ id: "canonical-chunk", text: "canonical memory remains authoritative" }],
       cache: [],
     });
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
-    await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
+    await expect(fs.access(legacyPath)).rejects.toThrow();
+    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
   });
 
-  it("copies conflicting custom sidecars to the canonical retry path", async () => {
+  it("archives conflicting custom derived indexes without creating a retry copy", async () => {
     const stateDir = path.join(rootDir, "state");
     const legacyPath = path.join(rootDir, "custom-memory", "main.sqlite");
     const retryPath = path.join(stateDir, "memory", "main.sqlite");
@@ -1255,19 +1254,14 @@ describe("memory-core doctor dreaming migration", () => {
     );
 
     expect(result.changes).toEqual([
-      `Copied Memory Core legacy memory index sidecar retry path -> ${retryPath}`,
+      "Resolved Memory Core legacy memory index conflict for agent main by keeping canonical per-agent SQLite rows",
+      expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
     ]);
-    expect(result.warnings).toEqual([
-      expect.stringContaining(
-        "Skipped Memory Core legacy memory index import for agent main because legacy rows could not be imported: Error: legacy memory files rows conflict",
-      ),
-    ]);
-    expect(retryPreview?.preview).toEqual([
-      `- Memory Core legacy memory index: ${retryPath} -> ${agentPath}`,
-    ]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
-    await expect(fs.access(retryPath)).resolves.toBeUndefined();
-    await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
+    expect(result.warnings).toEqual([]);
+    expect(retryPreview).toBeNull();
+    await expect(fs.access(legacyPath)).rejects.toThrow();
+    await expect(fs.access(retryPath)).rejects.toThrow();
+    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
   });
 
   it("copies custom sidecars to the retry path when canonical database setup fails", async () => {

--- a/extensions/memory-core/doctor-contract-api.ts
+++ b/extensions/memory-core/doctor-contract-api.ts
@@ -106,6 +106,12 @@ type LegacyMemorySidecarImportResult = {
 
 type MemoryFtsTokenizer = "unicode61" | "trigram";
 
+class LegacyMemoryRowsConflictError extends Error {
+  constructor(readonly tableName: string) {
+    super(`legacy memory ${tableName} rows conflict with canonical memory index rows`);
+  }
+}
+
 function tableExists(db: DatabaseSync, schema: string, tableName: string): boolean {
   return Boolean(db.prepare(`SELECT 1 FROM ${schema}.sqlite_master WHERE name = ?`).get(tableName));
 }
@@ -208,7 +214,7 @@ function formatLegacyVectorRows(count: number | undefined): string {
 function assertLegacyRowsCopied(db: DatabaseSync, query: string, tableName: string): void {
   const row = db.prepare(query).get() as { missing?: unknown } | undefined;
   if (Number(row?.missing ?? 0) > 0) {
-    throw new Error(`legacy memory ${tableName} rows conflict with canonical memory index rows`);
+    throw new LegacyMemoryRowsConflictError(tableName);
   }
 }
 
@@ -933,6 +939,14 @@ async function migrateLegacyMemorySidecarSource(params: {
         requireVectorRows: vectorEnabled,
       });
     } catch (err) {
+      if (err instanceof LegacyMemoryRowsConflictError && err.tableName === "files") {
+        // Memory index rows are derived from canonical memory sources. Keep the
+        // current per-agent index and let normal sync rebuild any stale entries.
+        params.changes.push(
+          `Resolved Memory Core legacy memory index conflict for agent ${params.source.agentId} by keeping canonical per-agent SQLite rows`,
+        );
+        return { archiveReady: true };
+      }
       await preserveLegacyMemorySidecarRetryPath(params);
       params.warnings.push(
         `Skipped Memory Core legacy memory index import for agent ${params.source.agentId} because legacy rows could not be imported: ${String(err)}`,


### PR DESCRIPTION
Related: #103281

## What Problem This Solves

Fixes an issue where container upgrades could remain unhealthy when startup migrations encountered recoverable legacy Codex session metadata and Memory Core index conflicts. The gateway would repeatedly refuse readiness even though the Codex sidecars had no possible session owner and the canonical Memory Core index was already authoritative.

## Why This Change Was Made

Codex ownership discovery now ignores metadata-only session rows that have no transcript identity, while retaining fail-closed validation for rows that claim a session ID. Memory Core now treats only a legacy `files` row conflict as a derived-index convergence case: it keeps the canonical per-agent SQLite rows and archives the obsolete sidecar. Other malformed, ambiguous, vector, FTS, metadata, and reference conflicts remain untouched for review.

## User Impact

Affected upgrades can complete during normal gateway startup without a separate `openclaw doctor --fix` container. Existing canonical session and memory data remains authoritative, and genuinely indeterminate migration state still blocks readiness instead of being discarded.

## Evidence

- Regressions reproduced the current-main blockers before the fix: a metadata-only session row caused `session index ... has invalid entries`, and conflicting legacy Memory Core `files` rows prevented archival.
- Rebased-head focused plugin contract suites: 51 tests passed (`23` Codex, `28` Memory Core) on Blacksmith Testbox `tbx_01kx8tzebxmewt0db5a9msxxxn`.
- `pnpm check:changed` passed on Blacksmith Testbox, including extension production/test typechecks, lint, database-first storage guard, runtime-sidecar-loader guard, and import-cycle check.
- Pinned `oxfmt` 0.58.0 check passed on all four changed files.
- Fresh local autoreview reported no accepted or actionable findings.
- Live container proof: a patch-identical image built from pre-rebase commit `e05f5a1adfa` upgraded the affected installation against its existing mounted volume and reached a healthy gateway startup without a separate doctor run.

AI-assisted: yes, with Codex. The author reviewed the migration behavior and confirmed the live container upgrade.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Selected redacted Codex session transcript</summary>

````text
source: local Codex session
redaction: local paths, email, raw tool output, environment and authentication details omitted

[user]
I built and updated to main, and startup still refuses readiness:
- Left 1093 Codex binding sidecars in place because the session index has invalid entries.
- Two Memory Core legacy indexes conflict with canonical memory index rows.

[assistant]
This is a narrower follow-up to #103281. Runtime normalization accepts metadata-only session rows without `sessionId`, but the migration rejects that shape and makes ownership indeterminate for every sidecar. Memory Core's file/chunk index is derived and rebuildable, so a legacy `files` conflict can safely keep canonical per-agent rows and archive the obsolete sidecar. Genuine malformed session identities and non-`files` integrity conflicts must remain blocking.

[assistant]
The first implementation was too broad; existing integrity tests showed it would also suppress vector, FTS, metadata and schema conflicts. The fix was narrowed to `files` conflicts only.

[assistant]
Focused proof is green: Codex 23/23 and Memory Core 28/28. The full changed-file gate and fresh autoreview are also clean.

[user]
Will the fix clear the container upgrade during normal startup, or will a separate `openclaw doctor --fix` container still be required?

[assistant]
For these exact blockers, the patched image should converge automatically against the existing mounted volume: metadata-only rows cannot own Codex sidecars, canonical Memory Core rows remain authoritative, and the obsolete derived sidecars are archived. Truly malformed or ambiguous state still fails closed.

[user]
I have confirmed my container upgrade is healthy with your fixes.
````

</details>
<!-- agent-transcript:end -->
