### PR TITLE
fix(gateway): choose valid LAN host when Windows route metrics are malformed

### DIFF
--- a/src/infra/advertised-lan-host.test.ts
+++ b/src/infra/advertised-lan-host.test.ts
@@ -89,6 +89,17 @@ describe("advertised LAN host", () => {
     ).toEqual([{ interfaceName: "ethernet 2" }, { interfaceName: "ethernet" }]);
   });
 
+  it("sorts invalid Windows route metric strings after valid route metrics", () => {
+    expect(
+      parseWindowsDefaultRouteHints(
+        JSON.stringify([
+          { InterfaceAlias: "Wi-Fi", RouteMetric: "1abc", InterfaceMetric: 0 },
+          { InterfaceAlias: "Ethernet", RouteMetric: "20", InterfaceMetric: 0 },
+        ]),
+      ),
+    ).toEqual([{ interfaceName: "ethernet" }, { interfaceName: "wi-fi" }]);
+  });
+
   it("parses macOS and Linux default route interfaces", () => {
     expect(parseMacOsDefaultRouteHints("   route to: default\ninterface: en9\n")).toEqual([
       { interfaceName: "en9" },
@@ -127,6 +138,27 @@ describe("advertised LAN host", () => {
       ],
       { timeoutMs: 3_000, maxOutputBytes: 16 * 1024 },
     );
+  });
+
+  it("does not prefer a Windows route with an invalid metric prefix", async () => {
+    const runner = createRouteRunner(
+      JSON.stringify([
+        { InterfaceAlias: "Wi-Fi", RouteMetric: "1abc", InterfaceMetric: 0 },
+        { InterfaceAlias: "Ethernet", RouteMetric: "20", InterfaceMetric: 0 },
+      ]),
+    );
+
+    await expect(
+      resolveAdvertisedLanHost({
+        platform: "win32",
+        runCommandWithTimeout: runner,
+        networkInterfaces: () =>
+          ({
+            "Wi-Fi": [ipv4("192.168.1.20")],
+            Ethernet: [ipv4("10.0.0.5")],
+          }) as NetworkInterfacesSnapshot,
+      }),
+    ).resolves.toBe("10.0.0.5");
   });
 
   it("fails open to first private IPv4 when route probing times out", async () => {

--- a/src/infra/advertised-lan-host.ts
+++ b/src/infra/advertised-lan-host.ts
@@ -13,6 +13,8 @@ const WINDOWS_DEFAULT_ROUTE_COMMAND =
   "Get-NetRoute -AddressFamily IPv4 -DestinationPrefix '0.0.0.0/0' | " +
   "Select-Object -Property InterfaceAlias,InterfaceIndex,NextHop,RouteMetric,InterfaceMetric,DestinationPrefix | " +
   "ConvertTo-Json -Compress";
+const INVALID_WINDOWS_ROUTE_METRIC = Number.MAX_SAFE_INTEGER;
+const VALID_WINDOWS_ROUTE_METRIC_TEXT = /^(?:0|[1-9]\d*)$/;
 
 export type AdvertisedLanHostCandidate = {
   interfaceName: string;
@@ -61,14 +63,22 @@ function normalizeInterfaceName(name: unknown): string {
 }
 
 function normalizeMetric(value: unknown): number {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
+  if (value == null) {
+    return 0;
   }
-  if (typeof value === "string" && value.trim()) {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isFinite(parsed) ? parsed : 0;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return 0;
+    }
+    if (!VALID_WINDOWS_ROUTE_METRIC_TEXT.test(trimmed)) {
+      return INVALID_WINDOWS_ROUTE_METRIC;
+    }
+    value = Number(trimmed);
   }
-  return 0;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : INVALID_WINDOWS_ROUTE_METRIC;
 }
 
 export function listAdvertisedLanHostCandidates(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening LAN Control UI, system info, or pairing links on Windows could see the wrong advertised LAN address when default-route metric data contains malformed metric text.

## Why This Change Was Made

Windows default-route hint parsing now accepts only complete non-negative metric values before using them for route ordering. Malformed present metrics are deprioritized instead of being prefix-parsed as low-cost routes, while missing metrics keep the existing fallback behavior.

## User Impact

Windows users get LAN URLs based on the valid default-route interface instead of a route row with contaminated metric text.

## Evidence

- Claim proved: malformed Windows route metric strings no longer outrank valid Windows default-route metrics when selecting the advertised LAN host.
- Current-head proof at `fbc6354d4d0b58372ad6429f565ca14d2a302e0e`: `node scripts/run-vitest.mjs src/infra/advertised-lan-host.test.ts` passed, with 1 test file and 10 tests passing.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD --engine claude` passed with no accepted/actionable findings.
- Observed result: `resolveAdvertisedLanHost` now selects the valid Ethernet address when the Wi-Fi route row reports `RouteMetric: "1abc"` and Ethernet reports `RouteMetric: "20"`.