### PR TITLE
fix(auto-reply): clean up empty inbound staging dirs

### DIFF
--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -67,7 +67,10 @@ vi.mock("./reply/session-reset-model.runtime.js", () => ({
   applyResetModelOverride: vi.fn(async () => undefined),
 }));
 vi.mock("./reply/stage-sandbox-media.runtime.js", () => ({
-  stageSandboxMedia: vi.fn(async () => undefined),
+  stageSandboxMedia: vi.fn(async () => ({
+    staged: new Map(),
+    cleanup: async () => undefined,
+  })),
 }));
 vi.mock("./reply/typing.js", () => ({
   createTypingController: vi.fn(() => createMockTypingController()),

--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -229,6 +229,14 @@ describe("stageSandboxMedia", () => {
       expect(sessionCtx.MediaPath).toBe(stagedPath);
       await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("host-pdf-bytes");
       await expect(fs.readFile(existingProjectFile, "utf8")).resolves.toBe("project-file");
+
+      const stagingDir = dirname(stagedPath);
+      await result.cleanup();
+      await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("host-pdf-bytes");
+
+      await fs.rm(stagedPath);
+      await result.cleanup();
+      await expect(fs.stat(stagingDir)).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts
@@ -1312,7 +1312,10 @@ describe("dispatchReplyFromConfig", () => {
       params.sessionCtx.MediaPaths = [stagedPath];
       params.sessionCtx.MediaUrl = stagedPath;
       params.sessionCtx.MediaUrls = [stagedPath];
-      return { staged: new Map([[rawPath, stagedPath]]) };
+      return {
+        staged: new Map([[rawPath, stagedPath]]),
+        cleanup: async () => undefined,
+      };
     });
     hookMocks.runner.hasHooks.mockImplementation(
       ((hookName?: string) =>

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -248,9 +248,15 @@ const replyMediaPathMocks = vi.hoisted(() => ({
   ),
 }));
 const stageSandboxMediaMocks = vi.hoisted(() => ({
-  stageSandboxMedia: vi.fn<(params: unknown) => Promise<{ staged: Map<string, string> }>>(
-    async () => ({ staged: new Map() }),
-  ),
+  stageSandboxMedia: vi.fn<
+    (params: unknown) => Promise<{
+      staged: Map<string, string>;
+      cleanup: () => Promise<void>;
+    }>
+  >(async () => ({
+    staged: new Map(),
+    cleanup: async () => undefined,
+  })),
 }));
 const runtimePluginMocks = vi.hoisted(() => ({
   ensureRuntimePluginsLoaded: vi.fn(),
@@ -733,6 +739,10 @@ export function resetPluginTtsAndThreadMocks() {
   replyMediaPathMocks.createReplyMediaPathNormalizer
     .mockReset()
     .mockReturnValue(async (payload: ReplyPayload) => payload);
+  stageSandboxMediaMocks.stageSandboxMedia.mockReset().mockResolvedValue({
+    staged: new Map(),
+    cleanup: async () => undefined,
+  });
   threadInfoMocks.parseSessionThreadInfo
     .mockReset()
     .mockImplementation(parseGenericThreadSessionInfo);

--- a/src/auto-reply/reply/dispatch-from-config.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test-harness.ts
@@ -564,7 +564,10 @@ export const describe0BeforeEach0 = () => {
   transcriptMocks.persistAcpDispatchTranscript.mockClear();
   transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
   stageSandboxMediaMocks.stageSandboxMedia.mockReset();
-  stageSandboxMediaMocks.stageSandboxMedia.mockResolvedValue({ staged: new Map() });
+  stageSandboxMediaMocks.stageSandboxMedia.mockResolvedValue({
+    staged: new Map(),
+    cleanup: async () => {},
+  });
   runtimePluginMocks.ensureRuntimePluginsLoaded.mockClear();
 };
 

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2465,10 +2465,11 @@ describe("runPreparedReply media-only handling", () => {
     expect(call.followupRun.abortSignal).toBe(sourceAbortController.signal);
   });
 
-  it("detaches queued user requests from superseded source abort signals", async () => {
+  it("detaches queued user requests while deferring cleanup until completion", async () => {
     const queueSettings = await import("./queue/settings-runtime.js");
     const embeddedAgentRuntime = await import("../../agents/embedded-agent.runtime.js");
     const abortController = new AbortController();
+    const cleanup = vi.fn(async () => undefined);
     vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({
       mode: "collect",
       debounceMs: 500,
@@ -2484,6 +2485,7 @@ describe("runPreparedReply media-only handling", () => {
 
     await runPreparedReply(
       baseParams({
+        queuedFollowupCleanup: cleanup,
         opts: { abortSignal: abortController.signal },
         ctx: {
           Body: "@bot keep this",
@@ -2511,6 +2513,11 @@ describe("runPreparedReply media-only handling", () => {
     expect(call.isActive).toBe(true);
     expect(call.followupRun.currentInboundEventKind).toBe("user_request");
     expect(call.followupRun.abortSignal).toBeUndefined();
+    expect(cleanup).not.toHaveBeenCalled();
+
+    call.followupRun.queuedLifecycle?.onComplete?.();
+
+    expect(cleanup).toHaveBeenCalledOnce();
   });
 
   it("queues active room events instead of interrupting active user requests", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -106,7 +106,7 @@ import {
 } from "./prompt-session-context.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { resolveQueueSettings } from "./queue/settings-runtime.js";
-import { withQueuedReplyCleanup } from "./queued-followup-cleanup.js";
+import { withQueuedReplyCleanup } from "./reply-cleanup.js";
 import {
   REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
   abortReplyRunBySessionId,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -106,6 +106,7 @@ import {
 } from "./prompt-session-context.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { resolveQueueSettings } from "./queue/settings-runtime.js";
+import { withQueuedReplyCleanup } from "./queued-followup-cleanup.js";
 import {
   REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
   abortReplyRunBySessionId,
@@ -491,6 +492,7 @@ type RunPreparedReplyParams = {
   workspaceDir: string;
   abortedLastRun: boolean;
   autoFallbackPrimaryProbe?: AutoFallbackPrimaryProbe;
+  queuedFollowupCleanup?: () => Promise<void>;
 };
 
 /** Runs a prepared reply turn after session, prompt, queue, and policy state are resolved. */
@@ -1414,13 +1416,8 @@ export async function runPreparedReply(
       extractedFileImages: opts?.extractedFileImages,
     }),
   );
-  // Abort-signal attachment for queued followups:
-  // - room_event: always inherit (source admission fence / ambient cancel).
-  // - Gateway-owned lifecycle (chat.send): always inherit so Esc can cancel a
-  //   turn after chat.send terminalizes while still queued.
-  // - plain user_request without lifecycle: deliberately detach from the
-  //   source/active-lane signal so a superseded parent abort does not cancel a
-  //   still-valid queued user turn.
+  // Room events and Gateway-owned lifecycles inherit cancellation. Plain queued
+  // user requests detach so an obsolete source abort cannot cancel valid work.
   const queuedFollowupAbortSignal =
     opts?.queuedFollowupLifecycle || inboundEventKind === "room_event"
       ? (opts?.queuedFollowupAbortSignal ?? opts?.abortSignal)
@@ -1518,7 +1515,10 @@ export async function runPreparedReply(
     currentInboundContext,
     ...(queuedFollowupAbortSignal ? { abortSignal: queuedFollowupAbortSignal } : {}),
     deliveryCorrelations: opts?.queuedDeliveryCorrelations,
-    queuedLifecycle: opts?.queuedFollowupLifecycle,
+    queuedLifecycle: withQueuedReplyCleanup(
+      opts?.queuedFollowupLifecycle,
+      params.queuedFollowupCleanup,
+    ),
     onFollowupAdmissionWaitChange: opts?.onFollowupAdmissionWaitChange,
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
     summaryLine: baseBodyTrimmedRaw,

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -4,7 +4,7 @@ import { logVerbose } from "../../globals.js";
 import type { ApplyMediaUnderstandingResult } from "../../media-understanding/apply.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../../sessions/agent-harness-session-key.js";
 import type { MsgContext } from "../templating.js";
-import { withFastReplyConfig } from "./get-reply-fast-path.js";
+import { withFastReplyConfig, withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
 import {
   buildGetReplyGroupCtx,
   createGetReplyContinueDirectivesResult,
@@ -148,7 +148,10 @@ async function resetMessageHookTestState() {
     aliasIndex: emptyAliasIndex(),
   });
   vi.mocked(runPreparedReplyMock).mockResolvedValue({ text: "ok" });
-  vi.mocked(stageSandboxMediaMock).mockResolvedValue({ staged: new Map() });
+  vi.mocked(stageSandboxMediaMock).mockResolvedValue({
+    staged: new Map(),
+    cleanup: async () => undefined,
+  });
   mocks.resolveReplySessionPreprocessingState.mockReturnValue({
     sessionEntry: undefined,
     sessionKey: "agent:main:telegram:-100123",
@@ -518,7 +521,10 @@ describe("getReplyFromConfig message hooks", () => {
       params.sessionCtx.MediaPaths = [stagedPath];
       params.sessionCtx.MediaUrl = stagedPath;
       params.sessionCtx.MediaUrls = [stagedPath];
-      return { staged: new Map([[remotePath, stagedPath]]) };
+      return {
+        staged: new Map([[remotePath, stagedPath]]),
+        cleanup: async () => undefined,
+      };
     });
     mocks.applyMediaUnderstanding.mockImplementationOnce(async (...args: unknown[]) => {
       order.push("understand");
@@ -565,6 +571,37 @@ describe("getReplyFromConfig message hooks", () => {
         workspaceDir: "/tmp/workspace",
       }),
     );
+  });
+
+  it("keeps host-staged media available until the prepared reply finishes", async () => {
+    const cleanup = vi.fn(async () => undefined);
+    mocks.resolveReplyDirectives.mockResolvedValueOnce(
+      createGetReplyContinueDirectivesResult({
+        body: "<media:audio>",
+        abortKey: "agent:main:telegram:-100123",
+        from: "telegram:user",
+        to: "telegram:ops",
+        senderId: "telegram:user",
+        commandSource: "message",
+        senderIsOwner: true,
+        resetHookTriggered: false,
+      }),
+    );
+    vi.mocked(stageSandboxMediaMock).mockResolvedValueOnce({
+      staged: new Map(),
+      cleanup,
+    });
+    vi.mocked(runPreparedReplyMock).mockImplementationOnce(async () => {
+      expect(cleanup).not.toHaveBeenCalled();
+      return { text: "ok" };
+    });
+
+    await expect(
+      getReplyFromConfig(buildCtx(), undefined, withFullRuntimeReplyConfig({})),
+    ).resolves.toEqual({ text: "ok" });
+
+    expect(stageSandboxMediaMock).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
   it("emits only preprocessed when no transcript is produced", async () => {

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -71,7 +71,10 @@ vi.mock("./session-reset-model.runtime.js", () => ({
 }));
 
 vi.mock("./stage-sandbox-media.runtime.js", () => ({
-  stageSandboxMedia: vi.fn(async () => undefined),
+  stageSandboxMedia: vi.fn(async () => ({
+    staged: new Map(),
+    cleanup: async () => undefined,
+  })),
 }));
 
 vi.mock("./typing.js", () => ({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1073,9 +1073,10 @@ export async function getReplyFromConfig(
   // synchronously so it could surface 5xx before respond(). Skipping here keeps
   // staging a single-call contract instead of relying on relative-path no-op
   // semantics in stageSandboxMedia.
+  let cleanupStagedMedia: (() => Promise<void>) | undefined;
   if (!useFastTestBootstrap && sessionKey && !ctx.MediaStaged && hasInboundMedia(ctx)) {
     const { stageSandboxMedia } = await loadStageSandboxMediaRuntime();
-    await traceGetReplyPhase("reply.stage_media", () =>
+    const stageResult = await traceGetReplyPhase("reply.stage_media", () =>
       stageSandboxMedia({
         ctx,
         sessionCtx,
@@ -1084,60 +1085,65 @@ export async function getReplyFromConfig(
         workspaceDir,
       }),
     );
+    cleanupStagedMedia = stageResult.cleanup;
   }
 
-  logResolverTiming("milestone", "before_run_prepared_reply");
-  const replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
-    runPreparedReply({
-      ctx,
-      sessionCtx,
-      cfg,
-      agentId,
-      agentDir,
-      agentCfg,
-      sessionCfg,
-      commandAuthorized,
-      command,
-      commandSource,
-      allowTextCommands,
-      directives,
-      defaultActivation,
-      resolvedThinkLevel,
-      resolvedFastMode,
-      resolvedFastModeAutoOnSeconds,
-      resolvedFastModeOverride,
-      resolvedFastModeAutoOnSecondsOverride,
-      resolvedVerboseLevel,
-      resolvedReasoningLevel,
-      resolvedElevatedLevel,
-      execOverrides,
-      elevatedEnabled,
-      elevatedAllowed,
-      blockStreamingEnabled,
-      blockReplyChunking,
-      resolvedBlockStreamingBreak,
-      modelState: runModelState,
-      provider: runProvider,
-      model: runModel,
-      perMessageQueueMode,
-      perMessageQueueOptions,
-      typing,
-      opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
-      defaultModel,
-      timeoutMs,
-      isNewSession,
-      resetTriggered,
-      systemSent,
-      sessionEntry,
-      sessionStore,
-      sessionKey,
-      sessionId,
-      storePath,
-      workspaceDir,
-      abortedLastRun,
-      autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
-    }),
-  );
-  logResolverTiming("completed", "prepared_reply");
-  return replyResult;
+  try {
+    logResolverTiming("milestone", "before_run_prepared_reply");
+    const replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
+      runPreparedReply({
+        ctx,
+        sessionCtx,
+        cfg,
+        agentId,
+        agentDir,
+        agentCfg,
+        sessionCfg,
+        commandAuthorized,
+        command,
+        commandSource,
+        allowTextCommands,
+        directives,
+        defaultActivation,
+        resolvedThinkLevel,
+        resolvedFastMode,
+        resolvedFastModeAutoOnSeconds,
+        resolvedFastModeOverride,
+        resolvedFastModeAutoOnSecondsOverride,
+        resolvedVerboseLevel,
+        resolvedReasoningLevel,
+        resolvedElevatedLevel,
+        execOverrides,
+        elevatedEnabled,
+        elevatedAllowed,
+        blockStreamingEnabled,
+        blockReplyChunking,
+        resolvedBlockStreamingBreak,
+        modelState: runModelState,
+        provider: runProvider,
+        model: runModel,
+        perMessageQueueMode,
+        perMessageQueueOptions,
+        typing,
+        opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
+        defaultModel,
+        timeoutMs,
+        isNewSession,
+        resetTriggered,
+        systemSent,
+        sessionEntry,
+        sessionStore,
+        sessionKey,
+        sessionId,
+        storePath,
+        workspaceDir,
+        abortedLastRun,
+        autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
+      }),
+    );
+    logResolverTiming("completed", "prepared_reply");
+    return replyResult;
+  } finally {
+    await cleanupStagedMedia?.();
+  }
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1069,10 +1069,7 @@ export async function getReplyFromConfig(
     }
   }
 
-  // ctx.MediaStaged=true means the caller (e.g. chat.send RPC) already staged
-  // synchronously so it could surface 5xx before respond(). Skipping here keeps
-  // staging a single-call contract instead of relying on relative-path no-op
-  // semantics in stageSandboxMedia.
+  // chat.send prestages media before responding; MediaStaged prevents a duplicate pass.
   let cleanupStagedMedia: (() => Promise<void>) | undefined;
   if (!useFastTestBootstrap && sessionKey && !ctx.MediaStaged && hasInboundMedia(ctx)) {
     const { stageSandboxMedia } = await loadStageSandboxMediaRuntime();
@@ -1088,62 +1085,59 @@ export async function getReplyFromConfig(
     cleanupStagedMedia = stageResult.cleanup;
   }
 
-  try {
-    logResolverTiming("milestone", "before_run_prepared_reply");
-    const replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
-      runPreparedReply({
-        ctx,
-        sessionCtx,
-        cfg,
-        agentId,
-        agentDir,
-        agentCfg,
-        sessionCfg,
-        commandAuthorized,
-        command,
-        commandSource,
-        allowTextCommands,
-        directives,
-        defaultActivation,
-        resolvedThinkLevel,
-        resolvedFastMode,
-        resolvedFastModeAutoOnSeconds,
-        resolvedFastModeOverride,
-        resolvedFastModeAutoOnSecondsOverride,
-        resolvedVerboseLevel,
-        resolvedReasoningLevel,
-        resolvedElevatedLevel,
-        execOverrides,
-        elevatedEnabled,
-        elevatedAllowed,
-        blockStreamingEnabled,
-        blockReplyChunking,
-        resolvedBlockStreamingBreak,
-        modelState: runModelState,
-        provider: runProvider,
-        model: runModel,
-        perMessageQueueMode,
-        perMessageQueueOptions,
-        typing,
-        opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
-        defaultModel,
-        timeoutMs,
-        isNewSession,
-        resetTriggered,
-        systemSent,
-        sessionEntry,
-        sessionStore,
-        sessionKey,
-        sessionId,
-        storePath,
-        workspaceDir,
-        abortedLastRun,
-        autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
-      }),
-    );
-    logResolverTiming("completed", "prepared_reply");
-    return replyResult;
-  } finally {
-    await cleanupStagedMedia?.();
-  }
+  logResolverTiming("milestone", "before_run_prepared_reply");
+  const replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
+    runPreparedReply({
+      ctx,
+      sessionCtx,
+      cfg,
+      agentId,
+      agentDir,
+      agentCfg,
+      sessionCfg,
+      commandAuthorized,
+      command,
+      commandSource,
+      allowTextCommands,
+      directives,
+      defaultActivation,
+      resolvedThinkLevel,
+      resolvedFastMode,
+      resolvedFastModeAutoOnSeconds,
+      resolvedFastModeOverride,
+      resolvedFastModeAutoOnSecondsOverride,
+      resolvedVerboseLevel,
+      resolvedReasoningLevel,
+      resolvedElevatedLevel,
+      execOverrides,
+      elevatedEnabled,
+      elevatedAllowed,
+      blockStreamingEnabled,
+      blockReplyChunking,
+      resolvedBlockStreamingBreak,
+      modelState: runModelState,
+      provider: runProvider,
+      model: runModel,
+      perMessageQueueMode,
+      perMessageQueueOptions,
+      typing,
+      opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
+      defaultModel,
+      timeoutMs,
+      isNewSession,
+      resetTriggered,
+      systemSent,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      sessionId,
+      storePath,
+      workspaceDir,
+      abortedLastRun,
+      autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
+      queuedFollowupCleanup: cleanupStagedMedia,
+    }),
+  ).finally(() => cleanupStagedMedia?.());
+  logResolverTiming("completed", "prepared_reply");
+  return replyResult;
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -64,6 +64,7 @@ import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
 import { createFastTestModelSelectionState, createModelSelectionState } from "./model-selection.js";
 import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
 import { attachProgressNarratorToReplyOptions } from "./progress-narrator.js";
+import { runWithReplyCleanup } from "./reply-cleanup.js";
 import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 import { initSessionState, resolveReplySessionPreprocessingState } from "./session.js";
 import { mergeSkillFilters } from "./skill-filter.js";
@@ -122,10 +123,6 @@ const commandsCoreRuntimeLoader = createLazyImportLoader(
 
 function loadSessionResetModelRuntime() {
   return sessionResetModelRuntimeLoader.load();
-}
-
-function loadStageSandboxMediaRuntime() {
-  return stageSandboxMediaRuntimeLoader.load();
 }
 
 function loadMediaUnderstandingApplyRuntime() {
@@ -1069,10 +1066,9 @@ export async function getReplyFromConfig(
     }
   }
 
-  // chat.send prestages media before responding; MediaStaged prevents a duplicate pass.
   let cleanupStagedMedia: (() => Promise<void>) | undefined;
   if (!useFastTestBootstrap && sessionKey && !ctx.MediaStaged && hasInboundMedia(ctx)) {
-    const { stageSandboxMedia } = await loadStageSandboxMediaRuntime();
+    const { stageSandboxMedia } = await stageSandboxMediaRuntimeLoader.load();
     const stageResult = await traceGetReplyPhase("reply.stage_media", () =>
       stageSandboxMedia({
         ctx,
@@ -1086,58 +1082,62 @@ export async function getReplyFromConfig(
   }
 
   logResolverTiming("milestone", "before_run_prepared_reply");
-  const replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
-    runPreparedReply({
-      ctx,
-      sessionCtx,
-      cfg,
-      agentId,
-      agentDir,
-      agentCfg,
-      sessionCfg,
-      commandAuthorized,
-      command,
-      commandSource,
-      allowTextCommands,
-      directives,
-      defaultActivation,
-      resolvedThinkLevel,
-      resolvedFastMode,
-      resolvedFastModeAutoOnSeconds,
-      resolvedFastModeOverride,
-      resolvedFastModeAutoOnSecondsOverride,
-      resolvedVerboseLevel,
-      resolvedReasoningLevel,
-      resolvedElevatedLevel,
-      execOverrides,
-      elevatedEnabled,
-      elevatedAllowed,
-      blockStreamingEnabled,
-      blockReplyChunking,
-      resolvedBlockStreamingBreak,
-      modelState: runModelState,
-      provider: runProvider,
-      model: runModel,
-      perMessageQueueMode,
-      perMessageQueueOptions,
-      typing,
-      opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
-      defaultModel,
-      timeoutMs,
-      isNewSession,
-      resetTriggered,
-      systemSent,
-      sessionEntry,
-      sessionStore,
-      sessionKey,
-      sessionId,
-      storePath,
-      workspaceDir,
-      abortedLastRun,
-      autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
-      queuedFollowupCleanup: cleanupStagedMedia,
-    }),
-  ).finally(() => cleanupStagedMedia?.());
+  const replyResult = await runWithReplyCleanup(
+    () =>
+      traceGetReplyPhase("reply.run_prepared_reply", () =>
+        runPreparedReply({
+          ctx,
+          sessionCtx,
+          cfg,
+          agentId,
+          agentDir,
+          agentCfg,
+          sessionCfg,
+          commandAuthorized,
+          command,
+          commandSource,
+          allowTextCommands,
+          directives,
+          defaultActivation,
+          resolvedThinkLevel,
+          resolvedFastMode,
+          resolvedFastModeAutoOnSeconds,
+          resolvedFastModeOverride,
+          resolvedFastModeAutoOnSecondsOverride,
+          resolvedVerboseLevel,
+          resolvedReasoningLevel,
+          resolvedElevatedLevel,
+          execOverrides,
+          elevatedEnabled,
+          elevatedAllowed,
+          blockStreamingEnabled,
+          blockReplyChunking,
+          resolvedBlockStreamingBreak,
+          modelState: runModelState,
+          provider: runProvider,
+          model: runModel,
+          perMessageQueueMode,
+          perMessageQueueOptions,
+          typing,
+          opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
+          defaultModel,
+          timeoutMs,
+          isNewSession,
+          resetTriggered,
+          systemSent,
+          sessionEntry,
+          sessionStore,
+          sessionKey,
+          sessionId,
+          storePath,
+          workspaceDir,
+          abortedLastRun,
+          autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
+          queuedFollowupCleanup: cleanupStagedMedia,
+        }),
+      ),
+    cleanupStagedMedia,
+  );
   logResolverTiming("completed", "prepared_reply");
   return replyResult;
 }

--- a/src/auto-reply/reply/queued-followup-cleanup.ts
+++ b/src/auto-reply/reply/queued-followup-cleanup.ts
@@ -1,0 +1,21 @@
+import type { QueuedReplyLifecycle } from "../get-reply-options.types.js";
+
+/** Defers a best-effort cleanup until a queued followup has finished consuming its inputs. */
+export function withQueuedReplyCleanup(
+  lifecycle: QueuedReplyLifecycle | undefined,
+  cleanup: (() => Promise<void>) | undefined,
+): QueuedReplyLifecycle | undefined {
+  if (!cleanup) {
+    return lifecycle;
+  }
+  return {
+    ...lifecycle,
+    onComplete: () => {
+      try {
+        lifecycle?.onComplete?.();
+      } finally {
+        void cleanup();
+      }
+    },
+  };
+}

--- a/src/auto-reply/reply/reply-cleanup.ts
+++ b/src/auto-reply/reply/reply-cleanup.ts
@@ -1,5 +1,16 @@
 import type { QueuedReplyLifecycle } from "../get-reply-options.types.js";
 
+export async function runWithReplyCleanup<T>(
+  run: () => Promise<T>,
+  cleanup: (() => Promise<void>) | undefined,
+): Promise<T> {
+  try {
+    return await run();
+  } finally {
+    await cleanup?.();
+  }
+}
+
 /** Defers a best-effort cleanup until a queued followup has finished consuming its inputs. */
 export function withQueuedReplyCleanup(
   lifecycle: QueuedReplyLifecycle | undefined,

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -34,9 +34,18 @@ export const SCP_STDERR_TAIL_CHARS = 16_384;
 // chat.send RPC already admitted under its 20MB cap).
 export type StageSandboxMediaResult = {
   staged: ReadonlyMap<string, string>;
+  /**
+   * Best-effort lifecycle cleanup for host-workspace staging. Callers must wait
+   * until every consumer is finished; cleanup never removes a non-empty dir.
+   */
+  cleanup: () => Promise<void>;
 };
 
-const EMPTY_STAGE_RESULT: StageSandboxMediaResult = { staged: new Map() };
+const NOOP_STAGE_CLEANUP = async () => {};
+const EMPTY_STAGE_RESULT: StageSandboxMediaResult = {
+  staged: new Map(),
+  cleanup: NOOP_STAGE_CLEANUP,
+};
 
 type StageableMediaSource = {
   lookupKey: string;
@@ -90,6 +99,12 @@ export async function stageSandboxMedia(params: {
     !sandbox && !ctx.MediaRemoteHost
       ? path.join("media", "inbound", `openclaw-staged-${crypto.randomUUID()}`)
       : undefined;
+  const cleanup = hostWorkspaceStagingDir
+    ? () =>
+        removeEmptyHostWorkspaceStagingDir(
+          path.join(effectiveWorkspaceDir, hostWorkspaceStagingDir),
+        )
+    : NOOP_STAGE_CLEANUP;
 
   for (const raw of rawPaths) {
     const source = await resolveStageableMediaSource(raw);
@@ -160,7 +175,25 @@ export async function stageSandboxMedia(params: {
     hasPathsArray,
   });
 
-  return { staged };
+  if (staged.size === 0) {
+    await cleanup();
+  }
+  return { staged, cleanup };
+}
+
+async function removeEmptyHostWorkspaceStagingDir(stagingDir: string): Promise<void> {
+  try {
+    // Non-recursive removal preserves files that a runner or tool still needs.
+    await fs.rmdir(stagingDir);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTEMPTY" || code === "EEXIST") {
+      return;
+    }
+    logVerbose(
+      `Failed to remove empty inbound media staging directory ${stagingDir}: ${String(error)}`,
+    );
+  }
 }
 
 function toPosixRelativePath(filePath: string): string {

--- a/src/gateway/server-methods/chat-media-path-offloads.ts
+++ b/src/gateway/server-methods/chat-media-path-offloads.ts
@@ -1,0 +1,176 @@
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
+import {
+  stageSandboxMedia,
+  type StageSandboxMediaResult,
+} from "../../auto-reply/reply/stage-sandbox-media.js";
+import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { parseInboundMediaUri } from "../../media/media-reference.js";
+import { deleteMediaBuffer, MEDIA_MAX_BYTES } from "../../media/store.js";
+import {
+  MediaOffloadError,
+  type OffloadedRef,
+  UnsupportedAttachmentError,
+} from "../chat-attachments.js";
+
+function isPdfOffloadedRef(ref: OffloadedRef): boolean {
+  const mime = ref.mimeType.trim().toLowerCase();
+  if (mime === "application/pdf" || mime.endsWith("+pdf")) {
+    return true;
+  }
+  return path.extname(ref.path.split(/[?#]/u)[0] ?? "").toLowerCase() === ".pdf";
+}
+
+// Managed inbound PDFs remain host-readable through media-understanding, so
+// sandbox staging may safely fall back to their managed media-store paths.
+function isManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
+  if (!isPdfOffloadedRef(ref)) {
+    return false;
+  }
+  try {
+    return parseInboundMediaUri(ref.mediaRef) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
+  return ref.sizeBytes > MEDIA_MAX_BYTES && isManagedInboundPdfOffloadRef(ref);
+}
+
+/**
+ * Stages media-path offloads before chat.send responds so staging failures
+ * remain synchronous. Callers must retain cleanup until dispatch consumption
+ * finishes and set ctx.MediaStaged to prevent a duplicate staging pass.
+ */
+export async function prestageMediaPathOffloads(params: {
+  offloadedRefs: OffloadedRef[];
+  includeImageRefs?: boolean;
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  agentId: string;
+}): Promise<{
+  paths: string[];
+  types: string[];
+  workspaceDir?: string;
+  cleanup?: StageSandboxMediaResult["cleanup"];
+}> {
+  const mediaPathRefs = params.offloadedRefs.filter(
+    (ref) => params.includeImageRefs || !ref.mimeType.startsWith("image/"),
+  );
+  if (mediaPathRefs.length === 0) {
+    return { paths: [], types: [] };
+  }
+  const refsByManagedPath = (refs: OffloadedRef[]) => ({
+    paths: refs.map((ref) => ref.path),
+    types: refs.map((ref) => ref.mimeType),
+  });
+
+  const passThroughRefs: OffloadedRef[] = [];
+  const refsToStage: OffloadedRef[] = [];
+  for (const ref of mediaPathRefs) {
+    (shouldPassThroughManagedInboundPdfOffloadRef(ref) ? passThroughRefs : refsToStage).push(ref);
+  }
+  if (refsToStage.length === 0) {
+    return refsByManagedPath(mediaPathRefs);
+  }
+
+  let cleanup: StageSandboxMediaResult["cleanup"] | undefined;
+  try {
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+    const sandbox = await ensureSandboxWorkspaceForSession({
+      config: params.cfg,
+      sessionKey: params.sessionKey,
+      workspaceDir,
+    });
+    if (!sandbox) {
+      return refsByManagedPath(mediaPathRefs);
+    }
+
+    // The RPC parse cap is larger than the sandbox staging cap. Managed PDFs
+    // can pass through host-side; other oversized files are client errors.
+    const oversizedForSandbox = refsToStage.filter((ref) => ref.sizeBytes > MEDIA_MAX_BYTES);
+    if (oversizedForSandbox.length > 0) {
+      const details = oversizedForSandbox
+        .map((ref) => `${ref.label} (${ref.sizeBytes} bytes)`)
+        .join(", ");
+      throw new UnsupportedAttachmentError(
+        "non-image-too-large-for-sandbox",
+        `attachments exceed sandbox staging limit (${MEDIA_MAX_BYTES} bytes): ${details}`,
+      );
+    }
+
+    const stagingCtx: MsgContext = {
+      MediaPath: expectDefined(refsToStage[0], "refs to stage entry at 0").path,
+      MediaPaths: refsToStage.map((ref) => ref.path),
+      MediaType: expectDefined(refsToStage[0], "refs to stage entry at 0").mimeType,
+      MediaTypes: refsToStage.map((ref) => ref.mimeType),
+    };
+    let stageResult: StageSandboxMediaResult;
+    try {
+      stageResult = await stageSandboxMedia({
+        ctx: stagingCtx,
+        sessionCtx: stagingCtx as TemplateContext,
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        workspaceDir,
+      });
+      cleanup = stageResult.cleanup;
+    } catch (stageErr) {
+      // Already-managed PDFs remain readable host-side after staging fails.
+      if (refsToStage.some((ref) => !isManagedInboundPdfOffloadRef(ref))) {
+        throw stageErr;
+      }
+      return refsByManagedPath(mediaPathRefs);
+    }
+
+    const stagedSources = stageResult.staged;
+    const missing = refsToStage.filter((ref) => !stagedSources.has(ref.path));
+    const unstageable = missing.filter((ref) => !isManagedInboundPdfOffloadRef(ref));
+    if (unstageable.length > 0) {
+      throw new Error(
+        `attachment staging incomplete: ${stagedSources.size}/${refsToStage.length} paths staged into sandbox workspace (missing: ${unstageable.map((ref) => ref.path).join(", ")})`,
+      );
+    }
+    const stagedPaths = stagingCtx.MediaPaths ?? [];
+    const stagedTypes = stagingCtx.MediaTypes ?? refsToStage.map((ref) => ref.mimeType);
+    const resolvedByRef = new Map<OffloadedRef, { path: string; mimeType: string }>();
+    refsToStage.forEach((ref, index) => {
+      resolvedByRef.set(ref, {
+        path: stagedPaths[index] ?? ref.path,
+        mimeType: stagedTypes[index] ?? ref.mimeType,
+      });
+    });
+    for (const ref of passThroughRefs) {
+      resolvedByRef.set(ref, { path: ref.path, mimeType: ref.mimeType });
+    }
+    const ordered = mediaPathRefs.map(
+      (ref) => resolvedByRef.get(ref) ?? { path: ref.path, mimeType: ref.mimeType },
+    );
+    return {
+      paths: ordered.map((entry) => entry.path),
+      types: ordered.map((entry) => entry.mimeType),
+      workspaceDir: sandbox.workspaceDir,
+      cleanup,
+    };
+  } catch (err) {
+    await cleanup?.();
+    await Promise.allSettled(
+      params.offloadedRefs.map((ref) => deleteMediaBuffer(ref.id, "inbound")),
+    );
+    if (err instanceof MediaOffloadError) {
+      throw err;
+    }
+    if (err instanceof UnsupportedAttachmentError) {
+      throw err;
+    }
+    throw new MediaOffloadError(
+      `[Gateway Error] Failed to stage attachments into agent workspace: ${formatErrorMessage(err)}`,
+      { cause: err },
+    );
+  }
+}

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -113,6 +113,7 @@ const mockState = vi.hoisted(() => ({
   maxActiveSaveMediaCalls: 0,
   sandboxWorkspace: null as { workspaceDir: string; containerWorkdir?: string } | null,
   stageSandboxMediaError: null as Error | null,
+  stageSandboxMediaCleanup: vi.fn(async () => undefined),
   stagedRelativePaths: null as string[] | null,
   hasBeforeAgentRunHooks: false,
   beforeMessageWriteBlock: false,
@@ -427,7 +428,7 @@ vi.mock("../../auto-reply/reply/stage-sandbox-media.js", () => ({
           staged.delete(source);
         }
       }
-      return { staged };
+      return { staged, cleanup: mockState.stageSandboxMediaCleanup };
     },
   ),
 }));
@@ -956,6 +957,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     bindingMocks.resolveByConversation.mockReturnValue(null);
     mockState.sandboxWorkspace = null;
     mockState.stageSandboxMediaError = null;
+    mockState.stageSandboxMediaCleanup.mockReset();
+    mockState.stageSandboxMediaCleanup.mockResolvedValue(undefined);
     mockState.stagedRelativePaths = null;
     mockState.unstagedSources = null;
     mockState.deleteMediaBufferCalls = [];
@@ -5756,6 +5759,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(mockState.lastDispatchCtx?.MediaPath).toBe("media/inbound/report.pdf");
     expect(mockState.lastDispatchCtx?.MediaWorkspaceDir).toBe("/sandbox/workspace");
     expect(mockState.lastDispatchCtx?.MediaStaged).toBe(true);
+    expect(mockState.stageSandboxMediaCleanup).toHaveBeenCalledTimes(1);
   });
 
   it("preserves staged non-image paths when plugin-bound sessions also carry inline images", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -27,14 +27,12 @@ import {
 import {
   listAgentIds,
   resolveDefaultAgentId,
-  resolveAgentWorkspaceDir,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
 import { modelCatalogBrowseRequiresFullDiscovery } from "../../agents/model-catalog-browse.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
-import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import {
@@ -43,13 +41,10 @@ import {
   type ReplyPayload,
 } from "../../auto-reply/reply-payload.js";
 import { isBtwRequestText } from "../../auto-reply/reply/btw-command.js";
+import { withQueuedReplyCleanup } from "../../auto-reply/reply/queued-followup-cleanup.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { isReplyRunAbortableForSignal } from "../../auto-reply/reply/reply-run-registry.js";
-import {
-  stageSandboxMedia,
-  type StageSandboxMediaResult,
-} from "../../auto-reply/reply/stage-sandbox-media.js";
-import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
+import type { MsgContext } from "../../auto-reply/templating.js";
 import { resolveSessionWorkStartError } from "../../config/sessions.js";
 import {
   resolveSessionRoutingContract,
@@ -73,9 +68,8 @@ import {
   appendLocalMediaParentRoots,
   getAgentScopedMediaLocalRoots,
 } from "../../media/local-roots.js";
-import { parseInboundMediaUri } from "../../media/media-reference.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
-import { deleteMediaBuffer, MEDIA_MAX_BYTES, type SavedMedia } from "../../media/store.js";
+import type { SavedMedia } from "../../media/store.js";
 import { createChannelMessageReplyPipeline } from "../../plugin-sdk/channel-outbound.js";
 import {
   retainGatewayRootWorkAdmissionContinuation,
@@ -115,7 +109,6 @@ import {
   parseMessageWithAttachments,
   persistInboundImagesForTranscript,
   resolveChatAttachmentMaxBytes,
-  UnsupportedAttachmentError,
 } from "../chat-attachments.js";
 import {
   augmentChatHistoryWithCanvasBlocks,
@@ -208,6 +201,7 @@ import {
   readChatHistoryMessageSeq,
   readChatHistoryPage,
 } from "./chat-history-pages.js";
+import { prestageMediaPathOffloads } from "./chat-media-path-offloads.js";
 import {
   explicitOriginTargetsAcpSession,
   explicitOriginTargetsPluginBinding,
@@ -608,210 +602,6 @@ function stripTrailingOffloadedMediaMarkers(message: string, refs: OffloadedRef[
     lines.pop();
   }
   return lines.join("\n").trimEnd();
-}
-
-function isPdfOffloadedRef(ref: OffloadedRef): boolean {
-  const mime = ref.mimeType.trim().toLowerCase();
-  if (mime === "application/pdf" || mime.endsWith("+pdf")) {
-    return true;
-  }
-  return path.extname(ref.path.split(/[?#]/u)[0] ?? "").toLowerCase() === ".pdf";
-}
-
-// A managed inbound PDF saved to the media store is safe to hand the agent as its
-// media path without sandbox staging: host-side media-understanding extracts its
-// text (see resolveFileExtractionLimits) by reading the media-store root, so even
-// locked-down agents receive the document. This gates both the up-front bypass for
-// oversized PDFs and the fallback to the managed path when sandbox staging fails
-// for an already-managed PDF. #90097
-function isManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
-  if (!isPdfOffloadedRef(ref)) {
-    return false;
-  }
-  try {
-    return parseInboundMediaUri(ref.mediaRef) !== null;
-  } catch {
-    return false;
-  }
-}
-
-// Oversized managed PDFs skip sandbox staging up front: copying a large PDF into
-// every sandbox is wasteful, and files above the 5MB staging cap would otherwise
-// be rejected as a 4xx (see prestageMediaPathOffloads).
-function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
-  return ref.sizeBytes > MEDIA_MAX_BYTES && isManagedInboundPdfOffloadRef(ref);
-}
-
-// Stages media-path offloads into the agent sandbox synchronously so chat.send
-// can surface 5xx before respond(). Throws MediaOffloadError when staging fails
-// for a ref that cannot fall back (ENOSPC / EPERM / partial-stage of a non-PDF or
-// unmanaged ref) so the outer chat.send handler maps it to UNAVAILABLE (5xx);
-// plain Error would be misclassified as 4xx. Already-managed inbound PDFs instead
-// fall back to their managed media path on staging failure (#90097), since
-// host-side media-understanding reads them from the media-store root. Offloaded
-// refs are cleaned up from the media store before rethrow.
-// Callers MUST set ctx.MediaStaged=true when this runs so the dispatch
-// pipeline skips its own stageSandboxMedia pass.
-//
-// Returned paths are absolute media-store paths when no sandbox is active, for
-// oversized managed PDFs that bypass staging, or for already-managed PDFs that
-// fall back when staging fails (#90097); files staged into the sandbox use
-// sandbox-relative paths plus `workspaceDir`. Host-side media-understanding
-// resolves both via MediaWorkspaceDir and the media-store root.
-async function prestageMediaPathOffloads(params: {
-  offloadedRefs: OffloadedRef[];
-  includeImageRefs?: boolean;
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  agentId: string;
-}): Promise<{
-  paths: string[];
-  types: string[];
-  workspaceDir?: string;
-  cleanup?: StageSandboxMediaResult["cleanup"];
-}> {
-  const mediaPathRefs = params.offloadedRefs.filter(
-    (ref) => params.includeImageRefs || !ref.mimeType.startsWith("image/"),
-  );
-  if (mediaPathRefs.length === 0) {
-    return { paths: [], types: [] };
-  }
-  const refsByManagedPath = (refs: OffloadedRef[]) => ({
-    paths: refs.map((ref) => ref.path),
-    types: refs.map((ref) => ref.mimeType),
-  });
-
-  // Oversized managed PDFs bypass sandbox staging and are read host-side, so they
-  // do not need a workspace copy or the staging-cap check below.
-  const passThroughRefs: OffloadedRef[] = [];
-  const refsToStage: OffloadedRef[] = [];
-  for (const ref of mediaPathRefs) {
-    (shouldPassThroughManagedInboundPdfOffloadRef(ref) ? passThroughRefs : refsToStage).push(ref);
-  }
-  if (refsToStage.length === 0) {
-    return refsByManagedPath(mediaPathRefs);
-  }
-
-  let cleanup: StageSandboxMediaResult["cleanup"] | undefined;
-  try {
-    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
-    const sandbox = await ensureSandboxWorkspaceForSession({
-      config: params.cfg,
-      sessionKey: params.sessionKey,
-      workspaceDir,
-    });
-    if (!sandbox) {
-      return refsByManagedPath(mediaPathRefs);
-    }
-
-    // stageSandboxMedia caps each file at STAGED_MEDIA_MAX_BYTES (=
-    // MEDIA_MAX_BYTES, 5MB) and silently skips oversized files. The parse cap
-    // (resolveChatAttachmentMaxBytes, default 20MB) is higher, so a sandboxed
-    // session receiving a non-PDF file between the two caps would otherwise
-    // pass parse, fail staging, and surface as a retryable 5xx even though
-    // retry cannot succeed. Reject here as a client-side 4xx instead. Managed
-    // PDFs in that range pass through above instead of being rejected.
-    const oversizedForSandbox = refsToStage.filter((ref) => ref.sizeBytes > MEDIA_MAX_BYTES);
-    if (oversizedForSandbox.length > 0) {
-      const details = oversizedForSandbox
-        .map((ref) => `${ref.label} (${ref.sizeBytes} bytes)`)
-        .join(", ");
-      throw new UnsupportedAttachmentError(
-        "non-image-too-large-for-sandbox",
-        `attachments exceed sandbox staging limit (${MEDIA_MAX_BYTES} bytes): ${details}`,
-      );
-    }
-
-    const stagingCtx: MsgContext = {
-      MediaPath: expectDefined(refsToStage[0], "refs to stage entry at 0").path,
-      MediaPaths: refsToStage.map((ref) => ref.path),
-      MediaType: expectDefined(refsToStage[0], "refs to stage entry at 0").mimeType,
-      MediaTypes: refsToStage.map((ref) => ref.mimeType),
-    };
-    let stageResult: StageSandboxMediaResult;
-    try {
-      stageResult = await stageSandboxMedia({
-        ctx: stagingCtx,
-        sessionCtx: stagingCtx as TemplateContext,
-        cfg: params.cfg,
-        sessionKey: params.sessionKey,
-        workspaceDir,
-      });
-      cleanup = stageResult.cleanup;
-    } catch (stageErr) {
-      // stageSandboxMedia threw before copying anything (e.g. workspace mkdir
-      // ENOSPC/EPERM), so nothing reached the sandbox. Already-managed inbound
-      // PDFs still reach the agent via their managed media path (host-side
-      // media-understanding reads the media-store root); fail the send only when a
-      // ref cannot fall back. #90097
-      if (refsToStage.some((ref) => !isManagedInboundPdfOffloadRef(ref))) {
-        throw stageErr;
-      }
-      return refsByManagedPath(mediaPathRefs);
-    }
-
-    // stageSandboxMedia silently keeps unstaged entries as their original
-    // absolute path, so length parity does not prove every file landed in the
-    // sandbox. The RPC max (20MB via resolveChatAttachmentMaxBytes) admits files
-    // above the staging cap (STAGED_MEDIA_MAX_BYTES = 5MB); check the returned
-    // `staged` map for missing sources. Already-managed inbound PDFs fall back to
-    // their absolute managed path (host-side media-understanding reads the
-    // media-store root); any other missing source is a 5xx MediaOffloadError the
-    // client can retry. #90097
-    const stagedSources = stageResult.staged;
-    const missing = refsToStage.filter((ref) => !stagedSources.has(ref.path));
-    const unstageable = missing.filter((ref) => !isManagedInboundPdfOffloadRef(ref));
-    if (unstageable.length > 0) {
-      throw new Error(
-        `attachment staging incomplete: ${stagedSources.size}/${refsToStage.length} paths staged into sandbox workspace (missing: ${unstageable.map((ref) => ref.path).join(", ")})`,
-      );
-    }
-    const stagedPaths = stagingCtx.MediaPaths ?? [];
-    const stagedTypes = stagingCtx.MediaTypes ?? refsToStage.map((ref) => ref.mimeType);
-
-    // Map each ref to its post-staging path. Staged files become sandbox-relative
-    // (e.g. `media/inbound/foo.pdf`) so the agent inside the container can read
-    // them; pass-through PDFs and managed PDFs that fell back from staging keep
-    // their absolute managed path (stagedPaths preserves the absolute path for any
-    // unstaged entry). Host-side media-understanding resolves both via
-    // ctx.MediaWorkspaceDir plus the media-store root. Preserve attachment order.
-    const resolvedByRef = new Map<OffloadedRef, { path: string; mimeType: string }>();
-    refsToStage.forEach((ref, index) => {
-      resolvedByRef.set(ref, {
-        path: stagedPaths[index] ?? ref.path,
-        mimeType: stagedTypes[index] ?? ref.mimeType,
-      });
-    });
-    for (const ref of passThroughRefs) {
-      resolvedByRef.set(ref, { path: ref.path, mimeType: ref.mimeType });
-    }
-    const ordered = mediaPathRefs.map(
-      (ref) => resolvedByRef.get(ref) ?? { path: ref.path, mimeType: ref.mimeType },
-    );
-    return {
-      paths: ordered.map((entry) => entry.path),
-      types: ordered.map((entry) => entry.mimeType),
-      workspaceDir: sandbox.workspaceDir,
-      cleanup,
-    };
-  } catch (err) {
-    await cleanup?.();
-    await Promise.allSettled(
-      params.offloadedRefs.map((ref) => deleteMediaBuffer(ref.id, "inbound")),
-    );
-    if (err instanceof MediaOffloadError) {
-      throw err;
-    }
-    // Sandbox-oversize rejections are client-side 4xx (see check above). Wrapping
-    // them as MediaOffloadError would misclassify them as retryable 5xx.
-    if (err instanceof UnsupportedAttachmentError) {
-      throw err;
-    }
-    throw new MediaOffloadError(
-      `[Gateway Error] Failed to stage attachments into agent workspace: ${formatErrorMessage(err)}`,
-      { cause: err },
-    );
-  }
 }
 
 type ChatSendManagedMediaFields = Partial<
@@ -2750,36 +2540,39 @@ export const chatHandlers: GatewayRequestHandlers = {
                   abortSignal: activeRunAbort.controller.signal,
                   // Keep a Gateway-owned cancel identity after this chat.send
                   // terminalizes while the prompt waits in followup/collect queue.
-                  queuedFollowupLifecycle: {
-                    ownerKey: queuedFollowupOwnerKey,
-                    onEnqueued: () => {
-                      queuedFollowupEnqueued = registerQueuedChatTurn({
-                        chatQueuedTurns: ensureChatQueuedTurns(context),
-                        runId: clientRunId,
-                        controller: activeRunAbort.controller,
-                        sessionId: backingSessionId ?? clientRunId,
-                        sessionKey,
-                        agentId: selectedAgent.agentId,
-                        ownerConnId: normalizeOptionalText(client?.connId),
-                        ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
-                      });
-                      return queuedFollowupEnqueued;
+                  queuedFollowupLifecycle: withQueuedReplyCleanup(
+                    {
+                      ownerKey: queuedFollowupOwnerKey,
+                      onEnqueued: () => {
+                        queuedFollowupEnqueued = registerQueuedChatTurn({
+                          chatQueuedTurns: ensureChatQueuedTurns(context),
+                          runId: clientRunId,
+                          controller: activeRunAbort.controller,
+                          sessionId: backingSessionId ?? clientRunId,
+                          sessionKey,
+                          agentId: selectedAgent.agentId,
+                          ownerConnId: normalizeOptionalText(client?.connId),
+                          ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
+                        });
+                        return queuedFollowupEnqueued;
+                      },
+                      onCancellationRetired: () => {
+                        retireQueuedChatTurnCancellation(
+                          ensureChatQueuedTurns(context),
+                          clientRunId,
+                          activeRunAbort.controller,
+                        );
+                      },
+                      onComplete: () => {
+                        completeQueuedChatTurn(
+                          ensureChatQueuedTurns(context),
+                          clientRunId,
+                          activeRunAbort.controller,
+                        );
+                      },
                     },
-                    onCancellationRetired: () => {
-                      retireQueuedChatTurnCancellation(
-                        ensureChatQueuedTurns(context),
-                        clientRunId,
-                        activeRunAbort.controller,
-                      );
-                    },
-                    onComplete: () => {
-                      completeQueuedChatTurn(
-                        ensureChatQueuedTurns(context),
-                        clientRunId,
-                        activeRunAbort.controller,
-                      );
-                    },
-                  },
+                    cleanupMediaPathOffloads,
+                  ),
                   images: replyOptionImages,
                   imageOrder: imageOrder.length > 0 ? imageOrder : undefined,
                   thinkingLevelOverride: p.thinking,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -41,7 +41,7 @@ import {
   type ReplyPayload,
 } from "../../auto-reply/reply-payload.js";
 import { isBtwRequestText } from "../../auto-reply/reply/btw-command.js";
-import { withQueuedReplyCleanup } from "../../auto-reply/reply/queued-followup-cleanup.js";
+import { withQueuedReplyCleanup } from "../../auto-reply/reply/reply-cleanup.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { isReplyRunAbortableForSignal } from "../../auto-reply/reply/reply-run-registry.js";
 import type { MsgContext } from "../../auto-reply/templating.js";

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -664,7 +664,12 @@ async function prestageMediaPathOffloads(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   agentId: string;
-}): Promise<{ paths: string[]; types: string[]; workspaceDir?: string }> {
+}): Promise<{
+  paths: string[];
+  types: string[];
+  workspaceDir?: string;
+  cleanup?: StageSandboxMediaResult["cleanup"];
+}> {
   const mediaPathRefs = params.offloadedRefs.filter(
     (ref) => params.includeImageRefs || !ref.mimeType.startsWith("image/"),
   );
@@ -687,6 +692,7 @@ async function prestageMediaPathOffloads(params: {
     return refsByManagedPath(mediaPathRefs);
   }
 
+  let cleanup: StageSandboxMediaResult["cleanup"] | undefined;
   try {
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
     const sandbox = await ensureSandboxWorkspaceForSession({
@@ -731,6 +737,7 @@ async function prestageMediaPathOffloads(params: {
         sessionKey: params.sessionKey,
         workspaceDir,
       });
+      cleanup = stageResult.cleanup;
     } catch (stageErr) {
       // stageSandboxMedia threw before copying anything (e.g. workspace mkdir
       // ENOSPC/EPERM), so nothing reached the sandbox. Already-managed inbound
@@ -785,8 +792,10 @@ async function prestageMediaPathOffloads(params: {
       paths: ordered.map((entry) => entry.path),
       types: ordered.map((entry) => entry.mimeType),
       workspaceDir: sandbox.workspaceDir,
+      cleanup,
     };
   } catch (err) {
+    await cleanup?.();
     await Promise.allSettled(
       params.offloadedRefs.map((ref) => deleteMediaBuffer(ref.id, "inbound")),
     );
@@ -1638,6 +1647,12 @@ export const chatHandlers: GatewayRequestHandlers = {
     let mediaPathOffloadPaths: string[] = [];
     let mediaPathOffloadTypes: string[] = [];
     let mediaPathOffloadWorkspaceDir: string | undefined;
+    let cleanupMediaPathOffloads: (() => Promise<void>) | undefined;
+    const cleanupPreparedAttachments = async () => {
+      const cleanup = cleanupMediaPathOffloads;
+      cleanupMediaPathOffloads = undefined;
+      await cleanup?.();
+    };
     const timeoutMs = resolveAgentTimeoutMs({
       cfg,
       overrideMs: p.timeoutMs,
@@ -2173,6 +2188,7 @@ export const chatHandlers: GatewayRequestHandlers = {
               paths: mediaPathOffloadPaths,
               types: mediaPathOffloadTypes,
               workspaceDir: mediaPathOffloadWorkspaceDir,
+              cleanup: cleanupMediaPathOffloads,
             } = await prestageMediaPathOffloads({
               offloadedRefs,
               // Text-only image offloads need ctx.MediaPaths so media-understanding
@@ -2197,6 +2213,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           performance.now() - prepareAttachmentsStartedAtMs,
         );
       } catch (err) {
+        await cleanupPreparedAttachments();
         cleanupAdmittedRun({ force: true });
         clearAgentRunContext(clientRunId, lifecycleGeneration);
         logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
@@ -2212,6 +2229,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       }
     }
     if (activeRunAbort.controller.signal.aborted) {
+      await cleanupPreparedAttachments();
       finishAbortedChatSend();
       return;
     }
@@ -2219,6 +2237,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     // Attachment preparation and admission can suspend. Recheck immediately
     // before ACK/dispatch so hot config reload cannot cross the send boundary.
     if (sessionRoutingChanged(context.getRuntimeConfig())) {
+      await cleanupPreparedAttachments();
       cleanupAdmittedRun({ force: true });
       clearAgentRunContext(clientRunId, lifecycleGeneration);
       respondSessionRoutingChanged();
@@ -2289,6 +2308,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           ) {
             throw new Error("chat admission ownership changed before terminalization");
           }
+          await cleanupPreparedAttachments();
           finishAbortedChatSend();
           return;
         }
@@ -2296,6 +2316,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           if (!(await terminalizeRestartSafeAdmission({ retryable: true, status: "failed" }))) {
             throw new Error("chat admission ownership changed before terminalization");
           }
+          await cleanupPreparedAttachments();
           cleanupAdmittedRun({ force: true });
           clearAgentRunContext(clientRunId, lifecycleGeneration);
           respondSessionRoutingChanged();
@@ -3763,6 +3784,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             errorMessage,
           });
         })
+        .then(cleanupPreparedAttachments)
         .finally(() => {
           const dispatchError = pendingDispatchLifecycleError;
           // Reserve error projection before cleanup retires the dispatch root. Restart
@@ -3831,6 +3853,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             .finally(() => releaseDispatchErrorRoot?.());
         });
     } catch (err) {
+      await cleanupPreparedAttachments();
       if (restartSafeAdmission) {
         const terminalized = await terminalizeRestartSafeAdmission({
           retryable: true,


### PR DESCRIPTION
Closes #104358

## What Problem This Solves

Fixes an issue where host-mode inbound media staging could leave empty `media/inbound/openclaw-staged-*` directories behind after a reply finished. Over time, these temporary-looking directories accumulated in agent workspaces and made the inbound media directory appear unhealthy.

## Why This Change Was Made

The staging result now carries a best-effort cleanup owner through both the normal reply path and the Gateway attachment-prestage path. Each consumer waits until media consumption is finished before attempting cleanup, and cleanup uses non-recursive directory removal so staged files that are still present are never deleted. Empty staging attempts are cleaned up immediately.

This keeps cleanup lifecycle-scoped instead of adding a startup or periodic filesystem janitor, and deliberately avoids recursive deletion.

## User Impact

Empty one-shot inbound staging directories are removed automatically after use. Non-empty staging directories and their files remain untouched, preserving media that a runner or tool still needs.

## Evidence

- Focused auto-reply and Gateway regression run: 659 tests passed across two routed Vitest shards (280 Gateway tests and 379 auto-reply tests).
- Added coverage proving cleanup does not remove a staged file, removes its directory once empty, and runs after both prepared-reply and Gateway dispatch lifetimes.
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed.
- Structured autoreview: `autoreview clean: no accepted/actionable findings reported` (`gpt-5.6-sol`, high reasoning).
- The patch was rebased onto `main` at `702ba19e3abaa8984d9627ebacbd7a9d830380f6`, then the focused test and static-check commands were rerun successfully.

Remote Testbox proof was unavailable in this environment because the Blacksmith CLI was not installed and the brokered AWS Crabbox client was not authenticated. The focused linked-worktree fallback was used; GitHub CI remains the broad typecheck/check gate.

AI-assisted: yes — implemented and reviewed with Codex.


### Live host-workspace proof (exact PR head)

- Head: `c3ad35d9276012bbf53d26ef0bbf96db1422900e`.
- Setup: isolated state/workspace, sandbox mode off, external channels disabled, normal inbound-channel dispatcher, real OpenAI/Codex `gpt-5.5` agent turn.
- The agent was instructed to read the staged attachment, remove only that file after consumption, and return its contents. The parent directory was left for the lifecycle cleanup owner.

```text
BEFORE_RUN staged_dir_count=0 source_bytes=26
DURING_RUN staging_dir=openclaw-staged-<uuid>
DURING_RUN file=pr104597-proof-delete.dat readable=yes bytes=26
DURING_RUN sha256=c327d80df2a615ef4a8d7d31747a5526c1b7c84140ba518fcd327b32c8951980
DURING_RUN content=PR104597-LIVE-PROOF-7f9c2a
LIVE_FINAL_REPLY=PR104597-LIVE-PROOF-7f9c2a
AFTER_RUN staged_dir_count=0 staged_file_count=0
```

This also confirmed the non-recursive safety contract separately: when a read-only consumer left the staged file present, cleanup preserved the non-empty directory. No source changes were made while gathering this proof.
