### PR TITLE
fix(browser): keep Chrome stderr hint tail UTF-16 safe

### DIFF
--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -1433,6 +1433,61 @@ describe("chrome.ts internal", () => {
       expect(fakeProc.kill).toHaveBeenCalledWith("SIGKILL");
     });
 
+    it("does not split a surrogate pair at the stderr hint char-cap boundary", async () => {
+      // The byte-bounded tail keeps the string intact; the separate
+      // CHROME_STDERR_HINT_MAX_CHARS char cap is a second slice that can still
+      // bisect a surrogate pair straddling the `length - cap` boundary.
+      const executablePath = path.join(tmpDir, "chrome");
+      await fsp.writeFile(executablePath, "");
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s === executablePath || s.endsWith("Local State") || s.endsWith("Preferences")) {
+          return true;
+        }
+        return false;
+      });
+      const fakeProc = makeFakeProc();
+      // Position 🦞 (2 UTF-16 code units) so its low half lands exactly on the
+      // char-cap cut index (`length - CHROME_STDERR_HINT_MAX_CHARS`): keep the
+      // emoji followed by exactly `cap - 1` trailing chars. The 64 KiB byte
+      // tail keeps the whole string intact, isolating the char-cap slice.
+      const newestMarker = "newest-stderr-marker";
+      const tail = `${newestMarker}${"y".repeat(CHROME_STDERR_HINT_MAX_CHARS - 1 - newestMarker.length)}`;
+      const stderrText = `${"x".repeat(50)}🦞${tail}`;
+      spawnMock.mockImplementation(() => {
+        void Promise.resolve().then(() => {
+          fakeProc.stderr.emit("data", Buffer.from(stderrText));
+        });
+        return fakeProc;
+      });
+      let now = 1_000_000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          now += 10_000;
+          throw new Error("ECONNREFUSED");
+        }),
+      );
+
+      const profile = { ...makeProfile(55559), executablePath } as ResolvedBrowserProfile;
+      let message = "";
+      try {
+        await launchOpenClawChrome(makeResolved({ localLaunchTimeoutMs: 1 }), profile);
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+
+      expect(message).toContain("Chrome stderr:");
+      const stderrHint = message.split("Chrome stderr:\n")[1] ?? "";
+      expect(stderrHint).not.toContain("�");
+      expect(stderrHint).not.toMatch(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+      );
+      expect(stderrHint).toContain(newestMarker);
+      expect(stderrHint.length).toBeLessThanOrEqual(CHROME_STDERR_HINT_MAX_CHARS);
+    });
+
     it("keeps early missing-display diagnostics for launch hints after the stderr tail rolls", async () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, "platform", { value: "linux" });

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -592,6 +592,37 @@ describe("chrome.ts internal", () => {
         ...overrides,
       }) as unknown as ResolvedBrowserConfig;
 
+    const captureFailedLaunchStderr = async (params: {
+      port: number;
+      chunks: readonly (Buffer | string)[];
+    }) => {
+      stubBrowserExecutableAndPrefs("present");
+      const proc = makeFakeProc();
+      spawnMock.mockImplementation(() => {
+        queueMicrotask(() => {
+          for (const chunk of params.chunks) {
+            proc.stderr.emit("data", chunk);
+          }
+        });
+        return proc;
+      });
+      mockExpiredLaunchPollingClock();
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+
+      const result = await launchOpenClawChrome(
+        makeResolved({ localLaunchTimeoutMs: 1 }),
+        makeProfile(params.port),
+      ).catch((err: unknown) => err);
+      if (!(result instanceof Error)) {
+        throw new Error("expected managed Chrome launch to fail");
+      }
+      return {
+        error: result,
+        proc,
+        stderrHint: result.message.split("Chrome stderr:\n")[1] ?? "",
+      };
+    };
+
     it("rejects a remote profile before attempting to spawn", async () => {
       const profile = {
         name: "openclaw",
@@ -1381,111 +1412,39 @@ describe("chrome.ts internal", () => {
     });
 
     it("keeps only a bounded UTF-8-safe newest stderr tail when launch fails after large stderr", async () => {
-      const executablePath = path.join(tmpDir, "chrome");
-      await fsp.writeFile(executablePath, "");
-      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
-        const s = String(p);
-        if (s === executablePath || s.endsWith("Local State") || s.endsWith("Preferences")) {
-          return true;
-        }
-        return false;
-      });
-      const fakeProc = makeFakeProc();
       const oldMarker = "older-stderr-marker";
       const newestMarker = "newest-stderr-marker";
       const splitEmoji = Buffer.from("🦞");
       const newestLine = Buffer.from(`\n${newestMarker}\n`);
       const tailMaxBytes = 64 * 1024;
       const filler = Buffer.alloc(tailMaxBytes + 2 - splitEmoji.length - newestLine.length, "x");
-      spawnMock.mockImplementation(() => {
-        void Promise.resolve().then(() => {
-          fakeProc.stderr.emit("data", Buffer.from(`${oldMarker}\n`));
-          fakeProc.stderr.emit("data", splitEmoji.subarray(0, 2));
-          fakeProc.stderr.emit("data", Buffer.concat([splitEmoji.subarray(2), filler, newestLine]));
-        });
-        return fakeProc;
+      const { error, proc, stderrHint } = await captureFailedLaunchStderr({
+        port: 55557,
+        chunks: [
+          Buffer.from(`${oldMarker}\n`),
+          splitEmoji.subarray(0, 2),
+          Buffer.concat([splitEmoji.subarray(2), filler, newestLine]),
+        ],
       });
-      let now = 1_000_000;
-      vi.spyOn(Date, "now").mockImplementation(() => now);
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async () => {
-          now += 10_000;
-          throw new Error("ECONNREFUSED");
-        }),
-      );
 
-      const profile = { ...makeProfile(55557), executablePath } as ResolvedBrowserProfile;
-      let message = "";
-      try {
-        await launchOpenClawChrome(makeResolved({ localLaunchTimeoutMs: 1 }), profile);
-      } catch (err) {
-        message = err instanceof Error ? err.message : String(err);
-      }
-
-      expect(message).toMatch(/Failed to start Chrome CDP/);
-      expect(message).toContain("Chrome stderr:");
-      const stderrHint = message.split("Chrome stderr:\n")[1] ?? "";
+      expect(error.message).toMatch(/Failed to start Chrome CDP/);
       expect(stderrHint).not.toContain(oldMarker);
       expect(stderrHint).toContain(newestMarker);
       expect(stderrHint).not.toContain("�");
       expect(stderrHint.length).toBeLessThanOrEqual(CHROME_STDERR_HINT_MAX_CHARS);
-      expect(fakeProc.kill).toHaveBeenCalledWith("SIGKILL");
+      expect(proc.kill).toHaveBeenCalledWith("SIGKILL");
     });
 
     it("does not split a surrogate pair at the stderr hint char-cap boundary", async () => {
-      // The byte-bounded tail keeps the string intact; the separate
-      // CHROME_STDERR_HINT_MAX_CHARS char cap is a second slice that can still
-      // bisect a surrogate pair straddling the `length - cap` boundary.
-      const executablePath = path.join(tmpDir, "chrome");
-      await fsp.writeFile(executablePath, "");
-      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
-        const s = String(p);
-        if (s === executablePath || s.endsWith("Local State") || s.endsWith("Preferences")) {
-          return true;
-        }
-        return false;
-      });
-      const fakeProc = makeFakeProc();
-      // Position 🦞 (2 UTF-16 code units) so its low half lands exactly on the
-      // char-cap cut index (`length - CHROME_STDERR_HINT_MAX_CHARS`): keep the
-      // emoji followed by exactly `cap - 1` trailing chars. The 64 KiB byte
-      // tail keeps the whole string intact, isolating the char-cap slice.
       const newestMarker = "newest-stderr-marker";
       const tail = `${newestMarker}${"y".repeat(CHROME_STDERR_HINT_MAX_CHARS - 1 - newestMarker.length)}`;
-      const stderrText = `${"x".repeat(50)}🦞${tail}`;
-      spawnMock.mockImplementation(() => {
-        void Promise.resolve().then(() => {
-          fakeProc.stderr.emit("data", Buffer.from(stderrText));
-        });
-        return fakeProc;
+      // The raw cap starts on 🦞's low surrogate; the safe slice drops the pair.
+      const { stderrHint } = await captureFailedLaunchStderr({
+        port: 55559,
+        chunks: [`${"x".repeat(50)}🦞${tail}`],
       });
-      let now = 1_000_000;
-      vi.spyOn(Date, "now").mockImplementation(() => now);
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async () => {
-          now += 10_000;
-          throw new Error("ECONNREFUSED");
-        }),
-      );
 
-      const profile = { ...makeProfile(55559), executablePath } as ResolvedBrowserProfile;
-      let message = "";
-      try {
-        await launchOpenClawChrome(makeResolved({ localLaunchTimeoutMs: 1 }), profile);
-      } catch (err) {
-        message = err instanceof Error ? err.message : String(err);
-      }
-
-      expect(message).toContain("Chrome stderr:");
-      const stderrHint = message.split("Chrome stderr:\n")[1] ?? "";
-      expect(stderrHint).not.toContain("�");
-      expect(stderrHint).not.toMatch(
-        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
-      );
-      expect(stderrHint).toContain(newestMarker);
-      expect(stderrHint.length).toBeLessThanOrEqual(CHROME_STDERR_HINT_MAX_CHARS);
+      expect(stderrHint).toBe(tail);
     });
 
     it("keeps early missing-display diagnostics for launch hints after the stderr tail rolls", async () => {

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -17,6 +17,7 @@ import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { prepareOomScoreAdjustedSpawn } from "openclaw/plugin-sdk/process-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
@@ -1308,7 +1309,7 @@ export async function launchOpenClawChrome(
             return await launchOnceAndWait(false);
           }
           const stderrHint = redactedStderrOutput
-            ? `\nChrome stderr:\n${redactedStderrOutput.slice(-CHROME_STDERR_HINT_MAX_CHARS)}`
+            ? `\nChrome stderr:\n${sliceUtf16Safe(redactedStderrOutput, -CHROME_STDERR_HINT_MAX_CHARS)}`
             : "";
           const launchHints = chromeLaunchHints({
             stderrOutput,


### PR DESCRIPTION
## Summary

- Problem: the Chrome launch-failure `stderr` hint can render a broken leading character (`�`) when the tail cap cuts through a multibyte character.
- Root cause: in `launchOpenClawChrome` (`extensions/browser/src/browser/chrome.ts`), the hint is built with `redactedStderrOutput.slice(-CHROME_STDERR_HINT_MAX_CHARS)`. The byte-bounded tail (`createBoundedUtf8Tail`) keeps the string well-formed, but this *second*, char-index tail cap can start on the low half of a surrogate pair, leaving a dangling code unit at the head of the shown text.
- Fix: use the repo's surrogate-safe slice helper — `sliceUtf16Safe(redactedStderrOutput, -CHROME_STDERR_HINT_MAX_CHARS)` — which advances past a dangling surrogate half at the cut boundary. Same helper/idiom just adopted for sibling stderr/output tails (`sliceUtf16Safe`/`truncateUtf16Safe`).
- Out of scope: the byte-bounded tail path is already surrogate-safe and unchanged; no other slice sites touched.

## Linked context

No linked issue; found while auditing char-index tail caps on user-visible text against the codebase's `sliceUtf16Safe` helper.

## Real behavior proof

- Behavior or issue addressed: the Chrome stderr diagnostic hint surfaced on launch failure could begin with a lone UTF-16 surrogate (renders as `�`) when a multibyte character straddled the `length - CHROME_STDERR_HINT_MAX_CHARS` cut point.
- Real environment tested: Windows 10, Node 22.22.2, OpenClaw main, production `sliceUtf16Safe` from `packages/normalization-core/src/utf16-slice.ts` and the real `launchOpenClawChrome` path via `chrome.internal.test.ts`.
- Exact steps or command run after this patch: imported the production `sliceUtf16Safe` via `node --import tsx` and compared the raw `.slice(-cap)` tail against the helper on a stderr string whose emoji straddles the cap boundary; also ran the extension test that drives the real launch-failure hint path.
- Evidence after fix:

```
$ node --import tsx probe.mjs
stderr length: 2051 cut index (length - cap): 51
BEFORE  redactedStderrOutput.slice(-cap):  head=U+dd9e  loneLowSurrogate=true  startsWith="\udd9enewest-"
AFTER   sliceUtf16Safe(text, -cap):        head=U+6e   loneLowSurrogate=false startsWith="newest-s"

$ node scripts/run-vitest.mjs extensions/browser/src/browser/chrome.internal.test.ts -t "does not split a surrogate pair at the stderr hint char-cap boundary"
 Tests  1 passed (1)
# reverting only the chrome.ts fix (keeping the test) makes it fail:
 AssertionError: expected '�newest-stderr-marker…' not to match /[\uD800-\uDBFF](?!…)|(?<!…)[\uDC00-\uDFFF]/
```

- Observed result after fix: the hint tail no longer starts with a lone low surrogate (`U+DD9E` → clean `newest-…`); the surrogate-pair regression test passes with the fix and fails without it.
- What was not tested: no live Chrome launch on this host (the extension test mocks the spawned process, as the neighboring stderr-tail tests do); no known gaps for the slicing behavior itself.

## Regression test plan

- Target test file: `extensions/browser/src/browser/chrome.internal.test.ts`
- Scenario locked in: `"does not split a surrogate pair at the stderr hint char-cap boundary"` — drives the real launch-failure path with an emoji positioned so its low surrogate lands exactly on the `length - CHROME_STDERR_HINT_MAX_CHARS` cut, and asserts the resulting hint contains no lone surrogate / `�`, still retains the newest marker, and stays within the cap. Verified failing before the fix, passing after.

## Risk checklist

- User-visible behavior changed? Yes — the Chrome stderr hint no longer shows a broken leading character; content is otherwise identical.
- Config/env/migration changed? No.
- Security/auth/secrets/network/tool-exec changed? No.
