### PR TITLE
fix(zalo): bound stalled inbound media header waits

### DIFF
--- a/extensions/zalo/src/monitor.image.polling.test.ts
+++ b/extensions/zalo/src/monitor.image.polling.test.ts
@@ -152,4 +152,88 @@ describe("Zalo polling image handling", () => {
     abort.abort();
     await run;
   });
+
+  it("times out inbound image downloads when photo_url headers never arrive", async () => {
+    const { createServer } = await import("node:http");
+    const { saveRemoteMedia } = await import("openclaw/plugin-sdk/media-runtime");
+    const { ZALO_MEDIA_READ_IDLE_TIMEOUT_MS, ZALO_MEDIA_RESPONSE_HEADER_TIMEOUT_MS } =
+      await import("./monitor.js");
+
+    const server = createServer((_req, _res) => {
+      // Accept the connection but never write status/headers.
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback TCP address");
+    }
+    const stallUrl = `http://127.0.0.1:${address.port}/stall.jpg`;
+    const headerTimeoutMs = 250;
+
+    // Production monitor passes the full timeout budget; the harness shortens
+    // only the actual fetch so the stalled-header case stays fast.
+    const saveRemoteMediaWithHeaderTimeout: typeof saveRemoteMedia = async (params) => {
+      expect(params).toEqual({
+        url: stallUrl,
+        maxBytes: 5 * 1024 * 1024,
+        responseHeaderTimeoutMs: ZALO_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
+        readIdleTimeoutMs: ZALO_MEDIA_READ_IDLE_TIMEOUT_MS,
+      });
+      return await saveRemoteMedia({
+        ...params,
+        responseHeaderTimeoutMs: headerTimeoutMs,
+        ssrfPolicy: { ...params.ssrfPolicy, dangerouslyAllowPrivateNetwork: true },
+      });
+    };
+    saveRemoteMediaMock.mockImplementation(saveRemoteMediaWithHeaderTimeout);
+
+    getUpdatesMock
+      .mockResolvedValueOnce({
+        ok: true,
+        result: createImageUpdate({
+          caption: "stalled photo",
+          photoUrl: stallUrl,
+        }),
+      })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const { monitorZaloProvider } = await loadCachedLifecycleMonitorModule("zalo-image-polling");
+    const abort = new AbortController();
+    const runtime = createRuntimeEnv();
+    const { account, config } = createLifecycleMonitorSetup({
+      accountId: "default",
+      dmPolicy: "open",
+    });
+    const started = Date.now();
+    const run = monitorZaloProvider({
+      token: "zalo-token", // pragma: allowlist secret
+      account,
+      config,
+      runtime,
+      abortSignal: abort.signal,
+    });
+
+    await vi.waitFor(() => expect(finalizeInboundContextMock).toHaveBeenCalledTimes(1));
+    const elapsedMs = Date.now() - started;
+    expect(elapsedMs).toBeGreaterThanOrEqual(headerTimeoutMs - 50);
+    expect(elapsedMs).toBeLessThan(headerTimeoutMs + 5_000);
+    expect(finalizeInboundContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: "stalled photo\n\n[zalo image attachment unavailable]",
+        MediaPath: undefined,
+      }),
+    );
+
+    abort.abort();
+    await run;
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
 });

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -49,6 +49,11 @@ import {
   tryHandleHostedZaloMediaRequest,
 } from "./outbound-media.js";
 
+/** Default idle timeout for Zalo inbound photo downloads (30 seconds). */
+export const ZALO_MEDIA_READ_IDLE_TIMEOUT_MS = 30_000;
+/** Maximum wait for Zalo inbound photo response headers (120 seconds). */
+export const ZALO_MEDIA_RESPONSE_HEADER_TIMEOUT_MS = 120_000;
+
 type ZaloMonitorOptions = {
   token: string;
   account: ResolvedZaloAccount;
@@ -378,7 +383,14 @@ async function handleImageMessage(params: ZaloImageMessageParams): Promise<void>
   if (photo_url) {
     try {
       const maxBytes = mediaMaxMb * 1024 * 1024;
-      const saved = await core.channel.media.saveRemoteMedia({ url: photo_url, maxBytes });
+      // Without header/idle deadlines, a stalled photo_url host can block inbound
+      // image preprocessing indefinitely (idle timeout never starts).
+      const saved = await core.channel.media.saveRemoteMedia({
+        url: photo_url,
+        maxBytes,
+        responseHeaderTimeoutMs: ZALO_MEDIA_RESPONSE_HEADER_TIMEOUT_MS,
+        readIdleTimeoutMs: ZALO_MEDIA_READ_IDLE_TIMEOUT_MS,
+      });
       mediaPath = saved.path;
       mediaType = saved.contentType;
     } catch (err) {

--- a/extensions/zalo/src/test-support/lifecycle-test-support.ts
+++ b/extensions/zalo/src/test-support/lifecycle-test-support.ts
@@ -178,7 +178,9 @@ export function createImageLifecycleCore() {
   // mockImplementation callbacks that inspect timeout options typecheck.
   const saveRemoteMediaMock = vi.fn<PluginRuntime["channel"]["media"]["saveRemoteMedia"]>(
     async (_params) => ({
+      id: "zalo-photo.jpg",
       path: "/tmp/zalo-photo.jpg",
+      size: Buffer.byteLength("image-bytes"),
       contentType: "image/jpeg",
     }),
   );

--- a/extensions/zalo/src/test-support/lifecycle-test-support.ts
+++ b/extensions/zalo/src/test-support/lifecycle-test-support.ts
@@ -176,8 +176,8 @@ export function createImageLifecycleCore() {
   }));
   // Keep the mock arity aligned with PluginRuntime.saveRemoteMedia so
   // mockImplementation callbacks that inspect timeout options typecheck.
-  const saveRemoteMediaMock = vi.fn(
-    async (_params: Parameters<PluginRuntime["channel"]["media"]["saveRemoteMedia"]>[0]) => ({
+  const saveRemoteMediaMock = vi.fn<PluginRuntime["channel"]["media"]["saveRemoteMedia"]>(
+    async (_params) => ({
       path: "/tmp/zalo-photo.jpg",
       contentType: "image/jpeg",
     }),

--- a/extensions/zalo/src/test-support/lifecycle-test-support.ts
+++ b/extensions/zalo/src/test-support/lifecycle-test-support.ts
@@ -174,10 +174,14 @@ export function createImageLifecycleCore() {
     buffer: Buffer.from("image-bytes"),
     contentType: "image/jpeg",
   }));
-  const saveRemoteMediaMock = vi.fn(async () => ({
-    path: "/tmp/zalo-photo.jpg",
-    contentType: "image/jpeg",
-  }));
+  // Keep the mock arity aligned with PluginRuntime.saveRemoteMedia so
+  // mockImplementation callbacks that inspect timeout options typecheck.
+  const saveRemoteMediaMock = vi.fn(
+    async (_params: Parameters<PluginRuntime["channel"]["media"]["saveRemoteMedia"]>[0]) => ({
+      path: "/tmp/zalo-photo.jpg",
+      contentType: "image/jpeg",
+    }),
+  );
   const saveMediaBufferMock = vi.fn(async () => ({
     path: "/tmp/zalo-photo.jpg",
     contentType: "image/jpeg",
@@ -377,6 +381,8 @@ export function expectImageLifecycleDelivery(params: {
   expect(saveRemoteMediaMock).toHaveBeenCalledWith({
     url: photoUrl,
     maxBytes: 5 * 1024 * 1024,
+    responseHeaderTimeoutMs: 120_000,
+    readIdleTimeoutMs: 30_000,
   });
   expect(params.saveMediaBufferMock).not.toHaveBeenCalled();
   expect(params.finalizeInboundContextMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Zalo inbound photo downloads could hang indefinitely when `photo_url` accepted the TCP connection but never returned HTTP response headers. The shared media fetch idle timer only starts after headers arrive, so image message preprocessing could stall the polling/webhook path.

## Why This Change Was Made

Pass Telegram/Tlon/Mattermost-style media timeout options (`responseHeaderTimeoutMs: 120s`, `readIdleTimeoutMs: 30s`) through `handleImageMessage` into `core.channel.media.saveRemoteMedia`, so stalled header waits fail closed and the message continues with an unavailable-media notice.

## User Impact

Inbound Zalo images on a stalled CDN/host fail within the header deadline and continue as `[zalo image attachment unavailable]`, instead of blocking the channel turn.

## Evidence

### Caller-path hang proof

```bash
node scripts/run-vitest.mjs extensions/zalo/src/monitor.image.polling.test.ts --reporter=verbose
node scripts/run-vitest.mjs extensions/zalo/src/monitor.webhook.test.ts --reporter=verbose
```

```text
 ✓ |extension-zalo| ... > downloads inbound image media from photo_url and preserves display_name 5764ms
 ✓ |extension-zalo| ... > rejects unauthorized DM images before downloading media 10ms
 ✓ |extension-zalo| ... > dispatches an unavailable notice when the inbound image download fails 54ms
 ✓ |extension-zalo| ... > times out inbound image downloads when photo_url headers never arrive 328ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
[test] passed 1 Vitest shard in 22.96s

 ✓ |extension-zalo| ... > downloads inbound image media from webhook photo_url and preserves display_name 5ms
 Test Files  1 passed (1)
      Tests  19 passed (19)
[test] passed 1 Vitest shard in 42.06s
```

The hang case runs the production caller `monitorZaloProvider` → `handleImageMessage` against a real loopback HTTP server that never writes headers, using the same option keys this PR wires for production (shortened to 250ms only in the proof harness via a typed `typeof saveRemoteMedia` wrapper).

### Typecheck fix

`saveRemoteMediaMock` now takes the real `PluginRuntime` `saveRemoteMedia` parameter signature so `check-test-types` accepts the hang harness `mockImplementation`.

## Real behavior proof

- **Behavior or issue addressed:** Zalo inbound `photo_url` downloads no longer hang forever when response headers never arrive.
- **Canonical reachability path:** Zalo polling image update → `monitorZaloProvider` → `handleImageMessage` → `core.channel.media.saveRemoteMedia({ responseHeaderTimeoutMs, readIdleTimeoutMs })` → unavailable-media notice on failure.
- **Boundary crossed:** local-runtime HTTP; loopback Node server + shared media runtime fetch path exercised through the production polling monitor caller.
- **Shared helper / provider constraint check:** Reused `saveRemoteMedia` timeout options already used by Telegram/Mattermost (`120s` header / `30s` idle); no new media API surface.
- **Real environment tested:** macOS, Node via `node scripts/run-vitest.mjs`, loopback `node:http` server that accepts connections without writing headers.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs extensions/zalo/src/monitor.image.polling.test.ts --reporter=verbose`
- **Evidence after fix:**

```text
 ✓ |extension-zalo| ... > times out inbound image downloads when photo_url headers never arrive 328ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
[test] passed 1 Vitest shard in 22.96s
```

- **Observed result after fix:** Production caller passes `120_000` / `30_000`; the hang harness shortens only the actual fetch deadline to 250ms and still surfaces `[zalo image attachment unavailable]` with no `MediaPath` after ~328ms.
- **What was not tested:** Live Zalo Bot API / CDN; full Gateway process with a real bot token.
- **Fix classification:** Root cause fix.

## Risk / Compatibility

Low. Only Zalo inbound photo downloads gain explicit header/idle deadlines. Successful downloads under those budgets are unchanged.
