### PR TITLE
test(release): harden prerelease timing contracts

### DIFF
--- a/extensions/qa-lab/src/ci-smoke-plan.test.ts
+++ b/extensions/qa-lab/src/ci-smoke-plan.test.ts
@@ -5,6 +5,21 @@ import { createQaSmokeCiPart } from "./ci-smoke-plan.js";
 import { readQaScenarioPack } from "./scenario-catalog.js";
 import { readQaScorecardTaxonomyReport } from "./scorecard-taxonomy.js";
 
+type QaScenario = ReturnType<typeof readQaScenarioPack>["scenarios"][number];
+
+function estimateScenarioCost(scenario: QaScenario | undefined): number {
+  if (!scenario) {
+    throw new Error("QA smoke plan selected an unknown scenario.");
+  }
+  if (scenario.execution.kind === "script") {
+    return 8;
+  }
+  if (scenario.execution.kind === "playwright") {
+    return 6;
+  }
+  return scenario.execution.kind === "flow" && scenario.execution.isolationReason ? 4 : 1;
+}
+
 describe("createQaSmokeCiPart", () => {
   it("balances the bounded automatic smoke set across two profile parts", () => {
     const first = createQaSmokeCiPart("profile-1");
@@ -40,10 +55,23 @@ describe("createQaSmokeCiPart", () => {
       .map((category) => category.id);
     expect(uncoveredCategoryIds).toEqual([]);
 
-    const primaryRunSizes = [first, second].map(
-      (part) => part.runs.find((run) => run.slug === "primary")?.scenario_ids.length ?? 0,
+    const primaryScenarioIds = [first, second].map(
+      (part) => part.runs.find((run) => run.slug === "primary")?.scenario_ids ?? [],
     );
-    expect(Math.abs(primaryRunSizes[0] - primaryRunSizes[1])).toBeLessThanOrEqual(2);
+    const primaryRunCosts = primaryScenarioIds.map((ids) =>
+      ids.reduce(
+        (cost, scenarioId) => cost + estimateScenarioCost(scenarioById.get(scenarioId)),
+        0,
+      ),
+    );
+    const largestScenarioCost = Math.max(
+      ...primaryScenarioIds.flatMap((ids) =>
+        ids.map((scenarioId) => estimateScenarioCost(scenarioById.get(scenarioId))),
+      ),
+    );
+    expect(Math.abs(primaryRunCosts[0] - primaryRunCosts[1])).toBeLessThanOrEqual(
+      largestScenarioCost,
+    );
   });
 
   it("rejects undeclared profile parts", () => {

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -125,7 +125,9 @@ async function flushTasks() {
 }
 
 async function waitForNextTask() {
-  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
 }
 
 async function waitMs(ms: number) {

--- a/extensions/whatsapp/src/login-qr.test.ts
+++ b/extensions/whatsapp/src/login-qr.test.ts
@@ -124,6 +124,10 @@ async function flushTasks() {
   await Promise.resolve();
 }
 
+async function waitForNextTask() {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
 async function waitMs(ms: number) {
   await new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -570,10 +574,10 @@ describe("login-qr", () => {
     });
     expect(start.qrDataUrl).toBe(encodedQr("qr-data"));
 
-    await waitMs(50);
-    await flushTasks();
+    await waitForQrRenderCallCount(2);
     resolveLogin();
-    await flushTasks();
+    await vi.waitFor(() => expect(readWebAuthExistsForDecisionMock).toHaveBeenCalledTimes(2));
+    await waitForNextTask();
 
     await expect(
       waitForWebLogin({


### PR DESCRIPTION
## What Problem This Solves

Resolves two flaky Plugin Prerelease assertions: WhatsApp login completion relied on a fixed number of microtasks, and QA smoke balancing compared scenario counts even though the planner balances weighted runtime cost.

## Why This Change Was Made

The WhatsApp test now observes the refreshed QR, waits for the durable-auth decision, and crosses the task boundary that commits terminal state. The QA test checks the weighted greedy-partition invariant using the planner's documented scenario costs.

## User Impact

No product behavior changes. Plugin Prerelease remains strict while avoiding failures caused by scheduler timing or unequal counts of differently weighted scenarios.

## Evidence

- Exact failing WhatsApp job: https://github.com/openclaw/openclaw/actions/runs/29161945382/job/86568414933
- WhatsApp Testbox: focused race 25/25; full suite 88 files, 1,042/1,042 tests — https://github.com/openclaw/openclaw/actions/runs/29162493859
- Exact failing QA job: https://github.com/openclaw/openclaw/actions/runs/29161945382/job/86568414919
- QA Testbox: focused 2/2; full suite 105 files, 1,425/1,425 tests; changed checks green — https://github.com/openclaw/openclaw/actions/runs/29162235876
- Fresh autoreview: zero accepted/actionable findings.
