### PR TITLE
fix(exec): long retained process output corrupts boundary emoji

### DIFF
--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -382,4 +382,37 @@ describe("process supervisor", () => {
     expect(exit.stdout.endsWith("stdout-tail")).toBe(true);
     expect(exit.stderr.endsWith("stderr-tail")).toBe(true);
   });
+
+  it("keeps retained stdout and stderr tails on complete UTF-16 boundaries", async () => {
+    const adapter = createStubChildAdapter();
+    createChildAdapterMock.mockResolvedValue(adapter);
+
+    const supervisor = createProcessSupervisor();
+    const maxCapturedOutputChars = 256;
+    const marker = `[openclaw: captured stdout truncated to last ${maxCapturedOutputChars} chars]\n`;
+    const tailChars = maxCapturedOutputChars - marker.length;
+    const evictedPrefixChars = marker.length + 1;
+    const boundaryChunk = "a".repeat(evictedPrefixChars - 1) + "😀" + "z".repeat(tailChars - 1);
+    const run = await spawnChild(supervisor, {
+      sessionId: "s-capture-unicode",
+      argv: createWriteStdoutArgv(boundaryChunk),
+      timeoutMs: 1_000,
+      stdinMode: "pipe-closed",
+      maxCapturedOutputChars,
+    });
+
+    adapter.emitStdout(boundaryChunk);
+    adapter.emitStderr(boundaryChunk);
+    adapter.settle(0);
+
+    const exit = await run.wait();
+    const unpairedSurrogate =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
+    expect(exit.stdout).not.toMatch(unpairedSurrogate);
+    expect(exit.stderr).not.toMatch(unpairedSurrogate);
+    expect(exit.stdout).not.toContain("\uFFFD");
+    expect(exit.stderr).not.toContain("\uFFFD");
+    expect(exit.stdout.length).toBeLessThanOrEqual(maxCapturedOutputChars);
+    expect(exit.stderr.length).toBeLessThanOrEqual(maxCapturedOutputChars);
+  });
 });

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -345,21 +345,25 @@ describe("process supervisor", () => {
     expect(exit.stdout).toBe("");
   });
 
-  it("bounds retained stdout and stderr while streaming full chunks", async () => {
+  it("bounds retained output on UTF-16 boundaries while streaming full chunks", async () => {
     const adapter = createStubChildAdapter();
     createChildAdapterMock.mockResolvedValue(adapter);
 
     const supervisor = createProcessSupervisor();
     let streamedStdout = "";
     let streamedStderr = "";
-    const stdoutChunk = `${"a".repeat(300)}stdout-tail`;
-    const stderrChunk = `${"b".repeat(300)}stderr-tail`;
+    const maxCapturedOutputChars = 256;
+    const stdoutMarker = `[openclaw: captured stdout truncated to last ${maxCapturedOutputChars} chars]\n`;
+    const stderrMarker = `[openclaw: captured stderr truncated to last ${maxCapturedOutputChars} chars]\n`;
+    const retainedChars = maxCapturedOutputChars - stdoutMarker.length - 1;
+    const stdoutChunk = `${"a".repeat(stdoutMarker.length)}😀${"s".repeat(retainedChars)}`;
+    const stderrChunk = `${"b".repeat(stderrMarker.length)}😀${"e".repeat(retainedChars)}`;
     const run = await spawnChild(supervisor, {
       sessionId: "s-capture-cap",
       argv: createWriteStdoutArgv(stdoutChunk),
       timeoutMs: 1_000,
       stdinMode: "pipe-closed",
-      maxCapturedOutputChars: 256,
+      maxCapturedOutputChars,
       onStdout: (chunk) => {
         streamedStdout += chunk;
       },
@@ -375,44 +379,7 @@ describe("process supervisor", () => {
     const exit = await run.wait();
     expect(streamedStdout).toBe(stdoutChunk);
     expect(streamedStderr).toBe(stderrChunk);
-    expect(exit.stdout.length).toBeLessThanOrEqual(256);
-    expect(exit.stderr.length).toBeLessThanOrEqual(256);
-    expect(exit.stdout).toContain("captured stdout truncated");
-    expect(exit.stderr).toContain("captured stderr truncated");
-    expect(exit.stdout.endsWith("stdout-tail")).toBe(true);
-    expect(exit.stderr.endsWith("stderr-tail")).toBe(true);
-  });
-
-  it("keeps retained stdout and stderr tails on complete UTF-16 boundaries", async () => {
-    const adapter = createStubChildAdapter();
-    createChildAdapterMock.mockResolvedValue(adapter);
-
-    const supervisor = createProcessSupervisor();
-    const maxCapturedOutputChars = 256;
-    const marker = `[openclaw: captured stdout truncated to last ${maxCapturedOutputChars} chars]\n`;
-    const tailChars = maxCapturedOutputChars - marker.length;
-    const evictedPrefixChars = marker.length + 1;
-    const boundaryChunk = "a".repeat(evictedPrefixChars - 1) + "😀" + "z".repeat(tailChars - 1);
-    const run = await spawnChild(supervisor, {
-      sessionId: "s-capture-unicode",
-      argv: createWriteStdoutArgv(boundaryChunk),
-      timeoutMs: 1_000,
-      stdinMode: "pipe-closed",
-      maxCapturedOutputChars,
-    });
-
-    adapter.emitStdout(boundaryChunk);
-    adapter.emitStderr(boundaryChunk);
-    adapter.settle(0);
-
-    const exit = await run.wait();
-    const unpairedSurrogate =
-      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
-    expect(exit.stdout).not.toMatch(unpairedSurrogate);
-    expect(exit.stderr).not.toMatch(unpairedSurrogate);
-    expect(exit.stdout).not.toContain("\uFFFD");
-    expect(exit.stderr).not.toContain("\uFFFD");
-    expect(exit.stdout.length).toBeLessThanOrEqual(maxCapturedOutputChars);
-    expect(exit.stderr.length).toBeLessThanOrEqual(maxCapturedOutputChars);
+    expect(exit.stdout).toBe(`${stdoutMarker}${"s".repeat(retainedChars)}`);
+    expect(exit.stderr).toBe(`${stderrMarker}${"e".repeat(retainedChars)}`);
   });
 });

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import { performance } from "node:perf_hooks";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getShellConfig } from "../../agents/shell-utils.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { createChildAdapter } from "./adapters/child.js";
@@ -54,7 +55,7 @@ function appendCapturedOutput(
   }
   const marker = `[openclaw: captured ${stream} truncated to last ${maxChars} chars]\n`;
   const tailChars = Math.max(0, maxChars - marker.length);
-  return `${marker}${next.slice(-tailChars)}`;
+  return `${marker}${sliceUtf16Safe(next, -tailChars)}`;
 }
 
 function isTimeoutReason(reason: TerminationReason) {


### PR DESCRIPTION
## What Problem This Solves

Long supervised stdout/stderr is retained behind a truncation marker. When the capture boundary landed between the two UTF-16 code units of an emoji or another non-BMP character, the retained output could contain a lone surrogate and render as a replacement character in downstream consumers such as on-exit run history.

## Why This Change Was Made

The process supervisor now uses the repository's canonical `sliceUtf16Safe` helper at the capture owner. Streaming callbacks, byte-independent character limits, truncation markers, lifecycle behavior, schemas, and persistence are unchanged.

The maintainer refactor folded the regression into the existing bounded-stream test. One test now proves full streaming, per-stream markers, exact bounded tails, and the surrogate boundary without a parallel fixture; the final patch has one net production line and no net test growth.

## User Impact

**Before:** a long command could expose malformed retained output when truncation bisected a surrogate pair.

**After:** the incomplete pair is dropped and retained stdout/stderr remains well-formed Unicode.

## Evidence

- Changed: `src/process/supervisor/supervisor.ts`
- Regression: `src/process/supervisor/supervisor.test.ts`
- Exact tested head: `c50a6534bddccf8d0cf9c983a9cc64d953967641`
- Sanitized AWS Crabbox: `run_56c83697a6cb`, public network, no Tailscale, no instance profile, no credential hydration
- Command: `pnpm test src/process/supervisor/supervisor.test.ts`
- Result: exit 0
- Fresh autoreview: no findings, correctness confidence 0.98
- Hosted exact-head CI: running

## Real behavior proof

- **Behavior addressed:** bounded supervisor capture no longer retains half of a surrogate pair.
- **Reachability:** child/PTY adapter output -> `appendCapturedOutput` -> `RunExit.stdout` / `RunExit.stderr` -> downstream process consumers.
- **Boundary crossed:** production capture helper for both output streams, with the test also verifying that unbounded streaming callbacks receive the full original chunks.
- **Fix classification:** root-cause fix.
- **Proof gap:** no additional live gateway run was needed; the changed owner is deterministic and its exact production output projection is covered directly.

- [x] AI-assisted (Cursor and Codex)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
