### PR TITLE
fix(gateway): demote expected startup socket aborts

### DIFF
--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -301,6 +301,28 @@ describe("attachGatewayWsConnectionHandler", () => {
     );
   });
 
+  it("keeps queued local app startup frames at warning level", async () => {
+    const logWsControl = createGatewayWsTestLogger();
+    const { socket } = attachGatewayWsForTest({
+      attach: attachGatewayWsConnectionHandler,
+      headers: { "user-agent": "OpenClaw/2607000290 CFNetwork/3860 Darwin/25" },
+      options: { isStartupPending: () => true, logWsControl: logWsControl as never },
+    });
+
+    socket.emit("message", Buffer.from('{"type":"req","id":"queued"}'));
+    socket.emit("close", 1006, Buffer.alloc(0));
+    await waitForLazyMessageHandler();
+
+    expect(logWsControl.warn).toHaveBeenCalledWith(
+      expect.stringContaining("closed before connect"),
+      expect.objectContaining({ phase: "ws_upgrade_started" }),
+    );
+    expect(logWsControl.debug).not.toHaveBeenCalledWith(
+      expect.stringContaining("closed before connect"),
+      expect.anything(),
+    );
+  });
+
   it("includes the last completed handshake phase on preauth timeout logs", async () => {
     vi.useFakeTimers();
     const { logWsControl } = await connectTestWs({

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -283,6 +283,24 @@ describe("attachGatewayWsConnectionHandler", () => {
     expect(context).toMatchObject({ phase: "ws_upgrade_started" });
   });
 
+  it("demotes local app startup aborts before the first frame", async () => {
+    const { socket, logWsControl } = await connectTestWs({
+      headers: { "user-agent": "OpenClaw/2607000290 CFNetwork/3860 Darwin/25" },
+      options: { isStartupPending: () => true },
+    });
+
+    socket.emit("close", 1006, Buffer.alloc(0));
+
+    expect(logWsControl.debug).toHaveBeenCalledWith(
+      expect.stringContaining("closed before connect"),
+      expect.objectContaining({ phase: "ws_upgrade_started" }),
+    );
+    expect(logWsControl.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("closed before connect"),
+      expect.anything(),
+    );
+  });
+
   it("includes the last completed handshake phase on preauth timeout logs", async () => {
     vi.useFakeTimers();
     const { logWsControl } = await connectTestWs({

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -297,6 +297,11 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     let lastFrameType: string | undefined;
     let lastFrameMethod: string | undefined;
     let lastFrameId: string | undefined;
+    let hasReceivedPreauthFrame = false;
+
+    socket.once("message", () => {
+      hasReceivedPreauthFrame = true;
+    });
 
     const advanceHandshakePhase = (next: WsHandshakePhase) => {
       if (WS_HANDSHAKE_PHASES.indexOf(next) > WS_HANDSHAKE_PHASES.indexOf(lastHandshakePhase)) {
@@ -426,6 +431,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       openedDuringStartup &&
       code === 1006 &&
       lastHandshakePhase === "ws_upgrade_started" &&
+      !hasReceivedPreauthFrame &&
       lastFrameType === undefined &&
       normalizeLowercaseStringOrEmpty(requestUserAgent).startsWith("openclaw/") &&
       isLoopbackAddress(remoteAddr);

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -273,6 +273,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     const requestUserAgent = headerValue(upgradeReq.headers["user-agent"]);
     const forwardedFor = headerValue(upgradeReq.headers["x-forwarded-for"]);
     const realIp = headerValue(upgradeReq.headers["x-real-ip"]);
+    const openedDuringStartup = isStartupPending?.() === true;
 
     const pluginNodeCapabilities = getPluginNodeCapabilities?.() ?? [];
     const pluginSurfaceBaseUrl =
@@ -421,6 +422,14 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       normalizeLowercaseStringOrEmpty(userAgent).includes("swiftpm-testing-helper") &&
       isLoopbackAddress(remote);
 
+    const isExpectedLocalAppStartupAbort = (code: number) =>
+      openedDuringStartup &&
+      code === 1006 &&
+      lastHandshakePhase === "ws_upgrade_started" &&
+      lastFrameType === undefined &&
+      normalizeLowercaseStringOrEmpty(requestUserAgent).startsWith("openclaw/") &&
+      isLoopbackAddress(remoteAddr);
+
     socket.once("close", (code, reason) => {
       const durationMs = Date.now() - openedAt;
       const logForwardedFor = sanitizeLogValue(forwardedFor);
@@ -452,7 +461,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         const isExpectedStartupRetryClose =
           closeCause === GATEWAY_STARTUP_PENDING_CLOSE_CAUSE && code === GATEWAY_STARTUP_CLOSE_CODE;
         const logFn =
-          isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr) || isExpectedStartupRetryClose
+          isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr) ||
+          isExpectedStartupRetryClose ||
+          isExpectedLocalAppStartupAbort(code)
             ? logWsControl.debug
             : logWsControl.warn;
         const authReason = stringMetaValue(closeMeta, "authReason");


### PR DESCRIPTION
## What Problem This Solves

The signed macOS app opens several loopback WebSocket connections while the Gateway is still starting. Those clients can abort before sending their first frame, producing repeated warning-level `closed before connect` entries even though the Gateway, app, and channels subsequently become healthy.

## Why This Change Was Made

Demote only the exact expected startup case to debug: the connection opened while startup was pending, came from loopback, identified as an OpenClaw client, closed with code 1006 at `ws_upgrade_started`, and sent no frame. Raw pre-auth frame receipt is marked before lazy-handler queuing, so queued-frame races and all other pre-connect failures remain warnings.

## User Impact

Restart-window audits no longer report benign local macOS app retry noise. Unexpected pre-auth disconnects remain visible at warning level.

## Evidence

- Reproduced four warning entries in one managed Gateway restart window; deep RPC and verbose health were otherwise green.
- Blacksmith Testbox `tbx_01kx96g2rj83ty64drp8b1q5yw`: `pnpm test src/gateway/server/ws-connection.test.ts` passed 56/56 assertions across four Gateway Vitest projects, including the queued-frame race.
- Autoreview after the queued-frame fix: clean, no accepted/actionable findings.
- `git diff --check` passed.

Testbox run: https://github.com/openclaw/openclaw/actions/runs/29163240827

Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29163297261
