### PR TITLE
test: align plugin prerelease expectations

### DIFF
--- a/extensions/browser/src/doctor-browser.test.ts
+++ b/extensions/browser/src/doctor-browser.test.ts
@@ -14,10 +14,7 @@ function requireFirstNoteText(noteFn: ReturnType<typeof vi.fn>): string {
   return String(message);
 }
 
-function requireNoteTextContaining(
-  noteFn: ReturnType<typeof vi.fn>,
-  expected: string,
-): string {
+function requireNoteTextContaining(noteFn: ReturnType<typeof vi.fn>, expected: string): string {
   const call = noteFn.mock.calls.find(([message]) => String(message).includes(expected));
   if (!call) {
     throw new Error(`expected browser doctor note containing ${expected}`);

--- a/extensions/browser/src/doctor-browser.test.ts
+++ b/extensions/browser/src/doctor-browser.test.ts
@@ -14,6 +14,17 @@ function requireFirstNoteText(noteFn: ReturnType<typeof vi.fn>): string {
   return String(message);
 }
 
+function requireNoteTextContaining(
+  noteFn: ReturnType<typeof vi.fn>,
+  expected: string,
+): string {
+  const call = noteFn.mock.calls.find(([message]) => String(message).includes(expected));
+  if (!call) {
+    throw new Error(`expected browser doctor note containing ${expected}`);
+  }
+  return String(call[0]);
+}
+
 describe("browser doctor readiness", () => {
   it("does nothing when Chrome MCP is not configured", async () => {
     const noteFn = vi.fn();
@@ -164,14 +175,16 @@ describe("browser doctor readiness", () => {
       {
         noteFn,
         platform: "darwin",
+        homeDir: "/__openclaw_browser_doctor_missing_home__",
         resolveChromeExecutable: () => null,
       },
     );
 
-    expect(noteFn).toHaveBeenCalledTimes(1);
-    const note = requireFirstNoteText(noteFn);
-    expect(note).toContain("Google Chrome was not found");
-    expect(note).toContain("brave://inspect/#remote-debugging");
+    const chromeNote = requireNoteTextContaining(noteFn, "Google Chrome was not found");
+    expect(chromeNote).toContain("brave://inspect/#remote-debugging");
+    const importNote = requireNoteTextContaining(noteFn, "System browser profile cookie import");
+    expect(importNote).toContain("enabled");
+    expect(importNote).toContain("Importable Chrome-family profile cookie databases found: 0");
   });
 
   it("warns when detected Chrome is too old for Chrome MCP", async () => {

--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -374,6 +374,7 @@ describe("createOllamaStreamFn thinking events", () => {
       "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
     const done = events.find((event) => event.type === "done") as {
@@ -422,6 +423,7 @@ describe("createOllamaStreamFn thinking events", () => {
       "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
     const done = events.find((event) => event.type === "done") as {


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation at `4b33199a65af2ad65c1d948f6e3473f186504173` found two deterministic Plugin Prerelease failures caused by stale test expectations after intentional runtime contract changes.

## Why This Change Was Made

- Browser doctor now emits an independent macOS system-profile import diagnostic before Chrome MCP readiness. The test now selects diagnostics by semantic content and verifies both notes instead of assuming one call.
- Plain-text tool-call promotion now emits the complete `toolcall_start` / `toolcall_delta` / `toolcall_end` lifecycle. The Ollama tests now assert that provider-neutral contract.

No production behavior changes.

## User Impact

Release validation no longer rejects the current, correct browser-doctor and tool-call event behavior.

## Evidence

- Exact failed Plugin Prerelease: https://github.com/openclaw/openclaw/actions/runs/29158342739
- Blacksmith Testbox: browser 11/11; Ollama 16/16
- Independent Ollama Testbox run: https://github.com/openclaw/openclaw/actions/runs/29158504362
- `git diff --check`
- Fresh autoreview: clean, no accepted/actionable findings
