### PR TITLE
fix(qa-lab): keep telegram QA progress detail truncation UTF-16 safe

### DIFF
--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
@@ -1365,4 +1365,15 @@ describe("telegram live qa runtime", () => {
     expect(message).toContain("Phase: unknown");
     expect(message).toContain("boom");
   });
+
+  it("keeps bounded telegram QA progress details on UTF-16 boundaries", () => {
+    // Regression: progress detail truncation used .slice(0, limit - 3),
+    // which can split an emoji surrogate pair and render as �.
+    const prefix = "a".repeat(237);
+    const details = testing.formatTelegramQaProgressDetails(`${prefix}😀after`);
+
+    expect(details).toBe(`${prefix}...`);
+    expect(details).not.toContain("�");
+    expect(details.length).toBe(240);
+  });
 });

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
@@ -1369,11 +1369,14 @@ describe("telegram live qa runtime", () => {
   it("keeps bounded telegram QA progress details on UTF-16 boundaries", () => {
     // Regression: progress detail truncation used .slice(0, limit - 3),
     // which can split an emoji surrogate pair and render as �.
-    const prefix = "a".repeat(237);
+    // Use 236-code-unit prefix so that .slice(0, 237) keeps only the
+    // high surrogate — current main produces a malformed string here;
+    // truncateUtf16Safe backs up to 236 and returns a clean result.
+    const prefix = "a".repeat(236);
     const details = testing.formatTelegramQaProgressDetails(`${prefix}😀after`);
 
     expect(details).toBe(`${prefix}...`);
     expect(details).not.toContain("�");
-    expect(details.length).toBe(240);
+    expect(details.length).toBe(239);
   });
 });

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
@@ -1367,16 +1367,8 @@ describe("telegram live qa runtime", () => {
   });
 
   it("keeps bounded telegram QA progress details on UTF-16 boundaries", () => {
-    // Regression: progress detail truncation used .slice(0, limit - 3),
-    // which can split an emoji surrogate pair and render as �.
-    // Use 236-code-unit prefix so that .slice(0, 237) keeps only the
-    // high surrogate — current main produces a malformed string here;
-    // truncateUtf16Safe backs up to 236 and returns a clean result.
     const prefix = "a".repeat(236);
-    const details = testing.formatTelegramQaProgressDetails(`${prefix}😀after`);
-
-    expect(details).toBe(`${prefix}...`);
-    expect(details).not.toContain("�");
-    expect(details.length).toBe(239);
+    expect(testing.formatTelegramQaProgressDetails(`${prefix}😀after`)).toBe(`${prefix}...`);
+    expect(testing.formatTelegramQaProgressDetails("a".repeat(241))).toBe(`${"a".repeat(237)}...`);
   });
 });

--- a/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
@@ -12,6 +12,7 @@ import {
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { isRecord, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { z } from "zod";
 import { createQaArtifactRunId } from "../../artifact-run-id.js";
 import {
@@ -481,7 +482,7 @@ function formatTelegramQaProgressDetails(details: string): string {
   if (sanitized.length <= TELEGRAM_QA_PROGRESS_DETAIL_LIMIT) {
     return sanitized;
   }
-  return `${sanitized.slice(0, TELEGRAM_QA_PROGRESS_DETAIL_LIMIT - 3).trimEnd()}...`;
+  return `${truncateUtf16Safe(sanitized, TELEGRAM_QA_PROGRESS_DETAIL_LIMIT - 3).trimEnd()}...`;
 }
 
 function resolveTelegramQaRuntimeEnv(env: NodeJS.ProcessEnv = process.env): TelegramQaRuntimeEnv {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA Lab Telegram live progress output can contain malformed text when a detail message has emoji at the 240-character truncation boundary.

## Why This Change Was Made

Bounded Telegram QA progress detail strings now use the existing UTF-16-safe truncation helper. The existing code-unit limit remains unchanged; this only backs a cut up to avoid splitting an emoji surrogate pair. No progress format, output prefix, or scenario behavior outside truncation changes.

## User Impact

Telegram QA progress details remain well-formed when scenario or canary diagnostics contain long emoji-containing values.

## Evidence

### Regression test crosses the actual cut
The test now uses a 236-code-unit ASCII prefix followed by emoji+after. With this input the emoji surrogate pair spans indices [236, 237] and current main raw `.slice(0, 237)` keeps only the high surrogate — the test **fails** on current main. The fixed path uses `truncateUtf16Safe(sanitized, 237)` which detects the split surrogate pair and backs up to index 236, producing 236 `a` chars + `...` (239 code units) with no lone surrogate.

### Terminal behavior proof (before vs. after)

**Before fix** (current main, raw `.slice(0, 237)`):
- Truncated: 236 `a` + lone high surrogate (U+D83D at index 236)
- Final output: 236 `a` + lone surrogate + `...` (240 code units)
- Lone surrogate detected: **yes** — emoji rendering breaks

**After fix** (`truncateUtf16Safe`):
- Truncated: 236 `a` (backed up to avoid splitting surrogate pair)
- Final output: 236 `a` + `...` (239 code units)
- Lone surrogate detected: **no** — emoji preserved cleanly

### Test suite
```
pnpm test extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.test.ts
✓ 45/45 passed
```

### Lint
```
node scripts/run-oxlint.mjs
✓ clean
```
