### PR TITLE
fix(ui): split-view pane header hides under the macOS traffic lights when the sidebar is collapsed

### DIFF
--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -127,6 +127,19 @@ openclaw-chat-pane {
   }
 }
 
+/* Native macOS floats the traffic lights plus the titlebar accessory
+   (sidebar toggle, back/forward — DashboardWindowController) over the
+   top-left ~194px of the page. With the nav column collapsed the split view
+   is the window's top surface, so reserve the titlebar band above the pane
+   headers; this also keeps the header buttons clear of the AppKit drag
+   region (x 78-254, y < 46) that would swallow their clicks. Drawer widths
+   (<=1100px) reserve a 58px topbar row instead (layout.mobile.css). */
+@media (min-width: 1101px) {
+  html.openclaw-native-macos .shell--nav-collapsed .chat-split-view {
+    padding-top: var(--openclaw-native-titlebar-height, 50px);
+  }
+}
+
 .chat-pane__header {
   display: flex;
   flex: 0 0 auto;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where, inside the macOS app, the chat split view's top-left pane header renders underneath the window traffic lights when the navigation sidebar is collapsed. The session title in that header (e.g. "home") is partially hidden behind the close/minimize/zoom buttons, and the header's leading area sits under the AppKit drag regions.

The dashboard window uses a full-size content view with a transparent titlebar (`DashboardWindowController`), so the native chrome — traffic lights plus the titlebar accessory hosting the sidebar toggle and back/forward — floats over roughly the top-left 194px of the page. The sidebar (`.sidebar-shell`) and the narrow-width topbar already reserve that band, but the desktop split view did not: with `.shell--nav-collapsed` the shell has no topbar row, so the first pane header becomes the window's top surface at y=0.

## Why This Change Was Made

The Control UI already advertises the native host via the `html.openclaw-native-macos` class and the `--openclaw-native-titlebar-height` variable that the Mac app injects. Reserving the titlebar band above `.chat-split-view` (only when the nav column is collapsed, only at desktop widths ≥1101px) mirrors the existing sidebar/topbar clearance and also keeps the pane-header buttons out of the AppKit drag region (x 78–254, y < 46) that would otherwise swallow their clicks. Drawer widths (≤1100px) already reserve a 58px topbar row via `layout.mobile.css`, so they are excluded.

A left-inset on the first header alone was rejected: it would need ~200px of dead padding and would leave the header's interactive controls under the native drag region.

## User Impact

macOS app users who collapse the sidebar while using chat split view can now read the full pane/session title and click the header controls; nothing hides behind the traffic lights or the native titlebar buttons. Browser users and narrow/drawer layouts are unaffected (`html.openclaw-native-macos` is only present inside the Mac app).

## Evidence

Reproduced against the control-ui mock dev server with the Mac app's chrome injection simulated (same classes/CSS as `DashboardWindowController.installNativeChromeScript`, traffic lights + accessory footprint overlaid):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-pane-native-titlebar-band/before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-pane-native-titlebar-band/after.png) |

- Before: pane title overlapped by the traffic lights (matches the report screenshot).
- After: 50px titlebar band reserved above the pane headers; `.chat-pane__header` top measured at y=50.
- Sidebar-expanded split view verified unchanged (headers start at the content column, x ≥ 240 — `NAV_WIDTH_MIN` — clear of the ~194px native chrome).
- CSS-only change gated on `html.openclaw-native-macos`; plain-browser rendering untouched.
