### PR TITLE
fix(browser): host-local profile administration is always rejected

### DIFF
--- a/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
+++ b/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
@@ -248,7 +248,7 @@ describe("browser.request profile selection", () => {
     { method: "DELETE", path: "/profiles/poc", body: undefined },
     { method: "POST", path: "/reset-profile", body: { profile: "poc", name: "poc" } },
   ])(
-    "blocks host-local persistent mutations for $method $path when no node handles the request",
+    "dispatches host-local admin mutations for $method $path when no node handles the request",
     async ({ method, path, body }) => {
       const { respond, nodeRegistry } = await runBrowserRequest(
         { method, path, body },
@@ -257,10 +257,11 @@ describe("browser.request profile selection", () => {
       );
 
       expect(nodeRegistry.invoke).not.toHaveBeenCalled();
+      expect(startBrowserControlServiceFromConfigMock).toHaveBeenCalledOnce();
       const [ok, payload, error] = firstRespondCall(respond);
       expect(ok).toBe(false);
       expect(payload).toBeUndefined();
-      expect(error?.message).toBe("browser.request cannot mutate persistent browser profiles");
+      expect(error?.message).toBe("browser control is disabled");
     },
   );
 

--- a/extensions/browser/src/gateway/browser-request.ts
+++ b/extensions/browser/src/gateway/browser-request.ts
@@ -20,7 +20,6 @@ import {
   errorShape,
   getRuntimeConfig,
   isBrowserHostLocalRoute,
-  isBrowserSystemProfileImport,
   isNodeCommandAllowed,
   isPersistentBrowserProfileMutation,
   persistBrowserProxyFiles,
@@ -217,24 +216,9 @@ export async function handleBrowserGatewayRequest({
     return;
   }
 
-  // Host-local dispatch: persistent profile mutations stay blocked here as on a
-  // node proxy, except system-profile import, which must run where the user's
-  // Keychain lives and cannot be proxied to a node.
-  if (
-    isPersistentBrowserProfileMutation(methodRaw, path) &&
-    !isBrowserSystemProfileImport(methodRaw, path)
-  ) {
-    respond(
-      false,
-      undefined,
-      errorShape(
-        ErrorCodes.INVALID_REQUEST,
-        "browser.request cannot mutate persistent browser profiles",
-      ),
-    );
-    return;
-  }
-
+  // `browser.request` already requires operator.admin. The owning host may run
+  // profile administration; the node-proxy branch above stays denied because
+  // `browser.proxy` is a separate remote-host authority.
   const ready = await startBrowserControlServiceFromConfig();
   if (!ready) {
     respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "browser control is disabled"));


### PR DESCRIPTION
Closes #104609

## What Problem This Solves

Fixes an issue where operators using the documented host-local browser CLI could never create, delete, or reset a persistent browser profile: the admin-scoped Gateway request was rejected before browser control received it.

## Why This Change Was Made

Host-local profile administration now follows the existing `operator.admin` authorization boundary. The separate node-proxy mutation denial remains intact because `browser.proxy` represents authority over another host; this change does not give agents or remote nodes a new mutation path.

## User Impact

Administrators can once again run `openclaw browser create-profile`, `delete-profile`, and `reset-profile` against the Gateway host. Reset cleanly terminates the managed browser, moves its isolated profile data to Trash, and lets the next browser action launch a fresh profile.

## Evidence

- Blacksmith Testbox focused run: 52/52 passing across browser request policy and profile dispatch coverage: https://github.com/openclaw/openclaw/actions/runs/29162891171
- Blacksmith Testbox changed gate: extension production/test type lanes, focused lint, formatting, DB-first, media, sidecar, and import-cycle checks all passed.
- Fresh autoreview: no actionable findings; patch correct at 0.91 confidence.
- Live isolated Gateway using a real OpenAI model and the managed Browser tool:
  - Before reset, agent run `38f7ec95-5ab1-4707-ac22-d2a4c82549ba` completed one Browser call with zero failures and returned `BEFORE_RESET Example Domain`; managed browser PID 52762.
  - The host-local reset command returned `ok: true`, moved the profile to the isolated Trash, killed PID 52762, and closed its CDP port.
  - After reset, agent run `a94b9d8a-84e9-499f-b14e-f061a53ae275` completed three Browser calls with zero failures and returned `AFTER_RESET Example Domains`; a new managed browser started as PID 67700.
  - Host-local create/delete for profile `admin-proof` both succeeded; the final profile list no longer contained it.
  - Gateway and both managed-browser processes/ports were stopped and verified closed after the scenario.

AI-assisted implementation and review. No secrets or private profile data are included.
