### PR TITLE
fix(crabbox): preserve UTF-16 boundaries in CLI failure detail truncation

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -7,7 +7,6 @@ import {
   type CrabboxCommandRunner,
   resolveCrabboxBinary,
   resolveOpenClawRoot,
-  testing,
 } from "./crabbox-worker-provider.js";
 
 const LEASE_ID = "cbx_012345abcdef";
@@ -18,6 +17,7 @@ const HOST_KEY_ERROR =
   "Crabbox inspect does not expose the SSH host key required by the worker provider contract";
 const OPENCLAW_ROOT = path.resolve(path.sep, "workspace", "openclaw");
 const SIBLING_BINARY = path.resolve(OPENCLAW_ROOT, "../crabbox/bin/crabbox");
+const INSPECT_FAILURE_PREFIX = "Crabbox inspect failed with exit code 2: ";
 const PROFILE = {
   provider: "aws",
   class: "standard",
@@ -62,6 +62,24 @@ function providerWithRunner(runCommand: CrabboxCommandRunner) {
     pathEnv: "",
     isExecutable: (candidate) => candidate === SIBLING_BINARY,
   });
+}
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        index += 1;
+        continue;
+      }
+      return true;
+    }
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
 }
 
 describe("Crabbox worker provider", () => {
@@ -633,22 +651,22 @@ describe("Crabbox worker provider", () => {
   it("bounds and redacts CLI failure details", async () => {
     const secret = ["sk", "abcdefghijklmnop"].join("-");
     const provider = providerWithRunner(async () =>
-      commandResult({ code: 2, stderr: `${secret} ${"failure ".repeat(200)}` }),
+      commandResult({
+        code: 2,
+        stderr: `${secret} ${"failure ".repeat(200)}`,
+        stdout: "stdout must not replace stderr",
+      }),
     );
 
     const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(Error);
     const message = error instanceof Error ? error.message : "";
     expect(message).not.toContain(secret);
-    expect(message.length).toBeLessThan(600);
+    expect(message).not.toContain("stdout must not replace stderr");
+    expect(message).toHaveLength(INSPECT_FAILURE_PREFIX.length + 512);
   });
 
-  it("preserves well-formed UTF-16 through the provider boundary when inspect stderr crosses the truncation limit", async () => {
-    // 511 ASCII code units + emoji: the emoji surrogate pair spans
-    // indices [511, 512].  The provider path (inspect → commandError →
-    // commandDetail → truncateUtf16Safe) must not leave a lone surrogate
-    // in the error message.  Current main splits the pair, leaving a
-    // lone high surrogate (U+D83D) at the boundary.
+  it("preserves UTF-16 boundaries in provider failure details", async () => {
     const prefix = "x".repeat(511);
     const provider = providerWithRunner(async () =>
       commandResult({ code: 2, stderr: `${prefix}😀after` }),
@@ -657,31 +675,21 @@ describe("Crabbox worker provider", () => {
     const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(Error);
     const message = error instanceof Error ? error.message : "";
-    for (const lone of ["\ud83d", "\ude00"]) {
-      expect(message).not.toContain(lone);
-    }
-    expect(message).not.toContain("�");
-    expect(message).toContain(`: ${prefix}`);
-    // must not contain the low-surrogate-only tail
-    expect(message).not.toContain("\ude00after");
+    expect(message).toBe(`${INSPECT_FAILURE_PREFIX}${prefix}`);
+    expect(hasLoneSurrogate(message)).toBe(false);
   });
 
-  it("preserves well-formed UTF-16 when CLI failure detail reaches the boundary limit", () => {
-    // 511 ASCII code units + emoji: the emoji surrogate pair spans
-    // indices [511, 512].  raw .slice(0, 512) keeps only the high
-    // surrogate (U+D83D) — current main produces a malformed string.
-    // truncateUtf16Safe detects the split pair and backs up to 511
-    // so the result is well-formed with no lone surrogates.
-    const prefix = "x".repeat(511);
-    const detail = testing.commandDetail(commandResult({ stderr: `${prefix}😀after` }));
-    // must not contain a lone high surrogate without its pair
-    for (const lone of ["\ud83d", "\ude00"]) {
-      expect(detail).not.toContain(lone);
-    }
-    expect(detail).not.toContain("�");
-    // truncateUtf16Safe backs up: ": " + 511 ASCII chars = 513 code units
-    expect(detail).toBe(`: ${prefix}`);
-    expect(detail.length).toBe(513);
+  it("keeps a complete boundary pair when falling back to stdout", async () => {
+    const detail = `${"x".repeat(510)}😀`;
+    const provider = providerWithRunner(async () =>
+      commandResult({ code: 2, stdout: `${detail}after` }),
+    );
+
+    const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(Error);
+    const message = error instanceof Error ? error.message : "";
+    expect(message).toBe(`${INSPECT_FAILURE_PREFIX}${detail}`);
+    expect(hasLoneSurrogate(message)).toBe(false);
   });
 
   it("destroys absent and already-stopped leases idempotently", async () => {

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -643,6 +643,29 @@ describe("Crabbox worker provider", () => {
     expect(message.length).toBeLessThan(600);
   });
 
+  it("preserves well-formed UTF-16 through the provider boundary when inspect stderr crosses the truncation limit", async () => {
+    // 511 ASCII code units + emoji: the emoji surrogate pair spans
+    // indices [511, 512].  The provider path (inspect → commandError →
+    // commandDetail → truncateUtf16Safe) must not leave a lone surrogate
+    // in the error message.  Current main splits the pair, leaving a
+    // lone high surrogate (U+D83D) at the boundary.
+    const prefix = "x".repeat(511);
+    const provider = providerWithRunner(async () =>
+      commandResult({ code: 2, stderr: `${prefix}😀after` }),
+    );
+
+    const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(Error);
+    const message = error instanceof Error ? error.message : "";
+    for (const lone of ["\ud83d", "\ude00"]) {
+      expect(message).not.toContain(lone);
+    }
+    expect(message).not.toContain("�");
+    expect(message).toContain(`: ${prefix}`);
+    // must not contain the low-surrogate-only tail
+    expect(message).not.toContain("\ude00after");
+  });
+
   it("preserves well-formed UTF-16 when CLI failure detail reaches the boundary limit", () => {
     // 511 ASCII code units + emoji: the emoji surrogate pair spans
     // indices [511, 512].  raw .slice(0, 512) keeps only the high

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -7,6 +7,7 @@ import {
   type CrabboxCommandRunner,
   resolveCrabboxBinary,
   resolveOpenClawRoot,
+  testing,
 } from "./crabbox-worker-provider.js";
 
 const LEASE_ID = "cbx_012345abcdef";
@@ -640,6 +641,24 @@ describe("Crabbox worker provider", () => {
     const message = error instanceof Error ? error.message : "";
     expect(message).not.toContain(secret);
     expect(message.length).toBeLessThan(600);
+  });
+
+  it("preserves well-formed UTF-16 when CLI failure detail reaches the boundary limit", () => {
+    // 511 ASCII code units + emoji: the emoji surrogate pair spans
+    // indices [511, 512].  raw .slice(0, 512) keeps only the high
+    // surrogate (U+D83D) — current main produces a malformed string.
+    // truncateUtf16Safe detects the split pair and backs up to 511
+    // so the result is well-formed with no lone surrogates.
+    const prefix = "x".repeat(511);
+    const detail = testing.commandDetail(commandResult({ stderr: `${prefix}😀after` }));
+    // must not contain a lone high surrogate without its pair
+    for (const lone of ["\ud83d", "\ude00"]) {
+      expect(detail).not.toContain(lone);
+    }
+    expect(detail).not.toContain("�");
+    // truncateUtf16Safe backs up: ": " + 511 ASCII chars = 513 code units
+    expect(detail).toBe(`: ${prefix}`);
+    expect(detail.length).toBe(513);
   });
 
   it("destroys absent and already-stopped leases idempotently", async () => {

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -10,6 +10,7 @@ import {
   type WorkerProvider,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { runCommandWithTimeout, type SpawnResult } from "openclaw/plugin-sdk/process-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export const CRABBOX_WORKER_PROVIDER_ID = "crabbox";
 const CRABBOX_KEY_REF_PROVIDER = "crabbox";
@@ -264,7 +265,8 @@ function commandDetail(result: SpawnResult): string {
   if (!raw) {
     return "";
   }
-  const redacted = redactSensitiveText(raw).replace(/\s+/gu, " ").slice(0, MAX_ERROR_DETAIL_CHARS);
+  const compressed = redactSensitiveText(raw).replace(/\s+/gu, " ");
+  const redacted = truncateUtf16Safe(compressed, MAX_ERROR_DETAIL_CHARS);
   return redacted ? `: ${redacted}` : "";
 }
 
@@ -776,3 +778,8 @@ export function createCrabboxWorkerProvider(
     },
   };
 }
+
+export const testing = {
+  commandDetail,
+};
+export { testing as __testing };

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -778,8 +778,3 @@ export function createCrabboxWorkerProvider(
     },
   };
 }
-
-export const testing = {
-  commandDetail,
-};
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Crabbox worker error details contain malformed text when a command's stderr has emoji at the 512-character truncation boundary.

## Why This Change Was Made

`commandDetail()` replaced raw `.slice(0, MAX_ERROR_DETAIL_CHARS)` with the shared `truncateUtf16Safe` helper from the public plugin SDK barrel. The `.replace(/\s+/gu, " ")` whitespace compression runs before truncation, making the content more dense — which increases the likelihood that non-ASCII characters (emoji in test output, script diagnostics) land on the 512 boundary. The existing code-unit limit and message format remain unchanged; this only backs a cut up to avoid splitting an emoji surrogate pair.

## User Impact

Crabbox worker CLI error messages (warmup/inspect/stop failures) remain well-formed when the remote command output contains long emoji-containing diagnostic text.

## Evidence

### Provider-path regression test (exercises real `provider.inspect()` → `commandError()` → `commandDetail()`)

The new test constructs 511 ASCII `x` chars + `😀after` in stderr and calls `provider.inspect()` with a mock CLI runner returning exit code 2. The full chain is: `provider.inspect()` → `inspectWithContext()` → `commandError("inspect", result)` → `commandDetail(result)` → `truncateUtf16Safe(compressed, 512)`. Current main's raw `.slice(0, 512)` splits the surrogate pair; the fix backs up to 511, preserving well-formed UTF-16.

### Direct-formatter regression test (exercises real `testing.commandDetail()`)

Same boundary construction (511 ASCII + emoji) but calls `commandDetail()` directly for focused coverage of the truncation path. Both tests complement each other — the provider-path test proves the real scenario, the direct test catches regressions at the narrowest boundary.

### Terminal behavior proof (before vs. after, live Node.js output)

```
=== PR #104612 Live Terminal Proof ===

Input: 511 'x' + emoji + 'after'
  stderr[511]=0xd83d (HIGH surrogate)
  stderr[512]=0xde00 (LOW surrogate)

--- BEFORE fix (current main) ---
  output: ": x...x\ud83d"
  length: 514 code units
  LONE SURROGATE at index 513: 0xd83d ← MALFORMED

--- AFTER fix (truncateUtf16Safe) ---
  output: ": x...x"
  length: 513 code units
  ✅ No lone surrogates — well-formed UTF-16
```

### Test suite
```
$ node scripts/run-vitest.mjs run extensions/crabbox/src/crabbox-worker-provider.test.ts -t "preserves well-formed UTF-16"
 ✓ |extensions| crabbox-worker-provider.test.ts > Crabbox worker provider > preserves well-formed UTF-16 through the provider boundary when inspect stderr crosses the truncation limit 63ms
 ✓ |extensions| crabbox-worker-provider.test.ts > Crabbox worker provider > preserves well-formed UTF-16 when CLI failure detail reaches the boundary limit 4ms
 Test Files  1 passed (1)
      Tests  2 passed | 45 skipped (47)

$ node scripts/run-vitest.mjs run extensions/crabbox/src/crabbox-worker-provider.test.ts
 ✓ 47/47 passed
```

### Lint
```
node scripts/run-oxlint.mjs extensions/crabbox/src/crabbox-worker-provider.ts extensions/crabbox/src/crabbox-worker-provider.test.ts
✓ clean
```
