### PR TITLE
improve(ui): polish sidebar scrolling and control alignment

### DIFF
--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -259,25 +259,21 @@ describe("AppSidebar session scroll fade", () => {
       scrollHeight: { configurable: true, get: () => scrollHeight },
     });
 
-    scroller.dispatchEvent(new Event("scroll"));
-    await sidebar.updateComplete;
-    expect(scroller.classList.contains("sidebar-recent-sessions--scroll-none")).toBe(true);
+    const expectScrollState = async (
+      scrollTop: number,
+      expected: "none" | "top" | "middle" | "bottom",
+    ) => {
+      scroller.scrollTop = scrollTop;
+      scroller.dispatchEvent(new Event("scroll"));
+      await sidebar.updateComplete;
+      expect(scroller.classList.contains(`sidebar-recent-sessions--scroll-${expected}`)).toBe(true);
+    };
 
+    await expectScrollState(0, "none");
     scrollHeight = 300;
-    scroller.scrollTop = 0;
-    scroller.dispatchEvent(new Event("scroll"));
-    await sidebar.updateComplete;
-    expect(scroller.classList.contains("sidebar-recent-sessions--scroll-top")).toBe(true);
-
-    scroller.scrollTop = 80;
-    scroller.dispatchEvent(new Event("scroll"));
-    await sidebar.updateComplete;
-    expect(scroller.classList.contains("sidebar-recent-sessions--scroll-middle")).toBe(true);
-
-    scroller.scrollTop = 200;
-    scroller.dispatchEvent(new Event("scroll"));
-    await sidebar.updateComplete;
-    expect(scroller.classList.contains("sidebar-recent-sessions--scroll-bottom")).toBe(true);
+    await expectScrollState(0, "top");
+    await expectScrollState(80, "middle");
+    await expectScrollState(200, "bottom");
   });
 });
 

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -244,6 +244,43 @@ describe("AppSidebar update card wiring", () => {
   });
 });
 
+describe("AppSidebar session scroll fade", () => {
+  it("shows fades only toward additional session content", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    const scroller = sidebar.querySelector<HTMLElement>(".sidebar-recent-sessions");
+    if (!scroller) {
+      throw new Error("Expected sidebar session scroller");
+    }
+
+    let scrollHeight = 100;
+    Object.defineProperties(scroller, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, get: () => scrollHeight },
+    });
+
+    scroller.dispatchEvent(new Event("scroll"));
+    await sidebar.updateComplete;
+    expect(scroller.classList.contains("sidebar-recent-sessions--scroll-none")).toBe(true);
+
+    scrollHeight = 300;
+    scroller.scrollTop = 0;
+    scroller.dispatchEvent(new Event("scroll"));
+    await sidebar.updateComplete;
+    expect(scroller.classList.contains("sidebar-recent-sessions--scroll-top")).toBe(true);
+
+    scroller.scrollTop = 80;
+    scroller.dispatchEvent(new Event("scroll"));
+    await sidebar.updateComplete;
+    expect(scroller.classList.contains("sidebar-recent-sessions--scroll-middle")).toBe(true);
+
+    scroller.scrollTop = 200;
+    scroller.dispatchEvent(new Event("scroll"));
+    await sidebar.updateComplete;
+    expect(scroller.classList.contains("sidebar-recent-sessions--scroll-bottom")).toBe(true);
+  });
+});
+
 describe("AppSidebar lobster outcome wiring", () => {
   it.each([
     ["panel", "failed", "error"],

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1387,7 +1387,6 @@ class AppSidebar extends OpenClawLightDomContentsElement {
         >
           <span class="nav-item__icon" aria-hidden="true">${icons.refresh}</span>
           <span class="sidebar-customize-menu__text">${t("nav.customizeReset")}</span>
-          <span class="sidebar-customize-menu__check" aria-hidden="true"></span>
         </button>
       </div>
     `;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1364,13 +1364,13 @@ class AppSidebar extends OpenClawLightDomContentsElement {
               aria-checked=${String(pinned)}
               @click=${() => this.togglePinnedRoute(routeId)}
             >
-              <span class="sidebar-customize-menu__check" aria-hidden="true">
-                ${pinned ? icons.check : nothing}
-              </span>
               <span class="nav-item__icon" aria-hidden="true"
                 >${icons[navigationIconForRoute(routeId)]}</span
               >
               <span class="sidebar-customize-menu__text">${titleForRoute(routeId)}</span>
+              <span class="sidebar-customize-menu__check" aria-hidden="true">
+                ${pinned ? icons.check : nothing}
+              </span>
             </button>
           `;
         })}
@@ -1385,9 +1385,9 @@ class AppSidebar extends OpenClawLightDomContentsElement {
             this.closeCustomizeMenu({ restoreFocus: true });
           }}
         >
-          <span class="sidebar-customize-menu__check" aria-hidden="true"></span>
           <span class="nav-item__icon" aria-hidden="true">${icons.refresh}</span>
           <span class="sidebar-customize-menu__text">${t("nav.customizeReset")}</span>
+          <span class="sidebar-customize-menu__check" aria-hidden="true"></span>
         </button>
       </div>
     `;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -314,11 +314,13 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     if (element !== this.sessionsScrollElement) {
       this.sessionsScrollResizeObserver?.disconnect();
       this.sessionsScrollElement = element;
-      this.sessionsScrollResizeObserver =
-        element && typeof ResizeObserver === "function"
-          ? new ResizeObserver(() => this.updateSessionsScrollState(element))
-          : null;
-      this.sessionsScrollResizeObserver?.observe(element);
+      this.sessionsScrollResizeObserver = null;
+      if (element && typeof ResizeObserver === "function") {
+        this.sessionsScrollResizeObserver = new ResizeObserver(() =>
+          this.updateSessionsScrollState(element),
+        );
+        this.sessionsScrollResizeObserver.observe(element);
+      }
     }
     if (element) {
       this.updateSessionsScrollState(element);

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -2143,7 +2143,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
           aria-expanded=${String(expanded)}
         >
           <span class="nav-section__label-text">${t("nav.more")}</span>
-          <span class="nav-section__chevron"> ${icons.chevronDown} </span>
+          <span class="nav-section__chevron">${icons.chevronDown}</span>
         </button>
         <div class="nav-section__items">
           ${moreRoutes.map((routeId) => this.renderRoute(routeId))}

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -113,6 +113,7 @@ type SidebarSessionGroupMenuState = {
 };
 
 type SidebarSessionSortMode = "created" | "updated";
+type SidebarSessionsScrollState = "none" | "top" | "middle" | "bottom";
 type SidebarSessionGroupDropTarget = {
   group: string;
   position: "before" | "after";
@@ -229,6 +230,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   @state() private sessionsAgentId: string | null = null;
   @state() private sessionsLoading = false;
   @state() private nativeSessionSidebarReady = false;
+  @state() private sessionsScrollState: SidebarSessionsScrollState = "none";
 
   private readonly subscriptions = new SubscriptionsController(this);
   private customizeMenuTrigger: HTMLElement | null = null;
@@ -245,6 +247,8 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   private gatewaySource: ApplicationContext<RouteId>["gateway"] | null = null;
   private gatewayClient: GatewayBrowserClient | null = null;
   private nativeSessionSidebarLoadStarted = false;
+  private sessionsScrollElement: HTMLElement | null = null;
+  private sessionsScrollResizeObserver: ResizeObserver | null = null;
   private readonly routePreloadTimers = new Map<
     EventTarget,
     ReturnType<typeof globalThis.setTimeout>
@@ -285,10 +289,14 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       globalThis.clearTimeout(timer);
     }
     this.routePreloadTimers.clear();
+    this.sessionsScrollResizeObserver?.disconnect();
+    this.sessionsScrollResizeObserver = null;
+    this.sessionsScrollElement = null;
     super.disconnectedCallback();
   }
 
   override updated() {
+    this.syncSessionsScrollObserver();
     const advertised = this.pluginTabs().some(
       (tab) => tab.id === "sessions" && (tab.pluginId === "codex" || tab.pluginId === "anthropic"),
     );
@@ -299,6 +307,39 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     void import("../pages/plugin/codex-sidebar.ts").then(() => {
       this.nativeSessionSidebarReady = true;
     });
+  }
+
+  private syncSessionsScrollObserver() {
+    const element = this.querySelector<HTMLElement>(".sidebar-recent-sessions");
+    if (element !== this.sessionsScrollElement) {
+      this.sessionsScrollResizeObserver?.disconnect();
+      this.sessionsScrollElement = element;
+      this.sessionsScrollResizeObserver =
+        element && typeof ResizeObserver === "function"
+          ? new ResizeObserver(() => this.updateSessionsScrollState(element))
+          : null;
+      this.sessionsScrollResizeObserver?.observe(element);
+    }
+    if (element) {
+      this.updateSessionsScrollState(element);
+    }
+  }
+
+  private updateSessionsScrollState(element: HTMLElement) {
+    const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
+    let nextState: SidebarSessionsScrollState = "none";
+    if (maxScrollTop > 1) {
+      if (element.scrollTop <= 1) {
+        nextState = "top";
+      } else if (element.scrollTop >= maxScrollTop - 1) {
+        nextState = "bottom";
+      } else {
+        nextState = "middle";
+      }
+    }
+    if (nextState !== this.sessionsScrollState) {
+      this.sessionsScrollState = nextState;
+    }
   }
 
   // The shell calls this before CSS hides the panel or drawer. Mounted menus
@@ -2009,7 +2050,13 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     const expandedAgentId = this.expandedAgentId();
     return html`
       <section class="sidebar-sessions">
-        <div class="sidebar-recent-sessions" aria-label=${titleForRoute("sessions")}>
+        <div
+          class="sidebar-recent-sessions sidebar-recent-sessions--scroll-${this
+            .sessionsScrollState}"
+          aria-label=${titleForRoute("sessions")}
+          @scroll=${(event: Event) =>
+            this.updateSessionsScrollState(event.currentTarget as HTMLElement)}
+        >
           <div class="sidebar-recent-sessions__head sidebar-recent-sessions__head--root">
             <span class="sidebar-recent-sessions__label-text">${t("sessionsView.title")}</span>
             <button

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1120,11 +1120,13 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 }
 
 .sidebar-session-group-count {
+  width: 26px;
   flex: 0 0 auto;
   color: var(--muted);
   font-size: 10px;
   font-variant-numeric: tabular-nums;
   opacity: 0.7;
+  text-align: center;
 }
 
 .sidebar-session-group-drag-handle {
@@ -1429,6 +1431,10 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 26px;
+  height: 26px;
+  min-width: 0;
+  flex: 0 0 26px;
   opacity: 0.5;
   transition: transform var(--duration-fast) ease;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -987,10 +987,16 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   margin: 0 -8px;
   min-height: 0;
   overflow-y: auto;
+  scrollbar-color: color-mix(in srgb, currentColor 8%, transparent) transparent;
   scrollbar-width: thin;
   /* Sessions are app chrome, not hyperlinks: the whole region uses the
      default arrow cursor; the pointer hand is reserved for real links. */
   cursor: default;
+}
+
+.sidebar-recent-sessions::-webkit-scrollbar,
+.sidebar-recent-sessions::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 /* The scroller's children must not flex-shrink: shrink squeezes each section

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1003,7 +1003,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   --sidebar-sessions-mask: linear-gradient(
     to bottom,
     black 0,
-    black calc(100% - 20px),
+    black calc(100% - 23px),
     transparent 100%
   );
 }
@@ -1012,14 +1012,14 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   --sidebar-sessions-mask: linear-gradient(
     to bottom,
     transparent 0,
-    black 20px,
-    black calc(100% - 20px),
+    black 23px,
+    black calc(100% - 23px),
     transparent 100%
   );
 }
 
 .sidebar-recent-sessions--scroll-bottom {
-  --sidebar-sessions-mask: linear-gradient(to bottom, transparent 0, black 20px, black 100%);
+  --sidebar-sessions-mask: linear-gradient(to bottom, transparent 0, black 23px, black 100%);
 }
 
 .sidebar-recent-sessions--scroll-top,

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -999,6 +999,36 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   background: transparent;
 }
 
+.sidebar-recent-sessions--scroll-top {
+  --sidebar-sessions-mask: linear-gradient(
+    to bottom,
+    black 0,
+    black calc(100% - 20px),
+    transparent 100%
+  );
+}
+
+.sidebar-recent-sessions--scroll-middle {
+  --sidebar-sessions-mask: linear-gradient(
+    to bottom,
+    transparent 0,
+    black 20px,
+    black calc(100% - 20px),
+    transparent 100%
+  );
+}
+
+.sidebar-recent-sessions--scroll-bottom {
+  --sidebar-sessions-mask: linear-gradient(to bottom, transparent 0, black 20px, black 100%);
+}
+
+.sidebar-recent-sessions--scroll-top,
+.sidebar-recent-sessions--scroll-middle,
+.sidebar-recent-sessions--scroll-bottom {
+  -webkit-mask-image: var(--sidebar-sessions-mask);
+  mask-image: var(--sidebar-sessions-mask);
+}
+
 /* The scroller's children must not flex-shrink: shrink squeezes each section
    to its min-height while the fixed-height rows inside overflow and paint
    over the following section. Fixed sizing makes the list scroll instead. */

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1524,6 +1524,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 }
 
 .sidebar-customize-menu__text {
+  flex: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## What Problem This Solves

The Control UI sidebar can feel visually inconsistent when session lists overflow: the scrollbar track adds unnecessary chrome, the list has no edge affordance for additional content, and trailing controls do not share a consistent alignment column.

## Why This Change Was Made

This PR keeps the session scrollbar track transparent, adds position-aware fades only where more session content is available, moves pinned-item checks to the trailing edge, and aligns sidebar trailing controls to one column. The fade state responds to scrolling, rerenders, and scroller resizing without changing session behavior.

## User Impact

Users get a clearer overflow affordance in long session lists and a more consistent sidebar layout across normal and resized widths.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` - 18 tests passed.
- `git diff --check` - passed.
- Mock browser validation confirmed top, middle, bottom, and no-overflow fade states.
- Trailing SVG centers matched exactly at sidebar widths of 258 px and 358 px.
- Remote Testbox was unavailable because the selected Crabbox binary failed its startup sanity check; the focused local fallback above was used.

### Before

![Proposed sidebar alignment before](https://amber-yarrow-jhdq.here.now/codex-clipboard-d5a34916-e8a2-4f56-8b87-7e62a79445eb.png)

### After

![Proposed sidebar alignment in this PR](https://spruce-waffle-6v8d.here.now/openclaw-sidebar-right-column-resized.png)
