### PR TITLE
fix(ci): handle missing temp report merge base

### DIFF
--- a/scripts/report-test-temp-creations.mjs
+++ b/scripts/report-test-temp-creations.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import ts from "typescript";
@@ -131,7 +131,25 @@ function parseArgs(argv) {
 }
 
 function readDiff(args, cwd = process.cwd()) {
-  const range = args.noMergeBase ? `${args.base}..${args.head}` : `${args.base}...${args.head}`;
+  let useMergeBase = !args.noMergeBase;
+  if (useMergeBase && !args.staged) {
+    const mergeBase = spawnSync("git", ["merge-base", args.base, args.head], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    if (mergeBase.error) {
+      throw mergeBase.error;
+    }
+    if (mergeBase.status === 1) {
+      // Delegated CI syncs can contain both refs without their shared history.
+      // Compare the endpoint trees so this warning-only report still runs.
+      useMergeBase = false;
+    } else if (mergeBase.status !== 0) {
+      throw new Error(mergeBase.stderr.trim() || "git merge-base failed");
+    }
+  }
+  const range = useMergeBase ? `${args.base}...${args.head}` : `${args.base}..${args.head}`;
   const diffArgs = args.staged
     ? ["diff", "--cached", "--unified=0", "--diff-filter=ACMR", "--"]
     : ["diff", "--unified=0", "--diff-filter=ACMR", range, "--"];

--- a/test/scripts/report-test-temp-creations.test.ts
+++ b/test/scripts/report-test-temp-creations.test.ts
@@ -507,4 +507,49 @@ describe("report-test-temp-creations", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("test/helpers/case.ts");
   });
+
+  it("falls back to a two-dot diff when refs have no merge base", () => {
+    const root = tempDirs.make("openclaw-temp-report-no-merge-base-");
+    const env = createNestedGitEnv();
+    const git = (...args: string[]) =>
+      execFileSync(
+        "git",
+        ["-c", "user.email=test@example.com", "-c", "user.name=Test User", ...args],
+        { cwd: root, env },
+      );
+    git("init", "-q", "--initial-branch=main");
+    git("commit", "--allow-empty", "-q", "-m", "base");
+    git("checkout", "--orphan", "feature", "-q");
+    fs.mkdirSync(path.join(root, "test", "scripts"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "test", "scripts", "feature.test.ts"),
+      'const tempRoot = fs.mkdtempSync("case-");\n',
+      "utf8",
+    );
+    git("add", "test/scripts/feature.test.ts");
+    git("commit", "-q", "-m", "feature");
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(repoRoot, "scripts", "report-test-temp-creations.mjs"),
+        "--base",
+        "main",
+        "--head",
+        "feature",
+        "--json",
+      ],
+      { cwd: root, encoding: "utf8", env },
+    );
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual([
+      {
+        file: "test/scripts/feature.test.ts",
+        line: 1,
+        reason: "new mkdtemp temp directory creation",
+        source: 'const tempRoot = fs.mkdtempSync("case-");',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

`pnpm check:changed` failed on delegated Blacksmith Testbox checkouts when the warning-only test temp creation report used `origin/main...HEAD` and the synced refs had no merge base.

## Why This Change Was Made

The report now probes `git merge-base` before choosing its diff range. A status-1 result, meaning the valid refs have no common ancestor, falls back to the already-supported two-dot endpoint-tree diff. Missing refs and other Git failures remain fatal.

## User Impact

Blacksmith Testbox `check:changed` runs no longer crash in the test temp creation warning lane solely because the delegated checkout lacks shared history with `origin/main`.

## Evidence

- Blacksmith Testbox `jade-crayfish` (`tbx_01kx906knmp3tf6jk5vr8s4k4w`): `corepack pnpm test test/scripts/report-test-temp-creations.test.ts` — 14/14 passed.
- Same Testbox: delegated `corepack pnpm check:changed` — passed, including `test temp creation report (warning-only)`.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings.
