### PR TITLE
fix(transport): strip MiniMax stream-boundary marker and sanitize text_delta

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -2392,6 +2392,76 @@ describe("anthropic transport stream", () => {
     );
   });
 
+  it("strips MiniMax stream-boundary markers from text_delta payloads (#104403)", async () => {
+    // MiniMax's Anthropic-compat endpoint injects `[e~[` as a stream boundary
+    // sentinel inside content_block_delta text fields. The transport must
+    // sanitize both the accumulated block text and the emitted text_delta
+    // event so the marker never reaches assistantTexts or user-visible output.
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "[e~[hello" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: " world[e~[" },
+        },
+        {
+          type: "content_block_stop",
+          index: 0,
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 6, output_tokens: 2 },
+        },
+      ]),
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        makeAnthropicTransportModel({
+          provider: "minimax",
+          baseUrl: "https://api.minimax.io/anthropic",
+        }),
+        {
+          messages: [{ role: "user", content: "hello" }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "minimax-key",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const textDeltas: string[] = [];
+    for await (const event of stream as AsyncIterable<{
+      type?: string;
+      delta?: string;
+    }>) {
+      if (event.type === "text_delta" && typeof event.delta === "string") {
+        textDeltas.push(event.delta);
+      }
+    }
+    const result = await stream.result();
+
+    expect(result.content).toEqual([{ type: "text", text: "hello world" }]);
+    expect(result.stopReason).toBe("stop");
+    // No emitted delta carries the boundary marker.
+    expect(textDeltas.some((delta) => delta.includes("[e~["))).toBe(false);
+    expect(textDeltas).toEqual(["hello", " world"]);
+  });
+
   it("skips malformed tools when building Anthropic payloads", async () => {
     await runTransportStream(
       makeAnthropicTransportModel(),

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -1654,11 +1654,12 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               delta?.type === "text_delta" &&
               typeof delta.text === "string"
             ) {
-              block.text += delta.text;
+              const sanitizedDelta = sanitizeTransportPayloadText(delta.text);
+              block.text += sanitizedDelta;
               eventSink.push({
                 type: "text_delta",
                 contentIndex: index,
-                delta: delta.text,
+                delta: sanitizedDelta,
                 partial: output as never,
               });
               continue;

--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -20,6 +20,20 @@ describe("transport stream shared helpers", () => {
     expect(sanitizeTransportPayloadText("emoji 🙈 ok")).toBe("emoji 🙈 ok");
   });
 
+  it("strips MiniMax stream-boundary markers from text payloads (#104403)", () => {
+    // MiniMax's Anthropic-compat endpoint injects `[e~[` as a stream boundary
+    // sentinel inside content_block_delta text fields. Shared sanitization
+    // must strip these markers wherever they appear.
+    expect(sanitizeTransportPayloadText("[e~[hello")).toBe("hello");
+    expect(sanitizeTransportPayloadText("hello[e~[")).toBe("hello");
+    expect(sanitizeTransportPayloadText("hello[e~[world")).toBe("helloworld");
+    expect(sanitizeTransportPayloadText("[e~[[e~[multi")).toBe("multi");
+    expect(sanitizeTransportPayloadText("plain text")).toBe("plain text");
+    // Payloads that become empty after stripping fall back to empty string,
+    // not to the original text.
+    expect(sanitizeTransportPayloadText("[e~[")).toBe("");
+  });
+
   it("returns empty string for nullish payloads instead of throwing", () => {
     expect(sanitizeTransportPayloadText(undefined as unknown as string)).toBe("");
     expect(sanitizeTransportPayloadText(null as unknown as string)).toBe("");

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -52,7 +52,7 @@ export function sanitizeTransportPayloadText(text: string): string {
   // Strip known provider-injected SSE framing markers that leak into text
   // content. MiniMax's Anthropic-compat endpoint injects `[e~[` as a stream
   // boundary sentinel inside content_block_delta text fields (#104403).
-  let result = text.replace(/\[e~\[/g, "");
+  const result = text.replace(/\[e~\[/g, "");
   return sanitizeSurrogates(result);
 }
 

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -49,7 +49,11 @@ export function sanitizeTransportPayloadText(text: string): string {
   if (typeof text !== "string") {
     return "";
   }
-  return sanitizeSurrogates(text);
+  // Strip known provider-injected SSE framing markers that leak into text
+  // content. MiniMax's Anthropic-compat endpoint injects `[e~[` as a stream
+  // boundary sentinel inside content_block_delta text fields (#104403).
+  let result = text.replace(/\[e~\[/g, "");
+  return sanitizeSurrogates(result);
 }
 
 export function sanitizeNonEmptyTransportPayloadText(


### PR DESCRIPTION
## What Problem This Solves

MiniMax's Anthropic-compat endpoint injects `[e~[` as a stream-boundary sentinel inside `content_block_delta` text fields. The marker leaked into assistantTexts, trajectory JSONL, and user-visible messages because:

1. `sanitizeTransportPayloadText` only stripped surrogates, not provider-injected framing markers
2. The `text_delta` handler in `anthropic-transport-stream.ts` appended `delta.text` directly without calling `sanitizeTransportPayloadText`, unlike the `content_block_start` and `reasoning_content` delta paths

## Fix

- Extend `sanitizeTransportPayloadText` to strip the `[e~[` marker globally. This helper is shared across all provider transports, so every provider benefits from the cleanup.
- Add the missing `sanitizeTransportPayloadText` call in the `text_delta` path of `anthropic-transport-stream.ts` for consistency with the other content paths.

## Evidence

### Before fix: boundary markers leak into output

```
SSE delta text: "[e~[hello"
Accumulated block.text: "[e~[hello"
Emitted text_delta event delta: "[e~[hello"
```

### After fix: markers stripped, content preserved

```
SSE delta text: "[e~[hello"
Accumulated block.text: "hello"
Emitted text_delta event delta: "hello"
```

## Test plan

- [x] New unit test in `transport-stream-shared.test.ts`: covers `[e~[` stripping (prefix, suffix, middle, multi, passthrough, empty-after-strip)
- [x] New integration test in `anthropic-transport-stream.test.ts`: asserts the MiniMax SSE path strips the boundary marker from both the accumulated block text and the emitted `text_delta` events
- [x] Other providers' streams unaffected — shared helper still preserves regular text, emoji, and surrogates