### PR TITLE
fix(cron): delete on-exit jobs after successful deleteAfterRun

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -72,6 +72,8 @@ Cron is the Gateway's built-in scheduler. It persists jobs, wakes the agent at t
 | `cron`    | `--cron`    | 5-field or 6-field cron expression with optional `--tz`                                                  |
 | `on-exit` | `--on-exit` | Fire once when a watched command exits (event trigger; survives turn teardown; optional `--on-exit-cwd`) |
 
+`on-exit` jobs honor `--delete-after-run` / `--keep-after-run` the same way as successful one-shot `--at` jobs: after a successful payload run, delete when requested; otherwise keep the job disabled (the Gateway exit watcher disables the job before the payload runs so a restart cannot re-arm the watched command). Failed payload runs are never auto-deleted.
+
 Timestamps without a timezone are treated as UTC. Add `--tz America/New_York` to interpret an offset-less `--at` datetime, or to evaluate a cron expression, in that IANA timezone. Cron expressions without `--tz` use the Gateway host timezone. `--tz` is not valid with `--every` or `--on-exit`.
 
 Recurring top-of-hour expressions (minute `0` with a wildcard hour field) are automatically staggered by up to 5 minutes to reduce load spikes. Use `--exact` to force precise timing, or `--stagger 30s` for an explicit window (cron schedules only).

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -72,7 +72,7 @@ Cron is the Gateway's built-in scheduler. It persists jobs, wakes the agent at t
 | `cron`    | `--cron`    | 5-field or 6-field cron expression with optional `--tz`                                                  |
 | `on-exit` | `--on-exit` | Fire once when a watched command exits (event trigger; survives turn teardown; optional `--on-exit-cwd`) |
 
-`on-exit` jobs honor `--delete-after-run` / `--keep-after-run` the same way as successful one-shot `--at` jobs: after a successful payload run, delete when requested; otherwise keep the job disabled (the Gateway exit watcher disables the job before the payload runs so a restart cannot re-arm the watched command). Failed payload runs are never auto-deleted.
+`on-exit` jobs honor successful `--delete-after-run` the same way as one-shot `--at` jobs: after a successful payload run, the job is removed when deletion was requested. The Gateway exit watcher still disables the job **before** the payload runs so a restart cannot re-arm the watched command; failed payloads and keep-after-run outcomes stay in the store (watcher-disabled when fired by the watcher). Operator-triggered force runs do not terminalize an armed `on-exit` job.
 
 Timestamps without a timezone are treated as UTC. Add `--tz America/New_York` to interpret an offset-less `--at` datetime, or to evaluate a cron expression, in that IANA timezone. Cron expressions without `--tz` use the Gateway host timezone. `--tz` is not valid with `--every` or `--on-exit`.
 

--- a/src/cron/service.removal-postcommit.test.ts
+++ b/src/cron/service.removal-postcommit.test.ts
@@ -35,6 +35,23 @@ function createDueOneShot(id: string, nowMs: number): CronJob {
   };
 }
 
+/** On-exit job already terminal-disabled by the Gateway exit watcher (pre-fire). */
+function createCompletedOnExitJob(id: string, nowMs: number, deleteAfterRun: boolean): CronJob {
+  return {
+    id,
+    name: `on-exit ${id}`,
+    enabled: false,
+    deleteAfterRun,
+    createdAtMs: nowMs - 60_000,
+    updatedAtMs: nowMs - 1_000,
+    schedule: { kind: "on-exit", command: "sh -c 'exit 0'" },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "do work" },
+    state: {},
+  };
+}
+
 function createState(params: {
   storePath: string;
   nowMs: number;
@@ -228,6 +245,106 @@ describe.each(removalPaths)("cron one-shot removal via %s", (path) => {
       expect(state.durableNextRunAtMsByJobId).toEqual(
         new Map([[job.id, durableBefore.jobs[0]?.state.nextRunAtMs]]),
       );
+    } finally {
+      clearStateTimer(state);
+    }
+  });
+});
+
+describe("cron on-exit deleteAfterRun finalization (#104518)", () => {
+  it("deletes a successful on-exit job after force run when deleteAfterRun is true", async () => {
+    const { storePath } = await makeStorePath();
+    const nowMs = Date.parse("2026-07-10T12:00:00.000Z");
+    // Mirrors Gateway watcher pre-fire disable, then payload force-run.
+    const job = createCompletedOnExitJob("on-exit-delete-ok", nowMs, true);
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+    const events: CronEvent[] = [];
+    const state = createState({
+      storePath,
+      nowMs,
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+
+    try {
+      await run(state, job.id, "force");
+
+      expect(events.map((event) => event.action)).toEqual(["started", "finished", "removed"]);
+      expect(state.store?.jobs).toEqual([]);
+      const durable = await loadCronStore(storePath);
+      expect(durable.jobs).toEqual([]);
+    } finally {
+      clearStateTimer(state);
+    }
+  });
+
+  it("keeps a successful on-exit job disabled when deleteAfterRun is false", async () => {
+    const { storePath } = await makeStorePath();
+    const nowMs = Date.parse("2026-07-10T12:00:00.000Z");
+    const job = createCompletedOnExitJob("on-exit-keep-disabled", nowMs, false);
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+    const events: CronEvent[] = [];
+    const state = createState({
+      storePath,
+      nowMs,
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+
+    try {
+      await run(state, job.id, "force");
+
+      expect(events.map((event) => event.action)).toEqual(["started", "finished"]);
+      expect(events.some((event) => event.action === "removed")).toBe(false);
+      const listed = await list(state, { includeDisabled: true });
+      expect(listed).toEqual([
+        expect.objectContaining({
+          id: job.id,
+          enabled: false,
+          deleteAfterRun: false,
+          state: expect.objectContaining({ lastRunStatus: "ok" }),
+        }),
+      ]);
+    } finally {
+      clearStateTimer(state);
+    }
+  });
+
+  it("keeps a failed on-exit job disabled when deleteAfterRun is true", async () => {
+    const { storePath } = await makeStorePath();
+    const nowMs = Date.parse("2026-07-10T12:00:00.000Z");
+    const job = createCompletedOnExitJob("on-exit-fail-keep", nowMs, true);
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+    const events: CronEvent[] = [];
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "error" as const,
+        error: "payload failed",
+        summary: "fail",
+      })),
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+
+    try {
+      await run(state, job.id, "force");
+
+      expect(events.some((event) => event.action === "removed")).toBe(false);
+      const listed = await list(state, { includeDisabled: true });
+      expect(listed).toEqual([
+        expect.objectContaining({
+          id: job.id,
+          enabled: false,
+          deleteAfterRun: true,
+          state: expect.objectContaining({ lastRunStatus: "error" }),
+        }),
+      ]);
     } finally {
       clearStateTimer(state);
     }

--- a/src/cron/service.removal-postcommit.test.ts
+++ b/src/cron/service.removal-postcommit.test.ts
@@ -52,6 +52,23 @@ function createCompletedOnExitJob(id: string, nowMs: number, deleteAfterRun: boo
   };
 }
 
+/** Armed on-exit job as an operator might force-run before the watched process exits. */
+function createArmedOnExitJob(id: string, nowMs: number, deleteAfterRun: boolean): CronJob {
+  return {
+    id,
+    name: `on-exit armed ${id}`,
+    enabled: true,
+    deleteAfterRun,
+    createdAtMs: nowMs - 60_000,
+    updatedAtMs: nowMs - 1_000,
+    schedule: { kind: "on-exit", command: "sh -c 'exit 0'" },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "do work" },
+    state: {},
+  };
+}
+
 function createState(params: {
   storePath: string;
   nowMs: number;
@@ -341,6 +358,78 @@ describe("cron on-exit deleteAfterRun finalization (#104518)", () => {
         expect.objectContaining({
           id: job.id,
           enabled: false,
+          deleteAfterRun: true,
+          state: expect.objectContaining({ lastRunStatus: "error" }),
+        }),
+      ]);
+    } finally {
+      clearStateTimer(state);
+    }
+  });
+
+  it("keeps an armed on-exit job enabled after manual keep-after-run success", async () => {
+    const { storePath } = await makeStorePath();
+    const nowMs = Date.parse("2026-07-10T12:00:00.000Z");
+    const job = createArmedOnExitJob("on-exit-armed-keep-ok", nowMs, false);
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+    const events: CronEvent[] = [];
+    const state = createState({
+      storePath,
+      nowMs,
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+
+    try {
+      await run(state, job.id, "force");
+
+      expect(events.map((event) => event.action)).toEqual(["started", "finished"]);
+      expect(events.some((event) => event.action === "removed")).toBe(false);
+      const listed = await list(state, { includeDisabled: true });
+      expect(listed).toEqual([
+        expect.objectContaining({
+          id: job.id,
+          enabled: true,
+          deleteAfterRun: false,
+          state: expect.objectContaining({ lastRunStatus: "ok" }),
+        }),
+      ]);
+    } finally {
+      clearStateTimer(state);
+    }
+  });
+
+  it("keeps an armed on-exit job enabled after manual force-run failure", async () => {
+    const { storePath } = await makeStorePath();
+    const nowMs = Date.parse("2026-07-10T12:00:00.000Z");
+    const job = createArmedOnExitJob("on-exit-armed-fail", nowMs, true);
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+    const events: CronEvent[] = [];
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => nowMs,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({
+        status: "error" as const,
+        error: "payload failed",
+        summary: "fail",
+      })),
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+
+    try {
+      await run(state, job.id, "force");
+
+      expect(events.some((event) => event.action === "removed")).toBe(false);
+      const listed = await list(state, { includeDisabled: true });
+      expect(listed).toEqual([
+        expect.objectContaining({
+          id: job.id,
+          enabled: true,
           deleteAfterRun: true,
           state: expect.objectContaining({ lastRunStatus: "error" }),
         }),

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -891,13 +891,10 @@ export function applyJobResult(
           );
         }
       }
-    } else if (job.schedule.kind === "on-exit") {
-      // Fire-once event schedule: after a payload run, never re-arm via timer.
-      // Exit watchers also disable pre-fire so a Gateway restart cannot re-run
-      // the watched command; keep that terminal retention when deletion is off
-      // or the payload did not succeed.
-      job.enabled = false;
-      job.state.nextRunAtMs = undefined;
+      // on-exit is intentionally omitted: the Gateway exit watcher already
+      // disables before payload fire. Operator force runs share this finalizer
+      // without a watcher-origin fact, so non-delete on-exit results must not
+      // cancel still-armed watches. Successful deleteAfterRun uses shouldDelete.
     } else if (result.status === "error" && isJobEnabled(job)) {
       const retryDecision = resolveTransientCronRetryDecision({
         cronConfig: state.deps.cronConfig,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -803,8 +803,14 @@ export function applyJobResult(
     job.state.lastFailureAlertAtMs = undefined;
   }
 
+  // Successful delete-after-run applies to fire-once schedules (`at` and
+  // `on-exit`). Recurring kinds never delete via this path.
+  // Gateway on-exit watchers disable the job before payload fire for replay
+  // safety; this finalizer still owns post-success removal when requested.
   const shouldDelete =
-    job.schedule.kind === "at" && job.deleteAfterRun === true && result.status === "ok";
+    (job.schedule.kind === "at" || job.schedule.kind === "on-exit") &&
+    job.deleteAfterRun === true &&
+    result.status === "ok";
   const retryDisabledHeartbeatOneShot = shouldRetryDisabledHeartbeatOneShot(job, result);
 
   if (!shouldDelete) {
@@ -885,6 +891,13 @@ export function applyJobResult(
           );
         }
       }
+    } else if (job.schedule.kind === "on-exit") {
+      // Fire-once event schedule: after a payload run, never re-arm via timer.
+      // Exit watchers also disable pre-fire so a Gateway restart cannot re-run
+      // the watched command; keep that terminal retention when deletion is off
+      // or the payload did not succeed.
+      job.enabled = false;
+      job.state.nextRunAtMs = undefined;
     } else if (result.status === "error" && isJobEnabled(job)) {
       const retryDecision = resolveTransientCronRetryDecision({
         cronConfig: state.deps.cronConfig,


### PR DESCRIPTION
Closes #104518

## What Problem This Solves

Fixes an issue where users who create an `on-exit` cron job with `--delete-after-run` would still find the job retained as **disabled** after a successful payload run, instead of being removed from the store. Manual `cron rm` was required for cleanup even though deletion was requested.

## Why This Change Was Made

Successful `deleteAfterRun` finalization previously applied only to one-shot `at` schedules. The Gateway exit watcher still disables an `on-exit` job **before** the payload runs (replay-safe if the Gateway restarts mid-fire). This change generalizes the post-success delete path to `on-exit` as well, while keeping non-success / keep-after-run jobs disabled rather than deleted.

## User Impact

Operators using `openclaw cron add --on-exit … --delete-after-run` get the documented cleanup contract: a successful fire removes the job. Failed fires remain disabled for inspection. Pre-fire disable for restart safety is unchanged.

## Evidence

Verification host: local macOS (isolated Gateway + focused Vitest)

Commands:

```text
node scripts/run-vitest.mjs src/cron/service.removal-postcommit.test.ts -t "on-exit"
# 5 passed | 9 skipped (includes armed keep/failure controls)
node scripts/run-vitest.mjs \
  src/cron/service.removal-postcommit.test.ts \
  src/gateway/cron-exit-watchers.test.ts \
  src/cron/service.runs-one-shot-main-job-disables-it.test.ts \
  src/cron/service.issue-regressions.test.ts
# all passed (cron 35 + gateway exit-watchers 15×4 shards)
```

Focused on-exit suite (post CS code fix):

```text
✓ deletes a successful on-exit job after force run when deleteAfterRun is true
✓ keeps a successful on-exit job disabled when deleteAfterRun is false
✓ keeps a failed on-exit job disabled when deleteAfterRun is true
✓ keeps an armed on-exit job enabled after manual keep-after-run success
✓ keeps an armed on-exit job enabled after manual force-run failure
```

Commit: `4c4e37cfa9c042c473ed465edebe85cc220b528f` on `fix/104518-on-exit-delete-after-run`

## Real behavior proof

- Behavior addressed: (1) Successful watcher-terminal `on-exit` + `deleteAfterRun` removes the job. (2) Non-delete / failed operator force runs no longer terminalize an armed `on-exit` job (CS P1 on `timer.ts`).
- Environment: local macOS; isolated Gateway via `OPENCLAW_STATE_DIR` + loopback port 61922; rebuilt runtime with `node scripts/run-node.mjs gateway` so the working-tree finalizer was live.
- Current-main contrast: On main, `shouldDelete` only covered `at`, so successful on-exit jobs stayed disabled in the store. An earlier stale-dist isolated run on this branch reproduced that retention; after rebuild with the PR finalizer, the same path removed the job.
- Exact steps after this patch:
  1. Start isolated Gateway (`auth token`, `OPENCLAW_SKIP_CHANNELS=1`, `cron.enabled=true`).
  2. `cron list --all --json` → `jobs: []`.
  3. `cron add --name pr104559-on-exit-delete-proof --on-exit "sh -c 'echo watched-exit; sleep 1; exit 0'" --system-event "pr104559 on-exit proof wake" --session main --delete-after-run --json`.
  4. Watched command exits; Gateway fires payload; finalizer applies successful `deleteAfterRun`.
  5. `cron list --all --json` → `jobs: []`, `total: 0` (durable store empty).
- Evidence after fix (redacted):
  - add returned job id `2e583284-f0f6-4a10-930f-70f35ed45c8e`, `deleteAfterRun: true`, `schedule.kind: on-exit`.
  - Immediate post-fire `cron list --all --json`: `{"jobs":[],"total":0,...}` (JOB REMOVED).
  - Focused regression tests cover armed keep-after-run success and armed force-run failure remaining `enabled: true`.
- Control / negative: watcher-pre-disabled keep-after-run and failed deleteAfterRun jobs stay in store as disabled (unit controls); armed non-delete paths no longer set `enabled=false` in the shared finalizer.
