### PR TITLE
refactor(ui): unify chat icon buttons on one borderless design and align top chrome rows

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -1045,7 +1045,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
 
     try {
       await page.goto(`${server.baseUrl}chat`);
-      await page.locator(".chat-workspace-open").click();
+      await page.locator(".chat-workspace-toggle").click();
       await page.getByText("AGENTS.md").waitFor({ timeout: 10_000 });
 
       await page.getByRole("button", { name: "Copy path" }).click();
@@ -1116,7 +1116,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}chat`);
       // Collapsed rails render nothing; the floating opener (with the
       // changed-file badge) is the only pointer affordance.
-      const opener = page.locator(".chat-workspace-open");
+      const opener = page.locator(".chat-workspace-toggle");
       await opener.waitFor({ timeout: 10_000 });
       expect(await gateway.getRequests("sessions.files.list")).toHaveLength(0);
       expect(await page.locator(".chat-workspace-rail").count()).toBe(0);
@@ -1188,7 +1188,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
 
     try {
       await page.goto(`${server.baseUrl}chat`);
-      await page.locator(".chat-workspace-open").click();
+      await page.locator(".chat-workspace-toggle").click();
       await page.locator(".chat-workspace-rail__file-name", { hasText: "file-60.ts" }).waitFor({
         timeout: 10_000,
       });

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1208,14 +1208,14 @@ class ChatPane extends OpenClawLightDomElement {
              drag-and-drop. -->
         <span class="chat-pane__session-title" title=${this.paneTitle}>${this.paneTitle}</span>
         <div class="chat-pane__actions">
-          ${renderSessionDiffToggle(sessionWorkspace, "pane-header")}
-          ${renderBackgroundTasksToggle(backgroundTasks, "pane-header")}
-          ${renderSessionWorkspaceToggle(sessionWorkspace, "pane-header")}
+          ${renderSessionDiffToggle(sessionWorkspace)}
+          ${renderBackgroundTasksToggle(backgroundTasks)}
+          ${renderSessionWorkspaceToggle(sessionWorkspace)}
           ${!this.narrow
             ? html`
                 <openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
                   <button
-                    class="btn btn--ghost btn--icon"
+                    class="btn btn--icon chat-icon-btn"
                     type="button"
                     aria-label=${t("chat.splitView.splitDown")}
                     @click=${() => this.onSplitDown?.(this.paneId)}
@@ -1225,7 +1225,7 @@ class ChatPane extends OpenClawLightDomElement {
                 </openclaw-tooltip>
                 <openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
                   <button
-                    class="btn btn--ghost btn--icon"
+                    class="btn btn--icon chat-icon-btn"
                     type="button"
                     aria-label=${t("chat.splitView.splitRight")}
                     @click=${() => this.onSplitRight?.(this.paneId)}
@@ -1237,7 +1237,7 @@ class ChatPane extends OpenClawLightDomElement {
             : nothing}
           <openclaw-tooltip .content=${t("chat.splitView.closePane")}>
             <button
-              class="btn btn--ghost btn--icon"
+              class="btn btn--icon chat-icon-btn"
               type="button"
               aria-label=${t("chat.splitView.closePane")}
               @click=${() => this.onClosePane?.(this.paneId)}

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1215,7 +1215,7 @@ class ChatPane extends OpenClawLightDomElement {
             ? html`
                 <openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
                   <button
-                    class="btn btn--icon chat-icon-btn"
+                    class="btn btn--ghost btn--icon chat-icon-btn"
                     type="button"
                     aria-label=${t("chat.splitView.splitDown")}
                     @click=${() => this.onSplitDown?.(this.paneId)}
@@ -1225,7 +1225,7 @@ class ChatPane extends OpenClawLightDomElement {
                 </openclaw-tooltip>
                 <openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
                   <button
-                    class="btn btn--icon chat-icon-btn"
+                    class="btn btn--ghost btn--icon chat-icon-btn"
                     type="button"
                     aria-label=${t("chat.splitView.splitRight")}
                     @click=${() => this.onSplitRight?.(this.paneId)}
@@ -1237,7 +1237,7 @@ class ChatPane extends OpenClawLightDomElement {
             : nothing}
           <openclaw-tooltip .content=${t("chat.splitView.closePane")}>
             <button
-              class="btn btn--icon chat-icon-btn"
+              class="btn btn--ghost btn--icon chat-icon-btn"
               type="button"
               aria-label=${t("chat.splitView.closePane")}
               @click=${() => this.onClosePane?.(this.paneId)}

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1463,7 +1463,7 @@ describe("chat composer workbench", () => {
 
     // A collapsed rail renders nothing — no icon strip in the layout.
     expect(container.querySelector(".chat-workspace-rail")).toBeNull();
-    const toggle = container.querySelector<HTMLButtonElement>(".chat-workspace-open");
+    const toggle = container.querySelector<HTMLButtonElement>(".chat-workspace-toggle");
     expect(toggle?.getAttribute("aria-label")).toBe("Show session files");
     expect(toggle?.getAttribute("aria-expanded")).toBe("false");
     expect(toggle?.getAttribute("aria-keyshortcuts")).toBe("Meta+Shift+B");
@@ -1523,7 +1523,7 @@ describe("chat composer workbench", () => {
       },
     });
 
-    expect(container.querySelector(".chat-workspace-open")).toBeNull();
+    expect(container.querySelector(".chat-workspace-toggle")).toBeNull();
     expect(container.querySelector(".chat-workspace-rail")).toBeNull();
   });
 

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -434,7 +434,7 @@ export function renderChat(props: ChatProps) {
                     ? html`
                         <openclaw-tooltip .content=${t("chat.splitView.open")}>
                           <button
-                            class="btn btn--sm btn--icon chat-open-split-view"
+                            class="btn btn--icon chat-icon-btn chat-open-split-view"
                             type="button"
                             aria-label=${t("chat.splitView.open")}
                             @click=${props.onOpenSplitView}
@@ -445,13 +445,13 @@ export function renderChat(props: ChatProps) {
                       `
                     : nothing}
                   ${props.sessionWorkspace?.collapsed
-                    ? renderSessionDiffToggle(props.sessionWorkspace, "floating")
+                    ? renderSessionDiffToggle(props.sessionWorkspace)
                     : nothing}
                   ${props.backgroundTasks?.collapsed
-                    ? renderBackgroundTasksToggle(props.backgroundTasks, "floating")
+                    ? renderBackgroundTasksToggle(props.backgroundTasks)
                     : nothing}
                   ${props.sessionWorkspace?.collapsed
-                    ? renderSessionWorkspaceToggle(props.sessionWorkspace, "floating")
+                    ? renderSessionWorkspaceToggle(props.sessionWorkspace)
                     : nothing}
                 </div>
               `

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -434,7 +434,7 @@ export function renderChat(props: ChatProps) {
                     ? html`
                         <openclaw-tooltip .content=${t("chat.splitView.open")}>
                           <button
-                            class="btn btn--icon chat-icon-btn chat-open-split-view"
+                            class="btn btn--ghost btn--icon chat-icon-btn chat-open-split-view"
                             type="button"
                             aria-label=${t("chat.splitView.open")}
                             @click=${props.onOpenSplitView}

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -308,7 +308,6 @@ export function backgroundTasksActiveCount(props: BackgroundTasksProps | undefin
 
 export function renderBackgroundTasksToggle(
   backgroundTasks: BackgroundTasksProps | undefined,
-  variant: "pane-header" | "floating",
 ): TemplateResult | typeof nothing {
   if (!backgroundTasks) {
     return nothing;
@@ -319,9 +318,7 @@ export function renderBackgroundTasksToggle(
   return html`
     <openclaw-tooltip .content=${label}>
       <button
-        class="${variant === "pane-header"
-          ? "btn btn--ghost btn--icon"
-          : "btn btn--sm btn--icon chat-tasks-open"} chat-tasks-toggle"
+        class="btn btn--icon chat-icon-btn chat-tasks-toggle"
         type="button"
         aria-label=${label}
         aria-expanded=${String(expanded)}

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -318,7 +318,7 @@ export function renderBackgroundTasksToggle(
   return html`
     <openclaw-tooltip .content=${label}>
       <button
-        class="btn btn--icon chat-icon-btn chat-tasks-toggle"
+        class="btn btn--ghost btn--icon chat-icon-btn chat-tasks-toggle"
         type="button"
         aria-label=${label}
         aria-expanded=${String(expanded)}

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -716,7 +716,7 @@ export function renderSessionWorkspaceToggle(
   return html`
     <openclaw-tooltip .content=${`${label} (⇧⌘B)`}>
       <button
-        class="btn btn--icon chat-icon-btn chat-workspace-toggle"
+        class="btn btn--ghost btn--icon chat-icon-btn chat-workspace-toggle"
         type="button"
         aria-label=${label}
         aria-keyshortcuts="Meta+Shift+B"
@@ -746,7 +746,7 @@ export function renderSessionDiffToggle(
   return html`
     <openclaw-tooltip .content=${label}>
       <button
-        class="btn btn--icon chat-icon-btn chat-session-diff-toggle"
+        class="btn btn--ghost btn--icon chat-icon-btn chat-session-diff-toggle"
         type="button"
         aria-label=${label}
         @click=${sessionWorkspace.onOpenDiff}

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -706,7 +706,6 @@ export function sessionWorkspaceModifiedCount(
  * this button is the only pointer affordance (⇧⌘B still works). */
 export function renderSessionWorkspaceToggle(
   sessionWorkspace: SessionWorkspaceProps | undefined,
-  variant: "pane-header" | "floating",
 ): TemplateResult | typeof nothing {
   if (!sessionWorkspace) {
     return nothing;
@@ -717,9 +716,7 @@ export function renderSessionWorkspaceToggle(
   return html`
     <openclaw-tooltip .content=${`${label} (⇧⌘B)`}>
       <button
-        class="${variant === "pane-header"
-          ? "btn btn--ghost btn--icon"
-          : "btn btn--sm btn--icon chat-workspace-open"} chat-workspace-toggle"
+        class="btn btn--icon chat-icon-btn chat-workspace-toggle"
         type="button"
         aria-label=${label}
         aria-keyshortcuts="Meta+Shift+B"
@@ -741,7 +738,6 @@ export function renderSessionWorkspaceToggle(
  * gateway does not advertise sessions.diff. */
 export function renderSessionDiffToggle(
   sessionWorkspace: SessionWorkspaceProps | undefined,
-  variant: "pane-header" | "floating",
 ): TemplateResult | typeof nothing {
   if (!sessionWorkspace?.onOpenDiff) {
     return nothing;
@@ -750,9 +746,7 @@ export function renderSessionDiffToggle(
   return html`
     <openclaw-tooltip .content=${label}>
       <button
-        class="${variant === "pane-header"
-          ? "btn btn--ghost btn--icon"
-          : "btn btn--sm btn--icon chat-diff-open"} chat-session-diff-toggle"
+        class="btn btn--icon chat-icon-btn chat-session-diff-toggle"
         type="button"
         aria-label=${label}
         @click=${sessionWorkspace.onOpenDiff}

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -55,27 +55,35 @@
    free as a window-drag surface in the native macOS app. */
 .chat-floating-toggles {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  /* 8px top + 2px row padding keeps the 28px buttons on the shared 24px
+     chrome centerline (sidebar brand row, pane-header actions). */
+  top: 8px;
+  right: 8px;
   z-index: 12;
   display: flex;
-  gap: 6px;
+  /* Same tight spacing as .chat-pane__actions so both rows read identical. */
+  gap: 2px;
+  /* Ghost buttons carry no chrome of their own, but scrolled thread content
+     passes under this row; a frosted wash keeps the icons legible without
+     reading as boxed buttons. Invisible over the empty titlebar band. */
+  padding: 2px;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }
 
 /* Compact icon button shared by the split-pane header actions and the
-   floating toggles above: one 28px boxed design so both surfaces match.
-   .btn--icon's 36px min-width/height would win otherwise. */
+   floating toggles above: one borderless 28px design so both surfaces match.
+   Sizing only — chrome stays ghost; .btn--icon's 36px min-width/height would
+   win otherwise. The floating row sits in the thread's reserved titlebar band
+   (never over content), so it needs no backdrop of its own. */
 .chat-icon-btn {
   width: 28px;
   min-width: 28px;
   height: 28px;
   min-height: 28px;
   padding: 5px;
-  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-  background: color-mix(in srgb, var(--panel) 92%, transparent);
-  box-shadow: var(--shadow-sm);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
 }
 
 /* The workspace rail adapts to the pane width (side column on wide panes,

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -62,12 +62,10 @@
   gap: 6px;
 }
 
-.chat-workspace-open,
-.chat-tasks-open,
-.chat-diff-open,
-.chat-open-split-view {
-  /* Match the 28px pane-header/split-view openers; .btn--icon's
-     min-width/height of 36px would win otherwise. */
+/* Compact icon button shared by the split-pane header actions and the
+   floating toggles above: one 28px boxed design so both surfaces match.
+   .btn--icon's 36px min-width/height would win otherwise. */
+.chat-icon-btn {
   width: 28px;
   min-width: 28px;
   height: 28px;
@@ -86,8 +84,7 @@
    side-dock only, so its toggles still hide on narrow viewports until it
    grows a narrow presentation. */
 @media (max-width: 1120px) {
-  .chat-tasks-open,
-  .chat-pane__actions .chat-tasks-toggle {
+  .chat-tasks-toggle {
     display: none;
   }
 }
@@ -1745,7 +1742,7 @@
 /* ── Session diff panel (sessions.diff sidebar content) ── */
 
 /* The floating diff opener sits in the .chat-floating-toggles row and shares
-   the .chat-workspace-open sizing/chrome rules near the top of this file. */
+   the .chat-icon-btn sizing/chrome rules near the top of this file. */
 
 .session-diff {
   display: flex;

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -159,16 +159,8 @@ openclaw-chat-pane {
 .chat-pane__actions {
   display: flex;
   align-items: center;
-  gap: 2px;
+  /* Boxed .chat-icon-btn buttons need more breathing room than the old
+     borderless icons; matches the .chat-floating-toggles row gap. */
+  gap: 6px;
   flex: 0 0 auto;
-}
-
-.chat-pane__actions .btn--icon {
-  width: 28px;
-  /* .btn--icon's min-width: 36px otherwise wins over width and stretches
-     these into 36x28 pills. */
-  min-width: 28px;
-  height: 28px;
-  min-height: 28px;
-  padding: 5px;
 }

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -132,7 +132,10 @@ openclaw-chat-pane {
   flex: 0 0 auto;
   align-items: center;
   gap: 8px;
-  min-height: 36px;
+  /* 48px centers the 28px actions on the app's shared 24px chrome
+     centerline (sidebar brand row, floating toggles), so split headers
+     line up with the sidebar across the top of the shell. */
+  min-height: 48px;
   padding: 0 6px 0 12px;
   border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
   background: color-mix(in srgb, var(--panel) 62%, transparent);
@@ -159,8 +162,6 @@ openclaw-chat-pane {
 .chat-pane__actions {
   display: flex;
   align-items: center;
-  /* Boxed .chat-icon-btn buttons need more breathing room than the old
-     borderless icons; matches the .chat-floating-toggles row gap. */
-  gap: 6px;
+  gap: 2px;
   flex: 0 0 auto;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -194,7 +194,10 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 
 .settings-sidebar__header {
   flex-shrink: 0;
-  padding: 14px 12px 6px;
+  /* 8px top pad centers the 32px back button on the shared 24px chrome
+     centerline, mirroring .sidebar-shell; macOS overrides with titlebar
+     clearance. */
+  padding: 8px 12px 6px;
 }
 
 .settings-sidebar__back {
@@ -717,7 +720,10 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   flex-direction: column;
   min-height: 0;
   flex: 1;
-  padding: 14px 10px 12px;
+  /* 9px top pad centers the brand row's 30px icons on the app's shared
+     24px chrome centerline (pane-header actions, floating toggles). The
+     macOS app overrides this with its 50px titlebar clearance. */
+  padding: 9px 10px 12px;
   border: none;
   border-radius: 0;
   background: transparent;


### PR DESCRIPTION
## What Problem This Solves

The Control UI chat surface rendered its session icon buttons in two different designs: split-pane headers used borderless ghost icons while the single-pane floating toggles used boxed buttons with a border, panel fill, and shadow. On top of that, the top chrome rows sat on three different centerlines — sidebar brand icons at y≈29, floating toggles at y≈24, pane-header actions at y≈18 — so the sidebar buttons never lined up with the buttons on the right.

## Why This Change Was Made

Unify on one borderless compact icon-button design and one shared chrome centerline:

- The `variant: "pane-header" | "floating"` parameter is removed from `renderSessionDiffToggle` / `renderBackgroundTasksToggle` / `renderSessionWorkspaceToggle`; every chat icon button now renders `btn btn--ghost btn--icon chat-icon-btn`, with the per-variant chrome classes (`chat-workspace-open`, `chat-tasks-open`, `chat-diff-open`) deleted and one shared `.chat-icon-btn` sizing rule replacing the `.chat-pane__actions .btn--icon` override.
- All three top rows now center on the same 24px line: the sidebar brand row (logo + wordmark + actions move together, so the OpenClaw wordmark stays centered with its icons), the floating toggle row, and split-pane headers (36px → 48px, matching the single-pane titlebar band height). The settings sidebar back button mirrors the same shift.
- Scrolled thread content passes under the floating toggles; since the ghost buttons carry no chrome, the row gets a subtle frosted wash (translucent `--bg` + blur, no border/shadow) that is invisible over the empty titlebar band but keeps icons legible over text.

## User Impact

Sidebar header buttons, split-pane header actions, and the floating toggles now share one borderless design and one centerline across the top of the shell, in light and dark themes. No white boxed buttons in light mode. No behavior changes; all actions, badges, tooltips, and the narrow-viewport tasks-toggle hiding work as before. The macOS app's 50px titlebar clearance overrides are untouched.

## Evidence

Verified in the mock dev harness (`pnpm dev:ui:mock`), light and dark themes:

- Split view: all 6 pane-header actions render identical ghost 28×28 buttons; buttons center at y=23.5–24 in the 48px header.
- Sidebar brand icons, wordmark, and logo all center at y=24; floating toggles center at y=24 (measured via `getBoundingClientRect`, Δ ≤ 0.5px).
- Scrolled thread under the floating row: icons stay legible on the frosted wash; no boxed look.
- Dark theme picks up the dark `--bg` wash and ghost hover states; no console errors.
- Settings sidebar back button: 32px control in an 8px-top-padded header → same 24px centerline (the mock harness only serves /chat, so this one is by construction, mirroring the verified brand-row math).

Test selectors that targeted the removed `chat-workspace-open` class now use the shared `chat-workspace-toggle` class (`ui/src/e2e/chat-flow.e2e.test.ts`, `ui/src/pages/chat/chat-view.test.ts`).
