### PR TITLE
fix(ui): stop chat welcome suggestion text overflowing chips on phones

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -503,6 +503,11 @@ body {
      macOS WKWebView (Mac app) and Safari rubber-band the whole window, even
      when nothing overflows. */
   overscroll-behavior: none;
+  /* iOS WKWebView font boosting inflates rendered text without re-running
+     layout, so labels spill out of fixed-size chrome (welcome chips, badges).
+     Locking text-size-adjust keeps rendered metrics equal to layout metrics. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 body {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4082,14 +4082,6 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   .agent-chat__composer-controls .chat-controls__model {
     min-width: 0;
   }
-
-  .agent-chat__suggestions {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .agent-chat__suggestion {
-    min-height: 44px;
-  }
 }
 
 @media (display-mode: standalone) and (max-width: 768px) {
@@ -4280,11 +4272,16 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .agent-chat__suggestion {
   min-height: 40px;
   font-size: 13px;
-  padding: 8px 16px;
+  line-height: 1.4;
+  padding: 10px 16px;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   background: var(--panel);
   color: var(--foreground);
+  /* Localized labels wrap to multiple lines; balance keeps the split even and
+     break-word stops long words from pushing past the chip border. */
+  text-wrap: balance;
+  overflow-wrap: break-word;
   transition:
     background 0.15s,
     border-color 0.15s;
@@ -4293,6 +4290,19 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .agent-chat__suggestion:hover {
   background: var(--panel-strong);
   border-color: var(--accent);
+}
+
+/* Must stay after the base suggestion rules: equal specificity, so source
+   order is what lets the phone layout win over the two-column default. */
+@media (max-width: 768px) {
+  .agent-chat__suggestions {
+    grid-template-columns: minmax(0, 1fr);
+    width: min(100%, 360px);
+  }
+
+  .agent-chat__suggestion {
+    min-height: 44px;
+  }
 }
 
 /* Mobile dropdown toggle — hidden on desktop */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the chat welcome screen's suggestion chips ("Summarize my recent sessions", "Help me configure a channel") would wrap onto a second line that rendered outside the chip border on iPhone-sized WebKit views, and the whole screen stayed on the cramped two-column chip layout even at phone widths.

Two root causes:

1. **Dead mobile override.** The `@media (max-width: 768px)` rules that switch `.agent-chat__suggestions` to a single column (and bump chips to 44px touch targets) sit *earlier* in `ui/src/styles/chat/layout.css` than the base welcome-state rules. Equal specificity means source order decides, so the base two-column rule always won and the mobile layout never applied.
2. **iOS font boosting.** The Control UI never locks `text-size-adjust`, so iOS WKWebView text autosizing can inflate rendered text without re-running layout — labels paint larger than the boxes that were laid out for them and spill past chip borders.

## Why This Change Was Made

Moves the welcome-suggestion mobile override after the base rules (with a comment documenting the cascade-order contract) so phones actually get the single-column, 44px-touch-target layout; locks `text-size-adjust: 100%` on the root, the standard app-shell guard against iOS text inflation; and hardens the chips themselves — `line-height: 1.4`, slightly taller padding, `text-wrap: balance` for even two-line splits, and `overflow-wrap: break-word` so long localized labels can never push past the border. CSS-only; no markup or i18n changes.

## User Impact

On phones and the iPhone app's WebView, the chat welcome screen now shows full-width, comfortably sized suggestion chips with no text spilling out of the boxes. Desktop keeps the two-column grid; wrapped labels (e.g. longer localized strings) now split evenly and grow the chip instead of overflowing.

## Evidence

Verified with Playwright against the mock-gateway dev harness (`pnpm dev:ui:mock`) in both WebKit and Chromium at 390/500/900px viewports: single column ≤768px, two columns above, `scrollHeight ≤ boxHeight` for every chip (no overflow), 44px min chip height on mobile. Long German labels wrapping to 3 lines grow the chip (77px) without overflow in WebKit.

| Before (WebKit 500px) | After (WebKit 500px) | After (WebKit 900px) |
|---|---|---|
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-welcome-suggestion-overflow/before-webkit-500.png) | ![after mobile](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-welcome-suggestion-overflow/after-webkit-500.png) | ![after desktop](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-welcome-suggestion-overflow/after-webkit-900.png) |

- `pnpm check:changed` delegated to Blacksmith Testbox: green (run noted in comments).
- Codex autoreview (`gpt-5.5`, xhigh): clean, no accepted/actionable findings.
