### PR TITLE
refactor(retry): add full-jitter mode and adopt it for mattermost client retries

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -13,6 +13,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
 
 import {
   createMattermostClient,
+  createMattermostDirectChannelWithRetry,
   createMattermostPost,
   normalizeMattermostBaseUrl,
   readMattermostError,
@@ -562,5 +563,42 @@ describe("updateMattermostPost", () => {
     expect(body.id).toBe("post1");
     expect(body.message).toBeUndefined();
     expect(body.props).toEqual({ attachments: [] });
+  });
+});
+
+describe("createMattermostDirectChannelWithRetry delay cap", () => {
+  it("keeps maxDelayMs authoritative when initialDelayMs exceeds it", async () => {
+    vi.useFakeTimers();
+    try {
+      const mockFetch = vi
+        .fn<typeof fetch>()
+        .mockRejectedValueOnce(new Error("Mattermost API 503 Service Unavailable"))
+        .mockRejectedValueOnce(new Error("Mattermost API 503 Service Unavailable"))
+        .mockResolvedValueOnce(Response.json({ id: "dm-channel-cap" }, { status: 201 }));
+      const client = createMattermostClient({
+        baseUrl: "https://mattermost.example.com",
+        botToken: "test-token",
+        fetchImpl: mockFetch,
+      });
+      const delays: number[] = [];
+      // The config schema allows initialDelayMs above the defaulted 10s
+      // maxDelayMs cap; the cap must still bound every retry delay instead of
+      // the base delay overriding it (regression guard for the core-retry
+      // migration, which raises maxDelayMs to the minDelayMs floor).
+      const promise = createMattermostDirectChannelWithRetry(client, ["user-1", "user-2"], {
+        maxRetries: 3,
+        initialDelayMs: 60_000,
+        onRetry: (_attempt, delayMs) => {
+          delays.push(delayMs);
+        },
+      });
+      await vi.runAllTimersAsync();
+      const result = await promise;
+      expect(result.id).toBe("dm-channel-cap");
+      expect(delays).toEqual([10_000, 10_000]);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -6,7 +6,7 @@ import {
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
-import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromPrivateNetworkOptIn,
@@ -444,55 +444,35 @@ export async function createMattermostDirectChannelWithRetry(
   } = options;
   const timeoutMs = resolveTimerTimeoutMs(rawTimeoutMs, 30000);
 
-  let lastError: Error | undefined;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
+  return await retryAsync(
+    async () => {
       // Use AbortController for per-request timeout
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
       try {
-        const result = await createMattermostDirectChannel(
-          client,
-          userIds,
-          controller.signal,
-          timeoutMs,
-        );
-        return result;
+        return await createMattermostDirectChannel(client, userIds, controller.signal, timeoutMs);
+      } catch (err) {
+        // Normalize before rethrowing so shouldRetry/onRetry below always see Errors.
+        throw err instanceof Error ? err : new Error(String(err));
       } finally {
         clearTimeout(timeoutId);
       }
-    } catch (err) {
-      lastError = err instanceof Error ? err : new Error(String(err));
-
-      // Don't retry on the last attempt
-      if (attempt >= maxRetries) {
-        break;
-      }
-
-      // Check if error is retryable
-      if (!isRetryableError(lastError)) {
-        throw lastError;
-      }
-
-      // Calculate exponential backoff delay with full-jitter
-      // Jitter is proportional to the exponential delay, not a fixed 1000ms
-      // This ensures backoff behaves correctly for small delay configurations
-      const exponentialDelay = initialDelayMs * 2 ** attempt;
-      const jitter = Math.random() * exponentialDelay;
-      const delayMs = Math.min(exponentialDelay + jitter, maxDelayMs);
-
-      if (onRetry) {
-        onRetry(attempt + 1, delayMs, lastError);
-      }
-
-      // Wait before retrying
-      await sleep(delayMs);
-    }
-  }
-
-  throw lastError ?? new Error("Failed to create DM channel after retries");
+    },
+    {
+      attempts: maxRetries + 1,
+      // Core retry raises maxDelayMs to the minDelayMs floor, but the schema
+      // allows initialDelayMs above the (defaulted) maxDelayMs cap. The cap is
+      // the documented contract here and the reply-delivery barrier budgets
+      // with it, so clamp the base instead of letting the floor win.
+      minDelayMs: Math.min(initialDelayMs, maxDelayMs),
+      maxDelayMs,
+      // Full jitter (uniform [delay, 2*delay) with maxDelayMs applied after
+      // the draw) preserves the schedule pinned by client.retry.test.ts.
+      jitter: "full",
+      shouldRetry: (err) => isRetryableError(err as Error),
+      onRetry: (info) => onRetry?.(info.attempt, info.delayMs, info.err as Error),
+    },
+  );
 }
 
 function isRetryableError(error: Error): boolean {

--- a/src/infra/retry.test.ts
+++ b/src/infra/retry.test.ts
@@ -278,6 +278,120 @@ describe("retryAsync", () => {
     expect(delays[0]).toBe(expectedDelay);
   });
 
+  async function runFullJitterCase(params: {
+    attempts: number;
+    minDelayMs: number;
+    maxDelayMs: number;
+    random: () => number;
+    failures: number;
+    retryAfterMs?: number;
+  }): Promise<number[]> {
+    vi.clearAllTimers();
+    vi.useFakeTimers();
+    try {
+      let fn = vi.fn();
+      for (let i = 0; i < params.failures; i += 1) {
+        fn = fn.mockRejectedValueOnce(new Error(`boom-${i}`));
+      }
+      fn = fn.mockResolvedValueOnce("ok");
+      const delays: number[] = [];
+      const promise = retryAsync(fn as () => Promise<unknown>, {
+        attempts: params.attempts,
+        minDelayMs: params.minDelayMs,
+        maxDelayMs: params.maxDelayMs,
+        jitter: "full",
+        random: params.random,
+        retryAfterMs: params.retryAfterMs === undefined ? undefined : () => params.retryAfterMs,
+        onRetry: (info) => delays.push(info.delayMs),
+      });
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toBe("ok");
+      return delays;
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  }
+
+  it.each([
+    {
+      name: "full jitter draws uniformly from [delay, 2*delay)",
+      random: () => 0.5,
+      expectedDelays: [150, 300],
+    },
+    {
+      name: "full jitter keeps the backoff delay as a hard floor",
+      random: () => 0,
+      expectedDelays: [100, 200],
+    },
+    {
+      name: "full jitter stays within twice the backoff delay at the draw ceiling",
+      random: () => 0.999,
+      expectedDelays: [200, 400],
+    },
+  ])("$name", async ({ random, expectedDelays }) => {
+    const delays = await runFullJitterCase({
+      attempts: 3,
+      minDelayMs: 100,
+      maxDelayMs: 10_000,
+      random,
+      failures: 2,
+    });
+    expect(delays).toEqual(expectedDelays);
+  });
+
+  it("full jitter applies maxDelayMs after the draw", async () => {
+    const delays = await runFullJitterCase({
+      attempts: 4,
+      minDelayMs: 1000,
+      maxDelayMs: 2500,
+      random: () => 0.75,
+      failures: 3,
+    });
+    // Second retry draws 2000 * 1.75 = 3500 before the cap clamps it; a
+    // cap-before-jitter schedule would have reported 3500 here.
+    expect(delays).toEqual([1750, 2500, 2500]);
+  });
+
+  it("full jitter draws on top of the minDelayMs floor for Retry-After hints", async () => {
+    const delays = await runFullJitterCase({
+      attempts: 2,
+      minDelayMs: 250,
+      maxDelayMs: 1000,
+      random: () => 0.5,
+      failures: 1,
+      retryAfterMs: 50,
+    });
+    expect(delays).toEqual([375]);
+  });
+
+  it("full jitter spreads below the cap for unsatisfiable Retry-After hints", async () => {
+    const delays = await runFullJitterCase({
+      attempts: 2,
+      minDelayMs: 100,
+      maxDelayMs: 1000,
+      random: () => 0.5,
+      failures: 1,
+      retryAfterMs: 5000,
+    });
+    // Lockstep at the 1000ms cap would reintroduce the herd the over-cap
+    // Retry-After exception exists to avoid; the draw must land in
+    // [cap/2, cap) instead.
+    expect(delays).toEqual([750]);
+  });
+
+  it("uses the injected random source instead of the secure default", async () => {
+    const delays = await runFullJitterCase({
+      attempts: 2,
+      minDelayMs: 100,
+      maxDelayMs: 1000,
+      random: () => 0.25,
+      failures: 1,
+    });
+    expect(delays).toEqual([125]);
+    expect(randomMocks.generateSecureFraction).not.toHaveBeenCalled();
+  });
+
   it("uses secure jitter when configured", async () => {
     vi.useFakeTimers();
     randomMocks.generateSecureFraction.mockReturnValue(1);
@@ -338,7 +452,17 @@ describe("resolveRetryConfig", () => {
         jitter: 0,
       },
     },
+    {
+      name: "passes through full jitter",
+      overrides: { jitter: "full" as const },
+      expected: { attempts: 3, minDelayMs: 300, maxDelayMs: 30000, jitter: "full" },
+    },
   ])("$name", ({ overrides, expected }) => {
     expect(resolveRetryConfig(undefined, overrides)).toEqual(expected);
+  });
+
+  it("keeps full-jitter defaults when the override is malformed", () => {
+    const defaults = { attempts: 3, minDelayMs: 300, maxDelayMs: 30000, jitter: "full" as const };
+    expect(resolveRetryConfig(defaults, { jitter: Number.NaN })).toEqual(defaults);
   });
 });

--- a/src/infra/retry.ts
+++ b/src/infra/retry.ts
@@ -11,7 +11,13 @@ export type RetryConfig = {
   attempts?: number;
   minDelayMs?: number;
   maxDelayMs?: number;
-  jitter?: number;
+  /**
+   * Delay spread strategy. A fraction (0-1) spreads proportionally around the
+   * backoff delay (existing behavior). `"full"` draws uniformly from
+   * [delay, 2*delay): the backoff delay stays a hard floor and `maxDelayMs`
+   * clamps after the draw, so capped attempts land exactly on the cap.
+   */
+  jitter?: number | "full";
 };
 
 /** Metadata emitted before a retry attempt sleeps and reruns the operation. */
@@ -30,6 +36,8 @@ export type RetryOptions = RetryConfig & {
   retryAfterMs?: (err: unknown) => number | undefined;
   retryAfterMaxDelayMs?: number;
   onRetry?: (info: RetryInfo) => void;
+  /** Random fraction source in [0, 1); injectable for deterministic tests. */
+  random?: () => number;
 };
 
 const DEFAULT_RETRY_CONFIG = {
@@ -79,6 +87,17 @@ function resolveRetryDelayMs(value: number): number {
   return resolveTimerTimeoutMs(value, 0, 0);
 }
 
+function resolveJitterConfig(value: unknown, fallback: number | "full"): number | "full" {
+  if (value === "full") {
+    return "full";
+  }
+  const fraction = asFiniteNumber(value);
+  if (fraction === undefined) {
+    return fallback;
+  }
+  return Math.min(Math.max(fraction, 0), 1);
+}
+
 /** Resolves retry config overrides into clamped timer-safe settings. */
 export function resolveRetryConfig(
   defaults: Required<RetryConfig> = DEFAULT_RETRY_CONFIG,
@@ -95,13 +114,34 @@ export function resolveRetryConfig(
     minDelayMs,
     resolveRetryDelayMs(Math.round(clampNumber(overrides?.maxDelayMs, defaults.maxDelayMs, 0))),
   );
-  const jitter = clampNumber(overrides?.jitter, defaults.jitter, 0, 1);
+  const jitter = resolveJitterConfig(overrides?.jitter, defaults.jitter);
   return { attempts, minDelayMs, maxDelayMs, jitter };
 }
 
 type JitterMode = "symmetric" | "positive";
 
-function applyJitter(delayMs: number, jitter: number, mode: JitterMode = "symmetric"): number {
+function applyJitter(
+  delayMs: number,
+  jitter: number | "full",
+  mode: JitterMode,
+  random: () => number,
+): number {
+  if (jitter === "full") {
+    if (mode === "symmetric") {
+      // Unsatisfiable over-cap Retry-After: an upward draw would be erased by
+      // the caller's cap clamp and every client would land in lockstep at the
+      // cap, so draw downward across one half-period instead. That preserves
+      // spread (the invariant the numeric symmetric fallback below protects)
+      // while staying as close to the server's hint as the cap allows.
+      return Math.max(0, Math.round(delayMs * (0.5 + random() * 0.5)));
+    }
+    // Full jitter draws uniformly from [delay, 2*delay): the backoff delay is
+    // a hard floor (never fire early), which also keeps honorable Retry-After
+    // lower bounds. Callers clamp `maxDelayMs` after this, so capped attempts
+    // land exactly on the cap (same boundary trade-off as `positive` mode
+    // below). Ceil preserves the floor contract for fractional bases.
+    return Math.max(0, Math.ceil(delayMs * (1 + random())));
+  }
   if (jitter <= 0) {
     return delayMs;
   }
@@ -111,7 +151,7 @@ function applyJitter(delayMs: number, jitter: number, mode: JitterMode = "symmet
   // lower bound the caller must respect (for example a server-supplied
   // Retry-After) so concurrent clients still spread without ever dipping
   // below the caller's floor.
-  const fraction = generateSecureFraction();
+  const fraction = random();
   const offset = mode === "positive" ? fraction * jitter : (fraction * 2 - 1) * jitter;
   const raw = delayMs * (1 + offset);
   // Rounding choice preserves the mode's contract. `positive` guarantees
@@ -164,6 +204,7 @@ export async function retryAsync<T>(
           resolveRetryDelayMs(Math.round(clampNumber(options.retryAfterMaxDelayMs, maxDelayMs, 0))),
         );
   const jitter = resolved.jitter;
+  const random = options.random ?? generateSecureFraction;
   const shouldRetry = options.shouldRetry ?? (() => true);
   const attemptErrors: unknown[] = [];
 
@@ -210,7 +251,13 @@ export async function retryAsync<T>(
       // unsatisfiable and we gain spread without adding a violation.
       const canHonorRetryAfter =
         hasRetryAfter && typeof retryAfterMs === "number" && retryAfterMs <= delayCap;
-      delay = applyJitter(delay, jitter, canHonorRetryAfter ? "positive" : "symmetric");
+      // Full jitter's upward draw is inherently positive, so it serves both
+      // plain backoff and honorable Retry-After floors; only the unsatisfiable
+      // over-cap hint must switch to the symmetric downward spread. Numeric
+      // jitter keeps the original positive/symmetric split.
+      const overCapRetryAfter = hasRetryAfter && !canHonorRetryAfter;
+      const wantsPositiveDraw = jitter === "full" ? !overCapRetryAfter : canHonorRetryAfter;
+      delay = applyJitter(delay, jitter, wantsPositiveDraw ? "positive" : "symmetric", random);
       delay = Math.min(Math.max(delay, minDelayMs), delayCap);
 
       options.onRetry?.({


### PR DESCRIPTION
Related: #104318

## What Problem This Solves

Mattermost was the last Phase-1 retry holdout: its full-jitter schedule (uniform [delay, 2·delay) with cap-after-draw and a minimum floor, pinned by tests) was inexpressible in core `retryAsync`, so #104431 had to skip it and it kept a hand-rolled loop.

## Why This Change Was Made

Core `RetryConfig.jitter` widens from `number` to `number | "full"` — no parallel field, no new config surface (config schemas stay number-only; the mode is code-declared). An injectable random source follows the existing streaming/tagline pattern for deterministic tests. Mattermost's client loop then migrates onto `retryAsync` via the standard SDK seam with its classification unchanged; its schedule-pinning test passes byte-identical. Two review-driven hardenings shipped with it: the documented cap now beats the floor when `initialDelayMs > maxDelayMs` (valid config the schema refine doesn't catch), and over-cap Retry-After draws spread downward in [cap/2, cap) so full-jitter retries don't collapse into an anti-herd-defeating lockstep at the cap — that spread is a deliberate design choice worth a reviewer glance.

## User Impact

No behavior change for existing callers (`jitter: number` semantics untouched); mattermost retry cadence unchanged by test proof.

## Evidence

- Testbox `tbx_01kx922d7amd3fqj33whea7b0g`: `extensions/mattermost/src` + `src/infra` suites (262+44 files) + full `pnpm check:changed` green; `client.retry.test.ts` unmodified and passing (the acceptance bar).
- New unit tests: full-jitter bounds, cap-after-draw, floor clamp regression, over-cap spread.
- Autoreview (codex gpt-5.6-sol, xhigh): two accepted findings fixed + verified; final run clean (0.95).
- SDK surface pins unaffected (option/type members aren't counted exports — verified against the report script).
