### PR TITLE
feat(slack): support native data visualizations

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1546,13 +1546,13 @@ readers, notifications, session mirroring, and clients that cannot render the
 block. Standard presentation sends to other OpenClaw channels receive that same
 deterministic chart data as text unless they advertise native chart support. If
 Slack rejects the chart with `invalid_blocks` during a phased rollout, OpenClaw
-retries once with the native chart replaced by visible mrkdwn fallback sections;
-valid sibling blocks remain intact.
+removes the rejected native data blocks, keeps any sibling controls, and sends
+the complete chart representation as visible text.
 
 Slack currently accepts up to two `data_visualization` blocks per message. When
-a presentation contains more than two valid charts, OpenClaw renders the first
-two natively and preserves each additional chart as deterministic visible text
-in the same message.
+a presentation contains more than two valid charts, OpenClaw keeps their order
+and continues native rendering in follow-up messages, with no more than two
+charts in each message.
 
 Slack's [developer launch](https://docs.slack.dev/changelog/2026/06/16/block-kit-data-visualization-block/)
 documents the block as an app-facing Block Kit feature and publishes no paid
@@ -1590,7 +1590,7 @@ No additional OAuth scope or Slack configuration is required beyond normal
 OpenClaw maps header and string cells to Slack `raw_text` cells. Numeric cells
 map to `raw_number`, with the finite numeric value preserved for native sorting
 and filtering. `rowHeaderColumnIndex`, when present, marks that zero-based
-column as Slack row headers; when omitted, Slack defaults to column `0`.
+column as Slack row headers.
 
 Slack's published `data_table` limits are enforced before native rendering:
 
@@ -1602,25 +1602,21 @@ Slack's published `data_table` limits are enforced before native rendering:
 Multiple valid table blocks can render natively while the message remains
 within the aggregate character limit. A table that cannot render within the
 native envelope becomes complete deterministic text instead of losing rows or
-cells. If that text exceeds one OpenClaw Slack text chunk, sends and slash
-responses use ordered chunks. Table edits fail with an explicit size error
-instead of silently truncating rows from an existing message.
-
-Slack permits at most [five messages from one interaction `response_url`](https://docs.slack.dev/interactivity/handling-user-interaction/#message_responses).
-OpenClaw shares that budget across streamed slash payloads, accounts for a
-possible native-block retry, and returns size guidance before publishing a
-partial table. Send exceptionally large results as a regular channel message
-instead.
+cells. If that text exceeds one Slack message, sends and slash responses use
+ordered text chunks. Table edits fail with an explicit size error instead of
+silently truncating rows from an existing message.
 
 Every native table produced from portable presentation also carries a top-level
 text representation for screen readers, notifications, session mirroring, and
 clients that cannot render the block. Raw chart and table values stay literal
-in that mrkdwn fallback, so cell data such as `<@U123>` does not become a Slack
-mention. If Slack rejects native chart or table blocks with `invalid_blocks`,
-OpenClaw retries once with those native blocks replaced by visible mrkdwn
-fallback sections. A genuinely invalid sibling block still fails closed. Table
-and chart sends preserve the complete representation through ordered preflight
-chunks whenever the top-level accessibility text exceeds one Slack post.
+in the fallback, so cell data such as `<@U123>` does not become a Slack mention.
+If Slack rejects native chart or table blocks with `invalid_blocks`, OpenClaw
+removes every native data block in one bounded recovery step, retains valid
+sibling blocks such as buttons and selects, and sends complete visible chart
+and table text with Slack formatting disabled. Slash-command delivery
+tracks Slack's five-call `response_url` budget across the command. Before each
+reply batch, it selects a complete plan that fits the remaining calls or fails
+before posting that batch.
 
 Only explicit `presentation` table blocks are promoted to native tables.
 Markdown pipe tables remain authored text; OpenClaw does not guess at table

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -617,6 +617,18 @@ Imperative Slack scenarios (`extensions/qa-lab/src/live-transports/slack/slack-l
 - `slack-reaction-glyph-native` - opt-in live message-tool reaction scenario.
   Instructs the agent to pass the exact `✅` glyph and confirms Slack stored
   `white_check_mark` for the SUT bot on the target message.
+- `slack-chart-presentation-native` - opt-in portable chart scenario that
+  verifies the native `data_visualization` block and exact accessible text.
+- `slack-table-presentation-native` - opt-in portable table scenario that
+  verifies the native `data_table` block, exact rows, and accessible text.
+- `slack-table-invalid-blocks-fallback` - opt-in direct-transport scenario
+  that sends a structurally readable over-limit raw table with 101 data rows
+  plus its header through the
+  production Slack send path, proves Slack itself returns `invalid_blocks`,
+  and verifies the stored formatting-disabled fallback is complete and has no
+  native data block. The report keeps only safe error-code, count, and boolean
+  evidence; raw synthetic table text follows
+  `OPENCLAW_QA_SLACK_CAPTURE_CONTENT`.
 - `slack-approval-exec-native` - opt-in native Slack exec approval scenario.
   Requests an exec approval through the gateway, verifies the Slack message
   has native approval buttons, resolves it, and verifies the resolved Slack

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -22,7 +22,6 @@ import { normalizeDiscordApprovalPayload } from "./outbound-approval.js";
 import {
   buildDiscordPresentationPayload,
   DISCORD_PRESENTATION_CAPABILITIES,
-  DISCORD_PRESENTATION_TEXT_LIMIT,
 } from "./outbound-components.js";
 import { sendDiscordOutboundPayload } from "./outbound-payload.js";
 import {
@@ -34,7 +33,7 @@ import {
 } from "./outbound-send-context.js";
 import { resolveDiscordReplyReference } from "./reply-reference.js";
 
-export const DISCORD_TEXT_CHUNK_LIMIT = DISCORD_PRESENTATION_TEXT_LIMIT;
+export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
 const DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_BLOCK_RE =
   /<\s*(system-reminder|previous_response)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi;
 const DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_SELF_CLOSING_RE =

--- a/extensions/discord/src/outbound-components.ts
+++ b/extensions/discord/src/outbound-components.ts
@@ -9,8 +9,12 @@ import { readDiscordComponentSpec, type DiscordComponentMessageSpec } from "./co
 type DiscordComponentSendFn = typeof import("./send.components.js").sendDiscordComponentMessage;
 type OutboundPayload = Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["payload"];
 
-export const DISCORD_PRESENTATION_TEXT_LIMIT = 2000;
 const DISCORD_MESSAGE_COMPONENT_LIMIT = 40;
+const DISCORD_TEXT_DISPLAY_LIMIT = 2000;
+const DISCORD_CONTEXT_PREFIX_LENGTH = Array.from("-# ").length;
+
+export const DISCORD_PRESENTATION_TEXT_LIMIT =
+  DISCORD_TEXT_DISPLAY_LIMIT - DISCORD_CONTEXT_PREFIX_LENGTH;
 
 export const DISCORD_PRESENTATION_CAPABILITIES = {
   supported: true,
@@ -112,6 +116,9 @@ export function isDiscordComponentSpecWithinMessageLimit(params: {
   includesMedia?: boolean;
 }): boolean {
   const countedSpec = addPayloadTextFallback(params.spec, { text: params.fallbackText });
+  if (countedSpec.text && Array.from(countedSpec.text).length > DISCORD_TEXT_DISPLAY_LIMIT) {
+    return false;
+  }
   return (
     countDiscordMessageComponents({
       spec: countedSpec,

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -17,6 +17,17 @@ function renderExpectedSlackChartAccessibleText(summaryText: string) {
   ].join("\n");
 }
 
+function renderExpectedSlackTableAccessibleText(summaryText: string) {
+  return [
+    summaryText,
+    "",
+    "QA pipeline report (table)",
+    "Account\tStage\tARR",
+    "Acme\tWon\t125000",
+    "Globex\tReview\t82000",
+  ].join("\n");
+}
+
 describe("Slack live QA runtime helpers", () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -90,6 +101,8 @@ describe("Slack live QA runtime helpers", () => {
       testing
         .findScenario([
           "slack-chart-presentation-native",
+          "slack-table-presentation-native",
+          "slack-table-invalid-blocks-fallback",
           "slack-reaction-glyph-native",
           "slack-approval-exec-native",
           "slack-approval-plugin-native",
@@ -99,6 +112,8 @@ describe("Slack live QA runtime helpers", () => {
         .map((scenario) => scenario.id),
     ).toEqual([
       "slack-chart-presentation-native",
+      "slack-table-presentation-native",
+      "slack-table-invalid-blocks-fallback",
       "slack-reaction-glyph-native",
       "slack-approval-exec-native",
       "slack-approval-plugin-native",
@@ -107,9 +122,16 @@ describe("Slack live QA runtime helpers", () => {
     ]);
     expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain("slack-approval-exec-native");
     expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain("slack-chart-presentation-native");
+    expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain("slack-table-presentation-native");
+    expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain(
+      "slack-table-invalid-blocks-fallback",
+    );
     expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain("slack-reaction-glyph-native");
     expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain(
       "slack-codex-approval-exec-native",
+    );
+    expect(testing.findScenario().map((scenario) => scenario.id)).not.toContain(
+      "slack-table-invalid-blocks-fallback",
     );
   });
 
@@ -426,6 +448,297 @@ describe("Slack live QA runtime helpers", () => {
 
     await vi.advanceTimersByTimeAsync(16_000);
     await result;
+  });
+
+  it("drives the live native table scenario through a portable message-tool presentation", () => {
+    const scenario = testing.findScenario(["slack-table-presentation-native"])[0];
+    const run = scenario?.buildRun("U999999999");
+    const input = run && "input" in run ? run.input : "";
+    const summaryText = input.match(/SLACK_QA_TABLE_SUMMARY_[A-Z0-9]+/u)?.[0];
+
+    expect(run).toMatchObject({ expectReply: true });
+    expect(scenario?.configOverrides).toEqual({ messageTool: true });
+    if (!summaryText) {
+      throw new Error("missing Slack table summary token");
+    }
+    expect(input).toContain(
+      JSON.stringify({
+        action: "send",
+        message: summaryText,
+        presentation: {
+          blocks: [
+            {
+              type: "table",
+              caption: "QA pipeline report",
+              headers: ["Account", "Stage", "ARR"],
+              rows: [
+                ["Acme", "Won", 125000],
+                ["Globex", "Review", 82000],
+              ],
+              rowHeaderColumnIndex: 0,
+            },
+          ],
+        },
+      }),
+    );
+    expect(run && "matchText" in run ? run.matchText : "").toMatch(
+      /^SLACK_QA_TABLE_DONE_[A-Z0-9]+$/u,
+    );
+  });
+
+  it("verifies the SUT-owned native table and exact accessible top-level text", async () => {
+    const scenario = testing.findScenario(["slack-table-presentation-native"])[0];
+    const run = scenario?.buildRun("U999999999");
+    const input = run && "input" in run ? run.input : "";
+    const summaryText = input.match(/SLACK_QA_TABLE_SUMMARY_[A-Z0-9]+/u)?.[0];
+    const afterReply = run && "afterReply" in run ? run.afterReply : undefined;
+    if (!summaryText || !afterReply) {
+      throw new Error("missing Slack table scenario verifier");
+    }
+    const accessibleText = renderExpectedSlackTableAccessibleText(summaryText);
+    const history = vi.fn(async () => ({
+      messages: [
+        {
+          blocks: [
+            {
+              type: "data_table",
+              caption: "QA pipeline report",
+              rows: [
+                [
+                  { type: "raw_text", text: "Account" },
+                  { type: "raw_text", text: "Stage" },
+                  { type: "raw_text", text: "ARR" },
+                ],
+                [
+                  { type: "raw_text", text: "Acme" },
+                  { type: "raw_text", text: "Won" },
+                  { type: "raw_number", value: 125000, text: "125000" },
+                ],
+                [
+                  { type: "raw_text", text: "Globex" },
+                  { type: "raw_text", text: "Review" },
+                  { type: "raw_number", value: 82000, text: "82000" },
+                ],
+              ],
+              row_header_column_index: 0,
+            },
+          ],
+          text: accessibleText.replace(/\s+/gu, " "),
+          ts: "2.000000",
+          user: "U999999999",
+        },
+      ],
+    }));
+
+    await expect(
+      afterReply(
+        {} as never,
+        {
+          channelId: "C123456789",
+          sentTs: "1.000000",
+          sutIdentity: { userId: "U999999999" },
+          sutReadClient: { conversations: { history } },
+        } as never,
+      ),
+    ).resolves.toBe("verified native data_table block and deterministic accessible text");
+  });
+
+  it("rejects fallback-only Slack table delivery", async () => {
+    vi.useFakeTimers();
+    const scenario = testing.findScenario(["slack-table-presentation-native"])[0];
+    const run = scenario?.buildRun("U999999999");
+    const input = run && "input" in run ? run.input : "";
+    const summaryText = input.match(/SLACK_QA_TABLE_SUMMARY_[A-Z0-9]+/u)?.[0];
+    const afterReply = run && "afterReply" in run ? run.afterReply : undefined;
+    if (!summaryText || !afterReply) {
+      throw new Error("missing Slack table scenario verifier");
+    }
+    const history = vi.fn(async () => ({
+      messages: [
+        {
+          text: renderExpectedSlackTableAccessibleText(summaryText).replace(/\s+/gu, " "),
+          ts: "2.000000",
+          user: "U999999999",
+        },
+      ],
+    }));
+    const result = expect(
+      afterReply(
+        {} as never,
+        {
+          channelId: "C123456789",
+          sentTs: "1.000000",
+          sutIdentity: { userId: "U999999999" },
+          sutReadClient: { conversations: { history } },
+        } as never,
+      ),
+    ).rejects.toThrow("waiting for Slack message");
+
+    await vi.advanceTimersByTimeAsync(16_000);
+    await result;
+  });
+
+  it("builds the invalid_blocks fallback probe as a direct transport scenario", () => {
+    const scenario = testing.findScenario(["slack-table-invalid-blocks-fallback"])[0];
+    const run = scenario?.buildRun("U999999999");
+    const probe = testing.buildSlackInvalidBlocksTableProbe();
+
+    expect(run).toMatchObject({ kind: "direct-transport" });
+    expect(probe.dataRowCount).toBe(101);
+    expect(probe.block).toMatchObject({
+      type: "data_table",
+      caption: "QA invalid_blocks fallback",
+      row_header_column_index: 0,
+    });
+    expect(probe.block.rows).toHaveLength(102);
+    expect(probe.block.rows[0]).toEqual([
+      { type: "raw_text", text: "Row" },
+      { type: "raw_text", text: "Value" },
+    ]);
+    expect(probe.firstRowText).toBe("row-001\tvalue-001");
+    expect(probe.finalRowText).toBe("row-101\tvalue-101");
+    expect(probe.fallbackText.split("\n")).toContain(probe.firstRowText);
+    expect(probe.fallbackText.split("\n")).toContain(probe.finalRowText);
+  });
+
+  it("proves the public Slack send path stores one complete formatting-disabled fallback", async () => {
+    const invalidBlocksError = Object.assign(new Error("An API error occurred: invalid_blocks"), {
+      code: "slack_webapi_platform_error",
+      data: { error: "invalid_blocks", ok: false },
+    });
+    let apiAttempt = 0;
+    let storedPayload: Record<string, unknown> | undefined;
+    const postMessage = vi.fn(async (payload: Record<string, unknown>) => {
+      apiAttempt += 1;
+      if (apiAttempt === 1) {
+        throw invalidBlocksError;
+      }
+      storedPayload = payload;
+      return { channel: "C123456789", ok: true, ts: "2.000000" };
+    });
+    const history = vi.fn(async () => ({
+      messages: storedPayload
+        ? [
+            {
+              blocks: storedPayload.blocks,
+              text: storedPayload.text,
+              ts: "2.000000",
+              user: "U999999999",
+            },
+          ]
+        : [],
+    }));
+    const sutWriteClient = { chat: { postMessage } };
+    const cfg = testing.buildSlackQaConfig(
+      {},
+      {
+        channelId: "C123456789",
+        driverBotUserId: "U111111111",
+        sutAccountId: "sut",
+        sutAppToken: "xapp-sut",
+        sutBotToken: "xoxb-sut",
+      },
+    );
+
+    const result = await testing.runSlackTableInvalidBlocksFallbackScenario({
+      cfg,
+      channelId: "C123456789",
+      sutAccountId: "sut",
+      sutIdentity: { userId: "U999999999" },
+      sutReadClient: { conversations: { history } } as never,
+      sutWriteClient: sutWriteClient as never,
+      timeoutMs: 0,
+    });
+
+    expect(postMessage).toHaveBeenCalledTimes(2);
+    const [nativeRequest] = postMessage.mock.calls[0] ?? [];
+    const [fallbackRequest] = postMessage.mock.calls[1] ?? [];
+    const nativeBlocks = nativeRequest?.blocks as Array<{ rows?: unknown[]; type?: string }>;
+    expect(nativeRequest).toMatchObject({ mrkdwn: false });
+    expect(nativeBlocks).toHaveLength(1);
+    expect(nativeBlocks[0]).toMatchObject({ type: "data_table" });
+    expect(nativeBlocks[0]?.rows).toHaveLength(102);
+    expect(fallbackRequest).not.toHaveProperty("blocks");
+    expect(fallbackRequest).toMatchObject({ mrkdwn: false });
+    const fallbackText = typeof fallbackRequest?.text === "string" ? fallbackRequest.text : "";
+    expect(fallbackText).toBe(nativeRequest?.text);
+    expect(fallbackText.split("\n")).toContain("row-001\tvalue-001");
+    expect(fallbackText.split("\n")).toContain("row-101\tvalue-101");
+    expect(result.message).toMatchObject({
+      text: fallbackText,
+      ts: "2.000000",
+      user: "U999999999",
+    });
+    expect(result.details).toContain("first API failure=invalid_blocks");
+    expect(result.details).toContain("fallback formatting disabled=true");
+    expect(result.details).toContain("complete delivery=true");
+    expect(sutWriteClient.chat.postMessage).toBe(postMessage);
+  });
+
+  it("fails with sanitized evidence when Slack returns a different first API code", async () => {
+    const postMessage = vi.fn(async () => {
+      throw Object.assign(new Error("do not persist this raw platform detail"), {
+        data: { error: "invalid_arguments", ok: false },
+      });
+    });
+    const sutWriteClient = { chat: { postMessage } };
+    const cfg = testing.buildSlackQaConfig(
+      {},
+      {
+        channelId: "C123456789",
+        driverBotUserId: "U111111111",
+        sutAccountId: "sut",
+        sutAppToken: "xapp-sut",
+        sutBotToken: "xoxb-sut",
+      },
+    );
+
+    await expect(
+      testing.runSlackTableInvalidBlocksFallbackScenario({
+        cfg,
+        channelId: "C123456789",
+        sutAccountId: "sut",
+        sutIdentity: { userId: "U999999999" },
+        sutReadClient: { conversations: { history: vi.fn() } } as never,
+        sutWriteClient: sutWriteClient as never,
+        timeoutMs: 0,
+      }),
+    ).rejects.toThrow(
+      "expected first Slack API failure code invalid_blocks; observed invalid_arguments",
+    );
+    expect(sutWriteClient.chat.postMessage).toBe(postMessage);
+  });
+
+  it("does not expose an untrusted Slack API error value", async () => {
+    const postMessage = vi.fn(async () => {
+      throw Object.assign(new Error("private platform detail"), {
+        data: { error: "unsafe private detail", ok: false },
+      });
+    });
+    const sutWriteClient = { chat: { postMessage } };
+    const cfg = testing.buildSlackQaConfig(
+      {},
+      {
+        channelId: "C123456789",
+        driverBotUserId: "U111111111",
+        sutAccountId: "sut",
+        sutAppToken: "xapp-sut",
+        sutBotToken: "xoxb-sut",
+      },
+    );
+
+    await expect(
+      testing.runSlackTableInvalidBlocksFallbackScenario({
+        cfg,
+        channelId: "C123456789",
+        sutAccountId: "sut",
+        sutIdentity: { userId: "U999999999" },
+        sutReadClient: { conversations: { history: vi.fn() } } as never,
+        sutWriteClient: sutWriteClient as never,
+        timeoutMs: 0,
+      }),
+    ).rejects.toThrow("expected first Slack API failure code invalid_blocks; observed none");
+    expect(sutWriteClient.chat.postMessage).toBe(postMessage);
   });
 
   it("enables the message tool for the live reaction scenario", () => {

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.ts
@@ -8,6 +8,7 @@ import {
   createSlackWebClient,
   createSlackWriteClient,
   listSlackReactions,
+  sendSlackMessage,
 } from "@openclaw/slack/api.js";
 import type { WebClient } from "@slack/web-api";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
@@ -74,13 +75,22 @@ const SLACK_QA_RETRYABLE_SCENARIO_ATTEMPTS = 2;
 const SLACK_QA_APPROVAL_DECISION_TIMEOUT_MS = 30_000;
 const SLACK_QA_APPROVAL_CHECKPOINT_DEFAULT_TIMEOUT_MS = 120_000;
 const SLACK_QA_REACTION_VERIFY_TIMEOUT_MS = 15_000;
-const SLACK_QA_CHART_VERIFY_TIMEOUT_MS = 15_000;
+const SLACK_QA_NATIVE_DATA_VERIFY_TIMEOUT_MS = 15_000;
+const SLACK_QA_INVALID_TABLE_DATA_ROW_COUNT = 101;
+const SLACK_QA_INVALID_TABLE_CAPTION = "QA invalid_blocks fallback";
+const SLACK_QA_INVALID_TABLE_HEADERS = ["Row", "Value"] as const;
 const SLACK_QA_CHART_TITLE = "QA latency trend";
 const SLACK_QA_CHART_CATEGORIES = ["P50", "P95"] as const;
 const SLACK_QA_CHART_SERIES_NAME = "Latency";
 const SLACK_QA_CHART_VALUES = [120, 240] as const;
 const SLACK_QA_CHART_X_LABEL = "Percentile";
 const SLACK_QA_CHART_Y_LABEL = "Milliseconds";
+const SLACK_QA_TABLE_CAPTION = "QA pipeline report";
+const SLACK_QA_TABLE_HEADERS = ["Account", "Stage", "ARR"] as const;
+const SLACK_QA_TABLE_ROWS = [
+  ["Acme", "Won", 125_000],
+  ["Globex", "Review", 82_000],
+] as const;
 const SLACK_QA_NATIVE_CHART = {
   type: "data_visualization",
   title: SLACK_QA_CHART_TITLE,
@@ -102,6 +112,21 @@ const SLACK_QA_NATIVE_CHART = {
     },
   },
 } as const;
+const SLACK_QA_NATIVE_TABLE = {
+  type: "data_table",
+  caption: SLACK_QA_TABLE_CAPTION,
+  rows: [
+    SLACK_QA_TABLE_HEADERS.map((text) => ({ type: "raw_text", text })),
+    ...SLACK_QA_TABLE_ROWS.map((row) =>
+      row.map((cell) =>
+        typeof cell === "number"
+          ? { type: "raw_number", value: cell, text: String(cell) }
+          : { type: "raw_text", text: cell },
+      ),
+    ),
+  ],
+  row_header_column_index: 0,
+} as const;
 // These scenarios force the Codex harness, whose default provider set is intentionally narrow.
 const SLACK_QA_CODEX_PROVIDER_IDS = new Set(["codex", "openai"]);
 
@@ -115,6 +140,8 @@ type SlackQaScenarioId =
   | "slack-chart-presentation-native"
   | "slack-mention-gating"
   | "slack-reaction-glyph-native"
+  | "slack-table-invalid-blocks-fallback"
+  | "slack-table-presentation-native"
   | "slack-top-level-reply-shape";
 
 type SlackQaApprovalKind = "exec" | "plugin";
@@ -147,6 +174,28 @@ type SlackQaMessageScenarioRun = {
   afterReply?: (message: SlackMessage, context: SlackQaScenarioContext) => Promise<string | void>;
 };
 
+type SlackQaDirectTransportScenarioRun = {
+  kind: "direct-transport";
+  execute: (
+    context: SlackQaDirectTransportScenarioContext,
+  ) => Promise<SlackQaDirectTransportScenarioResult>;
+};
+
+type SlackQaDirectTransportScenarioContext = {
+  cfg: OpenClawConfig;
+  channelId: string;
+  sutAccountId: string;
+  sutIdentity: SlackAuthIdentity;
+  sutReadClient: WebClient;
+  sutWriteClient: WebClient;
+  timeoutMs: number;
+};
+
+type SlackQaDirectTransportScenarioResult = {
+  details: string;
+  message: SlackMessage;
+};
+
 type SlackQaApprovalScenarioRun = {
   approvalKind: SlackQaApprovalKind;
   decision: SlackQaApprovalDecision;
@@ -165,6 +214,7 @@ type SlackQaCodexApprovalScenarioRun = {
 type SlackQaScenarioRun =
   | SlackQaApprovalScenarioRun
   | SlackQaCodexApprovalScenarioRun
+  | SlackQaDirectTransportScenarioRun
   | SlackQaMessageScenarioRun;
 
 type SlackQaBeforeRunResult =
@@ -202,6 +252,7 @@ type SlackQaScenarioContext = {
 type SlackQaScenarioDefinition = LiveTransportScenarioDefinition<SlackQaScenarioId> & {
   buildRun: (sutUserId: string) => SlackQaScenarioRun;
   configOverrides?: SlackQaConfigOverrides;
+  defaultEnabled?: boolean;
 };
 
 type SlackQaGatewayHarness = Awaited<ReturnType<typeof startQaLiveLaneGateway>>;
@@ -391,6 +442,70 @@ function renderSlackChartAccessibleText(summaryText: string) {
   ].join("\n");
 }
 
+function buildSlackTableMessageToolArgs(summaryText: string) {
+  return {
+    action: "send",
+    message: summaryText,
+    presentation: {
+      blocks: [
+        {
+          type: "table",
+          caption: SLACK_QA_TABLE_CAPTION,
+          headers: [...SLACK_QA_TABLE_HEADERS],
+          rows: SLACK_QA_TABLE_ROWS.map((row) => [...row]),
+          rowHeaderColumnIndex: 0,
+        },
+      ],
+    },
+  };
+}
+
+function renderSlackTableAccessibleText(summaryText: string) {
+  return [
+    summaryText,
+    "",
+    `${SLACK_QA_TABLE_CAPTION} (table)`,
+    SLACK_QA_TABLE_HEADERS.join("\t"),
+    ...SLACK_QA_TABLE_ROWS.map((row) => row.join("\t")),
+  ].join("\n");
+}
+
+function buildSlackInvalidBlocksTableRow(index: number) {
+  const rowId = String(index).padStart(3, "0");
+  return [`row-${rowId}`, `value-${rowId}`] as const;
+}
+
+function buildSlackInvalidBlocksTableProbe() {
+  const summaryText = `SLACK_QA_TABLE_INVALID_BLOCKS_${randomUUID().slice(0, 8).toUpperCase()}`;
+  const dataRows = Array.from({ length: SLACK_QA_INVALID_TABLE_DATA_ROW_COUNT }, (_entry, index) =>
+    buildSlackInvalidBlocksTableRow(index + 1),
+  );
+  const block = {
+    type: "data_table",
+    caption: SLACK_QA_INVALID_TABLE_CAPTION,
+    rows: [
+      SLACK_QA_INVALID_TABLE_HEADERS.map((text) => ({ type: "raw_text", text })),
+      ...dataRows.map((row) => row.map((text) => ({ type: "raw_text", text }))),
+    ],
+    row_header_column_index: 0,
+  } as const;
+  const fallbackText = [
+    summaryText,
+    "",
+    `${SLACK_QA_INVALID_TABLE_CAPTION} (table)`,
+    SLACK_QA_INVALID_TABLE_HEADERS.join("\t"),
+    ...dataRows.map((row) => row.join("\t")),
+  ].join("\n");
+  return {
+    block,
+    dataRowCount: dataRows.length,
+    fallbackText,
+    firstRowText: buildSlackInvalidBlocksTableRow(1).join("\t"),
+    finalRowText: buildSlackInvalidBlocksTableRow(SLACK_QA_INVALID_TABLE_DATA_ROW_COUNT).join("\t"),
+    summaryText,
+  };
+}
+
 const SLACK_QA_SCENARIOS: SlackQaScenarioDefinition[] = [
   {
     id: "slack-canary",
@@ -479,18 +594,70 @@ const SLACK_QA_SCENARIOS: SlackQaScenarioDefinition[] = [
         ].join(" "),
         matchText: finalMarker,
         afterReply: async (_message, context) => {
-          await waitForSlackNativeChart({
+          await waitForSlackStoredMessage({
             channelId: context.channelId,
             client: context.sutReadClient,
-            expectedAccessibleText: renderSlackChartAccessibleText(summaryText),
+            description: "message with native chart",
+            matchesMessage: (message) =>
+              isExpectedSlackNativeChartMessage(
+                message,
+                renderSlackChartAccessibleText(summaryText),
+              ),
             oldestTs: context.sentTs,
             sutIdentity: context.sutIdentity,
-            timeoutMs: SLACK_QA_CHART_VERIFY_TIMEOUT_MS,
+            timeoutMs: SLACK_QA_NATIVE_DATA_VERIFY_TIMEOUT_MS,
           });
           return "verified native data_visualization block and deterministic accessible text";
         },
       };
     },
+  },
+  {
+    id: "slack-table-presentation-native",
+    title: "Slack portable table renders as a native data table",
+    timeoutMs: 90_000,
+    configOverrides: { messageTool: true },
+    buildRun: (sutUserId) => {
+      const suffix = randomUUID().slice(0, 8).toUpperCase();
+      const summaryText = `SLACK_QA_TABLE_SUMMARY_${suffix}`;
+      const finalMarker = `SLACK_QA_TABLE_DONE_${suffix}`;
+      const messageToolArgs = buildSlackTableMessageToolArgs(summaryText);
+      return {
+        expectReply: true,
+        input: [
+          `<@${sutUserId}> Slack native table QA check ${summaryText}.`,
+          `Call the message tool exactly once with these exact arguments: ${JSON.stringify(messageToolArgs)}.`,
+          `After the table send succeeds, reply with only this exact marker: ${finalMarker}`,
+        ].join(" "),
+        matchText: finalMarker,
+        afterReply: async (_message, context) => {
+          await waitForSlackStoredMessage({
+            channelId: context.channelId,
+            client: context.sutReadClient,
+            description: "message with native table",
+            matchesMessage: (message) =>
+              isExpectedSlackNativeTableMessage(
+                message,
+                renderSlackTableAccessibleText(summaryText),
+              ),
+            oldestTs: context.sentTs,
+            sutIdentity: context.sutIdentity,
+            timeoutMs: SLACK_QA_NATIVE_DATA_VERIFY_TIMEOUT_MS,
+          });
+          return "verified native data_table block and deterministic accessible text";
+        },
+      };
+    },
+  },
+  {
+    id: "slack-table-invalid-blocks-fallback",
+    title: "Slack rejects an over-limit native table and stores its complete fallback",
+    defaultEnabled: false,
+    timeoutMs: 45_000,
+    buildRun: () => ({
+      kind: "direct-transport",
+      execute: runSlackTableInvalidBlocksFallbackScenario,
+    }),
   },
   {
     id: "slack-reaction-glyph-native",
@@ -650,17 +817,73 @@ function parseSlackQaCredentialPayload(payload: unknown): SlackQaRuntimeEnv {
 }
 
 function findScenario(ids?: string[]) {
-  return selectLiveTransportScenarios({
+  const selected = selectLiveTransportScenarios({
     ids,
     laneLabel: "Slack",
     scenarios: SLACK_QA_SCENARIOS,
   });
+  return ids?.length ? selected : selected.filter((scenario) => scenario.defaultEnabled !== false);
 }
 
 function asPlainRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+type SlackQaPostMessageAttempt = {
+  failureCode?: string;
+  formattingDisabled: boolean;
+  nativeDataBlockCount: number;
+  status: "failed" | "sent";
+};
+
+function countSlackNativeDataBlocks(value: unknown) {
+  if (!Array.isArray(value)) {
+    return 0;
+  }
+  return value.filter((block) => {
+    const type = asPlainRecord(block).type;
+    return type === "data_table" || type === "data_visualization";
+  }).length;
+}
+
+function readSlackApiFailureCode(error: unknown) {
+  const record = asPlainRecord(error);
+  const data = asPlainRecord(record.data);
+  const code = data.error ?? record.error;
+  return typeof code === "string" && /^[a-z0-9_]{1,64}$/u.test(code) ? code : undefined;
+}
+
+function instrumentSlackPostMessage(client: WebClient) {
+  const originalPostMessage = client.chat.postMessage;
+  const attempts: SlackQaPostMessageAttempt[] = [];
+  client.chat.postMessage = (async (payload) => {
+    const payloadRecord = payload as { blocks?: unknown; mrkdwn?: boolean };
+    const attempt = {
+      formattingDisabled: payloadRecord.mrkdwn === false,
+      nativeDataBlockCount: countSlackNativeDataBlocks(payloadRecord.blocks),
+    };
+    try {
+      const response = await originalPostMessage.call(client.chat, payload);
+      attempts.push({ ...attempt, status: "sent" });
+      return response;
+    } catch (error) {
+      const failureCode = readSlackApiFailureCode(error);
+      attempts.push({
+        ...attempt,
+        ...(failureCode ? { failureCode } : {}),
+        status: "failed",
+      });
+      throw error;
+    }
+  }) as typeof client.chat.postMessage;
+  return {
+    attempts,
+    restore: () => {
+      client.chat.postMessage = originalPostMessage;
+    },
+  };
 }
 
 function buildSlackQaConfig(
@@ -847,9 +1070,9 @@ async function sendSlackChannelMessage(params: {
   text: string;
   threadTs?: string;
 }) {
-  const sendSlackMessage = params.client.chat.postMessage.bind(params.client.chat);
+  const postSlackMessage = params.client.chat.postMessage.bind(params.client.chat);
   const sent = slackPostMessageSchema.parse(
-    await sendSlackMessage({
+    await postSlackMessage({
       channel: params.channelId,
       text: params.text,
       thread_ts: params.threadTs,
@@ -1027,10 +1250,11 @@ function isExpectedSlackNativeChartMessage(message: SlackMessage, expectedAccess
   });
 }
 
-async function waitForSlackNativeChart(params: {
+async function waitForSlackStoredMessage(params: {
   channelId: string;
   client: WebClient;
-  expectedAccessibleText: string;
+  description: string;
+  matchesMessage: (message: SlackMessage) => boolean;
   oldestTs: string;
   sutIdentity: SlackAuthIdentity;
   timeoutMs: number;
@@ -1046,7 +1270,7 @@ async function waitForSlackNativeChart(params: {
       (entry) =>
         entry.ts !== params.oldestTs &&
         isSutSlackMessage(entry, params.sutIdentity) &&
-        isExpectedSlackNativeChartMessage(entry, params.expectedAccessibleText),
+        params.matchesMessage(entry),
     );
     if (message) {
       return message;
@@ -1059,9 +1283,123 @@ async function waitForSlackNativeChart(params: {
       setTimeout(resolve, Math.min(1_000, remainingMs));
     });
   }
-  throw new Error(
-    `timed out after ${params.timeoutMs}ms waiting for Slack message with native chart`,
-  );
+  throw new Error(`timed out after ${params.timeoutMs}ms waiting for Slack ${params.description}`);
+}
+
+function isExpectedSlackNativeTableMessage(message: SlackMessage, expectedAccessibleText: string) {
+  if (
+    normalizeSlackAccessibleText(message.text ?? "") !==
+    normalizeSlackAccessibleText(expectedAccessibleText)
+  ) {
+    return false;
+  }
+  return (message.blocks ?? []).some((value) => {
+    const block = asPlainRecord(value);
+    return isDeepStrictEqual(
+      {
+        type: block.type,
+        caption: block.caption,
+        rows: block.rows,
+        row_header_column_index: block.row_header_column_index,
+      },
+      SLACK_QA_NATIVE_TABLE,
+    );
+  });
+}
+
+async function runSlackTableInvalidBlocksFallbackScenario(
+  context: SlackQaDirectTransportScenarioContext,
+): Promise<SlackQaDirectTransportScenarioResult> {
+  const probe = buildSlackInvalidBlocksTableProbe();
+  const oldestTs = ((Date.now() - 5_000) / 1_000).toFixed(6);
+  const instrumentation = instrumentSlackPostMessage(context.sutWriteClient);
+  let sent: Awaited<ReturnType<typeof sendSlackMessage>>;
+  try {
+    try {
+      sent = await sendSlackMessage(`channel:${context.channelId}`, probe.summaryText, {
+        accountId: context.sutAccountId,
+        blocks: [probe.block] as never,
+        cfg: context.cfg,
+        client: context.sutWriteClient,
+        nativeDataFallbackBaseText: probe.summaryText,
+      });
+    } catch {
+      const [nativeAttempt, fallbackAttempt] = instrumentation.attempts;
+      if (nativeAttempt?.failureCode !== "invalid_blocks") {
+        throw new Error(
+          `expected first Slack API failure code invalid_blocks; observed ${nativeAttempt?.failureCode ?? "none"}`,
+        );
+      }
+      throw new Error(
+        `Slack fallback failed after invalid_blocks; observed ${fallbackAttempt?.failureCode ?? "no fallback API failure code"}`,
+      );
+    }
+  } finally {
+    instrumentation.restore();
+  }
+
+  const [nativeAttempt, fallbackAttempt] = instrumentation.attempts;
+  if (instrumentation.attempts.length !== 2) {
+    throw new Error(
+      `expected exactly two Slack API attempts; observed ${instrumentation.attempts.length}`,
+    );
+  }
+  if (
+    nativeAttempt?.status !== "failed" ||
+    nativeAttempt.failureCode !== "invalid_blocks" ||
+    nativeAttempt.nativeDataBlockCount !== 1
+  ) {
+    throw new Error(
+      `expected first Slack API attempt to fail with invalid_blocks for one native data block; observed ${nativeAttempt?.failureCode ?? "none"}`,
+    );
+  }
+  if (
+    fallbackAttempt?.status !== "sent" ||
+    fallbackAttempt.nativeDataBlockCount !== 0 ||
+    !fallbackAttempt.formattingDisabled
+  ) {
+    throw new Error("Slack fallback did not use one formatting-disabled blockless API request");
+  }
+
+  const message = await waitForSlackStoredMessage({
+    channelId: context.channelId,
+    client: context.sutReadClient,
+    description: "stored invalid_blocks fallback message",
+    matchesMessage: (candidate) => candidate.ts === sent.messageId,
+    oldestTs,
+    sutIdentity: context.sutIdentity,
+    timeoutMs: context.timeoutMs,
+  });
+  const storedText = message.text ?? "";
+  if (countSlackNativeDataBlocks(message.blocks) !== 0) {
+    throw new Error("stored Slack fallback retained a native data block");
+  }
+  const storedLines = storedText.split("\n");
+  if (!storedLines.includes(probe.firstRowText)) {
+    throw new Error("stored Slack fallback omitted the exact first data row");
+  }
+  if (!storedLines.includes(probe.finalRowText)) {
+    throw new Error("stored Slack fallback omitted the exact final data row");
+  }
+  if (storedText !== probe.fallbackText) {
+    throw new Error(
+      `stored Slack fallback was incomplete: expected ${probe.fallbackText.length} characters, observed ${storedText.length}`,
+    );
+  }
+  return {
+    details: [
+      "direct transport",
+      "first API failure=invalid_blocks",
+      "API attempts=2",
+      `data rows=${probe.dataRowCount}`,
+      "fallback formatting disabled=true",
+      "stored native data blocks=0",
+      "first row=present",
+      "final row=present",
+      "complete delivery=true",
+    ].join("; "),
+    message,
+  };
 }
 
 async function waitForSlackScenarioReply(params: {
@@ -2589,6 +2927,60 @@ export async function runSlackQaLive(params: {
         let retryScenario = false;
         try {
           assertLeaseHealthy();
+          const scenarioRun = scenario.buildRun(sutIdentity.userId);
+          if (scenarioRun.kind === "direct-transport") {
+            const directResult = await scenarioRun.execute({
+              cfg: buildSlackQaConfig(
+                {},
+                {
+                  channelId: activeRuntimeEnv.channelId,
+                  driverBotUserId: driverIdentity.userId,
+                  overrides: scenario.configOverrides,
+                  primaryModel,
+                  sutAccountId,
+                  sutAppToken: activeRuntimeEnv.sutAppToken,
+                  sutBotToken: activeRuntimeEnv.sutBotToken,
+                },
+              ),
+              channelId: activeRuntimeEnv.channelId,
+              sutAccountId,
+              sutIdentity,
+              sutReadClient,
+              sutWriteClient: createSlackWriteClient(activeRuntimeEnv.sutBotToken, {
+                timeout: SLACK_QA_WEB_API_TIMEOUT_MS,
+              }),
+              timeoutMs: scenario.timeoutMs,
+            });
+            const message = directResult.message;
+            if (!message.ts) {
+              throw new Error("direct Slack transport scenario returned no stored message id");
+            }
+            observedMessages.push({
+              actionValues: collectSlackActionValues(message.blocks),
+              blockText: collectSlackBlockText(message.blocks),
+              botId: message.bot_id,
+              channelId: activeRuntimeEnv.channelId,
+              matchedScenario: true,
+              scenarioId: scenario.id,
+              scenarioTitle: scenario.title,
+              text: message.text ?? "",
+              threadTs: message.thread_ts,
+              ts: message.ts,
+              userId: message.user,
+            });
+            scenarioResults.push({
+              id: scenario.id,
+              title: scenario.title,
+              status: "pass",
+              details: [
+                directResult.details,
+                scenarioAttempt > 1 ? `retried ${scenarioAttempt - 1}x` : undefined,
+              ]
+                .filter(Boolean)
+                .join("; "),
+            });
+            break;
+          }
           gatewayHarness = await startQaLiveLaneGateway({
             repoRoot,
             transport: {
@@ -2613,7 +3005,6 @@ export async function runSlackQaLive(params: {
               }),
           });
           const activeGatewayHarness = gatewayHarness;
-          const scenarioRun = scenario.buildRun(sutIdentity.userId);
           if (
             scenarioRun.kind === "codex-approval" &&
             scenarioRun.appServerMethod === "item/fileChange/requestApproval"
@@ -2824,9 +3215,9 @@ export async function runSlackQaLive(params: {
                   ? `${formatErrorMessage(error)}; retried ${scenarioAttempt - 1}x`
                   : formatErrorMessage(error),
             });
-            preserveAttemptGatewayDebug = true;
-            preservedGatewayDebugArtifacts = true;
             if (gatewayHarness) {
+              preserveAttemptGatewayDebug = true;
+              preservedGatewayDebugArtifacts = true;
               const stopped = await preserveSlackGatewayDebugArtifacts({
                 cleanupIssues,
                 gatewayDebugDirPath,
@@ -2993,6 +3384,7 @@ export const testing = {
   assertSlackCodexApprovalModelSupported,
   assertCodexApprovalTranscriptSucceeded,
   buildCodexApprovalInstruction,
+  buildSlackInvalidBlocksTableProbe,
   buildSlackApprovalCheckpointMessage,
   buildSlackQaConfig,
   collectSlackActionValues,
@@ -3016,11 +3408,13 @@ export const testing = {
   resolveApprovalDecision,
   resolveSlackQaSutAccountId,
   resolveSlackQaRuntimeEnv,
+  runSlackTableInvalidBlocksFallbackScenario,
   sendSlackChannelMessage,
   listSlackMessages,
   listSlackThreadMessages,
   SLACK_QA_STANDARD_SCENARIO_IDS,
   toSlackQaScenarioArtifactResults,
+  waitForSlackStoredMessage,
   waitForSlackNoReply,
   waitForSlackReaction,
   waitForSlackChannelStable,

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -19,14 +19,34 @@ const reactSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
 const readSlackMessages = vi.fn(async (..._args: unknown[]) => ({}));
 const removeOwnSlackReactions = vi.fn(async (..._args: unknown[]) => ["thumbsup"]);
 const removeSlackReaction = vi.fn(async (..._args: unknown[]) => ({}));
+const resolveSlackConversationName = vi.fn(
+  async (..._args: unknown[]): Promise<string | undefined> => undefined,
+);
 const resolveSlackConversationInfo = vi.fn(
-  async (
-    ..._args: unknown[]
-  ): Promise<{
-    type: "channel" | "group" | "dm" | "unknown";
-    name?: string;
-    user?: string;
-  }> => ({ type: "channel" }),
+  async (params: {
+    cfg: OpenClawConfig;
+    channelId: string;
+    requireFreshName?: boolean;
+  }): Promise<{ type: "channel" | "group" | "dm" | "unknown"; name?: string; user?: string }> => {
+    if (/^D/i.test(params.channelId)) {
+      return { type: "dm", user: "U123" };
+    }
+    if (/^G/i.test(params.channelId)) {
+      return { type: "group" };
+    }
+    const slackConfig = params.cfg.channels?.slack as
+      | { userToken?: string; botToken?: string; channels?: Record<string, unknown> }
+      | undefined;
+    const token = slackConfig?.userToken ?? slackConfig?.botToken;
+    const tokenOverride = token && token !== slackConfig?.botToken ? { token } : {};
+    const channelName = params.requireFreshName
+      ? await resolveSlackConversationName(params.channelId, {
+          cfg: params.cfg,
+          ...tokenOverride,
+        })
+      : undefined;
+    return { type: "channel", ...(channelName ? { name: channelName } : {}) };
+  },
 );
 const sendSlackMessage = vi.fn(async (..._args: unknown[]) => ({ channelId: "C123" }));
 const unpinSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
@@ -245,7 +265,8 @@ describe("handleSlackAction", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    resolveSlackConversationInfo.mockReset().mockResolvedValue({ type: "channel" });
+    resolveSlackConversationName.mockReset().mockResolvedValue(undefined);
+    resolveSlackConversationInfo.mockClear();
     Object.assign(slackActionRuntime, originalSlackActionRuntime, {
       deleteSlackMessage,
       downloadSlackFile,
@@ -260,6 +281,7 @@ describe("handleSlackAction", () => {
       readSlackMessages,
       removeOwnSlackReactions,
       removeSlackReaction,
+      resolveSlackConversationName,
       resolveSlackConversationInfo,
       sendSlackMessage,
       unpinSlackMessage,
@@ -304,28 +326,6 @@ describe("handleSlackAction", () => {
       cfg,
     );
     expect(removeOwnSlackReactions).toHaveBeenCalledWith("C1", "123.456", { cfg });
-  });
-
-  it("rejects reaction clearing outside allowlisted Slack channels", async () => {
-    const cfg = slackConfig({
-      groupPolicy: "allowlist",
-      channels: {
-        C_ALLOWED: { enabled: true },
-      },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "react",
-          channelId: "C_OTHER",
-          messageId: "123.456",
-          emoji: "",
-        },
-        cfg,
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(removeOwnSlackReactions).not.toHaveBeenCalled();
   });
 
   it("removes reactions when remove flag set", async () => {
@@ -382,699 +382,6 @@ describe("handleSlackAction", () => {
 
     await expect(
       handleSlackAction({ action: "reactions", channelId: "C_OTHER", messageId: "123.456" }, cfg),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    {
-      name: "reaction add",
-      params: { action: "react", emoji: "✅" },
-      providerCall: reactSlackMessage,
-    },
-    {
-      name: "reaction removal",
-      params: { action: "react", emoji: "✅", remove: true },
-      providerCall: removeSlackReaction,
-    },
-    {
-      name: "message edit",
-      params: { action: "editMessage", content: "updated" },
-      providerCall: editSlackMessage,
-    },
-    {
-      name: "message deletion",
-      params: { action: "deleteMessage" },
-      providerCall: deleteSlackMessage,
-    },
-    {
-      name: "pin",
-      params: { action: "pinMessage" },
-      providerCall: pinSlackMessage,
-    },
-    {
-      name: "unpin",
-      params: { action: "unpinMessage" },
-      providerCall: unpinSlackMessage,
-    },
-  ])("rejects blocked Slack $name before mutation", async ({ params, providerCall }) => {
-    const cfg = slackConfig({
-      groupPolicy: "allowlist",
-      channels: {
-        C_ALLOWED: { enabled: true },
-      },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          channelId: "C_BLOCKED",
-          messageId: "123.456",
-          ...params,
-        },
-        cfg,
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-
-    expect(providerCall).not.toHaveBeenCalled();
-  });
-
-  it("allows a delegated read of the exact current Slack channel and account", async () => {
-    const cfg = slackConfig({
-      groupPolicy: "allowlist",
-      channels: {
-        C_ALLOWED: { enabled: true },
-      },
-    });
-
-    await handleSlackAction(
-      {
-        action: "reactions",
-        channelId: "C_CURRENT",
-        messageId: "123.456",
-      },
-      cfg,
-      {
-        requesterAccountId: "DEFAULT",
-        currentChannelProvider: "Slack",
-        currentChannelId: "C_CURRENT",
-      },
-    );
-
-    expect(listSlackReactions).toHaveBeenCalledWith("C_CURRENT", "123.456", { cfg });
-  });
-
-  it("does not borrow current Slack visibility from another account", async () => {
-    const cfg = slackConfig({
-      groupPolicy: "allowlist",
-      channels: {
-        C_ALLOWED: { enabled: true },
-      },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "C_CURRENT",
-          messageId: "123.456",
-        },
-        cfg,
-        {
-          requesterAccountId: "other",
-          currentChannelProvider: "slack",
-          currentChannelId: "C_CURRENT",
-        },
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("allows delegated member info for the current Slack requester and account", async () => {
-    const cfg = slackConfig();
-
-    await handleSlackAction({ action: "memberInfo", userId: "U123" }, cfg, {
-      conversationReadOrigin: "delegated",
-      requesterAccountId: "DEFAULT",
-      requesterSenderId: "u123",
-      currentChannelProvider: "Slack",
-    });
-
-    expect(getSlackMemberInfo).toHaveBeenCalledWith("U123", { cfg });
-  });
-
-  it.each([
-    {
-      name: "another user",
-      context: {
-        conversationReadOrigin: "delegated" as const,
-        requesterAccountId: "default",
-        requesterSenderId: "U123",
-        currentChannelProvider: "slack",
-      },
-      userId: "U999",
-    },
-    {
-      name: "another account",
-      context: {
-        conversationReadOrigin: "delegated" as const,
-        requesterAccountId: "other",
-        requesterSenderId: "U123",
-        currentChannelProvider: "slack",
-      },
-      userId: "U123",
-    },
-    {
-      name: "another provider",
-      context: {
-        conversationReadOrigin: "delegated" as const,
-        requesterAccountId: "default",
-        requesterSenderId: "U123",
-        currentChannelProvider: "telegram",
-      },
-      userId: "U123",
-    },
-    {
-      name: "missing trusted context",
-      context: undefined,
-      userId: "U123",
-    },
-  ])("rejects delegated member info for $name before provider access", async (testCase) => {
-    await expect(
-      handleSlackAction(
-        { action: "memberInfo", userId: testCase.userId },
-        slackConfig(),
-        testCase.context,
-      ),
-    ).rejects.toThrow("Delegated Slack member info is limited to the current requester.");
-
-    expect(getSlackMemberInfo).not.toHaveBeenCalled();
-  });
-
-  it("allows a direct operator to inspect another Slack member", async () => {
-    const cfg = slackConfig();
-
-    await handleSlackAction({ action: "memberInfo", userId: "U999" }, cfg, {
-      conversationReadOrigin: "direct-operator",
-    });
-
-    expect(getSlackMemberInfo).toHaveBeenCalledWith("U999", { cfg });
-  });
-
-  it("keeps explicitly disabled current Slack channels blocked", async () => {
-    const cfg = slackConfig({
-      groupPolicy: "allowlist",
-      channels: {
-        C_CURRENT: { enabled: false },
-      },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "C_CURRENT",
-          messageId: "123.456",
-        },
-        cfg,
-        {
-          requesterAccountId: "default",
-          currentChannelProvider: "slack",
-          currentChannelId: "C_CURRENT",
-        },
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(resolveSlackConversationInfo).not.toHaveBeenCalled();
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("lets a direct operator read an unconfigured Slack channel", async () => {
-    const cfg = slackConfig({
-      groupPolicy: "allowlist",
-      channels: {
-        C_ALLOWED: { enabled: true },
-      },
-    });
-
-    await handleSlackAction(
-      {
-        action: "reactions",
-        channelId: "C_OTHER",
-        messageId: "123.456",
-      },
-      cfg,
-      { conversationReadOrigin: "direct-operator" },
-    );
-
-    expect(listSlackReactions).toHaveBeenCalledWith("C_OTHER", "123.456", { cfg });
-    expect(resolveSlackConversationInfo).toHaveBeenCalledWith({
-      cfg,
-      accountId: "default",
-      channelId: "C_OTHER",
-      operation: "read",
-    });
-  });
-
-  it("keeps name-disabled Slack channels blocked for direct operators", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({
-      type: "channel",
-      name: "blocked-channel",
-    });
-    const cfg = slackConfig({
-      groupPolicy: "allowlist",
-      dangerouslyAllowNameMatching: true,
-      channels: {
-        "#blocked-channel": { enabled: false },
-      },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "C_BLOCKED",
-          messageId: "123.456",
-        },
-        cfg,
-        { conversationReadOrigin: "direct-operator" },
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(resolveSlackConversationInfo).toHaveBeenCalledWith({
-      cfg,
-      accountId: "default",
-      channelId: "C_BLOCKED",
-      operation: "read",
-      requireFreshName: true,
-    });
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("keeps wildcard-disabled Slack channels blocked for direct operators", async () => {
-    const cfg = slackConfig({
-      groupPolicy: "open",
-      channels: {
-        "*": { enabled: false },
-      },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "C_BLOCKED",
-          messageId: "123.456",
-        },
-        cfg,
-        { conversationReadOrigin: "direct-operator" },
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(resolveSlackConversationInfo).not.toHaveBeenCalled();
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("lets an explicit name allow override a wildcard denial for direct operators", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({
-      type: "channel",
-      name: "allowed-channel",
-    });
-    const cfg = slackConfig({
-      groupPolicy: "allowlist",
-      dangerouslyAllowNameMatching: true,
-      channels: {
-        "*": { enabled: false },
-        "#allowed-channel": { enabled: true },
-      },
-    });
-
-    await handleSlackAction(
-      {
-        action: "reactions",
-        channelId: "C_ALLOWED",
-        messageId: "123.456",
-      },
-      cfg,
-      { conversationReadOrigin: "direct-operator" },
-    );
-
-    expect(listSlackReactions).toHaveBeenCalledWith("C_ALLOWED", "123.456", { cfg });
-  });
-
-  it("does not make direct reads depend on unrelated named allows", async () => {
-    const cfg = slackConfig({
-      groupPolicy: "open",
-      dangerouslyAllowNameMatching: true,
-      channels: {
-        "#announcements": { enabled: true },
-      },
-      dm: { groupEnabled: true },
-    });
-
-    await handleSlackAction(
-      {
-        action: "reactions",
-        channelId: "C_OTHER",
-        messageId: "123.456",
-      },
-      cfg,
-      { conversationReadOrigin: "direct-operator" },
-    );
-
-    expect(resolveSlackConversationInfo).not.toHaveBeenCalled();
-    expect(listSlackReactions).toHaveBeenCalledWith("C_OTHER", "123.456", { cfg });
-  });
-
-  it("does not bypass a wildcard denial when Slack name lookup is unresolved", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({ type: "unknown" });
-    const cfg = slackConfig({
-      groupPolicy: "open",
-      dangerouslyAllowNameMatching: true,
-      channels: {
-        "*": { enabled: false },
-        "#allowed-channel": { enabled: true },
-      },
-      dm: { groupEnabled: true },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "C_UNRESOLVED",
-          messageId: "123.456",
-        },
-        cfg,
-        { conversationReadOrigin: "direct-operator" },
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("does not bypass a name denial when Slack metadata lookup is unresolved", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({ type: "unknown" });
-    const cfg = slackConfig({
-      groupPolicy: "open",
-      dangerouslyAllowNameMatching: true,
-      channels: {
-        "#blocked-channel": { enabled: false },
-      },
-      dm: { groupEnabled: true },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "C_UNRESOLVED",
-          messageId: "123.456",
-        },
-        cfg,
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("lets a direct operator read a DM when group reads are disabled", async () => {
-    const cfg = slackConfig({
-      groupPolicy: "disabled",
-      dmPolicy: "pairing",
-    });
-
-    await handleSlackAction(
-      {
-        action: "reactions",
-        channelId: "D_OTHER",
-        messageId: "123.456",
-      },
-      cfg,
-      { conversationReadOrigin: "direct-operator" },
-    );
-
-    expect(listSlackReactions).toHaveBeenCalledWith("D_OTHER", "123.456", { cfg });
-    expect(resolveSlackConversationInfo).not.toHaveBeenCalled();
-  });
-
-  it("lets a delegated model read its current Slack DM", async () => {
-    const cfg = slackConfig({
-      groupPolicy: "disabled",
-      dmPolicy: "pairing",
-    });
-
-    await handleSlackAction(
-      {
-        action: "reactions",
-        channelId: "D_CURRENT",
-        messageId: "123.456",
-      },
-      cfg,
-      {
-        conversationReadOrigin: "delegated",
-        requesterAccountId: "default",
-        currentChannelProvider: "slack",
-        currentChannelId: "D_CURRENT",
-      },
-    );
-
-    expect(listSlackReactions).toHaveBeenCalledWith("D_CURRENT", "123.456", { cfg });
-    expect(resolveSlackConversationInfo).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    {
-      name: "allowFrom peer",
-      overrides: { dmPolicy: "allowlist", allowFrom: ["slack:U0ALLOWED"] },
-    },
-    {
-      name: "per-DM peer",
-      overrides: { dmPolicy: "pairing", dms: { U0ALLOWED: { historyLimit: 5 } } },
-    },
-    {
-      name: "default target peer",
-      overrides: { dmPolicy: "pairing", defaultTo: "user:U0ALLOWED" },
-    },
-  ])(
-    "lets a delegated model read an explicitly configured Slack DM via $name",
-    async (testCase) => {
-      resolveSlackConversationInfo.mockResolvedValueOnce({ type: "dm", user: "U0ALLOWED" });
-      const cfg = slackConfig(testCase.overrides);
-
-      await handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "D_ALLOWED",
-          messageId: "123.456",
-        },
-        cfg,
-        { conversationReadOrigin: "delegated" },
-      );
-
-      expect(resolveSlackConversationInfo).toHaveBeenCalledOnce();
-      expect(listSlackReactions).toHaveBeenCalledWith("D_ALLOWED", "123.456", { cfg });
-    },
-  );
-
-  it("blocks an unconfigured delegated Slack DM before provider content access", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({ type: "dm", user: "U0OTHER01" });
-    const cfg = slackConfig({
-      dmPolicy: "pairing",
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "D_OTHER",
-          messageId: "123.456",
-        },
-        cfg,
-        { conversationReadOrigin: "delegated" },
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-
-    expect(resolveSlackConversationInfo).toHaveBeenCalledOnce();
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("does not treat an open-DM wildcard as a configured read target", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({ type: "dm", user: "U0OTHER01" });
-    const cfg = slackConfig({
-      dmPolicy: "open",
-      allowFrom: ["*"],
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "D_OTHER",
-          messageId: "123.456",
-        },
-        cfg,
-        { conversationReadOrigin: "delegated" },
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when Slack cannot resolve a delegated DM peer", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({ type: "dm" });
-    const cfg = slackConfig({
-      dmPolicy: "allowlist",
-      allowFrom: ["U0ALLOWED"],
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "D_UNKNOWN",
-          messageId: "123.456",
-        },
-        cfg,
-        { conversationReadOrigin: "delegated" },
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("lets a direct operator read an enabled Slack group DM", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({ type: "group" });
-    const cfg = slackConfig({
-      groupPolicy: "disabled",
-      dm: {
-        groupEnabled: true,
-        groupChannels: ["G_ALLOWED"],
-      },
-    });
-
-    await handleSlackAction(
-      {
-        action: "reactions",
-        channelId: "G_ALLOWED",
-        messageId: "123.456",
-      },
-      cfg,
-      { conversationReadOrigin: "direct-operator" },
-    );
-
-    expect(listSlackReactions).toHaveBeenCalledWith("G_ALLOWED", "123.456", { cfg });
-  });
-
-  it("blocks a C-prefixed MPIM when direct group-DM reads are disabled", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({ type: "group" });
-    const cfg = slackConfig({
-      groupPolicy: "open",
-      dm: { groupEnabled: false },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "C_MPIM",
-          messageId: "123.456",
-        },
-        cfg,
-        { conversationReadOrigin: "direct-operator" },
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("blocks a C-prefixed MPIM from delegated channel allowlists", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({ type: "group" });
-    const cfg = slackConfig({
-      groupPolicy: "allowlist",
-      channels: {
-        C_MPIM: { enabled: true },
-      },
-      dm: { groupEnabled: false },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "C_MPIM",
-          messageId: "123.456",
-        },
-        cfg,
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("rejects unknown Slack topology unless both possible read policies allow it", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({ type: "unknown" });
-    const cfg = slackConfig({
-      groupPolicy: "allowlist",
-      channels: {
-        C_AMBIGUOUS: { enabled: true },
-      },
-      dm: { groupEnabled: false },
-    });
-
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId: "C_AMBIGUOUS",
-          messageId: "123.456",
-        },
-        cfg,
-      ),
-    ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(listSlackReactions).not.toHaveBeenCalled();
-  });
-
-  it("allows unknown Slack topology when both possible read policies allow it", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({ type: "unknown" });
-    const cfg = slackConfig({
-      groupPolicy: "open",
-      dm: { groupEnabled: true },
-    });
-
-    await handleSlackAction(
-      {
-        action: "reactions",
-        channelId: "C_AMBIGUOUS",
-        messageId: "123.456",
-      },
-      cfg,
-    );
-
-    expect(listSlackReactions).toHaveBeenCalledWith("C_AMBIGUOUS", "123.456", { cfg });
-  });
-
-  it.each([
-    {
-      name: "disabled scope",
-      overrides: { groupPolicy: "disabled" },
-      channelId: "C_OTHER",
-      channelType: undefined,
-    },
-    {
-      name: "explicitly disabled channel",
-      overrides: {
-        groupPolicy: "allowlist",
-        channels: { C_BLOCKED: { enabled: false } },
-      },
-      channelId: "C_BLOCKED",
-      channelType: undefined,
-    },
-    {
-      name: "disabled DM scope",
-      overrides: {
-        groupPolicy: "open",
-        dmPolicy: "disabled",
-      },
-      channelId: "D_BLOCKED",
-      channelType: undefined,
-    },
-    {
-      name: "disabled group DM scope",
-      overrides: {
-        groupPolicy: "open",
-        dm: { groupEnabled: false },
-      },
-      channelId: "G_BLOCKED",
-      channelType: "group" as const,
-    },
-  ])("keeps $name blocked for direct operators", async ({ overrides, channelId, channelType }) => {
-    if (channelType) {
-      resolveSlackConversationInfo.mockResolvedValueOnce({ type: channelType });
-    }
-    await expect(
-      handleSlackAction(
-        {
-          action: "reactions",
-          channelId,
-          messageId: "123.456",
-        },
-        slackConfig(overrides),
-        { conversationReadOrigin: "direct-operator" },
-      ),
     ).rejects.toThrow("Slack read target channel is not allowed.");
     expect(listSlackReactions).not.toHaveBeenCalled();
   });
@@ -1395,6 +702,7 @@ describe("handleSlackAction", () => {
     const context = createReplyToFirstContext(hasRepliedRef);
     const content = "x".repeat(8001);
     const blocks = [{ type: "divider" }];
+    sendSlackMessage.mockResolvedValueOnce({ channelId: "controls" });
     sendSlackMessage.mockResolvedValueOnce({ channelId: "content" });
 
     const result = await handleSlackAction(
@@ -1409,14 +717,21 @@ describe("handleSlackAction", () => {
       context,
     );
 
-    expect(sendSlackMessage).toHaveBeenCalledOnce();
-    expectSlackSendCall(0, "channel:C123", content, {
+    expect(sendSlackMessage).toHaveBeenCalledTimes(2);
+    expectSlackSendCall(0, "channel:C123", "", {
       cfg,
       blocks,
-      replyBroadcast: true,
-      separateTextAndBlocks: true,
       threadTs: "1111111111.111111",
     });
+    expect(requireRecordArg(sendSlackMessage, "sendSlackMessage", 0, 2)).not.toHaveProperty(
+      "replyBroadcast",
+    );
+    const textOptions = expectSlackSendCall(1, "channel:C123", content, {
+      cfg,
+      replyBroadcast: true,
+      threadTs: "1111111111.111111",
+    });
+    expect(textOptions).not.toHaveProperty("blocks");
     expect(hasRepliedRef.value).toBe(true);
     expect(result.details).toEqual({
       ok: true,
@@ -1424,10 +739,16 @@ describe("handleSlackAction", () => {
     });
   });
 
-  it("separates explicitly marked short text from native blocks", async () => {
+  it("keeps overlong native-data accessibility and blocks in one send", async () => {
     const cfg = slackConfig();
-    const content = "Short portable table fallback";
-    const blocks = [{ type: "divider" }];
+    const content = `Pipeline summary\n\n${"x".repeat(8001)}`;
+    const blocks = [
+      {
+        type: "data_table",
+        caption: "Pipeline",
+        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
+      },
+    ];
 
     await handleSlackAction(
       {
@@ -1435,7 +756,7 @@ describe("handleSlackAction", () => {
         to: "channel:C123",
         content,
         blocks,
-        separateTextAndBlocks: true,
+        nativeDataFallbackBaseText: "Pipeline summary",
       },
       cfg,
     );
@@ -1444,9 +765,58 @@ describe("handleSlackAction", () => {
     expectSlackSendCall(0, "channel:C123", content, {
       cfg,
       blocks,
-      separateTextAndBlocks: true,
+      nativeDataFallbackBaseText: "Pipeline summary",
       threadTs: undefined,
     });
+  });
+
+  it("delivers a prepared presentation plan in order on one resolved thread", async () => {
+    const cfg = slackConfig();
+    const chartBlocks = [{ type: "data_visualization", title: "Revenue", chart: {} }];
+    const controlBlocks = [{ type: "actions", elements: [] }];
+    const hasRepliedRef = { value: false };
+
+    await handleSlackAction(
+      {
+        action: "sendMessage",
+        to: "channel:C123",
+        content: "Summary",
+        replyBroadcast: true,
+      },
+      cfg,
+      {
+        currentChannelId: "C123",
+        currentThreadTs: "1111111111.111111",
+        replyToMode: "first",
+        hasRepliedRef,
+        preparedMessages: [
+          { text: "Revenue", blocks: chartBlocks as never, authoredTextPlacement: "blocks" },
+          { text: "Wide table fallback", textIsSlackPlainText: true },
+          { text: "Refresh", blocks: controlBlocks as never, authoredTextPlacement: "none" },
+        ],
+      },
+    );
+
+    expect(sendSlackMessage).toHaveBeenCalledTimes(3);
+    expectSlackSendCall(0, "channel:C123", "Revenue", {
+      cfg,
+      blocks: chartBlocks,
+      authoredTextPlacement: "blocks",
+      replyBroadcast: true,
+      threadTs: "1111111111.111111",
+    });
+    expectSlackSendCall(1, "channel:C123", "Wide table fallback", {
+      cfg,
+      textIsSlackPlainText: true,
+      threadTs: "1111111111.111111",
+    });
+    expectSlackSendCall(2, "channel:C123", "Refresh", {
+      cfg,
+      blocks: controlBlocks,
+      authoredTextPlacement: "none",
+      threadTs: "1111111111.111111",
+    });
+    expect(hasRepliedRef.value).toBe(true);
   });
 
   it.each([
@@ -1922,10 +1292,7 @@ describe("handleSlackAction", () => {
   });
 
   it("resolves name-allowlisted reads from a core-shaped Slack threading context", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({
-      type: "channel",
-      name: "allowed-channel",
-    });
+    resolveSlackConversationName.mockResolvedValueOnce("allowed-channel");
     readSlackMessages.mockResolvedValueOnce({ messages: [], hasMore: false });
 
     const cfg = slackConfig({
@@ -1947,21 +1314,12 @@ describe("handleSlackAction", () => {
 
     await handleSlackAction({ action: "readMessages", channelId: "C0123456789" }, cfg, context);
 
-    expect(resolveSlackConversationInfo).toHaveBeenCalledWith({
-      cfg,
-      accountId: "default",
-      channelId: "C0123456789",
-      operation: "read",
-      requireFreshName: true,
-    });
+    expect(resolveSlackConversationName).toHaveBeenCalledWith("C0123456789", { cfg });
     expect(requireMockArg(readSlackMessages, "readSlackMessages", 0, 0)).toBe("C0123456789");
   });
 
   it("does not treat the core Channel provider value as a Slack room name", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({
-      type: "channel",
-      name: "actual-room",
-    });
+    resolveSlackConversationName.mockResolvedValueOnce("actual-room");
 
     const cfg = slackConfig({
       groupPolicy: "allowlist",
@@ -1983,21 +1341,12 @@ describe("handleSlackAction", () => {
     await expect(
       handleSlackAction({ action: "readMessages", channelId: "C0123456789" }, cfg, context),
     ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(resolveSlackConversationInfo).toHaveBeenCalledWith({
-      cfg,
-      accountId: "default",
-      channelId: "C0123456789",
-      operation: "read",
-      requireFreshName: true,
-    });
+    expect(resolveSlackConversationName).toHaveBeenCalledWith("C0123456789", { cfg });
     expect(readSlackMessages).not.toHaveBeenCalled();
   });
 
   it("does not authorize different Slack targets with the current context channel ID", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({
-      type: "channel",
-      name: "other-channel",
-    });
+    resolveSlackConversationName.mockResolvedValueOnce("other-channel");
 
     const cfg = slackConfig({
       groupPolicy: "allowlist",
@@ -2012,21 +1361,12 @@ describe("handleSlackAction", () => {
         currentChannelId: "C0123456789",
       }),
     ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(resolveSlackConversationInfo).toHaveBeenCalledWith({
-      cfg,
-      accountId: "default",
-      channelId: "C9876543210",
-      operation: "read",
-      requireFreshName: true,
-    });
+    expect(resolveSlackConversationName).toHaveBeenCalledWith("C9876543210", { cfg });
     expect(readSlackMessages).not.toHaveBeenCalled();
   });
 
-  it("requests read-scoped metadata for name-allowlisted channels", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({
-      type: "channel",
-      name: "allowed-channel",
-    });
+  it("uses the configured user read token to resolve name-allowlisted channels", async () => {
+    resolveSlackConversationName.mockResolvedValueOnce("allowed-channel");
     readSlackMessages.mockResolvedValueOnce({ messages: [], hasMore: false });
 
     const cfg = slackConfig({
@@ -2039,21 +1379,15 @@ describe("handleSlackAction", () => {
     });
     await handleSlackAction({ action: "readMessages", channelId: "C0123456789" }, cfg);
 
-    expect(resolveSlackConversationInfo).toHaveBeenCalledWith({
+    expect(resolveSlackConversationName).toHaveBeenCalledWith("C0123456789", {
       cfg,
-      accountId: "default",
-      channelId: "C0123456789",
-      operation: "read",
-      requireFreshName: true,
+      token: "xoxp-reader",
     });
     expect(requireMockArg(readSlackMessages, "readSlackMessages", 0, 0)).toBe("C0123456789");
   });
 
   it("resolves Slack target channel names before applying wildcard fallback denial", async () => {
-    resolveSlackConversationInfo.mockResolvedValueOnce({
-      type: "channel",
-      name: "allowed-channel",
-    });
+    resolveSlackConversationName.mockResolvedValueOnce("allowed-channel");
     readSlackMessages.mockResolvedValueOnce({ messages: [], hasMore: false });
 
     const cfg = slackConfig({
@@ -2066,13 +1400,7 @@ describe("handleSlackAction", () => {
     });
     await handleSlackAction({ action: "readMessages", channelId: "C0123456789" }, cfg);
 
-    expect(resolveSlackConversationInfo).toHaveBeenCalledWith({
-      cfg,
-      accountId: "default",
-      channelId: "C0123456789",
-      operation: "read",
-      requireFreshName: true,
-    });
+    expect(resolveSlackConversationName).toHaveBeenCalledWith("C0123456789", { cfg });
     expect(requireMockArg(readSlackMessages, "readSlackMessages", 0, 0)).toBe("C0123456789");
   });
 
@@ -2089,12 +1417,12 @@ describe("handleSlackAction", () => {
     await expect(
       handleSlackAction({ action: "readMessages", channelId: "C0123456789" }, cfg),
     ).rejects.toThrow("Slack read target channel is not allowed.");
-    expect(resolveSlackConversationInfo).not.toHaveBeenCalled();
+    expect(resolveSlackConversationName).not.toHaveBeenCalled();
     expect(readSlackMessages).not.toHaveBeenCalled();
   });
 
   it("fails closed before reading when Slack cannot resolve the target name", async () => {
-    resolveSlackConversationInfo.mockRejectedValueOnce(new Error("missing_scope"));
+    resolveSlackConversationName.mockRejectedValueOnce(new Error("missing_scope"));
     const cfg = slackConfig({
       groupPolicy: "allowlist",
       dangerouslyAllowNameMatching: true,

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -14,6 +14,7 @@ import { SLACK_TEXT_LIMIT } from "./limits.js";
 import { resolveSlackChannelConfig } from "./monitor/channel-config.js";
 import { isSlackChannelAllowedByPolicy } from "./monitor/policy.js";
 import { hasSlackNativeDataBlock } from "./native-data-blocks.js";
+import type { SlackReplyDeliveryMessage } from "./reply-blocks.js";
 import {
   createActionGate,
   imageResultFromFile,
@@ -110,6 +111,8 @@ export type SlackActionContext = {
   /** Allowed local media directories for file uploads. */
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
+  /** Slack-private ordered delivery plan prepared after presentation normalization. */
+  preparedMessages?: readonly SlackReplyDeliveryMessage[];
 };
 
 /**
@@ -531,8 +534,8 @@ export async function handleSlackAction(
       const { emoji, remove, isEmpty } = readReactionParams(params, {
         removeErrorMessage: "Emoji is required to remove a Slack reaction.",
       });
+      await assertReadTargetAllowed(channelId);
       if (remove) {
-        await assertReadTargetAllowed(channelId);
         if (writeOpts) {
           await slackActionRuntime.removeSlackReaction(channelId, messageId, emoji, writeOpts);
         } else {
@@ -541,13 +544,11 @@ export async function handleSlackAction(
         return jsonResult({ ok: true, removed: emoji });
       }
       if (isEmpty) {
-        await assertReadTargetAllowed(channelId);
         const removed = writeOpts
           ? await slackActionRuntime.removeOwnSlackReactions(channelId, messageId, writeOpts)
           : await slackActionRuntime.removeOwnSlackReactions(channelId, messageId);
         return jsonResult({ ok: true, removed });
       }
-      await assertReadTargetAllowed(channelId);
       if (writeOpts) {
         await slackActionRuntime.reactSlackMessage(channelId, messageId, emoji, writeOpts);
       } else {
@@ -576,8 +577,25 @@ export async function handleSlackAction(
         const blocks = readSlackBlocksParam(params);
         const replyBroadcast = readBooleanParam(params, "replyBroadcast");
         const textIsSlackMrkdwn = readBooleanParam(params, "textIsSlackMrkdwn");
-        const separateTextAndBlocks = readBooleanParam(params, "separateTextAndBlocks");
-        if (!content && !mediaUrl && !blocks) {
+        const textIsSlackPlainText = readBooleanParam(params, "textIsSlackPlainText");
+        const preparedMessages = context?.preparedMessages;
+        const authoredTextPlacement = readStringParam(params, "authoredTextPlacement") as
+          | "none"
+          | "blocks"
+          | "outside-blocks"
+          | undefined;
+        if (
+          authoredTextPlacement &&
+          authoredTextPlacement !== "none" &&
+          authoredTextPlacement !== "blocks" &&
+          authoredTextPlacement !== "outside-blocks"
+        ) {
+          throw new Error("Slack authoredTextPlacement is invalid.");
+        }
+        const nativeDataFallbackBaseText = readStringParam(params, "nativeDataFallbackBaseText", {
+          allowEmpty: true,
+        });
+        if (!content && !mediaUrl && !blocks && !preparedMessages?.length) {
           throw new Error("Slack sendMessage requires content, blocks, or mediaUrl.");
         }
         if (replyBroadcast && mediaUrl) {
@@ -593,47 +611,83 @@ export async function handleSlackAction(
             suppressImplicitThread: params.topLevel === true || params.threadTs === null,
           },
         );
-        const sendOpts = {
+        const baseSendOpts = {
           ...writeOpts,
           mediaLocalRoots: context?.mediaLocalRoots,
           mediaReadFile: context?.mediaReadFile,
           threadTs: threadTs ?? undefined,
+        };
+        const sendOpts = {
+          ...baseSendOpts,
           ...(replyBroadcast ? { replyBroadcast } : {}),
           ...(textIsSlackMrkdwn ? { textIsSlackMrkdwn: true } : {}),
+          ...(textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+          ...(authoredTextPlacement ? { authoredTextPlacement } : {}),
+          ...(nativeDataFallbackBaseText !== undefined ? { nativeDataFallbackBaseText } : {}),
         };
         const sendContentAndBlocks = async () => {
-          const nativeDataOwnsChunking = hasSlackNativeDataBlock(blocks);
-          if (
-            content &&
-            (separateTextAndBlocks ||
-              (content.length > SLACK_TEXT_LIMIT && !nativeDataOwnsChunking))
-          ) {
-            return await slackActionRuntime.sendSlackMessage(to, content, {
-              ...sendOpts,
+          const shouldSplitLongContent =
+            content && content.length > SLACK_TEXT_LIMIT && !hasSlackNativeDataBlock(blocks);
+          if (content && shouldSplitLongContent) {
+            // Reuse the resolved thread for both sends. Invoking the action twice
+            // could consume replyToMode=first and move the full text off-thread.
+            const { replyBroadcast: _replyBroadcast, ...blockSendOpts } = sendOpts;
+            await slackActionRuntime.sendSlackMessage(to, "", {
+              ...blockSendOpts,
               blocks,
-              separateTextAndBlocks: true,
             });
+            return await slackActionRuntime.sendSlackMessage(to, content, sendOpts);
           }
           return await slackActionRuntime.sendSlackMessage(to, content ?? "", {
             ...sendOpts,
             blocks,
           });
         };
-        const result = blocks
+        const result = preparedMessages?.length
           ? await (async () => {
+              let lastResult:
+                | Awaited<ReturnType<typeof slackActionRuntime.sendSlackMessage>>
+                | undefined;
               if (mediaUrl) {
-                await slackActionRuntime.sendSlackMessage(to, "", {
-                  ...sendOpts,
+                lastResult = await slackActionRuntime.sendSlackMessage(to, "", {
+                  ...baseSendOpts,
                   mediaUrl,
                 });
               }
-              return await sendContentAndBlocks();
+              for (const [index, message] of preparedMessages.entries()) {
+                lastResult = await slackActionRuntime.sendSlackMessage(to, message.text, {
+                  ...baseSendOpts,
+                  ...(index === 0 && replyBroadcast ? { replyBroadcast: true } : {}),
+                  ...(message.blocks ? { blocks: message.blocks } : {}),
+                  ...(message.authoredTextPlacement
+                    ? { authoredTextPlacement: message.authoredTextPlacement }
+                    : {}),
+                  ...(Object.hasOwn(message, "nativeDataFallbackBaseText")
+                    ? { nativeDataFallbackBaseText: message.nativeDataFallbackBaseText }
+                    : {}),
+                  ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+                });
+              }
+              if (!lastResult) {
+                throw new Error("Slack prepared message plan produced no delivery.");
+              }
+              return lastResult;
             })()
-          : await slackActionRuntime.sendSlackMessage(to, content ?? "", {
-              ...sendOpts,
-              mediaUrl: mediaUrl ?? undefined,
-              blocks,
-            });
+          : blocks
+            ? await (async () => {
+                if (mediaUrl) {
+                  await slackActionRuntime.sendSlackMessage(to, "", {
+                    ...sendOpts,
+                    mediaUrl,
+                  });
+                }
+                return await sendContentAndBlocks();
+              })()
+            : await slackActionRuntime.sendSlackMessage(to, content ?? "", {
+                ...sendOpts,
+                mediaUrl: mediaUrl ?? undefined,
+                blocks,
+              });
 
         // Keep "first" mode consistent even when the agent explicitly provided
         // threadTs: once we send a message to the current channel, consider the
@@ -862,7 +916,7 @@ export async function handleSlackAction(
     }
     const userId = readStringParam(params, "userId", { required: true });
     assertSlackMemberInfoAllowed({ account, context, userId });
-    const info = writeOpts
+    const info = readOpts
       ? await slackActionRuntime.getSlackMemberInfo(userId, readOpts)
       : await slackActionRuntime.getSlackMemberInfo(userId);
     return jsonResult({ ok: true, info });

--- a/extensions/slack/src/actions.blocks.test.ts
+++ b/extensions/slack/src/actions.blocks.test.ts
@@ -1,9 +1,70 @@
 // Slack tests cover actions.blocks plugin behavior.
 import { describe, expect, it } from "vitest";
-import { createSlackEditTestClient } from "./blocks.test-helpers.js";
+import { createSlackEditTestClient, createSlackSendTestClient } from "./blocks.test-helpers.js";
 
-const { editSlackMessage } = await import("./actions.js");
+const { editSlackMessage, sendSlackMessage } = await import("./actions.js");
 const SLACK_TEXT_LIMIT = 8000;
+const SLACK_EDIT_TEXT_LIMIT = 4000;
+
+function readFirstChatUpdatePayload(client: ReturnType<typeof createSlackEditTestClient>): {
+  text?: string;
+} {
+  const [call] = client.chat.update.mock.calls;
+  if (!call) {
+    throw new Error("expected Slack chat.update call");
+  }
+  const [payload] = call;
+  if (!payload || typeof payload !== "object") {
+    throw new Error("expected Slack chat.update payload");
+  }
+  return payload as { text?: string };
+}
+
+describe("sendSlackMessage blocks", () => {
+  it("uses the original action text once when a native table is rejected", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+    const blocks = [
+      {
+        type: "data_table",
+        caption: "Pipeline",
+        rows: [
+          [
+            { type: "raw_text", text: "Account" },
+            { type: "raw_text", text: "ARR" },
+          ],
+          [
+            { type: "raw_text", text: "Acme" },
+            { type: "raw_number", value: 125000, text: "125000" },
+          ],
+        ],
+      },
+    ] as never;
+
+    await sendSlackMessage(
+      "channel:C123",
+      "Pipeline summary\n\nPipeline (table)\n- Account: Acme; ARR: 125000",
+      {
+        cfg: { channels: { slack: { botToken: "xoxb-test" } } },
+        token: "xoxb-test",
+        client,
+        blocks,
+        nativeDataFallbackBaseText: "Pipeline summary",
+      },
+    );
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    const fallback = client.chat.postMessage.mock.calls[1]?.[0] as
+      | { blocks?: unknown; mrkdwn?: boolean; text?: string }
+      | undefined;
+    expect(fallback).toMatchObject({
+      mrkdwn: false,
+      text: "Pipeline summary\n\nPipeline (table)\nAccount\tARR\nAcme\t125000",
+    });
+    expect(fallback?.blocks).toBeUndefined();
+    expect(fallback?.text?.match(/Acme/gu)).toHaveLength(1);
+  });
+});
 
 describe("editSlackMessage blocks", () => {
   it("preserves long plain-text edits", async () => {
@@ -121,7 +182,7 @@ describe("editSlackMessage blocks", () => {
     });
   });
 
-  it("retries rejected native charts as visible fallback blocks", async () => {
+  it("retries rejected native charts with text fallback and surviving blocks", async () => {
     const client = createSlackEditTestClient();
     client.chat.update.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
     const blocks = [
@@ -161,16 +222,15 @@ describe("editSlackMessage blocks", () => {
         {
           type: "section",
           text: {
-            type: "mrkdwn",
+            type: "plain_text",
             text: "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
-            verbatim: true,
           },
         },
       ],
     });
   });
 
-  it("retries rejected native tables once with visible complete fallback blocks", async () => {
+  it("retries rejected native tables once with complete text and surviving blocks", async () => {
     const client = createSlackEditTestClient();
     client.chat.update.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
     const blocks = [
@@ -195,13 +255,15 @@ describe("editSlackMessage blocks", () => {
         row_header_column_index: 0,
       },
     ] as never;
-    const fallback = [
+    const firstAttemptFallback = [
       "Overview",
       "",
       "Pipeline report (table)",
       "- Account: Acme; ARR: $125k",
       "- Account: Globex; ARR: $82k",
     ].join("\n");
+    const retryFallback =
+      "Overview\n\nPipeline report (table)\nAccount\tARR\nAcme\t$125k\nGlobex\t$82k";
 
     await editSlackMessage("C123", "171234.567", "Overview", {
       token: "xoxb-test",
@@ -213,92 +275,24 @@ describe("editSlackMessage blocks", () => {
     expect(client.chat.update).toHaveBeenNthCalledWith(1, {
       channel: "C123",
       ts: "171234.567",
-      text: fallback,
+      text: firstAttemptFallback,
       blocks,
     });
     expect(client.chat.update).toHaveBeenNthCalledWith(2, {
       channel: "C123",
       ts: "171234.567",
-      text: fallback,
+      text: retryFallback,
       blocks: [
         blocks[0],
         {
           type: "section",
           text: {
-            type: "mrkdwn",
-            text: [
-              "Pipeline report (table)",
-              "- Account: Acme; ARR: $125k",
-              "- Account: Globex; ARR: $82k",
-            ].join("\n"),
-            verbatim: true,
+            type: "plain_text",
+            text: "Pipeline report (table)\nAccount\tARR\nAcme\t$125k\nGlobex\t$82k",
           },
         },
       ],
     });
-  });
-
-  it("includes every raw block and control in edit accessibility text", async () => {
-    const client = createSlackEditTestClient();
-    const blocks = [
-      { type: "section", text: { type: "mrkdwn", text: "Details" } },
-      {
-        type: "actions",
-        elements: [
-          {
-            type: "button",
-            action_id: "approve",
-            text: { type: "plain_text", text: "Approve" },
-            value: "approve",
-          },
-        ],
-      },
-    ];
-
-    await editSlackMessage("C123", "171234.567", "Summary", {
-      token: "xoxb-test",
-      client,
-      blocks,
-    });
-
-    expect(client.chat.update).toHaveBeenCalledWith({
-      channel: "C123",
-      ts: "171234.567",
-      text: "Summary\n\nDetails\n\n- Approve",
-      blocks,
-    });
-  });
-
-  it("fails closed when edit fallback expansion would drop 48 siblings", async () => {
-    const client = createSlackEditTestClient();
-    client.chat.update.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
-    const categories = Array.from(
-      { length: 20 },
-      (_entry, index) => `category-${String(index)}-${"x".repeat(80)}`,
-    );
-
-    await expect(
-      editSlackMessage("C123", "171234.567", "", {
-        token: "xoxb-test",
-        client,
-        blocks: [
-          ...Array.from({ length: 48 }, () => ({ type: "divider" })),
-          {
-            type: "data_visualization",
-            title: "Large chart",
-            chart: {
-              type: "bar",
-              axis_config: { categories },
-              series: Array.from({ length: 4 }, (_entry, index) => ({
-                name: `Series ${String(index)}`,
-                data: categories.map((label) => ({ label, value: index })),
-              })),
-            },
-          },
-        ] as never,
-      }),
-    ).rejects.toThrow(/fallback requires .* blocks to retain every sibling/i);
-    expect(client.chat.update).toHaveBeenCalledOnce();
   });
 
   it("rejects table edits whose complete fallback cannot fit one message", async () => {
@@ -323,46 +317,43 @@ describe("editSlackMessage blocks", () => {
         client,
         blocks,
       }),
-    ).rejects.toThrow(
-      "Slack block accessibility fallback exceeds OpenClaw's 8000-character per-edit limit",
-    );
+    ).rejects.toThrow("Slack native chart or table fallback exceeds the 4000-character edit limit");
     expect(client.chat.update).not.toHaveBeenCalled();
   });
 
-  it("rejects chart edits whose complete fallback cannot fit one message", async () => {
+  it("rejects native chart edits whose complete fallback cannot fit one message", async () => {
     const client = createSlackEditTestClient();
     const categories = Array.from({ length: 20 }, (_entry, index) =>
       `Category-${String(index)}`.padEnd(20, "x"),
     );
+    const blocks = [
+      {
+        type: "data_visualization",
+        title: "Maximum series chart",
+        chart: {
+          type: "bar",
+          series: Array.from({ length: 12 }, (_entry, seriesIndex) => ({
+            name: `Series-${String(seriesIndex)}`.padEnd(20, "x"),
+            data: categories.map((label) => ({ label, value: Number.MAX_VALUE })),
+          })),
+          axis_config: { categories },
+        },
+      },
+    ] as never;
 
     await expect(
       editSlackMessage("C123", "171234.567", "", {
         token: "xoxb-test",
         client,
-        blocks: [
-          {
-            type: "data_visualization",
-            title: "Large revenue report",
-            chart: {
-              type: "bar",
-              axis_config: { categories },
-              series: Array.from({ length: 12 }, (_entry, index) => ({
-                name: `Series-${String(index)}`.padEnd(20, "x"),
-                data: categories.map((label) => ({ label, value: Number.MAX_VALUE })),
-              })),
-            },
-          },
-        ] as never,
+        blocks,
       }),
-    ).rejects.toThrow(
-      "Slack block accessibility fallback exceeds OpenClaw's 8000-character per-edit limit",
-    );
+    ).rejects.toThrow("Slack native chart or table fallback exceeds the 4000-character edit limit");
     expect(client.chat.update).not.toHaveBeenCalled();
   });
 
-  it("rejects raw-block edits whose accessibility text cannot fit one message", async () => {
+  it("caps long block fallback text while preserving edit blocks", async () => {
     const client = createSlackEditTestClient();
-    const longContextText = "a".repeat(3000);
+    const longContextText = "a".repeat(1500);
     const blocks = [
       {
         type: "context",
@@ -374,16 +365,19 @@ describe("editSlackMessage blocks", () => {
       },
     ];
 
-    await expect(
-      editSlackMessage("C123", "171234.567", "", {
-        token: "xoxb-test",
-        client,
-        blocks,
-      }),
-    ).rejects.toThrow(
-      `Slack block accessibility fallback exceeds OpenClaw's ${String(SLACK_TEXT_LIMIT)}-character per-edit limit`,
-    );
-    expect(client.chat.update).not.toHaveBeenCalled();
+    await editSlackMessage("C123", "171234.567", "", {
+      token: "xoxb-test",
+      client,
+      blocks,
+    });
+
+    expect(client.chat.update).toHaveBeenCalledWith({
+      channel: "C123",
+      ts: "171234.567",
+      text: `${longContextText} ${longContextText} ${"a".repeat(SLACK_EDIT_TEXT_LIMIT - longContextText.length * 2 - 3)}…`,
+      blocks,
+    });
+    expect(readFirstChatUpdatePayload(client).text).toHaveLength(SLACK_EDIT_TEXT_LIMIT);
   });
 
   it("rejects empty blocks arrays", async () => {
@@ -427,5 +421,29 @@ describe("editSlackMessage blocks", () => {
     ).rejects.toThrow(/cannot exceed 50 items/i);
 
     expect(client.chat.update).not.toHaveBeenCalled();
+  });
+
+  it("checks escaped native edit fallback text against Slack's edit limit", async () => {
+    const client = createSlackEditTestClient();
+    client.chat.update.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+    const blocks = [
+      { type: "section", text: { type: "mrkdwn", text: "Overview" } },
+      { type: "section", text: { type: "mrkdwn", text: "<".repeat(1000) } },
+      {
+        type: "data_visualization",
+        title: "Chart",
+        chart: { type: "bar", series: [] },
+      },
+    ];
+
+    await expect(
+      editSlackMessage("C123", "171234.567", "Overview", {
+        token: "xoxb-test",
+        client,
+        blocks,
+      }),
+    ).rejects.toThrow(/fallback exceeds the 4000-character edit limit/u);
+
+    expect(client.chat.update).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -5,18 +5,22 @@ import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime"
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { z } from "zod";
 import { resolveSlackAccount } from "./accounts.js";
+import type { SlackAuthoredTextPlacement } from "./authored-text.js";
+import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackWebClient, getSlackWriteClient } from "./client.js";
 import { buildSlackEditTextPayload } from "./edit-text.js";
-import { SLACK_TEXT_LIMIT } from "./limits.js";
+import { SLACK_EDIT_TEXT_LIMIT } from "./limits.js";
 import { resolveSlackMedia } from "./monitor/media.js";
 import type { SlackMediaResult } from "./monitor/media.js";
+import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import {
   appendSlackNativeDataFallbackText,
-  buildSlackNativeDataFallbackBlocks,
   hasSlackNativeDataBlock,
   isSlackInvalidBlocksError,
+  stripSlackNativeDataBlocks,
 } from "./native-data-blocks.js";
+import { buildSlackNativeDataDeliveryPlan } from "./native-data-fallback.js";
 import { sendMessageSlack } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 import { truncateSlackText } from "./truncate.js";
@@ -315,8 +319,10 @@ export async function sendSlackMessage(
     uploadFileName?: string;
     uploadTitle?: string;
     blocks?: (Block | KnownBlock)[];
+    authoredTextPlacement?: SlackAuthoredTextPlacement;
+    nativeDataFallbackBaseText?: string;
     textIsSlackMrkdwn?: boolean;
-    separateTextAndBlocks?: boolean;
+    textIsSlackPlainText?: boolean;
   },
 ) {
   return await sendMessageSlack(to, content, {
@@ -331,7 +337,11 @@ export async function sendSlackMessage(
     threadTs: opts.threadTs,
     replyBroadcast: opts.replyBroadcast,
     ...(opts.textIsSlackMrkdwn ? { textIsSlackMrkdwn: true } : {}),
-    ...(opts.separateTextAndBlocks ? { separateTextAndBlocks: true } : {}),
+    ...(opts.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+    ...(opts.authoredTextPlacement ? { authoredTextPlacement: opts.authoredTextPlacement } : {}),
+    ...(Object.hasOwn(opts, "nativeDataFallbackBaseText")
+      ? { nativeDataFallbackBaseText: opts.nativeDataFallbackBaseText }
+      : {}),
     ...(opts.uploadFileName ? { uploadFileName: opts.uploadFileName } : {}),
     ...(opts.uploadTitle ? { uploadTitle: opts.uploadTitle } : {}),
     blocks: opts.blocks,
@@ -351,13 +361,13 @@ export async function editSlackMessage(
   const nativeFallbackText = hasNativeData
     ? appendSlackNativeDataFallbackText(editText, blocks)
     : editText;
-  if (blocks && nativeFallbackText.length > SLACK_TEXT_LIMIT) {
+  if (hasNativeData && nativeFallbackText.length > SLACK_EDIT_TEXT_LIMIT) {
     throw new Error(
-      `Slack block accessibility fallback exceeds OpenClaw's ${String(SLACK_TEXT_LIMIT)}-character per-edit limit. Send a new message instead.`,
+      `Slack native chart or table fallback exceeds the ${String(SLACK_EDIT_TEXT_LIMIT)}-character edit limit. Send a new message instead.`,
     );
   }
   const text = hasNativeData
-    ? truncateSlackText(nativeFallbackText, SLACK_TEXT_LIMIT)
+    ? truncateSlackText(nativeFallbackText, SLACK_EDIT_TEXT_LIMIT)
     : nativeFallbackText;
   const update = {
     channel: channelId,
@@ -372,12 +382,45 @@ export async function editSlackMessage(
       throw error;
     }
     logVerbose("slack edit: native data block rejected, retrying with text fallback");
-    const fallbackBlocks = buildSlackNativeDataFallbackBlocks(blocks);
+    const survivorBlocks = stripSlackNativeDataBlocks(blocks);
+    const survivorText = buildSlackBlocksFallbackText(survivorBlocks) ?? "";
+    const authoredEditText = content.trim();
+    const baseText =
+      authoredEditText && !survivorText.includes(authoredEditText) ? authoredEditText : "";
+    const fallbackPlan = buildSlackNativeDataDeliveryPlan({
+      baseText,
+      blocks: blocks ?? [],
+    });
+    if (fallbackPlan.fallbackMessages.length !== 1) {
+      throw new Error(
+        "Slack native chart or table edit fallback requires multiple messages. Send a new message instead.",
+        { cause: error },
+      );
+    }
+    const fallback = fallbackPlan.fallbackMessages[0];
+    if (!fallback || fallback.text.length > SLACK_EDIT_TEXT_LIMIT) {
+      throw new Error(
+        `Slack native chart or table fallback exceeds the ${String(SLACK_EDIT_TEXT_LIMIT)}-character edit limit. Send a new message instead.`,
+        { cause: error },
+      );
+    }
+    const fallbackText = fallback.blocks
+      ? escapeSlackMrkdwn(fallback.text)
+      : truncateSlackText(
+          appendSlackNativeDataFallbackText(editText, blocks),
+          SLACK_EDIT_TEXT_LIMIT,
+        );
+    if (fallbackText.length > SLACK_EDIT_TEXT_LIMIT) {
+      throw new Error(
+        `Slack native chart or table fallback exceeds the ${String(SLACK_EDIT_TEXT_LIMIT)}-character edit limit. Send a new message instead.`,
+        { cause: error },
+      );
+    }
     await client.chat.update({
       channel: channelId,
       ts: messageId,
-      text: truncateSlackText(appendSlackNativeDataFallbackText(text, blocks), SLACK_TEXT_LIMIT),
-      ...(fallbackBlocks?.length ? { blocks: fallbackBlocks } : {}),
+      text: fallbackText,
+      ...(fallback.blocks ? { blocks: fallback.blocks } : {}),
     });
   }
 }

--- a/extensions/slack/src/authored-text.ts
+++ b/extensions/slack/src/authored-text.ts
@@ -1,0 +1,59 @@
+// Slack-private authored text placement after block compilation.
+import type { InteractiveReply } from "openclaw/plugin-sdk/interactive-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export type SlackAuthoredTextPlacement = "none" | "blocks" | "outside-blocks";
+
+function normalizeComparableSlackText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function isSlackAuthoredTextRepresentedInInteractive(
+  text: string,
+  interactive?: InteractiveReply,
+): boolean {
+  return isSlackAuthoredTextRepresentedInFragments(
+    text,
+    interactive?.blocks.flatMap((block) => (block.type === "text" ? [block.text] : [])) ?? [],
+  );
+}
+
+function isSlackAuthoredTextRepresentedInFragments(
+  text: string,
+  rawFragments: readonly string[],
+): boolean {
+  const target = normalizeComparableSlackText(text);
+  const fragments = rawFragments.map(normalizeComparableSlackText).filter(Boolean);
+  // Legacy inline controls split surrounding text into multiple interactive text blocks.
+  for (let start = 0; start < fragments.length; start += 1) {
+    let combined = "";
+    for (let end = start; end < fragments.length; end += 1) {
+      combined = normalizeComparableSlackText(`${combined} ${fragments[end]}`);
+      if (combined === target) {
+        return true;
+      }
+      if (combined.length > target.length) {
+        break;
+      }
+    }
+  }
+  return false;
+}
+
+/** Resolve placement from producer facts, before accessibility text changes the payload text. */
+export function resolveSlackAuthoredTextPlacement(params: {
+  text?: string;
+  interactive?: InteractiveReply;
+  renderedInBlocks?: boolean;
+  renderedTextFragments?: readonly string[];
+}): SlackAuthoredTextPlacement {
+  const text = normalizeOptionalString(params.text);
+  if (!text) {
+    return "none";
+  }
+  const isRepresentedInBlocks =
+    params.renderedInBlocks ||
+    isSlackAuthoredTextRepresentedInFragments(text, params.renderedTextFragments ?? []) ||
+    isSlackAuthoredTextRepresentedInInteractive(text, params.interactive);
+  return isRepresentedInBlocks ? "blocks" : "outside-blocks";
+}

--- a/extensions/slack/src/blocks-fallback.ts
+++ b/extensions/slack/src/blocks-fallback.ts
@@ -1,242 +1,279 @@
 // Slack plugin module implements blocks fallback behavior.
-import { renderSlackDataTableMrkdwnFallbackText } from "./data-table.js";
-import { renderSlackDataVisualizationMrkdwnFallbackText } from "./data-visualization.js";
+import {
+  renderSlackDataTableFallbackText,
+  renderSlackDataTableMrkdwnFallbackText,
+} from "./data-table.js";
+import {
+  renderSlackDataVisualizationFallbackText,
+  renderSlackDataVisualizationMrkdwnFallbackText,
+} from "./data-visualization.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
-import { hasSlackNativeDataBlock } from "./native-data-blocks.js";
 
-type SlackTextObject = { text?: string; type?: string };
+export type SlackNativeDataFallbackFormat = "plain" | "mrkdwn-safe";
 
-type SlackActionElement = {
-  type?: string;
-  text?: SlackTextObject;
-  url?: string;
-  placeholder?: SlackTextObject;
-  options?: Array<{ text?: SlackTextObject }>;
+type RenderSlackBlockFallbackOptions = {
+  nativeDataFormat?: SlackNativeDataFallbackFormat;
+};
+
+type SlackBlockLike = {
+  type?: unknown;
+  text?: unknown;
+  title?: unknown;
+  alt_text?: unknown;
+  elements?: unknown;
+  fields?: unknown;
+  accessory?: unknown;
 };
 
 type SlackRichTextElement = {
-  type?: string;
-  text?: string;
-  url?: string;
-  user_id?: string;
-  channel_id?: string;
-  usergroup_id?: string;
-  name?: string;
-  range?: string;
-  fallback?: string;
-  elements?: unknown[];
+  type?: unknown;
+  text?: unknown;
+  url?: unknown;
+  user_id?: unknown;
+  channel_id?: unknown;
+  usergroup_id?: unknown;
+  name?: unknown;
+  range?: unknown;
+  fallback?: unknown;
+  elements?: unknown;
 };
 
-type SlackBlockWithFields = {
-  type?: string;
-  text?: SlackTextObject;
-  title?: SlackTextObject;
-  alt_text?: string;
-  elements?: unknown[];
-  fields?: SlackTextObject[];
-  accessory?: SlackActionElement;
-};
+const SLACK_SELECT_ELEMENT_TYPES = new Set([
+  "static_select",
+  "multi_static_select",
+  "external_select",
+  "multi_external_select",
+  "users_select",
+  "multi_users_select",
+  "conversations_select",
+  "multi_conversations_select",
+  "channels_select",
+  "multi_channels_select",
+]);
 
-function cleanCandidate(value: string | undefined): string | undefined {
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
-  const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized.length > 0 ? normalized : undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function readTextObject(
-  value: SlackTextObject | undefined,
-  defaultType?: "plain_text" | "mrkdwn",
+  value: unknown,
+  options: RenderSlackBlockFallbackOptions = {},
 ): string | undefined {
-  const text = cleanCandidate(value?.text);
-  return text && (value?.type ?? defaultType) === "plain_text" ? escapeSlackMrkdwn(text) : text;
-}
-
-function readSectionText(block: SlackBlockWithFields): string | undefined {
-  const parts = [
-    readTextObject(block.text),
-    ...(block.fields?.map((field) => readTextObject(field)).filter(Boolean) ?? []),
-    ...(block.accessory ? readSlackActionElementText(block.accessory) : []),
-  ].filter((value): value is string => Boolean(value));
-  return parts.length > 0 ? parts.join("\n") : undefined;
-}
-
-function readHeaderText(block: SlackBlockWithFields): string | undefined {
-  return readTextObject(block.text, "plain_text");
-}
-
-function readImageText(block: SlackBlockWithFields): string | undefined {
-  const altText = cleanCandidate(block.alt_text);
-  return (
-    (altText ? escapeSlackMrkdwn(altText) : undefined) ?? readTextObject(block.title, "plain_text")
-  );
-}
-
-function readVideoText(block: SlackBlockWithFields): string | undefined {
-  const altText = cleanCandidate(block.alt_text);
-  return (
-    readTextObject(block.title, "plain_text") ?? (altText ? escapeSlackMrkdwn(altText) : undefined)
-  );
-}
-
-function readContextText(block: SlackBlockWithFields): string | undefined {
-  if (!Array.isArray(block.elements)) {
+  const record = asRecord(value);
+  if (!record) {
     return undefined;
   }
-  const textParts = (block.elements as SlackTextObject[])
-    .map((element) => readTextObject(element, "plain_text"))
-    .filter((value): value is string => Boolean(value));
-  return textParts.length > 0 ? textParts.join(" ") : undefined;
-}
-
-function isTextOnlyContextBlock(block: SlackBlockWithFields): boolean {
-  if (!Array.isArray(block.elements) || block.elements.length === 0) {
-    return false;
+  const text = readNonEmptyString(record?.text);
+  if (!text) {
+    return undefined;
   }
-  return block.elements.every((rawElement) => {
-    if (!rawElement || typeof rawElement !== "object" || Array.isArray(rawElement)) {
-      return false;
-    }
-    const element = rawElement as SlackTextObject;
-    return (
-      (element.type === "plain_text" || element.type === "mrkdwn") &&
-      readTextObject(element) !== undefined
-    );
-  });
+  return record.type === "plain_text" && options.nativeDataFormat !== "plain"
+    ? escapeSlackMrkdwn(text)
+    : text;
 }
 
-function readSlackRichTextLeaf(element: SlackRichTextElement): string {
+function readTextValue(
+  value: unknown,
+  options: RenderSlackBlockFallbackOptions = {},
+): string | undefined {
+  return readNonEmptyString(value) ?? readTextObject(value, options);
+}
+
+function renderSlackRichTextLeaf(element: SlackRichTextElement): string {
   switch (element.type) {
     case "text":
       return typeof element.text === "string" ? escapeSlackMrkdwn(element.text) : "";
-    case "link": {
-      const value = element.text ?? element.url;
-      return typeof value === "string" ? escapeSlackMrkdwn(value) : "";
+    case "link":
+      return escapeSlackMrkdwn(
+        readNonEmptyString(element.text) ?? readNonEmptyString(element.url) ?? "",
+      );
+    case "user": {
+      const userId = readNonEmptyString(element.user_id);
+      return userId ? escapeSlackMrkdwn(`<@${userId}>`) : "";
     }
-    case "user":
-      return element.user_id ? `<@${element.user_id}>` : "";
-    case "channel":
-      return element.channel_id ? `<#${element.channel_id}>` : "";
-    case "usergroup":
-      return element.usergroup_id ? `<!subteam^${element.usergroup_id}>` : "";
-    case "broadcast":
-      return element.range ? `<!${element.range}>` : "";
-    case "emoji":
-      return element.name ? `:${element.name}:` : "";
+    case "channel": {
+      const channelId = readNonEmptyString(element.channel_id);
+      return channelId ? escapeSlackMrkdwn(`<#${channelId}>`) : "";
+    }
+    case "usergroup": {
+      const usergroupId = readNonEmptyString(element.usergroup_id);
+      return usergroupId ? escapeSlackMrkdwn(`<!subteam^${usergroupId}>`) : "";
+    }
+    case "broadcast": {
+      const range = readNonEmptyString(element.range);
+      return range ? escapeSlackMrkdwn(`<!${range}>`) : "";
+    }
+    case "emoji": {
+      const name = readNonEmptyString(element.name);
+      return name ? `:${name}:` : "";
+    }
     case "date":
-      return element.fallback ? escapeSlackMrkdwn(element.fallback) : "";
+      return escapeSlackMrkdwn(readNonEmptyString(element.fallback) ?? "");
     default:
       return "";
   }
 }
 
-function readSlackRichTextElements(elements: unknown): string {
-  if (!Array.isArray(elements)) {
+function renderSlackRichTextElement(value: unknown): string {
+  const element = asRecord(value) as SlackRichTextElement | undefined;
+  if (!element) {
     return "";
   }
-  const parts: string[] = [];
-  for (const rawElement of elements) {
-    if (!rawElement || typeof rawElement !== "object" || Array.isArray(rawElement)) {
-      continue;
-    }
-    const element = rawElement as SlackRichTextElement;
-    if (element.type === "rich_text_list") {
-      const items = (element.elements ?? [])
-        .map((item) =>
-          item && typeof item === "object" && !Array.isArray(item)
-            ? readSlackRichTextElements((item as SlackRichTextElement).elements)
-            : "",
-        )
-        .filter(Boolean);
-      if (items.length > 0) {
-        parts.push(items.join("\n"));
-      }
-      continue;
-    }
-    if (
-      element.type === "rich_text_section" ||
-      element.type === "rich_text_preformatted" ||
-      element.type === "rich_text_quote"
-    ) {
-      parts.push(readSlackRichTextElements(element.elements));
-      continue;
-    }
-    parts.push(readSlackRichTextLeaf(element));
+  switch (element.type) {
+    case "rich_text_section":
+    case "rich_text_preformatted":
+    case "rich_text_quote":
+      return renderSlackRichTextElements(element.elements, "");
+    case "rich_text_list":
+      return renderSlackRichTextElements(element.elements, "\n");
+    default:
+      return renderSlackRichTextLeaf(element);
   }
-  return parts.join("");
 }
 
-function readRichText(block: SlackBlockWithFields): string | undefined {
-  const text = readSlackRichTextElements(block.elements).trim();
-  return text || undefined;
+function renderSlackRichTextElements(value: unknown, separator: string): string {
+  if (!Array.isArray(value)) {
+    return "";
+  }
+  return value.map(renderSlackRichTextElement).filter(Boolean).join(separator);
 }
 
-function readSlackActionElementText(element: SlackActionElement): string[] {
-  if (element.type === "button") {
-    const label = readTextObject(element.text, "plain_text");
-    if (!label) {
-      return [];
-    }
-    const rawUrl = cleanCandidate(element.url);
-    const url = rawUrl ? escapeSlackMrkdwn(rawUrl) : undefined;
-    return [`- ${label}${url ? `: ${url}` : ""}`];
-  }
-  if (element.type === "static_select") {
-    const labels =
-      element.options
-        ?.map((option) => readTextObject(option.text, "plain_text"))
-        .filter((label): label is string => Boolean(label)) ?? [];
-    if (labels.length === 0) {
-      return [];
-    }
-    const heading = readTextObject(element.placeholder, "plain_text") ?? "Options";
-    return [`${heading}:\n${labels.map((label) => `- ${label}`).join("\n")}`];
-  }
-  return [];
+function readImageText(block: SlackBlockLike): string | undefined {
+  const altText = readNonEmptyString(block.alt_text);
+  return (altText ? escapeSlackMrkdwn(altText) : undefined) ?? readTextObject(block.title);
 }
 
-function readActionsText(block: SlackBlockWithFields): string | undefined {
+function readVideoText(
+  block: SlackBlockLike,
+  options: RenderSlackBlockFallbackOptions = {},
+): string | undefined {
+  const altText = readNonEmptyString(block.alt_text);
+  return readTextObject(block.title, options) ?? (altText ? escapeSlackMrkdwn(altText) : undefined);
+}
+
+function readContextText(
+  block: SlackBlockLike,
+  options: RenderSlackBlockFallbackOptions = {},
+): string | undefined {
   if (!Array.isArray(block.elements)) {
     return undefined;
   }
-  const parts = (block.elements as unknown as SlackActionElement[]).flatMap(
-    readSlackActionElementText,
-  );
-  return parts.length > 0 ? parts.join("\n") : undefined;
+  const parts = block.elements
+    .map((element) => {
+      const record = asRecord(element);
+      const altText = readNonEmptyString(record?.alt_text);
+      return readTextObject(record, options) ?? (altText ? escapeSlackMrkdwn(altText) : undefined);
+    })
+    .filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(" ") : undefined;
 }
 
-function readSlackBlockFallbackText(raw: unknown): string | undefined {
-  const block = raw as SlackBlockWithFields;
+function readControlElementText(
+  value: unknown,
+  options: RenderSlackBlockFallbackOptions = {},
+): string | undefined {
+  const element = asRecord(value);
+  const type = readNonEmptyString(element?.type);
+  if (type === "button" || type === "workflow_button") {
+    return readTextValue(element?.text, options);
+  }
+  if (type && SLACK_SELECT_ELEMENT_TYPES.has(type)) {
+    return readTextObject(element?.placeholder, options);
+  }
+  return undefined;
+}
+
+function readControlElementsText(
+  values: readonly unknown[],
+  options: RenderSlackBlockFallbackOptions = {},
+): string | undefined {
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  for (const value of values) {
+    const candidate = readControlElementText(value, options);
+    if (!candidate || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    labels.push(candidate);
+  }
+  return labels.length > 0 ? labels.join("\n") : undefined;
+}
+
+function readSectionText(
+  block: SlackBlockLike,
+  options: RenderSlackBlockFallbackOptions = {},
+): string | undefined {
+  const parts = [readTextObject(block.text, options)];
+  if (Array.isArray(block.fields)) {
+    parts.push(...block.fields.map((field) => readTextObject(field, options)));
+  }
+  parts.push(readControlElementText(block.accessory, options));
+  const visibleParts = parts.filter((part): part is string => Boolean(part));
+  return visibleParts.length > 0 ? visibleParts.join("\n") : undefined;
+}
+
+function readActionsText(
+  block: SlackBlockLike,
+  options: RenderSlackBlockFallbackOptions = {},
+): string | undefined {
+  return Array.isArray(block.elements)
+    ? readControlElementsText(block.elements, options)
+    : undefined;
+}
+
+/** Read only user-visible text from one Slack block. */
+export function renderSlackBlockFallbackText(
+  raw: unknown,
+  options: RenderSlackBlockFallbackOptions = {},
+): string | undefined {
+  const block = asRecord(raw) as SlackBlockLike | undefined;
+  if (!block) {
+    return undefined;
+  }
   switch (block.type) {
-    case "header":
-      return readHeaderText(block);
-    case "section":
-      return readSectionText(block);
     case "rich_text":
-      return readRichText(block);
+      return readNonEmptyString(renderSlackRichTextElements(block.elements, "\n"));
+    case "header":
+      return readTextObject(block.text, options);
+    case "section":
+      return readSectionText(block, options);
     case "image":
       return readImageText(block) ?? "Shared an image";
     case "video":
-      return readVideoText(block) ?? "Shared a video";
+      return readVideoText(block, options) ?? "Shared a video";
     case "file":
       return "Shared a file";
     case "context":
-      return readContextText(block);
+      return readContextText(block, options);
     case "actions":
-      return readActionsText(block);
+      return readActionsText(block, options);
     case "data_visualization":
-      return renderSlackDataVisualizationMrkdwnFallbackText(block);
+      return options.nativeDataFormat === "plain"
+        ? renderSlackDataVisualizationFallbackText(block)
+        : renderSlackDataVisualizationMrkdwnFallbackText(block);
     case "data_table":
-      return renderSlackDataTableMrkdwnFallbackText(block);
+      return options.nativeDataFormat === "plain"
+        ? renderSlackDataTableFallbackText(block)
+        : renderSlackDataTableMrkdwnFallbackText(block);
     default:
       return undefined;
   }
 }
 
 export function buildSlackBlocksFallbackText(blocks: readonly unknown[]): string {
-  for (const raw of blocks) {
-    const text = readSlackBlockFallbackText(raw);
+  for (const block of blocks) {
+    const text = renderSlackBlockFallbackText(block);
     if (text) {
       return text;
     }
@@ -245,131 +282,11 @@ export function buildSlackBlocksFallbackText(blocks: readonly unknown[]): string
   return "Shared a Block Kit message";
 }
 
-/** Build complete screen-reader fallback text for every retained sibling block. */
-export function buildSlackBlocksAccessibleFallbackText(blocks: readonly unknown[]): string {
-  const parts = blocks
-    .map(readSlackBlockFallbackText)
-    .filter((text): text is string => Boolean(text));
-  return parts.length > 0 ? parts.join("\n\n") : "Shared a Block Kit message";
-}
-
-/** Keep native-data posts compact while their complete fallback is sent separately. */
-export function buildSlackBlocksCompactAccessibleFallbackText(blocks: readonly unknown[]): string {
-  const parts = blocks
-    .map((raw) => {
-      const fallback = readSlackBlockFallbackText(raw);
-      return hasSlackNativeDataBlock([raw]) ? fallback?.split("\n", 1)[0] : fallback;
-    })
-    .filter((text): text is string => Boolean(text));
-  return parts.length > 0 ? parts.join("\n\n") : "Shared a Block Kit message";
-}
-
-/** Keep only native tables whose caption-level accessibility text fits the block post. */
-export function retainSlackDataTablesWithinCompactFallback<T>(
-  blocks: readonly T[],
-  limit: number,
-): T[] {
-  const retainedTables = new Set<T>();
-  for (const block of blocks) {
-    if ((block as SlackBlockWithFields).type !== "data_table") {
-      continue;
-    }
-    const candidate = blocks.filter(
-      (entry) =>
-        (entry as SlackBlockWithFields).type !== "data_table" ||
-        retainedTables.has(entry) ||
-        entry === block,
-    );
-    if (buildSlackBlocksCompactAccessibleFallbackText(candidate).length <= limit) {
-      retainedTables.add(block);
-    }
-  }
-  return blocks.filter(
-    (block) => (block as SlackBlockWithFields).type !== "data_table" || retainedTables.has(block),
-  );
-}
-
-/** Preserve non-data siblings when a later text part owns rejected native-data fallback. */
-export function buildSlackDeferredNativeDataRejectionFallback<T>(blocks: readonly T[]): {
-  blocks: T[];
-  text: string;
-} {
-  const retainedBlocks = blocks.filter((block) => !hasSlackNativeDataBlock([block]));
-  return {
-    blocks: retainedBlocks,
-    text:
-      retainedBlocks.length > 0
-        ? buildSlackBlocksAccessibleFallbackText(retainedBlocks)
-        : buildSlackBlocksCompactAccessibleFallbackText(blocks),
-  };
-}
-
-/** True when visible text can replace this block without losing interaction or media. */
-export function isSlackBlockRepresentedByTextFallback(raw: unknown): boolean {
-  const block = raw as SlackBlockWithFields;
-  switch (block.type) {
-    case "section":
-      return !block.accessory;
-    case "context":
-      return isTextOnlyContextBlock(block);
-    case "header":
-    case "rich_text":
-    case "data_visualization":
-    case "data_table":
-      return true;
-    default:
-      return false;
-  }
-}
-
-function comparableFallbackText(value: string): string {
-  return value
-    .replace(/(^|\n)[ \t]*[-*•][ \t]+/gu, "$1• ")
-    .replace(/\s+/gu, " ")
-    .trim();
-}
-
-/** Remove fallback paragraphs already represented by retained visible blocks. */
-export function removeSlackBlocksFallbackParagraphs(
-  text: string,
-  blocks: readonly unknown[],
-): string {
-  const represented = new Set(
-    blocks
-      .map(readSlackBlockFallbackText)
-      .filter((value): value is string => Boolean(value))
-      .map(comparableFallbackText),
-  );
-  return text
-    .split(/\n{2,}/u)
-    .filter((paragraph) => !represented.has(comparableFallbackText(paragraph)))
+export function buildSlackCompleteBlocksFallbackText(blocks: readonly unknown[]): string {
+  const text = blocks
+    .map((block) => renderSlackBlockFallbackText(block))
+    .filter(Boolean)
     .join("\n\n")
     .trim();
-}
-
-/** Append complete block accessibility text without repeating represented paragraphs. */
-export function appendSlackBlocksAccessibleFallbackText(
-  text: string,
-  blocks: readonly unknown[],
-): string {
-  const parts = text
-    .split(/\n{2,}/u)
-    .map((part) => part.trim())
-    .filter(Boolean);
-  const seen = new Set(parts.map(comparableFallbackText));
-  for (const block of blocks) {
-    const fallback = readSlackBlockFallbackText(block);
-    const comparable = fallback ? comparableFallbackText(fallback) : "";
-    if (
-      !fallback ||
-      !comparable ||
-      seen.has(comparable) ||
-      parts.some((part) => comparableFallbackText(part).includes(comparable))
-    ) {
-      continue;
-    }
-    seen.add(comparable);
-    parts.push(fallback);
-  }
-  return parts.join("\n\n");
+  return text || buildSlackBlocksFallbackText(blocks);
 }

--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -13,6 +13,7 @@ import type {
   MessagePresentationSelectBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 import {
   buildSlackDataTableBlock,
   countSlackDataTableBlocksCellCharacters,
@@ -46,7 +47,7 @@ const SLACK_BUTTON_URL_MAX = 3000;
 
 export type SlackBlock = Block | KnownBlock;
 
-type SlackBlockRenderOptions = {
+export type SlackBlockRenderOptions = {
   buttonIndexOffset?: number;
   dataTableCellCharacterCountOffset?: number;
   dataVisualizationCountOffset?: number;
@@ -293,7 +294,13 @@ export function buildSlackPresentationBlocks(
       if (block.type === "context") {
         blocks.push({
           type: "context",
-          elements: [{ type: "mrkdwn", text: truncateSlackText(text, SLACK_SECTION_TEXT_MAX) }],
+          elements: [
+            {
+              type: "mrkdwn",
+              text: truncateSlackText(text, SLACK_SECTION_TEXT_MAX),
+              verbatim: true,
+            },
+          ],
         });
       } else {
         blocks.push({
@@ -324,19 +331,15 @@ export function buildSlackPresentationBlocks(
         dataVisualizationCount += 1;
         blocks.push(rendered);
       } else {
-        blocks.push({
-          type: "context",
-          elements: [
-            {
-              type: "mrkdwn",
-              verbatim: true,
-              text: truncateSlackText(
-                renderSlackMessagePresentationChartFallbackText(block),
-                SLACK_SECTION_TEXT_MAX,
-              ),
-            },
-          ],
-        });
+        const fallback = renderSlackMessagePresentationChartFallbackText(block);
+        blocks.push(
+          ...chunkTextForOutbound(fallback, SLACK_SECTION_TEXT_MAX).map(
+            (text): SlackBlock => ({
+              type: "context",
+              elements: [{ type: "mrkdwn", text, verbatim: true }],
+            }),
+          ),
+        );
       }
       continue;
     }
@@ -453,6 +456,7 @@ export function canRenderSlackPresentation(
   if (!canRenderSlackPresentationTables(presentation, options)) {
     return false;
   }
+  let dataVisualizationCount = options.dataVisualizationCountOffset ?? 0;
   for (const block of presentation.blocks) {
     if (block.type === "text" || block.type === "context") {
       if (!isWithinSlackLimit(block.text.trim(), SLACK_SECTION_TEXT_MAX)) {
@@ -474,9 +478,10 @@ export function canRenderSlackPresentation(
       continue;
     }
     if (block.type === "select") {
+      const placeholder = normalizeOptionalString(block.placeholder) ?? "Choose an option";
       const allOptionsRenderable =
+        isWithinSlackLimit(placeholder, SLACK_ACTION_LABEL_MAX) &&
         block.options.length <= SLACK_STATIC_SELECT_OPTIONS_MAX &&
-        (!block.placeholder || isWithinSlackLimit(block.placeholder, SLACK_ACTION_LABEL_MAX)) &&
         block.options.every(
           (option) =>
             isWithinSlackLimit(option.label, SLACK_ACTION_LABEL_MAX) &&
@@ -491,11 +496,13 @@ export function canRenderSlackPresentation(
       continue;
     }
     if (block.type === "chart") {
-      if (!canRenderSlackDataVisualization(block)) {
+      if (
+        dataVisualizationCount >= SLACK_DATA_VISUALIZATION_BLOCKS_MAX ||
+        !canRenderSlackDataVisualization(block)
+      ) {
         return false;
       }
-      // The renderer preserves valid charts beyond Slack's native two-block
-      // budget as visible context, so count overflow is still lossless here.
+      dataVisualizationCount += 1;
       continue;
     }
     if (block.type === "table") {
@@ -503,6 +510,20 @@ export function canRenderSlackPresentation(
     }
   }
   return true;
+}
+
+/** True when every non-table block survives while tables use text fallback. */
+export function canRenderSlackPresentationWithoutTables(
+  presentation: MessagePresentation,
+  options: SlackBlockRenderOptions = {},
+): boolean {
+  return canRenderSlackPresentation(
+    {
+      ...presentation,
+      blocks: presentation.blocks.filter((block) => block.type !== "table"),
+    },
+    options,
+  );
 }
 
 function buildSlackPresentationSelectBlock(

--- a/extensions/slack/src/blocks.test.ts
+++ b/extensions/slack/src/blocks.test.ts
@@ -1,6 +1,6 @@
 // Slack tests cover blocks plugin behavior.
 import { describe, expect, it } from "vitest";
-import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
+import { buildSlackBlocksFallbackText, renderSlackBlockFallbackText } from "./blocks-fallback.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import {
   encodeSlackModalPrivateMetadata,
@@ -63,6 +63,127 @@ describe("buildSlackBlocksFallbackText", () => {
     ).toBe("Pipeline report (table)\n- Account: Acme; ARR: 125000");
   });
 
+  it("uses only visible action labels and select placeholders", () => {
+    const fallback = buildSlackBlocksFallbackText([
+      {
+        type: "actions",
+        block_id: "private-block-id",
+        elements: [
+          {
+            type: "button",
+            action_id: "private-action-id",
+            text: { type: "plain_text", text: "Approve" },
+            value: "private-button-value",
+          },
+          {
+            type: "static_select",
+            action_id: "private-select-id",
+            placeholder: { type: "plain_text", text: "Choose owner" },
+            options: [
+              { text: { type: "plain_text", text: "Secret option" }, value: "private-option" },
+            ],
+          },
+        ],
+      },
+    ] as never);
+
+    expect(fallback).toBe("Approve\nChoose owner");
+    expect(fallback).not.toMatch(/private|Secret option/u);
+  });
+
+  it("renders section text and fields together", () => {
+    expect(
+      renderSlackBlockFallbackText({
+        type: "section",
+        text: { type: "mrkdwn", text: "Deploy status" },
+        fields: [
+          { type: "mrkdwn", text: "*Region*\nus-east-1" },
+          { type: "plain_text", text: "Healthy" },
+        ],
+      }),
+    ).toBe("Deploy status\n*Region*\nus-east-1\nHealthy");
+  });
+
+  it("includes section accessory labels without hidden values", () => {
+    expect(
+      renderSlackBlockFallbackText({
+        type: "section",
+        text: { type: "mrkdwn", text: "Deploy status" },
+        accessory: {
+          type: "button",
+          text: { type: "plain_text", text: "Approve" },
+          value: "secret-approval-token",
+        },
+      }),
+    ).toBe("Deploy status\nApprove");
+  });
+
+  it("renders rich text and context without hidden metadata", () => {
+    const richText = renderSlackBlockFallbackText({
+      type: "rich_text",
+      block_id: "private-block-id",
+      elements: [
+        {
+          type: "rich_text_section",
+          elements: [
+            { type: "text", text: "Ask " },
+            { type: "user", user_id: "U123" },
+            { type: "text", text: " <!channel> in " },
+            { type: "channel", channel_id: "C123" },
+            { type: "text", text: " " },
+            { type: "emoji", name: "wave" },
+          ],
+        },
+        {
+          type: "rich_text_list",
+          elements: [
+            { type: "rich_text_section", elements: [{ type: "text", text: "First" }] },
+            {
+              type: "rich_text_section",
+              elements: [
+                {
+                  type: "link",
+                  url: "https://example.com/private-target",
+                  text: "Second",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const context = renderSlackBlockFallbackText({
+      type: "context",
+      elements: [
+        { type: "mrkdwn", text: "Updated now" },
+        { type: "image", alt_text: "Green status", image_url: "https://example.com/secret" },
+      ],
+    });
+
+    expect(richText).toBe(
+      "Ask &lt;@U123&gt; &lt;!channel&gt; in &lt;#C123&gt; :wave:\nFirst\nSecond",
+    );
+    expect(richText).not.toContain("private-block-id");
+    expect(richText).not.toContain("private-target");
+    expect(context).toBe("Updated now Green status");
+    expect(context).not.toContain("secret");
+  });
+
+  it("selects plain or mrkdwn-safe native data text explicitly", () => {
+    const table = {
+      type: "data_table",
+      caption: "<!channel> pipeline",
+      rows: [[{ type: "raw_text", text: "Owner" }], [{ type: "raw_text", text: "<@U123>" }]],
+    };
+
+    expect(renderSlackBlockFallbackText(table, { nativeDataFormat: "plain" })).toBe(
+      "<!channel> pipeline (table)\n- Owner: <@U123>",
+    );
+    expect(renderSlackBlockFallbackText(table, { nativeDataFormat: "mrkdwn-safe" })).toBe(
+      "&lt;!channel&gt; pipeline (table)\n- Owner: &lt;@U123&gt;",
+    );
+  });
+
   it("uses generic defaults for file and unknown blocks", () => {
     expect(
       buildSlackBlocksFallbackText([
@@ -72,6 +193,7 @@ describe("buildSlackBlocksFallbackText", () => {
     expect(buildSlackBlocksFallbackText([{ type: "divider" }] as never)).toBe(
       "Shared a Block Kit message",
     );
+    expect(renderSlackBlockFallbackText({ type: "video" })).toBe("Shared a video");
   });
 });
 

--- a/extensions/slack/src/client-delivery.ts
+++ b/extensions/slack/src/client-delivery.ts
@@ -10,14 +10,6 @@ import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
-import { hasSlackDataTableBlock } from "./data-table.js";
-import { SLACK_TEXT_LIMIT } from "./limits.js";
-import {
-  appendSlackNativeDataFallbackText,
-  buildSlackNativeDataFallbackBlocks,
-  hasSlackNativeDataBlock,
-  isSlackInvalidBlocksError,
-} from "./native-data-blocks.js";
 import {
   postSlackMessageWithIdentityFallback,
   type SlackPostMessageIdentity,
@@ -28,7 +20,6 @@ import {
   type SlackUnfurlOptions,
 } from "./post-message-payload.js";
 import { loadOutboundMediaFromUrl } from "./runtime-api.js";
-import { truncateSlackText } from "./truncate.js";
 
 const SLACK_COMMERCIAL_API_HOSTNAME = "slack.com";
 const SLACK_COMMERCIAL_UPLOAD_HOSTNAME = "files.slack.com";
@@ -228,62 +219,16 @@ export async function postSlackMessageBestEffort(params: {
   replyBroadcast?: boolean;
   identity?: SlackPostMessageIdentity;
   blocks?: (Block | KnownBlock)[];
-  nativeDataRejectionFallback?: {
-    text: string;
-    blocks?: (Block | KnownBlock)[];
-  };
   metadata?: MessageMetadata;
+  mrkdwn?: boolean;
   unfurl?: SlackUnfurlOptions;
 }) {
   const basePayload = buildSlackPostMessagePayload(params);
   const postChatMessage = params.client.chat.postMessage.bind(params.client.chat);
-  const post = async (payload: SlackPostMessagePayload, identity?: SlackPostMessageIdentity) => {
-    try {
-      return {
-        response: await withSlackDnsRequestRetry("chat.postMessage", () =>
-          postChatMessage(payload),
-        ),
-        identity,
-      };
-    } catch (error) {
-      if (!hasSlackNativeDataBlock(payload.blocks) || !isSlackInvalidBlocksError(error)) {
-        throw error;
-      }
-      const { blocks, ...textPayload } = payload;
-      if (params.nativeDataRejectionFallback) {
-        // A later text part already owns the complete native-data fallback.
-        // Retrying only retained siblings avoids rendering every table row twice.
-        const rejectionFallback = params.nativeDataRejectionFallback;
-        return {
-          response: await withSlackDnsRequestRetry("chat.postMessage", () =>
-            postChatMessage({
-              ...textPayload,
-              text: rejectionFallback.text,
-              ...(rejectionFallback.blocks?.length ? { blocks: rejectionFallback.blocks } : {}),
-            }),
-          ),
-          identity,
-        };
-      }
-      // Replace only native data blocks. If an authored sibling is actually invalid,
-      // the retry still fails closed instead of silently discarding its controls.
-      logVerbose("slack send: native data block rejected, retrying with text fallback");
-      const fallbackText = appendSlackNativeDataFallbackText(payload.text ?? "", blocks);
-      const fallbackBlocks = buildSlackNativeDataFallbackBlocks(blocks);
-      return {
-        response: await withSlackDnsRequestRetry("chat.postMessage", () =>
-          postChatMessage({
-            ...textPayload,
-            text: hasSlackDataTableBlock(blocks)
-              ? fallbackText
-              : truncateSlackText(fallbackText, SLACK_TEXT_LIMIT),
-            ...(fallbackBlocks?.length ? { blocks: fallbackBlocks } : {}),
-          }),
-        ),
-        identity,
-      };
-    }
-  };
+  const post = async (payload: SlackPostMessagePayload, identity?: SlackPostMessageIdentity) => ({
+    response: await withSlackDnsRequestRetry("chat.postMessage", () => postChatMessage(payload)),
+    identity,
+  });
   return await postSlackMessageWithIdentityFallback({
     basePayload,
     identity: params.identity,

--- a/extensions/slack/src/data-table.test.ts
+++ b/extensions/slack/src/data-table.test.ts
@@ -5,6 +5,7 @@ import {
   countSlackDataTableBlocksCellCharacters,
   countSlackDataTableCellCharacters,
   hasSlackDataTableBlock,
+  renderSlackDataTableCompactPlainTextFallback,
   renderSlackDataTableFallbackText,
   SLACK_DATA_TABLE_CELL_CHARACTERS_MAX,
 } from "./data-table.js";
@@ -129,6 +130,89 @@ describe("Slack data table blocks", () => {
         row_header_column_index: 0,
       }),
     ).toBe("Pipeline report (table)\n- Account: Acme; ARR: $125k; Owner: <@U123> ready");
+  });
+
+  it("renders a compact formatting-disabled fallback with each cell once", () => {
+    expect(
+      renderSlackDataTableCompactPlainTextFallback({
+        type: "data_table",
+        caption: "Pipeline report",
+        rows: [
+          [
+            { type: "raw_text", text: "Owner <!channel>" },
+            { type: "raw_text", text: "Link" },
+          ],
+          [
+            { type: "raw_text", text: "<@U1> & `literal`" },
+            { type: "raw_text", text: "<https://example.com|open>" },
+          ],
+        ],
+      }),
+    ).toBe(
+      [
+        "Pipeline report (table)",
+        "Owner <!channel>\tLink",
+        "<@U1> & `literal`\t<https://example.com|open>",
+      ].join("\n"),
+    );
+  });
+
+  it("reversibly escapes one-line table delimiters without collapsing authored whitespace", () => {
+    expect(
+      renderSlackDataTableCompactPlainTextFallback({
+        type: "data_table",
+        caption: " Path\\root\t\r\n  ",
+        rows: [
+          [
+            { type: "raw_text", text: "A  B" },
+            { type: "raw_text", text: "Column\tTwo" },
+          ],
+          [
+            { type: "raw_text", text: "line1\nline2\\tail" },
+            { type: "raw_text", text: "keep  spaces" },
+          ],
+        ],
+      }),
+    ).toBe(
+      [
+        " Path\\\\root\\t\\r\\n   (table)",
+        "A  B\tColumn\\tTwo",
+        "line1\\nline2\\\\tail\tkeep  spaces",
+      ].join("\n"),
+    );
+  });
+
+  it("rejects raw native tables outside Slack's documented bounds", () => {
+    const rows = Array.from({ length: 100 }, () => [{ type: "raw_text", text: "x" }]);
+    expect(
+      countSlackDataTableCellCharacters({
+        type: "data_table",
+        caption: "At limit",
+        rows: [[{ type: "raw_text", text: "&".repeat(9_900) }], ...rows],
+      }),
+    ).toBe(10_000);
+    const overCharacterLimit = {
+      type: "data_table",
+      caption: "Over limit",
+      rows: [[{ type: "raw_text", text: "&".repeat(9_901) }], ...rows],
+    };
+    expect(countSlackDataTableCellCharacters(overCharacterLimit)).toBeUndefined();
+    expect(renderSlackDataTableCompactPlainTextFallback(overCharacterLimit)).toContain(
+      "&".repeat(9_901),
+    );
+
+    const overRowLimit = {
+      type: "data_table",
+      caption: "Too many rows",
+      rows: [
+        [{ type: "raw_text", text: "Value" }],
+        ...Array.from({ length: 101 }, (_entry, index) => [
+          { type: "raw_text", text: `row-${String(index)}` },
+        ]),
+      ],
+    };
+    expect(countSlackDataTableCellCharacters(overRowLimit)).toBeUndefined();
+    expect(renderSlackDataTableCompactPlainTextFallback(overRowLimit)).toContain("row-100");
   });
 
   it("detects native tables and keeps a caption fallback for malformed raw blocks", () => {

--- a/extensions/slack/src/data-table.ts
+++ b/extensions/slack/src/data-table.ts
@@ -135,7 +135,10 @@ function readSlackDataTableCell(value: unknown, allowRichText: boolean): string 
   return undefined;
 }
 
-function parseSlackDataTable(value: unknown): ParsedSlackDataTable | undefined {
+function parseSlackDataTable(
+  value: unknown,
+  options: { enforceNativeLimits?: boolean } = {},
+): ParsedSlackDataTable | undefined {
   const block = asRecord(value);
   const caption = readNonEmptyString(block?.caption);
   if (block?.type !== "data_table" || !caption || !Array.isArray(block.rows)) {
@@ -166,6 +169,14 @@ function parseSlackDataTable(value: unknown): ParsedSlackDataTable | undefined {
     (total, cell) => total + countCharacters(cell),
     0,
   );
+  if (
+    options.enforceNativeLimits &&
+    (block.rows.length > SLACK_DATA_TABLE_ROWS_MAX + 1 ||
+      headers.length > SLACK_DATA_TABLE_COLUMNS_MAX ||
+      cellCharacterCount > SLACK_DATA_TABLE_CELL_CHARACTERS_MAX)
+  ) {
+    return undefined;
+  }
   return { caption, headers, rows, cellCharacterCount };
 }
 
@@ -178,7 +189,7 @@ export function hasSlackDataTableBlock(blocks?: readonly unknown[]): boolean {
 export function countSlackDataTableCellCharacters(value: SlackDataTableBlock): number;
 export function countSlackDataTableCellCharacters(value: unknown): number | undefined;
 export function countSlackDataTableCellCharacters(value: unknown): number | undefined {
-  return parseSlackDataTable(value)?.cellCharacterCount;
+  return parseSlackDataTable(value, { enforceNativeLimits: true })?.cellCharacterCount;
 }
 
 /** Count the aggregate native-table cell characters already present in a message. */
@@ -300,6 +311,31 @@ export function renderSlackDataTableFallbackText(value: unknown): string | undef
     });
   }
   return readNonEmptyString(block.caption)?.trim();
+}
+
+function escapeCompactFallbackCell(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\t", "\\t")
+    .replaceAll("\r", "\\r")
+    .replaceAll("\n", "\\n");
+}
+
+/** Render each native table cell once for bounded, formatting-disabled delivery. */
+export function renderSlackDataTableCompactPlainTextFallback(value: unknown): string | undefined {
+  const block = asRecord(value);
+  if (block?.type !== "data_table") {
+    return undefined;
+  }
+  const parsed = parseSlackDataTable(block);
+  if (!parsed) {
+    return readNonEmptyString(block.caption)?.trim();
+  }
+  return [
+    `${escapeCompactFallbackCell(parsed.caption)} (table)`,
+    parsed.headers.map(escapeCompactFallbackCell).join("\t"),
+    ...parsed.rows.map((row) => row.map(escapeCompactFallbackCell).join("\t")),
+  ].join("\n");
 }
 
 /** Render a native table as mrkdwn without activating raw cell control tokens. */

--- a/extensions/slack/src/edit-text.test.ts
+++ b/extensions/slack/src/edit-text.test.ts
@@ -1,0 +1,67 @@
+// Slack tests cover edit fallback text behavior.
+import { describe, expect, it } from "vitest";
+import { buildSlackEditTextPayload } from "./edit-text.js";
+
+describe("buildSlackEditTextPayload", () => {
+  it("preserves block fallback text when edited content has action blocks", () => {
+    const payload = buildSlackEditTextPayload("Approve deployment?", [
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Approve" },
+          },
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Deny" },
+          },
+        ],
+      },
+    ]);
+
+    expect(payload).toBe("Approve deployment?\n\nApprove\nDeny");
+  });
+
+  it("does not duplicate edited content already present in blocks", () => {
+    const payload = buildSlackEditTextPayload("Approve deployment?", [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "Approve deployment?" },
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "Approve" },
+          },
+        ],
+      },
+    ]);
+
+    expect(payload).toBe("Approve deployment?\n\nApprove");
+  });
+
+  it("does not append block fallback already present in edited content", () => {
+    const tableFallback = "Pipeline report (table)\nAccount\tARR\nAcme\t$125k";
+    const payload = buildSlackEditTextPayload(`Summary\n\n${tableFallback}`, [
+      {
+        type: "data_table",
+        caption: "Pipeline report",
+        rows: [
+          [
+            { type: "raw_text", text: "Account" },
+            { type: "raw_text", text: "ARR" },
+          ],
+          [
+            { type: "raw_text", text: "Acme" },
+            { type: "raw_number", value: 125000, text: "$125k" },
+          ],
+        ],
+      },
+    ] as never);
+
+    expect(payload).toBe(`Summary\n\n${tableFallback}`);
+  });
+});

--- a/extensions/slack/src/edit-text.ts
+++ b/extensions/slack/src/edit-text.ts
@@ -1,20 +1,35 @@
 // Slack plugin module implements edit text behavior.
 import type { Block, KnownBlock } from "@slack/web-api";
-import {
-  appendSlackBlocksAccessibleFallbackText,
-  buildSlackBlocksAccessibleFallbackText,
-} from "./blocks-fallback.js";
+import { buildSlackCompleteBlocksFallbackText } from "./blocks-fallback.js";
+import { SLACK_EDIT_TEXT_LIMIT } from "./limits.js";
+import { appendSlackNativeDataPlainTextFallback } from "./native-data-blocks.js";
+import { truncateSlackText } from "./truncate.js";
 
 export function buildSlackEditTextPayload(
   content: string,
   blocks?: (Block | KnownBlock)[],
 ): string {
   const trimmedContent = content.trim();
-  if (blocks?.length) {
-    return (
-      appendSlackBlocksAccessibleFallbackText(trimmedContent, blocks) ||
-      buildSlackBlocksAccessibleFallbackText(blocks)
-    );
+  const blockText = blocks?.length ? buildSlackCompleteBlocksFallbackText(blocks).trim() : "";
+  if (trimmedContent && !blockText) {
+    return trimmedContent;
   }
-  return trimmedContent || " ";
+  if (trimmedContent) {
+    const nativePlainText = blocks?.length
+      ? appendSlackNativeDataPlainTextFallback("", blocks).trim()
+      : "";
+    const contentContainsBlockText =
+      Boolean(blockText && trimmedContent.includes(blockText)) ||
+      Boolean(nativePlainText && trimmedContent.includes(nativePlainText));
+    const fallbackText = contentContainsBlockText
+      ? trimmedContent
+      : blockText && !blockText.includes(trimmedContent)
+        ? `${trimmedContent}\n\n${blockText}`
+        : blockText || trimmedContent;
+    return truncateSlackText(fallbackText, SLACK_EDIT_TEXT_LIMIT);
+  }
+  if (blockText) {
+    return truncateSlackText(blockText, SLACK_EDIT_TEXT_LIMIT);
+  }
+  return " ";
 }

--- a/extensions/slack/src/limits.ts
+++ b/extensions/slack/src/limits.ts
@@ -1,3 +1,10 @@
 // Slack plugin module implements limits behavior.
 export const SLACK_TEXT_LIMIT = 8000;
-export const SLACK_RESPONSE_URL_MAX_USES = 5;
+
+// chat.update rejects text above 4,000 characters with msg_too_long.
+// https://docs.slack.dev/reference/methods/chat.update/#errors
+export const SLACK_EDIT_TEXT_LIMIT = 4_000;
+
+// Slack truncates chat.postMessage text above 40,000 characters.
+// https://api.slack.com/methods/chat.postMessage#truncating
+export const SLACK_MESSAGE_TEXT_HARD_LIMIT = 40_000;

--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { handleSlackMessageAction } from "./message-action-dispatch.js";
 import { extractSlackToolSend } from "./message-actions.js";
+import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
 
 function createInvokeSpy() {
   return vi.fn(async (action: Record<string, unknown>, _cfg?: unknown, _toolContext?: unknown) => ({
@@ -36,6 +37,17 @@ function firstAction(invoke: ReturnType<typeof createInvokeSpy>) {
     throw new Error("expected first invoke action");
   }
   return action;
+}
+
+function preparedMessages(invoke: ReturnType<typeof createInvokeSpy>) {
+  const context = firstInvokeCall(invoke)[2] as
+    | { preparedMessages?: Array<Record<string, unknown>> }
+    | undefined;
+  const messages = context?.preparedMessages;
+  if (!messages?.length) {
+    throw new Error("expected prepared Slack messages");
+  }
+  return messages;
 }
 
 function blockAt(action: Record<string, unknown>, index: number) {
@@ -74,6 +86,7 @@ function largeTablePresentation() {
 describe("handleSlackMessageAction", () => {
   it("defaults reactions to the current inbound Slack message", async () => {
     const invoke = createInvokeSpy();
+    const toolContext = { currentMessageId: "171234.567" };
 
     await handleSlackMessageAction({
       providerId: "slack",
@@ -84,7 +97,7 @@ describe("handleSlackMessageAction", () => {
           channelId: "C1",
           emoji: "✅",
         },
-        toolContext: { currentMessageId: "171234.567" },
+        toolContext,
       } as never,
       invoke: invoke as never,
     });
@@ -95,6 +108,7 @@ describe("handleSlackMessageAction", () => {
       emoji: "✅",
       messageId: "171234.567",
     });
+    expect(firstInvokeCall(invoke)[2]).toBe(toolContext);
   });
 
   it("merges presentation and interactive blocks when sending", async () => {
@@ -125,9 +139,11 @@ describe("handleSlackMessageAction", () => {
     });
 
     const action = firstAction(invoke);
-    expect(blockAt(action, 0).type).toBe("section");
-    expect(blockAt(action, 1).type).toBe("section");
-    const actionsBlock = blockAt(action, 2);
+    expect(action).not.toHaveProperty("blocks");
+    const message = preparedMessages(invoke)[0]!;
+    expect(blockAt(message, 0).type).toBe("section");
+    expect(blockAt(message, 1).type).toBe("section");
+    const actionsBlock = blockAt(message, 2);
     expect(actionsBlock.type).toBe("actions");
     expect(elementAt(actionsBlock, 0).value).toBe("approve");
   });
@@ -162,10 +178,14 @@ describe("handleSlackMessageAction", () => {
     });
 
     const action = firstAction(invoke);
-    expect(action.content).toBe(
+    expect(action.content).toBe("Revenue summary");
+    expect(action).not.toHaveProperty("blocks");
+    expect(action).not.toHaveProperty("nativeDataFallbackBaseText");
+    const message = preparedMessages(invoke)[0]!;
+    expect(message.text).toBe(
       "Revenue summary\n\nRevenue mix (pie chart)\n- Product: 60\n- Services: 40",
     );
-    expect(blockAt(action, 1)).toEqual({
+    expect(blockAt(message, 1)).toEqual({
       type: "data_visualization",
       title: "Revenue mix",
       chart: {
@@ -207,8 +227,11 @@ describe("handleSlackMessageAction", () => {
       invoke: invoke as never,
     });
 
-    expect(firstAction(invoke).content).toBe(
-      "Pipeline summary\n\nPipeline (table)\n- Account: Acme; ARR: 125000\n- Account: Globex; ARR: 82000",
+    const action = firstAction(invoke);
+    expect(action.content).toBe("Pipeline summary");
+    const message = preparedMessages(invoke)[0]!;
+    expect(message.text).toBe(
+      "Pipeline summary\n\nPipeline (table)\nAccount\tARR\nAcme\t125000\nGlobex\t82000",
     );
   });
 
@@ -257,86 +280,37 @@ describe("handleSlackMessageAction", () => {
         cfg: {},
         params: {
           to: "channel:C1",
-          presentation: largeTablePresentation(),
+          message: "Summary",
+          presentation: {
+            blocks: [
+              {
+                type: "chart",
+                chartType: "pie",
+                title: "Revenue mix",
+                segments: [{ label: "Product", value: 60 }],
+              },
+              ...largeTablePresentation().blocks,
+              {
+                type: "buttons",
+                buttons: [{ label: "Stage", value: "stage" }],
+              },
+              {
+                type: "select",
+                placeholder: "Lane",
+                options: [{ label: "Production", value: "production" }],
+              },
+            ],
+          },
           interactive: {
             blocks: [
               {
                 type: "buttons",
                 buttons: [{ label: "Refresh", value: "refresh" }],
               },
-            ],
-          },
-        },
-      } as never,
-      invoke: invoke as never,
-    });
-
-    const action = firstAction(invoke);
-    expect(action.separateTextAndBlocks).toBe(true);
-    expect(action.textIsSlackMrkdwn).toBe(true);
-    expect(action.content).toContain("- Account: &lt;@U123&gt;");
-    expect(action.content).toContain("- Account: account-99");
-    const actionsBlock = blockAt(action, 0);
-    expect(actionsBlock.type).toBe("actions");
-    expect(elementAt(actionsBlock, 0).value).toBe("refresh");
-    expect(String(action.content).length).toBeGreaterThan(8000);
-  });
-
-  it("keeps lossless presentation controls native during table fallback", async () => {
-    const invoke = createInvokeSpy();
-
-    await handleSlackMessageAction({
-      providerId: "slack",
-      ctx: {
-        action: "send",
-        cfg: {},
-        params: {
-          to: "channel:C1",
-          message: "Pipeline summary",
-          presentation: {
-            title: "Quarterly report",
-            blocks: [
-              { type: "context", text: "Confidential" },
-              ...largeTablePresentation().blocks,
-              { type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] },
-            ],
-          },
-        },
-      } as never,
-      invoke: invoke as never,
-    });
-
-    const action = firstAction(invoke);
-    expect(action.separateTextAndBlocks).toBe(true);
-    expect(blockAt(action, 0)).toMatchObject({
-      type: "actions",
-      elements: [{ type: "button", value: "refresh" }],
-    });
-    expect(action.content).toContain("Quarterly report");
-    expect(action.content).toContain("Confidential");
-    expect(action.content).toContain("- Account: account-99");
-    expect(action.content).not.toContain("- Refresh");
-  });
-
-  it("keeps a native table while assigning its over-8k fallback one text owner", async () => {
-    const invoke = createInvokeSpy();
-
-    await handleSlackMessageAction({
-      providerId: "slack",
-      ctx: {
-        action: "send",
-        cfg: {},
-        params: {
-          to: "channel:C1",
-          presentation: {
-            blocks: [
               {
-                type: "table",
-                caption: "Pipeline",
-                headers: ["Account"],
-                rows: Array.from({ length: 100 }, (_entry, index) => [
-                  index === 0 ? "<@U123>" : `account-${String(index)} ${"x".repeat(65)}`,
-                ]),
+                type: "select",
+                placeholder: "Window",
+                options: [{ label: "Recent", value: "recent" }],
               },
             ],
           },
@@ -346,34 +320,50 @@ describe("handleSlackMessageAction", () => {
     });
 
     const action = firstAction(invoke);
-    expect(action.separateTextAndBlocks).toBe(true);
-    expect(blockAt(action, 0)).toMatchObject({ type: "data_table", caption: "Pipeline" });
-    expect(action.content).toContain("- Account: account-99");
-    expect(String(action.content).match(/Pipeline \(table\)/g)).toHaveLength(1);
+    expect(action).not.toHaveProperty("separateTextAndBlocks");
+    expect(action).not.toHaveProperty("blocks");
+    const messages = preparedMessages(invoke);
+    expect(messages).toHaveLength(3);
+    expect(messages[0]?.text).toBe("Summary\n\nRevenue mix (pie chart)\n- Product: 60");
+    expect(blockAt(messages[0]!, 1).type).toBe("data_visualization");
+    expect(messages[1]?.text).toContain("- Account: <@U123>");
+    expect(messages[1]?.text).toContain("- Account: account-99");
+    expect(messages[1]?.textIsSlackPlainText).toBe(true);
+    const controls = messages[2]!;
+    const presentationButtons = blockAt(controls, 0);
+    expect(presentationButtons.block_id).toBe("openclaw_reply_buttons_1");
+    expect(elementAt(presentationButtons, 0)).toMatchObject({
+      action_id: "openclaw:reply_button:1:1",
+      value: "stage",
+    });
+    const presentationSelect = blockAt(controls, 1);
+    expect(presentationSelect.block_id).toBe("openclaw_reply_select_1");
+    expect(elementAt(presentationSelect, 0).action_id).toBe("openclaw:reply_select:1");
+    const legacyButtons = blockAt(controls, 2);
+    expect(legacyButtons.block_id).toBe("openclaw_reply_buttons_2");
+    expect(elementAt(legacyButtons, 0)).toMatchObject({
+      action_id: "openclaw:reply_button:2:1",
+      value: "refresh",
+    });
+    const legacySelect = blockAt(controls, 3);
+    expect(legacySelect.block_id).toBe("openclaw_reply_select_2");
+    expect(elementAt(legacySelect, 0).action_id).toBe("openclaw:reply_select:2");
+    expect(String(messages[1]?.text).length).toBeGreaterThan(8000);
   });
 
-  it("keeps edit accessibility complete while rendering table fallback beside controls", async () => {
+  it("keeps an oversized portable control label complete in literal fallback", async () => {
     const invoke = createInvokeSpy();
+    const label = `Deploy ${"x".repeat(80)}`;
 
     await handleSlackMessageAction({
       providerId: "slack",
       ctx: {
-        action: "edit",
+        action: "send",
         cfg: {},
         params: {
-          channelId: "C1",
-          messageId: "171234.567",
+          to: "channel:C1",
           presentation: {
-            title: "Quarterly report",
-            blocks: [
-              {
-                type: "table",
-                caption: "Wide pipeline",
-                headers: Array.from({ length: 21 }, (_entry, index) => `Column ${String(index)}`),
-                rows: [Array.from({ length: 21 }, (_entry, index) => `Value ${String(index)}`)],
-              },
-              { type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] },
-            ],
+            blocks: [{ type: "buttons", buttons: [{ label, value: "deploy" }] }],
           },
         },
       } as never,
@@ -381,13 +371,9 @@ describe("handleSlackMessageAction", () => {
     });
 
     const action = firstAction(invoke);
-    expect(action.content).toContain("Quarterly report");
-    expect(action.content).toContain("- Refresh");
-    expect(blockAt(action, 0).type).toBe("actions");
-    expect(blockAt(action, 1)).toMatchObject({
-      type: "section",
-      text: { type: "mrkdwn", verbatim: true },
-    });
+    expect(action).not.toHaveProperty("blocks");
+    expect(action).not.toHaveProperty("preparedMessages");
+    expect(preparedMessages(invoke)).toEqual([{ text: `- ${label}`, textIsSlackPlainText: true }]);
   });
 
   it("uses text-only edits for non-native tables that fit one message", async () => {
@@ -424,6 +410,24 @@ describe("handleSlackMessageAction", () => {
 
   it("rejects non-native table edits whose complete fallback cannot fit", async () => {
     const invoke = createInvokeSpy();
+    const headers = Array.from({ length: 21 }, (_entry, index) => `Column ${String(index)}`);
+    const presentation = {
+      blocks: [
+        {
+          type: "table" as const,
+          caption: "Wide pipeline",
+          headers,
+          rows: Array.from({ length: 10 }, (_row, rowIndex) =>
+            headers.map(
+              (_header, columnIndex) => `Value ${String(rowIndex)}-${String(columnIndex)}`,
+            ),
+          ),
+        },
+      ],
+    };
+    const fallback = renderSlackMessagePresentationFallbackText({ presentation });
+    expect(fallback.length).toBeGreaterThan(4000);
+    expect(fallback.length).toBeLessThan(8000);
 
     await expect(
       handleSlackMessageAction({
@@ -434,15 +438,96 @@ describe("handleSlackMessageAction", () => {
           params: {
             channelId: "C1",
             messageId: "171234.567",
-            presentation: largeTablePresentation(),
+            presentation,
           },
         } as never,
         invoke: invoke as never,
       }),
-    ).rejects.toThrow(
-      "Slack presentation fallback exceeds OpenClaw's 8000-character per-edit limit",
-    );
+    ).rejects.toThrow("Slack presentation fallback exceeds the 4000-character edit limit");
     expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-native chart edits whose complete fallback cannot fit", async () => {
+    const invoke = createInvokeSpy();
+    const categories = Array.from(
+      { length: 21 },
+      (_entry, index) => `Category ${String(index)} ${"x".repeat(200)}`,
+    );
+    const presentation = {
+      blocks: [
+        {
+          type: "chart" as const,
+          chartType: "line" as const,
+          title: "Long trend",
+          categories,
+          series: [{ name: "Series", values: categories.map((_category, index) => index) }],
+        },
+      ],
+    };
+    expect(renderSlackMessagePresentationFallbackText({ presentation }).length).toBeGreaterThan(
+      4000,
+    );
+
+    await expect(
+      handleSlackMessageAction({
+        providerId: "slack",
+        ctx: {
+          action: "edit",
+          cfg: {},
+          params: { channelId: "C1", messageId: "171234.567", presentation },
+        } as never,
+        invoke: invoke as never,
+      }),
+    ).rejects.toThrow("Slack presentation fallback exceeds the 4000-character edit limit");
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("keeps an unrenderable control label complete in text-only edits", async () => {
+    const invoke = createInvokeSpy();
+    const label = `Deploy ${"x".repeat(80)}`;
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "edit",
+        cfg: {},
+        params: {
+          channelId: "C1",
+          messageId: "171234.567",
+          presentation: {
+            blocks: [{ type: "buttons", buttons: [{ label, value: "deploy" }] }],
+          },
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(firstAction(invoke)).toMatchObject({ content: `- ${label}`, blocks: undefined });
+  });
+
+  it("uses complete text-only fallback when an edit exceeds fifty blocks", async () => {
+    const invoke = createInvokeSpy();
+    const presentation = {
+      blocks: Array.from({ length: 51 }, (_entry, index) => ({
+        type: "text" as const,
+        text: `Detail ${String(index)}`,
+      })),
+    };
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "edit",
+        cfg: {},
+        params: { channelId: "C1", messageId: "171234.567", presentation },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    const action = firstAction(invoke);
+    expect(action.blocks).toBeUndefined();
+    expect(action.content).toContain("Detail 0");
+    expect(action.content).toContain("Detail 50");
   });
 
   it("keeps generated Slack control ids unique when presentation and interactive controls are merged", async () => {
@@ -478,10 +563,12 @@ describe("handleSlackMessageAction", () => {
     });
 
     const action = firstAction(invoke);
-    const firstButtons = blockAt(action, 1);
+    expect(action).not.toHaveProperty("blocks");
+    const message = preparedMessages(invoke)[0]!;
+    const firstButtons = blockAt(message, 1);
     expect(firstButtons.block_id).toBe("openclaw_reply_buttons_1");
     expect(elementAt(firstButtons, 0).action_id).toBe("openclaw:reply_button:1:1");
-    const secondButtons = blockAt(action, 2);
+    const secondButtons = blockAt(message, 2);
     expect(secondButtons.block_id).toBe("openclaw_reply_buttons_2");
     expect(elementAt(secondButtons, 0).action_id).toBe("openclaw:reply_button:2:1");
   });
@@ -516,13 +603,15 @@ describe("handleSlackMessageAction", () => {
     const action = firstAction(invoke);
     expect(action.action).toBe("sendMessage");
     expect(action.to).toBe("channel:C1");
-    expect(action.content).toBe("Approval required\n\n- Approve");
+    expect(action.content).toBe("Approval required");
     expect(action.mediaUrl).toBe("https://example.com/report.md");
-    const actionsBlock = blockAt(action, 0);
+    expect(action).not.toHaveProperty("blocks");
+    const message = preparedMessages(invoke)[0]!;
+    expect(blockAt(message, 0).type).toBe("section");
+    const actionsBlock = blockAt(message, 1);
     expect(actionsBlock.type).toBe("actions");
     expect(elementAt(actionsBlock, 0).value).toBe("approve");
     expectForwardedCfg(invoke, cfg);
-    expectNoForwardedToolContext(invoke);
   });
 
   it("passes replyBroadcast through for Slack thread sends", async () => {
@@ -739,36 +828,6 @@ describe("handleSlackMessageAction", () => {
     expect(firstInvokeCall(invoke)[1]).toEqual({});
   });
 
-  it.each(["react", "reactions", "read", "list-pins"] as const)(
-    "forwards trusted tool context for %s authorization",
-    async (action) => {
-      const invoke = createInvokeSpy();
-      const toolContext = {
-        currentChannelProvider: "slack",
-        currentChannelId: "C1",
-      };
-
-      await handleSlackMessageAction({
-        providerId: "slack",
-        ctx: {
-          action,
-          cfg: {},
-          params: {
-            channelId: "C1",
-            ...(action === "react"
-              ? { messageId: "1712345678.654321", emoji: "white_check_mark" }
-              : {}),
-            ...(action === "reactions" ? { messageId: "1712345678.654321" } : {}),
-          },
-          toolContext,
-        } as never,
-        invoke: invoke as never,
-      });
-
-      expect(firstInvokeCall(invoke)[2]).toBe(toolContext);
-    },
-  );
-
   it("rejects fractional read limits before invoking Slack actions", async () => {
     const invoke = createInvokeSpy();
 
@@ -935,6 +994,7 @@ describe("handleSlackMessageAction", () => {
 
   it("defaults member-info userId to the inbound sender when omitted", async () => {
     const invoke = createInvokeSpy();
+    const toolContext = { currentChannelProvider: " Slack " };
 
     await handleSlackMessageAction({
       providerId: "slack",
@@ -945,7 +1005,7 @@ describe("handleSlackMessageAction", () => {
         accountId: "OPS",
         requesterAccountId: "ops",
         requesterSenderId: "U123",
-        toolContext: { currentChannelProvider: " Slack " },
+        toolContext,
       } as never,
       invoke: invoke as never,
     });
@@ -953,12 +1013,13 @@ describe("handleSlackMessageAction", () => {
     expect(invoke).toHaveBeenCalledWith(
       expect.objectContaining({ action: "memberInfo", userId: "U123" }),
       expect.any(Object),
-      expect.objectContaining({ currentChannelProvider: " Slack " }),
+      toolContext,
     );
   });
 
   it("defaults member-info userId through the configured default Slack account", async () => {
     const invoke = createInvokeSpy();
+    const toolContext = { currentChannelProvider: "slack" };
 
     await handleSlackMessageAction({
       providerId: "slack",
@@ -968,7 +1029,7 @@ describe("handleSlackMessageAction", () => {
         params: {},
         requesterAccountId: "OPS",
         requesterSenderId: "U123",
-        toolContext: { currentChannelProvider: "slack" },
+        toolContext,
       } as never,
       invoke: invoke as never,
     });
@@ -976,7 +1037,7 @@ describe("handleSlackMessageAction", () => {
     expect(invoke).toHaveBeenCalledWith(
       expect.objectContaining({ action: "memberInfo", userId: "U123" }),
       expect.any(Object),
-      expect.objectContaining({ currentChannelProvider: "slack" }),
+      toolContext,
     );
   });
 
@@ -1016,6 +1077,7 @@ describe("handleSlackMessageAction", () => {
 
   it("prefers an explicit member-info userId over the inbound sender", async () => {
     const invoke = createInvokeSpy();
+    const toolContext = { currentChannelProvider: "telegram" };
 
     await handleSlackMessageAction({
       providerId: "slack",
@@ -1026,8 +1088,7 @@ describe("handleSlackMessageAction", () => {
         accountId: "other",
         requesterAccountId: "default",
         requesterSenderId: "U123",
-        conversationReadOrigin: "direct-operator",
-        toolContext: { currentChannelProvider: "telegram" },
+        toolContext,
       } as never,
       invoke: invoke as never,
     });
@@ -1035,7 +1096,7 @@ describe("handleSlackMessageAction", () => {
     expect(invoke).toHaveBeenCalledWith(
       expect.objectContaining({ action: "memberInfo", userId: "U999" }),
       expect.any(Object),
-      expect.objectContaining({ currentChannelProvider: "telegram" }),
+      toolContext,
     );
   });
 });

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -13,18 +13,54 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 import { resolveDefaultSlackAccountId } from "./accounts.js";
 import { SLACK_MAX_BLOCKS } from "./blocks-input.js";
-import { SLACK_TEXT_LIMIT } from "./limits.js";
-import { SLACK_SECTION_TEXT_MAX } from "./presentation.js";
-import { resolveSlackReplyRenderPlan } from "./reply-blocks.js";
+import { buildSlackPresentationBlocks, canRenderSlackPresentation } from "./blocks-render.js";
+import { SLACK_EDIT_TEXT_LIMIT } from "./limits.js";
+import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
+import {
+  resolveSlackReplyBlockResolution,
+  resolveSlackReplyDeliveryMessages,
+  type SlackReplyDeliveryMessage,
+} from "./reply-blocks.js";
 
 type SlackActionInvoke = (
   action: Record<string, unknown>,
   cfg: ChannelMessageActionContext["cfg"],
   toolContext?: ChannelMessageActionContext["toolContext"],
 ) => Promise<AgentToolResult<unknown>>;
+
+function resolveSlackPresentationText(
+  content: string | undefined,
+  presentation: ReturnType<typeof normalizeMessagePresentation>,
+): string {
+  const hasStructuredData = presentation?.blocks.some(
+    (block) => block.type === "chart" || block.type === "table",
+  );
+  return hasStructuredData
+    ? renderSlackMessagePresentationFallbackText({ text: content, presentation })
+    : (content ?? "");
+}
+
+function renderSlackActionPresentation(
+  presentation: ReturnType<typeof normalizeMessagePresentation>,
+): {
+  blocks?: ReturnType<typeof buildSlackPresentationBlocks>;
+  usesPresentationTextFallback: boolean;
+} {
+  if (!presentation) {
+    return { usesPresentationTextFallback: false };
+  }
+  const renderedBlocks = canRenderSlackPresentation(presentation)
+    ? buildSlackPresentationBlocks(presentation)
+    : undefined;
+  const usesPresentationTextFallback = !renderedBlocks || renderedBlocks.length > SLACK_MAX_BLOCKS;
+  const blocks = usesPresentationTextFallback ? undefined : renderedBlocks;
+  return {
+    ...(blocks?.length ? { blocks } : {}),
+    usesPresentationTextFallback,
+  };
+}
 
 /** Translate generic channel action requests into Slack-specific tool invocations and payload shapes. */
 export async function handleSlackMessageAction(params: {
@@ -53,13 +89,24 @@ export async function handleSlackMessageAction(params: {
     const mediaUrl = readStringParam(actionParams, "media", { trim: false });
     const presentation = normalizeMessagePresentation(actionParams.presentation);
     const interactive = normalizeInteractiveReply(actionParams.interactive);
-    const renderPlan = resolveSlackReplyRenderPlan({ presentation, interactive }, content, {
-      textLimit: SLACK_TEXT_LIMIT,
-    });
-    const blocks = renderPlan.mode === "single" ? renderPlan.blocks : renderPlan.blockPart?.blocks;
-    const accessibleContent =
-      renderPlan.mode === "single" ? renderPlan.text : renderPlan.fallbackText;
-    if (!accessibleContent && !mediaUrl && !blocks) {
+    const hasStructuredContent = Boolean(presentation || interactive?.blocks.length);
+    const resolution = resolveSlackReplyBlockResolution(
+      {
+        text: content,
+        presentation,
+        interactive,
+      },
+      { materializeAuthoredText: hasStructuredContent },
+    );
+    const preparedMessages =
+      resolution.segments.length > 0
+        ? resolveSlackReplyDeliveryMessages({
+            authoredTextPlacement: resolution.authoredTextPlacement,
+            segments: resolution.segments,
+            text: content,
+          })
+        : [];
+    if (!content && preparedMessages.length === 0 && !mediaUrl) {
       throw new Error("Slack send requires message, blocks, or media.");
     }
     const replyBroadcast = readBooleanParam(actionParams, "replyBroadcast");
@@ -70,25 +117,26 @@ export async function handleSlackMessageAction(params: {
     const replyTo = readStringParam(actionParams, "replyTo");
     const topLevel =
       readBooleanParam(actionParams, "topLevel") === true || actionParams.threadId === null;
+    const toolContext =
+      preparedMessages.length > 0
+        ? {
+            ...ctx.toolContext,
+            preparedMessages: preparedMessages satisfies readonly SlackReplyDeliveryMessage[],
+          }
+        : ctx.toolContext;
     return await invoke(
       {
         action: "sendMessage",
         to,
-        content: accessibleContent,
+        content: content ?? "",
         mediaUrl: mediaUrl ?? undefined,
         accountId,
         threadTs: threadId ?? replyTo ?? undefined,
         ...(topLevel ? { topLevel: true } : {}),
         ...(replyBroadcast ? { replyBroadcast } : {}),
-        ...(blocks ? { blocks } : {}),
-        ...(renderPlan.mode === "split"
-          ? { separateTextAndBlocks: true, textIsSlackMrkdwn: true }
-          : renderPlan.textIsSlackMrkdwn
-            ? { textIsSlackMrkdwn: true }
-            : {}),
       },
       cfg,
-      ctx.toolContext,
+      toolContext,
     );
   }
 
@@ -164,31 +212,23 @@ export async function handleSlackMessageAction(params: {
     });
     const content = readStringParam(actionParams, "message", { allowEmpty: true });
     const presentation = normalizeMessagePresentation(actionParams.presentation);
-    const renderPlan = resolveSlackReplyRenderPlan({ presentation }, content, {
-      textLimit: SLACK_TEXT_LIMIT,
-    });
-    const accessibleContent = renderPlan.hookText;
-    if (renderPlan.mode === "split" && accessibleContent.length > SLACK_TEXT_LIMIT) {
+    const renderedPresentation = renderSlackActionPresentation(presentation);
+    // Slack hides top-level text when blocks are present on updates. Keep an
+    // unrenderable presentation text-only so its complete fallback stays visible.
+    const blocks = renderedPresentation.usesPresentationTextFallback
+      ? undefined
+      : renderedPresentation.blocks;
+    const accessibleContent = renderedPresentation.usesPresentationTextFallback
+      ? renderSlackMessagePresentationFallbackText({ text: content, presentation })
+      : resolveSlackPresentationText(content, presentation);
+    if (
+      renderedPresentation.usesPresentationTextFallback &&
+      accessibleContent.length > SLACK_EDIT_TEXT_LIMIT
+    ) {
       throw new Error(
-        `Slack presentation fallback exceeds OpenClaw's ${String(SLACK_TEXT_LIMIT)}-character per-edit limit. Send a new message instead.`,
+        `Slack presentation fallback exceeds the ${String(SLACK_EDIT_TEXT_LIMIT)}-character edit limit. Send a new message instead.`,
       );
     }
-    const presentationFallbackBlocks =
-      renderPlan.mode === "split" && renderPlan.blockPart
-        ? chunkTextForOutbound(renderPlan.fallbackText, SLACK_SECTION_TEXT_MAX).map((text) => ({
-            type: "section" as const,
-            text: { type: "mrkdwn" as const, text, verbatim: true },
-          }))
-        : [];
-    const nativeBlocks =
-      renderPlan.mode === "single"
-        ? (renderPlan.blocks ?? [])
-        : (renderPlan.blockPart?.blocks ?? []);
-    const mergedBlocks = [...nativeBlocks, ...presentationFallbackBlocks];
-    if (mergedBlocks.length > SLACK_MAX_BLOCKS) {
-      throw new Error(`Slack blocks cannot exceed ${String(SLACK_MAX_BLOCKS)} items after render`);
-    }
-    const blocks = mergedBlocks.length > 0 ? mergedBlocks : undefined;
     if (!accessibleContent && !blocks) {
       throw new Error("Slack edit requires message or blocks.");
     }
@@ -261,7 +301,7 @@ export async function handleSlackMessageAction(params: {
     const limit = readPositiveIntegerParam(actionParams, "limit", {
       message: "limit must be a positive integer.",
     });
-    return await invoke({ action: "emojiList", limit, accountId }, cfg);
+    return await invoke({ action: "emojiList", limit, accountId }, cfg, ctx.toolContext);
   }
 
   if (action === "download-file") {

--- a/extensions/slack/src/monitor/block-text.test.ts
+++ b/extensions/slack/src/monitor/block-text.test.ts
@@ -2,6 +2,55 @@ import { describe, expect, it } from "vitest";
 import { chooseSlackPrimaryText, resolveSlackBlocksText } from "./block-text.js";
 
 describe("resolveSlackBlocksText data visualizations", () => {
+  it("uses the shared visible-text parser for rich text, fields, and controls", () => {
+    const resolved = resolveSlackBlocksText([
+      {
+        type: "rich_text",
+        elements: [
+          {
+            type: "rich_text_section",
+            elements: [
+              { type: "text", text: "Ask " },
+              { type: "user", user_id: "U123" },
+            ],
+          },
+        ],
+      },
+      {
+        type: "section",
+        text: { type: "plain_text", text: "Deploy" },
+        fields: [{ type: "plain_text", text: "Healthy" }],
+      },
+      {
+        type: "actions",
+        block_id: "private-block",
+        elements: [
+          {
+            type: "workflow_button",
+            text: { type: "plain_text", text: "Run workflow" },
+            action_id: "private-action",
+            workflow: { trigger: { url: "https://example.com/private" } },
+          },
+          {
+            type: "static_select",
+            placeholder: { type: "plain_text", text: "Choose owner" },
+            action_id: "private-select",
+            options: [
+              { text: { type: "plain_text", text: "Hidden option" }, value: "private-value" },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(resolved).toEqual({
+      text: "Ask &lt;@U123&gt;\nDeploy\nHealthy\nRun workflow\nChoose owner",
+      hasRichText: true,
+      hasNativeData: false,
+    });
+    expect(resolved?.text).not.toMatch(/private|Hidden option/u);
+  });
+
   it("preserves native chart values in inbound conversation context", () => {
     expect(
       resolveSlackBlocksText([

--- a/extensions/slack/src/monitor/block-text.ts
+++ b/extensions/slack/src/monitor/block-text.ts
@@ -1,34 +1,4 @@
-import {
-  normalizeOptionalString,
-  readStringValue as readString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
-import { renderSlackDataTableFallbackText } from "../data-table.js";
-import { renderSlackDataVisualizationFallbackText } from "../data-visualization.js";
-
-type SlackTextObject = {
-  text?: unknown;
-};
-
-type SlackRichTextElement = {
-  type?: unknown;
-  text?: unknown;
-  url?: unknown;
-  user_id?: unknown;
-  channel_id?: unknown;
-  usergroup_id?: unknown;
-  name?: unknown;
-  range?: unknown;
-  elements?: unknown;
-};
-
-type SlackBlockLike = {
-  type?: unknown;
-  text?: unknown;
-  elements?: unknown;
-  fields?: unknown;
-  alt_text?: unknown;
-  title?: unknown;
-};
+import { renderSlackBlockFallbackText } from "../blocks-fallback.js";
 
 type SlackBlocksText = {
   text: string;
@@ -36,127 +6,10 @@ type SlackBlocksText = {
   hasNativeData: boolean;
 };
 
-function readTextObject(value: unknown): string | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  return normalizeOptionalString(readString((value as SlackTextObject).text));
-}
-
-function renderSlackRichTextLeaf(element: SlackRichTextElement): string {
-  switch (element.type) {
-    case "text":
-      return readString(element.text) ?? "";
-    case "link":
-      return readString(element.text) ?? readString(element.url) ?? "";
-    case "user": {
-      const userId = readString(element.user_id);
-      return userId ? `<@${userId}>` : "";
-    }
-    case "channel": {
-      const channelId = readString(element.channel_id);
-      return channelId ? `<#${channelId}>` : "";
-    }
-    case "usergroup": {
-      const usergroupId = readString(element.usergroup_id);
-      return usergroupId ? `<!subteam^${usergroupId}>` : "";
-    }
-    case "broadcast": {
-      const range = readString(element.range);
-      return range ? `<!${range}>` : "";
-    }
-    case "emoji": {
-      const name = readString(element.name);
-      return name ? `:${name}:` : "";
-    }
-    default:
-      return "";
-  }
-}
-
-function renderSlackRichTextElements(elements: unknown): string {
-  if (!Array.isArray(elements)) {
-    return "";
-  }
-  const parts: string[] = [];
-  for (const rawElement of elements) {
-    if (!rawElement || typeof rawElement !== "object") {
-      continue;
-    }
-    const element = rawElement as SlackRichTextElement;
-    switch (element.type) {
-      case "rich_text_section":
-      case "rich_text_preformatted":
-      case "rich_text_quote":
-        parts.push(renderSlackRichTextElements(element.elements));
-        break;
-      case "rich_text_list": {
-        const listParts: string[] = [];
-        if (Array.isArray(element.elements)) {
-          for (const child of element.elements) {
-            if (!child || typeof child !== "object") {
-              continue;
-            }
-            const rendered = renderSlackRichTextElements((child as SlackRichTextElement).elements);
-            if (rendered) {
-              listParts.push(rendered);
-            }
-          }
-        }
-        parts.push(listParts.join("\n"));
-        break;
-      }
-      default:
-        parts.push(renderSlackRichTextLeaf(element));
-        break;
-    }
-  }
-  return parts.join("");
-}
-
-function readSlackBlockText(block: unknown): string | undefined {
-  if (!block || typeof block !== "object") {
-    return undefined;
-  }
-  const blockLike = block as SlackBlockLike;
-  switch (blockLike.type) {
-    case "rich_text":
-      return normalizeOptionalString(renderSlackRichTextElements(blockLike.elements));
-    case "section": {
-      const text = readTextObject(blockLike.text);
-      if (text) {
-        return text;
-      }
-      if (!Array.isArray(blockLike.fields)) {
-        return undefined;
-      }
-      const fields = blockLike.fields.flatMap((field) => readTextObject(field) ?? []);
-      return fields.length > 0 ? fields.join("\n") : undefined;
-    }
-    case "header":
-      return readTextObject(blockLike.text);
-    case "context": {
-      if (!Array.isArray(blockLike.elements)) {
-        return undefined;
-      }
-      const parts = blockLike.elements.flatMap((element) => readTextObject(element) ?? []);
-      return parts.length > 0 ? parts.join(" ") : undefined;
-    }
-    case "image":
-      return (
-        normalizeOptionalString(readString(blockLike.alt_text)) ?? readTextObject(blockLike.title)
-      );
-    case "video":
-      return (
-        readTextObject(blockLike.title) ?? normalizeOptionalString(readString(blockLike.alt_text))
-      );
-    case "data_visualization":
-      return renderSlackDataVisualizationFallbackText(block);
-    case "data_table":
-      return renderSlackDataTableFallbackText(block);
-    default:
-      return undefined;
-  }
+function readSlackBlockType(block: unknown): unknown {
+  return block && typeof block === "object" && !Array.isArray(block)
+    ? (block as { type?: unknown }).type
+    : undefined;
 }
 
 export function resolveSlackBlocksText(blocks: unknown[] | undefined): SlackBlocksText | undefined {
@@ -167,12 +20,10 @@ export function resolveSlackBlocksText(blocks: unknown[] | undefined): SlackBloc
   let hasRichText = false;
   let hasNativeData = false;
   for (const block of blocks) {
-    if (block && typeof block === "object") {
-      const blockType = (block as SlackBlockLike).type;
-      hasRichText ||= blockType === "rich_text";
-      hasNativeData ||= blockType === "data_visualization" || blockType === "data_table";
-    }
-    const text = readSlackBlockText(block);
+    const blockType = readSlackBlockType(block);
+    hasRichText ||= blockType === "rich_text";
+    hasNativeData ||= blockType === "data_visualization" || blockType === "data_table";
+    const text = renderSlackBlockFallbackText(block, { nativeDataFormat: "plain" });
     if (text) {
       parts.push(text);
     }

--- a/extensions/slack/src/monitor/message-handler/preview-finalize.test.ts
+++ b/extensions/slack/src/monitor/message-handler/preview-finalize.test.ts
@@ -169,4 +169,36 @@ describe("finalizeSlackPreviewEdit", () => {
       }),
     ).resolves.toBeUndefined();
   });
+
+  it("accepts native-data text fallback without blocks after an ambiguous retry response", async () => {
+    editSlackMessageMock.mockRejectedValueOnce(new Error("socket closed"));
+    const blocks = [
+      {
+        type: "data_visualization",
+        title: "Revenue mix",
+        chart: {
+          type: "pie",
+          segments: [
+            { label: "Product", value: 60 },
+            { label: "Services", value: 40 },
+          ],
+        },
+      },
+    ] as const;
+    const text = "Revenue mix (pie chart)\n- Product: 60\n- Services: 40";
+    const client = createClient({
+      historyMessages: [{ ts: "171234.567", text }],
+    });
+
+    await expect(
+      finalizeSlackPreviewEdit({
+        client,
+        token: "xoxb-test",
+        channelId: "C123",
+        messageId: "171234.567",
+        text: "",
+        blocks: blocks as unknown as Parameters<typeof finalizeSlackPreviewEdit>[0]["blocks"],
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/extensions/slack/src/monitor/message-handler/preview-finalize.ts
+++ b/extensions/slack/src/monitor/message-handler/preview-finalize.ts
@@ -2,12 +2,13 @@
 import type { Block, KnownBlock, WebClient } from "@slack/web-api";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { editSlackMessage } from "../../actions.js";
+import { buildSlackBlocksFallbackText } from "../../blocks-fallback.js";
 import { buildSlackEditTextPayload } from "../../edit-text.js";
 import { normalizeSlackOutboundText } from "../../format.js";
-import {
-  buildSlackNativeDataFallbackBlocks,
-  hasSlackNativeDataBlock,
-} from "../../native-data-blocks.js";
+import { SLACK_EDIT_TEXT_LIMIT } from "../../limits.js";
+import { hasSlackNativeDataBlock } from "../../native-data-blocks.js";
+import { buildSlackNativeDataDeliveryPlan } from "../../native-data-fallback.js";
+import { truncateSlackText } from "../../truncate.js";
 
 type SlackReadbackMessage = {
   ts?: string;
@@ -19,7 +20,36 @@ function buildExpectedSlackEditText(params: {
   text: string;
   blocks?: (Block | KnownBlock)[];
 }): string {
-  return normalizeSlackOutboundText(buildSlackEditTextPayload(params.text, params.blocks));
+  const trimmedText = params.text.trim();
+  if (trimmedText) {
+    return normalizeSlackOutboundText(trimmedText);
+  }
+  if (params.blocks?.length) {
+    return normalizeSlackOutboundText(buildSlackBlocksFallbackText(params.blocks));
+  }
+  return " ";
+}
+
+function buildAcceptedSlackEditTexts(params: {
+  text: string;
+  blocks?: (Block | KnownBlock)[];
+}): Set<string> {
+  const expected = buildExpectedSlackEditText(params);
+  const texts = new Set([
+    expected,
+    normalizeSlackOutboundText(truncateSlackText(expected, SLACK_EDIT_TEXT_LIMIT)),
+    normalizeSlackOutboundText(buildSlackEditTextPayload(params.text, params.blocks)),
+  ]);
+  if (params.blocks?.length && hasSlackNativeDataBlock(params.blocks)) {
+    const fallbackPlan = buildSlackNativeDataDeliveryPlan({
+      baseText: params.text,
+      blocks: params.blocks,
+    });
+    for (const message of fallbackPlan.fallbackMessages) {
+      texts.add(normalizeSlackOutboundText(message.text));
+    }
+  }
+  return texts;
 }
 
 function blocksMatch(expected?: (Block | KnownBlock)[], actual?: unknown[]): boolean {
@@ -27,7 +57,13 @@ function blocksMatch(expected?: (Block | KnownBlock)[], actual?: unknown[]): boo
     return !actual?.length;
   }
   if (!actual?.length) {
-    return false;
+    if (!hasSlackNativeDataBlock(expected)) {
+      return false;
+    }
+    const fallbackPlan = buildSlackNativeDataDeliveryPlan({
+      blocks: expected,
+    });
+    return fallbackPlan.fallbackMessages.every((message) => !message.blocks?.length);
   }
   if (JSON.stringify(expected) === JSON.stringify(actual)) {
     return true;
@@ -36,7 +72,19 @@ function blocksMatch(expected?: (Block | KnownBlock)[], actual?: unknown[]): boo
     return false;
   }
   try {
-    return JSON.stringify(buildSlackNativeDataFallbackBlocks(expected)) === JSON.stringify(actual);
+    const fallbackPlan = buildSlackNativeDataDeliveryPlan({
+      blocks: expected,
+    });
+    const fallbackBlocks = fallbackPlan.fallbackMessages.flatMap((message) => message.blocks ?? []);
+    if (JSON.stringify(fallbackBlocks) === JSON.stringify(actual)) {
+      return true;
+    }
+    const fallbackText = fallbackPlan.fallbackMessages
+      .map((message) => message.text)
+      .filter(Boolean)
+      .join("\n\n");
+    const actualText = buildSlackBlocksFallbackText(actual);
+    return normalizeSlackOutboundText(actualText) === normalizeSlackOutboundText(fallbackText);
   } catch {
     return false;
   }
@@ -96,9 +144,13 @@ async function didSlackPreviewEditApplyAfterError(params: {
     text: params.text,
     blocks: params.blocks,
   });
+  const acceptedTexts = buildAcceptedSlackEditTexts({
+    text: params.text,
+    blocks: params.blocks,
+  });
   const actualText = normalizeSlackOutboundText((readback.text ?? "").trim());
   if (params.blocks?.length) {
-    return actualText === expectedText && blocksMatch(params.blocks, readback.blocks);
+    return acceptedTexts.has(actualText) && blocksMatch(params.blocks, readback.blocks);
   }
   return actualText === expectedText;
 }

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -72,6 +72,28 @@ function requireSendCall(index = 0) {
   return call;
 }
 
+type SlashTestMessage = {
+  text: string;
+  blocks?: Array<Record<string, unknown>>;
+  mrkdwn?: false;
+  response_type?: "ephemeral" | "in_channel";
+};
+
+function requireSlashMessage(respond: ReturnType<typeof vi.fn>, index = 0): SlashTestMessage {
+  const message = respond.mock.calls[index]?.[0] as SlashTestMessage | undefined;
+  if (!message) {
+    throw new Error(`Slack response call ${String(index)} missing`);
+  }
+  return message;
+}
+
+function readPlainSectionTexts(message: SlashTestMessage): string[] {
+  return (message.blocks ?? []).flatMap((block) => {
+    const text = block.text as { type?: unknown; text?: unknown } | undefined;
+    return text?.type === "plain_text" && typeof text.text === "string" ? [text.text] : [];
+  });
+}
+
 describe("deliverReplies identity passthrough", () => {
   beforeAll(async () => {
     ({
@@ -136,19 +158,22 @@ describe("deliverReplies identity passthrough", () => {
       }),
     );
 
-    expect(sendMock).toHaveBeenCalledOnce();
-    const [_target, text, options] = requireSendCall();
-    expect(options.blocks).toEqual([
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    const [_textTarget, text, textOptions] = requireSendCall(0);
+    expect(text).toContain("- Account: <@U123>");
+    expect(text).toContain("- Account: account-99");
+    expect(text.length).toBeGreaterThan(8000);
+    expect(textOptions.textIsSlackPlainText).toBe(true);
+    expect(textOptions.blocks).toBeUndefined();
+
+    const [_blockTarget, blockText, blockOptions] = requireSendCall(1);
+    expect(blockText).toBe("");
+    expect(blockOptions.blocks).toEqual([
       expect.objectContaining({
         type: "actions",
         elements: [expect.objectContaining({ type: "button", value: "refresh" })],
       }),
     ]);
-    expect(text).toContain("- Account: &lt;@U123&gt;");
-    expect(text).toContain("- Account: account-99");
-    expect(text.length).toBeGreaterThan(8000);
-    expect(options.textIsSlackMrkdwn).toBe(true);
-    expect(options.separateTextAndBlocks).toBe(true);
   });
 
   it("delivers media before native chart blocks with the same reply context", async () => {
@@ -213,36 +238,32 @@ describe("deliverReplies identity passthrough", () => {
       identity,
       metadata,
     });
-    expect(sendMock).toHaveBeenNthCalledWith(
-      2,
-      "C123",
-      "Revenue summary\n\nRevenue mix (pie chart)\n- Product: 60\n- Services: 40",
-      {
-        cfg: enterpriseCfg,
-        token: "xoxb-test",
-        threadTs: "thread-ts",
-        accountId: "work",
-        client: listenerClient,
-        enterpriseEventScope: eventScope,
-        textLimit: 4000,
-        mediaMaxBytes: 1024,
-        blocks: [
-          {
-            type: "data_visualization",
-            title: "Revenue mix",
-            chart: {
-              type: "pie",
-              segments: [
-                { label: "Product", value: 60 },
-                { label: "Services", value: 40 },
-              ],
-            },
+    expect(sendMock).toHaveBeenNthCalledWith(2, "C123", "", {
+      cfg: enterpriseCfg,
+      token: "xoxb-test",
+      threadTs: "thread-ts",
+      accountId: "work",
+      client: listenerClient,
+      enterpriseEventScope: eventScope,
+      textLimit: 4000,
+      mediaMaxBytes: 1024,
+      blocks: [
+        {
+          type: "data_visualization",
+          title: "Revenue mix",
+          chart: {
+            type: "pie",
+            segments: [
+              { label: "Product", value: 60 },
+              { label: "Services", value: 40 },
+            ],
           },
-        ],
-        identity,
-        metadata,
-      },
-    );
+        },
+      ],
+      authoredTextPlacement: "none",
+      identity,
+      metadata,
+    });
     expect(result).toEqual({ messageId: "chart-ts", channelId: "C123" });
     expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
     const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
@@ -252,62 +273,6 @@ describe("deliverReplies identity passthrough", () => {
       success: true,
     });
     expect(event).not.toHaveProperty("messageId");
-  });
-
-  it("assigns an overlong native table fallback to the trailing block send after media", async () => {
-    sendMock
-      .mockResolvedValueOnce({ messageId: "media-ts", channelId: "C123" })
-      .mockResolvedValueOnce({ messageId: "table-ts", channelId: "C123" });
-
-    await deliverReplies(
-      baseParams({
-        textLimit: 8_000,
-        replies: [
-          {
-            text: "Pipeline summary",
-            mediaUrl: "https://example.com/report.png",
-            presentation: {
-              title: "Quarterly report",
-              blocks: [
-                { type: "context", text: "Confidential" },
-                {
-                  type: "table",
-                  caption: "Pipeline",
-                  headers: ["Account"],
-                  rows: Array.from({ length: 100 }, (_entry, index) => [
-                    index === 0 ? "<@U123>" : `account-${String(index)} ${"x".repeat(65)}`,
-                  ]),
-                },
-                { type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] },
-              ],
-            },
-          },
-        ],
-      }),
-    );
-
-    expect(sendMock).toHaveBeenCalledTimes(2);
-    expect(sendMock.mock.calls[0]?.[1]).toBe("");
-    expect(sendMock.mock.calls[0]?.[2]).toMatchObject({
-      mediaUrl: "https://example.com/report.png",
-    });
-    const [, fallbackText, options] = requireSendCall(1);
-    expect(fallbackText.length).toBeGreaterThan(8_000);
-    expect(fallbackText).toContain("- Account: account-99");
-    expect(options).toMatchObject({
-      separateTextAndBlocks: true,
-      textIsSlackMrkdwn: true,
-    });
-    expect((options.blocks as Array<{ type?: string }>).map((block) => block.type)).toEqual([
-      "data_table",
-      "actions",
-    ]);
-    expect(
-      sendMock.mock.calls
-        .map((call) => String(call[1] ?? ""))
-        .join("\n")
-        .match(/- Account: account-99/g),
-    ).toHaveLength(1);
   });
 
   it("omits identity key when not provided", async () => {
@@ -379,7 +344,7 @@ describe("deliverReplies identity passthrough", () => {
     expect(sendMock).toHaveBeenCalledOnce();
     const [target, text, options] = requireSendCall();
     expect(target).toBe("C123");
-    expect(text).toBe("- Option A");
+    expect(text).toBe("");
     expect(options.blocks).toStrictEqual(blocks);
   });
 
@@ -420,28 +385,33 @@ describe("deliverReplies identity passthrough", () => {
     expect(blocks[1]?.elements?.[0]?.value).toBe("approve");
   });
 
-  it("rejects replies when merged Slack blocks exceed the platform limit", async () => {
+  it("rolls ordered reply blocks into another Slack message at the platform limit", async () => {
     sendMock.mockResolvedValue(undefined);
 
-    await expect(
-      deliverReplies(
-        baseParams({
-          replies: [
-            {
-              text: "Choose",
-              channelData: {
-                slack: {
-                  blocks: Array.from({ length: 50 }, () => ({ type: "divider" })),
-                },
-              },
-              interactive: {
-                blocks: [{ type: "buttons", buttons: [{ label: "Retry", value: "retry" }] }],
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "Choose",
+            channelData: {
+              slack: {
+                blocks: Array.from({ length: 50 }, () => ({ type: "divider" })),
               },
             },
-          ],
-        }),
-      ),
-    ).rejects.toThrow(/Slack blocks cannot exceed 50 items/i);
+            interactive: {
+              blocks: [{ type: "buttons", buttons: [{ label: "Retry", value: "retry" }] }],
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(requireSendCall(0)[2].blocks as unknown[]).toHaveLength(50);
+    expect(requireSendCall(1)[2].blocks).toEqual([
+      expect.objectContaining({ type: "section" }),
+      expect.objectContaining({ type: "actions" }),
+    ]);
   });
 });
 
@@ -595,86 +565,35 @@ describe("deliverSlackSlashReplies chunking", () => {
 
     expect(respond).toHaveBeenCalledTimes(1);
     expect(respond).toHaveBeenCalledWith({
-      text: "",
+      text: "Shared a Block Kit message",
       blocks,
+      mrkdwn: false,
       response_type: "in_channel",
     });
   });
 
-  it("sends block-only slash replies when their fallback exceeds the chunk limit", async () => {
+  it("splits non-native blocks before slash accessibility text exceeds 40k", async () => {
     const respond = vi.fn(async () => undefined);
-    const blocks = [
-      {
-        type: "actions",
-        elements: [
-          {
-            type: "button",
-            action_id: "refresh",
-            text: { type: "plain_text", text: "Refresh" },
-            value: "refresh",
-          },
-        ],
-      },
-    ];
+    const blocks = Array.from({ length: 20 }, (_entry, index) => ({
+      type: "section",
+      text: { type: "plain_text", text: `${String(index)}-${"x".repeat(2_990)}` },
+    }));
 
     await deliverSlackSlashReplies({
       replies: [{ channelData: { slack: { blocks } } }],
       respond,
       ephemeral: true,
-      textLimit: 8,
+      textLimit: 8000,
     });
 
-    expect(respond).toHaveBeenCalledOnce();
-    expect(respond).toHaveBeenCalledWith({
-      text: "- Refresh",
-      blocks,
-      response_type: "ephemeral",
-    });
+    expect(respond).toHaveBeenCalledTimes(2);
+    const messages = respond.mock.calls.map((_call, index) => requireSlashMessage(respond, index));
+    expect(messages.every((message) => message.text.length <= 40_000)).toBe(true);
+    expect(messages.every((message) => message.mrkdwn === false)).toBe(true);
+    expect(messages.flatMap((message) => message.blocks ?? [])).toEqual(blocks);
   });
 
-  it("preserves command spans and entities across slash mrkdwn chunks", async () => {
-    const respond = vi.fn(
-      async (_message: { text: string; blocks?: unknown; response_type?: string }) => undefined,
-    );
-    const fallback = "- D: `/say &amp; &lt;@U111111111&gt;`";
-
-    await deliverSlackSlashReplies({
-      replies: [
-        {
-          presentation: {
-            blocks: [
-              {
-                type: "buttons",
-                buttons: [
-                  {
-                    label: "D",
-                    action: { type: "command", command: "/say & <@U111111111>" },
-                  },
-                ],
-              },
-            ],
-          },
-        },
-      ],
-      respond,
-      ephemeral: true,
-      textLimit: 16,
-    });
-
-    const messages = respond.mock.calls.map(([message]) => message);
-    const texts = messages.map((message) => message.text);
-    expect(texts.length).toBeGreaterThan(1);
-    expect(texts.length).toBeLessThanOrEqual(5);
-    expect(texts.every((text) => text.length <= 16)).toBe(true);
-    expect(texts.every((text) => (text.match(/`/gu)?.length ?? 0) % 2 === 0)).toBe(true);
-    expect(texts.every((text) => !/&(?:a|am|l|g|gt|lt)?$/u.test(text))).toBe(true);
-    expect(texts.every((text) => !/^(?:amp;|lt;|gt;)/u.test(text))).toBe(true);
-    expect(texts.join("").replaceAll("`", "")).toBe(fallback.replaceAll("`", ""));
-    expect(texts.every((text) => !text.includes("<@U111111111>"))).toBe(true);
-    expect(messages.every((message) => message.response_type === "ephemeral")).toBe(true);
-  });
-
-  it("retries rejected native charts as visible fallback blocks", async () => {
+  it("replaces rejected native data in place without duplicating authored text", async () => {
     const respond = vi
       .fn(async () => undefined)
       .mockRejectedValueOnce({ response: { data: { error: "invalid_blocks" } } });
@@ -691,49 +610,17 @@ describe("deliverSlackSlashReplies chunking", () => {
           ],
         },
       },
-    ];
-
-    await deliverSlackSlashReplies({
-      replies: [
-        {
-          text: "Overview",
-          channelData: { slack: { blocks } },
-        },
-      ],
-      respond,
-      ephemeral: true,
-      textLimit: 8000,
-    });
-
-    expect(respond).toHaveBeenCalledTimes(2);
-    expect(respond).toHaveBeenNthCalledWith(1, {
-      text: "Overview\n\nRevenue mix (pie chart)\n- Product: 60\n- Services: 40",
-      blocks,
-      response_type: "ephemeral",
-    });
-    expect(respond).toHaveBeenNthCalledWith(2, {
-      text: "Overview\n\nRevenue mix (pie chart)\n- Product: 60\n- Services: 40",
-      blocks: [
-        blocks[0],
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
-            verbatim: true,
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            action_id: "openclaw:reply_button",
+            text: { type: "plain_text", text: "Refresh" },
+            value: "refresh",
           },
-        },
-      ],
-      response_type: "ephemeral",
-    });
-  });
-
-  it("retries rejected native tables once with visible complete fallback blocks", async () => {
-    const respond = vi
-      .fn(async () => undefined)
-      .mockRejectedValueOnce({ response: { data: { error: "invalid_blocks" } } });
-    const blocks = [
-      { type: "section", text: { type: "mrkdwn", text: "Overview" } },
+        ],
+      },
       {
         type: "data_table",
         caption: "Pipeline report",
@@ -746,21 +633,9 @@ describe("deliverSlackSlashReplies chunking", () => {
             { type: "raw_text", text: "Acme" },
             { type: "raw_number", value: 125000, text: "$125k" },
           ],
-          [
-            { type: "raw_text", text: "Globex" },
-            { type: "raw_number", value: 82000, text: "$82k" },
-          ],
         ],
-        row_header_column_index: 0,
       },
-    ] as never;
-    const fallback = [
-      "Overview",
-      "",
-      "Pipeline report (table)",
-      "- Account: Acme; ARR: $125k",
-      "- Account: Globex; ARR: $82k",
-    ].join("\n");
+    ];
 
     await deliverSlackSlashReplies({
       replies: [
@@ -775,158 +650,44 @@ describe("deliverSlackSlashReplies chunking", () => {
     });
 
     expect(respond).toHaveBeenCalledTimes(2);
-    expect(respond).toHaveBeenNthCalledWith(1, {
-      text: fallback,
-      blocks,
-      response_type: "ephemeral",
-    });
-    expect(respond).toHaveBeenNthCalledWith(2, {
-      text: fallback,
-      blocks: [
-        blocks[0],
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: [
-              "Pipeline report (table)",
-              "- Account: Acme; ARR: $125k",
-              "- Account: Globex; ARR: $82k",
-            ].join("\n"),
-            verbatim: true,
-          },
-        },
-      ],
-      response_type: "ephemeral",
-    });
-  });
-
-  it("propagates invalid_blocks when a slash fallback retains an invalid sibling", async () => {
-    const invalidBlocks = { response: { data: { error: "invalid_blocks" } } };
-    const respond = vi.fn(async () => invalidBlocks);
-
-    await expect(
-      deliverSlackSlashReplies({
-        replies: [
-          {
-            text: "Overview",
-            channelData: {
-              slack: {
-                blocks: [
-                  { type: "section", text: { type: "mrkdwn", text: "Invalid sibling" } },
-                  {
-                    type: "data_visualization",
-                    title: "Revenue mix",
-                    chart: {
-                      type: "pie",
-                      segments: [{ label: "Product", value: 60 }],
-                    },
-                  },
-                ],
-              },
-            },
-          },
-        ],
-        respond,
-        ephemeral: true,
-        textLimit: 8000,
-      }),
-    ).rejects.toBe(invalidBlocks);
-
-    expect(respond).toHaveBeenCalledTimes(2);
-  });
-
-  it("chunks a long chart fallback before slash delivery while retaining siblings", async () => {
-    const respond = vi.fn(
-      async (_message: { text: string; blocks?: unknown; response_type?: string }) => undefined,
+    const native = requireSlashMessage(respond, 0);
+    const fallback = requireSlashMessage(respond, 1);
+    expect(native.blocks?.map((block) => block.type)).toEqual([
+      "section",
+      "data_visualization",
+      "actions",
+      "data_table",
+    ]);
+    expect(fallback.blocks?.map((block) => block.type)).toEqual([
+      "section",
+      "section",
+      "actions",
+      "section",
+    ]);
+    expect(readPlainSectionTexts(fallback)).toEqual([
+      "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
+      "Pipeline report (table)\nAccount\tARR\nAcme\t$125k",
+    ]);
+    expect(fallback.text).toBe(
+      [
+        "Overview",
+        "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
+        "Refresh",
+        "Pipeline report (table)\nAccount\tARR\nAcme\t$125k",
+      ].join("\n\n"),
     );
-    const categories = Array.from(
-      { length: 20 },
-      (_entry, index) => `category-${String(index)}-${"x".repeat(80)}`,
-    );
-
-    await deliverSlackSlashReplies({
-      replies: [
-        {
-          channelData: {
-            slack: {
-              blocks: [
-                ...Array.from({ length: 47 }, () => ({ type: "divider" })),
-                {
-                  type: "data_visualization",
-                  title: "Large chart",
-                  chart: {
-                    type: "bar",
-                    axis_config: { categories },
-                    series: Array.from({ length: 7 }, (_entry, index) => ({
-                      name: `Series ${String(index)}`,
-                      data: categories.map((label) => ({ label, value: index })),
-                    })),
-                  },
-                },
-              ],
-            },
-          },
-        },
-      ],
-      respond,
-      ephemeral: true,
-      textLimit: 8000,
-    });
-
-    expect(respond.mock.calls.length).toBeGreaterThan(1);
-    expect(respond.mock.calls[0]?.[0]).toMatchObject({
-      blocks: Array.from({ length: 47 }, () => ({ type: "divider" })),
-    });
-    expect(
-      respond.mock.calls.slice(1).every(([message]) => !(message as { blocks?: unknown }).blocks),
-    ).toBe(true);
-    expect(
-      respond.mock.calls.map(([message]) => (message as { text?: string }).text ?? "").join("\n"),
-    ).toContain("Series 6");
+    expect(fallback.text.match(/Overview/gu)).toHaveLength(1);
+    expect(fallback.mrkdwn).toBe(false);
   });
 
-  it("chunks overlong table fallbacks while preserving the native table and controls", async () => {
-    const respond = vi
-      .fn(async (_message: { text: string; blocks?: unknown; response_type?: string }) => undefined)
-      .mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
-    const header = "Account".padEnd(80, "x");
+  it("uses complete 40k blockless chunks for oversized native-only fallback", async () => {
+    const respond = vi.fn(async () => undefined);
+    const caption = "c".repeat(41_000);
     const blocks = [
-      { type: "section", text: { type: "mrkdwn", text: "Overview" } },
       {
         type: "data_table",
-        caption: "Large pipeline",
-        rows: [
-          [{ type: "raw_text", text: header }],
-          ...Array.from({ length: 100 }, (_entry, index) => [
-            {
-              type: "raw_text",
-              text: index === 0 ? "<@U123>" : `account-${String(index)}`,
-            },
-          ]),
-        ],
-      },
-      {
-        type: "data_visualization",
-        title: "Revenue mix",
-        chart: {
-          type: "pie",
-          segments: [
-            { label: "Product", value: 60 },
-            { label: "Services", value: 40 },
-          ],
-        },
-      },
-      {
-        type: "actions",
-        elements: [
-          {
-            type: "button",
-            text: { type: "plain_text", text: "Refresh" },
-            action_id: "refresh",
-            value: "refresh",
-          },
-        ],
+        caption,
+        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
       },
     ] as never;
 
@@ -937,309 +698,86 @@ describe("deliverSlackSlashReplies chunking", () => {
       textLimit: 8000,
     });
 
-    expect(respond.mock.calls.length).toBeGreaterThan(2);
-    const messages = respond.mock.calls.map(([message]) => message);
-    expect(messages[0]).toMatchObject({
-      text: "Large pipeline (table)\n\n- Refresh",
-      blocks: [blocks[1], blocks[3]],
-    });
-    expect(messages[1]).toMatchObject({ text: "- Refresh", blocks: [blocks[3]] });
-    expect(messages.slice(2).every((message) => message.blocks === undefined)).toBe(true);
-    expect(messages.every((message) => message.text.length <= 8000)).toBe(true);
-    const fallbackText = messages
-      .slice(2)
-      .map((message) => message.text)
-      .join("\n");
-    expect(fallbackText).toContain(`- ${header}: &lt;@U123&gt;`);
-    expect(fallbackText).toContain(`- ${header}: account-99`);
-    expect(fallbackText).toContain("Revenue mix (pie chart)");
-    expect(fallbackText.match(/Large pipeline \(table\)/g)).toHaveLength(1);
-    expect(fallbackText).not.toContain("<@U123>");
-  });
-
-  it("compacts native table accessibility text at a lower configured chunk limit", async () => {
-    const respond = vi.fn(
-      async (_message: {
-        text: string;
-        blocks?: Array<{ type?: string }>;
-        response_type?: string;
-      }) => undefined,
-    );
-    const header = "H".repeat(1_000);
-
-    await deliverSlackSlashReplies({
-      replies: [
-        {
-          presentation: {
-            blocks: [
-              {
-                type: "table",
-                caption: "Pipeline",
-                headers: [header],
-                rows: Array.from({ length: 5 }, (_entry, index) => [String(index)]),
-              },
-            ],
-          },
-        },
-      ],
-      respond,
-      ephemeral: true,
-      textLimit: 4_000,
-    });
-
-    expect(respond).toHaveBeenCalledTimes(3);
-    const messages = respond.mock.calls.map(([message]) => message);
-    expect(messages[0]).toMatchObject({ text: "Pipeline (table)" });
-    expect(messages[0]?.blocks?.some((block) => block.type === "data_table")).toBe(true);
-    expect(messages.slice(1).every((message) => message.blocks === undefined)).toBe(true);
-    expect(messages.every((message) => message.text.length <= 4_000)).toBe(true);
-    expect(messages[0]?.text).not.toContain(": 4");
-    expect(
-      messages
-        .slice(1)
-        .map((message) => message.text)
-        .join("")
-        .match(/: 4/gu),
-    ).toHaveLength(1);
-  });
-
-  it("uses fallback-only chunks when a native table would exceed the response_url budget", async () => {
-    const respond = vi.fn(
-      async (_message: { text: string; blocks?: unknown; response_type?: string }) => undefined,
-    );
-    const header = "Account".padEnd(150, "h");
-    const rows = Array.from({ length: 100 }, (_entry, index) => [
-      `account-${String(index)}`.padEnd(90, "x"),
-    ]);
-
-    await deliverSlackSlashReplies({
-      replies: [
-        {
-          presentation: {
-            blocks: [{ type: "table", caption: "Pipeline", headers: [header], rows }],
-          },
-        },
-      ],
-      respond,
-      ephemeral: true,
-      textLimit: 8000,
-    });
-
-    expect(respond).toHaveBeenCalledTimes(4);
-    expect(respond.mock.calls.every(([message]) => !(message as { blocks?: unknown }).blocks)).toBe(
-      true,
-    );
-    const text = respond.mock.calls
-      .map(([message]) => (message as { text: string }).text)
-      .join("\n");
-    expect(text).toContain("Pipeline (table)");
-    expect(text).toContain(`- ${header}: account-99`);
-    expect(text).not.toContain("too large for the remaining response_url budget");
-  });
-
-  it("degrades multiple small native tables to fit the response_url budget", async () => {
-    const respond = vi.fn(
-      async (_message: { text: string; blocks?: unknown[]; response_type?: string }) => undefined,
-    );
-    const responseUrlBudget = { used: 0 };
-
-    await deliverSlackSlashReplies({
-      replies: ["Alpha", "Beta", "Gamma"].map((caption) => ({
-        presentation: {
-          blocks: [{ type: "table" as const, caption, headers: ["Value"], rows: [[1]] }],
-        },
-      })),
-      respond,
-      responseUrlBudget,
-      ephemeral: true,
-      textLimit: 8_000,
-    });
-
-    expect(respond).toHaveBeenCalledTimes(3);
-    expect(responseUrlBudget).toEqual({ used: 3 });
-    for (const [index, caption] of ["Alpha", "Beta", "Gamma"].entries()) {
-      const message = respond.mock.calls[index]?.[0];
-      const text = `${caption} (table)\n- Value: 1`;
-      expect(message).toEqual({
-        text,
-        blocks: [
-          {
-            type: "section",
-            text: { type: "mrkdwn", text, verbatim: true },
-          },
-        ],
-        response_type: "ephemeral",
-      });
-    }
-    expect(
-      respond.mock.calls.some(([message]) =>
-        message.text.includes("too large for the remaining response_url budget"),
-      ),
-    ).toBe(false);
-  });
-
-  it("recognizes hard-split table fallback ownership within the response_url budget", async () => {
-    const respond = vi.fn(
-      async (_message: { text: string; blocks?: unknown[]; response_type?: string }) => undefined,
-    );
-    const header = "H".repeat(9_000);
-
-    await deliverSlackSlashReplies({
-      replies: [
-        {
-          presentation: {
-            blocks: [
-              {
-                type: "table",
-                caption: "Pipeline",
-                headers: [header],
-                rows: [["x"]],
-              },
-            ],
-          },
-        },
-      ],
-      respond,
-      ephemeral: true,
-      textLimit: 8_000,
-    });
-
-    expect(respond).toHaveBeenCalledTimes(4);
-    const messages = respond.mock.calls.map(([message]) => message);
+    expect(respond).toHaveBeenCalledTimes(2);
+    const messages = respond.mock.calls.map((_call, index) => requireSlashMessage(respond, index));
     expect(messages.every((message) => message.blocks === undefined)).toBe(true);
-    const text = messages.map((message) => message.text).join("");
-    expect(text).not.toContain("too large for the remaining response_url budget");
-    expect(text.match(/H/gu)).toHaveLength(9_000);
-    expect(text).toContain(": x");
-  });
-
-  it("explains slash replies that exceed Slack's response_url budget before sending content", async () => {
-    const respond = vi.fn(async () => undefined);
-    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
-
-    await deliverSlackSlashReplies({
-      replies: [{ text: "a".repeat(40_001) }],
-      respond,
-      ephemeral: true,
-      textLimit: 8000,
-      messageSentHookTarget: "user:U1",
-    });
-
-    expect(respond).toHaveBeenCalledOnce();
-    expect(respond).toHaveBeenCalledWith({
-      text: expect.stringContaining("6 responses needed; 5 available"),
-      response_type: "ephemeral",
-    });
-    expect(messageHookRunner.runMessageSent).toHaveBeenCalledOnce();
-    expect(messageHookRunner.runMessageSent.mock.calls[0]?.[0]).toMatchObject({
-      to: "user:U1",
-      success: false,
-      error: expect.stringContaining("6 responses needed; 5 available"),
-    });
-  });
-
-  it("shares the response_url budget across streamed slash deliveries", async () => {
-    const respond = vi.fn(
-      async (_message: { text: string; blocks?: unknown; response_type?: string }) => undefined,
+    expect(messages.every((message) => message.mrkdwn === false)).toBe(true);
+    expect(messages.every((message) => message.text.length <= 40_000)).toBe(true);
+    expect(messages.map((message) => message.text).join("")).toBe(
+      `${caption} (table)\nAccount\nAcme`,
     );
-    const responseUrlBudget = { used: 0 };
-
-    await deliverSlackSlashReplies({
-      replies: [{ text: "a".repeat(16_001) }],
-      respond,
-      responseUrlBudget,
-      ephemeral: true,
-      textLimit: 8000,
-    });
-    await deliverSlackSlashReplies({
-      replies: [{ text: "b".repeat(16_001) }],
-      respond,
-      responseUrlBudget,
-      ephemeral: true,
-      textLimit: 8000,
-    });
-
-    expect(responseUrlBudget).toEqual({ used: 4, closed: true });
-    expect(respond).toHaveBeenCalledTimes(4);
-    expect(respond.mock.calls[3]?.[0]).toEqual({
-      text: expect.stringContaining("3 responses needed; 2 available"),
-      response_type: "ephemeral",
-    });
   });
 
-  it("preserves controls while chunking non-native tables with media links", async () => {
-    const respond = vi.fn(
-      async (_message: { text: string; blocks?: unknown; response_type?: string }) => undefined,
-    );
-
-    await deliverSlackSlashReplies({
-      replies: [
+  it("batches in-place native fallback at 50 blocks without losing content", async () => {
+    const respond = vi
+      .fn(async () => undefined)
+      .mockRejectedValueOnce({ response: { data: { error: "invalid_blocks" } } });
+    const caption = "c".repeat(9_000);
+    const action = {
+      type: "actions",
+      elements: [
         {
-          presentation: largePortableTablePresentation(),
-          mediaUrls: ["https://example.com/report.png"],
-          interactive: {
-            blocks: [
-              {
-                type: "buttons",
-                buttons: [{ label: "Refresh", value: "refresh" }],
-              },
-            ],
-          },
+          type: "button",
+          action_id: "openclaw:reply_button",
+          text: { type: "plain_text", text: "Refresh" },
+          value: "refresh",
         },
       ],
-      respond,
-      ephemeral: true,
-      textLimit: 8000,
-    });
-
-    expect(respond.mock.calls.length).toBeGreaterThan(1);
-    const messages = respond.mock.calls.map(([message]) => message);
-    expect(messages[0]?.blocks).toEqual([
-      expect.objectContaining({
-        type: "actions",
-        elements: [expect.objectContaining({ type: "button", value: "refresh" })],
-      }),
-    ]);
-    expect(messages.slice(1).every((message) => message.blocks === undefined)).toBe(true);
-    const deliveredText = messages.map((message) => message.text).join("\n");
-    expect(deliveredText).toContain("- Account: &lt;@U123&gt;");
-    expect(deliveredText).toContain("- Account: account-99");
-    expect(deliveredText).toContain("https://example.com/report.png");
-    expect(deliveredText).not.toContain("<@U123>");
-  });
-
-  it("uses one sibling prelude when portable and raw tables both require fallback", async () => {
-    const respond = vi.fn(
-      async (_message: { text: string; blocks?: unknown; response_type?: string }) => undefined,
-    );
-    const header = "Raw account".padEnd(80, "x");
-    const rawBlocks = [
-      { type: "section", text: { type: "mrkdwn", text: "Raw overview" } },
+    };
+    const blocks = [
+      ...Array.from({ length: 48 }, () => ({ type: "divider" })),
+      action,
       {
         type: "data_table",
-        caption: "Raw pipeline",
-        rows: [
-          [{ type: "raw_text", text: header }],
-          ...Array.from({ length: 100 }, (_entry, index) => [
-            { type: "raw_text", text: `raw-${String(index)}` },
-          ]),
-        ],
+        caption,
+        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
       },
     ] as never;
 
     await deliverSlackSlashReplies({
+      replies: [{ channelData: { slack: { blocks } } }],
+      respond,
+      ephemeral: true,
+      textLimit: 8000,
+    });
+
+    expect(respond).toHaveBeenCalledTimes(3);
+    const fallback = [requireSlashMessage(respond, 1), requireSlashMessage(respond, 2)];
+    expect(fallback.every((message) => (message.blocks?.length ?? 0) <= 50)).toBe(true);
+    expect(fallback.every((message) => message.text.length <= 40_000)).toBe(true);
+    expect(fallback.every((message) => message.mrkdwn === false)).toBe(true);
+    expect(fallback[0]?.blocks?.[48]?.type).toBe("actions");
+    expect(fallback.flatMap(readPlainSectionTexts).join("")).toBe(
+      `${caption} (table)\nAccount\nAcme`,
+    );
+    expect(fallback.map((message) => message.text).join("\n")).toContain("Refresh");
+  });
+
+  it("preserves chart, unrenderable table, control, and media order", async () => {
+    const respond = vi.fn(async () => undefined);
+
+    await deliverSlackSlashReplies({
       replies: [
         {
-          presentation: largePortableTablePresentation(),
-          channelData: { slack: { blocks: rawBlocks } },
-          interactive: {
+          presentation: {
             blocks: [
               {
+                type: "chart",
+                chartType: "pie",
+                title: "Revenue mix",
+                segments: [
+                  { label: "Product", value: 60 },
+                  { label: "Services", value: 40 },
+                ],
+              },
+              ...largePortableTablePresentation().blocks,
+              {
                 type: "buttons",
-                buttons: [{ label: "Refresh", value: "refresh" }],
+                buttons: [{ label: "Refresh", value: "secret-refresh-token" }],
               },
             ],
           },
+          mediaUrls: ["https://example.com/report.png"],
         },
       ],
       respond,
@@ -1247,19 +785,65 @@ describe("deliverSlackSlashReplies chunking", () => {
       textLimit: 8000,
     });
 
-    const messages = respond.mock.calls.map(([message]) => message);
-    expect(messages[0]?.blocks).toEqual([
-      rawBlocks[0],
-      expect.objectContaining({
-        type: "actions",
-        elements: [expect.objectContaining({ type: "button", value: "refresh" })],
+    expect(respond).toHaveBeenCalledTimes(4);
+    const messages = respond.mock.calls.map((_call, index) => requireSlashMessage(respond, index));
+    expect(messages[0]?.blocks?.map((block) => block.type)).toEqual(["data_visualization"]);
+    expect(messages[0]?.text).toContain("Revenue mix (pie chart)");
+    expect(messages[1]?.blocks).toBeUndefined();
+    expect(messages[1]?.text).toContain("Large pipeline (table)");
+    expect(messages[1]?.text).toContain("- Account: <@U123>");
+    expect(messages[1]?.text).toContain("- Account: account-99");
+    expect(messages[2]?.blocks?.map((block) => block.type)).toEqual(["actions"]);
+    expect(messages[2]?.text).toBe("Refresh");
+    expect(messages[3]).toMatchObject({
+      text: "https://example.com/report.png",
+      mrkdwn: false,
+    });
+    expect(messages.map((message) => message.text).join("\n")).not.toContain(
+      "secret-refresh-token",
+    );
+  });
+
+  it("fails before content when the real response_url five-call budget is exceeded", async () => {
+    const respond = vi.fn(async () => undefined);
+
+    await expect(
+      deliverSlackSlashReplies({
+        replies: Array.from({ length: 6 }, (_entry, index) => ({
+          text: `reply-${String(index)}`,
+        })),
+        respond,
+        ephemeral: false,
+        textLimit: 8000,
       }),
-    ]);
-    expect(messages.slice(1).every((message) => message.blocks === undefined)).toBe(true);
-    const deliveredText = messages.map((message) => message.text).join("\n");
-    expect(deliveredText).toContain("- Account: account-99");
-    expect(deliveredText).toContain(`- ${header}: raw-99`);
-    expect(deliveredText.match(/Raw overview/g)).toHaveLength(1);
+    ).rejects.toThrow("response_url delivery budget");
+
+    expect(respond).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith({
+      text: "This Slack response is too large to deliver within the remaining response window.",
+      response_type: "ephemeral",
+    });
+  });
+
+  it("allows more than five follow-ups for uncapped Web API delivery", async () => {
+    const respond = vi.fn(async () => undefined);
+    const responseBudget = {
+      respond,
+      remaining: () => undefined,
+    };
+
+    await deliverSlackSlashReplies({
+      replies: Array.from({ length: 6 }, (_entry, index) => ({ text: `reply-${String(index)}` })),
+      respond,
+      responseBudget,
+      ephemeral: false,
+      textLimit: 8000,
+    });
+
+    expect(respond).toHaveBeenCalledTimes(6);
+    expect(
+      Array.from({ length: 6 }, (_entry, index) => requireSlashMessage(respond, index).text),
+    ).toEqual(["reply-0", "reply-1", "reply-2", "reply-3", "reply-4", "reply-5"]);
   });
 
   it("suppresses reasoning payloads in slash replies", async () => {

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -17,25 +17,35 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-reference";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { buildSlackDeferredNativeDataRejectionFallback } from "../blocks-fallback.js";
-import { chunkSlackMrkdwnText, markdownToSlackMrkdwnChunks } from "../format.js";
-import { SLACK_RESPONSE_URL_MAX_USES, SLACK_TEXT_LIMIT } from "../limits.js";
+import { buildSlackBlocksFallbackText } from "../blocks-fallback.js";
+import { markdownToSlackMrkdwnChunks } from "../format.js";
+import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { emitSlackMessageSentHooks } from "../message-sent-hook.js";
 import {
-  appendSlackNativeDataFallbackText,
-  buildSlackNativeDataFallbackBlocks,
-  hasCompleteSlackNativeDataFallbackText,
+  buildSlackNativeDataAccessibilityText,
   hasSlackNativeDataBlock,
   isSlackInvalidBlocksError,
 } from "../native-data-blocks.js";
-import { resolveSlackReplyRenderPlan } from "../reply-blocks.js";
-import { truncateSlackText } from "../truncate.js";
+import {
+  buildSlackNativeDataDeliveryPlan,
+  chunkSlackTextAtHardLimit,
+  type SlackFormattingDisabledMessage,
+} from "../native-data-fallback.js";
+import {
+  hasSlackReplyStructuredContent,
+  resolveSlackReplyBlockResolution,
+  resolveSlackReplyBlocks,
+} from "../reply-blocks.js";
 import type { SlackEventScope } from "./event-scope.js";
+import {
+  createSlackResponseUrlBudget,
+  SlackResponseAlreadyReportedError,
+  type SlackResponseUrlBudget as ResponseUrlBudget,
+} from "./response-url-budget.js";
 import { sendMessageSlack, type SlackSendIdentity, type SlackSendResult } from "./send.runtime.js";
 
 export function readSlackReplyBlocks(payload: ReplyPayload) {
-  const plan = resolveSlackReplyRenderPlan(payload);
-  return plan.mode === "single" ? plan.blocks : plan.blockPart?.blocks;
+  return resolveSlackReplyBlocks(payload);
 }
 
 function resolveSlackMediaHookSpokenText(payload: ReplyPayload): string | undefined {
@@ -93,18 +103,26 @@ export async function deliverReplies(params: {
     threadTs?: string | undefined;
     mediaUrl?: string | undefined;
     blocks?: (Block | KnownBlock)[] | undefined;
-    separateTextAndBlocks?: boolean;
+    authoredTextPlacement?: "none" | "blocks" | "outside-blocks";
+    nativeDataFallbackBaseText?: string;
     textIsSlackMrkdwn?: boolean;
+    textIsSlackPlainText?: boolean;
   }): Promise<SlackSendResult> => {
     return await sendMessageSlack(params.target, input.text, {
       cfg: params.cfg,
       token: params.token,
       threadTs: input.threadTs,
       accountId: params.accountId,
-      mediaUrl: input.mediaUrl,
-      blocks: input.blocks,
-      ...(input.separateTextAndBlocks ? { separateTextAndBlocks: true } : {}),
+      ...(input.mediaUrl ? { mediaUrl: input.mediaUrl } : {}),
+      ...(input.blocks ? { blocks: input.blocks } : {}),
+      ...(input.authoredTextPlacement
+        ? { authoredTextPlacement: input.authoredTextPlacement }
+        : {}),
+      ...(Object.hasOwn(input, "nativeDataFallbackBaseText")
+        ? { nativeDataFallbackBaseText: input.nativeDataFallbackBaseText }
+        : {}),
       ...(input.textIsSlackMrkdwn ? { textIsSlackMrkdwn: true } : {}),
+      ...(input.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
       ...(params.eventScope
         ? {
             client: params.eventScope.client,
@@ -127,24 +145,15 @@ export async function deliverReplies(params: {
       replyThreadTs: params.replyThreadTs,
     });
     const reply = resolveSendableOutboundReplyParts(payload);
-    const renderText =
+    const textRaw =
       reply.hasText && !isSilentReplyText(reply.trimmedText, SILENT_REPLY_TOKEN)
         ? reply.trimmedText
         : undefined;
-    const renderPlan = resolveSlackReplyRenderPlan(payload, renderText, {
-      includeAuthoredTextBlock: !reply.hasMedia,
+    const materializeAuthoredText = !reply.hasMedia && hasSlackReplyStructuredContent(payload);
+    const { authoredTextPlacement, segments } = resolveSlackReplyBlockResolution(payload, {
+      materializeAuthoredText,
     });
-    const slackBlocks =
-      renderPlan.mode === "single" ? renderPlan.blocks : renderPlan.blockPart?.blocks;
-    const tableFallbackText =
-      renderPlan.mode === "split" ? renderPlan.fallbackText.trim() : undefined;
-    const mediaBlockPartOwnsFallback = Boolean(
-      reply.hasMedia &&
-      renderPlan.mode === "split" &&
-      renderPlan.blockPart &&
-      hasCompleteSlackNativeDataFallbackText(renderPlan.fallbackText, renderPlan.blockPart.blocks),
-    );
-    if (!reply.hasContent && !slackBlocks?.length && !tableFallbackText) {
+    if (!textRaw && !reply.hasMedia && segments.length === 0) {
       continue;
     }
 
@@ -183,125 +192,80 @@ export async function deliverReplies(params: {
       });
     };
 
-    if (renderPlan.mode === "single" && !reply.hasMedia && slackBlocks?.length) {
-      const trimmed = renderPlan.text.trim();
-      if (!trimmed && !slackBlocks?.length) {
-        continue;
-      }
-      if (trimmed && isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
-        continue;
-      }
-      let result: SlackSendResult;
-      try {
-        result = await sendReply({
-          text: trimmed,
-          threadTs,
-          ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
-          ...(renderPlan.textIsSlackMrkdwn ? { textIsSlackMrkdwn: true } : {}),
-        });
-      } catch (error) {
-        emitFailed(trimmed, error);
-        throw error;
-      }
-      emitSent(trimmed, result);
-      latestResult = result;
-      params.runtime.log?.(`delivered reply to ${params.target}`);
-      continue;
-    }
-    if (renderPlan.mode === "split" && !reply.hasMedia) {
-      const trimmed = renderPlan.fallbackText.trim();
-      if (!trimmed && !renderPlan.blockPart) {
-        continue;
-      }
-      try {
-        const result = await sendReply({
-          text: trimmed,
-          threadTs,
-          ...(renderPlan.blockPart
-            ? {
-                blocks: renderPlan.blockPart.blocks,
-                separateTextAndBlocks: true,
-              }
-            : {}),
-          textIsSlackMrkdwn: true,
-        });
-        emitSent(renderPlan.hookText, result);
-        latestResult = result;
-      } catch (error) {
-        emitFailed(renderPlan.hookText, error);
-        throw error;
-      }
-      params.runtime.log?.(`delivered reply to ${params.target}`);
-      continue;
-    }
-
     const spokenText = resolveSlackMediaHookSpokenText(payload);
-    const mediaHookContent = reply.hasText ? reply.text : spokenText || reply.text;
-    const deliveryText =
-      (mediaBlockPartOwnsFallback ? "" : tableFallbackText) ??
-      (reply.hasMedia && renderPlan.mode === "single" && renderPlan.textVisibleInBlocks
-        ? ""
-        : reply.text);
-    const hookContent =
-      renderPlan.mode === "split"
-        ? renderPlan.hookText
-        : reply.hasMedia
-          ? renderPlan.hookText || mediaHookContent
-          : reply.trimmedText;
+    const hookParts: string[] = [];
+    let outsideText = authoredTextPlacement === "outside-blocks" ? (textRaw ?? "") : "";
     let lastResult: SlackSendResult | undefined;
-    let delivered: Awaited<ReturnType<typeof deliverTextOrMediaReply>>;
+    let delivered = false;
     try {
-      delivered = await deliverTextOrMediaReply({
-        payload,
-        text: deliveryText,
-        chunkText: !reply.hasMedia
-          ? (value) => {
-              const trimmed = value.trim();
-              if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
-                return [];
-              }
-              return [trimmed];
-            }
-          : undefined,
-        sendText: async (trimmed) => {
-          lastResult = await sendReply({
-            text: trimmed,
-            threadTs,
-            ...(renderPlan.mode === "split" ? { textIsSlackMrkdwn: true } : {}),
-          });
-        },
-        sendMedia: async ({ mediaUrl, caption }) => {
-          lastResult = await sendReply({
-            text: caption ?? "",
-            mediaUrl,
-            threadTs,
-            ...(renderPlan.mode === "split" ? { textIsSlackMrkdwn: true } : {}),
-          });
-        },
-      });
-      if (reply.hasMedia && slackBlocks?.length) {
-        // Slack file uploads cannot carry blocks. Preserve their ordering and
-        // report one terminal outcome only after the trailing block message.
-        const text =
-          mediaBlockPartOwnsFallback && renderPlan.mode === "split"
-            ? renderPlan.fallbackText
-            : renderPlan.mode === "split"
-              ? (renderPlan.blockPart?.text ?? "")
-              : renderPlan.text.trim();
-        lastResult = await sendReply({
-          text,
-          threadTs,
-          blocks: slackBlocks,
-          ...(mediaBlockPartOwnsFallback
-            ? { separateTextAndBlocks: true, textIsSlackMrkdwn: true }
-            : {}),
+      if (reply.hasMedia) {
+        const mediaCaption = outsideText;
+        if (mediaCaption) {
+          hookParts.push(mediaCaption);
+          outsideText = "";
+        } else if (!textRaw && spokenText) {
+          hookParts.push(spokenText);
+        }
+        const mediaDelivery = await deliverTextOrMediaReply({
+          payload,
+          text: mediaCaption,
+          sendText: async (text) => {
+            lastResult = await sendReply({ text, threadTs });
+          },
+          sendMedia: async ({ mediaUrl, caption }) => {
+            lastResult = await sendReply({ text: caption ?? "", mediaUrl, threadTs });
+          },
         });
+        delivered ||= mediaDelivery !== "empty";
+      }
+
+      for (const segment of segments) {
+        if (segment.kind === "text") {
+          const text = [outsideText, segment.text].filter(Boolean).join("\n\n");
+          outsideText = "";
+          if (!text) {
+            continue;
+          }
+          hookParts.push(text);
+          for (const chunk of chunkSlackTextAtHardLimit(text)) {
+            lastResult = await sendReply({ text: chunk, threadTs, textIsSlackPlainText: true });
+            delivered = true;
+          }
+          continue;
+        }
+        const baseText = outsideText;
+        outsideText = "";
+        const accessibilityText =
+          buildSlackNativeDataAccessibilityText(baseText, segment.blocks) ||
+          buildSlackBlocksFallbackText(segment.blocks);
+        hookParts.push(accessibilityText);
+        const segmentPlacement = baseText
+          ? "outside-blocks"
+          : authoredTextPlacement === "blocks"
+            ? "blocks"
+            : "none";
+        lastResult = await sendReply({
+          text: baseText,
+          threadTs,
+          blocks: segment.blocks,
+          authoredTextPlacement: segmentPlacement,
+          ...(baseText ? { nativeDataFallbackBaseText: baseText } : {}),
+        });
+        delivered = true;
+      }
+
+      if (outsideText && !reply.hasMedia) {
+        hookParts.push(outsideText);
+        lastResult = await sendReply({ text: outsideText, threadTs });
+        delivered = true;
       }
     } catch (error) {
+      const hookContent = hookParts.join("\n\n") || textRaw || spokenText || "";
       emitFailed(hookContent, error);
       throw error;
     }
-    if (delivered !== "empty") {
+    if (delivered) {
+      const hookContent = hookParts.join("\n\n") || textRaw || spokenText || "";
       // Preserve the media hook contract even when a trailing block send has a
       // message `ts`; the logical payload still spans multiple Slack objects.
       emitSent(hookContent, reply.hasMedia ? undefined : lastResult);
@@ -314,9 +278,12 @@ export async function deliverReplies(params: {
 
 export type SlackRespondFn = (payload: {
   text: string;
-  blocks?: ReturnType<typeof readSlackReplyBlocks>;
+  blocks?: (Block | KnownBlock)[];
+  mrkdwn?: false;
   response_type?: "ephemeral" | "in_channel";
 }) => Promise<unknown>;
+
+export type SlackResponseUrlBudget = ResponseUrlBudget<Parameters<SlackRespondFn>[0]>;
 
 /**
  * Compute effective threadTs for a Slack reply based on replyToMode.
@@ -346,92 +313,6 @@ type SlackReplyDeliveryPlan = {
   nextThreadTs: () => string | undefined;
   markSent: () => void;
 };
-
-type SlackSlashReplyWireMessage = {
-  text: string;
-  blocks?: ReturnType<typeof readSlackReplyBlocks>;
-};
-
-type SlackSlashReplyMessage = SlackSlashReplyWireMessage & {
-  nativeDataRejectionFallback?: SlackSlashReplyWireMessage;
-};
-
-type SlackNativeDataFallbackResolution = {
-  deferred: boolean;
-  message: SlackSlashReplyWireMessage;
-};
-
-type SlackSlashReplyDelivery = {
-  hookContent: string;
-  messages: SlackSlashReplyMessage[];
-};
-
-function countSlackResponseUrlUses(deliveries: readonly SlackSlashReplyDelivery[]): number {
-  return deliveries.reduce(
-    (total, delivery) =>
-      total +
-      delivery.messages.reduce(
-        (messageTotal, message) =>
-          messageTotal + 1 + (hasSlackNativeDataBlock(message.blocks) ? 1 : 0),
-        0,
-      ),
-    0,
-  );
-}
-
-function resolveSlackNativeDataFallback(
-  message: SlackSlashReplyMessage,
-): SlackNativeDataFallbackResolution | undefined {
-  if (!hasSlackNativeDataBlock(message.blocks)) {
-    return undefined;
-  }
-  if (message.nativeDataRejectionFallback) {
-    return { deferred: true, message: message.nativeDataRejectionFallback };
-  }
-  const blocks = buildSlackNativeDataFallbackBlocks(message.blocks);
-  return {
-    deferred: false,
-    message: {
-      text: truncateSlackText(
-        appendSlackNativeDataFallbackText(message.text, message.blocks),
-        SLACK_TEXT_LIMIT,
-      ),
-      ...(blocks?.length ? { blocks } : {}),
-    },
-  };
-}
-
-function degradeSlackResponseUrlNativeTables(
-  deliveries: readonly SlackSlashReplyDelivery[],
-  textLimit: number,
-): SlackSlashReplyDelivery[] {
-  return deliveries
-    .map((delivery) => ({
-      ...delivery,
-      messages: delivery.messages.flatMap((message) => {
-        if (!hasSlackNativeDataBlock(message.blocks)) {
-          return [message];
-        }
-        let fallback: SlackNativeDataFallbackResolution | undefined;
-        try {
-          fallback = resolveSlackNativeDataFallback(message);
-        } catch {
-          return [message];
-        }
-        if (!fallback) {
-          return [message];
-        }
-        if (fallback.deferred && !fallback.message.blocks?.length) {
-          return [];
-        }
-        if (fallback.message.text.length > textLimit) {
-          return [message];
-        }
-        return [fallback.message];
-      }),
-    }))
-    .filter((delivery) => delivery.messages.length > 0);
-}
 
 function createSlackReplyReferencePlanner(params: {
   replyToMode: "off" | "first" | "all" | "batched";
@@ -482,7 +363,6 @@ export function createSlackReplyDeliveryPlan(params: {
 export async function deliverSlackSlashReplies(params: {
   replies: ReplyPayload[];
   respond: SlackRespondFn;
-  responseUrlBudget?: { used: number; closed?: boolean };
   ephemeral: boolean;
   textLimit: number;
   tableMode?: MarkdownTableMode;
@@ -492,13 +372,44 @@ export async function deliverSlackSlashReplies(params: {
   sessionKeyForInternalHooks?: string;
   isGroup?: boolean;
   groupId?: string;
+  responseBudget?: SlackResponseUrlBudget;
 }) {
-  const responseUrlBudget = params.responseUrlBudget ?? { used: 0 };
-  if (responseUrlBudget.closed) {
-    return;
-  }
-  const deliveries: SlackSlashReplyDelivery[] = [];
-  const chunkLimit = Math.min(params.textLimit, SLACK_TEXT_LIMIT);
+  type SlashReplyMessage = {
+    text: string;
+    blocks?: (Block | KnownBlock)[];
+    mrkdwn?: false;
+  };
+  type PlannedSlashReplyMessage = {
+    message: SlashReplyMessage;
+    nativeFallback?: SlackFormattingDisabledMessage[];
+    skipOriginalBlocks?: true;
+  };
+  type SlashReplyDelivery = {
+    hookContent: string;
+    messages: PlannedSlashReplyMessage[];
+  };
+  const deliveries: SlashReplyDelivery[] = [];
+  const responseBudget = params.responseBudget ?? createSlackResponseUrlBudget(params.respond);
+  const chunkLimit = Math.max(1, Math.min(params.textLimit, SLACK_TEXT_LIMIT));
+  const createBlockMessagePlan = (input: {
+    blocks: NonNullable<ReturnType<typeof readSlackReplyBlocks>>;
+    baseText?: string;
+  }): PlannedSlashReplyMessage => {
+    const plan = buildSlackNativeDataDeliveryPlan({
+      blocks: input.blocks,
+      baseText: input.baseText,
+    });
+    return {
+      message: {
+        text: plan.accessibilityText,
+        blocks: input.blocks,
+        mrkdwn: false,
+      },
+      nativeFallback: plan.fallbackMessages,
+      ...(plan.skipOriginalBlocks ? { skipOriginalBlocks: true as const } : {}),
+    };
+  };
+
   for (const payload of params.replies) {
     if (payload.isReasoning === true) {
       continue;
@@ -508,157 +419,192 @@ export async function deliverSlackSlashReplies(params: {
       reply.hasText && !isSilentReplyText(reply.trimmedText, SILENT_REPLY_TOKEN)
         ? reply.trimmedText
         : undefined;
-    const renderPlan = resolveSlackReplyRenderPlan(payload, textRaw, { textLimit: chunkLimit });
-    if (renderPlan.mode === "single" && renderPlan.blocks?.length && !reply.hasMedia) {
-      deliveries.push({
-        hookContent: renderPlan.hookText,
-        messages: [{ text: renderPlan.text, blocks: renderPlan.blocks }],
-      });
+    const materializeAuthoredText = hasSlackReplyStructuredContent(payload);
+    const { authoredTextPlacement, segments } = resolveSlackReplyBlockResolution(payload, {
+      materializeAuthoredText,
+    });
+    let outsideText = authoredTextPlacement === "outside-blocks" ? (textRaw ?? "") : "";
+    const messages: PlannedSlashReplyMessage[] = [];
+    const hookParts: string[] = [];
+    for (const segment of segments) {
+      if (segment.kind === "text") {
+        const text = [outsideText, segment.text].filter(Boolean).join("\n\n");
+        outsideText = "";
+        if (text) {
+          hookParts.push(text);
+          messages.push(
+            ...chunkSlackTextAtHardLimit(text).map(
+              (chunk): PlannedSlashReplyMessage => ({
+                message: { text: chunk, mrkdwn: false },
+              }),
+            ),
+          );
+        }
+        continue;
+      }
+      const baseText = outsideText;
+      outsideText = "";
+      const accessibilityText =
+        buildSlackNativeDataAccessibilityText(baseText, segment.blocks) ||
+        buildSlackBlocksFallbackText(segment.blocks);
+      hookParts.push(accessibilityText);
+      const blockPlan = createBlockMessagePlan({ blocks: segment.blocks, baseText });
+      messages.push(
+        hasSlackNativeDataBlock(segment.blocks) || blockPlan.skipOriginalBlocks
+          ? blockPlan
+          : {
+              message: {
+                text: accessibilityText,
+                blocks: segment.blocks,
+                mrkdwn: false,
+              },
+            },
+      );
+    }
+    if (outsideText) {
+      hookParts.push(outsideText);
+    }
+    if (reply.mediaUrls.length > 0) {
+      hookParts.push(...reply.mediaUrls);
+    }
+
+    if (segments.length > 0) {
+      const trailingText = [outsideText, ...reply.mediaUrls].filter(Boolean).join("\n");
+      if (trailingText) {
+        messages.push(
+          ...chunkSlackTextAtHardLimit(trailingText).map(
+            (text): PlannedSlashReplyMessage => ({ message: { text, mrkdwn: false } }),
+          ),
+        );
+      }
+      if (messages.length > 0) {
+        deliveries.push({ hookContent: hookParts.filter(Boolean).join("\n\n"), messages });
+      }
       continue;
     }
-    const text = renderPlan.mode === "split" ? renderPlan.fallbackText : renderPlan.text;
-    const combined = [text ?? "", ...reply.mediaUrls].filter(Boolean).join("\n");
-    const blockPart = renderPlan.mode === "split" ? renderPlan.blockPart : undefined;
-    if (!combined && !blockPart) {
+
+    const combined = [textRaw ?? "", ...reply.mediaUrls].filter(Boolean).join("\n");
+    if (!combined) {
       continue;
     }
     const chunkMode = params.chunkMode ?? "length";
-    const chunks =
-      combined.length === 0
-        ? []
-        : renderPlan.mode === "split" || renderPlan.textIsSlackMrkdwn
-          ? chunkSlackMrkdwnText(combined, chunkLimit)
-          : (chunkMode === "newline"
-              ? chunkMarkdownTextWithMode(combined, chunkLimit, chunkMode)
-              : [combined]
-            ).flatMap((markdown) =>
-              markdownToSlackMrkdwnChunks(markdown, chunkLimit, { tableMode: params.tableMode }),
-            );
-    if (!chunks.length && combined) {
-      chunks.push(combined);
-    }
-    const messages: SlackSlashReplyMessage[] = chunks.map((chunk) => ({ text: chunk }));
-    if (blockPart) {
-      const ownsLaterNativeDataFallback =
-        renderPlan.mode === "split" &&
-        hasSlackNativeDataBlock(blockPart.blocks) &&
-        hasCompleteSlackNativeDataFallbackText(renderPlan.fallbackText, blockPart.blocks);
-      const deferredRejection = ownsLaterNativeDataFallback
-        ? buildSlackDeferredNativeDataRejectionFallback(blockPart.blocks)
-        : undefined;
-      messages.unshift({
-        text: blockPart.text,
-        blocks: blockPart.blocks,
-        ...(deferredRejection
-          ? {
-              nativeDataRejectionFallback: {
-                text: deferredRejection.text,
-                ...(deferredRejection.blocks.length > 0
-                  ? { blocks: deferredRejection.blocks }
-                  : {}),
-              },
-            }
-          : {}),
-      });
-    }
+    const chunks = (
+      chunkMode === "newline"
+        ? chunkMarkdownTextWithMode(combined, chunkLimit, chunkMode)
+        : [combined]
+    ).flatMap((markdown) =>
+      markdownToSlackMrkdwnChunks(markdown, chunkLimit, { tableMode: params.tableMode }),
+    );
     deliveries.push({
-      hookContent: renderPlan.hookText || resolveSlackMediaHookSpokenText(payload) || combined,
-      messages,
+      hookContent: textRaw ?? resolveSlackMediaHookSpokenText(payload) ?? combined,
+      messages: (chunks.length > 0 ? chunks : [combined]).map((text) => ({ message: { text } })),
     });
   }
 
   if (deliveries.length === 0) {
     return;
   }
-  const responseType = params.ephemeral ? "ephemeral" : "in_channel";
-  const responseUrlUsesRemaining = Math.max(
-    0,
-    SLACK_RESPONSE_URL_MAX_USES - responseUrlBudget.used,
-  );
-  let plannedDeliveries = deliveries;
-  let responseUrlUses = countSlackResponseUrlUses(plannedDeliveries);
-  if (responseUrlUses > responseUrlUsesRemaining) {
-    const degradedDeliveries = degradeSlackResponseUrlNativeTables(deliveries, chunkLimit);
-    const degradedUses = countSlackResponseUrlUses(degradedDeliveries);
-    if (degradedUses < responseUrlUses) {
-      plannedDeliveries = degradedDeliveries;
-      responseUrlUses = degradedUses;
-    }
-  }
-  if (responseUrlUses > responseUrlUsesRemaining) {
-    const errorText = `This Slack slash reply is too large for the remaining response_url budget (${String(responseUrlUses)} responses needed; ${String(responseUrlUsesRemaining)} available). Send the result as a regular message instead.`;
-    responseUrlBudget.closed = true;
-    if (params.messageSentHookTarget) {
-      emitSlackMessageSentHooks({
-        sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
-        to: params.messageSentHookTarget,
-        accountId: params.accountId,
-        content: plannedDeliveries
-          .map((delivery) => delivery.hookContent)
-          .filter(Boolean)
-          .join("\n"),
-        success: false,
-        error: errorText,
-        isGroup: params.isGroup,
-        groupId: params.groupId,
-      });
-    }
-    if (responseUrlUsesRemaining > 0) {
-      responseUrlBudget.used += 1;
-      await params.respond({ text: errorText, response_type: responseType });
-    }
-    return;
-  }
-
-  const respond = async (message: Parameters<SlackRespondFn>[0]) => {
-    responseUrlBudget.used += 1;
-    return await params.respond(message);
-  };
 
   // Slack slash command responses can be multi-part by sending follow-ups via response_url.
-  for (const delivery of plannedDeliveries) {
+  const responseType = params.ephemeral ? "ephemeral" : "in_channel";
+  const respond = async (message: SlashReplyMessage) =>
+    await responseBudget.respond({
+      text: message.text,
+      response_type: responseType,
+      ...(message.blocks ? { blocks: message.blocks } : {}),
+      ...(message.mrkdwn === false ? { mrkdwn: false as const } : {}),
+    });
+  const emitDeliveryFailure = (delivery: SlashReplyDelivery, error: unknown) => {
+    if (!params.messageSentHookTarget) {
+      return;
+    }
+    emitSlackMessageSentHooks({
+      sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
+      to: params.messageSentHookTarget,
+      accountId: params.accountId,
+      content: delivery.hookContent,
+      success: false,
+      error: formatErrorMessage(error),
+      isGroup: params.isGroup,
+      groupId: params.groupId,
+    });
+  };
+
+  const plannedMessages = deliveries.flatMap((delivery) => delivery.messages);
+  const minimumCalls = plannedMessages.map((planned) => planned.nativeFallback?.length ?? 1);
+  const minimumRemainingCalls = Array.from({ length: minimumCalls.length + 1 }, () => 0);
+  for (let index = minimumCalls.length - 1; index >= 0; index -= 1) {
+    minimumRemainingCalls[index] =
+      (minimumRemainingCalls[index + 1] ?? 0) + (minimumCalls[index] ?? 0);
+  }
+  const failOversizedDelivery = async (): Promise<never> => {
+    const message = "Slack response exceeds the remaining response_url delivery budget.";
+    let failure: unknown = new Error(message);
+    if (responseBudget.remaining() !== 0) {
+      try {
+        await responseBudget.respond({
+          text: "This Slack response is too large to deliver within the remaining response window.",
+          response_type: "ephemeral",
+        });
+        failure = new SlackResponseAlreadyReportedError(message);
+      } catch (error) {
+        failure = error;
+      }
+    }
+    for (const delivery of deliveries) {
+      emitDeliveryFailure(delivery, failure);
+    }
+    throw failure;
+  };
+  const initialRemaining = responseBudget.remaining();
+  if (initialRemaining !== undefined && minimumRemainingCalls[0] > initialRemaining) {
+    await failOversizedDelivery();
+  }
+
+  const deliverNativeFallback = async (messages: readonly SlackFormattingDisabledMessage[]) => {
+    for (const message of messages) {
+      const response = await respond(message);
+      if (isSlackInvalidBlocksError(response)) {
+        throw new Error("Slack rejected the native-data fallback blocks with invalid_blocks.");
+      }
+    }
+  };
+
+  let plannedIndex = 0;
+  for (const delivery of deliveries) {
     try {
-      for (const message of delivery.messages) {
-        const hasNativeData = hasSlackNativeDataBlock(message.blocks);
-        const outboundMessage: SlackSlashReplyWireMessage = {
-          text: message.text,
-          ...(message.blocks?.length ? { blocks: message.blocks } : {}),
-        };
+      for (const planned of delivery.messages) {
+        const minimumAfter = minimumRemainingCalls[plannedIndex + 1] ?? 0;
+        plannedIndex += 1;
+        const fallback = planned.nativeFallback;
+        if (!fallback) {
+          await respond(planned.message);
+          continue;
+        }
+        const remaining = responseBudget.remaining();
+        const canAttemptNative =
+          !planned.skipOriginalBlocks &&
+          (remaining === undefined || 1 + fallback.length + minimumAfter <= remaining);
+        if (!canAttemptNative) {
+          await deliverNativeFallback(fallback);
+          continue;
+        }
+        let rejectedNativeBlocks = false;
         try {
-          const response = await respond({ ...outboundMessage, response_type: responseType });
-          if (!hasNativeData || !isSlackInvalidBlocksError(response)) {
-            continue;
-          }
+          const response = await respond(planned.message);
+          rejectedNativeBlocks = isSlackInvalidBlocksError(response);
         } catch (error) {
-          if (!hasNativeData || !isSlackInvalidBlocksError(error)) {
+          if (!isSlackInvalidBlocksError(error)) {
             throw error;
           }
+          rejectedNativeBlocks = true;
         }
-        const fallback = resolveSlackNativeDataFallback(message);
-        if (!fallback) {
-          throw new Error("Slack native-data fallback was unavailable");
-        }
-        const fallbackResponse = await respond({
-          ...fallback.message,
-          response_type: responseType,
-        });
-        if (isSlackInvalidBlocksError(fallbackResponse)) {
-          throw fallbackResponse;
+        if (rejectedNativeBlocks) {
+          await deliverNativeFallback(fallback);
         }
       }
     } catch (error) {
-      if (params.messageSentHookTarget) {
-        emitSlackMessageSentHooks({
-          sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
-          to: params.messageSentHookTarget,
-          accountId: params.accountId,
-          content: delivery.hookContent,
-          success: false,
-          error: formatErrorMessage(error),
-          isGroup: params.isGroup,
-          groupId: params.groupId,
-        });
-      }
+      emitDeliveryFailure(delivery, error);
       throw error;
     }
     if (params.messageSentHookTarget) {

--- a/extensions/slack/src/monitor/response-url-budget.ts
+++ b/extensions/slack/src/monitor/response-url-budget.ts
@@ -1,0 +1,33 @@
+export type SlackResponseUrlBudget<TPayload> = {
+  respond: (payload: TPayload) => Promise<unknown>;
+  /** Remaining response_url calls, or undefined for an uncapped Web API transport. */
+  remaining: () => number | undefined;
+};
+
+export const SLACK_RESPONSE_URL_MAX_CALLS = 5;
+
+export class SlackResponseAlreadyReportedError extends Error {}
+
+export function isSlackResponseAlreadyReportedError(
+  error: unknown,
+): error is SlackResponseAlreadyReportedError {
+  return error instanceof SlackResponseAlreadyReportedError;
+}
+
+/** Count every response_url attempt, including requests Slack rejects. */
+export function createSlackResponseUrlBudget<TPayload>(
+  respond: (payload: TPayload) => Promise<unknown>,
+  maxCalls = SLACK_RESPONSE_URL_MAX_CALLS,
+): SlackResponseUrlBudget<TPayload> {
+  let remaining = maxCalls;
+  return {
+    remaining: () => remaining,
+    respond: async (payload) => {
+      if (remaining <= 0) {
+        throw new Error(`Slack response_url cannot be used more than ${String(maxCalls)} times.`);
+      }
+      remaining -= 1;
+      return await respond(payload);
+    },
+  };
+}

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -584,6 +584,30 @@ function responseTexts(mock: ReturnType<typeof vi.fn>): unknown[] {
   );
 }
 
+function mockSixDispatchedReplies() {
+  const { deliverSlackSlashRepliesMock } = getSlackSlashMocks();
+  deliverSlackSlashRepliesMock.mockImplementation(async (params: unknown) => {
+    const { replies, responseBudget } = params as {
+      replies: Array<{ text: string }>;
+      responseBudget: { respond: (payload: { text: string }) => Promise<unknown> };
+    };
+    for (const reply of replies) {
+      await responseBudget.respond({ text: reply.text });
+    }
+  });
+  dispatchMock.mockImplementation((params: unknown) => {
+    const deliver = (
+      params as {
+        dispatcherOptions: { deliver: (payload: { text: string }) => Promise<void> };
+      }
+    ).dispatcherOptions.deliver;
+    for (let index = 0; index < 6; index += 1) {
+      void deliver({ text: `reply ${String(index + 1)}` });
+    }
+    return { counts: { final: 6, tool: 0, block: 0 } };
+  });
+}
+
 describe("Slack native command argument menus", () => {
   let harness: ReturnType<typeof createArgMenusHarness>;
   let usageHandler: (args: unknown) => Promise<void>;
@@ -867,6 +891,75 @@ describe("Slack native command argument menus", () => {
     expect(dispatchMock).toHaveBeenCalledTimes(1);
     const call = firstDispatchArg() as { ctx?: { Body?: string } };
     expect(call.ctx?.Body).toBe("/usage tokens");
+  });
+
+  it("does not apply the response_url call cap to Web API action replies", async () => {
+    mockSixDispatchedReplies();
+
+    await runArgMenuAction(argMenuHandler, {
+      action: {
+        value: encodeValue({ command: "usage", arg: "mode", value: "tokens", userId: "U1" }),
+      },
+      includeRespond: false,
+    });
+
+    expect(harness.postEphemeral).toHaveBeenCalledTimes(6);
+  });
+
+  it("keeps table fallback tokens literal in Web API action replies", async () => {
+    const tableFallback = "Account\tOwner\nprod\t<@U123> & <!channel>";
+    const { deliverSlackSlashRepliesMock } = getSlackSlashMocks();
+    deliverSlackSlashRepliesMock.mockImplementation(async (params: unknown) => {
+      const responseBudget = (
+        params as {
+          responseBudget: {
+            respond: (payload: { text: string; mrkdwn?: false }) => Promise<unknown>;
+          };
+        }
+      ).responseBudget;
+      await responseBudget.respond({ text: tableFallback, mrkdwn: false });
+    });
+    dispatchMock.mockImplementation((params: unknown) => {
+      const deliver = (
+        params as {
+          dispatcherOptions: { deliver: (payload: { text: string }) => Promise<void> };
+        }
+      ).dispatcherOptions.deliver;
+      void deliver({ text: "table reply" });
+      return { counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    await runArgMenuAction(argMenuHandler, {
+      action: {
+        value: encodeValue({ command: "usage", arg: "mode", value: "tokens", userId: "U1" }),
+      },
+      includeRespond: false,
+    });
+
+    expect(harness.postEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({ text: tableFallback, mrkdwn: false }),
+    );
+  });
+
+  it("keeps the response_url call cap on action responders", async () => {
+    mockSixDispatchedReplies();
+
+    const respond = await runArgMenuAction(argMenuHandler, {
+      action: {
+        value: encodeValue({ command: "usage", arg: "mode", value: "tokens", userId: "U1" }),
+      },
+    });
+
+    expect(respond).toHaveBeenCalledTimes(5);
+    expect(harness.postEphemeral).not.toHaveBeenCalled();
+  });
+
+  it("keeps the response_url call cap on actual slash command replies", async () => {
+    mockSixDispatchedReplies();
+
+    const { respond } = await runCommandHandler(agentStatusHandler);
+
+    expect(respond).toHaveBeenCalledTimes(5);
   });
 
   it("tracks accepted slash command activity", async () => {
@@ -1486,18 +1579,31 @@ describe("slack slash command session metadata", () => {
   });
 
   it("passes canonical hook correlation to slash reply delivery", async () => {
+    dispatchMock.mockImplementation((params: unknown) => {
+      const deliver = (
+        params as {
+          dispatcherOptions: { deliver: (payload: { text: string }) => Promise<void> };
+        }
+      ).dispatcherOptions.deliver;
+      void deliver({ text: "final answer" });
+      void deliver({ text: "second answer" });
+      return { counts: { final: 2, tool: 0, block: 0 } };
+    });
     const harness = createPolicyHarness({ groupPolicy: "open" });
     await registerAndRunPolicySlash({ harness });
     const dispatchArg = firstDispatchArg() as {
       ctx?: { OriginatingTo?: string; SessionKey?: string };
-      dispatcherOptions?: { deliver?: (payload: { text: string }) => Promise<void> };
     };
+    const responseBudget = (
+      deliverSlackSlashRepliesMock.mock.calls.at(-1)?.[0] as
+        | { responseBudget?: unknown }
+        | undefined
+    )?.responseBudget;
 
-    await dispatchArg.dispatcherOptions?.deliver?.({ text: "final answer" });
-
+    expect(deliverSlackSlashRepliesMock).toHaveBeenCalledOnce();
     expect(deliverSlackSlashRepliesMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        replies: [{ text: "final answer" }],
+        replies: [{ text: "final answer" }, { text: "second answer" }],
         messageSentHookTarget: dispatchArg.ctx?.OriginatingTo,
         sessionKeyForInternalHooks: dispatchArg.ctx?.SessionKey,
         accountId: "acct",
@@ -1505,19 +1611,24 @@ describe("slack slash command session metadata", () => {
         groupId: harness.channelId,
       }),
     );
+    expect(responseBudget).toBeDefined();
   });
 
   it("targets the channel for public slash reply hooks", async () => {
+    dispatchMock.mockImplementation((params: unknown) => {
+      const deliver = (
+        params as {
+          dispatcherOptions: { deliver: (payload: { text: string }) => Promise<void> };
+        }
+      ).dispatcherOptions.deliver;
+      void deliver({ text: "public answer" });
+      return { counts: { final: 1, tool: 0, block: 0 } };
+    });
     const harness = createPolicyHarness({
       groupPolicy: "open",
       slashEphemeral: false,
     });
     await registerAndRunPolicySlash({ harness });
-    const dispatchArg = firstDispatchArg() as {
-      dispatcherOptions?: { deliver?: (payload: { text: string }) => Promise<void> };
-    };
-
-    await dispatchArg.dispatcherOptions?.deliver?.({ text: "public answer" });
 
     expect(firstDispatchArg().ctx?.OriginatingTo).toBe(`channel:${harness.channelId}`);
     expect(deliverSlackSlashRepliesMock).toHaveBeenCalledWith(

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -1,5 +1,6 @@
 // Slack plugin module implements slash behavior.
 import type { SlackActionMiddlewareArgs, SlackCommandMiddlewareArgs } from "@slack/bolt";
+import type { Block, KnownBlock } from "@slack/web-api";
 import { loadModelCatalog, resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
 import { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-outbound";
 import {
@@ -36,7 +37,6 @@ import {
   compileSlackInteractiveReplies,
   isSlackInteractiveRepliesEnabled,
 } from "../interactive-replies.js";
-import { SLACK_RESPONSE_URL_MAX_USES } from "../limits.js";
 import { truncateSlackText } from "../truncate.js";
 import { resolveSlackCommandIngress, resolveSlackEffectiveAllowFrom } from "./auth.js";
 import { resolveSlackChannelConfig, type SlackChannelConfigResolved } from "./channel-config.js";
@@ -51,9 +51,11 @@ import {
 } from "./external-arg-menu-store.js";
 import { escapeSlackMrkdwn } from "./mrkdwn.js";
 import { isSlackChannelAllowedByPolicy } from "./policy.js";
+import {
+  createSlackResponseUrlBudget,
+  isSlackResponseAlreadyReportedError,
+} from "./response-url-budget.js";
 import { resolveSlackRoomContextHints } from "./room-context.js";
-
-type SlackBlock = { type: string; [key: string]: unknown };
 
 const SLACK_COMMAND_ARG_ACTION_ID = "openclaw_cmdarg";
 const SLACK_COMMAND_ARG_ACTION_LISTENER = /^openclaw_cmdarg/;
@@ -386,13 +388,29 @@ export async function registerSlackMonitorSlashCommands(params: {
     command: SlackCommandMiddlewareArgs["command"];
     ack: SlackCommandMiddlewareArgs["ack"];
     respond: SlackCommandMiddlewareArgs["respond"];
+    responseTransport?: "response-url" | "web-api";
     body?: unknown;
     prompt: string;
     commandArgs?: CommandArgs;
     commandDefinition?: ChatCommandDefinition;
   }) => {
-    const { command, ack, respond, body, prompt, commandArgs, commandDefinition } = p;
-    const responseUrlBudget: { used: number; closed?: boolean } = { used: 0 };
+    const {
+      command,
+      ack,
+      respond: respondWithoutBudget,
+      body,
+      prompt,
+      commandArgs,
+      commandDefinition,
+    } = p;
+    const responseBudget =
+      p.responseTransport === "web-api"
+        ? {
+            respond: respondWithoutBudget,
+            remaining: () => undefined,
+          }
+        : createSlackResponseUrlBudget(respondWithoutBudget);
+    const respond = responseBudget.respond;
     const cfg = getRuntimeConfigSnapshot() ?? ctx.cfg;
     try {
       if (ctx.shouldDropMismatchedSlackEvent?.(body)) {
@@ -745,7 +763,6 @@ export async function registerSlackMonitorSlashCommands(params: {
         await deliverSlackSlashReplies({
           replies,
           respond,
-          responseUrlBudget,
           ephemeral: slashCommand.ephemeral,
           textLimit: ctx.textLimit,
           messageSentHookTarget,
@@ -759,15 +776,21 @@ export async function registerSlackMonitorSlashCommands(params: {
             channel: "slack",
             accountId: route.accountId,
           }),
+          responseBudget,
         });
       };
+      const pendingSlashReplies: ReplyPayload[] = [];
 
       const { counts } = await dispatchReplyWithDispatcher({
         ctx: ctxPayload,
         cfg,
         dispatcherOptions: {
           ...replyPipeline,
-          deliver: async (payload) => deliverSlashPayloads([payload]),
+          // response_url has one shared five-call budget. Plan the whole turn
+          // before its first post so a later payload cannot strand a partial reply.
+          deliver: async (payload) => {
+            pendingSlashReplies.push(payload);
+          },
           onError: (err, info) => {
             runtime.error?.(
               danger(`slack slash ${info.kind} reply failed: ${formatSlackError(err)}`),
@@ -779,13 +802,14 @@ export async function registerSlackMonitorSlashCommands(params: {
           onModelSelected,
         },
       });
-      if (counts.final + counts.tool + counts.block === 0) {
+      if (pendingSlashReplies.length > 0) {
+        await deliverSlashPayloads(pendingSlashReplies);
+      } else if (counts.final + counts.tool + counts.block === 0) {
         await deliverSlashPayloads([]);
       }
     } catch (err) {
       runtime.error?.(danger(`slack slash handler failed: ${formatErrorMessage(err)}`));
-      if (!responseUrlBudget.closed && responseUrlBudget.used < SLACK_RESPONSE_URL_MAX_USES) {
-        responseUrlBudget.used += 1;
+      if (!isSlackResponseAlreadyReportedError(err) && responseBudget.remaining() !== 0) {
         await respond({
           text: "Sorry, something went wrong handling that command.",
           response_type: "ephemeral",
@@ -968,25 +992,39 @@ export async function registerSlackMonitorSlashCommands(params: {
         action: NonNullable<(typeof ctx.app & { action?: unknown })["action"]>;
       }
     ).action(actionId, async (args: SlackActionMiddlewareArgs) => {
-      const { ack, body, respond } = args;
+      const { ack, body } = args;
+      const respond = (
+        args as unknown as {
+          respond?: SlackCommandMiddlewareArgs["respond"];
+        }
+      ).respond;
       const action = args.action as { value?: string; selected_option?: { value?: string } };
       await ack();
       if (ctx.shouldDropMismatchedSlackEvent?.(body)) {
         runtime.log?.("slack: drop slash arg action payload (mismatched app/team)");
         return;
       }
-      const respondFn =
+      const respondFn: SlackCommandMiddlewareArgs["respond"] =
         respond ??
-        (async (payload: { text: string; blocks?: SlackBlock[]; response_type?: string }) => {
+        (async (message) => {
           if (!body.channel?.id || !body.user?.id) {
             return;
           }
+          const payload =
+            typeof message === "string"
+              ? { text: message }
+              : (message as {
+                  text?: string;
+                  blocks?: (Block | KnownBlock)[];
+                  mrkdwn?: boolean;
+                });
           await ctx.app.client.chat.postEphemeral({
             token: ctx.botToken,
             channel: body.channel.id,
             user: body.user.id,
-            text: payload.text,
-            blocks: payload.blocks,
+            text: payload.text ?? "",
+            ...(payload.blocks ? { blocks: payload.blocks } : {}),
+            ...(typeof payload.mrkdwn === "boolean" ? { mrkdwn: payload.mrkdwn } : {}),
           });
         });
       const actionValue = action?.value ?? action?.selected_option?.value;
@@ -1033,6 +1071,9 @@ export async function registerSlackMonitorSlashCommands(params: {
         command: commandPayload,
         ack: async () => {},
         respond: respondFn,
+        // Bolt's action responder uses response_url; only the postEphemeral fallback
+        // goes through the uncapped Web API path.
+        responseTransport: respond ? "response-url" : "web-api",
         body,
         prompt,
         commandArgs,

--- a/extensions/slack/src/native-data-blocks.test.ts
+++ b/extensions/slack/src/native-data-blocks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   appendSlackNativeDataFallbackText,
+  buildSlackNativeDataAccessibilityText,
   hasSlackNativeDataBlock,
   isSlackInvalidBlocksError,
   renderSlackNativeDataFallbackText,
@@ -82,17 +83,99 @@ describe("Slack native data blocks", () => {
     ).toBe("&lt;!here&gt; revenue (pie chart)\n- &lt;@U456&gt;: 1");
   });
 
-  it("appends mixed native data in block order exactly once", () => {
+  it("appends mixed native data in block order without collapsing repeated blocks", () => {
     const chartText = "Revenue mix (pie chart)\n- Product: 60\n- Services: 40";
     const tableText = "Pipeline report (table)\n- Account: Acme; ARR: $125k";
     const expected = `Overview\n\n${chartText}\n\n${tableText}`;
 
-    expect(appendSlackNativeDataFallbackText("Overview", [chart, table, chart])).toBe(expected);
+    expect(appendSlackNativeDataFallbackText("Overview", [chart, table, chart])).toBe(
+      `${expected}\n\n${chartText}`,
+    );
     expect(appendSlackNativeDataFallbackText(expected, [chart, table])).toBe(expected);
     expect(
       appendSlackNativeDataFallbackText("Revenue mix (pie chart) - Product: 60 - Services: 40", [
         chart,
       ]),
     ).toBe("Revenue mix (pie chart) - Product: 60 - Services: 40");
+  });
+
+  it("builds formatting-disabled accessibility in actual block order", () => {
+    expect(
+      buildSlackNativeDataAccessibilityText("Outside", [
+        { type: "section", text: { type: "mrkdwn", text: "Before" } },
+        table,
+        { type: "section", text: { type: "mrkdwn", text: "After" } },
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              action_id: "private-action",
+              text: { type: "plain_text", text: "Approve" },
+              value: "private-value",
+            },
+            {
+              type: "users_select",
+              action_id: "private-select",
+              placeholder: { type: "plain_text", text: "Choose owner" },
+            },
+          ],
+        },
+      ]),
+    ).toBe(
+      [
+        "Outside",
+        "Before",
+        "Pipeline report (table)\nAccount\tARR\nAcme\t$125k",
+        "After",
+        "Approve\nChoose owner",
+      ].join("\n\n"),
+    );
+  });
+
+  it("keeps plain text objects literal in formatting-disabled accessibility", () => {
+    expect(
+      buildSlackNativeDataAccessibilityText("", [
+        { type: "section", text: { type: "plain_text", text: "1 < 2 & <@U123>" } },
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Keep <literal>" },
+            },
+          ],
+        },
+        table,
+      ]),
+    ).toBe(
+      [
+        "1 < 2 & <@U123>",
+        "Keep <literal>",
+        "Pipeline report (table)\nAccount\tARR\nAcme\t$125k",
+      ].join("\n\n"),
+    );
+  });
+
+  it("preserves repeated visible blocks even when their text matches the base", () => {
+    const chartText = "Revenue mix (pie chart)\n- Product: 60\n- Services: 40";
+
+    expect(buildSlackNativeDataAccessibilityText(chartText, [chart, chart])).toBe(
+      [chartText, chartText].join("\n\n"),
+    );
+    expect(
+      buildSlackNativeDataAccessibilityText("Refresh", [
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Refresh" },
+              value: "hidden",
+            },
+          ],
+        },
+      ]),
+    ).toBe("Refresh\n\nRefresh");
   });
 });

--- a/extensions/slack/src/native-data-blocks.ts
+++ b/extensions/slack/src/native-data-blocks.ts
@@ -1,13 +1,18 @@
 // Shared detection and text fallback for Slack's native chart and table blocks.
-import type { Block, KnownBlock } from "@slack/web-api";
-import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
-import { SLACK_MAX_BLOCKS } from "./blocks-input.js";
-import { hasSlackDataTableBlock, renderSlackDataTableMrkdwnFallbackText } from "./data-table.js";
+import { renderSlackBlockFallbackText } from "./blocks-fallback.js";
+import {
+  hasSlackDataTableBlock,
+  renderSlackDataTableCompactPlainTextFallback,
+  renderSlackDataTableMrkdwnFallbackText,
+} from "./data-table.js";
 import {
   hasSlackDataVisualizationBlock,
+  renderSlackDataVisualizationFallbackText,
   renderSlackDataVisualizationMrkdwnFallbackText,
 } from "./data-visualization.js";
-import { SLACK_SECTION_TEXT_MAX } from "./presentation.js";
+
+export const SLACK_MALFORMED_NATIVE_DATA_FALLBACK =
+  "Slack could not render this chart or table data.";
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -18,6 +23,14 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 /** Detect a native Slack chart or table block. */
 export function hasSlackNativeDataBlock(blocks?: readonly unknown[]): boolean {
   return hasSlackDataVisualizationBlock(blocks) || hasSlackDataTableBlock(blocks);
+}
+
+/** Keep every sibling block while removing Slack's native data blocks. */
+export function stripSlackNativeDataBlocks<T>(blocks?: readonly T[]): T[] {
+  return (blocks ?? []).filter((block) => {
+    const type = asRecord(block)?.type;
+    return type !== "data_table" && type !== "data_visualization";
+  });
 }
 
 /** Match Slack's Web API and response_url `invalid_blocks` error shapes. */
@@ -48,82 +61,110 @@ export function renderSlackNativeDataFallbackText(value: unknown): string | unde
   return undefined;
 }
 
-/** Replace rejected native data with visible mrkdwn while retaining valid sibling blocks. */
-export function buildSlackNativeDataFallbackBlocks(
-  blocks?: readonly (Block | KnownBlock)[],
-): (Block | KnownBlock)[] | undefined {
-  if (!blocks) {
-    return undefined;
-  }
-  const fallbackBlocks: (Block | KnownBlock)[] = [];
-  for (const block of blocks) {
-    const fallbackText = renderSlackNativeDataFallbackText(block);
-    if (!fallbackText) {
-      fallbackBlocks.push(block);
-      continue;
-    }
-    fallbackBlocks.push(
-      ...chunkTextForOutbound(fallbackText, SLACK_SECTION_TEXT_MAX).map(
-        (text): KnownBlock => ({
-          type: "section",
-          text: { type: "mrkdwn", text, verbatim: true },
-        }),
-      ),
-    );
-  }
-  if (fallbackBlocks.length > SLACK_MAX_BLOCKS) {
-    throw new Error(
-      `Slack native-data fallback requires ${String(fallbackBlocks.length)} blocks to retain every sibling; Slack allows ${String(SLACK_MAX_BLOCKS)}`,
-    );
-  }
-  return fallbackBlocks;
-}
-
 function comparableText(value: string): string {
   return value.replace(/\s+/gu, " ").trim();
 }
 
-/** True when text already contains every attached native-data fallback in full. */
-export function hasCompleteSlackNativeDataFallbackText(
+function countComparableOccurrences(value: string, candidate: string): number {
+  if (!candidate) {
+    return 0;
+  }
+  let count = 0;
+  let offset = 0;
+  while ((offset = value.indexOf(candidate, offset)) >= 0) {
+    count += 1;
+    offset += candidate.length;
+  }
+  return count;
+}
+
+/** Consume native fallback occurrences already carried by an explicit outside base. */
+export function createSlackNativeDataBaseTextConsumer(baseText: string): (text: string) => boolean {
+  const comparableBase = comparableText(baseText);
+  const remainingByText = new Map<string, number>();
+  return (text) => {
+    const comparable = comparableText(text);
+    const remaining =
+      remainingByText.get(comparable) ?? countComparableOccurrences(comparableBase, comparable);
+    if (remaining <= 0) {
+      return false;
+    }
+    remainingByText.set(comparable, remaining - 1);
+    return true;
+  };
+}
+
+function appendSlackNativeDataFallback(
   text: string,
-  blocks?: readonly unknown[],
-): boolean {
-  const comparableBase = comparableText(text);
-  let hasNativeDataFallback = false;
+  blocks: readonly unknown[] | undefined,
+  render: (value: unknown) => string | undefined,
+): string {
+  const base = text.trim();
+  const consumeFromBase = createSlackNativeDataBaseTextConsumer(base);
+  const dataTexts: string[] = [];
   for (const block of blocks ?? []) {
-    const dataText = renderSlackNativeDataFallbackText(block);
+    const dataText = render(block);
     if (!dataText) {
       continue;
     }
-    hasNativeDataFallback = true;
-    const comparable = comparableText(dataText);
-    if (!comparable || !comparableBase.includes(comparable)) {
-      return false;
+    if (!comparableText(dataText) || consumeFromBase(dataText)) {
+      continue;
     }
+    dataTexts.push(dataText);
   }
-  return hasNativeDataFallback;
+  return [base, ...dataTexts].filter(Boolean).join("\n\n");
 }
 
-/** Preserve every native data block's content once in the accessible fallback. */
+function renderSlackNativeDataPlainTextBlock(value: unknown): string | undefined {
+  const type = asRecord(value)?.type;
+  if (type === "data_table") {
+    return renderSlackDataTableCompactPlainTextFallback(value);
+  }
+  if (type === "data_visualization") {
+    return renderSlackDataVisualizationFallbackText(value);
+  }
+  return undefined;
+}
+
+/** Build formatting-disabled accessibility text from actual Slack block order. */
+export function buildSlackNativeDataAccessibilityText(
+  text: string,
+  blocks?: readonly unknown[],
+): string {
+  const parts: string[] = [];
+  const consumeFromBase = createSlackNativeDataBaseTextConsumer(text);
+  const append = (value: string | undefined) => {
+    if (value?.trim()) {
+      parts.push(value);
+    }
+  };
+  append(text);
+  for (const block of blocks ?? []) {
+    const isNativeData = hasSlackNativeDataBlock([block]);
+    const rendered =
+      renderSlackNativeDataPlainTextBlock(block) ??
+      renderSlackBlockFallbackText(block, { nativeDataFormat: "plain" }) ??
+      (isNativeData ? SLACK_MALFORMED_NATIVE_DATA_FALLBACK : undefined);
+    if (!rendered || (isNativeData && consumeFromBase(rendered))) {
+      continue;
+    }
+    append(rendered);
+  }
+  return parts.join("\n\n");
+}
+
+/** Preserve every native data block's content once when Slack requires a text-only retry. */
 export function appendSlackNativeDataFallbackText(
   text: string,
   blocks?: readonly unknown[],
 ): string {
-  const base = text.trim();
-  const comparableBase = comparableText(base);
-  const seen = new Set<string>();
-  const dataTexts: string[] = [];
-  for (const block of blocks ?? []) {
-    const dataText = renderSlackNativeDataFallbackText(block);
-    if (!dataText) {
-      continue;
-    }
-    const comparable = comparableText(dataText);
-    if (!comparable || comparableBase.includes(comparable) || seen.has(comparable)) {
-      continue;
-    }
-    seen.add(comparable);
-    dataTexts.push(dataText);
-  }
-  return [base, ...dataTexts].filter(Boolean).join("\n\n");
+  return appendSlackNativeDataFallback(text, blocks, renderSlackNativeDataFallbackText);
+}
+
+/** Build a bounded plain-text retry without activating control tokens. */
+export function appendSlackNativeDataPlainTextFallback(
+  text: string,
+  blocks?: readonly unknown[],
+): string {
+  return appendSlackNativeDataFallback(text, blocks, renderSlackNativeDataPlainTextBlock);
 }

--- a/extensions/slack/src/native-data-fallback.test.ts
+++ b/extensions/slack/src/native-data-fallback.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSlackNativeDataDeliveryPlan,
+  chunkSlackTextAtHardLimit,
+} from "./native-data-fallback.js";
+
+function tableBlock(caption: string) {
+  return {
+    type: "data_table",
+    caption,
+    rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
+  } as never;
+}
+
+function actionBlock(label: string, value: string) {
+  return {
+    type: "actions",
+    elements: [
+      {
+        type: "button",
+        action_id: "openclaw:reply_button",
+        text: { type: "plain_text", text: label },
+        value,
+      },
+    ],
+  } as never;
+}
+
+describe("buildSlackNativeDataDeliveryPlan", () => {
+  it("uses the generic accessibility label for non-data blocks without visible text", () => {
+    const plan = buildSlackNativeDataDeliveryPlan({ blocks: [{ type: "divider" } as never] });
+
+    expect(plan.accessibilityText).toBe("Shared a Block Kit message");
+    expect(plan.skipOriginalBlocks).toBe(false);
+  });
+
+  it("packs native-only emergency text at Slack's 40k hard limit", () => {
+    const caption = "x".repeat(41_000);
+    const plan = buildSlackNativeDataDeliveryPlan({ blocks: [tableBlock(caption)] });
+
+    expect(plan.skipOriginalBlocks).toBe(true);
+    expect(plan.fallbackMessages).toHaveLength(2);
+    expect(plan.fallbackMessages.every((message) => message.blocks === undefined)).toBe(true);
+    expect(plan.fallbackMessages.every((message) => message.text.length <= 40_000)).toBe(true);
+    expect(plan.fallbackMessages.map((message) => message.text).join("")).toBe(
+      `${caption} (table)\nAccount\nAcme`,
+    );
+  });
+
+  it("batches survivor controls and replacement sections without changing block order", () => {
+    const before = actionBlock("Before", "hidden-before");
+    const after = actionBlock("After", "hidden-after");
+    const caption = "x".repeat(80_000);
+    const plan = buildSlackNativeDataDeliveryPlan({
+      baseText: "Intro",
+      blocks: [before, tableBlock(caption), after],
+    });
+
+    const messages = plan.fallbackMessages;
+    expect(messages.length).toBeGreaterThan(1);
+    expect(messages.every((message) => (message.blocks?.length ?? 0) <= 50)).toBe(true);
+    expect(messages.every((message) => message.text.length <= 40_000)).toBe(true);
+    const blocks = messages.flatMap((message) => message.blocks ?? []);
+    expect(blocks[1]).toBe(before);
+    expect(blocks.at(-1)).toBe(after);
+    const plainText = blocks.flatMap((block) => {
+      const text = (block as { text?: { type?: string; text?: string } }).text;
+      return text?.type === "plain_text" && text.text ? [text.text] : [];
+    });
+    expect(plainText.join("")).toBe(`Intro${caption} (table)\nAccount\nAcme`);
+    expect(messages.map((message) => message.text).join(" ")).not.toContain("hidden-");
+  });
+
+  it("keeps survivor plain text literal when formatting is disabled", () => {
+    const plan = buildSlackNativeDataDeliveryPlan({
+      blocks: [
+        {
+          type: "section",
+          text: { type: "plain_text", text: "1 < 2 & <@U123>" },
+          accessory: {
+            type: "button",
+            text: { type: "plain_text", text: "Keep <literal>" },
+          },
+        } as never,
+        tableBlock("Pipeline"),
+      ],
+    });
+
+    expect(plan.fallbackMessages[0]?.mrkdwn).toBe(false);
+    expect(plan.fallbackMessages[0]?.text).toContain("1 < 2 & <@U123>");
+    expect(plan.fallbackMessages[0]?.text).toContain("Keep <literal>");
+    expect(plan.fallbackMessages[0]?.text).not.toContain("&lt;");
+  });
+
+  it("does not split astral characters at hard boundaries", () => {
+    expect(chunkSlackTextAtHardLimit(`A${"😀".repeat(3)}Z`, 3)).toEqual(["A😀", "😀", "😀Z"]);
+  });
+
+  it("keeps a visible failure marker for malformed native-only data with base text", () => {
+    const plan = buildSlackNativeDataDeliveryPlan({
+      baseText: "Overview",
+      blocks: [{ type: "data_table", rows: [] } as never],
+    });
+
+    expect(plan.accessibilityText).toBe(
+      "Overview\n\nSlack could not render this chart or table data.",
+    );
+    expect(plan.fallbackMessages).toEqual([{ text: plan.accessibilityText, mrkdwn: false }]);
+  });
+});

--- a/extensions/slack/src/native-data-fallback.ts
+++ b/extensions/slack/src/native-data-fallback.ts
@@ -1,0 +1,164 @@
+import type { Block, KnownBlock } from "@slack/web-api";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { renderSlackBlockFallbackText } from "./blocks-fallback.js";
+import { SLACK_MAX_BLOCKS } from "./blocks-input.js";
+import { SLACK_MESSAGE_TEXT_HARD_LIMIT } from "./limits.js";
+import {
+  buildSlackNativeDataAccessibilityText,
+  appendSlackNativeDataPlainTextFallback,
+  createSlackNativeDataBaseTextConsumer,
+  hasSlackNativeDataBlock,
+  SLACK_MALFORMED_NATIVE_DATA_FALLBACK,
+  stripSlackNativeDataBlocks,
+} from "./native-data-blocks.js";
+
+const SLACK_SECTION_PLAIN_TEXT_MAX = 3_000;
+const SLACK_EMPTY_BLOCK_FALLBACK = "Shared a Block Kit message";
+
+export type SlackFormattingDisabledMessage = {
+  text: string;
+  blocks?: (Block | KnownBlock)[];
+  mrkdwn: false;
+};
+
+export type SlackNativeDataDeliveryPlan = {
+  accessibilityText: string;
+  fallbackMessages: SlackFormattingDisabledMessage[];
+  skipOriginalBlocks: boolean;
+};
+
+type OrderedFallbackBlock = {
+  block: Block | KnownBlock;
+  text?: string;
+  continuesText?: boolean;
+};
+
+export function chunkSlackTextAtHardLimit(
+  text: string,
+  limit = SLACK_MESSAGE_TEXT_HARD_LIMIT,
+): string[] {
+  const effectiveLimit = Math.max(2, Math.floor(limit));
+  const chunks: string[] = [];
+  let offset = 0;
+  while (offset < text.length) {
+    const chunk = sliceUtf16Safe(text, offset, Math.min(text.length, offset + effectiveLimit));
+    if (!chunk) {
+      throw new Error("Slack plain-text fallback chunking made no progress.");
+    }
+    chunks.push(chunk);
+    offset += chunk.length;
+  }
+  return chunks;
+}
+
+function buildPlainTextBlocks(text: string): OrderedFallbackBlock[] {
+  return chunkSlackTextAtHardLimit(text, SLACK_SECTION_PLAIN_TEXT_MAX).map((chunk, index) => {
+    const fallbackBlock: OrderedFallbackBlock = {
+      block: {
+        type: "section",
+        text: { type: "plain_text", text: chunk },
+      },
+      text: chunk,
+    };
+    if (index > 0) {
+      fallbackBlock.continuesText = true;
+    }
+    return fallbackBlock;
+  });
+}
+
+function renderNativeDataPlainText(block: unknown): string {
+  return (
+    appendSlackNativeDataPlainTextFallback("", [block]).trim() ||
+    SLACK_MALFORMED_NATIVE_DATA_FALLBACK
+  );
+}
+
+function buildOrderedFallbackBlocks(params: {
+  baseText: string;
+  blocks: readonly (Block | KnownBlock)[];
+}): OrderedFallbackBlock[] {
+  const entries: OrderedFallbackBlock[] = [];
+  const consumeFromBase = createSlackNativeDataBaseTextConsumer(params.baseText);
+  if (params.baseText) {
+    entries.push(...buildPlainTextBlocks(params.baseText));
+  }
+  for (const block of params.blocks) {
+    if (hasSlackNativeDataBlock([block])) {
+      const nativeText = renderNativeDataPlainText(block);
+      if (!consumeFromBase(nativeText)) {
+        entries.push(...buildPlainTextBlocks(nativeText));
+      }
+      continue;
+    }
+    const text = renderSlackBlockFallbackText(block, { nativeDataFormat: "plain" });
+    entries.push({ block, ...(text ? { text } : {}) });
+  }
+  return entries;
+}
+
+function buildOrderedBlockMessages(entries: readonly OrderedFallbackBlock[]) {
+  const messages: SlackFormattingDisabledMessage[] = [];
+  let blocks: (Block | KnownBlock)[] = [];
+  let text = "";
+
+  const flush = () => {
+    if (blocks.length === 0) {
+      return;
+    }
+    messages.push({
+      text: text || SLACK_EMPTY_BLOCK_FALLBACK,
+      blocks,
+      mrkdwn: false,
+    });
+    blocks = [];
+    text = "";
+  };
+
+  for (const entry of entries) {
+    const separator = text && entry.text && !entry.continuesText ? "\n\n" : "";
+    const nextText = entry.text ? `${text}${separator}${entry.text}` : text;
+    if (blocks.length >= SLACK_MAX_BLOCKS || nextText.length > SLACK_MESSAGE_TEXT_HARD_LIMIT) {
+      flush();
+    }
+    const freshSeparator = text && entry.text && !entry.continuesText ? "\n\n" : "";
+    const freshText = entry.text ? `${text}${freshSeparator}${entry.text}` : text;
+    if (freshText.length > SLACK_MESSAGE_TEXT_HARD_LIMIT) {
+      throw new Error("One Slack fallback block exceeds the message text hard limit.");
+    }
+    blocks.push(entry.block);
+    text = freshText;
+  }
+  flush();
+  return messages;
+}
+
+/** Build one complete, ordered retry plan after Slack rejects native data blocks. */
+export function buildSlackNativeDataDeliveryPlan(params: {
+  baseText?: string;
+  blocks: readonly (Block | KnownBlock)[];
+}): SlackNativeDataDeliveryPlan {
+  const baseText = params.baseText?.trim() ?? "";
+  const hasNativeData = hasSlackNativeDataBlock(params.blocks);
+  const accessibilityText =
+    buildSlackNativeDataAccessibilityText(baseText, params.blocks) ||
+    (hasNativeData ? SLACK_MALFORMED_NATIVE_DATA_FALLBACK : SLACK_EMPTY_BLOCK_FALLBACK);
+  const survivorBlocks = stripSlackNativeDataBlocks(params.blocks);
+  const fallbackMessages =
+    survivorBlocks.length === 0
+      ? chunkSlackTextAtHardLimit(accessibilityText).map((text) => ({
+          text,
+          mrkdwn: false as const,
+        }))
+      : buildOrderedBlockMessages(
+          buildOrderedFallbackBlocks({
+            baseText,
+            blocks: params.blocks,
+          }),
+        );
+  return {
+    accessibilityText,
+    fallbackMessages,
+    skipOriginalBlocks: accessibilityText.length > SLACK_MESSAGE_TEXT_HARD_LIMIT,
+  };
+}

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -68,26 +68,22 @@ describe("slackOutbound", () => {
       mediaLocalRoots: ["/tmp/workspace"],
       mediaReadFile: undefined,
     });
-    expect(sendMessageSlackMock).toHaveBeenNthCalledWith(
-      3,
-      "C123",
-      "final text\n\nBlock body",
-      expect.objectContaining({
-        cfg,
-        threadTs: undefined,
-        accountId: "default",
-        blocks: [
-          {
-            type: "section",
-            text: { type: "mrkdwn", text: "final text" },
-          },
-          {
-            type: "section",
-            text: { type: "mrkdwn", text: "Block body" },
-          },
-        ],
-      }),
-    );
+    expect(sendMessageSlackMock).toHaveBeenNthCalledWith(3, "C123", "final text\n\nBlock body", {
+      cfg,
+      threadTs: undefined,
+      accountId: "default",
+      authoredTextPlacement: "blocks",
+      blocks: [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "final text", verbatim: true },
+        },
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "Block body" },
+        },
+      ],
+    });
     expect(result).toEqual({ channel: "slack", messageId: "m-final" });
   });
 
@@ -113,7 +109,11 @@ describe("slackOutbound", () => {
       cfg,
       threadTs: undefined,
       accountId: "default",
-      blocks: [{ type: "divider" }],
+      authoredTextPlacement: "blocks",
+      blocks: [
+        { type: "divider" },
+        { type: "section", text: { type: "mrkdwn", text: "fallback text", verbatim: true } },
+      ],
     });
     expect(result).toEqual({ channel: "slack", messageId: "m-blocks" });
   });
@@ -142,7 +142,11 @@ describe("slackOutbound", () => {
       cfg,
       threadTs: "1712345678.123456",
       accountId: "default",
-      blocks: [{ type: "divider" }],
+      authoredTextPlacement: "blocks",
+      blocks: [
+        { type: "divider" },
+        { type: "section", text: { type: "mrkdwn", text: "fallback text", verbatim: true } },
+      ],
     });
   });
 
@@ -170,7 +174,11 @@ describe("slackOutbound", () => {
       cfg,
       threadTs: undefined,
       accountId: "default",
-      blocks: [{ type: "divider" }],
+      authoredTextPlacement: "blocks",
+      blocks: [
+        { type: "divider" },
+        { type: "section", text: { type: "mrkdwn", text: "fallback text", verbatim: true } },
+      ],
     });
   });
 

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -7,9 +7,8 @@ import {
   createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
 import {
+  normalizeMessagePresentation,
   resolveInteractiveTextFallback,
-  type InteractiveReply,
-  type MessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
@@ -19,44 +18,40 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { parseSlackBlocksInput, SLACK_MAX_BLOCKS } from "./blocks-input.js";
 import {
-  buildSlackInteractiveBlocks,
-  buildSlackPresentationBlocks,
-  resolveSlackBlockOffsets,
-  type SlackBlock,
-} from "./blocks-render.js";
-import { markdownToSlackMrkdwnChunks } from "./format.js";
+  resolveSlackAuthoredTextPlacement,
+  type SlackAuthoredTextPlacement,
+} from "./authored-text.js";
 import {
   compileSlackInteractiveReplies,
   isSlackInteractiveRepliesEnabled,
 } from "./interactive-replies.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
-import { SLACK_PRESENTATION_CAPABILITIES, SLACK_SECTION_TEXT_MAX } from "./presentation.js";
-import { resolveSlackReplyRenderPlan, resolveSlackReplyText } from "./reply-blocks.js";
+import { SLACK_PRESENTATION_CAPABILITIES } from "./presentation.js";
+import {
+  parseSlackReplyBlockSegments,
+  resolveSlackReplyBlockResolution,
+  resolveSlackReplyDeliveryMessages,
+  type SlackReplyBlockResolution,
+  type SlackReplyBlockSegment,
+} from "./reply-blocks.js";
 import type { SlackSendIdentity } from "./send.js";
 import { resolveSlackThreadTsValue } from "./thread-ts.js";
 
 type SlackSendFn = typeof import("./send.runtime.js").sendMessageSlack;
 
 type SlackOutboundChannelData = Record<string, unknown> & {
+  authoredTextPlacement?: SlackAuthoredTextPlacement;
   blocks?: unknown;
-  presentationBlocks?: SlackBlock[];
-  presentationFallbackText?: string;
+  renderedPresentationProvenance?: unknown;
+  renderedPresentationSegments?: SlackReplyBlockSegment[];
 };
 
-const loadSlackSendRuntime = createLazyRuntimeModule(() => import("./send.runtime.js"));
+// Only renderPresentation can mint this identity. Direct channelData must not
+// turn private ordered segments into arbitrary platform-send fanout.
+const SLACK_RENDERED_PRESENTATION_PROVENANCE = Object.freeze({});
 
-function resolveRenderedInteractiveBlocks(
-  interactive?: InteractiveReply,
-  previousBlocks?: readonly SlackBlock[],
-): SlackBlock[] | undefined {
-  if (!interactive) {
-    return undefined;
-  }
-  const blocks = buildSlackInteractiveBlocks(interactive, resolveSlackBlockOffsets(previousBlocks));
-  return blocks.length > 0 ? blocks : undefined;
-}
+const loadSlackSendRuntime = createLazyRuntimeModule(() => import("./send.runtime.js"));
 
 function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentity | undefined {
   if (!identity) {
@@ -74,72 +69,65 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
   return { username, iconUrl, iconEmoji };
 }
 
-function buildSlackTextSectionBlocks(text: string): SlackBlock[] {
-  return markdownToSlackMrkdwnChunks(text.trim(), SLACK_SECTION_TEXT_MAX).map(
-    (chunk): SlackBlock => ({
-      type: "section",
-      text: { type: "mrkdwn", text: chunk },
-    }),
+function resolveSlackOutboundBlockResolution(payload: ReplyPayload): SlackReplyBlockResolution {
+  const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
+  const presentation = normalizeMessagePresentation(payload.presentation);
+  const hasStructuredContent = Boolean(
+    slackData?.blocks !== undefined || presentation || payload.interactive?.blocks.length,
+  );
+  if (!hasStructuredContent) {
+    return {
+      authoredTextPlacement: resolveSlackAuthoredTextPlacement(payload),
+      segments: [],
+    };
+  }
+
+  const {
+    authoredTextPlacement: _authoredTextPlacement,
+    renderedPresentationProvenance: _renderedPresentationProvenance,
+    renderedPresentationSegments: _renderedPresentationSegments,
+    ...preservedSlackData
+  } = slackData ?? {};
+  return resolveSlackReplyBlockResolution(
+    {
+      ...payload,
+      channelData: {
+        ...payload.channelData,
+        slack: preservedSlackData,
+      },
+    },
+    { materializeAuthoredText: true },
   );
 }
 
-function normalizeComparableSlackText(text: string): string {
-  return text.trim().replace(/\s+/g, " ");
-}
-
-function isPayloadTextRepresentedInInteractive(
-  text: string,
-  interactive?: InteractiveReply,
-): boolean {
-  const target = normalizeComparableSlackText(text);
-  const fragments =
-    interactive?.blocks.flatMap((block) =>
-      block.type === "text" ? [normalizeComparableSlackText(block.text)] : [],
-    ) ?? [];
-  // Legacy inline controls split surrounding text into multiple interactive text blocks.
-  for (let start = 0; start < fragments.length; start += 1) {
-    let combined = "";
-    for (let end = start; end < fragments.length; end += 1) {
-      combined = normalizeComparableSlackText(`${combined} ${fragments[end]}`);
-      if (combined === target) {
-        return true;
-      }
-      if (combined.length > target.length) {
-        break;
-      }
-    }
-  }
-  return false;
-}
-
-function buildSlackVisiblePayloadTextBlocks(payload: ReplyPayload): SlackBlock[] {
-  const text = normalizeOptionalString(payload.text);
-  if (!text || isPayloadTextRepresentedInInteractive(text, payload.interactive)) {
-    return [];
-  }
-  return buildSlackTextSectionBlocks(text);
-}
-
-function withSlackPresentationData(
+function withSlackRenderedPresentation(
   payload: ReplyPayload,
   slackData: SlackOutboundChannelData | undefined,
-  presentationData: Pick<
-    SlackOutboundChannelData,
-    "presentationBlocks" | "presentationFallbackText"
-  >,
+  resolution: SlackReplyBlockResolution,
 ): ReplyPayload {
   const {
-    presentationBlocks: _presentationBlocks,
-    presentationFallbackText: _presentationFallbackText,
+    authoredTextPlacement: _authoredTextPlacement,
+    blocks: _blocks,
+    renderedPresentationProvenance: _renderedPresentationProvenance,
+    renderedPresentationSegments: _renderedPresentationSegments,
     ...preservedSlackData
   } = slackData ?? {};
   return {
     ...payload,
     channelData: {
       ...payload.channelData,
-      slack: { ...preservedSlackData, ...presentationData },
+      slack: {
+        ...preservedSlackData,
+        authoredTextPlacement: resolution.authoredTextPlacement,
+        renderedPresentationProvenance: SLACK_RENDERED_PRESENTATION_PROVENANCE,
+        renderedPresentationSegments: resolution.segments,
+      },
     },
   };
+}
+
+function readSlackAuthoredTextPlacement(value: unknown): SlackAuthoredTextPlacement | undefined {
+  return value === "none" || value === "blocks" || value === "outside-blocks" ? value : undefined;
 }
 
 async function sendSlackOutboundMessage(params: {
@@ -154,8 +142,9 @@ async function sendSlackOutboundMessage(params: {
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
   blocks?: NonNullable<Parameters<SlackSendFn>[2]>["blocks"];
-  separateTextAndBlocks?: boolean;
-  textIsSlackMrkdwn?: boolean;
+  authoredTextPlacement?: SlackAuthoredTextPlacement;
+  nativeDataFallbackBaseText?: string;
+  textIsSlackPlainText?: boolean;
   accountId?: string | null;
   deps?: { [channelId: string]: unknown } | null;
   replyToId?: string | null;
@@ -179,7 +168,9 @@ async function sendSlackOutboundMessage(params: {
     replyToId: params.replyToId,
     threadId: params.threadId,
   });
-  const result = await send(params.to, params.text, {
+  const sendOptions: NonNullable<Parameters<SlackSendFn>[2]> & {
+    authoredTextPlacement?: SlackAuthoredTextPlacement;
+  } = {
     cfg: params.cfg,
     threadTs,
     accountId: params.accountId ?? undefined,
@@ -192,21 +183,31 @@ async function sendSlackOutboundMessage(params: {
         }
       : {}),
     ...(params.blocks ? { blocks: params.blocks } : {}),
-    ...(params.separateTextAndBlocks ? { separateTextAndBlocks: true } : {}),
-    ...(params.textIsSlackMrkdwn ? { textIsSlackMrkdwn: true } : {}),
+    ...(params.authoredTextPlacement
+      ? { authoredTextPlacement: params.authoredTextPlacement }
+      : {}),
+    ...(Object.hasOwn(params, "nativeDataFallbackBaseText")
+      ? { nativeDataFallbackBaseText: params.nativeDataFallbackBaseText }
+      : {}),
+    ...(params.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
     ...(slackIdentity ? { identity: slackIdentity } : {}),
-    deliveryQueueId: params.deliveryQueueId,
-    onPlatformSendDispatch: params.onPlatformSendDispatch,
-    onDeliveryResult: params.onDeliveryResult
-      ? async (progress) => {
-          await params.onDeliveryResult?.(attachChannelToResult("slack", progress));
+    ...(params.deliveryQueueId ? { deliveryQueueId: params.deliveryQueueId } : {}),
+    ...(params.onPlatformSendDispatch
+      ? { onPlatformSendDispatch: params.onPlatformSendDispatch }
+      : {}),
+    ...(params.onDeliveryResult
+      ? {
+          onDeliveryResult: async (progress) => {
+            await params.onDeliveryResult?.(attachChannelToResult("slack", progress));
+          },
         }
-      : undefined,
-  });
+      : {}),
+  };
+  const result = await send(params.to, params.text, sendOptions);
   return result;
 }
 
-function createSlackAttachedSendAdapter(textIsSlackMrkdwn = false) {
+function createSlackAttachedSendAdapter() {
   return createAttachedChannelResultAdapter({
     channel: "slack",
     sendText: async ({
@@ -226,7 +227,6 @@ function createSlackAttachedSendAdapter(textIsSlackMrkdwn = false) {
         cfg,
         to,
         text,
-        textIsSlackMrkdwn,
         accountId,
         deps,
         replyToId,
@@ -249,6 +249,7 @@ function createSlackAttachedSendAdapter(textIsSlackMrkdwn = false) {
       replyToId,
       threadId,
       identity,
+      deliveryQueueId,
       onPlatformSendDispatch,
       onDeliveryResult,
     }) =>
@@ -256,7 +257,6 @@ function createSlackAttachedSendAdapter(textIsSlackMrkdwn = false) {
         cfg,
         to,
         text,
-        textIsSlackMrkdwn,
         mediaUrl,
         mediaAccess,
         mediaLocalRoots,
@@ -266,43 +266,11 @@ function createSlackAttachedSendAdapter(textIsSlackMrkdwn = false) {
         replyToId,
         threadId,
         identity,
+        deliveryQueueId,
         onPlatformSendDispatch,
         onDeliveryResult,
       }),
   });
-}
-
-function resolveSlackBlocks(payload: {
-  channelData?: Record<string, unknown>;
-  interactive?: InteractiveReply;
-  presentation?: MessagePresentation;
-  text?: string;
-}) {
-  const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
-  const nativeBlocks = parseSlackBlocksInput(slackData?.blocks) as SlackBlock[] | undefined;
-  const renderedPresentation =
-    slackData?.presentationBlocks ??
-    (payload.presentation
-      ? [
-          ...buildSlackVisiblePayloadTextBlocks(payload),
-          ...buildSlackPresentationBlocks(
-            payload.presentation,
-            resolveSlackBlockOffsets(nativeBlocks),
-          ),
-        ]
-      : []);
-  const previousBlocks = [...(nativeBlocks ?? []), ...renderedPresentation];
-  const renderedInteractive = resolveRenderedInteractiveBlocks(payload.interactive, previousBlocks);
-  const mergedBlocks = [...previousBlocks, ...(renderedInteractive ?? [])];
-  if (mergedBlocks.length === 0) {
-    return undefined;
-  }
-  if (mergedBlocks.length > SLACK_MAX_BLOCKS) {
-    throw new Error(
-      `Slack blocks cannot exceed ${SLACK_MAX_BLOCKS} items after interactive render`,
-    );
-  }
-  return mergedBlocks;
 }
 
 export const slackOutbound: ChannelOutboundAdapter = {
@@ -314,7 +282,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
       ? compileSlackInteractiveReplies(payload)
       : payload,
   presentationCapabilities: SLACK_PRESENTATION_CAPABILITIES,
-  renderPresentation: ({ payload, presentation, ctx }) => {
+  renderPresentation: ({ payload, ctx }) => {
     const payloadForBudget = isSlackInteractiveRepliesEnabled({
       cfg: ctx.cfg,
       accountId: ctx.accountId,
@@ -322,35 +290,10 @@ export const slackOutbound: ChannelOutboundAdapter = {
       ? compileSlackInteractiveReplies(payload)
       : payload;
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
-    const nativeBlocks = parseSlackBlocksInput(slackData?.blocks) as SlackBlock[] | undefined;
-    const renderPlan = resolveSlackReplyRenderPlan(
-      {
-        presentation,
-        interactive: payloadForBudget.interactive,
-        ...(nativeBlocks?.length ? { channelData: { slack: { blocks: nativeBlocks } } } : {}),
-      },
-      payloadForBudget.text,
-    );
-    const { blocks: _blocks, ...slackDataWithoutBlocks } = slackData ?? {};
-    if (renderPlan.mode === "split") {
-      // Native and interactive blocks remain authored content during presentation fallback.
-      // Ordinary Slack validation still rejects them rather than silently dropping them.
-      return withSlackPresentationData(
-        { ...payloadForBudget, text: renderPlan.hookText, interactive: undefined },
-        slackDataWithoutBlocks,
-        {
-          presentationBlocks: renderPlan.blockPart?.blocks ?? [],
-          presentationFallbackText: renderPlan.fallbackText,
-        },
-      );
-    }
-    // The planner owns block ordering, offsets, and complete accessibility text.
-    // Rebuilding any subset here can duplicate or hide authored Slack content.
-    return withSlackPresentationData(
-      { ...payloadForBudget, text: renderPlan.text, interactive: undefined },
-      slackDataWithoutBlocks,
-      { presentationBlocks: renderPlan.blocks ?? [] },
-    );
+    const resolution = resolveSlackOutboundBlockResolution(payloadForBudget);
+    return resolution.segments.length > 0
+      ? withSlackRenderedPresentation(payloadForBudget, slackData, resolution)
+      : null;
   },
   sendPayload: async (ctx) => {
     const payload = {
@@ -361,34 +304,38 @@ export const slackOutbound: ChannelOutboundAdapter = {
           interactive: ctx.payload.interactive,
         }) ?? "",
     };
-    const accessibleText = resolveSlackReplyText(payload);
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
-    const presentationFallbackText = normalizeOptionalString(slackData?.presentationFallbackText);
-    const textIsSlackMrkdwn = Boolean(
-      presentationFallbackText ||
-      payload.presentation?.blocks.some(
-        (block) => block.type === "chart" || block.type === "table",
-      ),
-    );
-    const blocks = resolveSlackBlocks(payload);
-    if (!blocks) {
+    const hasRenderedPresentationProvenance =
+      slackData?.renderedPresentationProvenance === SLACK_RENDERED_PRESENTATION_PROVENANCE;
+    const renderedSegments = hasRenderedPresentationProvenance
+      ? parseSlackReplyBlockSegments(slackData?.renderedPresentationSegments)
+      : undefined;
+    const renderedPlacement = hasRenderedPresentationProvenance
+      ? readSlackAuthoredTextPlacement(slackData?.authoredTextPlacement)
+      : undefined;
+    let resolution: SlackReplyBlockResolution;
+    if (renderedSegments) {
+      if (!renderedPlacement) {
+        throw new Error("Slack rendered presentation is missing authored text placement");
+      }
+      resolution = { authoredTextPlacement: renderedPlacement, segments: renderedSegments };
+    } else {
+      resolution = resolveSlackOutboundBlockResolution(payload);
+    }
+    if (resolution.segments.length === 0) {
       return await sendTextMediaPayload({
         channel: "slack",
-        ctx: {
-          ...ctx,
-          payload: presentationFallbackText
-            ? {
-                ...payload,
-                text: presentationFallbackText,
-              }
-            : { ...payload, text: accessibleText },
-        },
-        adapter: presentationFallbackText
-          ? { ...slackOutbound, ...createSlackAttachedSendAdapter(true) }
-          : slackOutbound,
+        ctx: { ...ctx, payload },
+        adapter: slackOutbound,
       });
     }
     const mediaUrls = resolvePayloadMediaUrls(payload);
+    const deliveryMessages = resolveSlackReplyDeliveryMessages({
+      authoredTextPlacement: resolution.authoredTextPlacement,
+      segments: resolution.segments,
+      text: payload.text,
+    });
+    const useSingleDeliveryMarker = mediaUrls.length === 0 && deliveryMessages.length === 1;
     return attachChannelToResult(
       "slack",
       await sendPayloadMediaSequenceAndFinalize({
@@ -408,35 +355,46 @@ export const slackOutbound: ChannelOutboundAdapter = {
             replyToId: ctx.replyToId,
             threadId: ctx.threadId,
             identity: ctx.identity,
+            deliveryQueueId: useSingleDeliveryMarker ? ctx.deliveryQueueId : undefined,
+            onPlatformSendDispatch: useSingleDeliveryMarker
+              ? ctx.onPlatformSendDispatch
+              : undefined,
             onDeliveryResult: ctx.onDeliveryResult,
           }),
         finalize: async () => {
-          return await sendSlackOutboundMessage({
-            cfg: ctx.cfg,
-            to: ctx.to,
-            text: presentationFallbackText ?? accessibleText,
-            ...(presentationFallbackText
-              ? { separateTextAndBlocks: true, textIsSlackMrkdwn: true }
-              : textIsSlackMrkdwn
-                ? { textIsSlackMrkdwn: true }
+          let lastResult: Awaited<ReturnType<SlackSendFn>> | undefined;
+          for (const message of deliveryMessages) {
+            lastResult = await sendSlackOutboundMessage({
+              cfg: ctx.cfg,
+              to: ctx.to,
+              text: message.text,
+              mediaAccess: ctx.mediaAccess,
+              mediaLocalRoots: ctx.mediaLocalRoots,
+              mediaReadFile: ctx.mediaReadFile,
+              ...(message.blocks ? { blocks: message.blocks } : {}),
+              ...(message.authoredTextPlacement
+                ? { authoredTextPlacement: message.authoredTextPlacement }
                 : {}),
-            mediaAccess: ctx.mediaAccess,
-            mediaLocalRoots: ctx.mediaLocalRoots,
-            mediaReadFile: ctx.mediaReadFile,
-            blocks,
-            accountId: ctx.accountId,
-            deps: ctx.deps,
-            replyToId: ctx.replyToId,
-            threadId: ctx.threadId,
-            identity: ctx.identity,
-            ...(mediaUrls.length === 0
-              ? {
-                  deliveryQueueId: ctx.deliveryQueueId,
-                  onPlatformSendDispatch: ctx.onPlatformSendDispatch,
-                }
-              : {}),
-            onDeliveryResult: ctx.onDeliveryResult,
-          });
+              ...(message.nativeDataFallbackBaseText
+                ? { nativeDataFallbackBaseText: message.nativeDataFallbackBaseText }
+                : {}),
+              ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+              accountId: ctx.accountId,
+              deps: ctx.deps,
+              replyToId: ctx.replyToId,
+              threadId: ctx.threadId,
+              identity: ctx.identity,
+              deliveryQueueId: useSingleDeliveryMarker ? ctx.deliveryQueueId : undefined,
+              onPlatformSendDispatch: useSingleDeliveryMarker
+                ? ctx.onPlatformSendDispatch
+                : undefined,
+              onDeliveryResult: ctx.onDeliveryResult,
+            });
+          }
+          if (!lastResult) {
+            throw new Error("Slack rendered presentation produced no deliverable segment");
+          }
+          return lastResult;
         },
       }),
     );

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -1,9 +1,10 @@
 // Slack tests cover outbound payload plugin behavior.
 import { installChannelOutboundPayloadContractSuite } from "openclaw/plugin-sdk/channel-contract-testing";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSlackOutboundPayloadHarness, slackOutbound } from "../test-api.js";
 import { createSlackSendTestClient } from "./blocks.test-helpers.js";
+import type { SlackReplyBlockSegment } from "./reply-blocks.js";
 import { sendMessageSlack } from "./send.js";
 
 function createHarness(params: {
@@ -26,24 +27,65 @@ function sendCall(sendMock: MockWithCalls, index: number): unknown[] {
 }
 
 function sendOptions(call: unknown[]): {
+  authoredTextPlacement?: "none" | "blocks" | "outside-blocks";
   blocks?: Array<{
     block_id?: string;
     elements?: Array<{ action_id?: string }>;
     type?: string;
   }>;
   mediaUrl?: string;
+  nativeDataFallbackBaseText?: string;
+  textIsSlackPlainText?: boolean;
 } {
   const options = call?.[2];
   if (!options) {
     throw new Error("Expected Slack send options");
   }
   return options as {
+    authoredTextPlacement?: "none" | "blocks" | "outside-blocks";
     blocks?: Array<{
       block_id?: string;
       elements?: Array<{ action_id?: string }>;
       type?: string;
     }>;
     mediaUrl?: string;
+    nativeDataFallbackBaseText?: string;
+    textIsSlackPlainText?: boolean;
+  };
+}
+
+function renderedPresentationSegments(payload: ReplyPayload | null | undefined) {
+  const value = (
+    payload?.channelData?.slack as { renderedPresentationSegments?: unknown } | undefined
+  )?.renderedPresentationSegments;
+  if (!Array.isArray(value)) {
+    throw new Error("Expected rendered Slack presentation segments");
+  }
+  return value as SlackReplyBlockSegment[];
+}
+
+function createMixedPresentationPayload(): ReplyPayload {
+  const headers = Array.from({ length: 21 }, (_entry, index) => `Column ${String(index)}`);
+  return {
+    text: "Summary",
+    presentation: {
+      blocks: [
+        {
+          type: "chart",
+          chartType: "bar",
+          title: "Pipeline",
+          categories: ["Open"],
+          series: [{ name: "Issues", values: [5] }],
+        },
+        {
+          type: "table",
+          caption: "Wide pipeline",
+          headers,
+          rows: [headers.map((_header, index) => `Value ${String(index)}`)],
+        },
+        { type: "buttons", buttons: [{ label: "Stage", value: "stage" }] },
+      ],
+    },
   };
 }
 
@@ -63,11 +105,38 @@ describe("slackOutbound sendPayload", () => {
     expect(call[0]).toBe(to);
     expect(call[1]).toBe("Fallback summary");
     expect(sendOptions(call).blocks).toEqual([
-      { type: "section", text: { type: "mrkdwn", text: "Fallback summary" } },
+      { type: "section", text: { type: "mrkdwn", text: "Fallback summary", verbatim: true } },
       { type: "divider" },
     ]);
     expect(result.channel).toBe("slack");
     expect(result.messageId).toBe("sl-1");
+  });
+
+  it("keeps Markdown-authored text placed in its compiled section", async () => {
+    const payload: ReplyPayload = {
+      text: "**Overview**",
+      presentation: { blocks: [{ type: "divider" }] },
+    };
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: { cfg: {}, to: "C12345", text: payload.text ?? "", payload },
+    });
+    if (!rendered) {
+      throw new Error("Expected rendered Slack segments");
+    }
+    const { presentation: _presentation, ...payloadForSend } = rendered;
+    const { run, sendMock } = createHarness({ payload: payloadForSend });
+
+    await run();
+
+    const call = sendCall(sendMock, 0);
+    expect(call[1]).toBe("*Overview*");
+    expect(sendOptions(call).authoredTextPlacement).toBe("blocks");
+    expect(sendOptions(call).blocks).toEqual([
+      { type: "section", text: { type: "mrkdwn", text: "*Overview*", verbatim: true } },
+      { type: "divider" },
+    ]);
   });
 
   it("renders native charts with complete top-level accessibility text", async () => {
@@ -102,7 +171,7 @@ describe("slackOutbound sendPayload", () => {
       ].join("\n"),
     );
     expect(sendOptions(call).blocks).toEqual([
-      { type: "section", text: { type: "mrkdwn", text: "Revenue summary" } },
+      { type: "section", text: { type: "mrkdwn", text: "Revenue summary", verbatim: true } },
       {
         type: "data_visualization",
         title: "Quarterly revenue",
@@ -121,54 +190,8 @@ describe("slackOutbound sendPayload", () => {
         },
       },
     ]);
-  });
-
-  it("uses the prepared chart plan for raw siblings and interactive controls", async () => {
-    const payload: ReplyPayload = {
-      text: "Revenue summary",
-      channelData: {
-        slack: {
-          blocks: [{ type: "section", text: { type: "mrkdwn", text: "Raw workspace context" } }],
-        },
-      },
-      interactive: {
-        blocks: [{ type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] }],
-      },
-      presentation: {
-        blocks: [
-          {
-            type: "chart",
-            chartType: "pie",
-            title: "Revenue mix",
-            segments: [
-              { label: "Product", value: 60 },
-              { label: "Services", value: 40 },
-            ],
-          },
-        ],
-      },
-    };
-
-    const rendered = await slackOutbound.renderPresentation?.({
-      payload,
-      presentation: payload.presentation!,
-      ctx: { cfg: {}, to: "C12345", text: payload.text ?? "", payload },
-    });
-    const slackData = rendered?.channelData?.slack as {
-      blocks?: unknown[];
-      presentationBlocks?: Array<{ type?: string }>;
-    };
-
-    expect(slackData.blocks).toBeUndefined();
-    expect(slackData.presentationBlocks?.map((block) => block.type)).toEqual([
-      "section",
-      "section",
-      "data_visualization",
-      "actions",
-    ]);
-    expect(rendered?.interactive).toBeUndefined();
-    expect(rendered?.text).toContain("Raw workspace context");
-    expect(rendered?.text).toContain("- Refresh");
+    expect(sendOptions(call).authoredTextPlacement).toBe("blocks");
+    expect(sendOptions(call).nativeDataFallbackBaseText).toBeUndefined();
   });
 
   it("renders native tables with complete top-level accessibility text", async () => {
@@ -200,12 +223,13 @@ describe("slackOutbound sendPayload", () => {
         "Pipeline summary",
         "",
         "Open pipeline (table)",
-        "- Account: Acme; ARR: 125000",
-        "- Account: Globex; ARR: 82000",
+        "Account\tARR",
+        "Acme\t125000",
+        "Globex\t82000",
       ].join("\n"),
     );
     expect(sendOptions(call).blocks).toEqual([
-      { type: "section", text: { type: "mrkdwn", text: "Pipeline summary" } },
+      { type: "section", text: { type: "mrkdwn", text: "Pipeline summary", verbatim: true } },
       {
         type: "data_table",
         caption: "Open pipeline",
@@ -226,6 +250,165 @@ describe("slackOutbound sendPayload", () => {
         ],
       },
     ]);
+    expect(sendOptions(call).authoredTextPlacement).toBe("blocks");
+    expect(sendOptions(call).nativeDataFallbackBaseText).toBeUndefined();
+  });
+
+  it.each([
+    {
+      expectedPlacement: "blocks" as const,
+      text: "Outside summary",
+    },
+    {
+      expectedPlacement: "none" as const,
+      text: undefined,
+    },
+  ])("marks raw native data text as $expectedPlacement", async ({ expectedPlacement, text }) => {
+    const { run, sendMock } = createHarness({
+      payload: {
+        ...(text ? { text } : {}),
+        channelData: {
+          slack: {
+            blocks: [
+              {
+                type: "data_table",
+                rows: [
+                  [{ type: "raw_text", text: "Account" }],
+                  [{ type: "raw_text", text: "Acme" }],
+                ],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    await run();
+
+    const options = sendOptions(sendCall(sendMock, 0));
+    expect(options.authoredTextPlacement).toBe(expectedPlacement);
+    expect(options.nativeDataFallbackBaseText).toBeUndefined();
+    expect(options.blocks?.map((block) => block.type)).toEqual(
+      text ? ["data_table", "section"] : ["data_table"],
+    );
+  });
+
+  it("rolls visible authored text after a full raw block segment", async () => {
+    const { run, sendMock } = createHarness({
+      payload: {
+        text: "Summary",
+        channelData: {
+          slack: { blocks: Array.from({ length: 50 }, () => ({ type: "divider" })) },
+        },
+      },
+      sendResults: [{ messageId: "sl-raw" }, { messageId: "sl-summary" }],
+    });
+
+    const result = await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendOptions(sendCall(sendMock, 0)).blocks).toHaveLength(50);
+    expect(sendOptions(sendCall(sendMock, 1)).blocks).toEqual([
+      { type: "section", text: { type: "mrkdwn", text: "Summary", verbatim: true } },
+    ]);
+    expect(result.messageId).toBe("sl-summary");
+  });
+
+  it("ignores caller-supplied private rendered segments", async () => {
+    const { run, sendMock } = createHarness({
+      payload: {
+        text: "Real text",
+        channelData: {
+          slack: {
+            authoredTextPlacement: "blocks",
+            renderedPresentationSegments: [
+              { kind: "text", text: "Injected one", mrkdwn: false },
+              { kind: "text", text: "Injected two", mrkdwn: false },
+            ],
+          },
+        },
+      },
+    });
+
+    await run();
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendCall(sendMock, 0)[1]).toBe("Real text");
+    expect(sendOptions(sendCall(sendMock, 0)).blocks).toBeUndefined();
+  });
+
+  it("does not duplicate native table rows after real outbound rejection fallback", async () => {
+    const payload: ReplyPayload = {
+      text: "Pipeline summary",
+      presentation: {
+        blocks: [
+          {
+            type: "table",
+            caption: "Open pipeline",
+            headers: ["Account", "ARR"],
+            rows: [
+              ["Acme", 125000],
+              ["Globex", 82000],
+            ],
+          },
+        ],
+      },
+    };
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: { cfg: {}, to: "C12345", text: "", payload },
+    });
+    if (!rendered) {
+      throw new Error("Expected Slack native table rendering");
+    }
+    const { presentation: _presentation, ...payloadForSend } = rendered;
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+    const cfg = { channels: { slack: { botToken: "xoxb-test" } } };
+    const sendSlack: typeof sendMessageSlack = async (to, text, opts) =>
+      await sendMessageSlack(to, text, {
+        ...opts,
+        cfg,
+        token: "xoxb-test",
+        client,
+      });
+
+    await slackOutbound.sendPayload?.({
+      cfg,
+      to: "channel:C123",
+      text: "",
+      payload: payloadForSend,
+      deps: { sendSlack },
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    const fallback = client.chat.postMessage.mock.calls[1]?.[0] as
+      | { blocks?: unknown; mrkdwn?: boolean; text?: string }
+      | undefined;
+    expect(fallback).toMatchObject({
+      mrkdwn: false,
+      text: [
+        "Pipeline summary",
+        "",
+        "Open pipeline (table)",
+        "Account\tARR",
+        "Acme\t125000",
+        "Globex\t82000",
+      ].join("\n"),
+    });
+    expect(fallback?.blocks).toEqual([
+      { type: "section", text: { type: "mrkdwn", text: "Pipeline summary", verbatim: true } },
+      {
+        type: "section",
+        text: {
+          type: "plain_text",
+          text: "Open pipeline (table)\nAccount\tARR\nAcme\t125000\nGlobex\t82000",
+        },
+      },
+    ]);
+    expect(fallback?.text?.match(/Acme/gu)).toHaveLength(1);
+    expect(fallback?.text).not.toContain("- Account: Acme");
   });
 
   it("posts Slack-safe text when a portable table cannot render natively", async () => {
@@ -246,6 +429,11 @@ describe("slackOutbound sendPayload", () => {
             type: "buttons",
             buttons: [{ label: "Refresh", value: "refresh" }],
           },
+          {
+            type: "select",
+            placeholder: "Window",
+            options: [{ label: "Recent", value: "recent" }],
+          },
         ],
       },
       presentation: {
@@ -258,6 +446,15 @@ describe("slackOutbound sendPayload", () => {
             rows: Array.from({ length: 100 }, (_entry, index) => [
               index === 0 ? "<@U123>" : `owner-${String(index)} ${"x".repeat(110)}`,
             ]),
+          },
+          {
+            type: "buttons",
+            buttons: [{ label: "Stage", value: "stage" }],
+          },
+          {
+            type: "select",
+            placeholder: "Lane",
+            options: [{ label: "Production", value: "production" }],
           },
         ],
       },
@@ -274,13 +471,17 @@ describe("slackOutbound sendPayload", () => {
     const { presentation: _presentation, ...payloadForSend } = rendered;
     const client = createSlackSendTestClient();
     const cfg = { channels: { slack: { botToken: "xoxb-test" } } };
-    const sendSlack: typeof sendMessageSlack = async (to, text, opts) =>
-      await sendMessageSlack(to, text, {
+    const capturedSendOptions: Array<NonNullable<Parameters<typeof sendMessageSlack>[2]>> = [];
+    const onPlatformSendDispatch = vi.fn(async () => {});
+    const sendSlack: typeof sendMessageSlack = async (to, text, opts) => {
+      capturedSendOptions.push(opts ?? {});
+      return await sendMessageSlack(to, text, {
         ...opts,
         cfg,
         token: "xoxb-test",
         client,
       });
+    };
 
     await slackOutbound.sendPayload?.({
       cfg,
@@ -288,129 +489,68 @@ describe("slackOutbound sendPayload", () => {
       text: "",
       payload: payloadForSend,
       deps: { sendSlack },
+      deliveryQueueId: "queue-1",
+      onPlatformSendDispatch,
     });
 
-    const postedText = client.chat.postMessage.mock.calls
-      .map(([raw]) => (raw as { text?: string }).text ?? "")
-      .join("\n");
-    expect(client.chat.postMessage.mock.calls.length).toBeGreaterThan(1);
+    expect(client.chat.postMessage.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(capturedSendOptions).not.toHaveLength(0);
+    expect(capturedSendOptions.every((opts) => opts.deliveryQueueId === undefined)).toBe(true);
+    expect(capturedSendOptions.every((opts) => opts.onPlatformSendDispatch === undefined)).toBe(
+      true,
+    );
     expect(client.chat.postMessage.mock.calls[0]?.[0]).toMatchObject({
+      text: expect.stringContaining("Pipeline <!channel>"),
+      mrkdwn: false,
       blocks: [
         {
           type: "section",
           text: { type: "mrkdwn", text: "Existing raw block only" },
         },
         {
-          type: "actions",
-          elements: [expect.objectContaining({ type: "button", value: "refresh" })],
+          type: "header",
+          text: { type: "plain_text", text: "Pipeline <!channel>", emoji: true },
         },
       ],
     });
+    const fallbackCalls = client.chat.postMessage.mock.calls.slice(1, -1);
     expect(
-      client.chat.postMessage.mock.calls
-        .slice(1)
-        .every(([raw]) => (raw as { blocks?: unknown }).blocks === undefined),
+      fallbackCalls.every(
+        ([raw]) =>
+          (raw as { blocks?: unknown; mrkdwn?: boolean }).blocks === undefined &&
+          (raw as { mrkdwn?: boolean }).mrkdwn === false,
+      ),
     ).toBe(true);
-    expect(postedText).toContain("Pipeline &lt;!channel&gt;");
-    expect(postedText).toContain("Existing raw block only");
-    expect(postedText).toContain("- Owner: &lt;@U123&gt;");
-    expect(postedText).toContain("- Owner: owner-99");
-    expect(postedText).not.toContain("<!channel>");
-    expect(postedText).not.toContain("<@U123>");
-  });
-
-  it("keeps a native table beside its chunked accessibility fallback", async () => {
-    const payload: ReplyPayload = {
-      channelData: {
-        slack: {
-          blocks: [
-            {
-              type: "data_table",
-              caption: "Native accounts",
-              row_header_column_index: 0,
-              rows: [
-                [{ type: "raw_text", text: "Account" }],
-                ...Array.from({ length: 90 }, (_entry, index) => [
-                  {
-                    type: "raw_text",
-                    text: `owner-${String(index)}-${"x".repeat(80)}`,
-                  },
-                ]),
-              ],
-            },
-            {
-              type: "section",
-              text: { type: "mrkdwn", text: "Existing raw block only" },
-            },
-          ],
-        },
-      },
-      presentation: {
-        blocks: [
-          {
-            type: "buttons",
-            buttons: [{ label: "Refresh", value: "refresh" }],
-          },
-        ],
-      },
-    };
-
-    const rendered = await slackOutbound.renderPresentation?.({
-      payload,
-      presentation: payload.presentation!,
-      ctx: { cfg: {}, to: "C12345", text: "", payload },
-    });
-    if (!rendered) {
-      throw new Error("Expected Slack to split the native table fallback");
-    }
-    const slackData = rendered.channelData?.slack as {
-      blocks?: unknown[];
-      presentationBlocks?: unknown[];
-      presentationFallbackText?: string;
-    };
-    expect(slackData.blocks).toBeUndefined();
-    expect(slackData.presentationBlocks).toEqual([
-      expect.objectContaining({ type: "data_table", caption: "Native accounts" }),
-      expect.objectContaining({
-        type: "actions",
-        elements: [expect.objectContaining({ type: "button", value: "refresh" })],
-      }),
-    ]);
-    expect(slackData.presentationFallbackText).toContain("Existing raw block only");
-    expect(slackData.presentationFallbackText).toContain("Native accounts (table)");
-    expect(slackData.presentationFallbackText).toContain("owner-89-");
-
-    const { presentation: _presentation, ...payloadForSend } = rendered;
-    const client = createSlackSendTestClient();
-    const cfg = { channels: { slack: { botToken: "xoxb-test" } } };
-    const sendSlack: typeof sendMessageSlack = async (to, text, opts) =>
-      await sendMessageSlack(to, text, {
-        ...opts,
-        cfg,
-        token: "xoxb-test",
-        client,
-      });
-
-    await slackOutbound.sendPayload?.({
-      cfg,
-      to: "channel:C123",
-      text: "",
-      payload: payloadForSend,
-      deps: { sendSlack },
-    });
-
-    expect(client.chat.postMessage.mock.calls[0]?.[0]).toMatchObject({
-      text: "Native accounts (table)\n\n- Refresh",
+    const fallbackText = fallbackCalls
+      .map(([raw]) => (raw as { text?: string }).text ?? "")
+      .join("");
+    expect(fallbackText).toContain("- Owner: <@U123>");
+    expect(fallbackText).toContain("- Owner: owner-99");
+    expect(client.chat.postMessage.mock.calls.at(-1)?.[0]).toMatchObject({
+      mrkdwn: false,
       blocks: [
-        expect.objectContaining({ type: "data_table", caption: "Native accounts" }),
-        expect.objectContaining({ type: "actions" }),
+        {
+          type: "actions",
+          block_id: "openclaw_reply_buttons_1",
+          elements: [expect.objectContaining({ value: "stage" })],
+        },
+        {
+          type: "actions",
+          block_id: "openclaw_reply_select_1",
+          elements: [expect.objectContaining({ action_id: "openclaw:reply_select:1" })],
+        },
+        {
+          type: "actions",
+          block_id: "openclaw_reply_buttons_2",
+          elements: [expect.objectContaining({ value: "refresh" })],
+        },
+        {
+          type: "actions",
+          block_id: "openclaw_reply_select_2",
+          elements: [expect.objectContaining({ action_id: "openclaw:reply_select:2" })],
+        },
       ],
     });
-    expect(
-      client.chat.postMessage.mock.calls
-        .slice(1)
-        .every(([raw]) => (raw as { blocks?: unknown }).blocks === undefined),
-    ).toBe(true);
   });
 
   it("keeps the full portable fallback when any control cannot render natively", async () => {
@@ -439,11 +579,9 @@ describe("slackOutbound sendPayload", () => {
       },
     });
 
-    expect(rendered?.channelData?.slack).toEqual({
-      presentationBlocks: [],
-      presentationFallbackText: "Fallback\n\nActions\n\nChoose an action\n\n- Status: `/status`",
-    });
-    expect(rendered?.text).toBe("Fallback\n\nActions\n\nChoose an action\n\n- Status: `/status`");
+    const segments = renderedPresentationSegments(rendered);
+    expect(segments.map((segment) => segment.kind)).toEqual(["blocks", "text"]);
+    expect(segments[1]).toEqual({ kind: "text", text: "- Status: `/status`", mrkdwn: false });
   });
 
   it("renders the portable fallback visibly when native Slack blocks survive", async () => {
@@ -467,11 +605,17 @@ describe("slackOutbound sendPayload", () => {
       ctx: { cfg: {}, to: "C12345", text: "", payload },
     });
 
-    expect(rendered?.channelData?.slack).toEqual({
-      presentationBlocks: [{ type: "divider" }],
-      presentationFallbackText: "Actions\n\nChoose an action\n\n- Status: `/status`",
+    const segments = renderedPresentationSegments(rendered);
+    expect(segments.map((segment) => segment.kind)).toEqual(["blocks", "text"]);
+    expect(segments[0]).toMatchObject({
+      kind: "blocks",
+      blocks: [
+        { type: "divider" },
+        { type: "header", text: { text: "Actions" } },
+        { type: "section", text: { text: "Choose an action" } },
+      ],
     });
-    expect(rendered?.text).toBe("Actions\n\nChoose an action\n\n- Status: `/status`");
+    expect(segments[1]).toEqual({ kind: "text", text: "- Status: `/status`", mrkdwn: false });
   });
 
   it("renders web-app buttons as native Slack links", async () => {
@@ -498,8 +642,10 @@ describe("slackOutbound sendPayload", () => {
       ctx: { cfg: {}, to: "C12345", text: "", payload },
     });
 
-    expect(rendered?.channelData?.slack).toEqual({
-      presentationBlocks: [
+    const [segment] = renderedPresentationSegments(rendered);
+    expect(segment).toMatchObject({
+      kind: "blocks",
+      blocks: [
         expect.objectContaining({
           type: "actions",
           elements: [
@@ -512,11 +658,10 @@ describe("slackOutbound sendPayload", () => {
         }),
       ],
     });
-    const linkButton = (
-      rendered?.channelData?.slack as {
-        presentationBlocks?: Array<{ elements?: Array<Record<string, unknown>> }>;
-      }
-    )?.presentationBlocks?.[0]?.elements?.[0];
+    const linkButton =
+      segment?.kind === "blocks"
+        ? (segment.blocks[0] as { elements?: Array<Record<string, unknown>> }).elements?.[0]
+        : undefined;
     expect(linkButton).not.toHaveProperty("value");
   });
 
@@ -545,17 +690,12 @@ describe("slackOutbound sendPayload", () => {
       ctx: { cfg: {}, to: "C12345", text: "", payload },
     });
 
-    expect(rendered?.channelData?.slack).toEqual({
-      presentationBlocks: [],
-      presentationFallbackText:
-        presentation.title ??
-        (presentation.blocks[0] && "text" in presentation.blocks[0]
-          ? presentation.blocks[0].text
-          : undefined),
-    });
+    const segments = renderedPresentationSegments(rendered);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({ kind: "text", mrkdwn: false });
   });
 
-  it("marks a separate visible fallback when presentation cannot fit Slack's block limit", async () => {
+  it("starts a new segment when presentation content crosses Slack's block limit", async () => {
     const payload: ReplyPayload = {
       channelData: {
         slack: {
@@ -579,18 +719,78 @@ describe("slackOutbound sendPayload", () => {
       ctx: { cfg: {}, to: "C12345", text: "", payload },
     });
 
-    const slackData = rendered?.channelData?.slack as {
-      blocks?: unknown[];
-      presentationBlocks?: Array<{ type?: string }>;
-      presentationFallbackText?: string;
+    const segments = renderedPresentationSegments(rendered);
+    expect(segments.map((segment) => segment.kind)).toEqual(["blocks", "blocks"]);
+    expect(segments[0]?.kind === "blocks" ? segments[0].blocks : []).toHaveLength(50);
+    expect(segments[1]).toMatchObject({
+      kind: "blocks",
+      blocks: [{ type: "divider" }, { type: "actions" }],
+    });
+  });
+
+  it("uses the full ordered table fallback when preserved siblings exceed the block limit", async () => {
+    const headers = Array.from({ length: 21 }, (_entry, index) => `Column ${String(index)}`);
+    const payload: ReplyPayload = {
+      channelData: {
+        slack: { blocks: Array.from({ length: 49 }, () => ({ type: "divider" })) },
+      },
+      presentation: {
+        blocks: [
+          {
+            type: "table",
+            caption: "Wide pipeline",
+            headers,
+            rows: [headers.map((_header, index) => `Value ${String(index)}`)],
+          },
+          {
+            type: "buttons",
+            buttons: [{ label: "Stage", value: "stage" }],
+          },
+        ],
+      },
+      interactive: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Refresh", value: "refresh" }],
+          },
+        ],
+      },
     };
-    expect(slackData.blocks).toBeUndefined();
-    expect(slackData.presentationBlocks).toHaveLength(50);
-    expect(slackData.presentationBlocks?.slice(0, 49)).toEqual(
-      Array.from({ length: 49 }, () => ({ type: "divider" })),
-    );
-    expect(slackData.presentationBlocks?.at(-1)).toMatchObject({ type: "actions" });
-    expect(slackData.presentationFallbackText).toBe("Deploy status");
+
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: { cfg: {}, to: "C12345", text: "", payload },
+    });
+    if (!rendered) {
+      throw new Error("Expected Slack to render a full table fallback");
+    }
+    const segments = renderedPresentationSegments(rendered);
+    expect(segments.map((segment) => segment.kind)).toEqual(["blocks", "text", "blocks"]);
+    expect(segments[0]?.kind === "blocks" ? segments[0].blocks : []).toHaveLength(49);
+    const fallback = segments[1]?.kind === "text" ? segments[1].text : "";
+    expect(fallback).toContain("Wide pipeline (table)");
+    expect(fallback).toContain("Column 20: Value 20");
+    expect(segments[2]).toMatchObject({
+      kind: "blocks",
+      blocks: [{ block_id: "openclaw_reply_buttons_1" }, { block_id: "openclaw_reply_buttons_2" }],
+    });
+
+    const { run, sendMock } = createHarness({
+      payload: rendered,
+      sendResults: [
+        { messageId: "sl-before" },
+        { messageId: "sl-fallback" },
+        { messageId: "sl-after" },
+      ],
+    });
+    await expect(run()).resolves.toMatchObject({ messageId: "sl-after" });
+    expect(sendMock).toHaveBeenCalledTimes(3);
+    expect(sendOptions(sendCall(sendMock, 0)).blocks).toHaveLength(49);
+    expect(sendCall(sendMock, 1)[1]).toBe(fallback);
+    expect(sendOptions(sendCall(sendMock, 1)).blocks).toBeUndefined();
+    expect(sendOptions(sendCall(sendMock, 2)).blocks).toHaveLength(2);
   });
 
   it("counts legacy interactive blocks compiled after presentation rendering", async () => {
@@ -624,21 +824,13 @@ describe("slackOutbound sendPayload", () => {
       },
     });
 
-    const slackData = rendered?.channelData?.slack as {
-      blocks?: unknown[];
-      presentationBlocks?: Array<{ type?: string }>;
-      presentationFallbackText?: string;
-    };
-    expect(slackData.blocks).toBeUndefined();
-    expect(slackData.presentationBlocks).toHaveLength(50);
-    expect(slackData.presentationBlocks?.slice(0, 48)).toEqual(
-      Array.from({ length: 48 }, () => ({ type: "divider" })),
-    );
-    expect(slackData.presentationBlocks?.slice(-2)).toEqual([
-      expect.objectContaining({ type: "section" }),
-      expect.objectContaining({ type: "actions" }),
-    ]);
-    expect(slackData.presentationFallbackText).toContain("Deploy status");
+    const segments = renderedPresentationSegments(rendered);
+    expect(segments.map((segment) => segment.kind)).toEqual(["blocks", "blocks"]);
+    expect(segments[0]?.kind === "blocks" ? segments[0].blocks : []).toHaveLength(50);
+    expect(segments[1]).toMatchObject({
+      kind: "blocks",
+      blocks: [{ type: "section" }, { type: "actions" }],
+    });
   });
 
   it("does not duplicate text compiled around inline legacy controls", async () => {
@@ -667,40 +859,215 @@ describe("slackOutbound sendPayload", () => {
       },
     });
 
-    expect(rendered?.channelData?.slack).toEqual({
-      presentationBlocks: [
+    expect(rendered?.channelData?.slack).toMatchObject({ authoredTextPlacement: "blocks" });
+    const segments = renderedPresentationSegments(rendered);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      kind: "blocks",
+      blocks: [
         { type: "divider" },
-        { type: "section", text: { type: "mrkdwn", text: "Before" } },
-        expect.objectContaining({ type: "actions" }),
-        { type: "section", text: { type: "mrkdwn", text: "after" } },
+        { type: "section", text: { text: "Before" } },
+        { type: "actions" },
+        { type: "section", text: { text: "after" } },
       ],
     });
-    expect(rendered?.interactive).toBeUndefined();
+    expect(rendered?.interactive?.blocks).toEqual([
+      { type: "text", text: "Before" },
+      { type: "buttons", buttons: [{ label: "OK", value: "ok" }] },
+      { type: "text", text: "after" },
+    ]);
   });
 
-  it("sends a block-budget fallback as a separate visible message", async () => {
-    const { run, sendMock, to } = createHarness({
-      payload: {
-        text: "Notification fallback",
-        channelData: {
-          slack: {
-            blocks: [{ type: "divider" }],
-            presentationFallbackText: "Visible presentation fallback",
+  it("marks inline legacy text as represented when native data is compiled with it", async () => {
+    const payload: ReplyPayload = {
+      text: "Before [[slack_buttons: OK:ok]] after",
+      presentation: {
+        blocks: [
+          {
+            type: "table",
+            caption: "Accounts",
+            headers: ["Account"],
+            rows: [["Acme"]],
           },
+        ],
+      },
+    };
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+          appToken: "xapp-test",
+          capabilities: { interactiveReplies: true },
         },
       },
-      sendResults: [{ messageId: "sl-blocks" }],
+    };
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: {
+        cfg,
+        accountId: "default",
+        to: "C12345",
+        text: payload.text ?? "",
+        payload,
+      },
+    });
+    if (!rendered) {
+      throw new Error("Expected Slack native table rendering");
+    }
+
+    expect(rendered.channelData?.slack).toMatchObject({
+      authoredTextPlacement: "blocks",
+    });
+    const { presentation: _presentation, ...payloadForSend } = rendered;
+    const { run, sendMock } = createHarness({ payload: payloadForSend });
+
+    await run();
+
+    const options = sendOptions(sendCall(sendMock, 0));
+    expect(options.authoredTextPlacement).toBe("blocks");
+    expect(options.nativeDataFallbackBaseText).toBeUndefined();
+    expect(options.blocks?.map((block) => block.type)).toEqual([
+      "data_table",
+      "section",
+      "actions",
+      "section",
+    ]);
+  });
+
+  it("preserves mixed chart, table fallback, and control order after presentation stripping", async () => {
+    const payload = createMixedPresentationPayload();
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: { cfg: {}, to: "C12345", text: payload.text ?? "", payload },
+    });
+    if (!rendered) {
+      throw new Error("Expected rendered Slack segments");
+    }
+    const { presentation: _presentation, ...payloadForSend } = rendered;
+    const { run, sendMock } = createHarness({
+      payload: payloadForSend,
+      sendResults: [
+        { messageId: "sl-chart" },
+        { messageId: "sl-table" },
+        { messageId: "sl-controls" },
+      ],
     });
 
     const result = await run();
 
-    expect(sendMock).toHaveBeenCalledOnce();
-    const call = sendCall(sendMock, 0);
-    expect(call[0]).toBe(to);
-    expect(call[1]).toBe("Visible presentation fallback");
-    expect(sendOptions(call).blocks).toEqual([{ type: "divider" }]);
-    expect(call[2]).toMatchObject({ separateTextAndBlocks: true, textIsSlackMrkdwn: true });
-    expect(result.messageId).toBe("sl-blocks");
+    expect(sendMock).toHaveBeenCalledTimes(3);
+    expect(sendOptions(sendCall(sendMock, 0)).blocks?.map((block) => block.type)).toEqual([
+      "section",
+      "data_visualization",
+    ]);
+    expect(sendCall(sendMock, 1)[1]).toContain("Column 20: Value 20");
+    expect(sendOptions(sendCall(sendMock, 1)).blocks).toBeUndefined();
+    expect(sendOptions(sendCall(sendMock, 1)).textIsSlackPlainText).toBe(true);
+    expect(sendOptions(sendCall(sendMock, 2)).blocks?.map((block) => block.type)).toEqual([
+      "actions",
+    ]);
+    expect(result.messageId).toBe("sl-controls");
+  });
+
+  it("keeps mixed segment order when Slack rejects the native chart", async () => {
+    const payload = createMixedPresentationPayload();
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: { cfg: {}, to: "C12345", text: payload.text ?? "", payload },
+    });
+    if (!rendered) {
+      throw new Error("Expected rendered Slack segments");
+    }
+    const { presentation: _presentation, ...payloadForSend } = rendered;
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+    const cfg = { channels: { slack: { botToken: "xoxb-test" } } };
+    const sendSlack: typeof sendMessageSlack = async (to, text, opts) =>
+      await sendMessageSlack(to, text, { ...opts, cfg, token: "xoxb-test", client });
+
+    await slackOutbound.sendPayload?.({
+      cfg,
+      to: "channel:C123",
+      text: "",
+      payload: payloadForSend,
+      deps: { sendSlack },
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(4);
+    const firstFallbackRequest = client.chat.postMessage.mock.calls[1]?.[0] as
+      | { blocks?: Array<{ type?: string }> }
+      | undefined;
+    expect(firstFallbackRequest?.blocks?.map((block) => block.type)).toEqual([
+      "section",
+      "section",
+    ]);
+    expect(client.chat.postMessage.mock.calls[2]?.[0]).toMatchObject({
+      mrkdwn: false,
+      text: expect.stringContaining("Column 20: Value 20"),
+    });
+    const secondFallbackRequest = client.chat.postMessage.mock.calls[2]?.[0] as
+      | { blocks?: unknown }
+      | undefined;
+    expect(secondFallbackRequest?.blocks).toBeUndefined();
+    const finalFallbackRequest = client.chat.postMessage.mock.calls[3]?.[0] as
+      | { blocks?: Array<{ type?: string }> }
+      | undefined;
+    expect(finalFallbackRequest?.blocks?.map((block) => block.type)).toEqual(["actions"]);
+  });
+
+  it("does not duplicate authored text already represented by a raw block", async () => {
+    const payload: ReplyPayload = {
+      text: "Overview",
+      channelData: {
+        slack: {
+          blocks: [{ type: "section", text: { type: "mrkdwn", text: "Overview" } }],
+        },
+      },
+      presentation: {
+        blocks: [
+          {
+            type: "chart",
+            chartType: "bar",
+            title: "Pipeline",
+            categories: ["Open"],
+            series: [{ name: "Issues", values: [5] }],
+          },
+        ],
+      },
+    };
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: { cfg: {}, to: "C12345", text: payload.text ?? "", payload },
+    });
+    if (!rendered) {
+      throw new Error("Expected rendered Slack segments");
+    }
+    const { presentation: _presentation, ...payloadForSend } = rendered;
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+    const cfg = { channels: { slack: { botToken: "xoxb-test" } } };
+    const sendSlack: typeof sendMessageSlack = async (to, text, opts) =>
+      await sendMessageSlack(to, text, { ...opts, cfg, token: "xoxb-test", client });
+
+    await slackOutbound.sendPayload?.({
+      cfg,
+      to: "channel:C123",
+      text: "",
+      payload: payloadForSend,
+      deps: { sendSlack },
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    const fallback = client.chat.postMessage.mock.calls[1]?.[0] as {
+      blocks?: Array<{ text?: { text?: string }; type?: string }>;
+      text?: string;
+    };
+    expect(fallback.text?.match(/Overview/gu)).toHaveLength(1);
+    expect(fallback.blocks?.filter((block) => block.text?.text === "Overview")).toHaveLength(1);
   });
 
   it("sends media before a separate interactive blocks message", async () => {
@@ -730,13 +1097,16 @@ describe("slackOutbound sendPayload", () => {
     expect(mediaCall[2]).not.toHaveProperty("blocks");
     const controlsCall = sendCall(sendMock, 1);
     expect(controlsCall[0]).toBe(to);
-    expect(controlsCall[1]).toBe("Approval required");
-    expect(sendOptions(controlsCall).blocks?.[0]?.type).toBe("actions");
+    expect(controlsCall[1]).toBe("Approval required\n\nAllow");
+    expect(sendOptions(controlsCall).blocks?.map((block) => block.type)).toEqual([
+      "section",
+      "actions",
+    ]);
     expect(result.channel).toBe("slack");
     expect(result.messageId).toBe("sl-controls");
   });
 
-  it("rejects over-limit table fallbacks instead of dropping authored blocks", async () => {
+  it("rolls over authored blocks instead of dropping over-limit content", async () => {
     const { run, sendMock } = createHarness({
       payload: {
         channelData: {
@@ -756,8 +1126,13 @@ describe("slackOutbound sendPayload", () => {
       },
     });
 
-    await expect(run()).rejects.toThrow(/Slack blocks cannot exceed 50 items/i);
-    expect(sendMock).not.toHaveBeenCalled();
+    await expect(run()).resolves.toMatchObject({ messageId: "sl-1" });
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendOptions(sendCall(sendMock, 0)).blocks).toHaveLength(50);
+    expect(sendOptions(sendCall(sendMock, 1)).blocks?.map((block) => block.type)).toEqual([
+      "data_table",
+      "actions",
+    ]);
   });
 
   it("offsets presentation controls against native Slack blocks before standalone interactive controls", async () => {
@@ -799,7 +1174,7 @@ describe("slackOutbound sendPayload", () => {
     expect(sendMock).toHaveBeenCalledTimes(1);
     const call = sendCall(sendMock, 0);
     expect(call[0]).toBe(to);
-    expect(call[1]).toBe("Deploy?\n\n- Stage");
+    expect(call[1]).toBe("Deploy?\n\nStage\n\nApprove");
     const blocks = sendOptions(call).blocks;
     expect(blocks?.[0]?.block_id).toBe("openclaw_reply_buttons_1");
     expect(blocks?.[1]?.type).toBe("section");

--- a/extensions/slack/src/post-message-payload.ts
+++ b/extensions/slack/src/post-message-payload.ts
@@ -26,6 +26,7 @@ export type SlackBasePostMessagePayload = SlackPostThreadPayload & {
   text: string;
   blocks?: (Block | KnownBlock)[];
   metadata?: MessageMetadata;
+  mrkdwn?: boolean;
   unfurl_links?: boolean;
   unfurl_media?: boolean;
 };
@@ -51,6 +52,7 @@ export function buildSlackPostMessagePayload(params: {
   replyBroadcast?: boolean;
   blocks?: (Block | KnownBlock)[];
   metadata?: MessageMetadata;
+  mrkdwn?: boolean;
   unfurl?: SlackUnfurlOptions;
 }): SlackBasePostMessagePayload {
   const threadPayload =
@@ -66,6 +68,7 @@ export function buildSlackPostMessagePayload(params: {
       text: params.text,
       blocks: params.blocks,
       ...(params.metadata ? { metadata: params.metadata } : {}),
+      ...(typeof params.mrkdwn === "boolean" ? { mrkdwn: params.mrkdwn } : {}),
       ...threadPayload,
       ...unfurlPayload,
     };
@@ -74,6 +77,7 @@ export function buildSlackPostMessagePayload(params: {
     channel: params.channelId,
     text: params.text,
     ...(params.metadata ? { metadata: params.metadata } : {}),
+    ...(typeof params.mrkdwn === "boolean" ? { mrkdwn: params.mrkdwn } : {}),
     ...threadPayload,
     ...unfurlPayload,
   };

--- a/extensions/slack/src/presentation-fallback.ts
+++ b/extensions/slack/src/presentation-fallback.ts
@@ -3,47 +3,28 @@ import {
   renderMessagePresentationChartFallbackText,
   renderMessagePresentationFallbackText,
   renderMessagePresentationTableFallbackText,
+  normalizeMessagePresentation,
   type MessagePresentation,
   type MessagePresentationBlock,
-  type MessagePresentationButton,
   type MessagePresentationChartBlock,
   type MessagePresentationTableBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
-import { SLACK_SECTION_TEXT_MAX } from "./presentation.js";
 
-function escapeSlackFallbackCommand(command: string, escapedLabel: string): string | undefined {
-  // Slack parses mrkdwn before decoding these entities. That keeps mention/link
-  // tokens inert while preserving the displayed, copyable command bytes.
-  if (/[\r\n]/u.test(escapedLabel) || /[\\`\r\n]/u.test(command)) {
-    return undefined;
+const SLACK_UNCOPYABLE_COMMAND_WARNING = "not copyable: contains backtick";
+
+// Slack inline code cannot escape its ASCII backtick delimiter. Make the changed
+// byte explicit so the fallback cannot look like a copyable version of the command.
+function resolveSlackCommandFallback(command: string): {
+  command: string;
+  warning?: string;
+} {
+  if (!command.includes("`")) {
+    return { command };
   }
-  const escaped = command.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
-  const fallbackLine = `- ${escapedLabel}: \`${escaped}\``;
-  return Array.from(fallbackLine).length <= SLACK_SECTION_TEXT_MAX ? escaped : undefined;
-}
-
-function escapeSlackPresentationButton(
-  button: MessagePresentationButton,
-): MessagePresentationButton {
-  const { action, ...rest } = button;
-  const label = escapeSlackMrkdwn(button.label);
-  const command =
-    action?.type === "command" ? escapeSlackFallbackCommand(action.command, label) : undefined;
   return {
-    ...rest,
-    label,
-    ...(button.value ? { value: escapeSlackMrkdwn(button.value) } : {}),
-    ...(button.url ? { url: escapeSlackMrkdwn(button.url) } : {}),
-    ...(button.webApp ? { webApp: { url: escapeSlackMrkdwn(button.webApp.url) } } : {}),
-    ...(button.web_app ? { web_app: { url: escapeSlackMrkdwn(button.web_app.url) } } : {}),
-    ...(action?.type === "command"
-      ? command
-        ? { action: { ...action, command } }
-        : {}
-      : action
-        ? { action }
-        : {}),
+    command: command.replaceAll("`", "[backtick]"),
+    warning: SLACK_UNCOPYABLE_COMMAND_WARNING,
   };
 }
 
@@ -98,7 +79,31 @@ function escapeSlackPresentationFallbackBlock(
   if (block.type === "buttons") {
     return {
       ...block,
-      buttons: block.buttons.map(escapeSlackPresentationButton),
+      buttons: block.buttons.map((button) => {
+        const commandFallback =
+          button.action?.type === "command"
+            ? resolveSlackCommandFallback(button.action.command)
+            : undefined;
+        const label = commandFallback?.warning
+          ? `${button.label} [${commandFallback.warning}]`
+          : button.label;
+        return {
+          ...button,
+          label: escapeSlackMrkdwn(label),
+          ...(button.value ? { value: escapeSlackMrkdwn(button.value) } : {}),
+          ...(button.url ? { url: escapeSlackMrkdwn(button.url) } : {}),
+          ...(button.webApp ? { webApp: { url: escapeSlackMrkdwn(button.webApp.url) } } : {}),
+          ...(button.web_app ? { web_app: { url: escapeSlackMrkdwn(button.web_app.url) } } : {}),
+          ...(button.action?.type === "command" && commandFallback
+            ? {
+                action: {
+                  ...button.action,
+                  command: commandFallback.command,
+                },
+              }
+            : {}),
+        };
+      }),
     };
   }
   if (block.type === "select") {
@@ -124,6 +129,21 @@ export function renderSlackMessagePresentationTableFallbackText(
   block: MessagePresentationTableBlock,
 ): string {
   return renderMessagePresentationTableFallbackText(escapeSlackPresentationTableBlock(block));
+}
+
+/** Render only table data that must move out of native Slack blocks. */
+export function renderSlackMessagePresentationTablesFallbackText(params: {
+  presentation?: unknown;
+  text?: string | null;
+}): string {
+  const presentation = normalizeMessagePresentation(params.presentation);
+  const blocks = presentation?.blocks.filter(
+    (block): block is MessagePresentationTableBlock => block.type === "table",
+  );
+  return renderSlackMessagePresentationFallbackText({
+    text: params.text,
+    ...(blocks?.length ? { presentation: { blocks } } : {}),
+  });
 }
 
 export function renderSlackMessagePresentationFallbackText(params: {

--- a/extensions/slack/src/presentation.ts
+++ b/extensions/slack/src/presentation.ts
@@ -20,13 +20,11 @@ export const SLACK_PRESENTATION_CAPABILITIES = {
   limits: {
     actions: {
       maxActionsPerRow: SLACK_ACTION_BLOCK_ELEMENTS_MAX,
-      maxLabelLength: SLACK_ACTION_LABEL_MAX,
       maxValueBytes: SLACK_BUTTON_VALUE_MAX,
       supportsStyles: true,
     },
     selects: {
       maxOptions: SLACK_STATIC_SELECT_OPTIONS_MAX,
-      maxLabelLength: SLACK_ACTION_LABEL_MAX,
       maxValueBytes: SLACK_OPTION_VALUE_MAX,
     },
     text: {

--- a/extensions/slack/src/reply-blocks.test.ts
+++ b/extensions/slack/src/reply-blocks.test.ts
@@ -1,20 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { resolveSlackReplyRenderPlan, resolveSlackReplyText } from "./reply-blocks.js";
+import { resolveSlackReplyBlockResolution, resolveSlackReplyText } from "./reply-blocks.js";
 
 describe("resolveSlackReplyText", () => {
-  it("leaves long plain Markdown on the normal text chunking path", () => {
-    const text = `[link](https://example.com) ${"x".repeat(8_100)}`;
-    const plan = resolveSlackReplyRenderPlan({ text });
-
-    expect(plan.mode).toBe("single");
-    if (plan.mode !== "single") {
-      return;
-    }
-    expect(plan.blocks).toBeUndefined();
-    expect(plan.text).toBe(text);
-    expect(plan.textIsSlackMrkdwn).toBeUndefined();
-  });
-
   it("includes complete portable table data in Slack accessibility text", () => {
     expect(
       resolveSlackReplyText({
@@ -92,7 +79,7 @@ describe("resolveSlackReplyText", () => {
         "- Value: 1",
         "",
         "- Notify &lt;!here&gt;: https://example.com/?a=1&amp;b=2",
-        "- Run &lt;@U1&gt;: `/say &lt;!channel&gt;`",
+        "- Run &lt;@U1&gt;: `/say <!channel>`",
         "",
         "Owner &lt;!channel&gt;:",
         "- &lt;@U2&gt;",
@@ -100,9 +87,94 @@ describe("resolveSlackReplyText", () => {
     );
   });
 
-  it("marks non-native portable tables for text fallback while retaining native blocks", () => {
+  it("marks command fallbacks with backticks as not copyable", () => {
+    const rendered = resolveSlackReplyText({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Run",
+                action: {
+                  type: "command",
+                  command: "/run foo_bar C:\\tools\\run ` <!channel> <@U1>",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const codeSpans = [...rendered.matchAll(/`([^`]*)`/gs)];
+    expect(codeSpans).toHaveLength(1);
+    expect(codeSpans[0]?.[1]).toBe("/run foo_bar C:\\tools\\run [backtick] <!channel> <@U1>");
+    expect(rendered).toContain("Run [not copyable: contains backtick]");
+    expect(rendered).not.toMatch(/[\u02cb\uff40]/u);
+    expect(rendered.replace(/`[^`]*`/gs, "")).not.toMatch(/<!channel>|<@U1>/);
+  });
+
+  it("keeps safe command fallback bytes exact", () => {
+    expect(
+      resolveSlackReplyText({
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                {
+                  label: "Run",
+                  action: {
+                    type: "command",
+                    command: "/run foo_bar C:\\tools\\run <!channel> <@U1>",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ).toBe("- Run: `/run foo_bar C:\\tools\\run <!channel> <@U1>`");
+  });
+
+  it("keeps non-native table text between raw, portable, and legacy blocks", () => {
     const payload = {
-      channelData: { slack: { blocks: [{ type: "divider" }] } },
+      channelData: {
+        slack: {
+          blocks: [
+            {
+              type: "actions",
+              block_id: "openclaw_reply_buttons_1",
+              elements: [
+                {
+                  type: "button",
+                  action_id: "existing_button",
+                  text: { type: "plain_text", text: "Existing" },
+                  value: "existing",
+                },
+              ],
+            },
+            {
+              type: "actions",
+              block_id: "openclaw_reply_select_1",
+              elements: [
+                {
+                  type: "static_select",
+                  action_id: "existing_select",
+                  placeholder: { type: "plain_text", text: "Existing" },
+                  options: [
+                    {
+                      text: { type: "plain_text", text: "Existing" },
+                      value: "existing",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
       presentation: {
         blocks: [
           {
@@ -112,6 +184,229 @@ describe("resolveSlackReplyText", () => {
             rows: Array.from({ length: 100 }, (_entry, index) => [
               `account-${String(index)} ${"x".repeat(110)}`,
             ]),
+          },
+          {
+            type: "buttons" as const,
+            buttons: [{ label: "Stage", value: "stage" }],
+          },
+          {
+            type: "select" as const,
+            placeholder: "Lane",
+            options: [{ label: "Production", value: "production" }],
+          },
+        ],
+      },
+      interactive: {
+        blocks: [
+          {
+            type: "buttons" as const,
+            buttons: [{ label: "Refresh", value: "refresh" }],
+          },
+          {
+            type: "select" as const,
+            placeholder: "Window",
+            options: [{ label: "Recent", value: "recent" }],
+          },
+        ],
+      },
+    };
+
+    const { segments } = resolveSlackReplyBlockResolution(payload);
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toMatchObject({
+      kind: "blocks",
+      blocks: [
+        { type: "actions", block_id: "openclaw_reply_buttons_1" },
+        { type: "actions", block_id: "openclaw_reply_select_1" },
+      ],
+    });
+    expect(segments[1]).toMatchObject({ kind: "text" });
+    expect(segments[1]?.kind === "text" ? segments[1].text : "").toContain("- Account: account-99");
+    expect(segments[2]).toMatchObject({
+      kind: "blocks",
+      blocks: [
+        {
+          type: "actions",
+          block_id: "openclaw_reply_buttons_2",
+          elements: [{ action_id: "openclaw:reply_button:2:1", value: "stage" }],
+        },
+        {
+          type: "actions",
+          block_id: "openclaw_reply_select_2",
+          elements: [{ action_id: "openclaw:reply_select:2" }],
+        },
+        {
+          type: "actions",
+          block_id: "openclaw_reply_buttons_3",
+          elements: [{ action_id: "openclaw:reply_button:3:1", value: "refresh" }],
+        },
+        {
+          type: "actions",
+          block_id: "openclaw_reply_select_3",
+          elements: [{ action_id: "openclaw:reply_select:3" }],
+        },
+      ],
+    });
+    expect(resolveSlackReplyText(payload)).toContain("- Account: account-99");
+  });
+
+  it("coalesces adjacent fallbacks without changing their authored order", () => {
+    const payload = {
+      presentation: {
+        blocks: [
+          {
+            type: "table" as const,
+            caption: "Large pipeline",
+            headers: ["Account"],
+            rows: Array.from({ length: 100 }, (_entry, index) => [
+              `account-${String(index)} ${"x".repeat(110)}`,
+            ]),
+          },
+          {
+            type: "buttons" as const,
+            buttons: [
+              {
+                label: "Run",
+                action: { type: "command" as const, command: "/say <@U1>_now" },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const { segments } = resolveSlackReplyBlockResolution(payload);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]?.kind).toBe("text");
+    const fallback = segments[0]?.kind === "text" ? segments[0].text : "";
+    expect(fallback.indexOf("Large pipeline (table)")).toBeLessThan(fallback.indexOf("- Run"));
+    expect(fallback).toContain("- Account: account-99");
+    expect(fallback).toContain("- Run: `/say <@U1>_now`");
+  });
+
+  it("marks fallback segments as literal text without Slack entity escaping", () => {
+    const headers = Array.from({ length: 21 }, (_entry, index) => `Column ${String(index)}`);
+    const values = headers.map((_header, index) =>
+      index === 20 ? "<@U1> & <!channel>" : `Value ${String(index)}`,
+    );
+    const { segments } = resolveSlackReplyBlockResolution({
+      presentation: {
+        blocks: [
+          { type: "table", caption: "Owners", headers, rows: [values] },
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Run",
+                action: { type: "command", command: "/say ` <!channel>" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({ kind: "text", mrkdwn: false });
+    const fallback = segments[0]?.kind === "text" ? segments[0].text : "";
+    expect(fallback).toContain("<@U1> & <!channel>");
+    expect(fallback).toContain("/say ` <!channel>");
+    expect(fallback).not.toContain("&lt;");
+  });
+
+  it("recognizes authored text already carried by a fallback segment", () => {
+    const title = "This chart title is too long for Slack native chart rendering";
+    const text = `${title} (pie chart)\n- Open: 5`;
+    const resolution = resolveSlackReplyBlockResolution({
+      text,
+      presentation: {
+        blocks: [
+          {
+            type: "chart",
+            chartType: "pie",
+            title,
+            segments: [{ label: "Open", value: 5 }],
+          },
+        ],
+      },
+    });
+
+    expect(resolution.authoredTextPlacement).toBe("blocks");
+    expect(resolution.segments).toContainEqual({ kind: "text", text, mrkdwn: false });
+  });
+
+  it("materializes authored text blocks as verbatim mrkdwn", () => {
+    const resolution = resolveSlackReplyBlockResolution(
+      {
+        text: "<@U123> literal",
+        interactive: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] }],
+        },
+      },
+      { materializeAuthoredText: true },
+    );
+
+    expect(resolution.segments[0]?.kind).toBe("blocks");
+    const blocks = resolution.segments[0]?.kind === "blocks" ? resolution.segments[0].blocks : [];
+    expect(blocks[0]).toMatchObject({
+      type: "section",
+      text: { type: "mrkdwn", text: "<@U123> literal", verbatim: true },
+    });
+  });
+
+  it("recognizes authored text already represented by native chart data", () => {
+    const resolution = resolveSlackReplyBlockResolution({
+      text: "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
+      presentation: {
+        blocks: [
+          {
+            type: "chart",
+            chartType: "pie",
+            title: "Revenue mix",
+            segments: [
+              { label: "Product", value: 60 },
+              { label: "Services", value: 40 },
+            ],
+          },
+          { type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] },
+        ],
+      },
+    });
+
+    expect(resolution.authoredTextPlacement).toBe("blocks");
+  });
+
+  it("preserves mixed chart, table, and control order across native and text segments", () => {
+    const headers = Array.from({ length: 21 }, (_entry, index) => `Column ${String(index)}`);
+    const payload = {
+      presentation: {
+        blocks: [
+          {
+            type: "chart" as const,
+            chartType: "pie" as const,
+            title: "Issue share",
+            segments: [{ label: "Open", value: 5 }],
+          },
+          {
+            type: "table" as const,
+            caption: "Wide pipeline",
+            headers,
+            rows: [headers.map((_header, index) => `Value ${String(index)}`)],
+          },
+          {
+            type: "buttons" as const,
+            buttons: [{ label: "Stage", value: "stage" }],
+          },
+          {
+            type: "chart" as const,
+            chartType: "pie" as const,
+            title: "This chart title cannot fit Slack's native chart title limit",
+            segments: [{ label: "Closed", value: 8 }],
+          },
+          {
+            type: "select" as const,
+            placeholder: "Lane",
+            options: [{ label: "Production", value: "production" }],
           },
         ],
       },
@@ -125,33 +420,65 @@ describe("resolveSlackReplyText", () => {
       },
     };
 
-    expect(resolveSlackReplyRenderPlan(payload)).toEqual({
-      mode: "split",
-      blockPart: {
-        text: "- Refresh",
+    const { segments } = resolveSlackReplyBlockResolution(payload);
+    expect(segments.map((segment) => segment.kind)).toEqual([
+      "blocks",
+      "text",
+      "blocks",
+      "text",
+      "blocks",
+    ]);
+    expect(segments[0]).toMatchObject({
+      kind: "blocks",
+      blocks: [{ type: "data_visualization", title: "Issue share" }],
+    });
+    expect(segments[1]).toMatchObject({ kind: "text" });
+    expect(segments[1]?.kind === "text" ? segments[1].text : "").toContain("Column 20: Value 20");
+    expect(segments[2]).toMatchObject({
+      kind: "blocks",
+      blocks: [{ block_id: "openclaw_reply_buttons_1", elements: [{ value: "stage" }] }],
+    });
+    expect(segments[3]).toMatchObject({
+      kind: "text",
+      text: expect.stringContaining("Closed: 8"),
+    });
+    expect(segments[4]).toMatchObject({
+      kind: "blocks",
+      blocks: [
+        { block_id: "openclaw_reply_select_1" },
+        { block_id: "openclaw_reply_buttons_2", elements: [{ value: "refresh" }] },
+      ],
+    });
+  });
+
+  it("keeps complete unsupported chart data beyond Slack's section text limit", () => {
+    const categories = Array.from(
+      { length: 4 },
+      (_entry, index) => `category-${String(index)}-${"x".repeat(1_000)}`,
+    );
+    const { segments } = resolveSlackReplyBlockResolution({
+      presentation: {
         blocks: [
-          { type: "divider" },
           {
-            type: "actions",
-            block_id: "openclaw_reply_buttons_1",
-            elements: [
-              {
-                type: "button",
-                action_id: "openclaw:reply_button:1:1",
-                text: { type: "plain_text", text: "Refresh", emoji: true },
-                value: "refresh",
-              },
-            ],
+            type: "chart",
+            chartType: "line",
+            title: "Long labels",
+            categories,
+            series: [{ name: "Requests", values: [1, 2, 3, 4] }],
           },
         ],
       },
-      fallbackText: expect.stringContaining("- Account: account-99"),
-      hookText: expect.stringContaining("- Account: account-99"),
     });
-    expect(resolveSlackReplyText(payload)).toContain("- Account: account-99");
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]?.kind).toBe("text");
+    const fallback = segments[0]?.kind === "text" ? segments[0].text : "";
+    expect(fallback.length).toBeGreaterThan(3_000);
+    expect(fallback).toContain(categories.at(-1));
+    expect(fallback).toContain("category-3-");
   });
 
-  it("rejects over-limit table fallbacks instead of dropping authored blocks", () => {
+  it("starts a new native segment instead of dropping blocks beyond the message budget", () => {
     const payload = {
       channelData: {
         slack: { blocks: Array.from({ length: 50 }, () => ({ type: "divider" })) },
@@ -176,634 +503,16 @@ describe("resolveSlackReplyText", () => {
       },
     };
 
-    expect(() => resolveSlackReplyRenderPlan(payload)).toThrow(
-      /Slack blocks cannot exceed 50 items/i,
-    );
-  });
-
-  it("does not create an empty fallback message for non-textual overflow", () => {
-    const plan = resolveSlackReplyRenderPlan({
-      channelData: {
-        slack: { blocks: Array.from({ length: 50 }, () => ({ type: "divider" })) },
-      },
-      presentation: { blocks: [{ type: "divider" }] },
-    });
-
-    expect(plan.mode).toBe("single");
-    if (plan.mode !== "single") {
-      return;
-    }
-    expect(plan.blocks).toHaveLength(50);
-    expect(plan.text).toBe("Shared a Block Kit message");
-  });
-
-  it("keeps authored text visible before a native table", () => {
-    const plan = resolveSlackReplyRenderPlan({
-      text: "[Pipeline](https://example.com)",
-      presentation: {
-        blocks: [{ type: "table", caption: "Pipeline", headers: ["Account"], rows: [["Acme"]] }],
-      },
-    });
-
-    expect(plan.mode).toBe("single");
-    if (plan.mode !== "single") {
-      return;
-    }
-    expect(plan.blocks?.[0]).toEqual({
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "<https://example.com|Pipeline>",
-        verbatim: true,
-      },
-    });
-    expect(plan.blocks?.[1]).toMatchObject({ type: "data_table", caption: "Pipeline" });
-  });
-
-  it("moves long presentation text beside a table to complete fallback", () => {
-    const longText = `start-${"x".repeat(3980)}-tail`;
-    const plan = resolveSlackReplyRenderPlan({
-      presentation: {
-        blocks: [
-          { type: "text", text: longText },
-          { type: "table", caption: "Pipeline", headers: ["Account"], rows: [["Acme"]] },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart).toBeUndefined();
-    expect(plan.fallbackText).toContain("-tail");
-    expect(plan.fallbackText).toContain("Pipeline (table)");
-  });
-
-  it("moves standalone overlong presentation text to complete fallback", () => {
-    const longText = `standalone-${"x".repeat(3980)}-tail`;
-    const plan = resolveSlackReplyRenderPlan({
-      presentation: {
-        blocks: [
-          { type: "text", text: longText },
-          { type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart?.text).toBe("- Refresh");
-    expect(plan.fallbackText).toContain("-tail");
-    expect(plan.fallbackText).not.toContain("- Refresh");
-  });
-
-  it("moves an over-limit presentation control row to text fallback", () => {
-    const plan = resolveSlackReplyRenderPlan({
-      presentation: {
-        blocks: [
-          { type: "table", caption: "Pipeline", headers: ["Account"], rows: [["Acme"]] },
-          {
-            type: "buttons",
-            buttons: Array.from({ length: 26 }, (_entry, index) => ({
-              label: `Action ${String(index + 1)}`,
-              value: `action-${String(index + 1)}`,
-            })),
-          },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart).toBeUndefined();
-    expect(plan.fallbackText).toContain("- Action 26");
-  });
-
-  it("moves standalone over-limit controls to complete text fallback", () => {
-    const plan = resolveSlackReplyRenderPlan({
-      presentation: {
-        blocks: [
-          {
-            type: "buttons",
-            buttons: Array.from({ length: 26 }, (_entry, index) => ({
-              label: `Action ${String(index + 1)}`,
-              value: `action-${String(index + 1)}`,
-            })),
-          },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart).toBeUndefined();
-    expect(plan.fallbackText).toContain("- Action 26");
-  });
-
-  it("preserves safe command bytes and drops unsafe code-span fallbacks", () => {
-    const plan = resolveSlackReplyRenderPlan({
-      presentation: {
-        blocks: [
-          {
-            type: "buttons",
-            buttons: [
-              {
-                label: "Deny",
-                action: {
-                  type: "command",
-                  command: "/approve req_1 deny & <@U123>",
-                },
-              },
-              {
-                label: "Backtick",
-                action: { type: "command", command: "/run `unsafe` <!channel>" },
-              },
-              {
-                label: "Multiline",
-                action: { type: "command", command: "/run\n<!channel>" },
-              },
-              {
-                label: "Overlong",
-                action: { type: "command", command: `/${"x".repeat(3_000)}` },
-              },
-              {
-                label: "Backslash",
-                action: { type: "command", command: "/path\\" },
-              },
-              {
-                label: "Line\nbreak",
-                action: { type: "command", command: "/status" },
-              },
-              ...Array.from({ length: 20 }, (_entry, index) => ({
-                label: `Action ${String(index + 7)}`,
-                value: `action-${String(index + 7)}`,
-              })),
-            ],
-          },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.fallbackText).toContain("- Deny: `/approve req_1 deny &amp; &lt;@U123&gt;`");
-    expect(plan.fallbackText).not.toContain("req\\_1");
-    expect(plan.fallbackText).toContain("- Backtick");
-    expect(plan.fallbackText).toContain("- Multiline");
-    expect(plan.fallbackText).toContain("- Overlong");
-    expect(plan.fallbackText).toContain("- Backslash");
-    expect(plan.fallbackText).toContain("- Line\nbreak");
-    expect(plan.fallbackText).not.toContain("`unsafe`");
-    expect(plan.fallbackText).not.toContain("<!channel>");
-    expect(plan.fallbackText).not.toContain("x".repeat(3_000));
-    expect(plan.fallbackText).not.toContain("/path\\");
-    expect(plan.fallbackText).not.toContain("`/status`");
-  });
-
-  it("splits a valid native chart when its complete fallback exceeds 8k", () => {
-    const categories = Array.from({ length: 20 }, (_entry, index) =>
-      `Category-${String(index)}`.padEnd(20, "x"),
-    );
-    const plan = resolveSlackReplyRenderPlan({
-      presentation: {
-        blocks: [
-          {
-            type: "chart",
-            chartType: "bar",
-            title: "Large revenue report",
-            categories,
-            series: Array.from({ length: 12 }, (_entry, index) => ({
-              name: `Series-${String(index)}`.padEnd(20, "x"),
-              values: categories.map(() => Number.MAX_VALUE),
-            })),
-          },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart).toBeUndefined();
-    expect(plan.fallbackText).toContain("Series-11");
-    expect(plan.fallbackText.length).toBeGreaterThan(8_000);
-  });
-
-  it("keeps the first two charts native and falls back only the overflow", () => {
-    const plan = resolveSlackReplyRenderPlan({
-      presentation: {
-        blocks: [
-          {
-            type: "chart",
-            chartType: "pie",
-            title: "Revenue mix",
-            segments: [{ label: "Product", value: 60 }],
-          },
-          {
-            type: "chart",
-            chartType: "pie",
-            title: "Active accounts",
-            segments: [{ label: "Paid", value: 40 }],
-          },
-          {
-            type: "chart",
-            chartType: "pie",
-            title: "Active sessions",
-            segments: [{ label: "Desktop", value: 30 }],
-          },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("single");
-    if (plan.mode !== "single") {
-      return;
-    }
-    expect(plan.blocks?.map((block) => block.type)).toEqual([
-      "data_visualization",
-      "data_visualization",
-      "context",
-    ]);
-    expect(plan.blocks?.[2]).toMatchObject({
-      type: "context",
-      elements: [{ text: expect.stringContaining("Active sessions") }],
-    });
-    expect(plan.text).toContain("Revenue mix");
-    expect(plan.text).toContain("Active accounts");
-    expect(plan.text).toContain("Active sessions");
-  });
-
-  it("counts raw charts before retaining portable charts", () => {
-    const plan = resolveSlackReplyRenderPlan({
-      channelData: {
-        slack: {
-          blocks: [
-            {
-              type: "data_visualization",
-              title: "Raw traffic",
-              chart: {
-                type: "pie",
-                segments: [{ label: "Direct", value: 50 }],
-              },
-            },
-          ],
-        },
-      },
-      presentation: {
-        blocks: [
-          {
-            type: "chart",
-            chartType: "pie",
-            title: "Revenue mix",
-            segments: [{ label: "Product", value: 60 }],
-          },
-          {
-            type: "chart",
-            chartType: "pie",
-            title: "Active sessions",
-            segments: [{ label: "Desktop", value: 30 }],
-          },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("single");
-    if (plan.mode !== "single") {
-      return;
-    }
-    expect(plan.blocks?.map((block) => block.type)).toEqual([
-      "data_visualization",
-      "data_visualization",
-      "context",
-    ]);
-    expect(plan.blocks?.[2]).toMatchObject({
-      type: "context",
-      elements: [{ text: expect.stringContaining("Active sessions") }],
-    });
-    expect(plan.text).toContain("Raw traffic");
-    expect(plan.text).toContain("Revenue mix");
-    expect(plan.text).toContain("Active sessions");
-  });
-
-  it("keeps a native-eligible table when its rendered fallback exceeds 8k", () => {
-    const rows = Array.from({ length: 100 }, (_entry, index) => [
-      index === 0 ? "<@U123>" : `account-${String(index)} ${"x".repeat(65)}`,
-    ]);
-    const plan = resolveSlackReplyRenderPlan({
-      text: "Pipeline summary",
-      presentation: {
-        title: "Quarterly report",
-        blocks: [
-          { type: "context", text: "Confidential" },
-          { type: "table", caption: "Pipeline", headers: ["Account"], rows },
-          { type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart?.blocks.map((block) => block.type)).toEqual(["data_table", "actions"]);
-    expect(plan.blockPart?.text).toBe("Pipeline (table)\n\n- Refresh");
-    expect(plan.blockPart?.text.length).toBeLessThanOrEqual(8_000);
-    expect(plan.fallbackText).toContain("Quarterly report");
-    expect(plan.fallbackText).toContain("Confidential");
-    expect(plan.fallbackText).toContain("- Account: account-99");
-    expect(plan.fallbackText.match(/Pipeline \(table\)/g)).toHaveLength(1);
-    expect(plan.fallbackText).not.toContain("- Refresh");
-  });
-
-  it("compacts native table accessibility text at the active chunk limit", () => {
-    const header = "H".repeat(1_000);
-    const plan = resolveSlackReplyRenderPlan(
-      {
-        presentation: {
-          blocks: [
-            {
-              type: "table",
-              caption: "Pipeline",
-              headers: [header],
-              rows: Array.from({ length: 5 }, (_entry, index) => [String(index)]),
-            },
-          ],
-        },
-      },
-      undefined,
-      { textLimit: 4_000 },
-    );
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart?.text).toBe("Pipeline (table)");
-    expect(plan.blockPart?.text.length).toBeLessThanOrEqual(4_000);
-    expect(plan.fallbackText).toContain(": 4");
-  });
-
-  it("falls back a native-eligible table when its compact caption exceeds 8k", () => {
-    const caption = "c".repeat(8_100);
-    const plan = resolveSlackReplyRenderPlan({
-      presentation: {
-        blocks: [
-          { type: "table", caption, headers: ["Account"], rows: [["Acme"]] },
-          { type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart?.blocks.map((block) => block.type)).toEqual(["actions"]);
-    expect(plan.blockPart?.text).toBe("- Refresh");
-    expect(plan.fallbackText).toContain(`${caption} (table)`);
-    expect(plan.fallbackText).toContain("- Account: Acme");
-  });
-
-  it("escapes plain-text control labels in split accessibility fallbacks", () => {
-    const plan = resolveSlackReplyRenderPlan({
-      presentation: {
-        blocks: [
-          {
-            type: "table",
-            caption: "Pipeline",
-            headers: ["Account"],
-            rows: Array.from({ length: 100 }, (_entry, index) => [
-              `account-${String(index)}-${"x".repeat(110)}`,
-            ]),
-          },
-          { type: "buttons", buttons: [{ label: "<!here>", value: "refresh" }] },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart?.text).toBe("- &lt;!here&gt;");
-    expect(plan.blockPart?.text).not.toContain("<!here>");
-  });
-
-  it("keeps section fields and rich text in split accessibility fallbacks", () => {
-    const plan = resolveSlackReplyRenderPlan({
-      channelData: {
-        slack: {
-          blocks: [
-            {
-              type: "section",
-              fields: [
-                { type: "plain_text", text: "Owner <!here>" },
-                { type: "mrkdwn", text: "*Ready*" },
-              ],
-            },
-            {
-              type: "rich_text",
-              elements: [
-                {
-                  type: "rich_text_section",
-                  elements: [
-                    { type: "text", text: "Rich <!channel> " },
-                    { type: "user", user_id: "U123" },
-                  ],
-                },
-              ],
-            },
-            {
-              type: "section",
-              text: { type: "mrkdwn", text: "Overview" },
-              accessory: {
-                type: "button",
-                action_id: "open",
-                text: { type: "plain_text", text: "Open" },
-                value: "open",
-              },
-            },
-          ],
-        },
-      },
-      presentation: {
-        blocks: [
-          {
-            type: "table",
-            caption: "Pipeline",
-            headers: ["Account"],
-            rows: Array.from({ length: 100 }, (_entry, index) => [
-              `account-${String(index)}-${"x".repeat(110)}`,
-            ]),
-          },
-        ],
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart?.text).toBe(
-      "Owner &lt;!here&gt;\n*Ready*\n\nRich &lt;!channel&gt; <@U123>\n\nOverview\n- Open",
-    );
-  });
-
-  it("fails closed when retained raw-block accessibility exceeds 8k", () => {
-    const blocks = Array.from({ length: 3 }, (_entry, index) => ({
-      type: "image",
-      image_url: `https://example.com/${String(index)}.png`,
-      alt_text: `${String(index)}${"x".repeat(2999)}`,
-    }));
-
-    expect(() =>
-      resolveSlackReplyRenderPlan({
-        channelData: { slack: { blocks } },
-        presentation: {
-          blocks: [
-            {
-              type: "table",
-              caption: "Large pipeline",
-              headers: ["Account"],
-              rows: Array.from({ length: 100 }, (_entry, index) => [
-                `account-${String(index)} ${"x".repeat(110)}`,
-              ]),
-            },
-          ],
-        },
-      }),
-    ).toThrow(/retained-block accessibility fallback exceeds/i);
-  });
-
-  it("moves overlong raw text blocks to visible fallback chunks", () => {
-    const blocks = Array.from({ length: 3 }, (_entry, index) => ({
-      type: "section",
-      text: { type: "mrkdwn", text: `${String(index)}${"x".repeat(2999)}-tail` },
-    }));
-
-    const plan = resolveSlackReplyRenderPlan({ channelData: { slack: { blocks } } });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart).toBeUndefined();
-    expect(plan.fallbackText).toContain("2xxx");
-    expect(plan.fallbackText).toContain("-tail");
-    expect(plan.fallbackText.length).toBeGreaterThan(8_000);
-  });
-
-  it("retains image and mixed-media contexts when sibling text moves to fallback", () => {
-    const imageOnlyContext = {
-      type: "context",
-      elements: [
-        {
-          type: "image",
-          image_url: "https://example.com/status.png",
-          alt_text: "Status",
-        },
+    const { segments } = resolveSlackReplyBlockResolution(payload);
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({ kind: "blocks" });
+    expect(segments[0]?.kind === "blocks" ? segments[0].blocks : []).toHaveLength(50);
+    expect(segments[1]).toMatchObject({
+      kind: "blocks",
+      blocks: [
+        { type: "data_table", caption: "Accounts" },
+        { block_id: "openclaw_reply_buttons_1", elements: [{ value: "refresh" }] },
       ],
-    };
-    const mixedContext = {
-      type: "context",
-      elements: [
-        { type: "mrkdwn", text: "Status summary" },
-        {
-          type: "image",
-          image_url: "https://example.com/detail.png",
-          alt_text: "Detail",
-        },
-      ],
-    };
-    const textBlocks = Array.from({ length: 3 }, (_entry, index) => ({
-      type: "section",
-      text: { type: "mrkdwn", text: `${String(index)}${"x".repeat(2994)}-tail` },
-    }));
-
-    const plan = resolveSlackReplyRenderPlan({
-      channelData: {
-        slack: { blocks: [imageOnlyContext, mixedContext, ...textBlocks] },
-      },
     });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart).toEqual({
-      blocks: [imageOnlyContext, mixedContext],
-      text: "Status summary",
-    });
-    expect(plan.fallbackText).toContain("2xxx");
-    expect(plan.fallbackText).toContain("-tail");
-    expect(plan.fallbackText).not.toContain("Status summary");
-  });
-
-  it("converts authored Markdown before splitting around raw blocks", () => {
-    const plan = resolveSlackReplyRenderPlan({
-      text: `[docs](https://example.com) ${"x".repeat(8_100)}`,
-      channelData: {
-        slack: {
-          blocks: [
-            {
-              type: "actions",
-              elements: [
-                {
-                  type: "button",
-                  action_id: "refresh",
-                  text: { type: "plain_text", text: "Refresh" },
-                  value: "refresh",
-                },
-              ],
-            },
-          ],
-        },
-      },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart?.text).toBe("- Refresh");
-    expect(plan.fallbackText).toContain("<https://example.com|docs>");
-    expect(plan.fallbackText).not.toContain("[docs](https://example.com)");
-  });
-
-  it("keeps a long portable sibling complete beside a raw native table", () => {
-    const longText = `raw-table-sibling-${"x".repeat(3980)}-tail`;
-    const plan = resolveSlackReplyRenderPlan({
-      channelData: {
-        slack: {
-          blocks: [
-            {
-              type: "data_table",
-              caption: "Raw pipeline",
-              rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
-            },
-          ],
-        },
-      },
-      presentation: { blocks: [{ type: "text", text: longText }] },
-    });
-
-    expect(plan.mode).toBe("split");
-    if (plan.mode !== "split") {
-      return;
-    }
-    expect(plan.blockPart).toBeUndefined();
-    expect(plan.fallbackText).toContain("-tail");
-    expect(plan.fallbackText).toContain("Raw pipeline (table)");
-    expect(plan.hookText).toContain("-tail");
   });
 });

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -1,36 +1,116 @@
 import {
   normalizeMessagePresentation,
+  renderMessagePresentationFallbackText,
   type MessagePresentation,
-  type MessagePresentationBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
 // Slack plugin module implements reply blocks behavior.
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
-  appendSlackBlocksAccessibleFallbackText,
-  buildSlackBlocksAccessibleFallbackText,
-  buildSlackBlocksCompactAccessibleFallbackText,
-  isSlackBlockRepresentedByTextFallback,
-  removeSlackBlocksFallbackParagraphs,
-  retainSlackDataTablesWithinCompactFallback,
-} from "./blocks-fallback.js";
+  resolveSlackAuthoredTextPlacement,
+  type SlackAuthoredTextPlacement,
+} from "./authored-text.js";
+import { buildSlackBlocksFallbackText, renderSlackBlockFallbackText } from "./blocks-fallback.js";
 import { parseSlackBlocksInput, SLACK_MAX_BLOCKS } from "./blocks-input.js";
 import {
   buildSlackInteractiveBlocks,
   buildSlackPresentationBlocks,
   canRenderSlackPresentation,
-  canRenderSlackPresentationTables,
   resolveSlackBlockOffsets,
   type SlackBlock,
+  type SlackBlockRenderOptions,
 } from "./blocks-render.js";
-import { hasSlackDataTableBlock } from "./data-table.js";
 import { markdownToSlackMrkdwnChunks } from "./format.js";
-import { SLACK_TEXT_LIMIT } from "./limits.js";
 import {
   appendSlackNativeDataFallbackText,
+  buildSlackNativeDataAccessibilityText,
   hasSlackNativeDataBlock,
 } from "./native-data-blocks.js";
 import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
 import { SLACK_SECTION_TEXT_MAX } from "./presentation.js";
+
+export type SlackReplyBlockSegment =
+  | { kind: "blocks"; blocks: SlackBlock[] }
+  | { kind: "text"; text: string; mrkdwn: false };
+
+export type SlackReplyBlockResolution = {
+  authoredTextPlacement: SlackAuthoredTextPlacement;
+  segments: SlackReplyBlockSegment[];
+};
+
+export function parseSlackReplyBlockSegments(value: unknown): SlackReplyBlockSegment[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("Slack rendered presentation segments must be an array");
+  }
+  return value.map((raw): SlackReplyBlockSegment => {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error("Slack rendered presentation segment must be an object");
+    }
+    const segment = raw as { blocks?: unknown; kind?: unknown; mrkdwn?: unknown; text?: unknown };
+    if (segment.kind === "text" && typeof segment.text === "string" && segment.mrkdwn === false) {
+      return { kind: "text", text: segment.text, mrkdwn: false };
+    }
+    if (segment.kind === "blocks") {
+      const blocks = parseSlackBlocksInput(segment.blocks) as SlackBlock[] | undefined;
+      if (blocks?.length) {
+        return { kind: "blocks", blocks };
+      }
+    }
+    throw new Error("Slack rendered presentation segment is invalid");
+  });
+}
+
+export type SlackReplyDeliveryMessage = {
+  text: string;
+  blocks?: SlackBlock[];
+  authoredTextPlacement?: SlackAuthoredTextPlacement;
+  nativeDataFallbackBaseText?: string;
+  textIsSlackPlainText?: true;
+};
+
+/** Convert compiled segments into ordered sender calls without re-inferring text placement. */
+export function resolveSlackReplyDeliveryMessages(params: {
+  authoredTextPlacement: SlackAuthoredTextPlacement;
+  segments: readonly SlackReplyBlockSegment[];
+  text?: string;
+}): SlackReplyDeliveryMessage[] {
+  const messages: SlackReplyDeliveryMessage[] = [];
+  let outsideText =
+    params.authoredTextPlacement === "outside-blocks" ? (params.text?.trim() ?? "") : "";
+  for (const segment of params.segments) {
+    if (segment.kind === "text") {
+      const text = [outsideText, segment.text].filter(Boolean).join("\n\n");
+      outsideText = "";
+      if (text) {
+        messages.push({ text, textIsSlackPlainText: true });
+      }
+      continue;
+    }
+    const baseText = outsideText;
+    outsideText = "";
+    const text =
+      buildSlackNativeDataAccessibilityText(baseText, segment.blocks) ||
+      buildSlackBlocksFallbackText(segment.blocks);
+    const authoredTextPlacement: SlackAuthoredTextPlacement = baseText
+      ? "outside-blocks"
+      : params.authoredTextPlacement === "blocks"
+        ? "blocks"
+        : "none";
+    messages.push({
+      text,
+      blocks: segment.blocks,
+      authoredTextPlacement,
+      ...(baseText ? { nativeDataFallbackBaseText: baseText } : {}),
+    });
+  }
+  if (outsideText) {
+    messages.push({ text: outsideText });
+  }
+  return messages;
+}
 
 export function resolveSlackReplyText(payload: ReplyPayload, text = payload.text): string {
   const presentation = normalizeMessagePresentation(payload.presentation);
@@ -39,55 +119,77 @@ export function resolveSlackReplyText(payload: ReplyPayload, text = payload.text
     : (text ?? "");
 }
 
-function splitSlackPresentationForTextFallback(
-  presentation: MessagePresentation,
-  options: ReturnType<typeof resolveSlackBlockOffsets>,
-): {
-  fallback: MessagePresentation;
-  native?: MessagePresentation;
-} {
-  const nativeBlocks: MessagePresentationBlock[] = [];
-  const fallbackBlocks: MessagePresentationBlock[] = [];
-  for (const block of presentation.blocks) {
-    const isControl = block.type === "buttons" || block.type === "select";
-    const isDivider = block.type === "divider";
-    if ((isControl || isDivider) && canRenderSlackPresentation({ blocks: [block] }, options)) {
-      nativeBlocks.push(block);
-    } else {
-      fallbackBlocks.push(block);
-    }
-  }
-  return {
-    fallback: {
-      ...(presentation.title ? { title: presentation.title } : {}),
-      blocks: fallbackBlocks,
-    },
-    ...(nativeBlocks.length > 0 ? { native: { blocks: nativeBlocks } } : {}),
-  };
-}
-
-type SlackReplyBlockPart = {
-  blocks: SlackBlock[];
-  text: string;
-};
-
-export type SlackReplyRenderPlan =
+type SlackReplyRenderPlan =
   | {
       mode: "single";
-      textVisibleInBlocks?: true;
-      textIsSlackMrkdwn?: true;
-      blocks?: SlackBlock[];
-      hookText: string;
       text: string;
+      blocks?: SlackBlock[];
+      textIsSlackMrkdwn?: boolean;
     }
   | {
       mode: "split";
-      blockPart?: SlackReplyBlockPart;
       fallbackText: string;
-      hookText: string;
+      blockPart?: { text: string; blocks?: SlackBlock[] };
     };
 
-function resolveSlackChannelBlocks(payload: ReplyPayload): SlackBlock[] {
+export function resolveSlackReplyRenderPlan(
+  payload: ReplyPayload,
+  text = payload.text,
+): SlackReplyRenderPlan {
+  const hasStructuredContent = hasSlackReplyStructuredContent(payload);
+  // Live preview/streaming still consumes this compact plan shape. Derive it
+  // from canonical ordered segments so preview/streaming stays conservative
+  // without a second renderer.
+  const resolution = resolveSlackReplyBlockResolution(
+    { ...payload, text },
+    { materializeAuthoredText: hasStructuredContent },
+  );
+  const messages = resolveSlackReplyDeliveryMessages({
+    authoredTextPlacement: resolution.authoredTextPlacement,
+    segments: resolution.segments,
+    text,
+  });
+  if (messages.length <= 1) {
+    const [message] = messages;
+    const sourceText = text?.trim() ?? "";
+    const blocks =
+      message?.authoredTextPlacement === "blocks"
+        ? addPreviewVerbatimToAuthoredTextBlocks(message.blocks, sourceText)
+        : message?.blocks;
+    let renderedText = message?.text ?? resolveSlackReplyText(payload, text);
+    let textIsSlackMrkdwn = Boolean(
+      message &&
+      !message.textIsSlackPlainText &&
+      (message.authoredTextPlacement !== "outside-blocks" || message.nativeDataFallbackBaseText),
+    );
+    if (blocks?.length && sourceText) {
+      if (hasSlackNativeDataBlock(blocks)) {
+        renderedText = appendSlackNativeDataFallbackText(sourceText, blocks) || renderedText;
+        textIsSlackMrkdwn = true;
+      } else if (message?.authoredTextPlacement === "blocks") {
+        renderedText = sourceText;
+        textIsSlackMrkdwn = false;
+      }
+    }
+    return {
+      mode: "single",
+      text: renderedText,
+      ...(blocks ? { blocks } : {}),
+      ...(textIsSlackMrkdwn ? { textIsSlackMrkdwn: true } : {}),
+    };
+  }
+  const blockPart = messages.find((message) => message.blocks?.length);
+  return {
+    mode: "split",
+    fallbackText: messages
+      .map((message) => message.text)
+      .filter(Boolean)
+      .join("\n\n"),
+    ...(blockPart ? { blockPart: { text: blockPart.text, blocks: blockPart.blocks } } : {}),
+  };
+}
+
+function readSlackChannelBlocks(payload: ReplyPayload): SlackBlock[] {
   const slackData = payload.channelData?.slack;
   if (!slackData || typeof slackData !== "object" || Array.isArray(slackData)) {
     return [];
@@ -95,238 +197,223 @@ function resolveSlackChannelBlocks(payload: ReplyPayload): SlackBlock[] {
   return (parseSlackBlocksInput((slackData as { blocks?: unknown }).blocks) as SlackBlock[]) ?? [];
 }
 
-function buildSlackReplyBlockPart(
-  blocks: SlackBlock[],
-  compactLimit = SLACK_TEXT_LIMIT,
-): SlackReplyBlockPart | undefined {
-  if (blocks.length === 0) {
-    return undefined;
-  }
-  let text = buildSlackBlocksAccessibleFallbackText(blocks);
-  if (text.length > compactLimit && hasSlackDataTableBlock(blocks)) {
-    // The complete row fallback belongs to the following text chunks. This
-    // post still names the table and every retained control/media sibling.
-    text = buildSlackBlocksCompactAccessibleFallbackText(blocks);
-  }
-  if (text.length > SLACK_TEXT_LIMIT) {
-    throw new Error(
-      `Slack retained-block accessibility fallback exceeds OpenClaw's ${String(SLACK_TEXT_LIMIT)}-character limit`,
-    );
-  }
-  return { blocks, text };
+export function hasSlackReplyStructuredContent(payload: ReplyPayload): boolean {
+  return Boolean(
+    readSlackChannelBlocks(payload).length ||
+    normalizeMessagePresentation(payload.presentation) ||
+    payload.interactive?.blocks.length,
+  );
 }
 
-function buildSlackAuthoredTextBlocks(text: string | null | undefined): SlackBlock[] {
-  const trimmed = text?.trim();
-  if (!trimmed) {
-    return [];
-  }
-  return markdownToSlackMrkdwnChunks(trimmed, SLACK_SECTION_TEXT_MAX).map((chunk) => ({
+function renderSlackAuthoredTextFragments(blocks: readonly SlackBlock[]): string[] {
+  return blocks.flatMap((block) => {
+    if ((block as { type?: unknown }).type === "actions") {
+      return [];
+    }
+    const text = renderSlackBlockFallbackText(block, { nativeDataFormat: "plain" });
+    return text ? [text] : [];
+  });
+}
+
+function buildSlackAuthoredTextBlocks(text: string): SlackBlock[] {
+  return markdownToSlackMrkdwnChunks(text, SLACK_SECTION_TEXT_MAX).map((chunk) => ({
     type: "section",
     text: { type: "mrkdwn", text: chunk, verbatim: true },
   }));
 }
 
-function isSlackAuthoredTextRepresentedInInteractive(
-  text: string | null | undefined,
-  interactive: ReplyPayload["interactive"],
-): boolean {
-  const target = text?.trim().replace(/\s+/gu, " ");
-  if (!target) {
-    return false;
+function addPreviewVerbatimToAuthoredTextBlocks(
+  blocks: SlackBlock[] | undefined,
+  sourceText: string,
+): SlackBlock[] | undefined {
+  if (!blocks?.length || !sourceText) {
+    return blocks;
   }
-  const fragments =
-    interactive?.blocks.flatMap((block) =>
-      block.type === "text" && block.text.trim().length <= SLACK_SECTION_TEXT_MAX
-        ? [block.text.trim().replace(/\s+/gu, " ")]
-        : [],
-    ) ?? [];
-  for (let start = 0; start < fragments.length; start += 1) {
-    let combined = "";
-    for (let end = start; end < fragments.length; end += 1) {
-      combined = `${combined} ${fragments[end]}`.trim().replace(/\s+/gu, " ");
-      if (combined === target) {
-        return true;
-      }
-      if (combined.length > target.length) {
-        break;
-      }
+  const authoredChunks = new Set(markdownToSlackMrkdwnChunks(sourceText, SLACK_SECTION_TEXT_MAX));
+  return blocks.map((block) => {
+    const text = (block as { text?: { text?: unknown; type?: unknown; verbatim?: unknown } }).text;
+    if (
+      block.type !== "section" ||
+      text?.type !== "mrkdwn" ||
+      typeof text.text !== "string" ||
+      !authoredChunks.has(text.text)
+    ) {
+      return block;
     }
-  }
-  return false;
-}
-
-function renderSlackVisiblePresentationFallback(params: {
-  presentation?: MessagePresentation;
-  text?: string | null;
-}): string {
-  const authoredText = params.text?.trim()
-    ? markdownToSlackMrkdwnChunks(params.text.trim(), SLACK_TEXT_LIMIT).join("\n")
-    : undefined;
-  return renderSlackMessagePresentationFallbackText({
-    ...(authoredText ? { text: authoredText } : {}),
-    ...(params.presentation ? { presentation: params.presentation } : {}),
+    return {
+      ...block,
+      text: { ...text, verbatim: true },
+    } as SlackBlock;
   });
 }
 
-export function resolveSlackReplyRenderPlan(
-  payload: ReplyPayload,
-  text = payload.text,
-  options: { includeAuthoredTextBlock?: boolean; textLimit?: number } = {},
-): SlackReplyRenderPlan {
-  const textLimit = options.textLimit ?? SLACK_TEXT_LIMIT;
-  const channelBlocks = resolveSlackChannelBlocks(payload);
-  const presentation = normalizeMessagePresentation(payload.presentation);
-  const presentationOffsets = resolveSlackBlockOffsets(channelBlocks);
-  const hasPresentationTable = presentation?.blocks.some((block) => block.type === "table");
-  let usesPresentationTextFallback = Boolean(
-    presentation &&
-    (!canRenderSlackPresentation(presentation, presentationOffsets) ||
-      (hasPresentationTable &&
-        !canRenderSlackPresentationTables(presentation, presentationOffsets))),
-  );
-  const splitPresentation =
-    presentation && usesPresentationTextFallback
-      ? splitSlackPresentationForTextFallback(presentation, presentationOffsets)
-      : undefined;
-  let fallbackPresentation = splitPresentation?.fallback;
-  const presentationForBlocks = splitPresentation ? splitPresentation.native : presentation;
-  const authoredTextRepresentedInInteractive = isSlackAuthoredTextRepresentedInInteractive(
-    text,
-    payload.interactive,
-  );
-  const authoredTextRepresentedInChannelBlocks = Boolean(
-    text?.trim() && !removeSlackBlocksFallbackParagraphs(text, channelBlocks),
-  );
-  const authoredTextRepresentedInBlocks =
-    authoredTextRepresentedInInteractive || authoredTextRepresentedInChannelBlocks;
-  let authoredTextBlocks =
-    !usesPresentationTextFallback &&
-    options.includeAuthoredTextBlock !== false &&
-    (presentation || channelBlocks.length > 0) &&
-    !authoredTextRepresentedInBlocks
-      ? buildSlackAuthoredTextBlocks(text)
-      : [];
-  const presentationBlocks = buildSlackPresentationBlocks(
-    presentationForBlocks,
-    presentationOffsets,
-  );
-  let interactiveBlocks = buildSlackInteractiveBlocks(
-    payload.interactive,
-    resolveSlackBlockOffsets([...channelBlocks, ...authoredTextBlocks, ...presentationBlocks]),
-  );
-  let blocks = [
-    ...channelBlocks,
-    ...authoredTextBlocks,
-    ...presentationBlocks,
-    ...interactiveBlocks,
-  ];
-  if (blocks.length > SLACK_MAX_BLOCKS && presentation) {
-    // Portable presentation can degrade completely to text. Raw channel blocks
-    // and separately-authored interactive controls remain fail-closed.
-    authoredTextBlocks = [];
-    interactiveBlocks = buildSlackInteractiveBlocks(
-      payload.interactive,
-      resolveSlackBlockOffsets(channelBlocks),
-    );
-    blocks = [...channelBlocks, ...interactiveBlocks];
-    usesPresentationTextFallback = true;
-    fallbackPresentation = presentation;
-  }
-  if (blocks.length > SLACK_MAX_BLOCKS) {
-    throw new Error(
-      `Slack blocks cannot exceed ${SLACK_MAX_BLOCKS} items after interactive render`,
-    );
-  }
-  const hookText = appendSlackBlocksAccessibleFallbackText(resolveSlackReplyText(payload, text), [
-    ...channelBlocks,
-    ...interactiveBlocks,
-  ]);
-  if (usesPresentationTextFallback) {
-    let fallbackText = appendSlackNativeDataFallbackText(
-      renderSlackVisiblePresentationFallback({
-        text,
-        ...(fallbackPresentation ? { presentation: fallbackPresentation } : {}),
-      }),
-      blocks,
-    );
-    let retainedBlocks = blocks.filter((block) => !hasSlackNativeDataBlock([block]));
-    if (
-      retainedBlocks.length > 0 &&
-      buildSlackBlocksAccessibleFallbackText(retainedBlocks).length > SLACK_TEXT_LIMIT
-    ) {
-      const fallbackBlocks = retainedBlocks.filter(isSlackBlockRepresentedByTextFallback);
-      fallbackText = appendSlackBlocksAccessibleFallbackText(fallbackText, fallbackBlocks);
-      retainedBlocks = retainedBlocks.filter(
-        (block) => !isSlackBlockRepresentedByTextFallback(block),
-      );
-    }
-    const blockPart = buildSlackReplyBlockPart(retainedBlocks, textLimit);
-    if (!fallbackText.trim()) {
-      return {
-        mode: "single",
-        ...(blockPart ? { blocks: blockPart.blocks } : {}),
-        hookText,
-        text: blockPart?.text ?? hookText,
-      };
-    }
-    return {
-      mode: "split",
-      ...(blockPart ? { blockPart } : {}),
-      fallbackText,
-      hookText,
-    };
-  }
+function readLastBlockSegment(segments: SlackReplyBlockSegment[]): SlackBlock[] {
+  const last = segments.at(-1);
+  return last?.kind === "blocks" ? last.blocks : [];
+}
 
-  const textIsSlackMrkdwn =
-    presentation?.blocks.some((block) => block.type === "chart" || block.type === "table") ||
-    hasSlackNativeDataBlock(blocks);
-  const singleText = textIsSlackMrkdwn
-    ? appendSlackBlocksAccessibleFallbackText(
-        renderSlackVisiblePresentationFallback({ presentation, text }),
-        blocks,
-      )
-    : hookText;
-  if (blocks.length > 0 && singleText.length > textLimit) {
-    // A native-eligible table should remain native even when its expanded row
-    // fallback requires multiple messages. Other text-replaceable blocks move
-    // completely into those chunks.
-    const siblingCandidates = blocks.filter(
-      (block) => hasSlackDataTableBlock([block]) || !isSlackBlockRepresentedByTextFallback(block),
-    );
-    const siblingBlocks = retainSlackDataTablesWithinCompactFallback(siblingCandidates, textLimit);
-    const splitText = textIsSlackMrkdwn
-      ? singleText
-      : appendSlackBlocksAccessibleFallbackText(
-          renderSlackVisiblePresentationFallback({ presentation, text }),
-          blocks,
-        );
-    const fallbackText = removeSlackBlocksFallbackParagraphs(
-      splitText,
-      siblingBlocks.filter((block) => !hasSlackDataTableBlock([block])),
-    );
-    const blockPart = buildSlackReplyBlockPart(siblingBlocks, textLimit);
-    return {
-      mode: "split",
-      ...(blockPart ? { blockPart } : {}),
-      fallbackText,
-      hookText,
-    };
-  }
+function readAllNativeBlocks(segments: SlackReplyBlockSegment[]): SlackBlock[] {
+  return segments.flatMap((segment) => (segment.kind === "blocks" ? segment.blocks : []));
+}
 
+function appendTextSegment(segments: SlackReplyBlockSegment[], text: string): void {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return;
+  }
+  const last = segments.at(-1);
+  if (last?.kind === "text") {
+    last.text = `${last.text}\n\n${trimmed}`;
+    return;
+  }
+  segments.push({ kind: "text", text: trimmed, mrkdwn: false });
+}
+
+function appendBlockSegment(
+  segments: SlackReplyBlockSegment[],
+  blocks: SlackBlock[],
+  startNew = false,
+): void {
+  let shouldStartNew = startNew;
+  for (const block of blocks) {
+    const last = segments.at(-1);
+    if (!shouldStartNew && last?.kind === "blocks" && last.blocks.length < SLACK_MAX_BLOCKS) {
+      last.blocks.push(block);
+    } else {
+      segments.push({ kind: "blocks", blocks: [block] });
+    }
+    shouldStartNew = false;
+  }
+}
+
+function resolvePresentationRenderOptions(
+  segments: SlackReplyBlockSegment[],
+  mode: "current" | "new-message",
+): SlackBlockRenderOptions {
+  const allOffsets = resolveSlackBlockOffsets(readAllNativeBlocks(segments));
+  const messageOffsets =
+    mode === "current" ? resolveSlackBlockOffsets(readLastBlockSegment(segments)) : {};
+  // Control ids span the logical reply, while chart/table limits reset for
+  // each Slack message. Sharing one offset would needlessly discard native data.
   return {
-    mode: "single",
-    ...(authoredTextBlocks.length > 0 || authoredTextRepresentedInBlocks
-      ? { textVisibleInBlocks: true as const }
-      : {}),
-    ...(blocks.length > 0 ? { blocks } : {}),
-    ...(textIsSlackMrkdwn ? { textIsSlackMrkdwn: true as const } : {}),
-    hookText,
-    text: singleText,
+    ...messageOffsets,
+    buttonIndexOffset: allOffsets.buttonIndexOffset,
+    selectIndexOffset: allOffsets.selectIndexOffset,
   };
 }
 
+function renderNativePresentation(
+  presentation: MessagePresentation,
+  options: SlackBlockRenderOptions,
+): SlackBlock[] | undefined {
+  if (!canRenderSlackPresentation(presentation, options)) {
+    return undefined;
+  }
+  const blocks = buildSlackPresentationBlocks(presentation, options);
+  return blocks.length > 0 ? blocks : undefined;
+}
+
+function appendPresentationPart(
+  segments: SlackReplyBlockSegment[],
+  presentation: MessagePresentation,
+): void {
+  const currentBlocks = readLastBlockSegment(segments);
+  const currentRendered = renderNativePresentation(
+    presentation,
+    resolvePresentationRenderOptions(segments, "current"),
+  );
+  if (currentRendered && currentBlocks.length + currentRendered.length <= SLACK_MAX_BLOCKS) {
+    appendBlockSegment(segments, currentRendered);
+    return;
+  }
+
+  const freshRendered = renderNativePresentation(
+    presentation,
+    resolvePresentationRenderOptions(segments, "new-message"),
+  );
+  if (freshRendered) {
+    appendBlockSegment(segments, freshRendered, true);
+    return;
+  }
+
+  appendTextSegment(
+    segments,
+    // The caller sends fallback segments with mrkdwn disabled, so preserve
+    // authored tokens and command bytes instead of emitting visible entities.
+    renderMessagePresentationFallbackText({ presentation }),
+  );
+}
+
+/**
+ * Resolve reply content into transport-order segments. Each blocks segment is
+ * one Slack message; text segments carry complete fallback content between it.
+ */
+export function resolveSlackReplyBlockResolution(
+  payload: ReplyPayload,
+  options: { materializeAuthoredText?: boolean } = {},
+): SlackReplyBlockResolution {
+  const segments: SlackReplyBlockSegment[] = [];
+  const channelBlocks = readSlackChannelBlocks(payload);
+  let compiledChannelBlocks = channelBlocks;
+  let authoredTextKnownInBlocks = false;
+  if (options.materializeAuthoredText) {
+    const rawTextFragments = renderSlackAuthoredTextFragments(channelBlocks);
+    const initialPlacement = resolveSlackAuthoredTextPlacement({
+      text: payload.text,
+      interactive: payload.interactive,
+      renderedTextFragments: rawTextFragments,
+    });
+    authoredTextKnownInBlocks = initialPlacement === "blocks";
+    const text = normalizeOptionalString(payload.text);
+    if (text && initialPlacement === "outside-blocks") {
+      const textBlocks = buildSlackAuthoredTextBlocks(text);
+      const compiledText = renderSlackAuthoredTextFragments(textBlocks).join(" ");
+      const compiledPlacement = resolveSlackAuthoredTextPlacement({
+        text: compiledText,
+        renderedTextFragments: rawTextFragments,
+      });
+      if (compiledPlacement !== "blocks") {
+        compiledChannelBlocks = [...channelBlocks, ...textBlocks];
+      }
+      authoredTextKnownInBlocks = true;
+    }
+  }
+  if (compiledChannelBlocks.length > 0) {
+    appendBlockSegment(segments, compiledChannelBlocks);
+  }
+
+  const presentation = normalizeMessagePresentation(payload.presentation);
+  if (presentation?.title) {
+    appendPresentationPart(segments, { title: presentation.title, blocks: [] });
+  }
+  for (const block of presentation?.blocks ?? []) {
+    appendPresentationPart(segments, { blocks: [block] });
+  }
+
+  const interactiveBlocks = buildSlackInteractiveBlocks(
+    payload.interactive,
+    resolveSlackBlockOffsets(readAllNativeBlocks(segments)),
+  );
+  appendBlockSegment(segments, interactiveBlocks);
+  const renderedTextFragments = segments.flatMap((segment) => {
+    if (segment.kind === "text") {
+      return [segment.text];
+    }
+    return renderSlackAuthoredTextFragments(segment.blocks);
+  });
+  const authoredTextPlacement = resolveSlackAuthoredTextPlacement({
+    text: payload.text,
+    interactive: payload.interactive,
+    renderedTextFragments,
+  });
+  return {
+    authoredTextPlacement: authoredTextKnownInBlocks ? "blocks" : authoredTextPlacement,
+    segments,
+  };
+}
+
+/** Return the single-message native shape when no ordered text fallback is required. */
 export function resolveSlackReplyBlocks(payload: ReplyPayload): SlackBlock[] | undefined {
-  const plan = resolveSlackReplyRenderPlan(payload);
-  return plan.mode === "single" ? plan.blocks : plan.blockPart?.blocks;
+  const { segments } = resolveSlackReplyBlockResolution(payload);
+  return segments.length === 1 && segments[0]?.kind === "blocks" ? segments[0].blocks : undefined;
 }

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -33,16 +33,54 @@ function postedMessage(client: ReturnType<typeof createSlackSendTestClient>, cal
   return mockObjectArg(client.chat.postMessage, "chat.postMessage", callIndex);
 }
 
-function postedText(message: Record<string, unknown>): string {
-  const text = message.text;
-  if (text == null) {
-    return "";
-  }
-  if (typeof text !== "string") {
-    throw new Error("Expected chat.postMessage text to be a string");
-  }
-  return text;
+function interleavedNativeDataBlocks(): Array<Record<string, unknown>> {
+  return [
+    { type: "section", text: { type: "mrkdwn", text: "Before" } },
+    {
+      type: "data_table",
+      caption: "Pipeline report",
+      rows: [
+        [
+          { type: "raw_text", text: "Account" },
+          { type: "raw_text", text: "ARR" },
+        ],
+        [
+          { type: "raw_text", text: "Acme" },
+          { type: "raw_number", value: 125000, text: "$125k" },
+        ],
+      ],
+    },
+    { type: "section", text: { type: "mrkdwn", text: "After" } },
+    {
+      type: "actions",
+      block_id: "private-block",
+      elements: [
+        {
+          type: "button",
+          action_id: "private-button",
+          text: { type: "plain_text", text: "Approve" },
+          value: "private-value",
+        },
+        {
+          type: "static_select",
+          action_id: "private-select",
+          placeholder: { type: "plain_text", text: "Choose owner" },
+          options: [
+            { text: { type: "plain_text", text: "Secret option" }, value: "private-option" },
+          ],
+        },
+      ],
+    },
+  ];
 }
+
+const INTERLEAVED_NATIVE_DATA_ACCESSIBILITY = [
+  "Outside",
+  "Before",
+  "Pipeline report (table)\nAccount\tARR\nAcme\t$125k",
+  "After",
+  "Approve\nChoose owner",
+].join("\n\n");
 
 function slackDnsRequestError(): Error {
   return Object.assign(new Error("A request error occurred: getaddrinfo EAI_AGAIN slack.com"), {
@@ -178,6 +216,21 @@ describe("sendMessageSlack thread participation", () => {
 });
 
 describe("sendMessageSlack chunking", () => {
+  it("preserves boundary whitespace for formatting-disabled fallback text", async () => {
+    const client = createSlackSendTestClient();
+
+    await sendMessageSlack("channel:C123", "  literal fallback  ", {
+      cfg: SLACK_TEST_CFG,
+      client,
+      textIsSlackPlainText: true,
+    });
+
+    expect(postedMessage(client, 0)).toMatchObject({
+      text: "  literal fallback  ",
+      mrkdwn: false,
+    });
+  });
+
   it("keeps 4205-character text in a single Slack post by default", async () => {
     const client = createSlackSendTestClient();
     const message = "a".repeat(4205);
@@ -214,162 +267,25 @@ describe("sendMessageSlack chunking", () => {
     expect(postedTexts.join("")).toBe(message);
   });
 
-  it("keeps normal word boundaries for raw mrkdwn without protected tokens", async () => {
+  it("keeps Slack mrkdwn code spans closed around protected tokens when chunking", async () => {
     const client = createSlackSendTestClient();
-
-    await sendMessageSlack("channel:C123", "alpha beta", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      textIsSlackMrkdwn: true,
-      textLimit: 8,
-    });
-
-    const postedTexts = client.chat.postMessage.mock.calls.map((call) => String(call[0].text));
-    expect(postedTexts).toEqual(["alpha", "beta"]);
-  });
-
-  it("keeps native Slack angle tokens atomic across raw mrkdwn chunks", async () => {
-    const client = createSlackSendTestClient();
-
-    await sendMessageSlack("channel:C123", "abc <@U123>", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      textIsSlackMrkdwn: true,
-      textLimit: 8,
-    });
-
-    const postedTexts = client.chat.postMessage.mock.calls.map((call) => String(call[0].text));
-    expect(postedTexts).toEqual(["abc ", "<@U123>"]);
-    expect(postedTexts.join("")).toBe("abc <@U123>");
-  });
-
-  it("keeps oversized Slack angle tokens inert inside chunked code", async () => {
-    const client = createSlackSendTestClient();
-    const message = "`<@U123>`x";
+    const message = `\`${"a".repeat(SLACK_TEXT_LIMIT - 5)}<@U123>${"b".repeat(20)}\``;
 
     await sendMessageSlack("channel:C123", message, {
       token: "xoxb-test",
       cfg: SLACK_TEST_CFG,
       client,
       textIsSlackMrkdwn: true,
-      textLimit: 8,
     });
 
-    const postedTexts = client.chat.postMessage.mock.calls.map((call) => String(call[0].text));
+    const postedTexts = client.chat.postMessage.mock.calls.map((call) => call[0].text);
+
     expect(postedTexts.length).toBeGreaterThan(1);
-    expect(postedTexts.every((text) => text.length <= 8)).toBe(true);
-    expect(postedTexts.every((text) => (text.match(/`/gu)?.length ?? 0) % 2 === 0)).toBe(true);
-    expect(postedTexts.every((text) => !text.includes("<@U123>"))).toBe(true);
-    expect(postedTexts.join("").replaceAll("`", "")).toBe(message.replaceAll("`", ""));
-  });
-
-  it("preserves spaces while fragmenting an oversized Slack link inside code", async () => {
-    const client = createSlackSendTestClient();
-    const message = "`<https://x|two words>`z";
-
-    await sendMessageSlack("channel:C123", message, {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      textIsSlackMrkdwn: true,
-      textLimit: 10,
-    });
-
-    const postedTexts = client.chat.postMessage.mock.calls.map((call) => String(call[0].text));
-    expect(postedTexts.every((text) => text.length <= 10)).toBe(true);
-    expect(postedTexts.every((text) => (text.match(/`/gu)?.length ?? 0) % 2 === 0)).toBe(true);
-    expect(postedTexts.every((text) => !text.includes("<https://x|two words>"))).toBe(true);
-    expect(postedTexts.join("").replaceAll("`", "")).toBe(message.replaceAll("`", ""));
-  });
-
-  it("preserves short unmatched mrkdwn backticks byte-for-byte", async () => {
-    const client = createSlackSendTestClient();
-    const message = "literal ` marker";
-
-    await sendMessageSlack("channel:C123", message, {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      textIsSlackMrkdwn: true,
-      textLimit: 100,
-    });
-
-    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
-    expect(postedMessage(client).text).toBe(message);
-  });
-
-  it("preserves code spans and entities across small mrkdwn chunks", async () => {
-    const client = createSlackSendTestClient();
-    const message = "- Deny: `/approve req_1 deny &amp; &lt;@U123&gt;`";
-
-    await sendMessageSlack("channel:C123", message, {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      textIsSlackMrkdwn: true,
-      textLimit: 5,
-    });
-
-    const postedTexts = client.chat.postMessage.mock.calls.map((call) => String(call[0].text));
-    expect(postedTexts.length).toBeGreaterThan(1);
-    expect(postedTexts.every((text) => text.length <= 5)).toBe(true);
-    expect(postedTexts.every((text) => (text.match(/`/gu)?.length ?? 0) % 2 === 0)).toBe(true);
-    expect(postedTexts.every((text) => !/&(?:a|am|l|g|gt|lt)?$/u.test(text))).toBe(true);
-    expect(postedTexts.every((text) => !/^(?:amp;|lt;|gt;)/u.test(text))).toBe(true);
-    expect(postedTexts.join("").replaceAll("`", "")).toBe(message.replaceAll("`", ""));
-    expect(postedTexts.join("")).not.toContain("<@U123>");
-  });
-
-  it("preserves fenced code markers across raw mrkdwn chunks", async () => {
-    const client = createSlackSendTestClient();
-    const message = "```sql\nselect \\`name\\` from users;\n```";
-
-    await sendMessageSlack("channel:C123", message, {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      textIsSlackMrkdwn: true,
-      textLimit: 12,
-    });
-
-    const postedTexts = client.chat.postMessage.mock.calls.map((call) => String(call[0].text));
-    expect(postedTexts.length).toBeGreaterThan(1);
-    expect(postedTexts.every((text) => text.length <= 12)).toBe(true);
-    expect(postedTexts.every((text) => (text.match(/```/gu)?.length ?? 0) % 2 === 0)).toBe(true);
-    expect(postedTexts.join("").replaceAll("```", "")).toBe(message.replaceAll("```", ""));
-  });
-
-  it("balances fenced code at the smallest wrapped chunk limit", async () => {
-    const client = createSlackSendTestClient();
-
-    await sendMessageSlack("channel:C123", "```abcd```", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      textIsSlackMrkdwn: true,
-      textLimit: 7,
-    });
-
-    const postedTexts = client.chat.postMessage.mock.calls.map((call) => String(call[0].text));
-    expect(postedTexts).toEqual(["```a```", "```b```", "```c```", "```d```"]);
-  });
-
-  it("degrades fenced code to bounded plain text when wrappers cannot fit", async () => {
-    const client = createSlackSendTestClient();
-
-    await sendMessageSlack("channel:C123", "```abcdefg```", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      textIsSlackMrkdwn: true,
-      textLimit: 6,
-    });
-
-    const postedTexts = client.chat.postMessage.mock.calls.map((call) => String(call[0].text));
-    expect(postedTexts).toEqual(["abcdef", "g"]);
-    expect(postedTexts.every((text) => !text.includes("```"))).toBe(true);
+    const mentionChunk = postedTexts.find((text) => text?.includes("<@U123>"));
+    expect(mentionChunk).toBeDefined();
+    expect(mentionChunk?.startsWith("`")).toBe(true);
+    expect(mentionChunk?.endsWith("`")).toBe(true);
+    expect(postedTexts.every((text) => (text?.match(/`/gu) ?? []).length % 2 === 0)).toBe(true);
   });
 
   it("reports the first Slack chunk before a later chunk fails", async () => {
@@ -452,7 +368,91 @@ describe("sendMessageSlack blocks", () => {
     expect((receiptPart?.raw as Record<string, unknown> | undefined)?.channelId).toBe("C123");
   });
 
-  it("retries rejected native charts as visible accessible fallback blocks", async () => {
+  it("includes sibling block text in top-level fallback for raw block sends", async () => {
+    const client = createSlackSendTestClient();
+
+    await sendMessageSlack("channel:C123", "Summary", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      blocks: [
+        { type: "section", text: { type: "mrkdwn", text: "Details" } },
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Approve" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(postedMessage(client)).toMatchObject({
+      text: "Summary\n\nDetails\n\nApprove",
+    });
+  });
+
+  it("keeps interleaved native data and raw controls ordered in accepted accessibility text", async () => {
+    const client = createSlackSendTestClient();
+    const blocks = interleavedNativeDataBlocks();
+
+    await sendMessageSlack("channel:C123", "Outside", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      blocks: blocks as never,
+      nativeDataFallbackBaseText: "Outside",
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledOnce();
+    expect(postedMessage(client)).toMatchObject({
+      blocks: blocks as never,
+      mrkdwn: false,
+      text: INTERLEAVED_NATIVE_DATA_ACCESSIBILITY,
+    });
+    expect(postedMessage(client).text).not.toMatch(/private|Secret option/u);
+  });
+
+  it("keeps interleaved native data and raw controls ordered after invalid_blocks", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+    const blocks = interleavedNativeDataBlocks();
+
+    await sendMessageSlack("channel:C123", "Outside", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      blocks: blocks as never,
+      nativeDataFallbackBaseText: "Outside",
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(postedMessage(client, 0).text).toBe(INTERLEAVED_NATIVE_DATA_ACCESSIBILITY);
+    expect(postedMessage(client, 1)).toMatchObject({
+      blocks: [
+        { type: "section", text: { type: "plain_text", text: "Outside" } },
+        blocks[0],
+        {
+          type: "section",
+          text: {
+            type: "plain_text",
+            text: "Pipeline report (table)\nAccount\tARR\nAcme\t$125k",
+          },
+        },
+        blocks[2],
+        blocks[3],
+      ],
+      mrkdwn: false,
+      text: INTERLEAVED_NATIVE_DATA_ACCESSIBILITY,
+    });
+    for (const index of [0, 1]) {
+      expect(postedMessage(client, index).text).not.toMatch(/private|Secret option/u);
+    }
+  });
+
+  it("retries rejected native charts as accessible text", async () => {
     const client = createSlackSendTestClient();
     client.chat.postMessage.mockRejectedValueOnce(
       Object.assign(new Error("An API error occurred: invalid_blocks"), {
@@ -485,43 +485,23 @@ describe("sendMessageSlack blocks", () => {
     expect(postedMessage(client, 0).text).toBe(
       "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
     );
-    expect(postedMessage(client, 1).blocks).toEqual([
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
-          verbatim: true,
-        },
-      },
-    ]);
+    expect(postedMessage(client, 1).blocks).toBeUndefined();
     expect(postedMessage(client, 1).text).toBe(
       "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
     );
+    expect(postedMessage(client, 1).mrkdwn).toBe(false);
   });
 
-  it("chunks overlong chart fallbacks instead of truncating screen-reader text", async () => {
+  it("uses 40k blockless chunks only for oversized native data with no survivors", async () => {
     const client = createSlackSendTestClient();
-    const categories = Array.from({ length: 20 }, (_point, pointIndex) =>
-      `Category-${String(pointIndex)}`.padEnd(20, "x"),
-    );
+    const caption = "c".repeat(41_000);
     const blocks = [
       {
-        type: "data_visualization",
-        title: "Large revenue report",
-        chart: {
-          type: "bar",
-          series: Array.from({ length: 12 }, (_series, seriesIndex) => ({
-            name: `Series-${String(seriesIndex)}`.padEnd(20, "x"),
-            data: categories.map((label) => ({
-              label,
-              value: Number.MAX_VALUE,
-            })),
-          })),
-          axis_config: { categories },
-        },
+        type: "data_table",
+        caption,
+        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
       },
-    ];
+    ] as never;
 
     await sendMessageSlack("channel:C123", "", {
       token: "xoxb-test",
@@ -530,60 +510,54 @@ describe("sendMessageSlack blocks", () => {
       blocks,
     });
 
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
-    );
-    expect(posts.length).toBeGreaterThan(1);
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    const posts = [postedMessage(client, 0), postedMessage(client, 1)];
     expect(posts.every((post) => post.blocks === undefined)).toBe(true);
-    expect(posts.every((post) => Array.from(postedText(post)).length <= SLACK_TEXT_LIMIT)).toBe(
-      true,
-    );
-    expect(posts.map(postedText).join("\n")).toContain("Series-11");
+    expect(posts.every((post) => post.mrkdwn === false)).toBe(true);
+    expect(posts.every((post) => String(post.text).length <= 40_000)).toBe(true);
+    expect(posts.map((post) => post.text).join("")).toBe(`${caption} (table)\nAccount\nAcme`);
   });
 
-  it("chunks overlong chart fallback sent separately from authored text", async () => {
+  it("splits non-native blocks before their accessibility text exceeds 40k", async () => {
     const client = createSlackSendTestClient();
-    const categories = Array.from({ length: 20 }, (_point, pointIndex) =>
-      `Category-${String(pointIndex)}`.padEnd(20, "x"),
-    );
-    const blocks = [
-      {
-        type: "data_visualization",
-        title: "Large revenue report",
-        chart: {
-          type: "bar",
-          series: Array.from({ length: 12 }, (_series, seriesIndex) => ({
-            name: `Series-${String(seriesIndex)}`.padEnd(20, "x"),
-            data: categories.map((label) => ({ label, value: Number.MAX_VALUE })),
-          })),
-          axis_config: { categories },
-        },
-      },
-    ];
+    const blocks = Array.from({ length: 20 }, (_entry, index) => ({
+      type: "section",
+      text: { type: "plain_text", text: `${String(index)}-${"x".repeat(2_990)}` },
+    }));
 
-    await sendMessageSlack("channel:C123", "**Summary**", {
+    await sendMessageSlack("channel:C123", "", {
       token: "xoxb-test",
       cfg: SLACK_TEST_CFG,
       client,
       blocks,
-      separateTextAndBlocks: true,
+      authoredTextPlacement: "none",
     });
 
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
-    );
-    expect(posts.length).toBeGreaterThan(2);
-    expect(posts[0]).toMatchObject({
-      text: "Large revenue report (bar chart)",
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    const posts = [postedMessage(client, 0), postedMessage(client, 1)];
+    expect(posts.every((post) => String(post.text).length <= 40_000)).toBe(true);
+    expect(posts.every((post) => post.mrkdwn === false)).toBe(true);
+    expect(posts.flatMap((post) => post.blocks as unknown[])).toEqual(blocks);
+  });
+
+  it("keeps ordered non-native accessibility complete above the normal 8k text limit", async () => {
+    const client = createSlackSendTestClient();
+    const blocks = Array.from({ length: 3 }, (_entry, index) => ({
+      type: "section",
+      text: { type: "plain_text", text: `${String(index)}-${"x".repeat(2_990)}` },
+    }));
+
+    await sendMessageSlack("channel:C123", "", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
       blocks,
+      authoredTextPlacement: "none",
     });
-    expect(posts.slice(1).every((post) => post.blocks === undefined)).toBe(true);
-    expect(posts.every((post) => Array.from(postedText(post)).length <= SLACK_TEXT_LIMIT)).toBe(
-      true,
-    );
-    const fallbackText = posts.slice(1).map(postedText).join("\n");
-    expect(fallbackText).toContain("*Summary*");
-    expect(fallbackText.match(/Series-11/g)).toHaveLength(1);
+
+    expect(client.chat.postMessage).toHaveBeenCalledOnce();
+    expect(String(postedMessage(client, 0).text).length).toBeGreaterThan(8_000);
+    expect(postedMessage(client, 0).blocks).toEqual(blocks);
   });
 
   it("retries rejected native tables once with complete accessible text", async () => {
@@ -615,8 +589,9 @@ describe("sendMessageSlack blocks", () => {
       "Overview",
       "",
       "Pipeline report (table)",
-      "- Account: &lt;@U123&gt;; ARR: $125k",
-      "- Account: Globex; ARR: $82k",
+      "Account\tARR",
+      "<@U123>\t$125k",
+      "Globex\t$82k",
     ].join("\n");
 
     await sendMessageSlack("channel:C123", "Overview", {
@@ -624,77 +599,55 @@ describe("sendMessageSlack blocks", () => {
       cfg: SLACK_TEST_CFG,
       client,
       blocks,
+      authoredTextPlacement: "blocks",
     });
 
     expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
     expect(postedMessage(client, 0).blocks).toEqual(blocks);
     expect(postedMessage(client, 0).text).toBe(fallback);
+    expect(postedMessage(client, 0).mrkdwn).toBe(false);
     expect(postedMessage(client, 1).blocks).toEqual([
       blocks[0],
       {
         type: "section",
-        text: {
-          type: "mrkdwn",
-          text: [
-            "Pipeline report (table)",
-            "- Account: &lt;@U123&gt;; ARR: $125k",
-            "- Account: Globex; ARR: $82k",
-          ].join("\n"),
-          verbatim: true,
-        },
+        text: { type: "plain_text", text: fallback.split("\n\n")[1] },
       },
     ]);
-    expect(postedMessage(client, 1).text).toBe(fallback);
-  });
-
-  it("marks data-derived fallback mrkdwn verbatim", async () => {
-    const client = createSlackSendTestClient();
-    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
-
-    await sendMessageSlack("channel:C123", "", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      blocks: [
-        {
-          type: "data_table",
-          caption: "Alerts",
-          rows: [[{ type: "raw_text", text: "Owner" }], [{ type: "raw_text", text: "@here" }]],
-        },
-      ] as never,
+    expect(postedMessage(client, 1)).toMatchObject({
+      mrkdwn: false,
+      text: fallback,
     });
-
-    expect(postedMessage(client, 1).blocks).toEqual([
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "Alerts (table)\n- Owner: @here",
-          verbatim: true,
-        },
-      },
-    ]);
   });
 
-  it("chunks overlong table fallbacks while preserving the native table and controls", async () => {
+  it("preserves controls, delivery semantics, and complete mixed native-data fallback", async () => {
     const client = createSlackSendTestClient();
-    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
-    const header = "Account".padEnd(80, "x");
+    client.chat.postMessage
+      .mockRejectedValueOnce({ data: { error: "invalid_blocks" } })
+      .mockResolvedValueOnce({
+        ts: "171234.568",
+        channel: "C999",
+        message: { thread_ts: "171111.100" },
+      });
+    const onPlatformSendDispatch = vi.fn(async () => undefined);
+    const onDeliveryResult = vi.fn(async (_result: { messageId: string }) => undefined);
+    const metadata = {
+      event_type: "assistant_thread_context",
+      event_payload: { team_id: "T123" },
+    };
+    const section = { type: "section", text: { type: "mrkdwn", text: "Overview" } };
+    const actions = {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          action_id: "approve",
+          text: { type: "plain_text", text: "Approve" },
+          value: "yes",
+        },
+      ],
+    };
     const blocks = [
-      { type: "section", text: { type: "mrkdwn", text: "Overview" } },
-      {
-        type: "data_table",
-        caption: "Large pipeline",
-        rows: [
-          [{ type: "raw_text", text: header }],
-          ...Array.from({ length: 100 }, (_entry, index) => [
-            {
-              type: "raw_text",
-              text: index === 0 ? "<@U123>" : `account-${String(index)}`,
-            },
-          ]),
-        ],
-      },
+      section,
       {
         type: "data_visualization",
         title: "Revenue mix",
@@ -707,367 +660,326 @@ describe("sendMessageSlack blocks", () => {
         },
       },
       {
-        type: "actions",
-        elements: [
-          {
-            type: "button",
-            text: { type: "plain_text", text: "Refresh" },
-            action_id: "refresh",
-            value: "refresh",
-          },
+        type: "data_table",
+        caption: "Pipeline report",
+        rows: [
+          [
+            { type: "raw_text", text: "Account" },
+            { type: "raw_text", text: "ARR" },
+          ],
+          [
+            { type: "raw_text", text: "Acme" },
+            { type: "raw_number", value: 125000, text: "$125k" },
+          ],
         ],
       },
+      actions,
     ] as never;
+
+    const result = await sendMessageSlack("channel:C123", "Overview", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      blocks,
+      authoredTextPlacement: "blocks",
+      threadTs: "171000.100",
+      replyBroadcast: true,
+      identity: { username: "Claw", iconEmoji: ":crab:" },
+      metadata,
+      deliveryQueueId: "queue-1",
+      onPlatformSendDispatch,
+      onDeliveryResult,
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(postedMessage(client, 0).blocks).toEqual(blocks);
+    expect(postedMessage(client, 1)).toMatchObject({
+      blocks: [
+        section,
+        {
+          type: "section",
+          text: {
+            type: "plain_text",
+            text: "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
+          },
+        },
+        {
+          type: "section",
+          text: {
+            type: "plain_text",
+            text: "Pipeline report (table)\nAccount\tARR\nAcme\t$125k",
+          },
+        },
+        actions,
+      ],
+      thread_ts: "171000.100",
+      reply_broadcast: true,
+      username: "Claw",
+      icon_emoji: ":crab:",
+      metadata: {
+        event_type: "assistant_thread_context",
+        event_payload: {
+          team_id: "T123",
+          openclaw_delivery_part_index: 0,
+          openclaw_delivery_part_count: 1,
+        },
+      },
+      mrkdwn: false,
+    });
+    expect(postedMessage(client, 1).text).toContain(
+      "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
+    );
+    expect(postedMessage(client, 1).text).toContain(
+      "Pipeline report (table)\nAccount\tARR\nAcme\t$125k",
+    );
+    expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["171234.568"]);
+    expect(result).toMatchObject({
+      messageId: "171234.568",
+      channelId: "C999",
+      threadTs: "171111.100",
+    });
+    expect(result.receipt.platformMessageIds).toEqual(["171234.568"]);
+  });
+
+  it("propagates invalid_blocks when Slack also rejects the retained controls", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage
+      .mockRejectedValueOnce({ data: { error: "invalid_blocks" } })
+      .mockRejectedValueOnce(
+        Object.assign(new Error("An API error occurred: invalid_blocks"), {
+          data: { error: "invalid_blocks" },
+        }),
+      );
+    const onPlatformSendDispatch = vi.fn(async () => undefined);
+    const onDeliveryResult = vi.fn(async () => undefined);
+    const actions = {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          action_id: "approve",
+          text: { type: "plain_text", text: "Approve" },
+          value: "yes",
+        },
+      ],
+    };
+    const blocks = [
+      {
+        type: "data_table",
+        caption: "Pipeline",
+        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
+      },
+      actions,
+    ] as never;
+
+    await expect(
+      sendMessageSlack("channel:C123", "Pipeline", {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+        blocks,
+        onPlatformSendDispatch,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("invalid_blocks");
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(postedMessage(client, 1).blocks).toEqual([
+      { type: "section", text: { type: "plain_text", text: "Pipeline" } },
+      {
+        type: "section",
+        text: { type: "plain_text", text: "Pipeline (table)\nAccount\nAcme" },
+      },
+      actions,
+    ]);
+    expect(postedMessage(client, 1).text).toBe(
+      "Pipeline\n\nPipeline (table)\nAccount\nAcme\n\nApprove",
+    );
+    expect(postedMessage(client, 1).text).not.toContain("yes");
+    expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).not.toHaveBeenCalled();
+  });
+
+  it("uses a visible text fallback for a malformed rejected native table", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+    const onPlatformSendDispatch = vi.fn(async () => undefined);
 
     const result = await sendMessageSlack("channel:C123", "", {
       token: "xoxb-test",
       cfg: SLACK_TEST_CFG,
       client,
-      blocks,
-      threadTs: "171234.100",
-      replyBroadcast: true,
+      blocks: [{ type: "data_table" }] as never,
+      onPlatformSendDispatch,
     });
 
-    expect(client.chat.postMessage.mock.calls.length).toBeGreaterThan(2);
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
-    );
-    expect(posts[0]?.blocks).toEqual([blocks[1], blocks[3]]);
-    expect(posts[0]?.text).toBe("Large pipeline (table)\n\n- Refresh");
-    expect(posts[1]).toMatchObject({ text: "- Refresh", blocks: [blocks[3]] });
-    expect(posts.slice(2).every((post) => post.blocks === undefined)).toBe(true);
-    expect(posts.every((post) => Array.from(postedText(post)).length <= SLACK_TEXT_LIMIT)).toBe(
-      true,
-    );
-    expect(posts[0]?.reply_broadcast).toBeUndefined();
-    expect(posts[2]?.reply_broadcast).toBe(true);
-    expect(posts.every((post) => post.thread_ts === "171234.100")).toBe(true);
-    expect(result.receipt.parts[0]?.kind).toBe("card");
-    expect(result.receipt.parts.slice(1).every((part) => part.kind === "text")).toBe(true);
-    expect(result.receipt.parts.map((part) => part.index)).toEqual(
-      Array.from({ length: result.receipt.parts.length }, (_entry, index) => index),
-    );
-    const fallbackText = posts
-      .slice(2)
-      .map((post) => post.text)
-      .join("\n");
-    expect(fallbackText).toContain(`- ${header}: &lt;@U123&gt;`);
-    expect(fallbackText).toContain(`- ${header}: account-99`);
-    expect(fallbackText).toContain("Revenue mix (pie chart)");
-    expect(fallbackText.match(/Overview/g)).toHaveLength(1);
-    expect(fallbackText.match(/Large pipeline \(table\)/g)).toHaveLength(1);
-    expect(fallbackText).not.toContain("<@U123>");
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(postedMessage(client, 1).blocks).toBeUndefined();
+    expect(postedMessage(client, 1)).toMatchObject({
+      text: "Slack could not render this chart or table data.",
+      mrkdwn: false,
+    });
+    expect(result.receipt.platformMessageIds).toEqual(["171234.567"]);
+    expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
   });
 
-  it("renders rejected native table rows when separate text is unrelated", async () => {
+  it("posts a valid native table once when its accessibility fallback is overlong", async () => {
     const client = createSlackSendTestClient();
-    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
-    const blocks = [
-      {
-        type: "data_table",
-        caption: "Pipeline",
-        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
-      },
-    ] as never;
-
-    await sendMessageSlack("channel:C123", "Unrelated follow-up", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      blocks,
-      separateTextAndBlocks: true,
-      textIsSlackMrkdwn: true,
-    });
-
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
-    );
-    expect(posts).toHaveLength(3);
-    expect(posts[0]?.blocks).toEqual(blocks);
-    expect(posts[1]).toMatchObject({
-      text: "Pipeline (table)\n- Account: Acme",
-      blocks: [
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: "Pipeline (table)\n- Account: Acme",
-            verbatim: true,
-          },
-        },
-      ],
-    });
-    expect(posts[2]).toMatchObject({ text: "Unrelated follow-up" });
-    expect(posts[2]?.blocks).toBeUndefined();
-    expect(
-      posts.slice(1).filter((post) => JSON.stringify(post).includes("- Account: Acme")),
-    ).toHaveLength(1);
-  });
-
-  it("chunks overlong separate table fallbacks before native rejection retry", async () => {
-    const client = createSlackSendTestClient();
-    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
-    const authoredMarkdown = "**Important** [Docs](https://example.com)";
     const header = "Account".padEnd(80, "x");
+    const accounts = Array.from({ length: 100 }, (_entry, index) =>
+      (index === 0 ? "<@U123>" : `account-${String(index)}`).padEnd(99, "x"),
+    );
     const blocks = [
       {
         type: "data_table",
-        caption: "Pipeline",
+        caption: "Large pipeline",
         rows: [
           [{ type: "raw_text", text: header }],
-          ...Array.from({ length: 100 }, (_entry, index) => [
-            { type: "raw_text", text: `account-${String(index)}` },
-          ]),
-        ],
-      },
-      {
-        type: "data_visualization",
-        title: "Revenue",
-        chart: {
-          type: "pie",
-          segments: [
-            { label: "A", value: 1 },
-            { label: "B", value: 2 },
-          ],
-        },
-      },
-    ] as never;
-
-    await sendMessageSlack("channel:C123", authoredMarkdown, {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      blocks,
-      separateTextAndBlocks: true,
-    });
-
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
-    );
-    expect(posts.length).toBeGreaterThan(3);
-    const compactFallback = "Pipeline (table)\n\nRevenue (pie chart)";
-    expect(posts[0]).toMatchObject({ text: compactFallback, blocks });
-    expect(posts[1]).toMatchObject({ text: compactFallback });
-    expect(posts[1]?.blocks).toBeUndefined();
-    expect(posts.slice(2).every((post) => post.blocks === undefined)).toBe(true);
-    expect(posts.every((post) => Array.from(postedText(post)).length <= SLACK_TEXT_LIMIT)).toBe(
-      true,
-    );
-    const fallbackText = posts
-      .slice(2)
-      .map((post) => post.text)
-      .join("\n");
-    expect(fallbackText).toContain("*Important* <https://example.com|Docs>");
-    expect(fallbackText).not.toContain("**Important**");
-    expect(fallbackText).toContain(`- ${header}: account-99`);
-    expect(fallbackText.match(/Pipeline \(table\)/g)).toHaveLength(1);
-    const deliveredText = posts
-      .slice(1)
-      .map((post) => post.text)
-      .join("\n");
-    expect(deliveredText.match(/- A: 1/g)).toHaveLength(1);
-    expect(deliveredText.match(/- B: 2/g)).toHaveLength(1);
-  });
-
-  it("chunks a long-caption table fallback instead of throwing", async () => {
-    const client = createSlackSendTestClient();
-    const caption = "c".repeat(8_100);
-    const blocks = [
-      {
-        type: "data_table",
-        caption,
-        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
-      },
-      {
-        type: "actions",
-        elements: [
-          {
-            type: "button",
-            text: { type: "plain_text", text: "Refresh" },
-            action_id: "refresh",
-            value: "refresh",
-          },
+          ...accounts.map((text) => [{ type: "raw_text", text }]),
         ],
       },
     ] as never;
 
-    await sendMessageSlack("channel:C123", "Summary", {
+    await sendMessageSlack("channel:C123", "", {
       token: "xoxb-test",
       cfg: SLACK_TEST_CFG,
       client,
       blocks,
-      textIsSlackMrkdwn: true,
     });
 
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
+    expect(client.chat.postMessage).toHaveBeenCalledOnce();
+    expect(postedMessage(client).blocks).toEqual(blocks);
+    expect(postedMessage(client).text).toBe(
+      ["Large pipeline (table)", header, ...accounts].join("\n"),
     );
-    expect(posts[0]?.blocks).toEqual([blocks[1]]);
-    expect(posts.slice(1).every((post) => post.blocks === undefined)).toBe(true);
-    const fallbackText = posts
-      .slice(1)
-      .map((post) => post.text)
-      .join("");
-    expect(fallbackText).toContain(`${caption} (table)`);
-    expect(fallbackText).toContain("- Account: Acme");
+    expect(String(postedMessage(client).text).length).toBeGreaterThan(SLACK_TEXT_LIMIT);
+    expect(String(postedMessage(client).text).length).toBeLessThanOrEqual(40_000);
+    expect(postedMessage(client).mrkdwn).toBe(false);
   });
 
-  it("drops an overlong separate table while compacting retained native siblings", async () => {
+  it("retries an overlong native table once as complete blockless text", async () => {
     const client = createSlackSendTestClient();
-    const caption = "c".repeat(8_100);
+    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+    const onPlatformSendDispatch = vi.fn(async () => undefined);
+    const header = "Account".padEnd(80, "x");
+    const accounts = Array.from({ length: 100 }, (_entry, index) =>
+      (index === 0 ? "<@U123>" : `account-${String(index)}`).padEnd(99, "x"),
+    );
     const blocks = [
       {
         type: "data_table",
-        caption,
-        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
-      },
-      {
-        type: "data_visualization",
-        title: "Revenue",
-        chart: {
-          type: "pie",
-          segments: [
-            { label: "A", value: 1 },
-            { label: "B", value: 2 },
-          ],
-        },
+        caption: "Large pipeline",
+        rows: [
+          [{ type: "raw_text", text: header }],
+          ...accounts.map((text) => [{ type: "raw_text", text }]),
+        ],
       },
     ] as never;
 
-    await sendMessageSlack("channel:C123", "Summary", {
+    await sendMessageSlack("channel:C123", "", {
       token: "xoxb-test",
       cfg: SLACK_TEST_CFG,
       client,
       blocks,
-      separateTextAndBlocks: true,
+      onPlatformSendDispatch,
     });
 
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(postedMessage(client, 0).blocks).toEqual(blocks);
+    expect(postedMessage(client, 0).text).toBe(
+      ["Large pipeline (table)", header, ...accounts].join("\n"),
     );
-    expect(posts.length).toBeGreaterThan(1);
-    expect(posts[0]).toMatchObject({ text: "Revenue (pie chart)", blocks: [blocks[1]] });
-    expect(posts.slice(1).every((post) => post.blocks === undefined)).toBe(true);
-    expect(posts.every((post) => Array.from(postedText(post)).length <= SLACK_TEXT_LIMIT)).toBe(
-      true,
-    );
-    const fallbackText = posts
-      .slice(1)
-      .map((post) => post.text)
-      .join("");
-    expect(fallbackText).toContain("Summary");
-    expect(fallbackText).toContain(`${caption} (table)`);
-    expect(fallbackText).toContain("- Account: Acme");
-    expect(fallbackText.match(/- A: 1/g)).toHaveLength(1);
-    expect(fallbackText.match(/- B: 2/g)).toHaveLength(1);
+    expect(postedMessage(client, 0).mrkdwn).toBe(false);
+    const fallbackPost = postedMessage(client, 1);
+    expect(fallbackPost.blocks).toBeUndefined();
+    expect(fallbackPost.mrkdwn).toBe(false);
+    expect(String(fallbackPost.text).length).toBeLessThanOrEqual(40_000);
+    const deliveredText = fallbackPost.text;
+    expect(deliveredText).toBe(["Large pipeline (table)", header, ...accounts].join("\n"));
+    expect(deliveredText).toContain("<@U123>");
+    expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
   });
 
-  it("uses the account text limit when deciding whether to retain a native table", async () => {
+  it("batches more than 50 ordered fallback blocks across Web API posts", async () => {
     const client = createSlackSendTestClient();
-    const cfg = {
-      channels: {
-        slack: {
-          botToken: "xoxb-test",
-          textChunkLimit: 100,
-          accounts: { default: { textChunkLimit: 20 } },
+    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
+    const onPlatformSendDispatch = vi.fn(async () => undefined);
+    const caption = "c".repeat(9_000);
+    const actions = {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          action_id: "approve",
+          text: { type: "plain_text", text: "Approve" },
+          value: "yes",
         },
-      },
+      ],
     };
     const blocks = [
+      ...Array.from({ length: 48 }, () => ({ type: "divider" })),
+      actions,
       {
         type: "data_table",
-        caption: "Quarterly pipeline",
+        caption,
         rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
       },
     ] as never;
 
     await sendMessageSlack("channel:C123", "", {
       token: "xoxb-test",
-      cfg,
-      client,
-      blocks,
-    });
-
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
-    );
-    expect(posts.every((post) => post.blocks === undefined)).toBe(true);
-    expect(posts.every((post) => postedText(post).length <= 20)).toBe(true);
-    expect(
-      posts
-        .map((post) => post.text)
-        .join("")
-        .replace(/\s+/gu, ""),
-    ).toContain("Quarterlypipeline(table)-Account:Acme");
-  });
-
-  it("uses an explicit text limit for separate native fallback and rejection retry", async () => {
-    const client = createSlackSendTestClient();
-    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
-    const blocks = [
-      {
-        type: "data_table",
-        caption: "Pipeline",
-        rows: [
-          [{ type: "raw_text", text: "Account" }],
-          ...Array.from({ length: 10 }, (_entry, index) => [
-            { type: "raw_text", text: `account-${String(index)}` },
-          ]),
-        ],
-      },
-    ] as never;
-
-    await sendMessageSlack("channel:C123", "Summary", {
-      token: "xoxb-test",
-      cfg: { channels: { slack: { botToken: "xoxb-test", textChunkLimit: 100 } } },
-      client,
-      blocks,
-      separateTextAndBlocks: true,
-      textLimit: 40,
-    });
-
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
-    );
-    expect(posts[0]).toMatchObject({ text: "Pipeline (table)", blocks });
-    expect(posts[1]).toMatchObject({ text: "Pipeline (table)" });
-    expect(posts[1]?.blocks).toBeUndefined();
-    expect(posts.every((post) => postedText(post).length <= 40)).toBe(true);
-    expect(
-      posts
-        .slice(1)
-        .map((post) => post.text)
-        .join("\n")
-        .match(/- Account: account-9/g),
-    ).toHaveLength(1);
-  });
-
-  it("does not repeat retained block text in long separate text sends", async () => {
-    const client = createSlackSendTestClient();
-    const blocks = [
-      { type: "section", text: { type: "mrkdwn", text: "Visible summary" } },
-    ] as const;
-    const authoredText = `start-${"x".repeat(8_100)}-tail`;
-
-    await sendMessageSlack("channel:C123", authoredText, {
-      token: "xoxb-test",
       cfg: SLACK_TEST_CFG,
       client,
-      blocks: [...blocks],
-      separateTextAndBlocks: true,
-      textIsSlackMrkdwn: true,
+      blocks,
+      onPlatformSendDispatch,
     });
 
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(3);
+    expect(postedMessage(client, 0).blocks).toEqual(blocks);
+    const fallbackPosts = client.chat.postMessage.mock.calls
+      .slice(1)
+      .map((_call, index) => postedMessage(client, index + 1));
+    expect(fallbackPosts).toHaveLength(2);
+    expect(fallbackPosts.every((post) => (post.blocks as unknown[]).length <= 50)).toBe(true);
+    const firstFallbackBlocks = fallbackPosts[0]?.blocks as Array<{ type?: string }> | undefined;
+    expect(firstFallbackBlocks?.[48]?.type).toBe("actions");
+    expect(fallbackPosts.every((post) => post.mrkdwn === false)).toBe(true);
+    expect(fallbackPosts.every((post) => String(post.text).length <= 40_000)).toBe(true);
+    const fallbackSectionText = fallbackPosts
+      .flatMap((post) => post.blocks as Array<{ text?: { type?: string; text?: string } }>)
+      .flatMap((block) =>
+        block.text?.type === "plain_text" && block.text.text ? [block.text.text] : [],
+      )
+      .join("");
+    expect(fallbackSectionText).toBe(`${caption} (table)\nAccount\nAcme`);
+    expect(fallbackPosts.map((post) => post.text).join("\n")).not.toContain("yes");
+    expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
+  });
+
+  it("does not fall back from non-invalid_blocks native table errors", async () => {
+    const client = createSlackSendTestClient();
+    client.chat.postMessage.mockRejectedValueOnce(
+      Object.assign(new Error("An API error occurred: ratelimited"), {
+        data: { error: "ratelimited" },
+      }),
     );
-    expect(posts[0]?.blocks).toEqual(blocks);
-    expect(posts[0]?.text).toBe("Visible summary");
-    expect(posts.slice(1).every((post) => post.blocks === undefined)).toBe(true);
-    const chunkedText = posts.slice(1).map(postedText).join("\n");
-    expect(chunkedText).toContain("start-");
-    expect(chunkedText).toContain("-tail");
-    expect(chunkedText).not.toContain("Visible summary");
+
+    await expect(
+      sendMessageSlack("channel:C123", "Overview", {
+        token: "xoxb-test",
+        cfg: SLACK_TEST_CFG,
+        client,
+        blocks: [
+          {
+            type: "data_table",
+            caption: "Pipeline",
+            rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
+          },
+        ] as never,
+      }),
+    ).rejects.toThrow("ratelimited");
+    expect(client.chat.postMessage).toHaveBeenCalledOnce();
   });
 
   it("does not retry invalid non-data blocks", async () => {
@@ -1112,6 +1024,7 @@ describe("sendMessageSlack blocks", () => {
       cfg: SLACK_TEST_CFG,
       client,
       blocks,
+      authoredTextPlacement: "blocks",
     });
 
     expect(postedMessage(client, 0).text).toBe(
@@ -1120,58 +1033,7 @@ describe("sendMessageSlack blocks", () => {
     expect(postedMessage(client, 0).blocks).toEqual(blocks);
   });
 
-  it("includes every raw block and control in successful accessibility text", async () => {
-    const client = createSlackSendTestClient();
-    const blocks = [
-      { type: "section", text: { type: "mrkdwn", text: "Details" } },
-      {
-        type: "actions",
-        elements: [
-          {
-            type: "button",
-            action_id: "approve",
-            text: { type: "plain_text", text: "Approve" },
-            value: "approve",
-          },
-        ],
-      },
-    ];
-
-    await sendMessageSlack("channel:C123", "Summary", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      blocks,
-    });
-
-    expect(postedMessage(client, 0).text).toBe("Summary\n\nDetails\n\n- Approve");
-    expect(postedMessage(client, 0).blocks).toEqual(blocks);
-  });
-
-  it("chunks overlong raw text blocks without truncating accessibility text", async () => {
-    const client = createSlackSendTestClient();
-    const blocks = Array.from({ length: 3 }, (_entry, index) => ({
-      type: "section",
-      text: { type: "mrkdwn", text: `${String(index)}${"x".repeat(2999)}-tail` },
-    }));
-
-    await sendMessageSlack("channel:C123", "", {
-      token: "xoxb-test",
-      cfg: SLACK_TEST_CFG,
-      client,
-      blocks,
-    });
-
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
-    );
-    expect(posts.length).toBeGreaterThan(1);
-    expect(posts.every((post) => post.blocks === undefined)).toBe(true);
-    expect(posts.map(postedText).join("\n")).toContain("2xxx");
-    expect(posts.map(postedText).join("\n")).toContain("-tail");
-  });
-
-  it("replaces rejected native charts while preserving sibling blocks", async () => {
+  it("preserves non-data siblings and chart data when mixed blocks are rejected", async () => {
     const client = createSlackSendTestClient();
     client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
     const blocks = [
@@ -1194,6 +1056,7 @@ describe("sendMessageSlack blocks", () => {
       cfg: SLACK_TEST_CFG,
       client,
       blocks,
+      authoredTextPlacement: "blocks",
     });
 
     expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
@@ -1203,85 +1066,14 @@ describe("sendMessageSlack blocks", () => {
       {
         type: "section",
         text: {
-          type: "mrkdwn",
+          type: "plain_text",
           text: "Revenue mix (pie chart)\n- Product: 60\n- Services: 40",
-          verbatim: true,
         },
       },
     ]);
     expect(postedMessage(client, 1).text).toBe(
       "Overview\n\nRevenue mix (pie chart)\n- Product: 60\n- Services: 40",
     );
-  });
-
-  it("propagates invalid_blocks when a retained sibling is also invalid", async () => {
-    const client = createSlackSendTestClient();
-    client.chat.postMessage.mockRejectedValue({ data: { error: "invalid_blocks" } });
-
-    await expect(
-      sendMessageSlack("channel:C123", "Overview", {
-        token: "xoxb-test",
-        cfg: SLACK_TEST_CFG,
-        client,
-        blocks: [
-          { type: "section", text: { type: "mrkdwn", text: "Invalid sibling" } },
-          {
-            type: "data_visualization",
-            title: "Revenue mix",
-            chart: {
-              type: "pie",
-              segments: [{ label: "Product", value: 60 }],
-            },
-          },
-        ] as never,
-      }),
-    ).rejects.toMatchObject({ data: { error: "invalid_blocks" } });
-
-    expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
-    expect(postedMessage(client, 1).blocks).toEqual([
-      { type: "section", text: { type: "mrkdwn", text: "Invalid sibling" } },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "Revenue mix (pie chart)\n- Product: 60",
-          verbatim: true,
-        },
-      },
-    ]);
-  });
-
-  it("fails closed when native fallback expansion would drop 49 siblings", async () => {
-    const client = createSlackSendTestClient();
-    client.chat.postMessage.mockRejectedValueOnce({ data: { error: "invalid_blocks" } });
-    const categories = Array.from(
-      { length: 20 },
-      (_entry, index) => `category-${String(index)}-${"x".repeat(80)}`,
-    );
-
-    await expect(
-      sendMessageSlack("channel:C123", "", {
-        token: "xoxb-test",
-        cfg: SLACK_TEST_CFG,
-        client,
-        blocks: [
-          ...Array.from({ length: 49 }, () => ({ type: "divider" })),
-          {
-            type: "data_visualization",
-            title: "Large chart",
-            chart: {
-              type: "bar",
-              axis_config: { categories },
-              series: Array.from({ length: 2 }, (_entry, index) => ({
-                name: `Series ${String(index)}`,
-                data: categories.map((label) => ({ label, value: index })),
-              })),
-            },
-          },
-        ] as never,
-      }),
-    ).rejects.toThrow(/fallback requires .* blocks to retain every sibling/i);
-    expect(client.chat.postMessage).toHaveBeenCalledOnce();
   });
 
   it("uses canonical Slack response thread for block receipts and participation", async () => {
@@ -1468,7 +1260,7 @@ describe("sendMessageSlack blocks", () => {
     expect(postedMessage(client).text).toBe("Shared a file");
   });
 
-  it("chunks long block fallback text without truncation", async () => {
+  it("caps long fallback text while preserving blocks", async () => {
     const client = createSlackSendTestClient();
     const longContextText = "a".repeat(3000);
     const blocks = [
@@ -1489,16 +1281,10 @@ describe("sendMessageSlack blocks", () => {
       blocks,
     });
 
-    const posts = client.chat.postMessage.mock.calls.map((_call, index) =>
-      postedMessage(client, index),
-    );
-    expect(posts.length).toBeGreaterThan(1);
-    expect(posts.every((post) => post.blocks === undefined)).toBe(true);
-    expect(posts.every((post) => Array.from(String(post.text)).length <= SLACK_TEXT_LIMIT)).toBe(
-      true,
-    );
-    expect(posts.map((post) => String(post.text)).join("")).toContain(longContextText);
-    expect(posts.map((post) => String(post.text)).join("")).not.toContain("…");
+    const post = postedMessage(client);
+    expect(String(post.text).endsWith("…")).toBe(true);
+    expect(post.blocks).toBe(blocks);
+    expect(post.text).toHaveLength(SLACK_TEXT_LIMIT);
   });
 
   it("rejects blocks combined with mediaUrl", async () => {

--- a/extensions/slack/src/send.reconcile.test.ts
+++ b/extensions/slack/src/send.reconcile.test.ts
@@ -135,6 +135,127 @@ describe("reconcileSlackUnknownSend", () => {
     }
   });
 
+  it("attaches a complete single-part marker to successful block sends", async () => {
+    const client = createSlackReconcileTestClient();
+    const sent = await sendMessageSlack("channel:C123", "Status", {
+      cfg,
+      client,
+      deliveryQueueId: "queue-1",
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "Status" } }],
+    });
+    const request = client.chat.postMessage.mock.calls[0]?.[0] as ChatPostMessageArguments;
+    const metadata = request.metadata as MessageMetadata;
+
+    expect(metadata.event_payload).toMatchObject({
+      openclaw_delivery_part_index: 0,
+      openclaw_delivery_part_count: 1,
+    });
+    expect(sent.receipt.platformMessageIds).toEqual(["1782584647.000002"]);
+    client.conversations.history.mockResolvedValueOnce({
+      messages: [{ ts: "1782584647.000002", metadata }],
+    });
+
+    const reconciled = await reconcileSlackUnknownSend(createUnknownSendContext(), { client });
+    expect(reconciled.status).toBe("sent");
+    if (reconciled.status === "sent") {
+      expect(reconciled.receipt.platformMessageIds).toEqual(["1782584647.000002"]);
+    }
+  });
+
+  it("reconciles every ordered native-data fallback batch as one durable part set", async () => {
+    const client = createSlackReconcileTestClient();
+    client.chat.postMessage
+      .mockRejectedValueOnce(
+        Object.assign(new Error("An API error occurred: invalid_blocks"), {
+          data: { error: "invalid_blocks" },
+        }),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        channel: "C123",
+        ts: "1782584647.000001",
+        message: {},
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        channel: "C123",
+        ts: "1782584647.000002",
+        message: {},
+      });
+    const metadata = {
+      event_type: "assistant_thread_context",
+      event_payload: { team_id: "T123" },
+    };
+    const sent = await sendMessageSlack("channel:C123", "Pipeline", {
+      cfg,
+      client,
+      deliveryQueueId: "queue-1",
+      metadata,
+      blocks: [
+        ...Array.from({ length: 48 }, () => ({ type: "divider" })),
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              action_id: "approve",
+              text: { type: "plain_text", text: "Approve" },
+              value: "yes",
+            },
+          ],
+        },
+        {
+          type: "data_table",
+          caption: "c".repeat(9_000),
+          rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
+        },
+      ] as never,
+    });
+    const requests = client.chat.postMessage.mock.calls.map(
+      ([request]) => request as ChatPostMessageArguments,
+    );
+    const rejectedMetadata = requests[0]?.metadata as MessageMetadata;
+    const firstFallbackMetadata = requests[1]?.metadata as MessageMetadata;
+    const secondFallbackMetadata = requests[2]?.metadata as MessageMetadata;
+
+    expect(rejectedMetadata.event_payload.openclaw_delivery_part_count).toBe(1);
+    expect(
+      [firstFallbackMetadata, secondFallbackMetadata].map(
+        (part) => part.event_payload.openclaw_delivery_part_index,
+      ),
+    ).toEqual([0, 1]);
+    expect(
+      [firstFallbackMetadata, secondFallbackMetadata].map(
+        (part) => part.event_payload.openclaw_delivery_part_count,
+      ),
+    ).toEqual([2, 2]);
+    expect(firstFallbackMetadata.event_payload).toMatchObject({ team_id: "T123" });
+    expect(secondFallbackMetadata.event_payload).not.toHaveProperty("team_id");
+    expect(
+      new Set(
+        [firstFallbackMetadata, secondFallbackMetadata].map(
+          (part) => part.event_payload.openclaw_delivery_id,
+        ),
+      ).size,
+    ).toBe(1);
+    expect(sent.receipt.platformMessageIds).toEqual(["1782584647.000001", "1782584647.000002"]);
+    client.conversations.history.mockResolvedValueOnce({
+      messages: [
+        { ts: "1782584647.000002", metadata: secondFallbackMetadata },
+        { ts: "1782584647.000001", metadata: firstFallbackMetadata },
+      ],
+    });
+
+    const reconciled = await reconcileSlackUnknownSend(createUnknownSendContext(), { client });
+    expect(reconciled.status).toBe("sent");
+    if (reconciled.status === "sent") {
+      expect(reconciled.receipt.platformMessageIds).toEqual([
+        "1782584647.000001",
+        "1782584647.000002",
+      ]);
+    }
+  });
+
   it("refreshes durable timing after dequeue and before Slack API work", async () => {
     const client = createSlackReconcileTestClient();
     const order: string[] = [];

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -26,17 +26,11 @@ import {
   normalizeOptionalString,
   normalizeOptionalString as normalizeSlackApiString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { SlackTokenSource } from "./accounts.js";
 import { resolveSlackAccount, resolveSlackOperationToken } from "./accounts.js";
-import {
-  appendSlackBlocksAccessibleFallbackText,
-  buildSlackBlocksAccessibleFallbackText,
-  buildSlackBlocksCompactAccessibleFallbackText,
-  buildSlackDeferredNativeDataRejectionFallback,
-  isSlackBlockRepresentedByTextFallback,
-  removeSlackBlocksFallbackParagraphs,
-  retainSlackDataTablesWithinCompactFallback,
-} from "./blocks-fallback.js";
+import type { SlackAuthoredTextPlacement } from "./authored-text.js";
+import { buildSlackCompleteBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
 import {
   postSlackMessageBestEffort,
@@ -44,19 +38,15 @@ import {
   withSlackDnsRequestRetry,
 } from "./client-delivery.js";
 import { createSlackTokenCacheKey, createSlackWebClient, getSlackWriteClient } from "./client.js";
-import { hasSlackDataTableBlock } from "./data-table.js";
 import { assertSlackDirectSendAllowed } from "./direct-send-admission.js";
-import {
-  chunkSlackMrkdwnText,
-  markdownToSlackMrkdwn,
-  markdownToSlackMrkdwnChunks,
-} from "./format.js";
+import { chunkSlackMrkdwnText, markdownToSlackMrkdwnChunks } from "./format.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
 import {
-  appendSlackNativeDataFallbackText,
-  hasCompleteSlackNativeDataFallbackText,
+  buildSlackNativeDataAccessibilityText,
   hasSlackNativeDataBlock,
+  isSlackInvalidBlocksError,
 } from "./native-data-blocks.js";
+import { buildSlackNativeDataDeliveryPlan } from "./native-data-fallback.js";
 import { recordSlackThreadParticipation } from "./sent-thread-cache.js";
 import { canonicalizeSlackApiTargetId, parseSlackTarget } from "./target-parsing.js";
 import { normalizeSlackThreadTsCandidate, resolveSlackThreadTsValue } from "./thread-ts.js";
@@ -129,8 +119,12 @@ type SlackSendOpts = {
   textLimit?: number;
   /** Slack-private marker for text that is already safe mrkdwn and must not be parsed again. */
   textIsSlackMrkdwn?: boolean;
-  /** Post retained blocks as a prelude before visible text chunks in one queued send. */
-  separateTextAndBlocks?: boolean;
+  /** Slack-private literal fallback text; disables mrkdwn parsing. */
+  textIsSlackPlainText?: boolean;
+  /** Producer-owned placement of authored text after final block compilation. */
+  authoredTextPlacement?: SlackAuthoredTextPlacement;
+  /** Slack-private authored text outside blocks; enables ordered plain accessibility text. */
+  nativeDataFallbackBaseText?: string;
   mediaMaxBytes?: number;
   threadTs?: string;
   replyBroadcast?: boolean;
@@ -139,7 +133,7 @@ type SlackSendOpts = {
   metadata?: MessageMetadata;
   /** Opaque durable intent id used to reconcile ambiguous platform outcomes. */
   deliveryQueueId?: string;
-  /** Refresh durable timing before recipient-visible or finalizing platform I/O. */
+  /** Refresh durable timing after the per-target queue and before Slack API work. */
   onPlatformSendDispatch?: () => Promise<void>;
   /** Persist each concrete platform send before any later chunk can fail. */
   onDeliveryResult?: (result: SlackSendResult) => Promise<void> | void;
@@ -317,20 +311,6 @@ function createSlackSendReceipt(params: {
   });
 }
 
-function createCombinedSlackSendReceipt(
-  partReceipts: readonly MessageReceipt[],
-  threadTs?: string,
-): MessageReceipt {
-  const receipt = createMessageReceiptFromOutboundResults({
-    results: partReceipts.map((partReceipt) => ({ channel: "slack", receipt: partReceipt })),
-    threadId: threadTs,
-  });
-  receipt.parts.forEach((part, index) => {
-    part.index = index;
-  });
-  return receipt;
-}
-
 function resolveToken(params: {
   explicit?: string;
   accountId: string;
@@ -399,30 +379,33 @@ function resolveEnterpriseEventScope(params: {
   return scope;
 }
 
-function resolveSlackTextLimit(params: {
-  cfg: OpenClawConfig;
-  accountId?: string;
-  textLimit?: number;
-}): number {
-  const configuredLimit =
-    params.textLimit ??
-    resolveTextChunkLimit(params.cfg, "slack", params.accountId, {
-      fallbackLimit: SLACK_TEXT_LIMIT,
-    });
-  return Math.min(configuredLimit, SLACK_TEXT_LIMIT);
-}
-
 function resolveSlackTextChunks(params: {
   cfg: OpenClawConfig;
   accountId?: string;
   text: string;
   textLimit?: number;
   textIsSlackMrkdwn?: boolean;
+  preservePlainText?: boolean;
 }): string[] {
-  const text = params.text.trim();
-  const chunkLimit = resolveSlackTextLimit(params);
+  const text = params.preservePlainText ? params.text : params.text.trim();
+  const configuredLimit =
+    params.textLimit ??
+    resolveTextChunkLimit(params.cfg, "slack", params.accountId, {
+      fallbackLimit: SLACK_TEXT_LIMIT,
+    });
+  const chunkLimit = Math.min(configuredLimit, SLACK_TEXT_LIMIT);
+  if (params.preservePlainText) {
+    const chunks: string[] = [];
+    let remaining = text;
+    while (remaining) {
+      const chunk = sliceUtf16Safe(remaining, 0, chunkLimit) || Array.from(remaining)[0] || "";
+      chunks.push(chunk);
+      remaining = remaining.slice(chunk.length);
+    }
+    return chunks;
+  }
   if (params.textIsSlackMrkdwn) {
-    return chunkSlackMrkdwnText(text, chunkLimit);
+    return resolveTextChunksWithFallback(text, chunkSlackMrkdwnText(text, chunkLimit));
   }
   const tableMode = resolveMarkdownTableMode({
     cfg: params.cfg,
@@ -977,7 +960,9 @@ export async function sendMessageSlack(
   message: string,
   opts: SlackSendOpts,
 ): Promise<SlackSendResult> {
-  const trimmedMessage = normalizeOptionalString(message) ?? "";
+  const normalizedMessage = normalizeOptionalString(message) ?? "";
+  const trimmedMessage =
+    opts.textIsSlackPlainText && normalizedMessage ? message : normalizedMessage;
   const cfg = requireRuntimeConfig(opts.cfg, "Slack send");
   const account = resolveSlackAccount({
     cfg,
@@ -993,7 +978,7 @@ export async function sendMessageSlack(
           : {}),
       })
     : undefined;
-  if (isSilentReplyText(trimmedMessage) && !opts.mediaUrl && !opts.blocks) {
+  if (isSilentReplyText(normalizedMessage) && !opts.mediaUrl && !opts.blocks) {
     logVerbose("slack send: suppressed NO_REPLY token before API call");
     return {
       messageId: "suppressed",
@@ -1002,7 +987,7 @@ export async function sendMessageSlack(
     };
   }
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);
-  if (!trimmedMessage && !opts.mediaUrl && !blocks) {
+  if (!normalizedMessage && !opts.mediaUrl && !blocks) {
     throw new Error("Slack send requires text, blocks, or media");
   }
   const token = enterpriseDelivery
@@ -1078,11 +1063,6 @@ async function sendMessageSlackQueuedInner(params: {
 }): Promise<SlackSendResult> {
   const { opts, cfg, account, token, recipient, blocks, trimmedMessage, enterpriseDelivery } =
     params;
-  const textLimit = resolveSlackTextLimit({
-    cfg,
-    accountId: account.accountId,
-    ...(opts.textLimit !== undefined ? { textLimit: opts.textLimit } : {}),
-  });
   const client = enterpriseDelivery?.client ?? opts.client ?? getSlackWriteClient(token);
   const identity = enterpriseDelivery
     ? normalizeSlackSendIdentity(opts.identity)
@@ -1118,112 +1098,202 @@ async function sendMessageSlackQueuedInner(params: {
     await opts.onDeliveryResult?.(result);
     return result;
   };
-  const blockFallbackText = blocks
-    ? appendSlackBlocksAccessibleFallbackText(trimmedMessage, blocks) ||
-      buildSlackBlocksAccessibleFallbackText(blocks)
+  let didDispatch = false;
+  const dispatchOnce = async () => {
+    if (didDispatch) {
+      return;
+    }
+    didDispatch = true;
+    await opts.onPlatformSendDispatch?.();
+  };
+  const explicitNativeDataFallbackBase = Object.hasOwn(opts, "nativeDataFallbackBaseText")
+    ? (opts.nativeDataFallbackBaseText?.trim() ?? "")
     : undefined;
-  const separateBlocksFallbackText =
-    opts.separateTextAndBlocks && blocks
-      ? buildSlackBlocksAccessibleFallbackText(blocks)
+  const authoredTextPlacement = opts.authoredTextPlacement ?? "outside-blocks";
+  const nativeDataFallbackBase =
+    blocks && authoredTextPlacement === "outside-blocks"
+      ? (explicitNativeDataFallbackBase ?? trimmedMessage)
+      : "";
+  const hasNativeData = Boolean(blocks && hasSlackNativeDataBlock(blocks));
+  const usesOrderedBlockAccessibility = Boolean(
+    blocks && (hasNativeData || opts.authoredTextPlacement !== undefined),
+  );
+  const orderedBlockDeliveryPlan =
+    blocks && usesOrderedBlockAccessibility
+      ? buildSlackNativeDataDeliveryPlan({
+          baseText: nativeDataFallbackBase,
+          blocks,
+        })
       : undefined;
-  const requiresSeparateNativeDataFallbackChunks = Boolean(
-    blocks &&
-    separateBlocksFallbackText &&
-    separateBlocksFallbackText.length > textLimit &&
-    hasSlackNativeDataBlock(blocks),
-  );
-  // Split-plan callers already own the independent visible fallback. Recombining
-  // retained blocks here would repeat their content in later text chunks.
-  const requiresChunkedBlockFallback = Boolean(
-    !opts.separateTextAndBlocks &&
-    blocks &&
-    blockFallbackText &&
-    blockFallbackText.length > textLimit,
-  );
-  const chunkedBlockSiblingCandidates = requiresChunkedBlockFallback
-    ? blocks?.filter(
-        (block) => hasSlackDataTableBlock([block]) || !isSlackBlockRepresentedByTextFallback(block),
-      )
+  const orderedBlockAccessibilityText =
+    blocks && usesOrderedBlockAccessibility
+      ? (orderedBlockDeliveryPlan?.accessibilityText ??
+        (buildSlackNativeDataAccessibilityText(nativeDataFallbackBase, blocks) ||
+          "Slack could not render this Block Kit message."))
+      : undefined;
+  const completeBlockFallbackText = blocks ? buildSlackCompleteBlocksFallbackText(blocks) : "";
+  const rawBlockAccessibilityText = trimmedMessage
+    ? [
+        trimmedMessage,
+        ...(completeBlockFallbackText.includes(trimmedMessage) ? [] : [completeBlockFallbackText]),
+      ].join("\n\n")
+    : completeBlockFallbackText;
+  const blockAccessibilityText = blocks
+    ? (orderedBlockAccessibilityText ?? rawBlockAccessibilityText)
     : undefined;
-  const chunkedBlockSiblingBlocks = chunkedBlockSiblingCandidates
-    ? retainSlackDataTablesWithinCompactFallback(chunkedBlockSiblingCandidates, textLimit)
-    : undefined;
-  const separateSiblingBlocks = opts.separateTextAndBlocks
-    ? requiresSeparateNativeDataFallbackChunks && blocks
-      ? retainSlackDataTablesWithinCompactFallback(blocks, textLimit)
-      : blocks
-    : chunkedBlockSiblingBlocks;
-  const chunkedBlockFallbackText = requiresChunkedBlockFallback
-    ? removeSlackBlocksFallbackParagraphs(
-        blockFallbackText ?? "",
-        chunkedBlockSiblingBlocks?.filter((block) => !hasSlackDataTableBlock([block])) ?? [],
-      )
-    : undefined;
+  let pendingBlockFallback =
+    (hasNativeData || opts.authoredTextPlacement !== undefined) &&
+    orderedBlockDeliveryPlan?.skipOriginalBlocks
+      ? orderedBlockDeliveryPlan
+      : undefined;
+  const sentMessageIds: string[] = [];
+  let lastMessageId = "";
+  let deliveredChannelId = channelId;
+  let canonicalDeliveredThreadTs: string | undefined;
+  let sendIdentity = identity;
   if (blocks && opts.mediaUrl) {
     throw new Error("Slack send does not support blocks with mediaUrl");
   }
-  if (blocks && !requiresChunkedBlockFallback && !opts.separateTextAndBlocks) {
-    const fallbackText = truncateSlackText(blockFallbackText ?? "", textLimit);
-    await opts.onPlatformSendDispatch?.();
-    const { response } = await postSlackMessageBestEffort({
-      client,
-      channelId,
-      text: fallbackText,
-      threadTs: opts.threadTs,
-      replyBroadcast: opts.replyBroadcast,
-      identity,
-      blocks,
-      metadata: opts.metadata,
-      unfurl,
-    });
-    if (enterpriseDelivery && (!response.ok || !response.ts)) {
-      throw new Error(
-        response.ok
-          ? "Slack chat.postMessage returned no message timestamp"
-          : `Slack chat.postMessage failed: ${response.error ?? "unknown error"}`,
-      );
-    }
-    const messageId = response.ts ?? "unknown";
-    const deliveredChannelId = resolvePostedMessageChannelId(response, channelId);
-    const deliveredThreadTs =
-      resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
-    return await reportDelivery({
-      messageId,
-      channelId: deliveredChannelId,
-      threadTs: deliveredThreadTs,
-      receipt: createSlackSendReceipt({
-        platformMessageIds: [messageId],
-        channelId: deliveredChannelId,
-        kind: "card",
-        threadTs: deliveredThreadTs,
-      }),
-    });
-  }
-  const separateAuthoredText =
-    requiresSeparateNativeDataFallbackChunks && !opts.textIsSlackMrkdwn
-      ? markdownToSlackMrkdwn(trimmedMessage, {
-          tableMode: resolveMarkdownTableMode({
-            cfg,
-            channel: "slack",
-            ...(account.accountId ? { accountId: account.accountId } : {}),
+  if (blocks) {
+    if (pendingBlockFallback) {
+      // A truncated top-level fallback makes block content inaccessible to screen readers.
+      // Deliver controls plus complete text instead of attempting the native blocks.
+      logVerbose("slack send: native data accessibility exceeds hard limit, using text fallback");
+    } else {
+      const accessibilityText = hasNativeData
+        ? (blockAccessibilityText ?? "Slack could not render this Block Kit message.")
+        : usesOrderedBlockAccessibility
+          ? (blockAccessibilityText ?? "Slack could not render this Block Kit message.")
+          : truncateSlackText(blockAccessibilityText ?? "", SLACK_TEXT_LIMIT);
+      const initialBlockMetadata = withSlackDeliveryMetadata(opts.metadata, {
+        queueId: opts.deliveryQueueId,
+        channelId,
+        threadTs: opts.threadTs,
+        partIndex: 0,
+        partCount: 1,
+      });
+      await dispatchOnce();
+      try {
+        const { response } = await postSlackMessageBestEffort({
+          client,
+          channelId,
+          text: accessibilityText,
+          threadTs: opts.threadTs,
+          replyBroadcast: opts.replyBroadcast,
+          identity,
+          blocks,
+          metadata: initialBlockMetadata,
+          ...(usesOrderedBlockAccessibility ? { mrkdwn: false } : {}),
+          unfurl,
+        });
+        if (enterpriseDelivery && (!response.ok || !response.ts)) {
+          throw new Error(
+            response.ok
+              ? "Slack chat.postMessage returned no message timestamp"
+              : `Slack chat.postMessage failed: ${response.error ?? "unknown error"}`,
+          );
+        }
+        const messageId = response.ts ?? "unknown";
+        const postedChannelId = resolvePostedMessageChannelId(response, channelId);
+        const deliveredThreadTs =
+          resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
+        return await reportDelivery({
+          messageId,
+          channelId: postedChannelId,
+          threadTs: deliveredThreadTs,
+          receipt: createSlackSendReceipt({
+            platformMessageIds: [messageId],
+            channelId: deliveredChannelId,
+            kind: "card",
+            threadTs: deliveredThreadTs,
           }),
-        })
-      : trimmedMessage;
-  const chunkSourceText = requiresChunkedBlockFallback
-    ? (chunkedBlockFallbackText ?? blockFallbackText ?? trimmedMessage)
-    : requiresSeparateNativeDataFallbackChunks && blocks
-      ? appendSlackNativeDataFallbackText(separateAuthoredText, blocks)
-      : trimmedMessage;
+        });
+      } catch (error) {
+        if (!hasNativeData || !isSlackInvalidBlocksError(error)) {
+          throw error;
+        }
+        logVerbose("slack send: native data rejected, delivering complete text fallback");
+        pendingBlockFallback = orderedBlockDeliveryPlan;
+      }
+    }
+    if (pendingBlockFallback) {
+      const fallbackMessages = pendingBlockFallback.fallbackMessages;
+      for (const [partIndex, fallback] of fallbackMessages.entries()) {
+        const metadata = withSlackDeliveryMetadata(partIndex === 0 ? opts.metadata : undefined, {
+          queueId: opts.deliveryQueueId,
+          channelId,
+          threadTs: opts.threadTs,
+          partIndex,
+          partCount: fallbackMessages.length,
+        });
+        if (partIndex === 0) {
+          await dispatchOnce();
+        }
+        const posted = await postSlackMessageBestEffort({
+          client,
+          channelId,
+          text: fallback.text,
+          threadTs: opts.threadTs,
+          replyBroadcast: partIndex === 0 ? opts.replyBroadcast : undefined,
+          identity: sendIdentity,
+          ...(fallback.blocks ? { blocks: fallback.blocks } : {}),
+          metadata,
+          mrkdwn: false,
+          unfurl,
+        });
+        const response = posted.response;
+        if (enterpriseDelivery && (!response.ok || !response.ts)) {
+          throw new Error(
+            response.ok
+              ? "Slack chat.postMessage returned no message timestamp"
+              : `Slack chat.postMessage failed: ${response.error ?? "unknown error"}`,
+          );
+        }
+        sendIdentity = posted.identity;
+        lastMessageId = response.ts ?? lastMessageId;
+        deliveredChannelId = resolvePostedMessageChannelId(response, deliveredChannelId);
+        canonicalDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);
+        if (!response.ts) {
+          continue;
+        }
+        sentMessageIds.push(response.ts);
+        const deliveredThreadTs =
+          resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
+        await reportDelivery({
+          messageId: response.ts,
+          channelId: deliveredChannelId,
+          threadTs: deliveredThreadTs,
+          receipt: createSlackSendReceipt({
+            platformMessageIds: [response.ts],
+            channelId: deliveredChannelId,
+            kind: fallback.blocks ? "card" : "text",
+            threadTs: deliveredThreadTs,
+          }),
+        });
+      }
+      const messageId = lastMessageId || "unknown";
+      const deliveredThreadTs =
+        canonicalDeliveredThreadTs ?? normalizeSlackThreadTsCandidate(opts.threadTs);
+      return {
+        messageId,
+        channelId: deliveredChannelId,
+        threadTs: deliveredThreadTs,
+        receipt: createSlackSendReceipt({
+          platformMessageIds: sentMessageIds.length ? sentMessageIds : [messageId],
+          channelId: deliveredChannelId,
+          kind: fallbackMessages.some((message) => message.blocks) ? "card" : "text",
+          threadTs: deliveredThreadTs,
+        }),
+      };
+    }
+  }
   const resolvedChunks = resolveSlackTextChunks({
     cfg,
     accountId: account.accountId,
-    text: chunkSourceText,
-    textLimit,
-    ...(opts.textIsSlackMrkdwn ||
-    requiresChunkedBlockFallback ||
-    requiresSeparateNativeDataFallbackChunks
-      ? { textIsSlackMrkdwn: true }
-      : {}),
+    text: trimmedMessage,
+    ...(opts.textLimit !== undefined ? { textLimit: opts.textLimit } : {}),
+    ...(opts.textIsSlackMrkdwn ? { textIsSlackMrkdwn: true } : {}),
+    ...(opts.textIsSlackPlainText ? { preservePlainText: true } : {}),
   });
   const mediaMaxBytes =
     opts.mediaMaxBytes ??
@@ -1231,20 +1301,7 @@ async function sendMessageSlackQueuedInner(params: {
       ? account.config.mediaMaxMb * 1024 * 1024
       : undefined);
 
-  const sentMessageIds: string[] = [];
-  const sentPartReceipts: MessageReceipt[] = [];
-  let lastMessageId = "";
-  let deliveredChannelId = channelId;
-  let canonicalDeliveredThreadTs: string | undefined;
-  let replyBroadcastPartIndex = 0;
-  let partsToPost: Array<{
-    text: string;
-    blocks?: (Block | KnownBlock)[];
-    nativeDataRejectionFallback?: {
-      text: string;
-      blocks?: (Block | KnownBlock)[];
-    };
-  }>;
+  let chunksToPost: string[];
   if (opts.mediaUrl) {
     if (enterpriseDelivery && !enterpriseDelivery.uploadCompletionClient) {
       throw new Error("missing_enterprise_slack_upload_completion_client");
@@ -1265,77 +1322,30 @@ async function sendMessageSlackQueuedInner(params: {
       caption: firstChunk,
       threadTs: opts.threadTs,
       maxBytes: mediaMaxBytes,
-      onPlatformSendDispatch: opts.onPlatformSendDispatch,
+      onPlatformSendDispatch: dispatchOnce,
       ...(enterpriseDelivery ? { auditContext: "slack-enterprise-immediate-upload" } : {}),
     });
     sentMessageIds.push(lastMessageId);
-    const mediaReceipt = createSlackSendReceipt({
-      platformMessageIds: [lastMessageId],
-      channelId,
-      kind: "media",
-      threadTs: normalizeSlackThreadTsCandidate(opts.threadTs),
-    });
-    sentPartReceipts.push(mediaReceipt);
     await reportDelivery({
       messageId: lastMessageId,
       channelId,
       threadTs: normalizeSlackThreadTsCandidate(opts.threadTs),
-      receipt: mediaReceipt,
+      receipt: createSlackSendReceipt({
+        platformMessageIds: [lastMessageId],
+        channelId,
+        kind: "media",
+        threadTs: normalizeSlackThreadTsCandidate(opts.threadTs),
+      }),
     });
-    partsToPost = rest.map((text) => ({ text }));
+    chunksToPost = rest;
   } else {
-    const textParts = (resolvedChunks.length ? resolvedChunks : [""]).map((text) => ({ text }));
-    if (separateSiblingBlocks?.length) {
-      // Top-level text is hidden when blocks render. Keep authored siblings in
-      // their own message so every native-data fallback chunk remains visible.
-      let siblingText = buildSlackBlocksAccessibleFallbackText(separateSiblingBlocks);
-      const ownsLaterNativeDataFallback =
-        hasSlackNativeDataBlock(separateSiblingBlocks) &&
-        hasCompleteSlackNativeDataFallbackText(chunkSourceText, separateSiblingBlocks);
-      if (ownsLaterNativeDataFallback) {
-        // The complete native-data fallback belongs to following text chunks.
-        // Keep its native blocks and non-data siblings in one compact post.
-        siblingText = buildSlackBlocksCompactAccessibleFallbackText(separateSiblingBlocks);
-      }
-      if (siblingText.length > textLimit) {
-        throw new Error(
-          `Slack retained-block accessibility fallback exceeds OpenClaw's ${String(textLimit)}-character limit`,
-        );
-      }
-      const deferredRejection = ownsLaterNativeDataFallback
-        ? buildSlackDeferredNativeDataRejectionFallback(separateSiblingBlocks)
-        : undefined;
-      if (deferredRejection && deferredRejection.text.length > textLimit) {
-        throw new Error(
-          `Slack retained-block accessibility fallback exceeds OpenClaw's ${String(textLimit)}-character limit`,
-        );
-      }
-      partsToPost = [
-        {
-          text: siblingText,
-          blocks: separateSiblingBlocks,
-          ...(deferredRejection
-            ? {
-                nativeDataRejectionFallback: {
-                  text: deferredRejection.text,
-                  ...(deferredRejection.blocks.length > 0
-                    ? { blocks: deferredRejection.blocks }
-                    : {}),
-                },
-              }
-            : {}),
-        },
-        ...textParts,
-      ];
-      replyBroadcastPartIndex = 1;
-    } else {
-      partsToPost = textParts;
-    }
+    chunksToPost = resolvedChunks.length ? resolvedChunks : [""];
   }
 
-  let sendIdentity = identity;
-  for (const [partIndex, part] of partsToPost.entries()) {
-    const baseMetadata = sentMessageIds.length === 0 ? opts.metadata : undefined;
+  for (const [partIndex, chunk] of chunksToPost.entries()) {
+    const carriesPrimaryMessageOptions =
+      partIndex === 0 && !opts.mediaUrl && sentMessageIds.length === 0;
+    const baseMetadata = carriesPrimaryMessageOptions ? opts.metadata : undefined;
     // Every post carries its index/count so reconciliation proves the complete
     // logical text send and never mistakes a partial chunk fanout for success.
     const metadata = opts.mediaUrl
@@ -1345,25 +1355,21 @@ async function sendMessageSlackQueuedInner(params: {
           channelId,
           threadTs: opts.threadTs,
           partIndex,
-          partCount: partsToPost.length,
+          partCount: chunksToPost.length,
         });
     if (partIndex === 0 && !opts.mediaUrl) {
-      await opts.onPlatformSendDispatch?.();
+      await dispatchOnce();
     }
     const posted = await postSlackMessageBestEffort({
       client,
       channelId,
-      text: part.text,
+      text: chunk,
       threadTs: opts.threadTs,
-      replyBroadcast:
-        !opts.mediaUrl && partIndex === replyBroadcastPartIndex ? opts.replyBroadcast : undefined,
+      replyBroadcast: carriesPrimaryMessageOptions ? opts.replyBroadcast : undefined,
       identity: sendIdentity,
       metadata,
+      ...(opts.textIsSlackPlainText ? { mrkdwn: false } : {}),
       unfurl,
-      ...(part.blocks?.length ? { blocks: part.blocks } : {}),
-      ...(part.nativeDataRejectionFallback
-        ? { nativeDataRejectionFallback: part.nativeDataRejectionFallback }
-        : {}),
     });
     const response = posted.response;
     if (enterpriseDelivery && (!response.ok || !response.ts)) {
@@ -1379,20 +1385,19 @@ async function sendMessageSlackQueuedInner(params: {
     canonicalDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);
     if (response.ts) {
       sentMessageIds.push(response.ts);
-      const partThreadTs =
-        resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
-      const partReceipt = createSlackSendReceipt({
-        platformMessageIds: [response.ts],
-        channelId: deliveredChannelId,
-        kind: part.blocks?.length ? "card" : "text",
-        threadTs: partThreadTs,
-      });
-      sentPartReceipts.push(partReceipt);
       await reportDelivery({
         messageId: response.ts,
         channelId: deliveredChannelId,
-        threadTs: partThreadTs,
-        receipt: partReceipt,
+        threadTs:
+          resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs),
+        receipt: createSlackSendReceipt({
+          platformMessageIds: [response.ts],
+          channelId: deliveredChannelId,
+          kind: "text",
+          threadTs:
+            resolvePostedMessageThreadTs(response) ??
+            normalizeSlackThreadTsCandidate(opts.threadTs),
+        }),
       });
     }
   }
@@ -1404,14 +1409,11 @@ async function sendMessageSlackQueuedInner(params: {
     messageId,
     channelId: deliveredChannelId,
     threadTs: deliveredThreadTs,
-    receipt:
-      sentPartReceipts.length > 0
-        ? createCombinedSlackSendReceipt(sentPartReceipts, deliveredThreadTs)
-        : createSlackSendReceipt({
-            platformMessageIds: sentMessageIds.length ? sentMessageIds : [messageId],
-            channelId: deliveredChannelId,
-            kind: opts.mediaUrl ? "media" : "text",
-            threadTs: deliveredThreadTs,
-          }),
+    receipt: createSlackSendReceipt({
+      platformMessageIds: sentMessageIds.length ? sentMessageIds : [messageId],
+      channelId: deliveredChannelId,
+      kind: opts.mediaUrl ? "media" : "text",
+      threadTs: deliveredThreadTs,
+    }),
   };
 }

--- a/extensions/slack/src/shared-interactive.test.ts
+++ b/extensions/slack/src/shared-interactive.test.ts
@@ -98,6 +98,31 @@ describe("buildSlackInteractiveBlocks", () => {
     expect(buttonBlock.elements?.[0]?.value).toBe(long);
   });
 
+  it.each([
+    {
+      name: "button label",
+      block: { type: "buttons" as const, buttons: [{ label: "x".repeat(76), value: "go" }] },
+    },
+    {
+      name: "select placeholder",
+      block: {
+        type: "select" as const,
+        placeholder: "x".repeat(76),
+        options: [{ label: "Go", value: "go" }],
+      },
+    },
+    {
+      name: "select option label",
+      block: {
+        type: "select" as const,
+        placeholder: "Choose",
+        options: [{ label: "x".repeat(76), value: "go" }],
+      },
+    },
+  ])("does not silently truncate an oversized portable $name", ({ block }) => {
+    expect(canRenderSlackPresentation({ blocks: [block] })).toBe(false);
+  });
+
   it("preserves original callback payloads for round-tripping", () => {
     const blocks = buildSlackInteractiveBlocks({
       blocks: [
@@ -458,6 +483,35 @@ describe("buildSlackPresentationBlocks", () => {
     ]);
   });
 
+  it("chunks Slack-incompatible chart fallback without truncating its data", () => {
+    const categories = Array.from(
+      { length: 4 },
+      (_entry, index) => `category-${String(index)}-${"x".repeat(1_000)}`,
+    );
+    const blocks = buildSlackPresentationBlocks({
+      blocks: [
+        {
+          type: "chart",
+          chartType: "line",
+          title: "Long labels",
+          categories,
+          series: [{ name: "Requests", values: [1, 2, 3, 4] }],
+        },
+      ],
+    });
+    const chunks = blocks.flatMap((block) => {
+      const context = block as { type?: string; elements?: Array<{ text?: string }> };
+      return context.type === "context"
+        ? (context.elements ?? []).flatMap((element) => (element.text ? [element.text] : []))
+        : [];
+    });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 3_000)).toBe(true);
+    expect(chunks.join("\n")).toContain(categories.at(-1));
+    expect(chunks.join("\n")).toContain(": 4");
+  });
+
   it("renders at most two native charts per message", () => {
     const blocks = buildSlackPresentationBlocks({
       blocks: [
@@ -509,21 +563,18 @@ describe("buildSlackPresentationBlocks", () => {
     } as SlackBlock;
     const offsets = resolveSlackBlockOffsets([nativeChart, nativeChart]);
 
-    expect(
-      buildSlackPresentationBlocks(
+    const presentation = {
+      blocks: [
         {
-          blocks: [
-            {
-              type: "chart",
-              chartType: "pie",
-              title: "Presentation chart",
-              segments: [{ label: "Closed", value: 8 }],
-            },
-          ],
+          type: "chart" as const,
+          chartType: "pie" as const,
+          title: "Presentation chart",
+          segments: [{ label: "Closed", value: 8 }],
         },
-        offsets,
-      ),
-    ).toEqual([
+      ],
+    };
+    expect(canRenderSlackPresentation(presentation, offsets)).toBe(false);
+    expect(buildSlackPresentationBlocks(presentation, offsets)).toEqual([
       {
         type: "context",
         elements: [

--- a/src/channels/plugins/outbound/interactive.test.ts
+++ b/src/channels/plugins/outbound/interactive.test.ts
@@ -1,5 +1,6 @@
 // Interactive outbound tests cover channel outbound interactive payload construction.
 import { describe, expect, it } from "vitest";
+import { renderMessagePresentationChartFallbackText } from "../../../interactive/payload.js";
 import {
   adaptMessagePresentationForChannel,
   applyPresentationActionLimits,
@@ -826,6 +827,42 @@ describe("presentation capability limits", () => {
     ).toBe("text");
   });
 
+  it("splits chart fallback without losing the final series or category", () => {
+    const categories = Array.from(
+      { length: 20 },
+      (_, index) => `Category-${String(index).padStart(2, "0")}`,
+    );
+    const series = Array.from({ length: 12 }, (_, seriesIndex) => ({
+      name: `Series-${String(seriesIndex).padStart(2, "0")}`,
+      values: categories.map((_category, categoryIndex) => seriesIndex * 100 + categoryIndex),
+    }));
+    const chart = {
+      type: "chart" as const,
+      chartType: "line" as const,
+      title: "Quarterly revenue",
+      categories,
+      series,
+    };
+    const maxLength = 500;
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: { blocks: [chart] },
+      capabilities: {
+        context: true,
+        limits: { text: { maxLength, encoding: "characters" } },
+      },
+    });
+    const fallbackBlocks = presentation.blocks.map((block) => {
+      expect(block.type).toBe("context");
+      return block.type === "context" ? block.text : "";
+    });
+
+    expect(fallbackBlocks.length).toBeGreaterThan(1);
+    expect(fallbackBlocks.every((text) => Array.from(text).length <= maxLength)).toBe(true);
+    const fallbackText = fallbackBlocks.join("");
+    expect(fallbackText).toBe(renderMessagePresentationChartFallbackText(chart));
+    expect(fallbackText).toContain("Category-19: 1119");
+  });
+
   it("keeps tables only for channels that explicitly advertise native support", () => {
     const table = {
       type: "table" as const,
@@ -867,43 +904,92 @@ describe("presentation capability limits", () => {
     ).toBe("text");
   });
 
-  it("splits unsupported table fallback blocks without dropping tail rows", () => {
+  it.each([
+    {
+      encoding: "characters" as const,
+      length: (value: string) => Array.from(value).length,
+    },
+    {
+      encoding: "utf8-bytes" as const,
+      length: (value: string) => Buffer.byteLength(value, "utf8"),
+    },
+    {
+      encoding: "utf16-units" as const,
+      length: (value: string) => value.length,
+    },
+  ])(
+    "splits table fallback by line without losing rows for $encoding limits",
+    ({ encoding, length }) => {
+      const rows = Array.from({ length: 12 }, (_, index) => [
+        `Account-${String(index).padStart(2, "0")}`,
+        `Stage-${index}`,
+      ]);
+      const maxLength = 64;
+      const presentation = adaptMessagePresentationForChannel({
+        presentation: {
+          blocks: [
+            {
+              type: "table",
+              caption: "Pipeline report",
+              headers: ["Account", "Stage"],
+              rows,
+            },
+          ],
+        },
+        capabilities: {
+          context: true,
+          limits: { text: { maxLength, encoding } },
+        },
+      });
+      const fallbackBlocks = presentation.blocks.map((block) => {
+        expect(block.type).toBe("context");
+        return block.type === "context" ? block.text : "";
+      });
+
+      expect(fallbackBlocks.length).toBeGreaterThan(1);
+      expect(fallbackBlocks.every((text) => length(text) <= maxLength)).toBe(true);
+      expect(fallbackBlocks.join("")).toBe(
+        [
+          "Pipeline report (table)",
+          ...rows.map(([account, stage]) => `- Account: ${account}; Stage: ${stage}`),
+        ].join("\n"),
+      );
+    },
+  );
+
+  it("hard-splits an oversized table row without breaking UTF-16 surrogate pairs", () => {
+    const value = "😀".repeat(20);
+    const maxLength = 10;
     const presentation = adaptMessagePresentationForChannel({
       presentation: {
         blocks: [
           {
             type: "table",
-            caption: "Pipeline report",
-            headers: ["Account", "Stage"],
-            rows: [
-              ["Acme", "Won"],
-              ["Globex", "Review"],
-              ["Initech", "Discovery"],
-            ],
+            caption: "R",
+            headers: ["Value"],
+            rows: [[value]],
           },
         ],
       },
       capabilities: {
-        tables: false,
-        context: true,
-        limits: {
-          text: { maxLength: 40, encoding: "characters" },
-        },
+        context: false,
+        limits: { text: { maxLength, encoding: "utf16-units" } },
       },
     });
+    const fallbackBlocks = presentation.blocks.map((block) => {
+      expect(block.type).toBe("text");
+      return block.type === "text" ? block.text : "";
+    });
 
-    expect(presentation.blocks.length).toBeGreaterThan(1);
+    expect(fallbackBlocks.every((text) => text.length <= maxLength)).toBe(true);
     expect(
-      presentation.blocks.every(
-        (block) =>
-          (block.type === "text" || block.type === "context") &&
-          Array.from(block.text).length <= 40,
-      ),
+      fallbackBlocks.every((text) => {
+        const first = text.charCodeAt(0);
+        const last = text.charCodeAt(text.length - 1);
+        return !(first >= 0xdc00 && first <= 0xdfff) && !(last >= 0xd800 && last <= 0xdbff);
+      }),
     ).toBe(true);
-    const fallback = presentation.blocks
-      .map((block) => (block.type === "text" || block.type === "context" ? block.text : ""))
-      .join("");
-    expect(fallback).toContain("- Account: Acme; Stage: Won");
-    expect(fallback).toContain("- Account: Initech; Stage: Discovery");
+    expect(fallbackBlocks[0]).toBe("R (table)\n");
+    expect(fallbackBlocks.slice(1).join("")).toBe(`- Value: ${value}`);
   });
 });

--- a/src/channels/plugins/outbound/presentation-limits.ts
+++ b/src/channels/plugins/outbound/presentation-limits.ts
@@ -4,6 +4,7 @@
  * Truncates and reshapes portable presentation blocks to match per-channel limits.
  */
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   renderMessagePresentationChartFallbackText,
   renderMessagePresentationTableFallbackText,
@@ -71,7 +72,7 @@ function truncatePresentationText(value: string, limits: TextLimits | undefined)
     return truncateUtf8Bytes(value, limit);
   }
   if (limits?.encoding === "utf16-units") {
-    return value.length > limit ? value.slice(0, limit) : value;
+    return truncateUtf16Safe(value, limit);
   }
   const chars = Array.from(value);
   return chars.length > limit ? chars.slice(0, limit).join("") : value;


### PR DESCRIPTION
## What Problem This Solves

Resolves a gap where Slack users could ask for chart/table-style visual output, but OpenClaw could only degrade that content to generic text or unsupported Block Kit shapes instead of using Slack's native chart and table blocks with reliable fallbacks.

## Why This Change Was Made

Adds Slack-native data visualization/table rendering behind the existing portable presentation path, with ordered fallback delivery for Slack plans that reject native data blocks. The change also hardens Slack fallback/accessibility behavior for edits, slash responses, previews, raw blocks, and multi-message delivery so authored text, controls, and data rows stay visible exactly once.

## User Impact

Slack conversations can now render portable line, bar, pie, and area charts plus data tables as native Slack blocks when the workspace supports them, while unsupported clients/workspaces receive readable ordered fallback text. Discord and core outbound paths keep their existing portable presentation behavior.

## Evidence

- Live Slack DM proof on `steipeteclaw`: native chart/table blocks rendered; fallback path exercised where Slack rejected native data.
- Autoreview: clean, no accepted/actionable findings (`patch is correct`).
- Remote typecheck: `run_d4a3245ab5a9` — `corepack pnpm tsgo:extensions`.
- Remote matrix: `run_088a58fd9332` — 425 Slack tests plus Discord/core touched tests passed.
- Focused local proof included Slack fallback/edit/native-data suites while iterating.
