### PR TITLE
feat(android): add chat image previews

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -5731,7 +5731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 159,
+      "line": 167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -5739,7 +5739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 159,
+      "line": 167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -5747,7 +5747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 266,
+      "line": 274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Preview · $domain",
       "surface": "android",
@@ -5755,7 +5755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 275,
+      "line": 283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Expand link preview",
       "surface": "android",
@@ -5763,7 +5763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 318,
+      "line": 326,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Loading preview…",
       "surface": "android",
@@ -5771,7 +5771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 319,
+      "line": 327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "No preview available",
       "surface": "android",
@@ -5779,7 +5779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 365,
+      "line": 373,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Thinking...",
       "surface": "android",
@@ -5787,7 +5787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 381,
+      "line": 389,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Tools",
       "surface": "android",
@@ -5795,7 +5795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 384,
+      "line": 392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Running tools...",
       "surface": "android",
@@ -5803,7 +5803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 387,
+      "line": 395,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "${display.emoji} ${display.label}",
       "surface": "android",
@@ -5811,7 +5811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 405,
+      "line": 413,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "... +${toolCalls.size - 6} more",
       "surface": "android",
@@ -5819,7 +5819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 437,
+      "line": 445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "You",
       "surface": "android",
@@ -5827,7 +5827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 444,
+      "line": 452,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "📎 ${attachment.fileName}",
       "surface": "android",
@@ -5835,7 +5835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 460,
+      "line": 468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Retry",
       "surface": "android",
@@ -5843,7 +5843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 465,
+      "line": 473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Delete",
       "surface": "android",
@@ -5851,7 +5851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 497,
+      "line": 505,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -5859,7 +5859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 534,
+      "line": 542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "System",
       "surface": "android",
@@ -5867,15 +5867,31 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 535,
+      "line": 543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
       "id": "native.android.82e9fe45e93909b6"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 579,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Open image preview",
+      "surface": "android",
+      "id": "native.android.316927b46135a7ab"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 611,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Close image preview",
+      "surface": "android",
+      "id": "native.android.7f8cf7bee5cc491f"
+    },
+    {
       "kind": "ui-call",
-      "line": 561,
+      "line": 620,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",
@@ -5979,7 +5995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1037,
+      "line": 1042,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -5987,7 +6003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1037,
+      "line": 1042,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -5995,7 +6011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1058,
+      "line": 1063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -6003,7 +6019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1060,
+      "line": 1065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -6011,7 +6027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1063,
+      "line": 1068,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -6019,7 +6035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1073,
+      "line": 1078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -6027,7 +6043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1074,
+      "line": 1079,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -6035,7 +6051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1253,
+      "line": 1258,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -6043,7 +6059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1350,
+      "line": 1355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -6051,7 +6067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1416,
+      "line": 1421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -6059,7 +6075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1416,
+      "line": 1421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -6067,7 +6083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1433,
+      "line": 1438,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -6075,7 +6091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1495,
+      "line": 1500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -6083,7 +6099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1541,
+      "line": 1546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -6091,7 +6107,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1541,
+      "line": 1546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -6099,7 +6115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1601,
+      "line": 1606,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -6107,7 +6123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1636,
+      "line": 1641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -6115,7 +6131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1652,
+      "line": 1657,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open voice",
       "surface": "android",
@@ -6123,7 +6139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1701,
+      "line": 1706,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -6131,7 +6147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1722,
+      "line": 1727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -6139,7 +6155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1730,
+      "line": 1735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -6147,7 +6163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1789,
+      "line": 1794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -6155,7 +6171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1820,
+      "line": 1825,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -29,9 +29,13 @@ import ai.openclaw.app.ui.mobileWarning
 import ai.openclaw.app.ui.mobileWarningSoft
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -40,8 +44,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material.icons.filled.OpenInFull
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -68,6 +74,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import java.util.Locale
 
 private data class ChatBubbleStyle(
@@ -536,26 +544,77 @@ private fun roleLabel(role: String): String =
   }
 
 @Composable
-private fun ChatBase64Image(
+internal fun ChatBase64Image(
   base64: String,
   mimeType: String?,
 ) {
   val imageState = rememberBase64ImageState(base64)
+  var previewVisible by rememberSaveable(base64) { mutableStateOf(false) }
   val image = imageState.image
 
   if (image != null) {
     Surface(
+      onClick = { previewVisible = true },
       shape = RoundedCornerShape(10.dp),
       border = BorderStroke(1.dp, mobileBorder),
       color = mobileCardSurface,
       modifier = Modifier.fillMaxWidth(),
     ) {
-      Image(
-        bitmap = image,
-        contentDescription = mimeType ?: "attachment",
-        contentScale = ContentScale.Fit,
-        modifier = Modifier.fillMaxWidth(),
-      )
+      Box {
+        Image(
+          bitmap = image,
+          contentDescription = mimeType ?: "attachment",
+          contentScale = ContentScale.Fit,
+          modifier = Modifier.fillMaxWidth(),
+        )
+        Surface(
+          modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp).size(32.dp),
+          shape = CircleShape,
+          color = Color.Black.copy(alpha = 0.62f),
+          contentColor = Color.White,
+        ) {
+          Box(contentAlignment = Alignment.Center) {
+            Icon(
+              imageVector = Icons.Default.OpenInFull,
+              contentDescription = "Open image preview",
+              modifier = Modifier.size(17.dp),
+            )
+          }
+        }
+      }
+    }
+    if (previewVisible) {
+      Dialog(
+        onDismissRequest = { previewVisible = false },
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+      ) {
+        Box(
+          modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.96f)).clickable { previewVisible = false },
+          contentAlignment = Alignment.Center,
+        ) {
+          Image(
+            bitmap = image,
+            contentDescription = "Image preview",
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.fillMaxSize().padding(20.dp),
+          )
+          Surface(
+            onClick = { previewVisible = false },
+            modifier = Modifier.align(Alignment.TopEnd).padding(16.dp).size(44.dp),
+            shape = CircleShape,
+            color = Color.Black.copy(alpha = 0.62f),
+            contentColor = Color.White,
+          ) {
+            Box(contentAlignment = Alignment.Center) {
+              Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "Close image preview",
+                modifier = Modifier.size(22.dp),
+              )
+            }
+          }
+        }
+      }
     }
   } else if (imageState.failed) {
     Text("Unsupported attachment", style = mobileCaption1, color = mobileTextSecondary)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -981,6 +981,11 @@ private fun ChatBubble(
             when {
               part.type == "text" -> ChatText(text = part.text.orEmpty(), textColor = ClawTheme.colors.text, isStreaming = live)
               part.isAudioAttachment() -> VoiceNoteMessageRow(durationMs = part.durationMs)
+              part.type == "image" ->
+                ChatBase64Image(
+                  base64 = checkNotNull(part.base64),
+                  mimeType = part.mimeType,
+                )
               else -> Text(text = part.fileName ?: "Attachment", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
             }
           }


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

Inline Base64 image parts in active Android chat messages currently fall through to a filename-only attachment row, so users cannot see or inspect that image in the conversation.

## Why This Change Was Made

The active chat bubble now routes image parts containing inline Base64 data through the existing Base64 image renderer. The renderer adds a clear expand affordance and a full-screen fit preview while leaving text, voice-note, and generic attachment handling unchanged.

This scope is intentionally limited to inline Base64 images. Managed Gateway-generated images delivered through authenticated `url`/`openUrl` blocks were not tested and remain unchanged; Android currently drops those fields before rendering.

## User Impact

Inline Base64 images render directly inside Android chat. Tapping one opens a full-screen preview; Back, the close button, or tapping the background dismisses it. Managed `url`/`openUrl` images are not covered by this PR.

## Evidence

Android emulator behavior was verified with the exact patched APK against an isolated paired OpenClaw gateway. The proof specifically exercised the inline Base64 path; it did not exercise the managed-image `url`/`openUrl` path. The app reported Gateway online, Nodes 1/1, and Approvals 0.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="260" src="https://github.com/user-attachments/assets/caaf5c50-5c1c-44e5-a2fc-e881d6bd6d08" alt="Before: Android chat shows the Base64 image filename" /></td>
    <td><img width="260" src="https://github.com/user-attachments/assets/908f33a6-cbf4-4527-b8d3-e1652b7cdd4a" alt="After: Android chat opens the Base64 image in a full-screen preview" /></td>
  </tr>
</table>

Android emulator interaction proof: online gate, inline Base64 image, full-screen preview, and dismissal.

https://github.com/user-attachments/assets/6482310a-4fac-46d6-a469-6b35725ac8ca

Checks:
- `pnpm native:i18n:check`
- `pnpm android:i18n:check`
- Android app assemble
- Exact installed APK SHA-256 match
