### PR TITLE
fix(agents): protect provider auth exchange output by sensitivity, not input marker

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -2,6 +2,7 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
+import { looksLikeSecretSentinel, resolveSecretSentinel } from "../secrets/sentinel.js";
 
 const streamSimpleMock = vi.fn();
 const readFileMock = vi.fn();
@@ -1383,7 +1384,10 @@ describe("runBtwSideQuestion", () => {
       id: "gpt-5.4",
       baseUrl: "https://api.enterprise.githubcopilot.com",
     });
-    expectRecordFields(streamOptions, { apiKey: "copilot-runtime-token" });
+    const streamKey = (streamOptions as { apiKey?: string }).apiKey ?? "";
+    expect(looksLikeSecretSentinel(streamKey)).toBe(true);
+    expect(streamKey).not.toBe("copilot-runtime-token");
+    expect(resolveSecretSentinel(streamKey)).toBe("copilot-runtime-token");
   });
 
   it("uses the provider's stream fn when registered so provider URL construction runs (#68336)", async () => {

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -757,7 +757,6 @@ export async function runBtwSideQuestion(
       : requireApiKey(apiKeyInfo, model.provider);
   if (apiKey) {
     const preparedAuth = protectPreparedProviderRuntimeAuth({
-      sourceApiKey: apiKey,
       provider: model.provider,
       preparedAuth: await prepareProviderRuntimeAuth({
         provider: model.provider,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -733,7 +733,6 @@ async function compactEmbeddedAgentSessionDirectOnce(
       }
     } else {
       const preparedAuth = protectPreparedProviderRuntimeAuth({
-        sourceApiKey: apiKeyInfo.apiKey,
         provider: runtimeModel.provider,
         preparedAuth: await prepareProviderRuntimeAuth({
           provider: runtimeModel.provider,

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -85,6 +85,12 @@ type MutableAuthControllerHarness = {
 
 type RuntimeApiKeySetter = Mock<(provider: string, apiKey: string) => void>;
 
+function expectProtectedRuntimeValue(value: string | undefined, plaintext: string): void {
+  expect(value).not.toBe(plaintext);
+  expect(looksLikeSecretSentinel(value ?? "")).toBe(true);
+  expect(resolveSecretSentinel(value ?? "")).toBe(plaintext);
+}
+
 function createMutableAuthControllerHarness(): MutableAuthControllerHarness {
   // Mutable harness mirrors the runner fields the auth controller updates
   // through injected getters/setters.
@@ -202,14 +208,14 @@ describe("createEmbeddedRunAuthController", () => {
     expect(apiKeyParams?.agentDir).toBe("/tmp/agent");
     expect(apiKeyParams?.workspaceDir).toBe("/tmp/workspace");
     expect(harness.runtimeModel.baseUrl).toBe("https://runtime.example.com/v1");
-    expect(harness.runtimeModel.headers).toEqual({
-      "api-key": "runtime-header-token",
-    });
+    expectProtectedRuntimeValue(harness.runtimeModel.headers?.["api-key"], "runtime-header-token");
     expect(harness.effectiveModel.baseUrl).toBe("https://runtime.example.com/v1");
-    expect(harness.effectiveModel.headers).toEqual({
-      "api-key": "runtime-header-token",
-    });
-    expect(setRuntimeApiKey).toHaveBeenCalledWith("custom-openai", "runtime-api-key");
+    expectProtectedRuntimeValue(
+      harness.effectiveModel.headers?.["api-key"],
+      "runtime-header-token",
+    );
+    const storedApiKey = setRuntimeApiKey.mock.calls[0]?.[1];
+    expectProtectedRuntimeValue(storedApiKey, "runtime-api-key");
     expect(harness.runtimeAuthState?.sourceApiKey).toBe("source-api-key");
     expect(harness.runtimeAuthState?.authMode).toBe("api-key");
     expect(harness.runtimeAuthState?.profileId).toBe("default");
@@ -509,9 +515,8 @@ describe("createEmbeddedRunAuthController", () => {
       await controller.advanceAuthProfile();
       expect(getRuntimeAuthSnapshot(harness.runtimeAuthState)?.profileId).toBe("backup");
       expect(harness.runtimeModel.baseUrl).toBe("https://backup-runtime.example.com/v1");
-      expect(harness.runtimeModel.headers).toEqual({
-        "api-key": "backup-runtime-header-token",
-      });
+      const backupHeader = harness.runtimeModel.headers?.["api-key"];
+      expectProtectedRuntimeValue(backupHeader, "backup-runtime-header-token");
 
       staleRefresh.resolve({
         apiKey: "default-runtime-api-key-refreshed",
@@ -530,10 +535,9 @@ describe("createEmbeddedRunAuthController", () => {
 
       expect(getRuntimeAuthSnapshot(harness.runtimeAuthState)?.profileId).toBe("backup");
       expect(harness.runtimeModel.baseUrl).toBe("https://backup-runtime.example.com/v1");
-      expect(harness.runtimeModel.headers).toEqual({
-        "api-key": "backup-runtime-header-token",
-      });
-      expect(setRuntimeApiKey).toHaveBeenLastCalledWith("custom-openai", "backup-runtime-api-key");
+      expect(harness.runtimeModel.headers?.["api-key"]).toBe(backupHeader);
+      const storedBackupApiKey = setRuntimeApiKey.mock.calls.at(-1)?.[1];
+      expectProtectedRuntimeValue(storedBackupApiKey, "backup-runtime-api-key");
       controller.stopRuntimeAuthRefreshTimer();
     } finally {
       vi.useRealTimers();
@@ -563,7 +567,8 @@ describe("createEmbeddedRunAuthController", () => {
 
       await controller.initializeAuthProfile();
 
-      expect(setRuntimeApiKey).toHaveBeenCalledWith("custom-openai", "imds-runtime-token");
+      expect(setRuntimeApiKey.mock.calls[0]?.[0]).toBe("custom-openai");
+      expectProtectedRuntimeValue(setRuntimeApiKey.mock.calls[0]?.[1], "imds-runtime-token");
       expect(harness.runtimeAuthState?.sourceApiKey).toBe("__aws_sdk_auth__");
       expect(harness.runtimeAuthState?.authMode).toBe("aws-sdk");
       expect(harness.runtimeAuthState?.expiresAt).toBeGreaterThan(Date.now());

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -144,7 +144,6 @@ export function createEmbeddedRunAuthController(params: {
       },
     });
     return protectPreparedProviderRuntimeAuth({
-      sourceApiKey: prepareParams.apiKey,
       provider: prepareParams.runtimeModel.provider,
       preparedAuth,
     });

--- a/src/agents/provider-secret-egress.test.ts
+++ b/src/agents/provider-secret-egress.test.ts
@@ -1,10 +1,46 @@
 import { describe, expect, it } from "vitest";
-import { mintSecretSentinel } from "../secrets/sentinel.js";
+import { isSecretValueRegisteredForRedaction } from "../logging/secret-redaction-registry.js";
+import { looksLikeSecretSentinel, mintSecretSentinel } from "../secrets/sentinel.js";
 import {
   attachModelProviderRequestTransport,
   getModelProviderRequestTransport,
 } from "./provider-request-config.js";
-import { unwrapModelHeaderSentinelsForProviderEgress } from "./provider-secret-egress.js";
+import {
+  protectPreparedProviderRuntimeAuth,
+  unwrapModelHeaderSentinelsForProviderEgress,
+} from "./provider-secret-egress.js";
+
+describe("protectPreparedProviderRuntimeAuth", () => {
+  it("sentinels a real credential returned by the auth exchange and registers it for redaction", () => {
+    const runtimeToken = "bedrock-api-key-egress-runtime-token";
+    const result = protectPreparedProviderRuntimeAuth({
+      provider: "amazon-bedrock-mantle",
+      preparedAuth: {
+        apiKey: runtimeToken,
+        request: {
+          auth: { mode: "authorization-bearer", token: runtimeToken },
+        },
+      },
+    });
+
+    expect(result?.apiKey).not.toBe(runtimeToken);
+    expect(looksLikeSecretSentinel(result?.apiKey ?? "")).toBe(true);
+    const auth = result?.request?.auth;
+    const bearerToken = auth?.mode === "authorization-bearer" ? auth.token : "";
+    expect(looksLikeSecretSentinel(bearerToken)).toBe(true);
+    expect(isSecretValueRegisteredForRedaction(runtimeToken)).toBe(true);
+  });
+
+  it("leaves non-secret auth markers untouched", () => {
+    const result = protectPreparedProviderRuntimeAuth({
+      provider: "ollama",
+      preparedAuth: { apiKey: "ollama-local" },
+    });
+
+    expect(result?.apiKey).toBe("ollama-local");
+    expect(isSecretValueRegisteredForRedaction("ollama-local")).toBe(false);
+  });
+});
 
 describe("unwrapModelHeaderSentinelsForProviderEgress", () => {
   it("unwraps sentinels in visible headers and attached request transport overrides", () => {

--- a/src/agents/provider-secret-egress.ts
+++ b/src/agents/provider-secret-egress.ts
@@ -1,9 +1,9 @@
-import { isSecretValueRegisteredForRedaction } from "../logging/secret-redaction-registry.js";
 import {
   looksLikeSecretSentinel,
   mintSecretSentinel,
   swapSecretSentinelsInText,
 } from "../secrets/sentinel.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import {
   attachModelProviderRequestTransport,
   getModelProviderRequestTransport,
@@ -34,7 +34,6 @@ function protectRuntimeAuthValue(params: {
 
 /** Re-sentinels credentials returned by a provider auth exchange. */
 export function protectPreparedProviderRuntimeAuth(params: {
-  sourceApiKey: string;
   provider: string;
   preparedAuth: PreparedProviderRuntimeAuth | null | undefined;
 }): PreparedProviderRuntimeAuth | undefined {
@@ -42,14 +41,10 @@ export function protectPreparedProviderRuntimeAuth(params: {
   if (!preparedAuth) {
     return undefined;
   }
-  if (
-    !looksLikeSecretSentinel(params.sourceApiKey) &&
-    !isSecretValueRegisteredForRedaction(params.sourceApiKey)
-  ) {
-    return preparedAuth;
-  }
-  const protect = (value: string, label: string) =>
-    protectRuntimeAuthValue({ value, provider: params.provider, label });
+  const protect = (value: string, label: string): string =>
+    !value || isNonSecretApiKeyMarker(value)
+      ? value
+      : protectRuntimeAuthValue({ value, provider: params.provider, label });
   const request = preparedAuth.request;
   const headers = request?.headers
     ? Object.fromEntries(

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -248,10 +248,14 @@ describe("prepareSimpleCompletionModel", () => {
       githubToken: "ghu_test",
       config: undefined,
     });
-    expect(hoisted.setRuntimeApiKeyMock).toHaveBeenCalledWith(
-      "github-copilot",
-      "copilot-runtime-token",
-    );
+    const [storedProvider, storedKey] = hoisted.setRuntimeApiKeyMock.mock.calls[0] as [
+      string,
+      string,
+    ];
+    expect(storedProvider).toBe("github-copilot");
+    expect(looksLikeSecretSentinel(storedKey)).toBe(true);
+    expect(storedKey).not.toBe("copilot-runtime-token");
+    expect(resolveSecretSentinel(storedKey)).toBe("copilot-runtime-token");
   });
 
   it("returns exchanged copilot token in auth.apiKey for github-copilot provider", async () => {
@@ -284,7 +288,8 @@ describe("prepareSimpleCompletionModel", () => {
 
     // Callers must only receive the short-lived Copilot runtime token. The
     // original GitHub token is broader auth material and must not leave prep.
-    expect(result.auth.apiKey).toBe("copilot-runtime-token");
+    expect(looksLikeSecretSentinel(result.auth.apiKey ?? "")).toBe(true);
+    expect(resolveSecretSentinel(result.auth.apiKey ?? "")).toBe("copilot-runtime-token");
     expect(result.auth.apiKey).not.toBe("ghu_original_github_token");
   });
 
@@ -466,13 +471,18 @@ describe("prepareSimpleCompletionModel", () => {
     expect(runtimeAuthInput.context?.authMode).toBe("api-key");
     expect(runtimeAuthInput.context?.modelId).toBe("anthropic.claude-opus-4-7");
     expect(runtimeAuthInput.context?.profileId).toBe("mantle");
-    expect(hoisted.setRuntimeApiKeyMock).toHaveBeenCalledWith(
-      "amazon-bedrock-mantle",
-      "bedrock-runtime-token",
-    );
+    const [storedProvider, storedKey] = hoisted.setRuntimeApiKeyMock.mock.calls[0] as [
+      string,
+      string,
+    ];
+    expect(storedProvider).toBe("amazon-bedrock-mantle");
+    expect(looksLikeSecretSentinel(storedKey)).toBe(true);
+    expect(storedKey).not.toBe("bedrock-runtime-token");
+    expect(resolveSecretSentinel(storedKey)).toBe("bedrock-runtime-token");
     expectPreparedModelResult(result);
     expect(result.model.baseUrl).toBe("https://bedrock-mantle.us-east-1.api.aws/anthropic");
-    expect(result.auth.apiKey).toBe("bedrock-runtime-token");
+    expect(looksLikeSecretSentinel(result.auth.apiKey ?? "")).toBe(true);
+    expect(resolveSecretSentinel(result.auth.apiKey ?? "")).toBe("bedrock-runtime-token");
   });
 
   it("can skip agent model/auth discovery for config-scoped one-shot completions", async () => {

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -182,7 +182,6 @@ async function setRuntimeApiKeyForCompletion(params: {
       config: params.cfg,
     });
     const protectedAuth = protectPreparedProviderRuntimeAuth({
-      sourceApiKey: params.apiKey,
       provider: params.model.provider,
       preparedAuth: {
         apiKey: copilotToken.token,
@@ -197,7 +196,6 @@ async function setRuntimeApiKeyForCompletion(params: {
     };
   }
   const preparedAuth = protectPreparedProviderRuntimeAuth({
-    sourceApiKey: params.apiKey,
     provider: params.model.provider,
     preparedAuth: await prepareProviderRuntimeAuth({
       provider: params.model.provider,

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -1463,14 +1463,18 @@ describe("describeImageWithModel", () => {
       githubToken: "oauth-test",
       config: {},
     });
-    expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("github-copilot", "copilot-api-token");
+    const storedToken = setRuntimeApiKeyMock.mock.calls[0]?.[1] as string;
+    expect(setRuntimeApiKeyMock.mock.calls[0]?.[0]).toBe("github-copilot");
+    expect(looksLikeSecretSentinel(storedToken)).toBe(true);
+    expect(storedToken).not.toBe("copilot-api-token");
+    expect(resolveSecretSentinel(storedToken)).toBe("copilot-api-token");
     const [completionModel, context, options] = providerStreamFn.mock.calls[0] as unknown as [
       { baseUrl?: string },
       { systemPrompt?: string; messages?: Array<{ role: string; content: unknown[] }> },
       { apiKey?: string; headers?: Record<string, string> },
     ];
     expect(completionModel.baseUrl).toBe("https://api.githubcopilot.com");
-    expect(options.apiKey).toBe("copilot-api-token");
+    expect(options.apiKey).toBe(storedToken);
     expect(options.headers).toMatchObject({
       "Copilot-Integration-Id": "vscode-chat",
       "Copilot-Vision-Request": "true",

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -263,7 +263,6 @@ async function prepareResolvedImageRuntime(
       config: params.cfg,
     });
     const protectedAuth = protectPreparedProviderRuntimeAuth({
-      sourceApiKey: apiKey,
       provider: model.provider,
       preparedAuth: { apiKey: copilotToken.token, baseUrl: copilotToken.baseUrl },
     });


### PR DESCRIPTION
## What Problem This Solves

`protectPreparedProviderRuntimeAuth` (`src/agents/provider-secret-egress.ts`) is the guard that
re-sentinels credentials returned by a provider auth exchange so real tokens are never stored or
logged in the clear. It decided *whether* to protect from the shape of the INPUT `sourceApiKey`: if
that input was not already a sentinel and not registered for redaction, it returned the exchange
OUTPUT completely untouched. That assumes output sensitivity mirrors input sensitivity, which is
false for any provider that turns a non-secret marker into a real credential.

The bundled `amazon-bedrock-mantle` plugin is a live instance:

- Its stored config `apiKey` is the marker `__amazon_bedrock_mantle_iam__`
  (`extensions/amazon-bedrock-mantle/discovery.ts`), which the plugin manifest does NOT declare in
  `nonSecretAuthMarkers`, so `resolveUsableCustomProviderApiKey` returns it raw as the source key.
- At request time `prepareRuntimeAuth` -> `resolveMantleRuntimeBearerToken` mints a real IAM-derived
  Bedrock bearer token (`bedrock-api-key-...`).
- That real token passed through the guard unprotected because the source marker is neither a
  sentinel nor registered.

In any environment using implicit mantle auth (no explicit `AWS_BEARER_TOKEN_BEDROCK`, ambient AWS
credentials present) the generated bearer token flowed through auth storage and request headers
unencrypted and unregistered for redaction.

## Why This Change Was Made

Fix the guard at its own ownership boundary: protect based on OUTPUT sensitivity, which is the
function's documented job ("Re-sentinels credentials returned by a provider auth exchange").

Before:

```ts
if (
  !looksLikeSecretSentinel(params.sourceApiKey) &&
  !isSecretValueRegisteredForRedaction(params.sourceApiKey)
) {
  return preparedAuth;
}
const protect = (value, label) => protectRuntimeAuthValue({ value, provider: params.provider, label });
```

After:

```ts
const protect = (value: string, label: string): string =>
  !value || isNonSecretApiKeyMarker(value)
    ? value
    : protectRuntimeAuthValue({ value, provider: params.provider, label });
```

The input-based short-circuit and the now-dead `sourceApiKey` parameter are removed. Protection is
gated per output value: skip empty values and non-secret markers, protect everything else.
`protectRuntimeAuthValue` already skips values that are already sentinels.

The alternative of declaring `__amazon_bedrock_mantle_iam__` in the plugin's `nonSecretAuthMarkers`
was rejected: tracing `resolveUsableCustomProviderApiKey` shows that path would make it return
`null` for mantle (marker recognized -> skip raw-return -> not an env marker -> remote baseUrl fails
the local-provider branch -> `null`), breaking mantle auth; and even if it resolved, a non-secret
marker source would still fail the old guard, so the token would remain unprotected. Keying off
output sensitivity is the only fix that stops the leak and prevents recurrence for the next plugin.

Sibling providers are unaffected: lmstudio/ollama/codex/anthropic-vertex `prepareRuntimeAuth` echo
their own markers (`lmstudio-local`, `ollama-local`, `codex-app-server`, `gcp-vertex-credentials`),
all of which `isNonSecretApiKeyMarker` returns true for and are skipped. Only outputs that are real
credentials from a non-registered source (mantle) newly get protected. The apiKey-minting plus
egress-unwrap round-trip is already exercised today by the sentinel-source path, so no new unhandled
egress path is introduced.

`resolveUsableCustomProviderApiKey` returning inline `models.json` literal keys raw is a separate
classification quirk and is out of scope here; for mantle it is harmless (the marker is not itself a
secret; the real token is minted downstream and is what this PR protects).

## User Impact

Operators running implicit amazon-bedrock-mantle auth no longer have their IAM-derived Bedrock
bearer token stored or logged in plaintext; it is sentinel-wrapped in auth storage and headers and
registered for exact-value log redaction, matching every other provider whose auth exchange yields a
real credential. No config or plugin-author action required. No behavior change for providers that
return non-secret markers.

## Evidence

Verification (scoped, from a deps-enabled worktree at the same base):

- `run-vitest.mjs src/agents/provider-secret-egress.test.ts` -> 6 passed. The new regression
  assertion fails on pristine `main` (guard returns the raw token) and passes with the patch.
- `oxfmt --check` on the 7 changed files -> clean.
- `oxlint` on the 7 changed files -> clean.
- `run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` -> clean.

Novelty: #102009 (merged) introduced the process-local sentinel egress system and #102420 (merged)
added capture/retention hardening plus tests, but neither touches this input-vs-output guard, the
`model-auth-markers` path, or the mantle marker. #93952 (open) edits `auth-controller.ts` near this
call but changes the `RuntimeAuthState.sourceApiKey` field, not the `protectPreparedProviderRuntimeAuth`
call; a trivial rebase may be needed if it lands first.

## Real behavior proof
Behavior addressed: with implicit amazon-bedrock-mantle auth, the IAM-derived Bedrock bearer token minted by the plugin flows through protectPreparedProviderRuntimeAuth unprotected (not sentinel-wrapped, not registered for redaction).
Real environment tested: drove the real amazon-bedrock-mantle resolveMantleRuntimeBearerToken and the real protectPreparedProviderRuntimeAuth guard on pristine main 4b33199a and on the patched tree with identical inputs. Real: the mantle resolver, the MANTLE_IAM_TOKEN_MARKER constant, region resolution, sentinel minting, and the secret-redaction registry. The only external seam was the injected AWS token provider factory, standing in for the @aws/bedrock-token-generator IAM network call.
Exact steps or command run after this patch: called resolveMantleRuntimeBearerToken({ apiKey: MANTLE_IAM_TOKEN_MARKER, env: { AWS_REGION: "us-east-1" }, tokenProviderFactory: () => async () => "bedrock-api-key-PROOFTOKEN" }) to mint the real token, then passed the result through protectPreparedProviderRuntimeAuth for provider amazon-bedrock-mantle, and printed the guard output apiKey, whether it is a sentinel placeholder, and whether the raw token is registered for redaction.
Evidence after fix:
```
# BEFORE (pristine main 4b33199a)
mantle resolver minted apiKey: bedrock-api-key-PROOFTOKEN
guard output apiKey: bedrock-api-key-PROOFTOKEN
guard output apiKey is a sentinel placeholder: false
real token registered for redaction: false
# AFTER (this patch, identical inputs)
mantle resolver minted apiKey: bedrock-api-key-PROOFTOKEN
guard output apiKey: oc-sent-v2.ncxUhekdrlTvEHc6l2OuRuoqm_hglZgliAdD2QBRh9_tH_t7K2xVTks-K4DZNNcW7X9gYgncqgYEavBAJws.end
guard output apiKey is a sentinel placeholder: true
real token registered for redaction: true
```
Observed result after fix: the same real Bedrock bearer token that leaked in the clear before is now replaced by a sentinel placeholder in the guard output and registered for exact-value redaction, while the mantle resolver output feeding the guard is byte-identical across both runs.
What was not tested: no live AWS IAM call (the token provider factory was injected in place of the network round-trip); the full build was not run.
