### PR TITLE
fix(slack): preserve canonical block delivery receipts

### DIFF
--- a/extensions/slack/src/channel.message-adapter.test.ts
+++ b/extensions/slack/src/channel.message-adapter.test.ts
@@ -1,5 +1,6 @@
 // Slack tests cover channel.message adapter plugin behavior.
 import {
+  createMessageReceiptFromOutboundResults,
   verifyChannelMessageAdapterCapabilityProofs,
   verifyChannelMessageLiveCapabilityAdapterProofs,
   verifyChannelMessageLiveFinalizerProofs,
@@ -205,6 +206,14 @@ describe("slack channel message adapter", () => {
   });
 
   it("renders portable presentations through the facade as card receipts (#95440)", async () => {
+    sendSlack.mockResolvedValueOnce({
+      messageId: "msg-1",
+      channelId: "C123",
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ channel: "slack", messageId: "msg-1", channelId: "C123" }],
+        kind: "card",
+      }),
+    });
     const outbound = slackPlugin.outbound;
     const renderPresentation = outbound?.renderPresentation;
     if (!renderPresentation) {

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1269,6 +1269,7 @@ describe("slackPlugin outbound", () => {
         text: {
           type: "mrkdwn",
           text: "hello",
+          verbatim: true,
         },
       },
       {
@@ -1321,7 +1322,9 @@ describe("slackPlugin outbound", () => {
     });
 
     expect(requireMockCallArgValue(sendSlack, 0, 0)).toBe("user:U123");
-    expect(requireMockCallArgValue(sendSlack, 0, 1)).toBe("Slack interactive smoke.");
+    expect(requireMockCallArgValue(sendSlack, 0, 1)).toBe(
+      "Slack interactive smoke.\n\nApprove\nReject\n\nChoose a target",
+    );
     const blocks = requireArray(requireMockCallArg(sendSlack, 0, 2).blocks, "Slack blocks");
     expectRecordFields(blocks[0], "text block", { type: "section" });
     expectRecordFields(blocks[1], "button actions block", { type: "actions" });

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -1194,12 +1194,12 @@ async function sendMessageSlackQueuedInner(params: {
           );
         }
         const messageId = response.ts ?? "unknown";
-        const postedChannelId = resolvePostedMessageChannelId(response, channelId);
+        deliveredChannelId = resolvePostedMessageChannelId(response, channelId);
         const deliveredThreadTs =
           resolvePostedMessageThreadTs(response) ?? normalizeSlackThreadTsCandidate(opts.threadTs);
         return await reportDelivery({
           messageId,
-          channelId: postedChannelId,
+          channelId: deliveredChannelId,
           threadTs: deliveredThreadTs,
           receipt: createSlackSendReceipt({
             platformMessageIds: [messageId],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where direct Slack block messages could report a user ID in the delivery receipt even though Slack returned the canonical direct-message channel ID. It also updates prerelease assertions to the current block rendering and receipt contracts.

## Why This Change Was Made

The Slack response channel now becomes the single delivered channel value used by both the outbound result and its receipt. Tests assert authored mrkdwn, accessible control-label fallbacks, and real card receipts.

## User Impact

Callers receive a consistent canonical channel ID for direct Slack block sends, and the plugin prerelease suite no longer fails on stale contract expectations.

## Evidence

- Blacksmith Testbox focused Slack proof: 107/107 tests passed.
- Blacksmith Testbox full Slack proof: 118 files, 1,822/1,822 tests passed.
- `check:changed`: green, including extension and test tsgo, oxlint, guards, and import-cycle checks.
- Fresh autoreview: clean, no actionable findings.
- Exact failing prerelease job diagnosed: https://github.com/openclaw/openclaw/actions/runs/29159990543/job/86563333454
