### PR TITLE
fix(sessions): change skipCache to false in loadReplySessionInitializationSnapshot

### DIFF
--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -2251,7 +2251,7 @@ export function loadReplySessionInitializationSnapshot(params: {
   storePath: string;
   sessionKey: string;
 }): ReplySessionInitializationSnapshot {
-  const store = loadSessionStore(params.storePath, { skipCache: true, clone: false });
+  const store = loadSessionStore(params.storePath, { skipCache: false, clone: false });
   const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
   const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
   const entries = cloneSessionEntries(store);


### PR DESCRIPTION
Sets skipCache to false when loading the session initialization snapshot. This ensures the snapshot reader references the same memory-cached store as the write transaction, avoiding concurrency locking conflict errors during quick successive turns or dashboard sync status checks.