### PR TITLE
fix(admin-http-rpc): time out incomplete request bodies

### DIFF
--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -30,6 +30,22 @@ function createRequest(body: unknown, method = "POST") {
   return req as import("node:http").IncomingMessage;
 }
 
+function createHangingRequest() {
+  const req = new Readable({
+    read() {
+      // Keep the body open so the handler's request-body timeout owns settlement.
+    },
+  });
+  Object.assign(req, {
+    method: "POST",
+    url: "/api/v1/admin/rpc",
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+  return req as import("node:http").IncomingMessage;
+}
+
 function createResponse() {
   const captured: CapturedResponse = {
     statusCode: 200,
@@ -54,8 +70,12 @@ function createResponse() {
 }
 
 async function invoke(body: unknown, method = "POST") {
+  return invokeRequest(createRequest(body, method));
+}
+
+async function invokeRequest(req: import("node:http").IncomingMessage, bodyTimeoutMs?: number) {
   const { res, captured } = createResponse();
-  const handled = await handleAdminHttpRpcRequest(createRequest(body, method), res);
+  const handled = await handleAdminHttpRpcRequest(req, res, { bodyTimeoutMs });
   return {
     handled,
     captured,
@@ -204,6 +224,21 @@ describe("admin-http-rpc plugin handler", () => {
 
     expect(result.captured.statusCode).toBe(405);
     expect(result.captured.headers.allow).toBe("POST");
+    expect(dispatchGatewayMethod).not.toHaveBeenCalled();
+  });
+
+  it("times out incomplete request bodies before dispatch", async () => {
+    const result = await invokeRequest(createHangingRequest(), 1);
+
+    expect(result.handled).toBe(true);
+    expect(result.captured.statusCode).toBe(408);
+    expect(result.json).toEqual({
+      ok: false,
+      error: {
+        type: "invalid_request",
+        message: "Request body timeout",
+      },
+    });
     expect(dispatchGatewayMethod).not.toHaveBeenCalled();
   });
 });

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -1,4 +1,6 @@
 // Admin Http Rpc tests cover handler plugin behavior.
+import { createServer, type Server } from "node:http";
+import { connect, type Socket } from "node:net";
 import { Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleAdminHttpRpcRequest } from "./handler.js";
@@ -73,14 +75,43 @@ async function invoke(body: unknown, method = "POST") {
   return invokeRequest(createRequest(body, method));
 }
 
-async function invokeRequest(req: import("node:http").IncomingMessage, bodyTimeoutMs?: number) {
+async function invokeRequest(req: import("node:http").IncomingMessage) {
   const { res, captured } = createResponse();
-  const handled = await handleAdminHttpRpcRequest(req, res, { bodyTimeoutMs });
+  const handled = await handleAdminHttpRpcRequest(req, res);
   return {
     handled,
     captured,
     json: captured.body ? (JSON.parse(captured.body) as unknown) : undefined,
   };
+}
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected TCP server address");
+  }
+  return address.port;
+}
+
+async function readSocketResponse(socket: Socket): Promise<string> {
+  const chunks: Buffer[] = [];
+  return await new Promise((resolve, reject) => {
+    let done = false;
+    const finish = () => {
+      if (done) {
+        return;
+      }
+      done = true;
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    };
+    socket.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    socket.on("end", finish);
+    socket.on("close", finish);
+    socket.on("error", reject);
+  });
 }
 
 describe("admin-http-rpc plugin handler", () => {
@@ -228,17 +259,79 @@ describe("admin-http-rpc plugin handler", () => {
   });
 
   it("times out incomplete request bodies before dispatch", async () => {
-    const result = await invokeRequest(createHangingRequest(), 1);
+    vi.useFakeTimers();
+    try {
+      const resultPromise = invokeRequest(createHangingRequest());
+      await vi.advanceTimersByTimeAsync(30_000);
+      const result = await resultPromise;
 
-    expect(result.handled).toBe(true);
-    expect(result.captured.statusCode).toBe(408);
-    expect(result.json).toEqual({
-      ok: false,
-      error: {
-        type: "invalid_request",
-        message: "Request body timeout",
-      },
+      expect(result.handled).toBe(true);
+      expect(result.captured.statusCode).toBe(408);
+      expect(result.json).toEqual({
+        ok: false,
+        error: {
+          type: "invalid_request",
+          message: "Request body timeout",
+        },
+      });
+      expect(dispatchGatewayMethod).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("delivers a real HTTP 408 response before closing timed-out partial bodies", async () => {
+    vi.useFakeTimers();
+    let markRequestStarted: (() => void) | undefined;
+    const requestStarted = new Promise<void>((resolve) => {
+      markRequestStarted = resolve;
     });
-    expect(dispatchGatewayMethod).not.toHaveBeenCalled();
+    const server = createServer((req, res) => {
+      void handleAdminHttpRpcRequest(req, res);
+      markRequestStarted?.();
+    });
+    let socket: Socket | undefined;
+    try {
+      const port = await listen(server);
+      socket = connect({ host: "127.0.0.1", port });
+      await new Promise<void>((resolve) => {
+        socket?.once("connect", resolve);
+      });
+
+      socket.write(
+        [
+          "POST /api/v1/admin/rpc HTTP/1.1",
+          "Host: 127.0.0.1",
+          "Content-Type: application/json",
+          "Content-Length: 64",
+          "Connection: close",
+          "",
+          "{",
+        ].join("\r\n"),
+      );
+
+      await requestStarted;
+      const responsePromise = readSocketResponse(socket);
+      await vi.advanceTimersByTimeAsync(30_000);
+      const response = await responsePromise;
+      const [, rawBody = ""] = response.split("\r\n\r\n", 2);
+
+      expect(response).toContain("HTTP/1.1 408");
+      expect(response).toContain("Connection: close");
+      expect(JSON.parse(rawBody) as unknown).toEqual({
+        ok: false,
+        error: {
+          type: "invalid_request",
+          message: "Request body timeout",
+        },
+      });
+      expect(dispatchGatewayMethod).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      socket?.destroy();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 });

--- a/extensions/admin-http-rpc/src/handler.ts
+++ b/extensions/admin-http-rpc/src/handler.ts
@@ -6,9 +6,14 @@ import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { dispatchGatewayMethod } from "openclaw/plugin-sdk/gateway-method-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  readJsonBodyWithLimit,
+  requestBodyErrorToText,
+} from "openclaw/plugin-sdk/webhook-request-guards";
 import { isAdminHttpRpcAllowedMethod, listAdminHttpRpcAllowedMethods } from "./methods.js";
 
 const DEFAULT_RPC_BODY_BYTES = 1024 * 1024;
+const DEFAULT_RPC_BODY_TIMEOUT_MS = 30_000;
 
 const ErrorCodes = {
   AGENT_TIMEOUT: "AGENT_TIMEOUT",
@@ -42,6 +47,12 @@ type ParsedRequest = {
   method: string;
   params?: unknown;
 };
+
+type RequestBodyLimitFailureCode =
+  | "PAYLOAD_TOO_LARGE"
+  | "REQUEST_BODY_TIMEOUT"
+  | "CONNECTION_CLOSED";
+type ReadJsonBodyFailureCode = RequestBodyLimitFailureCode | "INVALID_JSON";
 
 function createError(code: string, message: string): RpcError {
   return { code, message };
@@ -82,31 +93,42 @@ function sendError(res: ServerResponse, status: number, error: { type: string; m
 async function readJsonBody(
   req: IncomingMessage,
   maxBytes: number,
+  timeoutMs: number,
 ): Promise<{ ok: true; value: unknown } | { ok: false; status: number; message: string }> {
-  const chunks: Buffer[] = [];
-  let totalBytes = 0;
-  try {
-    for await (const chunk of req) {
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      totalBytes += buffer.byteLength;
-      if (totalBytes > maxBytes) {
-        return { ok: false, status: 413, message: "Payload too large" };
-      }
-      chunks.push(buffer);
-    }
-  } catch {
-    return { ok: false, status: 400, message: "failed to read request body" };
+  const body = await readJsonBodyWithLimit(req, {
+    maxBytes,
+    timeoutMs,
+    emptyObjectOnEmpty: false,
+  });
+  if (body.ok) {
+    return body;
   }
+  return {
+    ok: false,
+    status: statusForBodyErrorCode(body.code),
+    message: messageForBodyError(body),
+  };
+}
 
-  const raw = Buffer.concat(chunks).toString("utf8");
-  if (!raw.trim()) {
-    return { ok: false, status: 400, message: "request body must be JSON" };
+function statusForBodyErrorCode(code: ReadJsonBodyFailureCode): number {
+  switch (code) {
+    case "PAYLOAD_TOO_LARGE":
+      return 413;
+    case "REQUEST_BODY_TIMEOUT":
+      return 408;
+    case "CONNECTION_CLOSED":
+    case "INVALID_JSON":
+      return 400;
   }
-  try {
-    return { ok: true, value: JSON.parse(raw) };
-  } catch {
-    return { ok: false, status: 400, message: "request body must be valid JSON" };
+}
+
+function messageForBodyError(body: { code: ReadJsonBodyFailureCode; error: string }): string {
+  if (body.code === "INVALID_JSON") {
+    return body.error === "empty payload"
+      ? "request body must be JSON"
+      : "request body must be valid JSON";
   }
+  return requestBodyErrorToText(body.code);
 }
 
 function readRpcRequestBody(body: unknown):
@@ -192,6 +214,7 @@ async function dispatchAdminRpc(request: ParsedRequest): Promise<RpcResponse> {
 export async function handleAdminHttpRpcRequest(
   req: IncomingMessage,
   res: ServerResponse,
+  options?: { bodyTimeoutMs?: number },
 ): Promise<boolean> {
   if ((req.method ?? "GET").toUpperCase() !== "POST") {
     res.setHeader("Allow", "POST");
@@ -202,7 +225,11 @@ export async function handleAdminHttpRpcRequest(
     return true;
   }
 
-  const body = await readJsonBody(req, DEFAULT_RPC_BODY_BYTES);
+  const body = await readJsonBody(
+    req,
+    DEFAULT_RPC_BODY_BYTES,
+    options?.bodyTimeoutMs ?? DEFAULT_RPC_BODY_TIMEOUT_MS,
+  );
   if (!body.ok) {
     sendError(res, body.status, {
       type: "invalid_request",

--- a/extensions/admin-http-rpc/src/handler.ts
+++ b/extensions/admin-http-rpc/src/handler.ts
@@ -7,13 +7,10 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { dispatchGatewayMethod } from "openclaw/plugin-sdk/gateway-method-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
-  readJsonBodyWithLimit,
   requestBodyErrorToText,
+  WEBHOOK_BODY_READ_DEFAULTS,
 } from "openclaw/plugin-sdk/webhook-request-guards";
 import { isAdminHttpRpcAllowedMethod, listAdminHttpRpcAllowedMethods } from "./methods.js";
-
-const DEFAULT_RPC_BODY_BYTES = 1024 * 1024;
-const DEFAULT_RPC_BODY_TIMEOUT_MS = 30_000;
 
 const ErrorCodes = {
   AGENT_TIMEOUT: "AGENT_TIMEOUT",
@@ -52,7 +49,17 @@ type RequestBodyLimitFailureCode =
   | "PAYLOAD_TOO_LARGE"
   | "REQUEST_BODY_TIMEOUT"
   | "CONNECTION_CLOSED";
-type ReadJsonBodyFailureCode = RequestBodyLimitFailureCode | "INVALID_JSON";
+type ReadJsonBodyResult =
+  | { ok: true; value: unknown }
+  | {
+      ok: false;
+      status: number;
+      message: string;
+      closeAfterResponse?: boolean;
+    };
+type ReadRawBodyResult =
+  | { ok: true; raw: string }
+  | { ok: false; code: RequestBodyLimitFailureCode; closeAfterResponse?: boolean };
 
 function createError(code: string, message: string): RpcError {
   return { code, message };
@@ -94,41 +101,142 @@ async function readJsonBody(
   req: IncomingMessage,
   maxBytes: number,
   timeoutMs: number,
-): Promise<{ ok: true; value: unknown } | { ok: false; status: number; message: string }> {
-  const body = await readJsonBodyWithLimit(req, {
-    maxBytes,
-    timeoutMs,
-    emptyObjectOnEmpty: false,
-  });
-  if (body.ok) {
-    return body;
+): Promise<ReadJsonBodyResult> {
+  const body = await readRawBodyWithLimit(req, maxBytes, timeoutMs);
+  if (!body.ok) {
+    return {
+      ok: false,
+      status: statusForBodyErrorCode(body.code),
+      message: requestBodyErrorToText(body.code),
+      closeAfterResponse: body.closeAfterResponse,
+    };
   }
-  return {
-    ok: false,
-    status: statusForBodyErrorCode(body.code),
-    message: messageForBodyError(body),
-  };
+
+  const raw = body.raw.trim();
+  if (!raw) {
+    return { ok: false, status: 400, message: "request body must be JSON" };
+  }
+  try {
+    return { ok: true, value: JSON.parse(raw) as unknown };
+  } catch {
+    return { ok: false, status: 400, message: "request body must be valid JSON" };
+  }
 }
 
-function statusForBodyErrorCode(code: ReadJsonBodyFailureCode): number {
+function statusForBodyErrorCode(code: RequestBodyLimitFailureCode): number {
   switch (code) {
     case "PAYLOAD_TOO_LARGE":
       return 413;
     case "REQUEST_BODY_TIMEOUT":
       return 408;
     case "CONNECTION_CLOSED":
-    case "INVALID_JSON":
       return 400;
   }
+  return 400;
 }
 
-function messageForBodyError(body: { code: ReadJsonBodyFailureCode; error: string }): string {
-  if (body.code === "INVALID_JSON") {
-    return body.error === "empty payload"
-      ? "request body must be JSON"
-      : "request body must be valid JSON";
+async function readRawBodyWithLimit(
+  req: IncomingMessage,
+  maxBytes: number,
+  timeoutMs: number,
+): Promise<ReadRawBodyResult> {
+  const declaredLength = readDeclaredContentLength(req);
+  if (declaredLength !== null && declaredLength > maxBytes) {
+    req.pause();
+    return { ok: false, code: "PAYLOAD_TOO_LARGE", closeAfterResponse: true };
   }
-  return requestBodyErrorToText(body.code);
+
+  return await new Promise((resolve) => {
+    let done = false;
+    let ended = false;
+    let totalBytes = 0;
+    const chunks: Buffer[] = [];
+
+    const cleanup = () => {
+      req.removeListener("data", onData);
+      req.removeListener("end", onEnd);
+      req.removeListener("error", onError);
+      req.removeListener("close", onClose);
+      clearTimeout(timer);
+    };
+
+    const finish = (result: ReadRawBodyResult) => {
+      if (done) {
+        return;
+      }
+      done = true;
+      cleanup();
+      resolve(result);
+    };
+
+    const failAfterResponse = (code: RequestBodyLimitFailureCode) => {
+      req.pause();
+      finish({ ok: false, code, closeAfterResponse: true });
+    };
+
+    const timer = setTimeout(() => {
+      failAfterResponse("REQUEST_BODY_TIMEOUT");
+    }, timeoutMs);
+
+    const onData = (chunk: Buffer | string) => {
+      if (done) {
+        return;
+      }
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.byteLength;
+      if (totalBytes > maxBytes) {
+        failAfterResponse("PAYLOAD_TOO_LARGE");
+        return;
+      }
+      chunks.push(buffer);
+    };
+
+    const onEnd = () => {
+      ended = true;
+      finish({ ok: true, raw: Buffer.concat(chunks).toString("utf8") });
+    };
+
+    const onError = () => {
+      finish({ ok: false, code: "CONNECTION_CLOSED" });
+    };
+
+    const onClose = () => {
+      if (done || ended) {
+        return;
+      }
+      finish({ ok: false, code: "CONNECTION_CLOSED" });
+    };
+
+    req.on("data", onData);
+    req.on("end", onEnd);
+    req.on("error", onError);
+    req.on("close", onClose);
+  });
+}
+
+function readDeclaredContentLength(req: IncomingMessage): number | null {
+  const header = req.headers["content-length"];
+  const raw = Array.isArray(header) ? header[0] : header;
+  if (typeof raw !== "string" || !/^\d+$/.test(raw)) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : Number.MAX_SAFE_INTEGER;
+}
+
+function closeRequestAfterResponse(req: IncomingMessage, res: ServerResponse): void {
+  const once = (res as { once?: ServerResponse["once"] }).once;
+  if (typeof once !== "function") {
+    return;
+  }
+  res.setHeader("Connection", "close");
+  once.call(res, "finish", () => {
+    // Timeout/size failures must flush JSON first; destroying before finish drops
+    // the HTTP response on real partial-body sockets.
+    if (!req.destroyed) {
+      req.destroy();
+    }
+  });
 }
 
 function readRpcRequestBody(body: unknown):
@@ -214,7 +322,6 @@ async function dispatchAdminRpc(request: ParsedRequest): Promise<RpcResponse> {
 export async function handleAdminHttpRpcRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  options?: { bodyTimeoutMs?: number },
 ): Promise<boolean> {
   if ((req.method ?? "GET").toUpperCase() !== "POST") {
     res.setHeader("Allow", "POST");
@@ -227,10 +334,13 @@ export async function handleAdminHttpRpcRequest(
 
   const body = await readJsonBody(
     req,
-    DEFAULT_RPC_BODY_BYTES,
-    options?.bodyTimeoutMs ?? DEFAULT_RPC_BODY_TIMEOUT_MS,
+    WEBHOOK_BODY_READ_DEFAULTS.postAuth.maxBytes,
+    WEBHOOK_BODY_READ_DEFAULTS.postAuth.timeoutMs,
   );
   if (!body.ok) {
+    if (body.closeAfterResponse) {
+      closeRequestAfterResponse(req, res);
+    }
     sendError(res, body.status, {
       type: "invalid_request",
       message: body.message,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where authenticated Admin HTTP RPC callers could leave an incomplete request body open and keep `POST /api/v1/admin/rpc` waiting before the request is rejected.

## Why This Change Was Made

Admin HTTP RPC now uses a response-safe bounded JSON body reader at the route boundary: timeout and size failures stop body consumption, flush the JSON HTTP error response, and then close the request connection. This preserves the existing 1 MiB size limit and invalid-JSON messages, stays within the admin-http-rpc plugin route, and does not change the method allowlist, auth model, config, or dispatch behavior.

## User Impact

Trusted host automation receives a delivered HTTP 408 JSON response for incomplete request bodies instead of leaving the Admin HTTP RPC request pending indefinitely or losing the timeout response when the socket closes.

## Evidence

- Claim proved: incomplete Admin HTTP RPC request bodies time out before gateway dispatch, and a real partial-body HTTP client receives the JSON 408 before the connection closes.
- Current-head proof at `6ef40b353c04c9413b545021a5dca22f9ded2ab7`:
  - `node scripts/run-vitest.mjs extensions/admin-http-rpc/src/handler.test.ts` passed with 13 tests passing, including the raw-socket partial-body regression.
  - `node scripts/run-vitest.mjs src/infra/http-body.test.ts` passed with 13 tests passing.
  - Real HTTP socket proof against `handleAdminHttpRpcRequest` produced:

```text
status=HTTP/1.1 408 Request Timeout
connection: close
body={"ok":false,"error":{"type":"invalid_request","message":"Request body timeout"}}
```

- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD --model gpt-5.6-terra` passed with no accepted/actionable findings.
- Observed result: the focused regression returns HTTP 408 with `Request body timeout`, the real socket receives that JSON response before close, and `dispatchGatewayMethod` is not called for the incomplete body.