### PR TITLE
fix(file-transfer): audit dir fetch archive size

### DIFF
--- a/extensions/file-transfer/src/shared/node-invoke-policy.stream-errors.test.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.stream-errors.test.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 // File Transfer tests cover archive-policy child-output failures.
 import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -64,11 +65,17 @@ describe("dir.fetch archive policy output lifecycle", () => {
     });
     const { testing } = await importWithSpawn(spawnMock);
 
+    const archive = Buffer.from("archive");
     await expect(
       testing.listDirFetchArchiveEntries({
-        tarBase64: Buffer.from("archive").toString("base64"),
+        tarBase64: archive.toString("base64"),
       }),
-    ).resolves.toEqual({ ok: true, entries: ["ok.txt"] });
+    ).resolves.toEqual({
+      ok: true,
+      entries: ["ok.txt"],
+      sizeBytes: archive.byteLength,
+      sha256: crypto.createHash("sha256").update(archive).digest("hex"),
+    });
   });
 
   it("surfaces UTF-16 safe tar stderr tail when archive listing fails with emoji at projection boundary", async () => {

--- a/extensions/file-transfer/src/shared/node-invoke-policy.test.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import { gzipSync } from "node:zlib";
 import type { OpenClawPluginNodeInvokePolicyContext } from "openclaw/plugin-sdk/plugin-entry";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { appendFileTransferAudit } from "./audit.js";
 import { createFileTransferNodeInvokePolicy } from "./node-invoke-policy.js";
 
 vi.mock("./audit.js", () => ({
@@ -628,6 +629,56 @@ describe("file-transfer node invoke policy", () => {
       expect(requireInvokeParams(invokeNode, 1).preflightOnly).toBeUndefined();
     },
   );
+
+  it("audits dir.fetch archive bytes after a successful transfer", async () => {
+    const policy = createFileTransferNodeInvokePolicy();
+    const tarBase64 = tarEntries({
+      "a.txt": "a",
+    });
+    const tarBytes = Buffer.from(tarBase64, "base64").byteLength;
+    const sha256 = "c".repeat(64);
+    const { ctx } = createCtx({
+      command: "dir.fetch",
+      params: { path: "/tmp/project" },
+    });
+    const invokeNode = vi.mocked(ctx.invokeNode);
+    invokeNode
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          ok: true,
+          path: "/tmp/project",
+          entries: ["a.txt"],
+          fileCount: 1,
+          preflightOnly: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          ok: true,
+          path: "/tmp/project",
+          tarBase64,
+          tarBytes,
+          sha256,
+          fileCount: 1,
+        },
+      });
+
+    const result = await policy.handle(ctx);
+
+    expectResultFields(result, { ok: true });
+    expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        op: "dir.fetch",
+        requestedPath: "/tmp/project",
+        canonicalPath: "/tmp/project",
+        decision: "allowed",
+        sizeBytes: tarBytes,
+        sha256,
+      }),
+    );
+  });
 
   testUnlessWindows(
     "checks final dir.fetch archive entries before returning the archive",

--- a/extensions/file-transfer/src/shared/node-invoke-policy.test.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.test.ts
@@ -630,58 +630,55 @@ describe("file-transfer node invoke policy", () => {
     },
   );
 
-  testUnlessWindows(
-    "audits dir.fetch archive bytes after a successful transfer",
-    async () => {
-      const policy = createFileTransferNodeInvokePolicy();
-      const tarBase64 = tarEntries({
-        "a.txt": "a",
-      });
-      const tarBytes = Buffer.from(tarBase64, "base64").byteLength;
-      const sha256 = "c".repeat(64);
-      const { ctx } = createCtx({
-        command: "dir.fetch",
-        params: { path: "/tmp/project" },
-      });
-      const invokeNode = vi.mocked(ctx.invokeNode);
-      invokeNode
-        .mockResolvedValueOnce({
+  testUnlessWindows("audits dir.fetch archive bytes after a successful transfer", async () => {
+    const policy = createFileTransferNodeInvokePolicy();
+    const tarBase64 = tarEntries({
+      "a.txt": "a",
+    });
+    const tarBytes = Buffer.from(tarBase64, "base64").byteLength;
+    const sha256 = "c".repeat(64);
+    const { ctx } = createCtx({
+      command: "dir.fetch",
+      params: { path: "/tmp/project" },
+    });
+    const invokeNode = vi.mocked(ctx.invokeNode);
+    invokeNode
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
           ok: true,
-          payload: {
-            ok: true,
-            path: "/tmp/project",
-            entries: ["a.txt"],
-            fileCount: 1,
-            preflightOnly: true,
-          },
-        })
-        .mockResolvedValueOnce({
+          path: "/tmp/project",
+          entries: ["a.txt"],
+          fileCount: 1,
+          preflightOnly: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
           ok: true,
-          payload: {
-            ok: true,
-            path: "/tmp/project",
-            tarBase64,
-            tarBytes,
-            sha256,
-            fileCount: 1,
-          },
-        });
-
-      const result = await policy.handle(ctx);
-
-      expectResultFields(result, { ok: true });
-      expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          op: "dir.fetch",
-          requestedPath: "/tmp/project",
-          canonicalPath: "/tmp/project",
-          decision: "allowed",
-          sizeBytes: tarBytes,
+          path: "/tmp/project",
+          tarBase64,
+          tarBytes,
           sha256,
-        }),
-      );
-    },
-  );
+          fileCount: 1,
+        },
+      });
+
+    const result = await policy.handle(ctx);
+
+    expectResultFields(result, { ok: true });
+    expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        op: "dir.fetch",
+        requestedPath: "/tmp/project",
+        canonicalPath: "/tmp/project",
+        decision: "allowed",
+        sizeBytes: tarBytes,
+        sha256,
+      }),
+    );
+  });
 
   testUnlessWindows(
     "checks final dir.fetch archive entries before returning the archive",

--- a/extensions/file-transfer/src/shared/node-invoke-policy.test.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.test.ts
@@ -1,10 +1,11 @@
 // File Transfer tests cover node invoke policy plugin behavior.
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import { gzipSync } from "node:zlib";
 import type { OpenClawPluginNodeInvokePolicyContext } from "openclaw/plugin-sdk/plugin-entry";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { appendFileTransferAudit } from "./audit.js";
-import { createFileTransferNodeInvokePolicy } from "./node-invoke-policy.js";
+import { createFileTransferNodeInvokePolicy, testing } from "./node-invoke-policy.js";
 
 vi.mock("./audit.js", () => ({
   appendFileTransferAudit: vi.fn(async () => undefined),
@@ -44,6 +45,14 @@ function tarEntries(entries: Record<string, string>): string {
   }
   blocks.push(Buffer.alloc(1024));
   return gzipSync(Buffer.concat(blocks)).toString("base64");
+}
+
+function archiveMetadata(tarBase64: string): { tarBytes: number; sha256: string } {
+  const buffer = Buffer.from(tarBase64, "base64");
+  return {
+    tarBytes: buffer.byteLength,
+    sha256: crypto.createHash("sha256").update(buffer).digest("hex"),
+  };
 }
 
 function writeTarString(header: Buffer, offset: number, length: number, value: string): void {
@@ -146,6 +155,13 @@ function requireInvokeParams(
 }
 
 describe("file-transfer node invoke policy", () => {
+  it("maps only transfer payload sizes into audit records", () => {
+    expect(testing.readAuditSizeBytes("file.fetch", { size: 3 })).toBe(3);
+    expect(testing.readAuditSizeBytes("file.write", { size: 4 })).toBe(4);
+    expect(testing.readAuditSizeBytes("dir.fetch", { tarBytes: 999 }, 5)).toBe(5);
+    expect(testing.readAuditSizeBytes("dir.list", { size: 6 })).toBeUndefined();
+  });
+
   it("injects policy-owned limits before invoking the node", async () => {
     const policy = createFileTransferNodeInvokePolicy();
     const { ctx, invokeNode } = createCtx({
@@ -611,8 +627,7 @@ describe("file-transfer node invoke policy", () => {
             ok: true,
             path: "/tmp/project",
             tarBase64,
-            tarBytes: 7,
-            sha256: "c".repeat(64),
+            ...archiveMetadata(tarBase64),
             fileCount: 2,
             entries: ["a.txt", "sub/b.txt"],
           },
@@ -635,8 +650,7 @@ describe("file-transfer node invoke policy", () => {
     const tarBase64 = tarEntries({
       "a.txt": "a",
     });
-    const tarBytes = Buffer.from(tarBase64, "base64").byteLength;
-    const sha256 = "c".repeat(64);
+    const { tarBytes, sha256 } = archiveMetadata(tarBase64);
     const { ctx } = createCtx({
       command: "dir.fetch",
       params: { path: "/tmp/project" },
@@ -680,6 +694,48 @@ describe("file-transfer node invoke policy", () => {
     );
   });
 
+  testUnlessWindows("rejects mismatched dir.fetch archive integrity metadata", async () => {
+    const policy = createFileTransferNodeInvokePolicy();
+    const tarBase64 = tarEntries({ "a.txt": "a" });
+    const { ctx, invokeNode } = createCtx({
+      command: "dir.fetch",
+      params: { path: "/tmp/project" },
+    });
+    invokeNode
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          ok: true,
+          path: "/tmp/project",
+          entries: ["a.txt"],
+          fileCount: 1,
+          preflightOnly: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          ok: true,
+          path: "/tmp/project",
+          tarBase64,
+          tarBytes: 1,
+          sha256: "c".repeat(64),
+          fileCount: 1,
+        },
+      });
+
+    const result = await policy.handle(ctx);
+
+    expectResultFields(result, { ok: false, code: "ARCHIVE_SIZE_MISMATCH" });
+    expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        op: "dir.fetch",
+        decision: "error",
+        errorCode: "ARCHIVE_SIZE_MISMATCH",
+      }),
+    );
+  });
+
   testUnlessWindows(
     "checks final dir.fetch archive entries before returning the archive",
     async () => {
@@ -717,8 +773,7 @@ describe("file-transfer node invoke policy", () => {
             ok: true,
             path: "/home/me",
             tarBase64,
-            tarBytes: 7,
-            sha256: "c".repeat(64),
+            ...archiveMetadata(tarBase64),
             fileCount: 2,
           },
         });
@@ -766,8 +821,7 @@ describe("file-transfer node invoke policy", () => {
           ok: true,
           path: "/tmp/project",
           tarBase64,
-          tarBytes: 7,
-          sha256: "c".repeat(64),
+          ...archiveMetadata(tarBase64),
           fileCount: 5001,
         },
       });

--- a/extensions/file-transfer/src/shared/node-invoke-policy.test.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.test.ts
@@ -630,55 +630,58 @@ describe("file-transfer node invoke policy", () => {
     },
   );
 
-  it("audits dir.fetch archive bytes after a successful transfer", async () => {
-    const policy = createFileTransferNodeInvokePolicy();
-    const tarBase64 = tarEntries({
-      "a.txt": "a",
-    });
-    const tarBytes = Buffer.from(tarBase64, "base64").byteLength;
-    const sha256 = "c".repeat(64);
-    const { ctx } = createCtx({
-      command: "dir.fetch",
-      params: { path: "/tmp/project" },
-    });
-    const invokeNode = vi.mocked(ctx.invokeNode);
-    invokeNode
-      .mockResolvedValueOnce({
-        ok: true,
-        payload: {
-          ok: true,
-          path: "/tmp/project",
-          entries: ["a.txt"],
-          fileCount: 1,
-          preflightOnly: true,
-        },
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        payload: {
-          ok: true,
-          path: "/tmp/project",
-          tarBase64,
-          tarBytes,
-          sha256,
-          fileCount: 1,
-        },
+  testUnlessWindows(
+    "audits dir.fetch archive bytes after a successful transfer",
+    async () => {
+      const policy = createFileTransferNodeInvokePolicy();
+      const tarBase64 = tarEntries({
+        "a.txt": "a",
       });
+      const tarBytes = Buffer.from(tarBase64, "base64").byteLength;
+      const sha256 = "c".repeat(64);
+      const { ctx } = createCtx({
+        command: "dir.fetch",
+        params: { path: "/tmp/project" },
+      });
+      const invokeNode = vi.mocked(ctx.invokeNode);
+      invokeNode
+        .mockResolvedValueOnce({
+          ok: true,
+          payload: {
+            ok: true,
+            path: "/tmp/project",
+            entries: ["a.txt"],
+            fileCount: 1,
+            preflightOnly: true,
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          payload: {
+            ok: true,
+            path: "/tmp/project",
+            tarBase64,
+            tarBytes,
+            sha256,
+            fileCount: 1,
+          },
+        });
 
-    const result = await policy.handle(ctx);
+      const result = await policy.handle(ctx);
 
-    expectResultFields(result, { ok: true });
-    expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        op: "dir.fetch",
-        requestedPath: "/tmp/project",
-        canonicalPath: "/tmp/project",
-        decision: "allowed",
-        sizeBytes: tarBytes,
-        sha256,
-      }),
-    );
-  });
+      expectResultFields(result, { ok: true });
+      expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          op: "dir.fetch",
+          requestedPath: "/tmp/project",
+          canonicalPath: "/tmp/project",
+          decision: "allowed",
+          sizeBytes: tarBytes,
+          sha256,
+        }),
+      );
+    },
+  );
 
   testUnlessWindows(
     "checks final dir.fetch archive entries before returning the archive",

--- a/extensions/file-transfer/src/shared/node-invoke-policy.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.ts
@@ -272,6 +272,14 @@ function readResultPayload(result: { payload?: unknown }): Record<string, unknow
     : null;
 }
 
+function readAuditSizeBytes(
+  command: FileTransferCommand,
+  payload: Record<string, unknown> | null,
+): number | undefined {
+  const value = command === "dir.fetch" ? payload?.tarBytes : payload?.size;
+  return typeof value === "number" ? value : undefined;
+}
+
 function joinRemotePolicyPath(root: string, relPath: string): string {
   const rel = relPath.replace(/\\/gu, "/").replace(/^\.\//u, "");
   if (!rel || rel === ".") {
@@ -944,7 +952,7 @@ async function handleFileTransferInvoke(
     requestedPath,
     canonicalPath,
     decision: "allowed",
-    sizeBytes: typeof payload?.size === "number" ? payload.size : undefined,
+    sizeBytes: readAuditSizeBytes(command, payload),
     sha256: typeof payload?.sha256 === "string" ? payload.sha256 : undefined,
     durationMs: Date.now() - startedAt,
   });

--- a/extensions/file-transfer/src/shared/node-invoke-policy.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.ts
@@ -1,5 +1,6 @@
 // File Transfer plugin module implements node invoke policy behavior.
 import { spawn } from "node:child_process";
+import crypto from "node:crypto";
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type {
   OpenClawPluginNodeInvokePolicy,
@@ -275,9 +276,15 @@ function readResultPayload(result: { payload?: unknown }): Record<string, unknow
 function readAuditSizeBytes(
   command: FileTransferCommand,
   payload: Record<string, unknown> | null,
+  verifiedDirFetchBytes?: number,
 ): number | undefined {
-  const value = command === "dir.fetch" ? payload?.tarBytes : payload?.size;
-  return typeof value === "number" ? value : undefined;
+  if (command === "dir.fetch") {
+    return verifiedDirFetchBytes;
+  }
+  if (command === "dir.list") {
+    return undefined;
+  }
+  return typeof payload?.size === "number" ? payload.size : undefined;
 }
 
 function joinRemotePolicyPath(root: string, relPath: string): string {
@@ -317,7 +324,10 @@ function normalizeTarEntryPath(entry: string): string | null {
 
 async function listDirFetchArchiveEntries(
   payload: Record<string, unknown> | null,
-): Promise<{ ok: true; entries: string[] } | { ok: false; code: string; reason: string }> {
+): Promise<
+  | { ok: true; entries: string[]; sizeBytes: number; sha256: string }
+  | { ok: false; code: string; reason: string }
+> {
   const tarBase64 = typeof payload?.tarBase64 === "string" ? payload.tarBase64 : "";
   if (!tarBase64) {
     return {
@@ -327,8 +337,25 @@ async function listDirFetchArchiveEntries(
     };
   }
   const tarBuffer = Buffer.from(tarBase64, "base64");
+  const sizeBytes = tarBuffer.byteLength;
+  if (typeof payload?.tarBytes === "number" && payload.tarBytes !== sizeBytes) {
+    return {
+      ok: false,
+      code: "ARCHIVE_SIZE_MISMATCH",
+      reason: `dir.fetch archive size mismatch: payload says ${payload.tarBytes} bytes, decoded ${sizeBytes}`,
+    };
+  }
+  const sha256 = crypto.createHash("sha256").update(tarBuffer).digest("hex");
+  if (typeof payload?.sha256 === "string" && payload.sha256.toLowerCase() !== sha256) {
+    return {
+      ok: false,
+      code: "ARCHIVE_INTEGRITY_FAILURE",
+      reason: `dir.fetch archive sha256 mismatch: payload says ${payload.sha256.toLowerCase()}, decoded ${sha256}`,
+    };
+  }
   return await new Promise<
-    { ok: true; entries: string[] } | { ok: false; code: string; reason: string }
+    | { ok: true; entries: string[]; sizeBytes: number; sha256: string }
+    | { ok: false; code: string; reason: string }
   >((resolve) => {
     const tarBin = process.platform !== "win32" ? "/usr/bin/tar" : "tar";
     const child = spawn(tarBin, ["-tzf", "-"], { stdio: ["pipe", "pipe", "pipe"] });
@@ -338,7 +365,9 @@ async function listDirFetchArchiveEntries(
     let stderr = "";
     let settled = false;
     const finish = (
-      result: { ok: true; entries: string[] } | { ok: false; code: string; reason: string },
+      result:
+        | { ok: true; entries: string[]; sizeBytes: number; sha256: string }
+        | { ok: false; code: string; reason: string },
     ): void => {
       if (settled) {
         return;
@@ -438,7 +467,7 @@ async function listDirFetchArchiveEntries(
           return;
         }
       }
-      finish({ ok: true, entries });
+      finish({ ok: true, entries, sizeBytes, sha256 });
     });
     child.on("error", (error) => {
       finish({
@@ -910,6 +939,7 @@ async function handleFileTransferInvoke(
       };
     }
   }
+  let verifiedDirFetchArchive: { sizeBytes: number; sha256: string } | undefined;
   if (command === "dir.fetch") {
     const archiveEntries = await listDirFetchArchiveEntries(payload);
     if (!archiveEntries.ok) {
@@ -943,6 +973,10 @@ async function handleFileTransferInvoke(
     if (archiveDeny) {
       return archiveDeny;
     }
+    verifiedDirFetchArchive = {
+      sizeBytes: archiveEntries.sizeBytes,
+      sha256: archiveEntries.sha256,
+    };
   }
 
   await appendFileTransferAudit({
@@ -952,8 +986,13 @@ async function handleFileTransferInvoke(
     requestedPath,
     canonicalPath,
     decision: "allowed",
-    sizeBytes: readAuditSizeBytes(command, payload),
-    sha256: typeof payload?.sha256 === "string" ? payload.sha256 : undefined,
+    sizeBytes: readAuditSizeBytes(command, payload, verifiedDirFetchArchive?.sizeBytes),
+    sha256:
+      command === "dir.fetch"
+        ? verifiedDirFetchArchive?.sha256
+        : typeof payload?.sha256 === "string"
+          ? payload.sha256
+          : undefined,
     durationMs: Date.now() - startedAt,
   });
 
@@ -969,4 +1008,5 @@ export function createFileTransferNodeInvokePolicy(): OpenClawPluginNodeInvokePo
 
 export const testing = {
   listDirFetchArchiveEntries,
+  readAuditSizeBytes,
 };


### PR DESCRIPTION
## What Problem This Solves

Raw file-transfer `dir.fetch` node-invoke transfers could complete without recording the transferred archive size in the file-transfer audit entry.

## Why This Change Was Made

The file-transfer node-invoke policy now carries the decoded archive byte count and SHA-256 from its existing archive-validation boundary into the successful audit record. It rejects conflicting node-reported integrity metadata, keeps `payload.size` for `file.fetch` and `file.write`, and leaves `dir.list` without a transfer size.

This stays inside the file-transfer owner boundary and does not change configuration or the node command protocol.

## User Impact

Operators reviewing file-transfer audit records see the verified compressed archive size and hash for successful raw `dir.fetch` transfers instead of an empty or node-forgeable value.

## Evidence

- Current head: `4b582c70fdcbdb489812c1fbca7460ab268992d1`.
- Blacksmith Testbox `tbx_01kx93ja7q8aschcx4xmv9wyp1`: 25 focused tests passed across `node-invoke-policy.test.ts` and `node-invoke-policy.stream-errors.test.ts` on the clean current-main branch.
- Regressions cover verified decoded size/hash, mismatched metadata rejection, and the sibling audit mapping for `file.fetch`, `file.write`, and `dir.list`.
- Fresh autoreview: no accepted or actionable findings.
- `oxfmt` and `git diff --check`: clean.

AI-assisted: yes. The maintainer review traced the raw node-invoke policy, node-host archive contract, Gateway tool sibling, audit persistence, archive validation, and current-main behavior.
