### PR TITLE
fix(macos): dashboard titlebar buttons sit too close together

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -496,9 +496,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 
         let stack = NSStackView(views: [sidebar, back, forward])
         stack.orientation = .horizontal
-        stack.spacing = 6
+        stack.spacing = 12
         stack.edgeInsets = NSEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
-        stack.setFrameSize(NSSize(width: 104, height: 28))
+        // Fixed accessory frame: 12 leading inset + three ~27pt buttons + two
+        // 12pt gaps. Keep in sync with `spacing`/`edgeInsets` above.
+        stack.setFrameSize(NSSize(width: 116, height: 28))
 
         let accessory = NSTitlebarAccessoryViewController()
         accessory.view = stack


### PR DESCRIPTION
Related: #104380

## What Problem This Solves

Fixes an issue where the macOS dashboard window's titlebar controls (sidebar toggle, back, forward) sit too close together next to the traffic lights, making them look cramped and easy to mis-click.

## Why This Change Was Made

The titlebar accessory introduced in #104380 laid out the three buttons in an `NSStackView` with a 6pt gap. Doubling the gap to 12pt (Safari-like spacing) and widening the fixed accessory frame accordingly keeps the button sizes unchanged while giving each control breathing room.

## User Impact

The sidebar toggle and back/forward buttons in the macOS app titlebar are visually separated and easier to hit; no behavior change.

## Evidence

- `swift build` of `apps/macos` succeeds on macOS (Darwin 25.5).
- Geometry: accessory frame width goes 104 → 116 to absorb the two extra 6pt gaps (12 leading inset + 3 × ~27pt buttons + 2 × 12pt spacing), so button hit areas are unchanged.
- No tests or web-UI CSS reference the accessory width; only the titlebar height CSS variable (unchanged) is shared with `ui/`.
