### PR TITLE
feat(tooling): adopt noUncheckedIndexedAccess via a strict-ratchet lane (phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1472,6 +1472,12 @@ jobs:
                 echo "Current CI targets must provide the tsgo:scripts package script." >&2
                 exit 1
               fi
+              if pnpm run --silent 2>/dev/null | grep -q '^  tsgo:strict-ratchet$'; then
+                pnpm tsgo:strict-ratchet
+              elif [[ "$HISTORICAL_TARGET" != "true" ]]; then
+                echo "Current CI targets must provide the tsgo:strict-ratchet package script." >&2
+                exit 1
+              fi
               if pnpm run --silent 2>/dev/null | grep -q '^  tsgo:test:root$'; then
                 pnpm tsgo:test:root
               elif [[ "$HISTORICAL_TARGET" != "true" ]]; then

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -228,6 +228,21 @@
     "**/node_modules/**"
   ],
   "overrides": [
+    // Keep these package globs aligned with the noUncheckedIndexedAccess ratchet lane.
+    {
+      "files": [
+        "packages/markdown-core/**/*.ts",
+        "packages/net-policy/**/*.ts",
+        "packages/media-understanding-common/**/*.ts",
+        "packages/terminal-core/**/*.ts",
+        "packages/normalization-core/**/*.ts",
+        "packages/model-catalog-core/**/*.ts",
+        "packages/web-content-core/**/*.ts"
+      ],
+      "rules": {
+        "typescript/no-non-null-assertion": "error"
+      }
+    },
     {
       "files": [
         "**/*.test.ts",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -228,7 +228,6 @@
     "**/node_modules/**"
   ],
   "overrides": [
-    // Keep these package globs aligned with the noUncheckedIndexedAccess ratchet lane.
     {
       "files": [
         "packages/markdown-core/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -1963,6 +1963,7 @@
     "tsgo:prod": "pnpm tsgo:core && pnpm tsgo:ui && pnpm tsgo:extensions",
     "tsgo:profile": "node scripts/profile-tsgo.mjs",
     "tsgo:scripts": "node scripts/run-tsgo.mjs -p tsconfig.scripts.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/scripts.tsbuildinfo",
+    "tsgo:strict-ratchet": "node scripts/run-tsgo.mjs -p tsconfig.strict-ratchet.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/strict-ratchet.tsbuildinfo",
     "tsgo:test": "pnpm tsgo:core:test && pnpm tsgo:extensions:test && pnpm tsgo:test:root",
     "tsgo:test:extensions": "pnpm tsgo:extensions:test",
     "tsgo:test:packages": "node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.packages.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-packages.tsbuildinfo",

--- a/packages/markdown-core/src/chunk-text.ts
+++ b/packages/markdown-core/src/chunk-text.ts
@@ -18,7 +18,7 @@ function scanParenAwareBreakpoints(text: string): { lastNewline: number; lastWhi
   let depth = 0;
 
   for (let i = 0; i < text.length; i++) {
-    const char = text[i];
+    const char = text.charAt(i);
     // Parenthesized spans often contain rewritten links or file references;
     // avoid splitting them unless the window has no safer outside break.
     if (char === "(") {

--- a/packages/markdown-core/src/fences.ts
+++ b/packages/markdown-core/src/fences.ts
@@ -45,9 +45,15 @@ export function scanFenceSpans(
 
     const match = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/);
     if (match && (offset > 0 || startsAtLineStart)) {
-      const indent = match[1];
-      const marker = match[2];
-      const markerChar = marker[0];
+      const [, indent, marker, trailing] = match;
+      if (indent === undefined || marker === undefined || trailing === undefined) {
+        if (nextNewline === -1) {
+          break;
+        }
+        offset = nextNewline + 1;
+        continue;
+      }
+      const markerChar = marker.charAt(0);
       const markerLen = marker.length;
       if (!open) {
         open = {
@@ -61,7 +67,7 @@ export function scanFenceSpans(
       } else if (
         open.markerChar === markerChar &&
         markerLen >= open.markerLen &&
-        /^[ \t]*$/.test(match[3])
+        /^[ \t]*$/.test(trailing)
       ) {
         // CommonMark permits only spaces or tabs after a closing fence. A marker line carrying
         // other trailing text is code content, not a close, so it must not end the block.

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -88,7 +88,10 @@ function extractMultiLineValue(
   let i = startIndex + 1;
 
   while (i < lines.length) {
-    const line = lines[i];
+    const line = lines.at(i);
+    if (line === undefined) {
+      break;
+    }
     if (line.length > 0 && !line.startsWith(" ") && !line.startsWith("\t")) {
       break;
     }
@@ -106,23 +109,26 @@ function parseLineFrontmatter(block: string): Record<string, ParsedFrontmatterLi
   let i = 0;
 
   while (i < lines.length) {
-    const line = lines[i];
+    const line = lines.at(i);
+    if (line === undefined) {
+      break;
+    }
     const match = line.match(/^([\w-]+):\s*(.*)$/);
     if (!match) {
       i += 1;
       continue;
     }
 
-    const key = match[1];
-    const inlineValue = match[2].trim();
-    if (!key) {
+    const [, key, rawInlineValue] = match;
+    if (!key || rawInlineValue === undefined) {
       i += 1;
       continue;
     }
+    const inlineValue = rawInlineValue.trim();
 
     if (!inlineValue && i + 1 < lines.length) {
-      const nextLine = lines[i + 1];
-      if (nextLine.startsWith(" ") || nextLine.startsWith("\t")) {
+      const nextLine = lines.at(i + 1);
+      if (nextLine?.startsWith(" ") || nextLine?.startsWith("\t")) {
         const { value, linesConsumed } = extractMultiLineValue(lines, i);
         if (value) {
           result[key] = {

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -306,8 +306,9 @@ function closeStyle(
 ) {
   const target = resolveRenderTarget(state);
   for (let i = target.openStyles.length - 1; i >= 0; i -= 1) {
-    if (target.openStyles[i]?.style === style) {
-      const start = target.openStyles[i].start;
+    const open = target.openStyles.at(i);
+    if (open?.style === style) {
+      const start = open.start;
       target.openStyles.splice(i, 1);
       const end =
         options?.trimTrailingParagraphSeparator && target.text.endsWith("\n\n")
@@ -649,10 +650,10 @@ function renderTableAsCode(state: RenderState) {
 
   const widths = Array.from({ length: columnCount }, () => 0);
   const updateWidths = (cells: TableCell[]) => {
-    for (let i = 0; i < columnCount; i += 1) {
+    for (const [i, currentWidth] of widths.entries()) {
       const cell = cells[i];
       const width = visibleWidth(cell?.text ?? "");
-      if (widths[i] < width) {
+      if (currentWidth < width) {
         widths[i] = width;
       }
     }
@@ -666,14 +667,14 @@ function renderTableAsCode(state: RenderState) {
 
   const appendRow = (cells: TableCell[]) => {
     state.text += "|";
-    for (let i = 0; i < columnCount; i += 1) {
+    for (const [i, width] of widths.entries()) {
       state.text += " ";
       const cell = cells[i];
       if (cell) {
         // Use text-only append to avoid overlapping styles with code_block
         appendCellTextOnly(state, cell);
       }
-      const pad = widths[i] - visibleWidth(cell?.text ?? "");
+      const pad = width - visibleWidth(cell?.text ?? "");
       if (pad > 0) {
         state.text += " ".repeat(pad);
       }
@@ -684,8 +685,8 @@ function renderTableAsCode(state: RenderState) {
 
   const appendDivider = () => {
     state.text += "|";
-    for (let i = 0; i < columnCount; i += 1) {
-      const dashCount = Math.max(3, widths[i]);
+    for (const width of widths) {
+      const dashCount = Math.max(3, width);
       state.text += ` ${"-".repeat(dashCount)} |`;
     }
     state.text += "\n";
@@ -926,8 +927,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
 }
 
 function closeRemainingStyles(target: RenderTarget) {
-  for (let i = target.openStyles.length - 1; i >= 0; i -= 1) {
-    const open = target.openStyles[i];
+  for (const open of target.openStyles.toReversed()) {
     const end = target.text.length;
     if (end > open.start) {
       target.styles.push({

--- a/packages/markdown-core/src/render-aware-chunking.ts
+++ b/packages/markdown-core/src/render-aware-chunking.ts
@@ -162,7 +162,7 @@ function findMarkdownIRPreservedSplitIndex(text: string, start: number, limit: n
   let sawNonWhitespace = false;
 
   for (let index = start; index < maxEnd; index += 1) {
-    const char = text[index];
+    const char = text.charAt(index);
     // Parenthesized text often carries rewritten file/link references; prefer
     // keeping it intact unless no outside break exists in the current window.
     if (char === "(") {

--- a/packages/markdown-core/src/render.ts
+++ b/packages/markdown-core/src/render.ts
@@ -130,9 +130,7 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
       };
   let out = "";
 
-  for (let i = 0; i < points.length; i += 1) {
-    const pos = points[i];
-
+  for (const [i, pos] of points.entries()) {
     // Close all elements at this boundary before opening replacements at the same offset.
     while (stack.length && stack[stack.length - 1]?.end === pos) {
       const item = stack.pop();
@@ -195,7 +193,7 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
       }
     }
 
-    const next = points[i + 1];
+    const next = points.at(i + 1);
     if (next === undefined) {
       break;
     }

--- a/packages/media-understanding-common/src/format.ts
+++ b/packages/media-understanding-common/src/format.ts
@@ -97,7 +97,11 @@ export function formatMediaUnderstandingBody(params: {
 /** Formats one or more audio transcript outputs for legacy transcript-only callers. */
 export function formatAudioTranscripts(outputs: MediaUnderstandingOutput[]): string {
   if (outputs.length === 1) {
-    return outputs[0].text;
+    const [output] = outputs;
+    if (output) {
+      return output.text;
+    }
+    throw new Error("expected single audio transcript to be defined");
   }
   return outputs.map((output, index) => `Audio ${index + 1}:\n${output.text}`).join("\n\n");
 }

--- a/packages/media-understanding-common/src/output-extract.ts
+++ b/packages/media-understanding-common/src/output-extract.ts
@@ -15,7 +15,7 @@ function extractLastJsonObject(raw: string): unknown {
   let candidateHasContent = false;
 
   for (let index = 0; index < trimmed.length; index += 1) {
-    const character = trimmed[index];
+    const character = trimmed.charAt(index);
     if (inString) {
       if (character === "\n" || character === "\r") {
         starts.length = 0;
@@ -106,8 +106,7 @@ function extractLastJsonObject(raw: string): unknown {
     }
   }
 
-  for (let index = ranges.length - 1; index >= 0; index -= 1) {
-    const range = ranges[index];
+  for (const range of ranges.toReversed()) {
     try {
       return JSON.parse(trimmed.slice(range.start, range.end + 1));
     } catch {

--- a/packages/memory-host-sdk/src/host/embeddings.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.ts
@@ -1,3 +1,4 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { DEFAULT_LOCAL_MODEL } from "./embedding-defaults.js";
 import { sanitizeAndNormalizeEmbedding } from "./embedding-vectors.js";
 import { createLocalEmbeddingWorkerProvider } from "./embeddings-worker.js";
@@ -33,7 +34,7 @@ function copyEmbeddingVector(vector: ArrayLike<number>, maxLength?: number): num
   const length = Math.min(maxLength ?? vector.length, vector.length);
   const values: number[] = [];
   for (let index = 0; index < length; index += 1) {
-    values.push(vector[index]);
+    values.push(expectDefined(vector[index], `embedding value ${index}`));
   }
   return values;
 }

--- a/packages/memory-host-sdk/src/host/query-expansion.ts
+++ b/packages/memory-host-sdk/src/host/query-expansion.ts
@@ -693,7 +693,7 @@ function tokenize(text: string, opts?: { ftsTokenizer?: "unicode61" | "trigram" 
           tokens.push(part);
           if (!useTrigram) {
             for (let i = 0; i < part.length - 1; i++) {
-              tokens.push(part[i] + part[i + 1]);
+              tokens.push(part.slice(i, i + 2));
             }
           }
         } else {
@@ -715,7 +715,7 @@ function tokenize(text: string, opts?: { ftsTokenizer?: "unicode61" | "trigram" 
         // Default mode: unigrams + bigrams for phrase matching
         tokens.push(...chars);
         for (let i = 0; i < chars.length - 1; i++) {
-          tokens.push(chars[i] + chars[i + 1]);
+          tokens.push(chars.slice(i, i + 2).join(""));
         }
       }
     } else if (/[\uac00-\ud7af\u3131-\u3163]/.test(segment)) {

--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -422,9 +422,11 @@ function normalizeModelCatalogCompat(value: unknown): ModelCatalogCompatConfig |
 
   if (isRecord(value.reasoningEffortMap)) {
     const reasoningEffortMap = Object.fromEntries(
-      Object.entries(value.reasoningEffortMap)
-        .map(([key, mapped]) => [key.trim(), typeof mapped === "string" ? mapped.trim() : ""])
-        .filter(([key, mapped]) => key.length > 0 && mapped.length > 0),
+      Object.entries(value.reasoningEffortMap).flatMap(([rawKey, rawMapped]) => {
+        const key = rawKey.trim();
+        const mapped = typeof rawMapped === "string" ? rawMapped.trim() : "";
+        return key && mapped ? [[key, mapped]] : [];
+      }),
     );
     if (Object.keys(reasoningEffortMap).length > 0) {
       compat.reasoningEffortMap = reasoningEffortMap;

--- a/packages/net-policy/src/ip.ts
+++ b/packages/net-policy/src/ip.ts
@@ -18,6 +18,26 @@ export type ParsedIpAddress = ipaddr.IPv4 | ipaddr.IPv6;
 type Ipv4Range = ReturnType<ipaddr.IPv4["range"]>;
 type Ipv6Range = ReturnType<ipaddr.IPv6["range"]>;
 type BlockedIpv6Range = Ipv6Range | "discard";
+type Ipv6Hextets = readonly [number, number, number, number, number, number, number, number];
+
+// ipaddr.js guarantees 8 hextets; throw loudly on an impossible shape instead of
+// failing open (a silent undefined here would skip SSRF embedded-IPv4 blocking).
+function expectIpv6Hextets(parts: readonly number[]): Ipv6Hextets {
+  const [a, b, c, d, e, f, g, h] = parts;
+  if (
+    a === undefined ||
+    b === undefined ||
+    c === undefined ||
+    d === undefined ||
+    e === undefined ||
+    f === undefined ||
+    g === undefined ||
+    h === undefined
+  ) {
+    throw new Error("expected IPv6 address to expose 8 hextets");
+  }
+  return [a, b, c, d, e, f, g, h];
+}
 
 const BLOCKED_IPV4_SPECIAL_USE_RANGES = new Set<Ipv4Range>([
   "unspecified",
@@ -74,8 +94,8 @@ export type Ipv6SpecialUseBlockOptions = {
 };
 
 const EMBEDDED_IPV4_SENTINEL_RULES: Array<{
-  matches: (parts: number[]) => boolean;
-  toHextets: (parts: number[]) => [high: number, low: number];
+  matches: (parts: Ipv6Hextets) => boolean;
+  toHextets: (parts: Ipv6Hextets) => [high: number, low: number];
 }> = [
   {
     // IPv4-compatible form ::w.x.y.z (deprecated, but still seen in parser edge-cases).
@@ -136,12 +156,18 @@ function parseIpv6WithEmbeddedIpv4(raw: string): ipaddr.IPv6 | undefined {
     return undefined;
   }
   const [, prefix, embeddedIpv4, zoneSuffix = ""] = match;
+  if (prefix === undefined || embeddedIpv4 === undefined) {
+    return undefined;
+  }
   if (!ipaddr.IPv4.isValidFourPartDecimal(embeddedIpv4)) {
     return undefined;
   }
-  const octets = embeddedIpv4.split(".").map((part) => Number.parseInt(part, 10));
-  const high = ((octets[0] << 8) | octets[1]).toString(16);
-  const low = ((octets[2] << 8) | octets[3]).toString(16);
+  const [a, b, c, d] = embeddedIpv4.split(".").map((part) => Number.parseInt(part, 10));
+  if (a === undefined || b === undefined || c === undefined || d === undefined) {
+    return undefined;
+  }
+  const high = ((a << 8) | b).toString(16);
+  const low = ((c << 8) | d).toString(16);
   const normalizedIpv6 = `${prefix}${high}:${low}${zoneSuffix}`;
   if (!ipaddr.IPv6.isValid(normalizedIpv6)) {
     return undefined;
@@ -330,7 +356,8 @@ export function isBlockedSpecialUseIpv6Address(
     return true;
   }
   // ipaddr.js does not classify deprecated site-local fec0::/10 as private.
-  return (address.parts[0] & 0xffc0) === 0xfec0;
+  const [firstPart] = expectIpv6Hextets(address.parts);
+  return (firstPart & 0xffc0) === 0xfec0;
 }
 
 /** True for canonical IPv4 literals in RFC 1918 private ranges. */
@@ -378,17 +405,18 @@ export function extractEmbeddedIpv4FromIpv6(address: ipaddr.IPv6): ipaddr.IPv4 |
   if (address.isIPv4MappedAddress()) {
     return address.toIPv4Address();
   }
+  const parts = expectIpv6Hextets(address.parts);
   if (address.range() === "rfc6145") {
-    return decodeIpv4FromHextets(address.parts[6], address.parts[7]);
+    return decodeIpv4FromHextets(parts[6], parts[7]);
   }
   if (address.range() === "rfc6052") {
-    return decodeIpv4FromHextets(address.parts[6], address.parts[7]);
+    return decodeIpv4FromHextets(parts[6], parts[7]);
   }
   for (const rule of EMBEDDED_IPV4_SENTINEL_RULES) {
-    if (!rule.matches(address.parts)) {
+    if (!rule.matches(parts)) {
       continue;
     }
-    const [high, low] = rule.toHextets(address.parts);
+    const [high, low] = rule.toHextets(parts);
     return decodeIpv4FromHextets(high, low);
   }
   return undefined;

--- a/packages/normalization-core/package.json
+++ b/packages/normalization-core/package.json
@@ -24,6 +24,11 @@
       "import": "./dist/error-coercion.mjs",
       "default": "./dist/error-coercion.mjs"
     },
+    "./expect": {
+      "types": "./dist/expect.d.mts",
+      "import": "./dist/expect.mjs",
+      "default": "./dist/expect.mjs"
+    },
     "./number-coercion": {
       "types": "./dist/number-coercion.d.mts",
       "import": "./dist/number-coercion.mjs",
@@ -51,6 +56,6 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/boolean-coercion.ts src/error-coercion.ts src/number-coercion.ts src/record-coerce.ts src/string-coerce.ts src/string-normalization.ts src/utf16-slice.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
+    "build": "tsdown src/index.ts src/boolean-coercion.ts src/error-coercion.ts src/expect.ts src/number-coercion.ts src/record-coerce.ts src/string-coerce.ts src/string-normalization.ts src/utf16-slice.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
   }
 }

--- a/packages/normalization-core/src/expect.test.ts
+++ b/packages/normalization-core/src/expect.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { expectDefined, first, last } from "./expect.js";
+
+describe("expect helpers", () => {
+  it("returns defined values", () => {
+    expect(expectDefined(0, "number")).toBe(0);
+  });
+
+  it.each([null, undefined])("rejects missing values", (value) => {
+    expect(() => expectDefined(value, "test value")).toThrow("expected test value to be defined");
+  });
+
+  it("reads array boundaries without claiming they exist", () => {
+    expect(first(["a", "b"])).toBe("a");
+    expect(last(["a", "b"])).toBe("b");
+    expect(first([])).toBeUndefined();
+    expect(last([])).toBeUndefined();
+  });
+});

--- a/packages/normalization-core/src/expect.ts
+++ b/packages/normalization-core/src/expect.ts
@@ -1,0 +1,17 @@
+/** Returns the value or throws with the named context; use for genuine invariants only. */
+export function expectDefined<T>(value: T | null | undefined, context: string): T {
+  if (value === null || value === undefined) {
+    throw new Error("expected " + context + " to be defined");
+  }
+  return value;
+}
+
+/** First element with honest optionality; callers own the absent case. */
+export function first<T>(values: readonly T[]): T | undefined {
+  return values.at(0);
+}
+
+/** Last element with honest optionality; callers own the absent case. */
+export function last<T>(values: readonly T[]): T | undefined {
+  return values.at(-1);
+}

--- a/packages/normalization-core/src/format.ts
+++ b/packages/normalization-core/src/format.ts
@@ -1,3 +1,5 @@
+import { expectDefined } from "./expect.js";
+
 type ByteSizeUnit = "byte" | "kilo" | "mega" | "giga" | "tera";
 type ByteSizeStyle = "iec" | "legacy-binary";
 
@@ -26,16 +28,17 @@ export function formatByteSize(bytes: number, options: ByteSizeFormatOptions): s
     unitIndex += 1;
   }
 
-  const unit = BYTE_SIZE_UNITS[unitIndex];
+  const unit = expectDefined(BYTE_SIZE_UNITS[unitIndex], "byte-size unit");
+  const label = expectDefined(labels[unitIndex], "byte-size label");
   const fractionDigits =
     typeof options.fractionDigits === "function"
       ? options.fractionDigits(value, unit)
       : options.fractionDigits;
   if (fractionDigits === null) {
-    return `${value}${options.separator}${labels[unitIndex]}`;
+    return `${value}${options.separator}${label}`;
   }
   if (options.floorUnits?.includes(unit)) {
     value = Math.floor(value * 10 ** fractionDigits) / 10 ** fractionDigits;
   }
-  return `${value.toFixed(fractionDigits)}${options.separator}${labels[unitIndex]}`;
+  return `${value.toFixed(fractionDigits)}${options.separator}${label}`;
 }

--- a/packages/normalization-core/src/index.ts
+++ b/packages/normalization-core/src/index.ts
@@ -2,6 +2,7 @@
 
 export * from "./boolean-coercion.js";
 export * from "./error-coercion.js";
+export * from "./expect.js";
 export * from "./format.js";
 export * from "./json-coercion.js";
 export * from "./number-coercion.js";

--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -126,7 +126,7 @@ function stripAnsiInternal(
       if (code <= 0x1f || code === 0x7f) {
         // These controls execute independently; the caller still owns whether
         // to retain, remove, or escape them in its output format.
-        controls.push(input[cursor]);
+        controls.push(input.charAt(cursor));
         cursor += 1;
         continue;
       }

--- a/packages/terminal-core/src/display-string.ts
+++ b/packages/terminal-core/src/display-string.ts
@@ -89,12 +89,12 @@ function replaceHomePath(input: string, display: { home: string; prefix: string 
     const after = input[homeEnd];
     const startsToken = before === undefined || /[\s("'`:=[{,]/u.test(before);
     let punctuationEnd = homeEnd;
-    while (punctuationEnd < input.length && /[)"'`:,;.\]}]/u.test(input[punctuationEnd])) {
+    while (punctuationEnd < input.length && /[)"'`:,;.\]}]/u.test(input.charAt(punctuationEnd))) {
       punctuationEnd += 1;
     }
     const punctuationEndsToken =
       punctuationEnd > homeEnd &&
-      (punctuationEnd === input.length || /\s/u.test(input[punctuationEnd]));
+      (punctuationEnd === input.length || /\s/u.test(input.charAt(punctuationEnd)));
     const endsTokenOrContinuesPath =
       after === undefined || after === "/" || after === "\\" || punctuationEndsToken;
     if (startsToken && endsTokenOrContinuesPath) {

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -581,7 +581,13 @@ export function renderTable(opts: RenderTableOptions): string {
   const hLine = (left: string, mid: string, right: string) =>
     `${left}${widths.map((w) => repeat(box.h, w)).join(mid)}${right}`;
 
-  const contentWidthFor = (i: number) => Math.max(1, widths[i] - padding * 2);
+  const contentWidthFor = (i: number) => {
+    const width = widths.at(i);
+    if (width === undefined) {
+      throw new Error(`expected table column width ${i} to be defined`);
+    }
+    return Math.max(1, width - padding * 2);
+  };
   const padStr = repeat(" ", padding);
 
   const renderRow = (record: Record<string, string>, isHeader = false) => {

--- a/packages/web-content-core/src/provider-runtime-shared.ts
+++ b/packages/web-content-core/src/provider-runtime-shared.ts
@@ -102,7 +102,8 @@ function coerceSecretRef(value: unknown): SecretRef | null {
         : null;
     }
     const match = ENV_SECRET_TEMPLATE_RE.exec(trimmed) ?? ENV_SECRET_SHORTHAND_RE.exec(trimmed);
-    return match ? { source: "env", provider: DEFAULT_SECRET_PROVIDER_ALIAS, id: match[1] } : null;
+    const id = match?.[1];
+    return id ? { source: "env", provider: DEFAULT_SECRET_PROVIDER_ALIAS, id } : null;
   }
   if (
     isRecord(value) &&

--- a/scripts/changed-lanes.d.mts
+++ b/scripts/changed-lanes.d.mts
@@ -5,6 +5,7 @@ export type ChangedLane =
   | "extensions"
   | "extensionTests"
   | "scripts"
+  | "strictRatchet"
   | "testRoot"
   | "apps"
   | "docs"
@@ -54,3 +55,4 @@ export function isPackageScriptOnlyChange(before: string, after: string): boolea
 
 export const LIVE_DOCKER_AUTH_SHELL_TARGETS: string[];
 export const RELEASE_METADATA_PATHS: Set<string>;
+export const STRICT_RATCHET_PACKAGE_DIRS: string[];

--- a/scripts/changed-lanes.mjs
+++ b/scripts/changed-lanes.mjs
@@ -16,6 +16,16 @@ const CORE_PATH_RE = /^(?:src\/|packages\/)/u;
 const UI_PATH_RE = /^(?:ui\/|tsconfig\.ui\.json$)/u;
 const SCRIPTS_TYPECHECK_PATH_RE =
   /^(?:scripts\/.*\.(?:[cm]?ts|[cm]?tsx)|tsconfig\.scripts\.json)$/u;
+// Keep aligned with tsconfig.strict-ratchet.json includes and its oxlint override.
+export const STRICT_RATCHET_PACKAGE_DIRS = [
+  "packages/markdown-core",
+  "packages/net-policy",
+  "packages/media-understanding-common",
+  "packages/terminal-core",
+  "packages/normalization-core",
+  "packages/model-catalog-core",
+  "packages/web-content-core",
+];
 const TEST_ROOT_TYPECHECK_PATH_RE =
   /^(?:test\/(?!fixtures\/).*\.(?:[cm]?ts|[cm]?tsx)|test\/tsconfig\/tsconfig\.test\.root\.json)$/u;
 const TOOLING_PATH_RE =
@@ -59,7 +69,7 @@ export const RELEASE_METADATA_PATHS = new Set([
   "package.json",
 ]);
 
-/** @typedef {"core" | "coreTests" | "ui" | "extensions" | "extensionTests" | "scripts" | "testRoot" | "apps" | "docs" | "tooling" | "liveDockerTooling" | "releaseMetadata" | "all"} ChangedLane */
+/** @typedef {"core" | "coreTests" | "ui" | "extensions" | "extensionTests" | "scripts" | "strictRatchet" | "testRoot" | "apps" | "docs" | "tooling" | "liveDockerTooling" | "releaseMetadata" | "all"} ChangedLane */
 
 /**
  * @typedef {{
@@ -92,6 +102,7 @@ export function createEmptyChangedLanes() {
     extensions: false,
     extensionTests: false,
     scripts: false,
+    strictRatchet: false,
     testRoot: false,
     apps: false,
     docs: false,
@@ -149,6 +160,14 @@ export function detectChangedLanes(changedPaths, options = {}) {
   for (const changedPath of paths) {
     if (SCRIPTS_TYPECHECK_PATH_RE.test(changedPath)) {
       lanes.scripts = true;
+    }
+    if (
+      changedPath === "tsconfig.strict-ratchet.json" ||
+      STRICT_RATCHET_PACKAGE_DIRS.some(
+        (packageDir) => changedPath === packageDir || changedPath.startsWith(`${packageDir}/`),
+      )
+    ) {
+      lanes.strictRatchet = true;
     }
     if (TEST_ROOT_TYPECHECK_PATH_RE.test(changedPath)) {
       lanes.testRoot = true;

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -397,6 +397,9 @@ export function createChangedCheckPlan(result, options = {}) {
   if (lanes.scripts) {
     addTypecheck("typecheck scripts", ["tsgo:scripts"]);
   }
+  if (lanes.strictRatchet) {
+    addTypecheck("typecheck strict ratchet", ["tsgo:strict-ratchet"]);
+  }
   if (lanes.testRoot) {
     addTypecheck("typecheck test root", ["tsgo:test:root"]);
   }

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -119,6 +119,7 @@ export async function main(argv = process.argv.slice(2)) {
         : [
             { name: "typecheck prod", args: ["tsgo:prod"] },
             { name: "typecheck scripts", args: ["tsgo:scripts"] },
+            { name: "typecheck strict ratchet", args: ["tsgo:strict-ratchet"] },
             { name: "typecheck test root", args: ["tsgo:test:root"] },
           ],
     },

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -567,6 +567,7 @@ describe("scripts/changed-lanes", () => {
     expectLanes(result.lanes, {
       core: true,
       coreTests: true,
+      strictRatchet: true,
     });
     expect(plan.commands.map((command) => command.args[0])).toContain(
       "check:database-first-legacy-stores",
@@ -970,6 +971,7 @@ describe("scripts/changed-lanes", () => {
 
     expectLanes(result.lanes, {
       coreTests: true,
+      strictRatchet: true,
     });
     expect(createChangedCheckPlan(result).commands.map((command) => command.args[0])).toContain(
       "tsgo:core:test",
@@ -1880,6 +1882,7 @@ describe("scripts/changed-lanes", () => {
       extensions: false,
       extensionTests: false,
       scripts: false,
+      strictRatchet: false,
       testRoot: false,
       apps: false,
       docs: false,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1703,6 +1703,7 @@ describe("ci workflow guards", () => {
       "${{ needs.preflight.outputs.historical_target }}",
     );
     expect(checkShard.run).toContain("pnpm tsgo:scripts");
+    expect(checkShard.run).toContain("pnpm tsgo:strict-ratchet");
     expect(checkShard.run).toContain('elif [[ "$HISTORICAL_TARGET" != "true" ]]');
   });
 

--- a/test/scripts/oxlint-config.test.ts
+++ b/test/scripts/oxlint-config.test.ts
@@ -1,5 +1,6 @@
 // Oxlint Config tests cover oxlint config script behavior.
 import fs from "node:fs";
+import JSON5 from "json5";
 import { describe, expect, it } from "vitest";
 
 type OxlintConfig = {
@@ -95,7 +96,7 @@ const ZERO_BASELINE_RULES = [
 ];
 
 function readJson(path: string): unknown {
-  return JSON.parse(fs.readFileSync(path, "utf8")) as unknown;
+  return JSON5.parse(fs.readFileSync(path, "utf8"));
 }
 
 describe("oxlint config", () => {
@@ -159,10 +160,24 @@ describe("oxlint config", () => {
     ]);
   });
 
-  it("keeps lint overrides limited to the explicit test-file carve-out", () => {
+  it("keeps lint overrides limited to the strict-ratchet and test-file policies", () => {
     const config = readJson(".oxlintrc.json") as OxlintConfig;
 
     expect(config.overrides).toEqual([
+      {
+        files: [
+          "packages/markdown-core/**/*.ts",
+          "packages/net-policy/**/*.ts",
+          "packages/media-understanding-common/**/*.ts",
+          "packages/terminal-core/**/*.ts",
+          "packages/normalization-core/**/*.ts",
+          "packages/model-catalog-core/**/*.ts",
+          "packages/web-content-core/**/*.ts",
+        ],
+        rules: {
+          "typescript/no-non-null-assertion": "error",
+        },
+      },
       {
         files: [
           "**/*.test.ts",

--- a/test/scripts/strict-ratchet-sync.test.ts
+++ b/test/scripts/strict-ratchet-sync.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import JSON5 from "json5";
+import { describe, expect, it } from "vitest";
+import { STRICT_RATCHET_PACKAGE_DIRS, detectChangedLanes } from "../../scripts/changed-lanes.mjs";
+import { createChangedCheckPlan } from "../../scripts/check-changed.mjs";
+
+const config: unknown = JSON5.parse(fs.readFileSync("tsconfig.strict-ratchet.json", "utf8"));
+if (
+  !config ||
+  typeof config !== "object" ||
+  !("include" in config) ||
+  !Array.isArray(config.include) ||
+  !config.include.every((entry) => typeof entry === "string")
+) {
+  throw new Error("expected strict-ratchet tsconfig includes to be strings");
+}
+const includedPackageDirs = config.include
+  .filter((entry) => entry.startsWith("packages/") && entry.endsWith("/src/**/*"))
+  .map((entry) => entry.replace(/\/src\/\*\*\/\*$/u, ""));
+
+describe("strict ratchet routing", () => {
+  it("keeps the changed-lane package list pinned to the tsconfig", () => {
+    expect(includedPackageDirs).toEqual(STRICT_RATCHET_PACKAGE_DIRS);
+  });
+
+  it.each(includedPackageDirs)("routes %s changes through the ratchet lane", (packageDir) => {
+    const result = detectChangedLanes([`${packageDir}/src/example.ts`]);
+    const plan = createChangedCheckPlan(result);
+
+    expect(result.lanes.strictRatchet).toBe(true);
+    expect(plan.commands.map((command) => command.args[0])).toContain("tsgo:strict-ratchet");
+  });
+
+  it("routes the ratchet tsconfig through its lane", () => {
+    expect(detectChangedLanes(["tsconfig.strict-ratchet.json"]).lanes.strictRatchet).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -140,6 +140,7 @@
       "@openclaw/normalization-core/error-coercion": [
         "./packages/normalization-core/src/error-coercion.ts"
       ],
+      "@openclaw/normalization-core/expect": ["./packages/normalization-core/src/expect.ts"],
       "@openclaw/normalization-core/number-coercion": [
         "./packages/normalization-core/src/number-coercion.ts"
       ],

--- a/tsconfig.projects.json
+++ b/tsconfig.projects.json
@@ -4,6 +4,7 @@
     { "path": "./tsconfig.core.projects.json" },
     { "path": "./tsconfig.extensions.projects.json" },
     { "path": "./tsconfig.scripts.json" },
+    { "path": "./tsconfig.strict-ratchet.json" },
     { "path": "./test/tsconfig/tsconfig.test.root.json" }
   ]
 }

--- a/tsconfig.strict-ratchet.json
+++ b/tsconfig.strict-ratchet.json
@@ -1,0 +1,26 @@
+// noUncheckedIndexedAccess ratchet: grow include as directories migrate.
+// Keep aligned with the oxlint no-non-null-assertion override and changed-lanes routing.
+// Delete this lane when the base tsconfig enables noUncheckedIndexedAccess.
+// memory-host-sdk is excluded: it re-exports core src/** directly, so the flag
+// would apply transitively to all of core; it migrates together with src/.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "tsBuildInfoFile": ".artifacts/tsgo-cache/strict-ratchet.tsbuildinfo"
+  },
+  "include": [
+    "packages/markdown-core/src/**/*",
+    "packages/net-policy/src/**/*",
+    "packages/media-understanding-common/src/**/*",
+    "packages/terminal-core/src/**/*",
+    "packages/normalization-core/src/**/*",
+    "packages/model-catalog-core/src/**/*",
+    "packages/web-content-core/src/**/*",
+    "src/**/*.d.ts",
+    "packages/**/*.d.ts"
+  ],
+  "exclude": ["node_modules", "dist", "**/dist/**", "**/*.test.ts", "**/*.test.tsx", "test/**"]
+}


### PR DESCRIPTION
Closes #104558

## What Problem This Solves

`noUncheckedIndexedAccess` is off, so `arr[i]`/`record[key]` reads typecheck as always-defined; a fresh probe counts 1,750 would-be errors repo-wide, including real crash paths behind regex-group indexing. Flipping globally is intractable in one change, and an unguided migration would degenerate into `!` spam (~1,200 non-null assertions already exist unenforced).

## Why This Change Was Made

Phase 1 of an include-list ratchet:

- **`tsconfig.strict-ratchet.json`** compiles seven packages (`markdown-core`, `net-policy`, `media-understanding-common`, `terminal-core`, `normalization-core`, `model-catalog-core`, `web-content-core`) with `noUncheckedIndexedAccess: true`. Wired into `tsgo:strict-ratchet`, `check.mjs`, the CI `test-types` shard (with a historical-target guard matching existing patterns), `tsgo:all` project references, and `check:changed` routing (new `strictRatchet` lane); a sync test pins the tsconfig include list, the changed-lanes constant, and routing together so they cannot drift.
- **`memory-host-sdk` was planned for phase 1 but excluded with a documented reason**: it re-exports core `src/**` directly, so the flag would apply transitively to all of core (1,267 errors); it migrates together with `src/`. Its 5 index-safety fixes are kept — they are valid improvements under the core lane.
- **All 65 in-scope errors fixed, behavior-identical**: iteration over index loops (`.entries()`, `toReversed()`), `charAt`/`slice` for character access, regex-group guards, and a validated fixed-length hextet tuple in `net-policy/ip.ts`. In that security-relevant file, impossible invariant violations now throw loudly instead of failing open (a silent `undefined` would have skipped SSRF embedded-IPv4 blocking).
- **New invariant helpers `@openclaw/normalization-core/expect`** (`expectDefined`, `first`, `last`) with subpath export, build entry, and tests; `expectDefined` has three production call sites in this diff. `getOrCreate` was deliberately omitted (no call sites yet — helpers must pay rent).
- **`typescript/no-non-null-assertion: error`** scoped to the seven migrated packages (they contain zero `!` today), so fixed code cannot regress into assertion spam.

No `any`, no casts, no `@ts-expect-error`, no fabricated defaults. Later phases: `packages/ai` + `agent-core` (196 errors), `ui/` (304), `src/` dir-by-dir; the lane is deleted when the base flag flips.

## User Impact

No runtime behavior change. Index/lookup reads in the migrated packages are now compile-time-proven defined or explicitly handled, and the pattern for the remaining phases is established.

## Evidence

- `node scripts/run-tsgo.mjs -p tsconfig.strict-ratchet.json` → 0 errors (failed with 65 before the burn-down); all existing lanes (core, ui, extensions, scripts, core-test, root-test) fresh non-incremental → 0 errors.
- Blacksmith Testbox (Linux Node 24): `pnpm build` (new package export packaged), full `pnpm check`, `pnpm check:test-types`, package test suites for all eight touched packages plus the ratchet sync, oxlint-config, changed-lanes, and ci-workflow-guards tests — run link in PR checks.
- `node scripts/run-oxlint.mjs packages` clean with the new override; `node scripts/check-tsgo-core-boundary.mjs` pass.
- Fresh autoreview on the final tree with no accepted findings.
