### PR TITLE
fix(admin-http-rpc): reject oversized declared request bodies

### DIFF
--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -39,6 +39,7 @@ function createResponse() {
     headers: {},
     body: "",
   };
+  let onFinish: (() => void) | undefined;
   const res = {
     get statusCode() {
       return captured.statusCode;
@@ -49,8 +50,15 @@ function createResponse() {
     setHeader(name: string, value: string | number | readonly string[]) {
       captured.headers[name.toLowerCase()] = value;
     },
+    once(event: string, listener: () => void) {
+      if (event === "finish") {
+        onFinish = listener;
+      }
+      return res;
+    },
     end(chunk?: string | Buffer) {
       captured.body = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : (chunk ?? "");
+      onFinish?.();
     },
   } as import("node:http").ServerResponse;
   return { res, captured };
@@ -115,6 +123,63 @@ async function requestRealAdminRpc(
     });
     clientReq.on("error", reject);
     clientReq.end(options.body);
+  });
+}
+
+async function requestContinuingStream(port: number): Promise<
+  CapturedResponse & { closed: boolean; writesAfterLimit: number }
+> {
+  return await new Promise((resolve, reject) => {
+    let response: CapturedResponse | undefined;
+    let writesAfterLimit = 0;
+    const clientReq = request(
+      {
+        host: "127.0.0.1",
+        port,
+        method: "POST",
+        path: "/api/v1/admin/rpc",
+        headers: { "content-type": "application/json" },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          const headers: CapturedResponse["headers"] = {};
+          for (const [name, value] of Object.entries(res.headers)) {
+            if (value !== undefined) {
+              headers[name] = value;
+            }
+          }
+          response = {
+            statusCode: res.statusCode ?? 0,
+            headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          };
+        });
+      },
+    );
+    const timer = setTimeout(() => {
+      clientReq.destroy(new Error("timed out waiting for Admin RPC connection close"));
+    }, 2_000);
+    clientReq.on("close", () => {
+      clearTimeout(timer);
+      if (!response) {
+        reject(new Error("Admin RPC connection closed before its 413 response"));
+        return;
+      }
+      resolve({ ...response, closed: true, writesAfterLimit });
+    });
+    clientReq.on("error", (error) => {
+      if (!response) {
+        reject(error);
+      }
+    });
+
+    clientReq.write(Buffer.alloc(1024 * 1024 + 1, "x"));
+    for (let index = 0; index < 4; index += 1) {
+      clientReq.write("x");
+      writesAfterLimit += 1;
+    }
   });
 }
 
@@ -313,6 +378,34 @@ describe("admin-http-rpc plugin handler", () => {
       });
 
       expect(result.statusCode).toBe(413);
+      expect(JSON.parse(result.body) as unknown).toEqual({
+        ok: false,
+        error: {
+          type: "invalid_request",
+          message: "Payload too large",
+        },
+      });
+      expect(dispatchGatewayMethod).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("closes a continuing streamed request after delivering its 413 response", async () => {
+    const server = createServer((req, res) => {
+      void handleAdminHttpRpcRequest(req, res);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address() as AddressInfo;
+      const result = await requestContinuingStream(address.port);
+
+      expect(result.statusCode).toBe(413);
+      expect(result.closed).toBe(true);
+      expect(result.writesAfterLimit).toBeGreaterThan(0);
       expect(JSON.parse(result.body) as unknown).toEqual({
         ok: false,
         error: {

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -1,4 +1,6 @@
 // Admin Http Rpc tests cover handler plugin behavior.
+import { createServer, request } from "node:http";
+import type { AddressInfo } from "node:net";
 import { Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleAdminHttpRpcRequest } from "./handler.js";
@@ -62,6 +64,45 @@ async function invoke(body: unknown, method = "POST", headers?: Record<string, s
     captured,
     json: captured.body ? (JSON.parse(captured.body) as unknown) : undefined,
   };
+}
+
+function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function requestRealAdminRpc(port: number, contentLength: number): Promise<CapturedResponse> {
+  return await new Promise((resolve, reject) => {
+    const clientReq = request(
+      {
+        host: "127.0.0.1",
+        port,
+        method: "POST",
+        path: "/api/v1/admin/rpc",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(contentLength),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+    clientReq.setTimeout(2_000, () => {
+      clientReq.destroy(new Error("timed out waiting for Admin RPC response"));
+    });
+    clientReq.on("error", reject);
+    clientReq.end();
+  });
 }
 
 describe("admin-http-rpc plugin handler", () => {
@@ -214,6 +255,30 @@ describe("admin-http-rpc plugin handler", () => {
       },
     });
     expect(dispatchGatewayMethod).not.toHaveBeenCalled();
+  });
+
+  it("delivers 413 to a real HTTP client for declared oversized request bodies", async () => {
+    const server = createServer((req, res) => {
+      void handleAdminHttpRpcRequest(req, res);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const address = server.address() as AddressInfo;
+      const result = await requestRealAdminRpc(address.port, 1024 * 1024 + 1);
+
+      expect(result.statusCode).toBe(413);
+      expect(JSON.parse(result.body) as unknown).toEqual({
+        ok: false,
+        error: {
+          type: "invalid_request",
+          message: "Payload too large",
+        },
+      });
+      expect(dispatchGatewayMethod).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
   });
 
   it("only accepts POST", async () => {

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -18,13 +18,14 @@ type CapturedResponse = {
   body: string;
 };
 
-function createRequest(body: unknown, method = "POST") {
+function createRequest(body: unknown, method = "POST", headers?: Record<string, string>) {
   const req = Readable.from([typeof body === "string" ? body : JSON.stringify(body)]);
   Object.assign(req, {
     method,
     url: "/api/v1/admin/rpc",
     headers: {
       "content-type": "application/json",
+      ...headers,
     },
   });
   return req as import("node:http").IncomingMessage;
@@ -53,9 +54,9 @@ function createResponse() {
   return { res, captured };
 }
 
-async function invoke(body: unknown, method = "POST") {
+async function invoke(body: unknown, method = "POST", headers?: Record<string, string>) {
   const { res, captured } = createResponse();
-  const handled = await handleAdminHttpRpcRequest(createRequest(body, method), res);
+  const handled = await handleAdminHttpRpcRequest(createRequest(body, method, headers), res);
   return {
     handled,
     captured,
@@ -194,6 +195,22 @@ describe("admin-http-rpc plugin handler", () => {
       error: {
         type: "invalid_request",
         message: "method must be a non-empty string",
+      },
+    });
+    expect(dispatchGatewayMethod).not.toHaveBeenCalled();
+  });
+
+  it("rejects declared oversized request bodies before dispatch", async () => {
+    const result = await invoke("", "POST", {
+      "content-length": String(1024 * 1024 + 1),
+    });
+
+    expect(result.captured.statusCode).toBe(413);
+    expect(result.json).toEqual({
+      ok: false,
+      error: {
+        type: "invalid_request",
+        message: "Payload too large",
       },
     });
     expect(dispatchGatewayMethod).not.toHaveBeenCalled();

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -261,7 +261,9 @@ describe("admin-http-rpc plugin handler", () => {
     const server = createServer((req, res) => {
       void handleAdminHttpRpcRequest(req, res);
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
 
     try {
       const address = server.address() as AddressInfo;

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -82,7 +82,7 @@ function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
 
 async function requestRealAdminRpc(
   port: number,
-  options: { body?: Buffer | string; contentLength?: number },
+  options: { body?: Buffer | string; contentLength?: number | string },
 ): Promise<CapturedResponse> {
   return await new Promise((resolve, reject) => {
     const headers: Record<string, string> = {
@@ -347,6 +347,34 @@ describe("admin-http-rpc plugin handler", () => {
       const address = server.address() as AddressInfo;
       const result = await requestRealAdminRpc(address.port, {
         contentLength: 1024 * 1024 + 1,
+      });
+
+      expect(result.statusCode).toBe(413);
+      expect(JSON.parse(result.body) as unknown).toEqual({
+        ok: false,
+        error: {
+          type: "invalid_request",
+          message: "Payload too large",
+        },
+      });
+      expect(dispatchGatewayMethod).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("rejects declared lengths above the safe integer range before dispatch", async () => {
+    const server = createServer((req, res) => {
+      void handleAdminHttpRpcRequest(req, res);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address() as AddressInfo;
+      const result = await requestRealAdminRpc(address.port, {
+        contentLength: "9007199254740992",
       });
 
       expect(result.statusCode).toBe(413);

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -89,14 +89,15 @@ async function requestRealAdminRpc(port: number, contentLength: number): Promise
         const chunks: Buffer[] = [];
         res.on("data", (chunk: Buffer) => chunks.push(chunk));
         res.on("end", () => {
+          const headers: CapturedResponse["headers"] = {};
+          for (const [name, value] of Object.entries(res.headers)) {
+            if (value !== undefined) {
+              headers[name] = value;
+            }
+          }
           resolve({
             statusCode: res.statusCode ?? 0,
-            headers: Object.fromEntries(
-              Object.entries(res.headers).filter(
-                (entry): entry is [string, string | number | readonly string[]] =>
-                  entry[1] !== undefined,
-              ),
-            ),
+            headers,
             body: Buffer.concat(chunks).toString("utf8"),
           });
         });

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -91,7 +91,12 @@ async function requestRealAdminRpc(port: number, contentLength: number): Promise
         res.on("end", () => {
           resolve({
             statusCode: res.statusCode ?? 0,
-            headers: res.headers,
+            headers: Object.fromEntries(
+              Object.entries(res.headers).filter(
+                (entry): entry is [string, string | number | readonly string[]] =>
+                  entry[1] !== undefined,
+              ),
+            ),
             body: Buffer.concat(chunks).toString("utf8"),
           });
         });

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -126,9 +126,9 @@ async function requestRealAdminRpc(
   });
 }
 
-async function requestContinuingStream(port: number): Promise<
-  CapturedResponse & { closed: boolean; writesAfterLimit: number }
-> {
+async function requestContinuingStream(
+  port: number,
+): Promise<CapturedResponse & { closed: boolean; writesAfterLimit: number }> {
   return await new Promise((resolve, reject) => {
     let response: CapturedResponse | undefined;
     let writesAfterLimit = 0;

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -72,32 +72,39 @@ function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
   });
 }
 
-async function requestRealAdminRpc(port: number, contentLength: number): Promise<CapturedResponse> {
+async function requestRealAdminRpc(
+  port: number,
+  options: { body?: Buffer | string; contentLength?: number },
+): Promise<CapturedResponse> {
   return await new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (options.contentLength !== undefined) {
+      headers["content-length"] = String(options.contentLength);
+    }
+
     const clientReq = request(
       {
         host: "127.0.0.1",
         port,
         method: "POST",
         path: "/api/v1/admin/rpc",
-        headers: {
-          "content-type": "application/json",
-          "content-length": String(contentLength),
-        },
+        headers,
       },
       (res) => {
         const chunks: Buffer[] = [];
         res.on("data", (chunk: Buffer) => chunks.push(chunk));
         res.on("end", () => {
-          const headers: CapturedResponse["headers"] = {};
+          const responseHeaders: CapturedResponse["headers"] = {};
           for (const [name, value] of Object.entries(res.headers)) {
             if (value !== undefined) {
-              headers[name] = value;
+              responseHeaders[name] = value;
             }
           }
           resolve({
             statusCode: res.statusCode ?? 0,
-            headers,
+            headers: responseHeaders,
             body: Buffer.concat(chunks).toString("utf8"),
           });
         });
@@ -107,7 +114,7 @@ async function requestRealAdminRpc(port: number, contentLength: number): Promise
       clientReq.destroy(new Error("timed out waiting for Admin RPC response"));
     });
     clientReq.on("error", reject);
-    clientReq.end();
+    clientReq.end(options.body);
   });
 }
 
@@ -273,7 +280,37 @@ describe("admin-http-rpc plugin handler", () => {
 
     try {
       const address = server.address() as AddressInfo;
-      const result = await requestRealAdminRpc(address.port, 1024 * 1024 + 1);
+      const result = await requestRealAdminRpc(address.port, {
+        contentLength: 1024 * 1024 + 1,
+      });
+
+      expect(result.statusCode).toBe(413);
+      expect(JSON.parse(result.body) as unknown).toEqual({
+        ok: false,
+        error: {
+          type: "invalid_request",
+          message: "Payload too large",
+        },
+      });
+      expect(dispatchGatewayMethod).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("delivers 413 to a real HTTP client for streamed oversized request bodies", async () => {
+    const server = createServer((req, res) => {
+      void handleAdminHttpRpcRequest(req, res);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address() as AddressInfo;
+      const result = await requestRealAdminRpc(address.port, {
+        body: Buffer.alloc(1024 * 1024 + 1, "x"),
+      });
 
       expect(result.statusCode).toBe(413);
       expect(JSON.parse(result.body) as unknown).toEqual({

--- a/extensions/admin-http-rpc/src/handler.ts
+++ b/extensions/admin-http-rpc/src/handler.ts
@@ -5,6 +5,7 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { dispatchGatewayMethod } from "openclaw/plugin-sdk/gateway-method-runtime";
+import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   readJsonBodyWithLimit,
@@ -81,6 +82,16 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
 
 function sendError(res: ServerResponse, status: number, error: { type: string; message: string }) {
   sendJson(res, status, { ok: false, error });
+}
+
+function declaredContentLengthExceeds(req: IncomingMessage, maxBytes: number): boolean {
+  const header = req.headers["content-length"];
+  const raw = Array.isArray(header) ? header[0] : header;
+  if (typeof raw !== "string") {
+    return false;
+  }
+  const declaredLength = parseStrictNonNegativeInteger(raw);
+  return declaredLength !== undefined && declaredLength > maxBytes;
 }
 
 async function readJsonBody(
@@ -206,6 +217,15 @@ export async function handleAdminHttpRpcRequest(
     sendError(res, 405, {
       type: "method_not_allowed",
       message: "Method Not Allowed",
+    });
+    return true;
+  }
+
+  if (declaredContentLengthExceeds(req, DEFAULT_RPC_BODY_BYTES)) {
+    res.setHeader("Connection", "close");
+    sendError(res, 413, {
+      type: "invalid_request",
+      message: "Payload too large",
     });
     return true;
   }

--- a/extensions/admin-http-rpc/src/handler.ts
+++ b/extensions/admin-http-rpc/src/handler.ts
@@ -5,7 +5,6 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { dispatchGatewayMethod } from "openclaw/plugin-sdk/gateway-method-runtime";
-import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isAdminHttpRpcAllowedMethod, listAdminHttpRpcAllowedMethods } from "./methods.js";
 
@@ -83,11 +82,13 @@ function sendError(res: ServerResponse, status: number, error: { type: string; m
 function declaredContentLengthExceeds(req: IncomingMessage, maxBytes: number): boolean {
   const header = req.headers["content-length"];
   const raw = Array.isArray(header) ? header[0] : header;
-  if (typeof raw !== "string") {
+  if (typeof raw !== "string" || !/^\d+$/.test(raw)) {
     return false;
   }
-  const declaredLength = parseStrictNonNegativeInteger(raw);
-  return declaredLength !== undefined && declaredLength > maxBytes;
+  // Preserve decimal precision because HTTP lengths can exceed JavaScript's safe integer range.
+  const normalized = raw.replace(/^0+/, "") || "0";
+  const max = String(maxBytes);
+  return normalized.length > max.length || (normalized.length === max.length && normalized > max);
 }
 
 async function readJsonBody(

--- a/extensions/admin-http-rpc/src/handler.ts
+++ b/extensions/admin-http-rpc/src/handler.ts
@@ -7,10 +7,6 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { dispatchGatewayMethod } from "openclaw/plugin-sdk/gateway-method-runtime";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  readJsonBodyWithLimit,
-  requestBodyErrorToText,
-} from "openclaw/plugin-sdk/webhook-request-guards";
 import { isAdminHttpRpcAllowedMethod, listAdminHttpRpcAllowedMethods } from "./methods.js";
 
 const DEFAULT_RPC_BODY_BYTES = 1024 * 1024;
@@ -98,32 +94,30 @@ async function readJsonBody(
   req: IncomingMessage,
   maxBytes: number,
 ): Promise<{ ok: true; value: unknown } | { ok: false; status: number; message: string }> {
-  const body = await readJsonBodyWithLimit(req, {
-    maxBytes,
-    emptyObjectOnEmpty: false,
-  });
-  if (body.ok) {
-    return { ok: true, value: body.value };
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  try {
+    for await (const chunk of req.iterator({ destroyOnReturn: false })) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.byteLength;
+      if (totalBytes > maxBytes) {
+        req.resume();
+        return { ok: false, status: 413, message: "Payload too large" };
+      }
+      chunks.push(buffer);
+    }
+  } catch {
+    return { ok: false, status: 400, message: "failed to read request body" };
   }
 
-  switch (body.code) {
-    case "PAYLOAD_TOO_LARGE":
-      return { ok: false, status: 413, message: requestBodyErrorToText(body.code) };
-    case "REQUEST_BODY_TIMEOUT":
-      return { ok: false, status: 408, message: requestBodyErrorToText(body.code) };
-    case "CONNECTION_CLOSED":
-      return { ok: false, status: 400, message: requestBodyErrorToText(body.code) };
-    case "INVALID_JSON":
-      return {
-        ok: false,
-        status: 400,
-        message:
-          body.error === "empty payload"
-            ? "request body must be JSON"
-            : "request body must be valid JSON",
-      };
-    default:
-      return { ok: false, status: 400, message: "request body must be valid JSON" };
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (!raw.trim()) {
+    return { ok: false, status: 400, message: "request body must be JSON" };
+  }
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch {
+    return { ok: false, status: 400, message: "request body must be valid JSON" };
   }
 }
 
@@ -231,6 +225,9 @@ export async function handleAdminHttpRpcRequest(
 
   const body = await readJsonBody(req, DEFAULT_RPC_BODY_BYTES);
   if (!body.ok) {
+    if (body.status === 413) {
+      res.setHeader("Connection", "close");
+    }
     sendError(res, body.status, {
       type: "invalid_request",
       message: body.message,

--- a/extensions/admin-http-rpc/src/handler.ts
+++ b/extensions/admin-http-rpc/src/handler.ts
@@ -101,7 +101,6 @@ async function readJsonBody(
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       totalBytes += buffer.byteLength;
       if (totalBytes > maxBytes) {
-        req.resume();
         return { ok: false, status: 413, message: "Payload too large" };
       }
       chunks.push(buffer);
@@ -227,6 +226,11 @@ export async function handleAdminHttpRpcRequest(
   if (!body.ok) {
     if (body.status === 413) {
       res.setHeader("Connection", "close");
+      res.once("finish", () => {
+        if (!req.destroyed) {
+          req.destroy();
+        }
+      });
     }
     sendError(res, body.status, {
       type: "invalid_request",

--- a/extensions/admin-http-rpc/src/handler.ts
+++ b/extensions/admin-http-rpc/src/handler.ts
@@ -123,7 +123,6 @@ async function readJsonBody(
             : "request body must be valid JSON",
       };
     default:
-      body satisfies never;
       return { ok: false, status: 400, message: "request body must be valid JSON" };
   }
 }

--- a/extensions/admin-http-rpc/src/handler.ts
+++ b/extensions/admin-http-rpc/src/handler.ts
@@ -6,6 +6,10 @@ import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { dispatchGatewayMethod } from "openclaw/plugin-sdk/gateway-method-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  readJsonBodyWithLimit,
+  requestBodyErrorToText,
+} from "openclaw/plugin-sdk/webhook-request-guards";
 import { isAdminHttpRpcAllowedMethod, listAdminHttpRpcAllowedMethods } from "./methods.js";
 
 const DEFAULT_RPC_BODY_BYTES = 1024 * 1024;
@@ -83,29 +87,33 @@ async function readJsonBody(
   req: IncomingMessage,
   maxBytes: number,
 ): Promise<{ ok: true; value: unknown } | { ok: false; status: number; message: string }> {
-  const chunks: Buffer[] = [];
-  let totalBytes = 0;
-  try {
-    for await (const chunk of req) {
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      totalBytes += buffer.byteLength;
-      if (totalBytes > maxBytes) {
-        return { ok: false, status: 413, message: "Payload too large" };
-      }
-      chunks.push(buffer);
-    }
-  } catch {
-    return { ok: false, status: 400, message: "failed to read request body" };
+  const body = await readJsonBodyWithLimit(req, {
+    maxBytes,
+    emptyObjectOnEmpty: false,
+  });
+  if (body.ok) {
+    return { ok: true, value: body.value };
   }
 
-  const raw = Buffer.concat(chunks).toString("utf8");
-  if (!raw.trim()) {
-    return { ok: false, status: 400, message: "request body must be JSON" };
-  }
-  try {
-    return { ok: true, value: JSON.parse(raw) };
-  } catch {
-    return { ok: false, status: 400, message: "request body must be valid JSON" };
+  switch (body.code) {
+    case "PAYLOAD_TOO_LARGE":
+      return { ok: false, status: 413, message: requestBodyErrorToText(body.code) };
+    case "REQUEST_BODY_TIMEOUT":
+      return { ok: false, status: 408, message: requestBodyErrorToText(body.code) };
+    case "CONNECTION_CLOSED":
+      return { ok: false, status: 400, message: requestBodyErrorToText(body.code) };
+    case "INVALID_JSON":
+      return {
+        ok: false,
+        status: 400,
+        message:
+          body.error === "empty payload"
+            ? "request body must be JSON"
+            : "request body must be valid JSON",
+      };
+    default:
+      body satisfies never;
+      return { ok: false, status: 400, message: "request body must be valid JSON" };
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Admin HTTP RPC callers could declare a JSON request body larger than the 1 MiB route limit using a valid decimal `Content-Length` outside JavaScript's safe-integer range, leaving the request to wait for a body instead of returning the structured 413 response.

## Why This Change Was Made

The Admin HTTP RPC handler compares decimal `Content-Length` digits directly with the route limit before reading the body. This preserves precision for arbitrarily large valid declarations while retaining the existing streamed-overflow response and cleanup path.

## User Impact

Operators and host tooling using `POST /api/v1/admin/rpc` now receive the same HTTP 413 JSON response for every valid oversized declared length, including values beyond JavaScript's safe integer range. The rejected request does not reach Gateway RPC dispatch.

## Evidence

- Claim proved: the current-head changed-node CI shard passed the claim-matched Admin HTTP RPC regression path in `extensions/admin-http-rpc/src/handler.test.ts`.
- Real loopback behavior covered by that path: a real Node HTTP server and client receive HTTP 413 with JSON `Payload too large` for an oversized declared length, a decimal length above the safe-integer range, and a streamed oversized body; the handler does not dispatch the Gateway RPC method, and a continuing stream is closed after the 413 response.
- Current head: `df9ed9934afc52f400418080ccbf268b11a09a93`.
- Current-head checks: [checks-node-changed](https://github.com/openclaw/openclaw/actions/runs/29747123622/job/88367927058) and [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/29747123622/job/88369160643) passed on this head.
- Diff hygiene: `git diff --check upstream/main...HEAD` passed.

AI-assisted: yes. I reviewed the Admin HTTP RPC route boundary, the shared safe-integer parser contract, and the real HTTP regression path.
