### PR TITLE
fix(clawrouter): guard usage snapshot fetch against SSRF redirects

### DIFF
--- a/extensions/clawrouter/index.ts
+++ b/extensions/clawrouter/index.ts
@@ -219,7 +219,6 @@ export default definePluginEntry({
           token: ctx.token,
           baseUrl: configuredBaseUrl(ctx.config),
           timeoutMs: ctx.timeoutMs,
-          fetchFn: ctx.fetchFn,
         }),
     });
   },

--- a/extensions/clawrouter/usage.test.ts
+++ b/extensions/clawrouter/usage.test.ts
@@ -1,9 +1,55 @@
-import { describe, expect, it, vi } from "vitest";
-import { fetchClawRouterUsage } from "./usage.js";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi, type MockedFunction } from "vitest";
+import { fetchClawRouterUsage, type ClawRouterUsageFetchGuard } from "./usage.js";
+
+const runningServers: Server[] = [];
+
+async function startUsageServer(
+  handler: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => void,
+): Promise<{ baseUrl: string; requests: string[] }> {
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    requests.push(`${req.method ?? "GET"} ${req.url ?? "/"}`);
+    handler(req, res);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  runningServers.push(server);
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    runningServers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+function mockFetchGuard(response: Response): MockedFunction<ClawRouterUsageFetchGuard> {
+  return vi.fn(async ({ url }) => ({
+    response,
+    finalUrl: url,
+    release: async () => undefined,
+  }));
+}
 
 describe("ClawRouter usage", () => {
   it("maps the managed monthly budget and usage totals", async () => {
-    const fetchFn = vi.fn(async () =>
+    const fetchGuard = mockFetchGuard(
       Response.json({
         budget: {
           configured: true,
@@ -27,7 +73,7 @@ describe("ClawRouter usage", () => {
       token: "proxy-key",
       baseUrl: "https://clawrouter.example/v1",
       timeoutMs: 5000,
-      fetchFn: fetchFn as unknown as typeof fetch,
+      fetchGuard,
     });
 
     expect(snapshot).toEqual({
@@ -53,27 +99,31 @@ describe("ClawRouter usage", () => {
       summary: "12 requests · 34,567 tokens · $25.00 used",
       plan: "Managed monthly budget",
     });
-    expect(fetchFn).toHaveBeenCalledWith(
-      "https://clawrouter.example/v1/usage",
+    expect(fetchGuard).toHaveBeenCalledWith(
       expect.objectContaining({
-        headers: {
-          Accept: "application/json",
-          Authorization: "Bearer proxy-key",
-        },
+        url: "https://clawrouter.example/v1/usage",
+        init: expect.objectContaining({
+          headers: {
+            Accept: "application/json",
+            Authorization: "Bearer proxy-key",
+          },
+        }),
+        auditContext: "clawrouter.usage",
       }),
     );
+    expect(fetchGuard.mock.calls[0]?.[0]).not.toHaveProperty("fetchImpl");
   });
 
   it("shows aggregate usage for an unmetered key", async () => {
     const snapshot = await fetchClawRouterUsage({
       token: "proxy-key",
       timeoutMs: 5000,
-      fetchFn: vi.fn(async () =>
+      fetchGuard: mockFetchGuard(
         Response.json({
           budget: { configured: false, ledger: "unmetered" },
           usage: { summary: { requestCount: 0, totalTokens: 0, actualCostMicros: 0 } },
         }),
-      ) as unknown as typeof fetch,
+      ),
     });
 
     expect(snapshot.windows).toEqual([]);
@@ -87,9 +137,7 @@ describe("ClawRouter usage", () => {
       fetchClawRouterUsage({
         token: "proxy-key",
         timeoutMs: 5000,
-        fetchFn: vi.fn(
-          async () => new Response("secret details", { status: 403 }),
-        ) as unknown as typeof fetch,
+        fetchGuard: mockFetchGuard(new Response("secret details", { status: 403 })),
       }),
     ).rejects.toThrow("ClawRouter usage request failed (HTTP 403)");
   });
@@ -105,11 +153,51 @@ describe("ClawRouter usage", () => {
       fetchClawRouterUsage({
         token: "proxy-key",
         timeoutMs: 5000,
-        fetchFn: async () =>
+        fetchGuard: mockFetchGuard(
           new Response(oversizedPayload, {
             headers: { "content-type": "application/json" },
           }),
+        ),
       }),
     ).rejects.toThrow("ClawRouter usage response exceeds");
+  });
+
+  it("fetches usage through the production SSRF-guarded transport", async () => {
+    const { baseUrl, requests } = await startUsageServer((req, res) => {
+      expect(req.headers.authorization).toBe("Bearer proxy-key");
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          budget: { configured: false, ledger: "unmetered" },
+          usage: { summary: { requestCount: 3, totalTokens: 9, actualCostMicros: 0 } },
+        }),
+      );
+    });
+
+    const snapshot = await fetchClawRouterUsage({
+      token: "proxy-key",
+      baseUrl,
+      timeoutMs: 5000,
+    });
+
+    expect(snapshot.summary).toBe("3 requests · 9 tokens · $0.00 used");
+    expect(snapshot.plan).toBe("Unmetered proxy key");
+    expect(requests).toEqual(["GET /v1/usage"]);
+  });
+
+  it("blocks private-network redirects on the production transport path", async () => {
+    const { baseUrl, requests } = await startUsageServer((_req, res) => {
+      res.writeHead(302, { Location: "http://10.0.0.1:9/v1/usage" });
+      res.end();
+    });
+
+    await expect(
+      fetchClawRouterUsage({
+        token: "proxy-key",
+        baseUrl,
+        timeoutMs: 5000,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(requests).toEqual(["GET /v1/usage"]);
   });
 });

--- a/extensions/clawrouter/usage.test.ts
+++ b/extensions/clawrouter/usage.test.ts
@@ -1,9 +1,34 @@
 import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
-import { afterEach, describe, expect, it, vi, type MockedFunction } from "vitest";
+import { connect, type AddressInfo } from "node:net";
+import type { Duplex } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi, type MockedFunction } from "vitest";
 import { fetchClawRouterUsage, type ClawRouterUsageFetchGuard } from "./usage.js";
 
 const runningServers: Server[] = [];
+const runningSockets = new Set<Duplex>();
+const PROXY_ENV_KEYS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+] as const;
+const savedProxyEnv = new Map<string, string | undefined>();
+
+function trackSocket(socket: Duplex): void {
+  runningSockets.add(socket);
+  socket.once("close", () => runningSockets.delete(socket));
+}
+
+async function listenOnLoopback(server: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  runningServers.push(server);
+  return (server.address() as AddressInfo).port;
+}
 
 async function startUsageServer(
   handler: (
@@ -16,19 +41,53 @@ async function startUsageServer(
     requests.push(`${req.method ?? "GET"} ${req.url ?? "/"}`);
     handler(req, res);
   });
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => resolve());
-  });
-  runningServers.push(server);
-  const address = server.address() as AddressInfo;
+  const port = await listenOnLoopback(server);
   return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
+    baseUrl: `http://127.0.0.1:${port}`,
     requests,
   };
 }
 
+async function startConnectProxy(): Promise<{ proxyUrl: string; connects: string[] }> {
+  const connects: string[] = [];
+  const server = createServer();
+  server.on("connect", (req, clientSocket, head) => {
+    const target = req.url;
+    if (!target) {
+      clientSocket.destroy();
+      return;
+    }
+    connects.push(target);
+    trackSocket(clientSocket);
+    const targetUrl = new URL(`http://${target}`);
+    const targetSocket = connect(Number(targetUrl.port), targetUrl.hostname, () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.length > 0) {
+        targetSocket.write(head);
+      }
+      clientSocket.pipe(targetSocket);
+      targetSocket.pipe(clientSocket);
+    });
+    trackSocket(targetSocket);
+    targetSocket.on("error", () => clientSocket.destroy());
+    clientSocket.on("error", () => targetSocket.destroy());
+  });
+  const port = await listenOnLoopback(server);
+  return { proxyUrl: `http://127.0.0.1:${port}`, connects };
+}
+
+beforeEach(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    savedProxyEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+});
+
 afterEach(async () => {
+  for (const socket of runningSockets) {
+    socket.destroy();
+  }
+  runningSockets.clear();
   await Promise.all(
     runningServers.splice(0).map(
       (server) =>
@@ -37,6 +96,15 @@ afterEach(async () => {
         }),
     ),
   );
+  for (const key of PROXY_ENV_KEYS) {
+    const value = savedProxyEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  savedProxyEnv.clear();
 });
 
 function mockFetchGuard(response: Response): MockedFunction<ClawRouterUsageFetchGuard> {
@@ -109,6 +177,7 @@ describe("ClawRouter usage", () => {
           },
         }),
         auditContext: "clawrouter.usage",
+        mode: "trusted_env_proxy",
       }),
     );
     expect(fetchGuard.mock.calls[0]?.[0]).not.toHaveProperty("fetchImpl");
@@ -185,11 +254,36 @@ describe("ClawRouter usage", () => {
     expect(requests).toEqual(["GET /v1/usage"]);
   });
 
-  it("blocks private-network redirects on the production transport path", async () => {
+  it("preserves provider usage routing through the env proxy", async () => {
+    const { baseUrl } = await startUsageServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json", connection: "close" });
+      res.end(
+        JSON.stringify({
+          budget: { configured: false, ledger: "unmetered" },
+          usage: { summary: { requestCount: 2, totalTokens: 8, actualCostMicros: 0 } },
+        }),
+      );
+    });
+    const { proxyUrl, connects } = await startConnectProxy();
+    process.env.HTTP_PROXY = proxyUrl;
+
+    const snapshot = await fetchClawRouterUsage({
+      token: "proxy-key",
+      baseUrl,
+      timeoutMs: 5000,
+    });
+
+    expect(snapshot.summary).toBe("2 requests · 8 tokens · $0.00 used");
+    expect(connects).toEqual([new URL(baseUrl).host]);
+  });
+
+  it("blocks private-network redirects before a second proxied request", async () => {
     const { baseUrl, requests } = await startUsageServer((_req, res) => {
       res.writeHead(302, { Location: "http://10.0.0.1:9/v1/usage" });
       res.end();
     });
+    const { proxyUrl, connects } = await startConnectProxy();
+    process.env.HTTP_PROXY = proxyUrl;
 
     await expect(
       fetchClawRouterUsage({
@@ -199,5 +293,6 @@ describe("ClawRouter usage", () => {
       }),
     ).rejects.toThrow(/private|internal|blocked/i);
     expect(requests).toEqual(["GET /v1/usage"]);
+    expect(connects).toEqual([new URL(baseUrl).host]);
   });
 });

--- a/extensions/clawrouter/usage.ts
+++ b/extensions/clawrouter/usage.ts
@@ -1,3 +1,4 @@
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import type { ProviderUsageSnapshot } from "openclaw/plugin-sdk/provider-usage";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
@@ -91,23 +92,25 @@ export async function fetchClawRouterUsage(params: {
   /** Test-only seam; production keeps the shared SSRF guard owning transport. */
   fetchGuard?: ClawRouterUsageFetchGuard;
 }): Promise<ProviderUsageSnapshot> {
-  // Operator-configured baseUrl can redirect anywhere. Match live catalog discovery:
-  // the shared guard owns the dispatcher (no caller fetchImpl), so DNS pinning and
-  // private redirect rejection cannot be bypassed by provider usage proxy wrappers.
+  // Operator-configured baseUrl can redirect anywhere. The guard owns transport and
+  // rechecks every hop; env proxy mode preserves provider-usage proxy support while
+  // direct and NO_PROXY requests retain pinned DNS.
   const rootUrl = normalizeClawRouterRootUrl(params.baseUrl);
   const fetchGuard = params.fetchGuard ?? fetchWithSsrFGuard;
-  const { response, release } = await fetchGuard({
-    url: `${rootUrl}/v1/usage`,
-    init: {
-      headers: {
-        Accept: "application/json",
-        Authorization: `Bearer ${params.token}`,
+  const { response, release } = await fetchGuard(
+    withTrustedEnvProxyGuardedFetchMode({
+      url: `${rootUrl}/v1/usage`,
+      init: {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${params.token}`,
+        },
       },
-    },
-    timeoutMs: params.timeoutMs,
-    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(rootUrl),
-    auditContext: "clawrouter.usage",
-  });
+      timeoutMs: params.timeoutMs,
+      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(rootUrl),
+      auditContext: "clawrouter.usage",
+    }),
+  );
   try {
     if (!response.ok) {
       throw new Error(`ClawRouter usage request failed (HTTP ${response.status})`);

--- a/extensions/clawrouter/usage.ts
+++ b/extensions/clawrouter/usage.ts
@@ -1,8 +1,14 @@
 import type { ProviderUsageSnapshot } from "openclaw/plugin-sdk/provider-usage";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedHostname,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeClawRouterRootUrl } from "./provider-catalog.js";
 
 const CLAWROUTER_USAGE_RESPONSE_MAX_BYTES = 1024 * 1024;
+
+export type ClawRouterUsageFetchGuard = typeof fetchWithSsrFGuard;
 
 type ClawRouterBudget = {
   configured?: unknown;
@@ -82,53 +88,68 @@ export async function fetchClawRouterUsage(params: {
   token: string;
   baseUrl?: string;
   timeoutMs: number;
-  fetchFn: typeof fetch;
+  /** Test-only seam; production keeps the shared SSRF guard owning transport. */
+  fetchGuard?: ClawRouterUsageFetchGuard;
 }): Promise<ProviderUsageSnapshot> {
-  const response = await params.fetchFn(`${normalizeClawRouterRootUrl(params.baseUrl)}/v1/usage`, {
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${params.token}`,
+  // Operator-configured baseUrl can redirect anywhere. Match live catalog discovery:
+  // the shared guard owns the dispatcher (no caller fetchImpl), so DNS pinning and
+  // private redirect rejection cannot be bypassed by provider usage proxy wrappers.
+  const rootUrl = normalizeClawRouterRootUrl(params.baseUrl);
+  const fetchGuard = params.fetchGuard ?? fetchWithSsrFGuard;
+  const { response, release } = await fetchGuard({
+    url: `${rootUrl}/v1/usage`,
+    init: {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${params.token}`,
+      },
     },
-    signal: AbortSignal.timeout(params.timeoutMs),
+    timeoutMs: params.timeoutMs,
+    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(rootUrl),
+    auditContext: "clawrouter.usage",
   });
-  if (!response.ok) {
-    throw new Error(`ClawRouter usage request failed (HTTP ${response.status})`);
+  try {
+    if (!response.ok) {
+      throw new Error(`ClawRouter usage request failed (HTTP ${response.status})`);
+    }
+    const payload = await readClawRouterUsagePayload(response, params.timeoutMs);
+    const budget = payload.budget;
+    const limitMicros = nonNegativeNumber(budget?.limitMicros);
+    const spentMicros = nonNegativeNumber(budget?.spentMicros);
+    const costMicros = nonNegativeNumber(payload.usage?.summary?.actualCostMicros);
+    const resetAt = resolveMonthlyResetAt(budget?.windowKey);
+    const windows = [];
+    if (budget?.configured === true && limitMicros !== undefined && spentMicros !== undefined) {
+      windows.push({
+        label: "Monthly budget",
+        usedPercent: limitMicros === 0 ? 100 : Math.min(100, (spentMicros / limitMicros) * 100),
+        resetAt,
+      });
+    }
+    const billing: ProviderUsageSnapshot["billing"] =
+      budget?.configured === true && limitMicros !== undefined && spentMicros !== undefined
+        ? [
+            {
+              type: "budget",
+              used: spentMicros / 1_000_000,
+              limit: limitMicros / 1_000_000,
+              unit: "USD",
+              period: "month",
+              resetAt,
+            },
+          ]
+        : costMicros !== undefined
+          ? [{ type: "spend", amount: costMicros / 1_000_000, unit: "USD" }]
+          : undefined;
+    return {
+      provider: "clawrouter" as ProviderUsageSnapshot["provider"],
+      displayName: "ClawRouter",
+      windows,
+      ...(billing ? { billing } : {}),
+      summary: buildSummary(payload),
+      plan: budget?.configured === true ? "Managed monthly budget" : "Unmetered proxy key",
+    };
+  } finally {
+    await release();
   }
-  const payload = await readClawRouterUsagePayload(response, params.timeoutMs);
-  const budget = payload.budget;
-  const limitMicros = nonNegativeNumber(budget?.limitMicros);
-  const spentMicros = nonNegativeNumber(budget?.spentMicros);
-  const costMicros = nonNegativeNumber(payload.usage?.summary?.actualCostMicros);
-  const resetAt = resolveMonthlyResetAt(budget?.windowKey);
-  const windows = [];
-  if (budget?.configured === true && limitMicros !== undefined && spentMicros !== undefined) {
-    windows.push({
-      label: "Monthly budget",
-      usedPercent: limitMicros === 0 ? 100 : Math.min(100, (spentMicros / limitMicros) * 100),
-      resetAt,
-    });
-  }
-  const billing: ProviderUsageSnapshot["billing"] =
-    budget?.configured === true && limitMicros !== undefined && spentMicros !== undefined
-      ? [
-          {
-            type: "budget",
-            used: spentMicros / 1_000_000,
-            limit: limitMicros / 1_000_000,
-            unit: "USD",
-            period: "month",
-            resetAt,
-          },
-        ]
-      : costMicros !== undefined
-        ? [{ type: "spend", amount: costMicros / 1_000_000, unit: "USD" }]
-        : undefined;
-  return {
-    provider: "clawrouter" as ProviderUsageSnapshot["provider"],
-    displayName: "ClawRouter",
-    windows,
-    ...(billing ? { billing } : {}),
-    summary: buildSummary(payload),
-    plan: budget?.configured === true ? "Managed monthly budget" : "Unmetered proxy key",
-  };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClawRouter usage snapshot fetches used an unguarded `fetch` against an operator-configured `baseUrl`. A malicious or compromised usage endpoint could redirect the request onto a private/internal address, and the call path skipped the shared SSRF guard already used for ClawRouter live catalog discovery.

## Why This Change Was Made

Route `fetchClawRouterUsage` through `fetchWithSsrFGuard` the same way live catalog discovery does: the guard owns production transport (no caller `fetchImpl`), so DNS pinning cannot be overwritten by provider usage proxy wrappers. Tests inject an optional `fetchGuard` seam; production callers no longer pass `ctx.fetchFn`.

## User Impact

ClawRouter `/usage` status no longer follows redirects from the configured host into private/internal networks. Healthy public ClawRouter usage endpoints continue to work.

## Evidence

### Unit + controlled-server production-transport proof

```bash
node scripts/run-vitest.mjs extensions/clawrouter/usage.test.ts --reporter=verbose
```

```text
 ✓ ... > maps the managed monthly budget and usage totals 151ms
 ✓ ... > shows aggregate usage for an unmetered key 2ms
 ✓ ... > does not expose an upstream error body 1ms
 ✓ ... > bounds successful usage response bodies 17ms
 ✓ ... > fetches usage through the production SSRF-guarded transport 326ms
 ✓ ... > blocks private-network redirects on the production transport path 55ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
[test] passed 1 Vitest shard in 5.62s
```

The last two cases exercise production `fetchClawRouterUsage` with no injected fetch/guard: a real `node:http` loopback server for healthy usage, and a `302` to `http://10.0.0.1:9/v1/usage` that the shared guard rejects before a second hop.

## Real behavior proof

- **Behavior or issue addressed:** ClawRouter usage fetches no longer follow redirects from the configured host onto private/internal targets, and production transport stays under the shared SSRF guard's dispatcher.
- **Canonical reachability path:** provider usage snapshot → `fetchUsageSnapshot` in `extensions/clawrouter/index.ts` → `fetchClawRouterUsage` → `fetchWithSsrFGuard` (no `fetchImpl`).
- **Boundary crossed:** local-runtime SSRF guard; controlled `node:http` server on loopback; private redirect target.
- **Shared helper / provider constraint check:** Reused `fetchWithSsrFGuard` + `ssrfPolicyFromHttpBaseUrlAllowedHostname` already used by ClawRouter live catalog discovery; same guard-owned transport shape as catalog (no provider usage proxy as `fetchImpl`).
- **Real environment tested:** macOS, Node via `node scripts/run-vitest.mjs` with real HTTP listeners.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs extensions/clawrouter/usage.test.ts --reporter=verbose`
- **Evidence after fix:**

```text
 ✓ |extensions| extensions/clawrouter/usage.test.ts > ClawRouter usage > fetches usage through the production SSRF-guarded transport 326ms
 ✓ |extensions| extensions/clawrouter/usage.test.ts > ClawRouter usage > blocks private-network redirects on the production transport path 55ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
[test] passed 1 Vitest shard in 5.62s
```

- **Observed result after fix:** Healthy usage returns the mapped snapshot over the guard-owned transport; private-network redirect rejects with a blocked/private/internal error and the controlled server sees only the first hop.
- **What was not tested:** Live ClawRouter cloud `/v1/usage` against a real proxy key; Gateway status UI end-to-end; HTTP_PROXY-managed usage routing (usage now matches catalog and uses guard-owned direct transport rather than `resolveProxyFetchFromEnv` as `fetchImpl`).
- **Fix classification:** Root cause fix.

## Risk / Compatibility

Low. Only the ClawRouter usage HTTP transport gains the shared SSRF guard with guard-owned dispatcher. Successful responses from the configured host are unchanged; operator-configured private base URLs remain allowed when that hostname is the configured endpoint (same policy shape as catalog discovery). Usage snapshot fetching no longer routes through the provider usage proxy fetch wrapper, matching catalog discovery.
