### PR TITLE
fix(write): report actual UTF-8 byte count in success message

### DIFF
--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -54,7 +54,7 @@ describe("write tool", () => {
     // Remote transports can report cancellation after the write landed; verify
     // by readback before surfacing a false failure to the model.
     const filePath = await createTempPath();
-    const content = "finished 😀\n";
+    const expectedContent = "finished 😀\n";
     const controller = new AbortController();
     const tool = createWriteTool(tmpDir, {
       operations: createRecoverableOperations(async (absolutePath, content) => {
@@ -64,11 +64,15 @@ describe("write tool", () => {
       }),
     });
 
-    const result = await tool.execute("call-1", { path: filePath, content }, controller.signal);
+    const result = await tool.execute(
+      "call-1",
+      { path: filePath, content: expectedContent },
+      controller.signal,
+    );
 
     expect(result.content[0]).toEqual({
       type: "text",
-      text: `Successfully wrote ${Buffer.byteLength(content, "utf8")} bytes to ${filePath}`,
+      text: `Successfully wrote ${Buffer.byteLength(expectedContent, "utf8")} bytes to ${filePath}`,
     });
   });
 

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -54,6 +54,7 @@ describe("write tool", () => {
     // Remote transports can report cancellation after the write landed; verify
     // by readback before surfacing a false failure to the model.
     const filePath = await createTempPath();
+    const content = "finished 😀\n";
     const controller = new AbortController();
     const tool = createWriteTool(tmpDir, {
       operations: createRecoverableOperations(async (absolutePath, content) => {
@@ -63,15 +64,11 @@ describe("write tool", () => {
       }),
     });
 
-    const result = await tool.execute(
-      "call-1",
-      { path: filePath, content: "finished\n" },
-      controller.signal,
-    );
+    const result = await tool.execute("call-1", { path: filePath, content }, controller.signal);
 
     expect(result.content[0]).toEqual({
       type: "text",
-      text: `Successfully wrote ${"finished\n".length} bytes to ${filePath}`,
+      text: `Successfully wrote ${Buffer.byteLength(content, "utf8")} bytes to ${filePath}`,
     });
   });
 
@@ -142,17 +139,16 @@ describe("write tool", () => {
 
   it("writes different content successfully (no false positive for no-op)", async () => {
     const filePath = await createTempPath("different.txt");
+    const content = "new 😀\n";
     await fs.writeFile(filePath, "old\n", "utf-8");
     const tool = createWriteTool(tmpDir);
 
-    const result = await tool.execute(
-      "call-1",
-      { path: "different.txt", content: "new\n" },
-      undefined,
-    );
+    const result = await tool.execute("call-1", { path: "different.txt", content }, undefined);
 
-    const tc1 = result.content[0];
-    expect("text" in tc1 ? tc1.text : "").toContain("Successfully wrote");
-    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new\n");
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: `Successfully wrote ${Buffer.byteLength(content, "utf8")} bytes to different.txt`,
+    });
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(content);
   });
 });

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -375,7 +375,7 @@ async function recoverSuccessfulWrite(params: {
     content: [
       {
         type: "text" as const,
-        text: `Successfully wrote ${params.content.length} bytes to ${params.path}`,
+        text: `Successfully wrote ${Buffer.byteLength(params.content, "utf8")} bytes to ${params.path}`,
       },
     ],
     details: undefined,
@@ -435,7 +435,7 @@ export function createWriteToolDefinition(
             content: [
               {
                 type: "text" as const,
-                text: `Successfully wrote ${content.length} bytes to ${path}`,
+                text: `Successfully wrote ${Buffer.byteLength(content, "utf8")} bytes to ${path}`,
               },
             ],
             details: undefined,

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -350,6 +350,13 @@ function isWriteRecoveryCandidate(error: unknown, signal: AbortSignal | undefine
   );
 }
 
+function successfulWriteResult(path: string, content: string) {
+  return textResult(
+    `Successfully wrote ${Buffer.byteLength(content, "utf8")} bytes to ${path}`,
+    undefined,
+  );
+}
+
 async function recoverSuccessfulWrite(params: {
   absolutePath: string;
   content: string;
@@ -371,15 +378,7 @@ async function recoverSuccessfulWrite(params: {
   if (currentContent !== params.content || !changed) {
     return null;
   }
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: `Successfully wrote ${Buffer.byteLength(params.content, "utf8")} bytes to ${params.path}`,
-      },
-    ],
-    details: undefined,
-  };
+  return successfulWriteResult(params.path, params.content);
 }
 
 export function createWriteToolDefinition(
@@ -431,15 +430,7 @@ export function createWriteToolDefinition(
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Successfully wrote ${Buffer.byteLength(content, "utf8")} bytes to ${path}`,
-              },
-            ],
-            details: undefined,
-          };
+          return successfulWriteResult(path, content);
         } catch (error: unknown) {
           const recovered = await recoverSuccessfulWrite({
             absolutePath,


### PR DESCRIPTION
## What Problem This Solves

The built-in `write` tool labels its success count as bytes, but both the normal and post-abort recovery paths used JavaScript UTF-16 code-unit length. Non-ASCII UTF-8 writes therefore reported the wrong size.

## Why This Change Was Made

Success reporting now uses `Buffer.byteLength(content, "utf8")`, matching the default filesystem encoding and the write precheck's existing size contract. The maintainer refactor routes normal and recovered success through one `successfulWriteResult` helper, deleting the duplicate result construction so the two paths cannot drift again.

Existing normal-write and recovery tests now use emoji content and assert the exact UTF-8 count and result shape.

## User Impact

Agents and users see the actual UTF-8 byte count after normal writes and after verified recovery from a post-write abort or timeout.

## Evidence

- Changed: `src/agents/sessions/tools/write.ts`
- Regressions: `src/agents/sessions/tools/write.test.ts`
- Exact tested head: `9da1689c4460d5860b72e2d20f480df663690946`
- Sanitized AWS Crabbox: `run_8fc99759e285`, public network, no Tailscale, no instance profile, no credential hydration
- Command: `pnpm test src/agents/sessions/tools/write.test.ts`
- Result: exit 0
- Fresh autoreview after the CI repair: no findings, correctness confidence 0.98
- Targeted formatting and `git diff --check`: passed
- Hosted exact-head CI: green

## Real behavior proof

- **Behavior addressed:** normal and recovered write success messages report UTF-8 bytes, not UTF-16 code units.
- **Reachability:** `createWriteToolDefinition().execute(...)` -> normal write or verified readback recovery -> shared `successfulWriteResult`.
- **Boundary crossed:** multibyte content is persisted through the real default write tool in the normal-path regression; injected operations exercise recovery semantics.
- **Fix classification:** root-cause fix plus duplicate-path removal.

- [x] AI-assisted (Claude and Codex)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
