### PR TITLE
fix(mattermost): bound stalled inbound media header waits

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -123,43 +123,43 @@ describe("mattermost monitor resources", () => {
         resolve();
       });
     });
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("expected loopback TCP address");
-    }
-    const fileId = "file-stall";
-    const headerTimeoutMs = 250;
-    const saveRemoteMediaWithHeaderTimeout: typeof saveRemoteMedia = (params) =>
-      saveRemoteMedia({
-        ...params,
-        responseHeaderTimeoutMs: headerTimeoutMs,
-        readIdleTimeoutMs: MATTERMOST_MEDIA_READ_IDLE_TIMEOUT_MS,
-        ssrfPolicy: { ...params.ssrfPolicy, dangerouslyAllowPrivateNetwork: true },
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected loopback TCP address");
+      }
+      const fileId = "file-stall";
+      const headerTimeoutMs = 250;
+      const saveRemoteMediaWithHeaderTimeout: typeof saveRemoteMedia = (params) =>
+        saveRemoteMedia({
+          ...params,
+          responseHeaderTimeoutMs: headerTimeoutMs,
+          readIdleTimeoutMs: MATTERMOST_MEDIA_READ_IDLE_TIMEOUT_MS,
+          ssrfPolicy: { ...params.ssrfPolicy, dangerouslyAllowPrivateNetwork: true },
+        });
+
+      const resources = createMattermostMonitorResources({
+        accountId: "default",
+        callbackUrl: "https://openclaw.test/callback",
+        client: {
+          apiBaseUrl: `http://127.0.0.1:${address.port}/api/v4`,
+          baseUrl: `http://127.0.0.1:${address.port}`,
+          token: "bot-token",
+        } as never,
+        logger: {},
+        mediaMaxBytes: 1024,
+        saveRemoteMedia: saveRemoteMediaWithHeaderTimeout,
+        mediaKindFromMime: () => "image",
       });
 
-    const resources = createMattermostMonitorResources({
-      accountId: "default",
-      callbackUrl: "https://openclaw.test/callback",
-      client: {
-        apiBaseUrl: `http://127.0.0.1:${address.port}/api/v4`,
-        baseUrl: `http://127.0.0.1:${address.port}`,
-        token: "bot-token",
-      } as never,
-      logger: {},
-      mediaMaxBytes: 1024,
-      saveRemoteMedia: saveRemoteMediaWithHeaderTimeout,
-      mediaKindFromMime: () => "image",
-    });
-
-    const started = Date.now();
-    await expect(resources.resolveMattermostMedia([fileId])).resolves.toEqual([]);
-    const elapsedMs = Date.now() - started;
-    expect(elapsedMs).toBeGreaterThanOrEqual(headerTimeoutMs - 50);
-    expect(elapsedMs).toBeLessThan(headerTimeoutMs + 2_000);
-
-    await new Promise<void>((resolve) => {
-      server.close(() => resolve());
-    });
+      const started = Date.now();
+      await expect(resources.resolveMattermostMedia([fileId])).resolves.toEqual([]);
+      const elapsedMs = Date.now() - started;
+      expect(elapsedMs).toBeGreaterThanOrEqual(headerTimeoutMs - 50);
+      expect(elapsedMs).toBeLessThan(headerTimeoutMs + 2_000);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("caches channel and user lookups and falls back to empty picker props", async () => {

--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -158,7 +158,11 @@ describe("mattermost monitor resources", () => {
       expect(elapsedMs).toBeGreaterThanOrEqual(headerTimeoutMs - 50);
       expect(elapsedMs).toBeLessThan(headerTimeoutMs + 2_000);
     } finally {
-      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await new Promise<void>((resolve) => {
+        server.close(() => {
+          resolve();
+        });
+      });
     }
   });
 

--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -21,10 +21,16 @@ vi.mock("./interactions.js", () => ({
 describe("mattermost monitor resources", () => {
   let createMattermostMonitorResources: typeof import("./monitor-resources.js").createMattermostMonitorResources;
   let formatMattermostInboundMediaText: typeof import("./monitor-resources.js").formatMattermostInboundMediaText;
+  let MATTERMOST_MEDIA_RESPONSE_HEADER_TIMEOUT_MS: typeof import("./monitor-resources.js").MATTERMOST_MEDIA_RESPONSE_HEADER_TIMEOUT_MS;
+  let MATTERMOST_MEDIA_READ_IDLE_TIMEOUT_MS: typeof import("./monitor-resources.js").MATTERMOST_MEDIA_READ_IDLE_TIMEOUT_MS;
 
   beforeAll(async () => {
-    ({ createMattermostMonitorResources, formatMattermostInboundMediaText } =
-      await import("./monitor-resources.js"));
+    ({
+      createMattermostMonitorResources,
+      formatMattermostInboundMediaText,
+      MATTERMOST_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
+      MATTERMOST_MEDIA_READ_IDLE_TIMEOUT_MS,
+    } = await import("./monitor-resources.js"));
   });
 
   it("keeps media-only download failures visible to the agent", () => {
@@ -99,6 +105,60 @@ describe("mattermost monitor resources", () => {
       filePathHint: "file-1",
       maxBytes: 1024,
       ssrfPolicy: { allowedHostnames: ["chat.example.com"] },
+      responseHeaderTimeoutMs: MATTERMOST_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
+      readIdleTimeoutMs: MATTERMOST_MEDIA_READ_IDLE_TIMEOUT_MS,
+    });
+  });
+
+  it("times out inbound media downloads when response headers never arrive", async () => {
+    const { createServer } = await import("node:http");
+    const { saveRemoteMedia } = await import("openclaw/plugin-sdk/media-runtime");
+    const server = createServer((_req, _res) => {
+      // Accept the connection but never write status/headers.
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback TCP address");
+    }
+    const fileId = "file-stall";
+    const headerTimeoutMs = 250;
+    const saveRemoteMediaWithHeaderTimeout: typeof saveRemoteMedia = (params) =>
+      saveRemoteMedia({
+        ...params,
+        responseHeaderTimeoutMs: headerTimeoutMs,
+        readIdleTimeoutMs: MATTERMOST_MEDIA_READ_IDLE_TIMEOUT_MS,
+        ssrfPolicy: { ...params.ssrfPolicy, dangerouslyAllowPrivateNetwork: true },
+      });
+
+    const resources = createMattermostMonitorResources({
+      accountId: "default",
+      callbackUrl: "https://openclaw.test/callback",
+      client: {
+        apiBaseUrl: `http://127.0.0.1:${address.port}/api/v4`,
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        token: "bot-token",
+      } as never,
+      logger: {},
+      mediaMaxBytes: 1024,
+      saveRemoteMedia: saveRemoteMediaWithHeaderTimeout,
+      mediaKindFromMime: () => "image",
+    });
+
+    const started = Date.now();
+    await expect(resources.resolveMattermostMedia([fileId])).resolves.toEqual([]);
+    const elapsedMs = Date.now() - started;
+    expect(elapsedMs).toBeGreaterThanOrEqual(headerTimeoutMs - 50);
+    expect(elapsedMs).toBeLessThan(headerTimeoutMs + 2_000);
+
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
     });
   });
 

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -45,6 +45,9 @@ export function formatMattermostInboundMediaText(params: {
 const CHANNEL_CACHE_TTL_MS = 5 * 60_000;
 const USER_CACHE_TTL_MS = 10 * 60_000;
 const MONITOR_RESOURCE_CACHE_MAX_ENTRIES = 1000;
+// Match Telegram/Tlon inbound media: header wait is independent of body idle.
+export const MATTERMOST_MEDIA_RESPONSE_HEADER_TIMEOUT_MS = 120_000;
+export const MATTERMOST_MEDIA_READ_IDLE_TIMEOUT_MS = 30_000;
 
 type SaveRemoteMedia = (params: {
   url: string;
@@ -52,6 +55,8 @@ type SaveRemoteMedia = (params: {
   filePathHint?: string;
   maxBytes: number;
   ssrfPolicy?: { allowedHostnames?: string[] };
+  responseHeaderTimeoutMs?: number;
+  readIdleTimeoutMs?: number;
 }) => Promise<{ path: string; contentType?: string | null }>;
 
 export function createMattermostMonitorResources(params: {
@@ -128,6 +133,10 @@ export function createMattermostMonitorResources(params: {
           filePathHint: fileId,
           maxBytes: mediaMaxBytes,
           ssrfPolicy: { allowedHostnames: [new URL(client.baseUrl).hostname] },
+          // Without these, a Mattermost host that never returns headers can stall
+          // inbound preprocessing indefinitely (idle timeout never starts).
+          responseHeaderTimeoutMs: MATTERMOST_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
+          readIdleTimeoutMs: MATTERMOST_MEDIA_READ_IDLE_TIMEOUT_MS,
         });
         const contentType = saved.contentType ?? undefined;
         out.push({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Mattermost inbound file downloads could hang indefinitely when the remote host accepted the TCP connection but never returned HTTP response headers. The shared media fetch idle timer only starts after headers arrive, so preprocessing of attachment messages could stall the channel path.

## Why This Change Was Made

Pass the same Telegram/Tlon media timeout options (`responseHeaderTimeoutMs: 120s`, `readIdleTimeoutMs: 30s`) through `resolveMattermostMedia` into `saveRemoteMedia`, so stalled header waits fail closed while healthy transfers still get a long header window and an idle body cap.

## User Impact

Inbound Mattermost attachments on a stalled file host fail within the header deadline and continue as unavailable media, instead of blocking message handling.

## Evidence

### Unit + caller-path hang proof

```bash
node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor-resources.test.ts --reporter=verbose
```

```text
 ✓ ... > downloads media, preserves auth headers, and infers media kind 4ms
 ✓ ... > times out inbound media downloads when response headers never arrive 321ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

The hang case runs the production caller `resolveMattermostMedia` against a real loopback HTTP server that never writes headers, using the same option keys this PR wires for production (shortened to 250ms only in the proof harness).

## Real behavior proof

- **Behavior or issue addressed:** Mattermost inbound file downloads no longer hang forever when response headers never arrive.
- **Canonical reachability path:** inbound Mattermost post with `file_ids` → `createMattermostMonitorResources().resolveMattermostMedia` → `core.channel.media.saveRemoteMedia` with `responseHeaderTimeoutMs` / `readIdleTimeoutMs`.
- **Boundary crossed:** local-runtime HTTP; loopback Node server + shared media runtime fetch path.
- **Shared helper / provider constraint check:** Reused `saveRemoteMedia` timeout options already used by Telegram (`120s` header / `30s` idle) and Tlon; no new media API surface.
- **Real environment tested:** macOS, Node via `node scripts/run-vitest.mjs`, loopback `node:http` server that accepts connections without writing headers.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor-resources.test.ts --reporter=verbose`
- **Evidence after fix:**

```text
 ✓ |extension-mattermost| ... > times out inbound media downloads when response headers never arrive 321ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
[test] passed 1 Vitest shard in 60.77s
```

- **Observed result after fix:** Stalled-header download rejects near the harness header deadline (~250ms); `resolveMattermostMedia` returns `[]` so inbound handling continues without the attachment. Production constants remain `120_000` / `30_000`.
- **What was not tested:** Live Mattermost Cloud/self-hosted file API; full Gateway monitor loop with a real bot token.
- **Fix classification:** Root cause fix.

## Risk / Compatibility

Low. Only Mattermost inbound media downloads gain explicit header/idle deadlines. Successful downloads under those budgets are unchanged.
