### PR TITLE
fix(control-ui): long chat transcripts cannot load older messages beyond the first page

### DIFF
--- a/ui/src/e2e/chat-history-pagination-proof.e2e.test.ts
+++ b/ui/src/e2e/chat-history-pagination-proof.e2e.test.ts
@@ -111,7 +111,9 @@ async function waitForNewHistoryOffset(
         return latest;
       }
     }
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
   }
   throw new Error(
     `Timed out waiting for new chat.history offset=${offset} after ${previousCount} requests`,

--- a/ui/src/e2e/chat-history-pagination-proof.e2e.test.ts
+++ b/ui/src/e2e/chat-history-pagination-proof.e2e.test.ts
@@ -1,0 +1,299 @@
+// Control UI browser proof for delayed older-history pages and deep scroll.
+import { copyFile, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+  type MockGatewayControls,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describePaginationProof =
+  chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+const TOTAL_MESSAGES = 2_200;
+const FIRST_PAGE_COUNT = 2_050;
+const OLDER_PAGE_COUNT = TOTAL_MESSAGES - FIRST_PAGE_COUNT;
+const HARD_CAP = 2_000;
+const DELAYED_PAGE_MS = 1_000;
+
+const artifactDir = path.resolve(
+  process.env.OPENCLAW_CHAT_HISTORY_PAGINATION_PROOF_OUTPUT_DIR ??
+    path.join(process.cwd(), ".artifacts", "control-ui-e2e", "chat-history-pagination-proof"),
+);
+
+let server: ControlUiE2eServer;
+const contextBrowsers = new WeakMap<BrowserContext, Browser>();
+
+function buildTranscript(total: number) {
+  return Array.from({ length: total }, (_, index) => ({
+    content: [{ text: `msg-${index}`, type: "text" as const }],
+    role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+    timestamp: index + 1,
+  }));
+}
+
+function historyPagePayload(params: {
+  hasMore: boolean;
+  messages: ReturnType<typeof buildTranscript>;
+  nextOffset?: number;
+  offset: number;
+  totalMessages: number;
+}) {
+  return {
+    hasMore: params.hasMore,
+    messages: params.messages,
+    offset: params.offset,
+    sessionId: "control-ui-e2e-session",
+    thinkingLevel: null,
+    totalMessages: params.totalMessages,
+    ...(params.nextOffset != null ? { nextOffset: params.nextOffset } : {}),
+  };
+}
+
+async function newBrowserContext(options: Parameters<Browser["newContext"]>[0]) {
+  const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  try {
+    const context = await browser.newContext(options);
+    contextBrowsers.set(context, browser);
+    return context;
+  } catch (error) {
+    await browser.close().catch(() => {});
+    throw error;
+  }
+}
+
+async function closeBrowserContext(context: BrowserContext): Promise<void> {
+  const browser = contextBrowsers.get(context);
+  contextBrowsers.delete(context);
+  await context.close().catch(() => {});
+  await browser?.close().catch(() => {});
+}
+
+async function scrollChatThreadToTop(page: Page) {
+  await page.locator(".chat-thread").evaluate((element) => {
+    element.scrollTop = 0;
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+}
+
+async function expandLocalRenderWindow(page: Page, times: number) {
+  for (let index = 0; index < times; index += 1) {
+    await scrollChatThreadToTop(page);
+    await page.waitForTimeout(30);
+  }
+}
+
+async function waitForNewHistoryOffset(
+  gateway: MockGatewayControls,
+  offset: number,
+  previousCount: number,
+  timeoutMs = 20_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const requests = await gateway.getRequests("chat.history");
+    if (requests.length > previousCount) {
+      const latest = requests[requests.length - 1];
+      const params = latest?.params;
+      const latestOffset =
+        params && typeof params === "object" && !Array.isArray(params)
+          ? (params as { offset?: unknown }).offset
+          : undefined;
+      if (latestOffset === offset) {
+        return latest;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `Timed out waiting for new chat.history offset=${offset} after ${previousCount} requests`,
+  );
+}
+
+describePaginationProof("Control UI chat history pagination browser proof", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, set PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH to a compatible browser, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    await mkdir(artifactDir, { recursive: true });
+    server = await startControlUiE2eServer();
+  });
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("keeps the viewport stable across a delayed older page and reaches past the hard cap", async () => {
+    const rawVideoDir = path.join(artifactDir, "raw-video");
+    await mkdir(rawVideoDir, { recursive: true });
+    const context = await newBrowserContext({
+      locale: "en-US",
+      recordVideo: { dir: rawVideoDir, size: { height: 900, width: 1280 } },
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const transcript = buildTranscript(TOTAL_MESSAGES);
+    const newestPage = transcript.slice(OLDER_PAGE_COUNT);
+    const olderPage = transcript.slice(0, OLDER_PAGE_COUNT);
+    const firstPage = historyPagePayload({
+      hasMore: true,
+      messages: newestPage,
+      nextOffset: FIRST_PAGE_COUNT,
+      offset: 0,
+      totalMessages: TOTAL_MESSAGES,
+    });
+    const gateway = await installMockGateway(page, {
+      historyMessages: transcript,
+      methodResponses: {
+        "chat.history": {
+          cases: [
+            {
+              match: { offset: 0 },
+              response: firstPage,
+            },
+            {
+              match: { offset: FIRST_PAGE_COUNT },
+              response: historyPagePayload({
+                hasMore: false,
+                messages: olderPage,
+                offset: FIRST_PAGE_COUNT,
+                totalMessages: TOTAL_MESSAGES,
+              }),
+            },
+          ],
+        },
+        "chat.startup": {
+          ...firstPage,
+          agentsList: {
+            agents: [
+              {
+                id: "main",
+                identity: { name: "OpenClaw" },
+                name: "OpenClaw",
+                workspaceGit: false,
+              },
+            ],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+          },
+          metadata: {
+            models: [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
+          },
+        },
+      },
+    });
+    const startedAt = new Date().toISOString();
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByText(`msg-${TOTAL_MESSAGES - 1}`).waitFor({ timeout: 30_000 });
+      await page.screenshot({
+        path: path.join(artifactDir, "01-newest-page.png"),
+        fullPage: true,
+      });
+
+      // Exhaust the local render window until the delayed older-page request fires.
+      const historyCountBefore = (await gateway.getRequests("chat.history")).length;
+      await gateway.deferNext("chat.history");
+      let requestedOlder = false;
+      for (let attempt = 0; attempt < 90; attempt += 1) {
+        await scrollChatThreadToTop(page);
+        try {
+          await waitForNewHistoryOffset(gateway, FIRST_PAGE_COUNT, historyCountBefore, 150);
+          requestedOlder = true;
+          break;
+        } catch {
+          // Keep expanding until the gateway older page is requested.
+        }
+      }
+      if (!requestedOlder) {
+        await waitForNewHistoryOffset(gateway, FIRST_PAGE_COUNT, historyCountBefore);
+      }
+
+      const thread = page.locator(".chat-thread");
+      const scrollTopBeforeResolve = await thread.evaluate((element) => element.scrollTop);
+      await page.screenshot({
+        path: path.join(artifactDir, "02-waiting-delayed-older-page.png"),
+        fullPage: true,
+      });
+
+      await page.waitForTimeout(DELAYED_PAGE_MS);
+      await gateway.resolveDeferred("chat.history");
+      await page.getByText("msg-0").waitFor({ timeout: 30_000 });
+
+      // Viewport should remain near the pre-fetch anchor after the delayed prepend.
+      const scrollTopAfterResolve = await thread.evaluate((element) => element.scrollTop);
+      expect(scrollTopAfterResolve).toBeGreaterThanOrEqual(scrollTopBeforeResolve);
+
+      await page.screenshot({
+        path: path.join(artifactDir, "03-after-delayed-older-page.png"),
+        fullPage: true,
+      });
+
+      // Slide the bounded DOM window through the >2,000 loaded messages.
+      await expandLocalRenderWindow(page, 20);
+      await page.getByText("msg-0").waitFor({ timeout: 20_000 });
+      await page.getByText(/Showing 2000 messages/).waitFor({ timeout: 10_000 });
+      expect(await page.getByText(`msg-${TOTAL_MESSAGES - 1}`).count()).toBe(0);
+
+      await page.screenshot({
+        path: path.join(artifactDir, "04-deep-scroll-past-hard-cap.png"),
+        fullPage: true,
+      });
+
+      const historyRequests = await gateway.getRequests("chat.history");
+      const olderRequests = historyRequests.filter((request) => {
+        const params = request.params;
+        return (
+          params &&
+          typeof params === "object" &&
+          !Array.isArray(params) &&
+          (params as { offset?: unknown }).offset === FIRST_PAGE_COUNT
+        );
+      });
+      expect(olderRequests).toHaveLength(1);
+      expect(FIRST_PAGE_COUNT).toBeGreaterThan(HARD_CAP);
+
+      await writeFile(
+        path.join(artifactDir, "chat-history-pagination-proof.json"),
+        `${JSON.stringify(
+          {
+            delayedOlderPageMs: DELAYED_PAGE_MS,
+            finishedAt: new Date().toISOString(),
+            firstPageCount: FIRST_PAGE_COUNT,
+            hardCap: HARD_CAP,
+            olderPageCount: OLDER_PAGE_COUNT,
+            olderPageOffset: FIRST_PAGE_COUNT,
+            redacted: true,
+            scrollTopAfterResolve,
+            scrollTopBeforeResolve,
+            startedAt,
+            status: "pass",
+            totalMessages: TOTAL_MESSAGES,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } finally {
+      const video = page.video();
+      await closeBrowserContext(context);
+      const videoPath = await video?.path().catch(() => undefined);
+      if (videoPath) {
+        await copyFile(videoPath, path.join(artifactDir, "chat-history-pagination-proof.webm"));
+      }
+    }
+  }, 180_000);
+});

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -57,6 +57,8 @@ export type ChatItem =
   | { kind: "reading-indicator"; key: string };
 
 export const CHAT_HISTORY_RENDER_LIMIT = 100;
+/** Absolute ceiling across paginated loads; char budget still applies. */
+export const CHAT_HISTORY_RENDER_HARD_CAP = 2000;
 export const CHAT_HISTORY_RENDER_CHAR_BUDGET = 240_000;
 
 export type ChatStreamSegment = {

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -11,7 +11,12 @@ import {
   handleChatSideResultGatewayEvent,
   type ChatEventPayload,
 } from "./chat-gateway.ts";
-import { GatewayRequestError, loadChatHistory, type ChatState } from "./chat-history.ts";
+import {
+  GatewayRequestError,
+  loadChatHistory,
+  loadOlderChatHistory,
+  type ChatState,
+} from "./chat-history.ts";
 import {
   requestChatSend,
   requestSkillWorkshopRevisionChatSend,
@@ -2137,6 +2142,7 @@ describe("loadChatHistory filtering", () => {
     expect(request).toHaveBeenCalledWith("chat.startup", {
       sessionKey: "global",
       limit: 100,
+      offset: 0,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "ready" }] },
@@ -2164,6 +2170,7 @@ describe("loadChatHistory filtering", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
       limit: 100,
+      offset: 0,
     });
   });
 });
@@ -2626,10 +2633,12 @@ describe("loadChatHistory retry handling", () => {
     expect(request).toHaveBeenNthCalledWith(1, "chat.startup", {
       sessionKey: "main",
       limit: 100,
+      offset: 0,
     });
     expect(request).toHaveBeenNthCalledWith(2, "chat.history", {
       sessionKey: "main",
       limit: 100,
+      offset: 0,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "fallback" }] },
@@ -2698,6 +2707,7 @@ describe("loadChatHistory retry handling", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
       limit: 100,
+      offset: 0,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "visible answer" }] },
@@ -3910,5 +3920,105 @@ describe("loadChatHistory retry handling", () => {
       { role: "assistant", content: [{ type: "text", text: "visible old" }] },
     ]);
     expect(state.chatThinkingLevel).toBeNull();
+  });
+});
+
+describe("chat.history offset pagination", () => {
+  it("requests the first page with offset 0 and stores pagination cursors", async () => {
+    const newest = Array.from({ length: 100 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `page1-${index}`,
+      __openclaw: { seq: index + 101 },
+    }));
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({
+        messages: newest,
+        offset: 0,
+        nextOffset: 100,
+        hasMore: true,
+        totalMessages: 250,
+      }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      "chat.history",
+      expect.objectContaining({ limit: 100, offset: 0, sessionKey: "main" }),
+    );
+    expect(state.chatMessages).toHaveLength(100);
+    expect(state.chatHistoryHasMore).toBe(true);
+    expect(state.chatHistoryNextOffset).toBe(100);
+    expect(state.chatHistoryTotalMessages).toBe(250);
+    expect(state.chatHistoryOffset).toBe(0);
+  });
+
+  it("loads older pages with nextOffset and prepends without dropping the newest page", async () => {
+    const newest = [
+      { role: "user", content: "newest-user", __openclaw: { seq: 3 } },
+      { role: "assistant", content: "newest-assistant", __openclaw: { seq: 4 } },
+    ];
+    const older = [
+      { role: "user", content: "older-user", __openclaw: { seq: 1 } },
+      { role: "assistant", content: "older-assistant", __openclaw: { seq: 2 } },
+    ];
+    const mockClient = {
+      request: vi
+        .fn()
+        .mockResolvedValueOnce({
+          messages: newest,
+          offset: 0,
+          nextOffset: 2,
+          hasMore: true,
+          totalMessages: 4,
+        })
+        .mockResolvedValueOnce({
+          messages: older,
+          offset: 2,
+          hasMore: false,
+          totalMessages: 4,
+        }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+    await loadOlderChatHistory(state);
+
+    expect(mockClient.request).toHaveBeenNthCalledWith(
+      2,
+      "chat.history",
+      expect.objectContaining({ limit: 100, offset: 2, sessionKey: "main" }),
+    );
+    expect(state.chatMessages).toEqual([...older, ...newest]);
+    expect(state.chatHistoryHasMore).toBe(false);
+    expect(state.chatHistoryNextOffset).toBeNull();
+    expect(state.chatHistoryLoadingOlder).toBe(false);
+  });
+
+  it("does not request an older page when hasMore is false", async () => {
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({
+        messages: [{ role: "user", content: "only" }],
+        offset: 0,
+        hasMore: false,
+        totalMessages: 1,
+      }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+    await loadOlderChatHistory(state);
+
+    expect(mockClient.request).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -526,7 +526,7 @@ function setChatError(state: ChatState, error: string | null) {
   state.chatError = error;
 }
 
-function resetChatHistoryPagination(state: ChatState) {
+export function resetChatHistoryPagination(state: ChatState) {
   state.chatHistoryOffset = null;
   state.chatHistoryNextOffset = null;
   state.chatHistoryHasMore = false;

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -439,6 +439,16 @@ export type ChatState = {
   chatLoading: boolean;
   chatMessages: unknown[];
   chatMessagesBySession?: ChatMessageCache;
+  /** Offset cursor from the last successful chat.history / chat.startup page. */
+  chatHistoryOffset?: number | null;
+  /** Next older-page offset from the gateway; null when no further pages. */
+  chatHistoryNextOffset?: number | null;
+  /** True when older transcript pages remain on the server. */
+  chatHistoryHasMore?: boolean;
+  /** Total transcript messages reported by the gateway for the selected session. */
+  chatHistoryTotalMessages?: number | null;
+  /** True while an older-page fetch is in flight. */
+  chatHistoryLoadingOlder?: boolean;
   chatThinkingLevel: string | null;
   chatVerboseLevel: string | null;
   chatSending: boolean;
@@ -486,6 +496,14 @@ export type ChatHistoryResult = {
   sessionInfo?: GatewaySessionRow;
   agentsList?: AgentsListResult;
   metadata?: ChatMetadataResult;
+  /** Absolute transcript offset for this page when offset pagination is active. */
+  offset?: number;
+  /** Older-page cursor; omitted/null when hasMore is false. */
+  nextOffset?: number | null;
+  /** True when older messages remain beyond this page. */
+  hasMore?: boolean;
+  /** Total transcript message count for the session. */
+  totalMessages?: number;
 };
 
 export type ChatMetadataResult = CommandsListResult & {
@@ -506,6 +524,89 @@ export type ChatEventPayload = {
 function setChatError(state: ChatState, error: string | null) {
   state.lastError = error;
   state.chatError = error;
+}
+
+function resetChatHistoryPagination(state: ChatState) {
+  state.chatHistoryOffset = null;
+  state.chatHistoryNextOffset = null;
+  state.chatHistoryHasMore = false;
+  state.chatHistoryTotalMessages = null;
+  state.chatHistoryLoadingOlder = false;
+}
+
+function applyChatHistoryPagination(state: ChatState, res: ChatHistoryResult) {
+  const offset =
+    typeof res.offset === "number" && Number.isFinite(res.offset)
+      ? Math.max(0, Math.floor(res.offset))
+      : null;
+  const totalMessages =
+    typeof res.totalMessages === "number" && Number.isFinite(res.totalMessages)
+      ? Math.max(0, Math.floor(res.totalMessages))
+      : null;
+  const nextOffset =
+    typeof res.nextOffset === "number" && Number.isFinite(res.nextOffset)
+      ? Math.max(0, Math.floor(res.nextOffset))
+      : null;
+  const hasMore =
+    typeof res.hasMore === "boolean"
+      ? res.hasMore
+      : nextOffset !== null && totalMessages !== null
+        ? nextOffset < totalMessages
+        : false;
+  state.chatHistoryOffset = offset;
+  state.chatHistoryNextOffset = hasMore ? nextOffset : null;
+  state.chatHistoryHasMore = hasMore;
+  state.chatHistoryTotalMessages = totalMessages;
+}
+
+function readChatHistoryMessageIdentity(message: unknown): string | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+  const record = message as Record<string, unknown>;
+  const openclaw = record.__openclaw;
+  if (openclaw && typeof openclaw === "object") {
+    const meta = openclaw as Record<string, unknown>;
+    if (typeof meta.seq === "number" && Number.isSafeInteger(meta.seq) && meta.seq > 0) {
+      return `seq:${meta.seq}`;
+    }
+    if (typeof meta.id === "string" && meta.id.trim()) {
+      return `id:${meta.id.trim()}`;
+    }
+  }
+  if (typeof record.id === "string" && record.id.trim()) {
+    return `id:${record.id.trim()}`;
+  }
+  const role = typeof record.role === "string" ? record.role : "";
+  const timestamp =
+    typeof record.timestamp === "number"
+      ? String(record.timestamp)
+      : typeof record.timestamp === "string"
+        ? record.timestamp
+        : "";
+  if (!role && !timestamp) {
+    return null;
+  }
+  return `rt:${role}:${timestamp}:${extractText(message) ?? ""}`;
+}
+
+function prependOlderChatHistoryMessages(existing: unknown[], olderPage: unknown[]): unknown[] {
+  if (olderPage.length === 0) {
+    return existing;
+  }
+  const existingIds = new Set(
+    existing
+      .map((message) => readChatHistoryMessageIdentity(message))
+      .filter((id): id is string => Boolean(id)),
+  );
+  const uniqueOlder = olderPage.filter((message) => {
+    const id = readChatHistoryMessageIdentity(message);
+    return !id || !existingIds.has(id);
+  });
+  if (uniqueOlder.length === 0) {
+    return existing;
+  }
+  return [...uniqueOlder, ...existing];
 }
 
 function chatScopedEventAgentScopeMatches(
@@ -963,6 +1064,7 @@ async function loadChatHistoryUncached(
   // Any pending input-history snapshot becomes invalid once we start reloading transcript state.
   state.resetChatInputHistoryNavigation?.();
   state.chatLoading = true;
+  state.chatHistoryLoadingOlder = false;
   setChatError(state, null);
   try {
     let res: ChatHistoryResult;
@@ -972,6 +1074,9 @@ async function loadChatHistoryUncached(
           sessionKey,
           ...(requestAgentId ? { agentId: requestAgentId } : {}),
           limit: CHAT_HISTORY_REQUEST_LIMIT,
+          // Offset pagination is opt-in on the gateway: omitting offset skips
+          // hasMore/nextOffset metadata, so first-page loads must pass 0.
+          offset: 0,
         });
         break;
       } catch (err) {
@@ -991,6 +1096,7 @@ async function loadChatHistoryUncached(
             sessionKey,
             ...(requestAgentId ? { agentId: requestAgentId } : {}),
             limit: CHAT_HISTORY_REQUEST_LIMIT,
+            offset: 0,
           });
           break;
         }
@@ -1015,6 +1121,7 @@ async function loadChatHistoryUncached(
     }
     const messages = Array.isArray(res.messages) ? res.messages : [];
     applyChatAgentsList(state, res.agentsList, client);
+    applyChatHistoryPagination(state, res);
     const visibleMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
     const lateOptimisticTail = collectLateOptimisticTailMessages(
       previousMessages,
@@ -1138,6 +1245,7 @@ async function loadChatHistoryUncached(
       state.chatMessages = [];
       state.chatThinkingLevel = null;
       state.chatVerboseLevel = null;
+      resetChatHistoryPagination(state);
       setChatError(state, formatMissingOperatorReadScopeMessage("existing chat history"));
     } else {
       setChatError(state, String(err));
@@ -1148,4 +1256,68 @@ async function loadChatHistoryUncached(
     }
   }
   return undefined;
+}
+
+/**
+ * Fetch the next older chat.history page and prepend it into the selected
+ * transcript. No-ops when pagination says there is nothing left, or when a
+ * full history reload / older-page fetch is already in flight.
+ */
+export async function loadOlderChatHistory(
+  state: ChatState,
+): Promise<ChatHistoryResult | undefined> {
+  if (!state.client || !state.connected) {
+    return undefined;
+  }
+  if (state.chatLoading || state.chatHistoryLoadingOlder) {
+    return undefined;
+  }
+  if (!state.chatHistoryHasMore) {
+    return undefined;
+  }
+  const nextOffset = state.chatHistoryNextOffset;
+  if (typeof nextOffset !== "number" || !Number.isFinite(nextOffset)) {
+    return undefined;
+  }
+  const sessionKey = state.sessionKey;
+  const requestAgentId = isUiSelectedGlobalSessionKey(sessionKey)
+    ? resolveUiSelectedSessionAgentId(state)
+    : undefined;
+  const client = state.client;
+  const connectionEpoch = state.connectionEpoch;
+  const ownership = beginChatHistoryRequest(
+    state,
+    client,
+    connectionEpoch,
+    sessionKey,
+    requestAgentId,
+  );
+  state.chatHistoryLoadingOlder = true;
+  try {
+    const res = await client.request<ChatHistoryResult>("chat.history", {
+      sessionKey,
+      ...(requestAgentId ? { agentId: requestAgentId } : {}),
+      limit: CHAT_HISTORY_REQUEST_LIMIT,
+      offset: Math.max(0, Math.floor(nextOffset)),
+    });
+    if (!shouldApplyChatHistoryResult(state, ownership)) {
+      return undefined;
+    }
+    const messages = Array.isArray(res.messages) ? res.messages : [];
+    const visibleOlder = messages.filter((message) => !shouldHideHistoryMessage(message));
+    state.chatMessages = prependOlderChatHistoryMessages(state.chatMessages, visibleOlder);
+    replaceCachedChatMessages(state, sessionKey, state.chatMessages, requestAgentId);
+    applyChatHistoryPagination(state, res);
+    return res;
+  } catch (err) {
+    if (!shouldApplyChatHistoryResult(state, ownership)) {
+      return undefined;
+    }
+    setChatError(state, String(err));
+    return undefined;
+  } finally {
+    if (ownsChatHistoryRequest(state, ownership)) {
+      state.chatHistoryLoadingOlder = false;
+    }
+  }
 }

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -564,7 +564,7 @@ function readChatHistoryMessageIdentity(message: unknown): string | null {
     return null;
   }
   const record = message as Record<string, unknown>;
-  const openclaw = record.__openclaw;
+  const openclaw = record["__openclaw"];
   if (openclaw && typeof openclaw === "object") {
     const meta = openclaw as Record<string, unknown>;
     if (typeof meta.seq === "number" && Number.isSafeInteger(meta.seq) && meta.seq > 0) {

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1324,7 +1324,7 @@ class ChatPane extends OpenClawLightDomElement {
       historyTotalMessages: state.chatHistoryTotalMessages ?? null,
       historyLoadingOlder: Boolean(state.chatHistoryLoadingOlder),
       onLoadOlderHistory: () => {
-        void loadOlderChatHistory(state).finally(() => state.requestUpdate?.());
+        return loadOlderChatHistory(state).finally(() => state.requestUpdate?.());
       },
       assistantAvatarUrl: resolveChatAvatarUrl(state),
       sendShortcut: state.settings.chatSendShortcut,

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1319,6 +1319,12 @@ class ChatPane extends OpenClawLightDomElement {
       streamSegments: state.chatStreamSegments,
       stream: state.chatStream,
       streamStartedAt: state.chatStreamStartedAt,
+      historyHasMore: Boolean(state.chatHistoryHasMore),
+      historyTotalMessages: state.chatHistoryTotalMessages ?? null,
+      historyLoadingOlder: Boolean(state.chatHistoryLoadingOlder),
+      onLoadOlderHistory: () => {
+        void loadOlderChatHistory(state).finally(() => state.requestUpdate?.());
+      },
       assistantAvatarUrl: resolveChatAvatarUrl(state),
       sendShortcut: state.settings.chatSendShortcut,
       draft: state.chatMessage,

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -50,6 +50,7 @@ import {
   applyChatAgentsList,
   clearChatHistory,
   loadChatHistory,
+  loadOlderChatHistory,
   syncSelectedSessionMessageSubscription,
 } from "./chat-history.ts";
 import { markQueuedChatSendsWaitingForReconnect } from "./chat-queue.ts";

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -402,6 +402,7 @@ describe("refreshChat", () => {
     expect(host.chatLoading).toBe(true);
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
+      offset: 0,
       limit: 100,
     });
     expect(request).not.toHaveBeenCalledWith("models.list", { view: "configured" });
@@ -430,6 +431,7 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "global",
       agentId: "work",
+      offset: 0,
       limit: 100,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
@@ -450,6 +452,7 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "agent:work:main",
       agentId: "work",
+      offset: 0,
       limit: 100,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
@@ -469,6 +472,7 @@ describe("refreshChat", () => {
     expect(outcome).toBe("resolved");
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "agent:work:dashboard",
+      offset: 0,
       limit: 100,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
@@ -494,6 +498,7 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "global",
       agentId: "ops",
+      offset: 0,
       limit: 100,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
@@ -514,6 +519,7 @@ describe("refreshChat", () => {
     expect(outcome).toBe("resolved");
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "unknown",
+      offset: 0,
       limit: 100,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
@@ -6496,6 +6502,7 @@ describe("handleSendChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "global",
       agentId: "work",
+      offset: 0,
       limit: 100,
     });
     expect(host.chatMessages).toStrictEqual([]);
@@ -6631,6 +6638,7 @@ describe("handleSendChat", () => {
     expect(host.lastError).toContain("clear request may have completed");
     expect(replacementRequest).toHaveBeenCalledWith("chat.history", {
       sessionKey: "agent:main",
+      offset: 0,
       limit: 100,
     });
 
@@ -6683,6 +6691,7 @@ describe("handleSendChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "global",
       agentId: "work",
+      offset: 0,
       limit: 100,
     });
     expect(listStoredChatOutboxes(host)).toStrictEqual([]);

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -7,6 +7,12 @@ import {
   resetChatSlashCommandMetadataForTest,
 } from "./chat-commands.ts";
 import {
+  loadChatHistory,
+  loadOlderChatHistory,
+  type ChatHistoryResult,
+  type ChatState,
+} from "./chat-history.ts";
+import {
   admitQueuedMessageForSession,
   removeQueuedMessage,
   subscribeChatOutboxProjection,
@@ -474,6 +480,57 @@ describe("route composer fallback", () => {
     expect(state.chatError).toContain("remains available in this tab");
     expect(resetChatInputHistoryNavigation).toHaveBeenCalledTimes(2);
     expect(resetChatScroll).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears history pagination on route switch so a failed reload cannot reuse the old offset", async () => {
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    const { state } = createRouteState("");
+    // Session A established older-page cursors.
+    state.chatHistoryOffset = 0;
+    state.chatHistoryNextOffset = 100;
+    state.chatHistoryHasMore = true;
+    state.chatHistoryTotalMessages = 250;
+    state.chatHistoryLoadingOlder = false;
+
+    const request = vi
+      .fn<(method: string, params: unknown) => Promise<ChatHistoryResult>>()
+      .mockRejectedValueOnce(new Error("history unavailable"))
+      .mockResolvedValueOnce({
+        messages: [{ role: "user", content: "b-newest", __openclaw: { seq: 5 } }],
+        offset: 0,
+        nextOffset: 100,
+        hasMore: true,
+        totalMessages: 180,
+      });
+    state.client = { request } as unknown as ChatPageHost["client"];
+    state.connected = true;
+    state.connectionEpoch = 0;
+
+    resetChatStateForRouteSession(state, "agent:main:second");
+
+    // Adopting a new session must drop the previous session's cursors atomically.
+    expect(state.chatHistoryHasMore).toBe(false);
+    expect(state.chatHistoryNextOffset).toBeNull();
+    expect(state.chatHistoryOffset).toBeNull();
+    expect(state.chatHistoryTotalMessages).toBeNull();
+    expect(state.chatHistoryLoadingOlder).toBe(false);
+
+    // The new session's first history load fails; a generic error must not
+    // resurrect the previous session's cursors.
+    await loadChatHistory(state as unknown as ChatState);
+    expect(state.chatHistoryHasMore).toBe(false);
+    expect(state.chatHistoryNextOffset).toBeNull();
+
+    // Top-scroll must be rejected: no older-page request may fire with a stale
+    // offset for the newly selected session.
+    await loadOlderChatHistory(state as unknown as ChatState);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    // A later successful load establishes the new session's own cursor.
+    await loadChatHistory(state as unknown as ChatState);
+    expect(state.chatHistoryHasMore).toBe(true);
+    expect(state.chatHistoryNextOffset).toBe(100);
+    expect(state.chatHistoryTotalMessages).toBe(180);
   });
 
   it("adopts an unresolved bare-main fallback when the default agent becomes known", () => {

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -57,6 +57,7 @@ import {
 import {
   chatScopedEventSessionMatches,
   loadChatHistory,
+  resetChatHistoryPagination,
   type ChatMetadataResult,
   type ChatState,
 } from "./chat-history.ts";
@@ -549,6 +550,10 @@ export function resetChatStateForRouteSession(
   state.chatAttachments = [];
   state.chatReplyTarget = null;
   state.chatMessages = restoreChatMessagesForSession(state, sessionKey);
+  // Pagination cursors are transcript-scoped. Drop the previous session's
+  // offset/hasMore with the adopted session so a failed initial history load
+  // cannot let a top-scroll request the new session at the old session's offset.
+  resetChatHistoryPagination(state);
   state.chatToolMessages = [];
   state.chatStreamSegments = [];
   state.chatThinkingLevel = null;

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -57,7 +57,6 @@ import {
 import {
   chatScopedEventSessionMatches,
   loadChatHistory,
-  loadOlderChatHistory,
   type ChatMetadataResult,
   type ChatState,
 } from "./chat-history.ts";

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -57,6 +57,7 @@ import {
 import {
   chatScopedEventSessionMatches,
   loadChatHistory,
+  loadOlderChatHistory,
   type ChatMetadataResult,
   type ChatState,
 } from "./chat-history.ts";
@@ -1263,6 +1264,11 @@ export function createPageState(
     chatSending: false,
     chatMessage: "",
     chatMessages: [] as unknown[],
+    chatHistoryOffset: null as number | null,
+    chatHistoryNextOffset: null as number | null,
+    chatHistoryHasMore: false,
+    chatHistoryTotalMessages: null as number | null,
+    chatHistoryLoadingOlder: false,
     chatToolMessages: [] as Record<string, unknown>[],
     chatThinkingLevel: null,
     chatVerboseLevel: null,

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1171,6 +1171,25 @@ describe("buildChatItems", () => {
     expect(messageRecord(groups[groups.length - 1]).content).toBe("message 104");
   });
 
+  it("distinguishes server-side older pages from locally hidden loaded messages", () => {
+    const items = buildChatItems(
+      createProps({
+        historyRenderLimit: 30,
+        historyHasMore: true,
+        historyTotalMessages: 250,
+        messages: Array.from({ length: 100 }, (_, index) => ({
+          role: index % 2 === 0 ? "user" : "assistant",
+          content: `message ${index}`,
+          timestamp: index,
+        })),
+      }),
+    );
+
+    expect(messageRecord(requireGroup(items[0])).content).toBe(
+      "Showing last 30 of 250 messages (70 loaded but not shown). Older messages are available on the server — scroll up to load more.",
+    );
+  });
+
   it("budgets rendered history by tool-result content size", () => {
     const largeOutput = "x".repeat(100_000);
     const items = buildChatItems(

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1190,6 +1190,39 @@ describe("buildChatItems", () => {
     );
   });
 
+  it("moves the bounded render window into older fetched pages past the hard cap", () => {
+    const messages = Array.from({ length: 2_100 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index,
+    }));
+
+    const newestTail = buildChatItems(
+      createProps({
+        historyRenderLimit: 2_000,
+        historyRenderOffsetFromEnd: 0,
+        messages,
+      }),
+    );
+    const newestGroups = newestTail.filter((item) => item.kind === "group");
+    expect(messageRecord(newestGroups[1]).content).toBe("message 100");
+    expect(messageRecord(newestGroups[newestGroups.length - 1]).content).toBe("message 2099");
+
+    const olderWindow = buildChatItems(
+      createProps({
+        historyRenderLimit: 2_000,
+        historyRenderOffsetFromEnd: 100,
+        messages,
+      }),
+    );
+    const olderGroups = olderWindow.filter((item) => item.kind === "group");
+    expect(messageRecord(requireGroup(olderWindow[0])).content).toBe(
+      "Showing 2000 messages (100 hidden).",
+    );
+    expect(messageRecord(olderGroups[1]).content).toBe("message 0");
+    expect(messageRecord(olderGroups[olderGroups.length - 1]).content).toBe("message 1999");
+  });
+
   it("budgets rendered history by tool-result content size", () => {
     const largeOutput = "x".repeat(100_000);
     const items = buildChatItems(

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -12,6 +12,7 @@ import type {
 } from "../../lib/chat/chat-types.ts";
 import {
   CHAT_HISTORY_RENDER_CHAR_BUDGET,
+  CHAT_HISTORY_RENDER_HARD_CAP,
   CHAT_HISTORY_RENDER_LIMIT,
 } from "../../lib/chat/chat-types.ts";
 import {
@@ -49,6 +50,10 @@ export type BuildChatItemsProps = {
   searchOpen?: boolean;
   searchQuery?: string;
   historyRenderLimit?: number;
+  /** True when older transcript pages remain on the server. */
+  historyHasMore?: boolean;
+  /** Total transcript messages reported by the gateway, when known. */
+  historyTotalMessages?: number | null;
 };
 
 type CachedChatItems = {
@@ -1062,7 +1067,30 @@ function resolveHistoryRenderLimit(limit: number | undefined): number {
   if (typeof limit !== "number" || !Number.isFinite(limit)) {
     return CHAT_HISTORY_RENDER_LIMIT;
   }
-  return Math.max(1, Math.min(CHAT_HISTORY_RENDER_LIMIT, Math.floor(limit)));
+  return Math.max(1, Math.min(CHAT_HISTORY_RENDER_HARD_CAP, Math.floor(limit)));
+}
+
+function formatChatHistoryNotice(params: {
+  visibleHistoryCount: number;
+  hiddenHistoryCount: number;
+  historyHasMore?: boolean;
+  historyTotalMessages?: number | null;
+}): string {
+  const { visibleHistoryCount, hiddenHistoryCount, historyHasMore, historyTotalMessages } = params;
+  const totalLabel =
+    typeof historyTotalMessages === "number" && Number.isFinite(historyTotalMessages)
+      ? ` of ${Math.max(0, Math.floor(historyTotalMessages))}`
+      : "";
+  if (historyHasMore && hiddenHistoryCount > 0) {
+    return `Showing last ${visibleHistoryCount}${totalLabel} messages (${hiddenHistoryCount} loaded but not shown). Older messages are available on the server — scroll up to load more.`;
+  }
+  if (historyHasMore) {
+    return `Showing last ${visibleHistoryCount}${totalLabel} messages. Older messages are available on the server — scroll up to load more.`;
+  }
+  if (hiddenHistoryCount > 0) {
+    return `Showing last ${visibleHistoryCount} messages (${hiddenHistoryCount} hidden).`;
+  }
+  return `Showing last ${visibleHistoryCount} messages.`;
 }
 
 function resolveHistoryStartIndex(
@@ -1116,13 +1144,18 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     history.slice(historyStart),
     props.showToolCalls,
   );
-  if (hiddenHistoryCount > 0) {
+  if (hiddenHistoryCount > 0 || props.historyHasMore) {
     items.push({
       kind: "message",
       key: "chat:history:notice",
       message: {
         role: "system",
-        content: `Showing last ${visibleHistoryCount} messages (${hiddenHistoryCount} hidden).`,
+        content: formatChatHistoryNotice({
+          visibleHistoryCount,
+          hiddenHistoryCount,
+          historyHasMore: props.historyHasMore,
+          historyTotalMessages: props.historyTotalMessages,
+        }),
         timestamp: Date.now(),
       },
     });
@@ -1351,7 +1384,9 @@ function sameChatItemsInput(previous: BuildChatItemsProps, next: BuildChatItemsP
     previous.showToolCalls === next.showToolCalls &&
     previous.searchOpen === next.searchOpen &&
     previous.searchQuery === next.searchQuery &&
-    previous.historyRenderLimit === next.historyRenderLimit
+    previous.historyRenderLimit === next.historyRenderLimit &&
+    previous.historyHasMore === next.historyHasMore &&
+    previous.historyTotalMessages === next.historyTotalMessages
   );
 }
 

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -50,6 +50,12 @@ export type BuildChatItemsProps = {
   searchOpen?: boolean;
   searchQuery?: string;
   historyRenderLimit?: number;
+  /**
+   * Exclusive end of the bounded render window, measured as an offset from
+   * `messages.length`. 0 keeps the window pinned to the newest messages;
+   * larger values slide into older fetched pages without unbounded DOM growth.
+   */
+  historyRenderOffsetFromEnd?: number;
   /** True when older transcript pages remain on the server. */
   historyHasMore?: boolean;
   /** Total transcript messages reported by the gateway, when known. */
@@ -1075,33 +1081,53 @@ function formatChatHistoryNotice(params: {
   hiddenHistoryCount: number;
   historyHasMore?: boolean;
   historyTotalMessages?: number | null;
+  pinnedToNewest?: boolean;
 }): string {
-  const { visibleHistoryCount, hiddenHistoryCount, historyHasMore, historyTotalMessages } = params;
+  const {
+    visibleHistoryCount,
+    hiddenHistoryCount,
+    historyHasMore,
+    historyTotalMessages,
+    pinnedToNewest = true,
+  } = params;
   const totalLabel =
     typeof historyTotalMessages === "number" && Number.isFinite(historyTotalMessages)
       ? ` of ${Math.max(0, Math.floor(historyTotalMessages))}`
       : "";
+  const showingLabel = pinnedToNewest
+    ? `Showing last ${visibleHistoryCount}`
+    : `Showing ${visibleHistoryCount}`;
   if (historyHasMore && hiddenHistoryCount > 0) {
-    return `Showing last ${visibleHistoryCount}${totalLabel} messages (${hiddenHistoryCount} loaded but not shown). Older messages are available on the server — scroll up to load more.`;
+    return `${showingLabel}${totalLabel} messages (${hiddenHistoryCount} loaded but not shown). Older messages are available on the server — scroll up to load more.`;
   }
   if (historyHasMore) {
-    return `Showing last ${visibleHistoryCount}${totalLabel} messages. Older messages are available on the server — scroll up to load more.`;
+    return `${showingLabel}${totalLabel} messages. Older messages are available on the server — scroll up to load more.`;
   }
   if (hiddenHistoryCount > 0) {
-    return `Showing last ${visibleHistoryCount} messages (${hiddenHistoryCount} hidden).`;
+    return `${showingLabel} messages (${hiddenHistoryCount} hidden).`;
   }
-  return `Showing last ${visibleHistoryCount} messages.`;
+  return `${showingLabel} messages.`;
+}
+
+function resolveHistoryWindowEnd(messageCount: number, offsetFromEnd: number | undefined): number {
+  if (typeof offsetFromEnd !== "number" || !Number.isFinite(offsetFromEnd)) {
+    return messageCount;
+  }
+  const normalizedOffset = Math.max(0, Math.floor(offsetFromEnd));
+  return Math.max(0, messageCount - normalizedOffset);
 }
 
 function resolveHistoryStartIndex(
   messages: unknown[],
   showToolCalls: boolean,
   renderLimit: number,
+  windowEnd: number = messages.length,
 ): number {
+  const endIndex = Math.max(0, Math.min(messages.length, Math.floor(windowEnd)));
   let visibleCount = 0;
   let renderChars = 0;
-  let startIndex = messages.length;
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
+  let startIndex = endIndex;
+  for (let index = endIndex - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (isHiddenToolMessage(message, showToolCalls)) {
       continue;
@@ -1135,15 +1161,24 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     text: string | null;
     timestamp: number | null;
   }>;
-  const historyStart = resolveHistoryStartIndex(history, props.showToolCalls, historyRenderLimit);
-  const hiddenHistoryCount = countVisibleHistoryMessages(
-    history.slice(0, historyStart),
-    props.showToolCalls,
+  const historyWindowEnd = resolveHistoryWindowEnd(
+    history.length,
+    props.historyRenderOffsetFromEnd,
   );
+  const historyStart = resolveHistoryStartIndex(
+    history,
+    props.showToolCalls,
+    historyRenderLimit,
+    historyWindowEnd,
+  );
+  const hiddenHistoryCount =
+    countVisibleHistoryMessages(history.slice(0, historyStart), props.showToolCalls) +
+    countVisibleHistoryMessages(history.slice(historyWindowEnd), props.showToolCalls);
   const visibleHistoryCount = countVisibleHistoryMessages(
-    history.slice(historyStart),
+    history.slice(historyStart, historyWindowEnd),
     props.showToolCalls,
   );
+  const pinnedToNewest = historyWindowEnd >= history.length;
   if (hiddenHistoryCount > 0 || props.historyHasMore) {
     items.push({
       kind: "message",
@@ -1155,12 +1190,13 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
           hiddenHistoryCount,
           historyHasMore: props.historyHasMore,
           historyTotalMessages: props.historyTotalMessages,
+          pinnedToNewest,
         }),
         timestamp: Date.now(),
       },
     });
   }
-  for (let i = historyStart; i < history.length; i++) {
+  for (let i = historyStart; i < historyWindowEnd; i++) {
     const msg = history[i];
     const normalized = safeNormalizeMessage(msg);
     if (!normalized) {
@@ -1385,6 +1421,7 @@ function sameChatItemsInput(previous: BuildChatItemsProps, next: BuildChatItemsP
     previous.searchOpen === next.searchOpen &&
     previous.searchQuery === next.searchQuery &&
     previous.historyRenderLimit === next.historyRenderLimit &&
+    previous.historyRenderOffsetFromEnd === next.historyRenderOffsetFromEnd &&
     previous.historyHasMore === next.historyHasMore &&
     previous.historyTotalMessages === next.historyTotalMessages
   );

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1156,6 +1156,144 @@ describe("chat history render window", () => {
       }),
     );
   });
+
+  it("restores the scroll anchor only after a delayed older-history page renders", async () => {
+    const messages = Array.from({ length: 80 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index,
+    }));
+    const deferred = createDeferred<void>();
+    const onLoadOlderHistory = vi.fn(() => deferred.promise);
+    const onRequestUpdate = vi.fn();
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const container = renderChatView({
+      messages,
+      historyHasMore: true,
+      onLoadOlderHistory,
+      onRequestUpdate,
+    });
+    const thread = requireElement(container, ".chat-thread", "chat thread") as HTMLElement;
+    Object.defineProperties(thread, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 300 },
+    });
+
+    // Grow the local window to the loaded cap without requesting another page.
+    for (let i = 0; i < 2; i += 1) {
+      thread.scrollTop = 0;
+      thread.dispatchEvent(new Event("scroll", { bubbles: true }));
+      renderChatView({
+        messages,
+        historyHasMore: true,
+        onLoadOlderHistory,
+        onRequestUpdate,
+      });
+    }
+    expect(onLoadOlderHistory).not.toHaveBeenCalled();
+    frameCallbacks.splice(0);
+
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event("scroll", { bubbles: true }));
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // Pre-fetch frames must not clear the saved anchor before the page arrives.
+    for (const callback of frameCallbacks.splice(0)) {
+      callback(0);
+    }
+    expect(thread.scrollTop).toBe(0);
+
+    deferred.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const olderMessages = [
+      ...Array.from({ length: 30 }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `older ${index}`,
+        timestamp: index - 30,
+      })),
+      ...messages,
+    ];
+    Object.defineProperty(thread, "scrollHeight", { configurable: true, value: 600 });
+    renderChatView({
+      messages: olderMessages,
+      historyHasMore: true,
+      onLoadOlderHistory,
+      onRequestUpdate,
+    });
+
+    for (let attempt = 0; attempt < 10 && thread.scrollTop === 0; attempt += 1) {
+      for (const callback of frameCallbacks.splice(0)) {
+        callback(0);
+      }
+    }
+    expect(thread.scrollTop).toBe(300);
+  });
+
+  it("slides the bounded window into older loaded messages once the hard cap is full", () => {
+    const messages = Array.from({ length: 2_060 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `message ${index}`,
+      timestamp: index,
+    }));
+    const onLoadOlderHistory = vi.fn();
+    const onRequestUpdate = vi.fn();
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const container = renderChatView({ messages, onRequestUpdate, onLoadOlderHistory });
+    const thread = requireElement(container, ".chat-thread", "chat thread") as HTMLElement;
+    // Drop auto-fill frames so only explicit top-scroll expansion moves the window.
+    frameCallbacks.splice(0);
+
+    for (let i = 0; i < 66; i += 1) {
+      thread.scrollTop = 0;
+      thread.dispatchEvent(new Event("scroll", { bubbles: true }));
+      renderChatView({ messages, onRequestUpdate, onLoadOlderHistory });
+      frameCallbacks.splice(0);
+    }
+
+    buildChatItemsMock.mockClear();
+    renderChatView({ messages, onRequestUpdate, onLoadOlderHistory });
+    expect(buildChatItemsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages,
+        historyRenderLimit: 2_000,
+        historyRenderOffsetFromEnd: 0,
+      }),
+    );
+
+    buildChatItemsMock.mockClear();
+    thread.scrollTop = 0;
+    thread.dispatchEvent(new Event("scroll", { bubbles: true }));
+    renderChatView({ messages, onRequestUpdate, onLoadOlderHistory });
+
+    expect(onLoadOlderHistory).not.toHaveBeenCalled();
+    expect(buildChatItemsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages,
+        historyRenderLimit: 2_000,
+        historyRenderOffsetFromEnd: 30,
+      }),
+    );
+  });
 });
 
 describe("chat goal status", () => {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -162,7 +162,7 @@ export type ChatProps = {
   historyHasMore?: boolean;
   historyTotalMessages?: number | null;
   historyLoadingOlder?: boolean;
-  onLoadOlderHistory?: () => void;
+  onLoadOlderHistory?: () => void | Promise<unknown>;
   basePath?: string;
   composerControls?: TemplateResult | typeof nothing;
   replyTarget?: { messageId: string; text: string; senderLabel?: string | null } | null;

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -159,6 +159,10 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  historyHasMore?: boolean;
+  historyTotalMessages?: number | null;
+  historyLoadingOlder?: boolean;
+  onLoadOlderHistory?: () => void;
   basePath?: string;
   composerControls?: TemplateResult | typeof nothing;
   replyTarget?: { messageId: string; text: string; senderLabel?: string | null } | null;
@@ -238,6 +242,10 @@ export function renderChat(props: ChatProps) {
     onRequestUpdate: requestUpdate,
     onScrollToBottom: props.onScrollToBottom,
     onChatScroll: props.onChatScroll,
+    historyHasMore: props.historyHasMore,
+    historyTotalMessages: props.historyTotalMessages,
+    historyLoadingOlder: props.historyLoadingOlder,
+    onLoadOlderHistory: props.onLoadOlderHistory,
     onDraftChange: props.onDraftChange,
     getDraft: props.getDraft,
     onSend: props.onSend,

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -73,6 +73,10 @@ type ChatThreadState = {
   historyRenderMessagesRef: unknown[] | null;
   historyRenderMessageCount: number;
   historyRenderLimit: number;
+  /** Offset from messages.length for the exclusive render-window end. */
+  historyRenderOffsetFromEnd: number;
+  /** True while an older-history fetch is in flight and the scroll anchor must wait for prepend+render. */
+  historyRenderAwaitingOlderPrepend: boolean;
   historyRenderLastScrollTop: number | null;
   historyRenderExpansionFrame: number | null;
   historyRenderAnchorAdjustment: {
@@ -123,8 +127,12 @@ type ChatThreadProps = {
   onRequestUpdate?: () => void;
   onScrollToBottom?: () => void;
   onChatScroll?: (event: Event) => void;
-  /** Fetch older transcript pages when the local render window is exhausted. */
-  onLoadOlderHistory?: () => void;
+  /**
+   * Fetch older transcript pages when the local render window is exhausted.
+   * May return a Promise; scroll-anchor restoration waits until it settles and
+   * the prepended page has rendered.
+   */
+  onLoadOlderHistory?: () => void | Promise<unknown>;
   /** True when older transcript pages remain on the server. */
   historyHasMore?: boolean;
   historyTotalMessages?: number | null;
@@ -153,6 +161,8 @@ function createChatThreadState(): ChatThreadState {
     historyRenderMessagesRef: null,
     historyRenderMessageCount: 0,
     historyRenderLimit: 0,
+    historyRenderOffsetFromEnd: 0,
+    historyRenderAwaitingOlderPrepend: false,
     historyRenderLastScrollTop: null,
     historyRenderExpansionFrame: null,
     historyRenderAnchorAdjustment: null,
@@ -260,6 +270,8 @@ function resolveChatHistoryRenderWindow(
   const previousCount = state.historyRenderMessageCount;
   if (sessionChanged || (refChanged && previousCount === 0)) {
     state.historyRenderLastScrollTop = null;
+    state.historyRenderOffsetFromEnd = 0;
+    state.historyRenderAwaitingOlderPrepend = false;
   }
 
   if (cap === 0) {
@@ -267,6 +279,8 @@ function resolveChatHistoryRenderWindow(
     state.historyRenderMessagesRef = messages;
     state.historyRenderMessageCount = messages.length;
     state.historyRenderLimit = 0;
+    state.historyRenderOffsetFromEnd = 0;
+    state.historyRenderAwaitingOlderPrepend = false;
     state.historyRenderLastScrollTop = null;
     return 0;
   }
@@ -276,13 +290,28 @@ function resolveChatHistoryRenderWindow(
     state.historyRenderMessagesRef = messages;
     state.historyRenderMessageCount = messages.length;
     state.historyRenderLimit = cap;
+    state.historyRenderOffsetFromEnd = 0;
     return cap;
   }
 
   if (sessionChanged || (refChanged && previousCount === 0)) {
     state.historyRenderLimit = Math.min(INITIAL_CHAT_HISTORY_RENDER_WINDOW, cap);
+    state.historyRenderOffsetFromEnd = 0;
   } else if (refChanged) {
     const grewBy = messages.length - previousCount;
+    // Keep the exclusive window end stable across prepend/append so a movable
+    // older window does not jump when the message array grows. Pinned-newest
+    // (offset 0) stays pinned unless an older-page fetch is landing.
+    if (grewBy > 0) {
+      if (state.historyRenderAwaitingOlderPrepend || state.historyRenderOffsetFromEnd > 0) {
+        state.historyRenderOffsetFromEnd += grewBy;
+      }
+    } else if (grewBy < 0) {
+      state.historyRenderOffsetFromEnd = 0;
+    }
+    if (state.historyRenderAwaitingOlderPrepend && grewBy > 0) {
+      state.historyRenderAwaitingOlderPrepend = false;
+    }
     if (state.historyRenderLimit >= previousCount) {
       state.historyRenderLimit = cap;
     } else if (grewBy > 0 && grewBy <= CHAT_HISTORY_RENDER_WINDOW_BATCH) {
@@ -299,7 +328,26 @@ function resolveChatHistoryRenderWindow(
   state.historyRenderMessagesRef = messages;
   state.historyRenderMessageCount = messages.length;
   state.historyRenderLimit = Math.min(Math.max(1, state.historyRenderLimit), cap);
+  const maxOffset = Math.max(0, messages.length - state.historyRenderLimit);
+  state.historyRenderOffsetFromEnd = Math.min(
+    Math.max(0, state.historyRenderOffsetFromEnd),
+    maxOffset,
+  );
   return state.historyRenderLimit;
+}
+
+function captureChatHistoryRenderAnchor(state: ChatThreadState, thread: HTMLElement) {
+  // A newer top-scroll capture supersedes any pending apply from an earlier
+  // expand; otherwise a stubbed/unflushed rAF leaves historyRenderAnchorFrame
+  // set and silently drops the post-fetch restoration.
+  if (state.historyRenderAnchorFrame != null) {
+    cancelAnimationFrame(state.historyRenderAnchorFrame);
+    state.historyRenderAnchorFrame = null;
+  }
+  state.historyRenderAnchorAdjustment = {
+    scrollHeight: thread.scrollHeight,
+    scrollTop: Math.max(0, thread.scrollTop),
+  };
 }
 
 function maybeExpandChatHistoryRenderWindow(
@@ -309,7 +357,7 @@ function maybeExpandChatHistoryRenderWindow(
   opts: {
     historyHasMore?: boolean;
     historyLoadingOlder?: boolean;
-    onLoadOlderHistory?: () => void;
+    onLoadOlderHistory?: () => void | Promise<unknown>;
   } = {},
 ) {
   const target = event.currentTarget;
@@ -323,6 +371,12 @@ function maybeExpandChatHistoryRenderWindow(
   const isTop = scrollTop <= CHAT_HISTORY_RENDER_EXPAND_SCROLL_TOP_PX;
   const isBottomAutoScroll =
     scrollTop > 0 && distanceFromBottom <= CHAT_HISTORY_RENDER_EXPAND_SCROLL_TOP_PX;
+  // Return to the newest edge when the user scrolls back to the live tail.
+  if (isBottomAutoScroll && state.historyRenderOffsetFromEnd > 0) {
+    state.historyRenderOffsetFromEnd = 0;
+    requestUpdate();
+    return;
+  }
   const isTopScrollUp =
     isTop &&
     (scrollTop === 0 ||
@@ -330,34 +384,49 @@ function maybeExpandChatHistoryRenderWindow(
   if (!isTopScrollUp) {
     return;
   }
-  const cap = resolveChatHistoryRenderCap(state.historyRenderMessageCount);
-  if (state.historyRenderLimit >= cap) {
-    // Local window already shows every loaded message — fetch an older page
-    // when the gateway says more transcript remains.
-    if (
-      opts.historyHasMore &&
-      !opts.historyLoadingOlder &&
-      typeof opts.onLoadOlderHistory === "function"
-    ) {
-      state.historyRenderAnchorAdjustment = {
-        scrollHeight: target.scrollHeight,
-        scrollTop,
-      };
-      scheduleChatHistoryRenderAnchorPreservation(state, target);
-      opts.onLoadOlderHistory();
-    }
+  const messageCount = state.historyRenderMessageCount;
+  const windowEnd = Math.max(0, messageCount - state.historyRenderOffsetFromEnd);
+  const windowCap = Math.min(CHAT_HISTORY_RENDER_HARD_CAP, windowEnd);
+  if (state.historyRenderLimit < windowCap) {
+    captureChatHistoryRenderAnchor(state, target);
+    scheduleChatHistoryRenderAnchorPreservation(state, target);
+    state.historyRenderLimit = Math.min(
+      windowCap,
+      state.historyRenderLimit + CHAT_HISTORY_RENDER_WINDOW_BATCH,
+    );
+    requestUpdate();
     return;
   }
-  state.historyRenderAnchorAdjustment = {
-    scrollHeight: target.scrollHeight,
-    scrollTop,
-  };
-  scheduleChatHistoryRenderAnchorPreservation(state, target);
-  state.historyRenderLimit = Math.min(
-    cap,
-    state.historyRenderLimit + CHAT_HISTORY_RENDER_WINDOW_BATCH,
-  );
-  requestUpdate();
+
+  // Local window already fills the hard cap for the current end — slide into
+  // older loaded messages before asking the gateway for another page.
+  const maxOffsetFromEnd = Math.max(0, messageCount - state.historyRenderLimit);
+  if (state.historyRenderOffsetFromEnd < maxOffsetFromEnd) {
+    captureChatHistoryRenderAnchor(state, target);
+    scheduleChatHistoryRenderAnchorPreservation(state, target);
+    state.historyRenderOffsetFromEnd = Math.min(
+      maxOffsetFromEnd,
+      state.historyRenderOffsetFromEnd + CHAT_HISTORY_RENDER_WINDOW_BATCH,
+    );
+    requestUpdate();
+    return;
+  }
+
+  if (
+    opts.historyHasMore &&
+    !opts.historyLoadingOlder &&
+    !state.historyRenderAwaitingOlderPrepend &&
+    typeof opts.onLoadOlderHistory === "function"
+  ) {
+    captureChatHistoryRenderAnchor(state, target);
+    state.historyRenderAwaitingOlderPrepend = true;
+    // Do not schedule the anchor frame yet: the gateway fetch is async and a
+    // premature rAF clears the adjustment before Lit renders the prepend.
+    const loadResult = opts.onLoadOlderHistory();
+    void Promise.resolve(loadResult).finally(() => {
+      scheduleChatHistoryRenderAnchorPreservationAfterRender(state, target);
+    });
+  }
 }
 
 function scheduleChatHistoryRenderAnchorPreservation(state: ChatThreadState, thread: HTMLElement) {
@@ -376,6 +445,41 @@ function scheduleChatHistoryRenderAnchorPreservation(state: ChatThreadState, thr
   });
 }
 
+/**
+ * Keep the pre-fetch scroll anchor until after Lit commits the prepended page
+ * and layout grows scrollHeight. A single pre-fetch rAF observes no growth and
+ * would clear the adjustment too early.
+ */
+function scheduleChatHistoryRenderAnchorPreservationAfterRender(
+  state: ChatThreadState,
+  thread: HTMLElement,
+  attempts = 0,
+) {
+  const adjustment = state.historyRenderAnchorAdjustment;
+  if (!adjustment || state.historyRenderAnchorFrame != null) {
+    return;
+  }
+  state.historyRenderAnchorFrame = requestAnimationFrame(() => {
+    state.historyRenderAnchorFrame = null;
+    if (state.historyRenderAnchorAdjustment !== adjustment) {
+      return;
+    }
+    const heightDelta = thread.scrollHeight - adjustment.scrollHeight;
+    if (heightDelta <= 0) {
+      if (attempts < 8) {
+        scheduleChatHistoryRenderAnchorPreservationAfterRender(state, thread, attempts + 1);
+        return;
+      }
+      // Fetch failed or produced no DOM growth — release the in-flight gate.
+      state.historyRenderAnchorAdjustment = null;
+      state.historyRenderAwaitingOlderPrepend = false;
+      return;
+    }
+    state.historyRenderAnchorAdjustment = null;
+    thread.scrollTop = adjustment.scrollTop + heightDelta;
+  });
+}
+
 function scheduleChatHistoryRenderWindowFill(
   state: ChatThreadState,
   thread: HTMLElement | null,
@@ -385,14 +489,19 @@ function scheduleChatHistoryRenderWindowFill(
   if (!thread || state.historyRenderExpansionFrame != null) {
     return;
   }
-  const cap = resolveChatHistoryRenderCap(state.historyRenderMessageCount);
-  if (state.historyRenderLimit >= cap) {
+  const windowEnd = Math.max(0, state.historyRenderMessageCount - state.historyRenderOffsetFromEnd);
+  const windowCap = Math.min(CHAT_HISTORY_RENDER_HARD_CAP, windowEnd);
+  if (state.historyRenderLimit >= windowCap) {
     return;
   }
   state.historyRenderExpansionFrame = requestAnimationFrame(() => {
     state.historyRenderExpansionFrame = null;
-    const nextCap = resolveChatHistoryRenderCap(state.historyRenderMessageCount);
-    if (state.historyRenderLimit >= nextCap) {
+    const nextWindowEnd = Math.max(
+      0,
+      state.historyRenderMessageCount - state.historyRenderOffsetFromEnd,
+    );
+    const nextWindowCap = Math.min(CHAT_HISTORY_RENDER_HARD_CAP, nextWindowEnd);
+    if (state.historyRenderLimit >= nextWindowCap) {
       return;
     }
     const canScroll = thread.scrollHeight - thread.clientHeight > 1;
@@ -400,7 +509,7 @@ function scheduleChatHistoryRenderWindowFill(
       return;
     }
     state.historyRenderLimit = Math.min(
-      nextCap,
+      nextWindowCap,
       state.historyRenderLimit + CHAT_HISTORY_RENDER_WINDOW_BATCH,
     );
     requestUpdate();
@@ -782,6 +891,7 @@ export function renderChatThread(props: ChatThreadProps) {
     searchOpen: state.searchOpen,
     searchQuery: state.searchQuery,
     historyRenderLimit,
+    historyRenderOffsetFromEnd: state.historyRenderOffsetFromEnd,
     historyHasMore: props.historyHasMore,
     historyTotalMessages: props.historyTotalMessages,
   });

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -14,7 +14,7 @@ import {
   handleMarkdownCodeBlockCopy,
   markdownFileLinkFromEvent,
 } from "../../../components/markdown.ts";
-import { CHAT_HISTORY_RENDER_LIMIT } from "../../../lib/chat/chat-types.ts";
+import { CHAT_HISTORY_RENDER_HARD_CAP } from "../../../lib/chat/chat-types.ts";
 import type { ChatQueueItem, ChatStreamSegment } from "../../../lib/chat/chat-types.ts";
 import { extractTextCached } from "../../../lib/chat/message-extract.ts";
 import {
@@ -123,6 +123,12 @@ type ChatThreadProps = {
   onRequestUpdate?: () => void;
   onScrollToBottom?: () => void;
   onChatScroll?: (event: Event) => void;
+  /** Fetch older transcript pages when the local render window is exhausted. */
+  onLoadOlderHistory?: () => void;
+  /** True when older transcript pages remain on the server. */
+  historyHasMore?: boolean;
+  historyTotalMessages?: number | null;
+  historyLoadingOlder?: boolean;
   onDraftChange: (next: string) => void;
   /** Current composer draft; the selection popup preserves it when prefilling. */
   getDraft?: () => string;
@@ -233,7 +239,7 @@ export function resetChatThreadPresentationState(paneId?: string) {
 }
 
 function resolveChatHistoryRenderCap(messageCount: number): number {
-  return Math.min(Math.max(0, messageCount), CHAT_HISTORY_RENDER_LIMIT);
+  return Math.min(Math.max(0, messageCount), CHAT_HISTORY_RENDER_HARD_CAP);
 }
 
 function shouldRenderFullChatHistoryWindow(state: ChatThreadState, messageCount: number): boolean {
@@ -300,6 +306,11 @@ function maybeExpandChatHistoryRenderWindow(
   state: ChatThreadState,
   event: Event,
   requestUpdate: () => void,
+  opts: {
+    historyHasMore?: boolean;
+    historyLoadingOlder?: boolean;
+    onLoadOlderHistory?: () => void;
+  } = {},
 ) {
   const target = event.currentTarget;
   if (!(target instanceof HTMLElement)) {
@@ -321,6 +332,20 @@ function maybeExpandChatHistoryRenderWindow(
   }
   const cap = resolveChatHistoryRenderCap(state.historyRenderMessageCount);
   if (state.historyRenderLimit >= cap) {
+    // Local window already shows every loaded message — fetch an older page
+    // when the gateway says more transcript remains.
+    if (
+      opts.historyHasMore &&
+      !opts.historyLoadingOlder &&
+      typeof opts.onLoadOlderHistory === "function"
+    ) {
+      state.historyRenderAnchorAdjustment = {
+        scrollHeight: target.scrollHeight,
+        scrollTop,
+      };
+      scheduleChatHistoryRenderAnchorPreservation(state, target);
+      opts.onLoadOlderHistory();
+    }
     return;
   }
   state.historyRenderAnchorAdjustment = {
@@ -757,6 +782,8 @@ export function renderChatThread(props: ChatThreadProps) {
     searchOpen: state.searchOpen,
     searchQuery: state.searchQuery,
     historyRenderLimit,
+    historyHasMore: props.historyHasMore,
+    historyTotalMessages: props.historyTotalMessages,
   });
   syncToolCardExpansionState(props.sessionKey, chatItems, Boolean(props.autoExpandToolCalls));
   const expandedToolCards = getExpandedToolCards(props.sessionKey);
@@ -788,7 +815,11 @@ export function renderChatThread(props: ChatThreadProps) {
   const threadContextWindow =
     activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null;
   const handleChatThreadScroll = (event: Event) => {
-    maybeExpandChatHistoryRenderWindow(state, event, requestUpdate);
+    maybeExpandChatHistoryRenderWindow(state, event, requestUpdate, {
+      historyHasMore: props.historyHasMore,
+      historyLoadingOlder: props.historyLoadingOlder,
+      onLoadOlderHistory: props.onLoadOlderHistory,
+    });
     props.onChatScroll?.(event);
   };
 

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -501,6 +501,40 @@ function installControlUiMockGateway(input: {
     };
   }
 
+  function buildPaginatedHistoryPayload(params: unknown): Record<string, unknown> {
+    const all = scenario.historyMessages;
+    const totalMessages = all.length;
+    const base = {
+      sessionId: "control-ui-e2e-session",
+      thinkingLevel: null,
+    };
+    const hasOffset =
+      isRecord(params) && typeof params.offset === "number" && Number.isFinite(params.offset);
+    // Preserve the legacy all-messages response when callers omit offset so
+    // existing non-paginated Control UI e2e fixtures stay deterministic.
+    if (!hasOffset) {
+      return { ...base, messages: all };
+    }
+    const offset = Math.max(0, Math.floor(params.offset as number));
+    const limit =
+      isRecord(params) && typeof params.limit === "number" && Number.isFinite(params.limit)
+        ? Math.max(1, Math.floor(params.limit))
+        : 100;
+    const end = Math.max(0, totalMessages - offset);
+    const start = Math.max(0, end - limit);
+    const messages = all.slice(start, end);
+    const nextOffset = offset + messages.length;
+    const hasMore = nextOffset < totalMessages;
+    return {
+      ...base,
+      messages,
+      offset,
+      hasMore,
+      totalMessages,
+      ...(hasMore ? { nextOffset } : {}),
+    };
+  }
+
   function buildResponse(method: string, params: unknown): unknown {
     if (method === "sessions.patch") {
       recordSessionPatch(params);
@@ -587,13 +621,10 @@ function installControlUiMockGateway(input: {
       case "artifacts.download":
         return null;
       case "chat.history":
-        return {
-          messages: scenario.historyMessages,
-          sessionId: "control-ui-e2e-session",
-          thinkingLevel: null,
-        };
+        return buildPaginatedHistoryPayload(params);
       case "chat.startup":
         return {
+          ...buildPaginatedHistoryPayload(params),
           agentsList: {
             agents: [
               {
@@ -607,12 +638,9 @@ function installControlUiMockGateway(input: {
             mainKey: "main",
             scope: "agent",
           },
-          messages: scenario.historyMessages,
           metadata: {
             models: scenario.models,
           },
-          sessionId: "control-ui-e2e-session",
-          thinkingLevel: null,
         };
       case "chat.metadata":
         return {


### PR DESCRIPTION
Closes #104543

AI-assisted

## What Problem This Solves

Fixes an issue where users viewing a long Control UI chat transcript would only see the first `chat.history` page (limit 100) and could expand only within that already-loaded window. Scrolling to the top never requested older transcript pages, so prior messages on the server looked missing even though `chat.history` already supports `offset` / `nextOffset` / `hasMore` / `totalMessages`.

## Why This Change Was Made

The Control UI now requests the first history page with `offset: 0` so pagination metadata is returned, keeps the cursor on chat state, and fetches the next older page when the user scrolls to the top after the local render window is exhausted. Older messages are prepended with scroll-anchor preservation that waits until after the async page renders, and the bounded DOM window can slide into older fetched pages once the 2,000-message hard cap is full. The hidden-history notice distinguishes locally unrendered loaded messages from older server pages that have not been fetched yet.

## User Impact

On long sessions, scrolling near the top of the transcript loads older messages from the gateway instead of stopping at the first 100. After more than 2,000 messages are loaded, scrolling up continues through older fetched pages without unbounded DOM growth. The history notice makes it clear when more messages still exist on the server.

## Evidence

Focused UI unit tests (local) on head `31d09f3b12`:

```text
pnpm test ui/src/pages/chat/chat-gateway.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-send.test.ts
# Test Files  4 passed (4)
# Tests  569 passed (569)
```

Redacted Control UI browser proof (Playwright + mocked Gateway) on head `31d09f3b12`:

```text
pnpm test:ui:e2e ui/src/e2e/chat-history-pagination-proof.e2e.test.ts
# Test Files  1 passed (1)
# Tests  1 passed (1)
```

Proven in browser:
- first page loads newest edge of a 2,200-message transcript with pagination metadata
- top-scroll requests an older `chat.history` page
- older page intentionally delayed 1,000ms before resolve; pre-fetch scroll top preserved
- after prepend, deep scroll reaches `msg-0` through the movable 2,000-message DOM window
- notice shows `Showing 2000 messages (200 hidden)` while newest messages are not rendered

Artifacts (redacted synthetic `msg-N` labels only):
- Release: https://github.com/tiffanychum/openclaw/releases/tag/proof-104570-3d6c9dc962
- Newest page: https://github.com/tiffanychum/openclaw/releases/download/proof-104570-3d6c9dc962/01-newest-page.png
- Waiting on delayed older page: https://github.com/tiffanychum/openclaw/releases/download/proof-104570-3d6c9dc962/02-waiting-delayed-older-page.png
- After delayed older page: https://github.com/tiffanychum/openclaw/releases/download/proof-104570-3d6c9dc962/03-after-delayed-older-page.png
- Deep scroll past hard cap: https://github.com/tiffanychum/openclaw/releases/download/proof-104570-3d6c9dc962/04-deep-scroll-past-hard-cap.png
- Recording: https://github.com/tiffanychum/openclaw/releases/download/proof-104570-3d6c9dc962/chat-history-pagination-proof.webm
- Metadata: https://github.com/tiffanychum/openclaw/releases/download/proof-104570-3d6c9dc962/chat-history-pagination-proof.json

Replay harness: `ui/src/e2e/chat-history-pagination-proof.e2e.test.ts`
