### PR TITLE
fix(gateway): keep worker SSH tunnel stderr tails UTF-16 safe

### DIFF
--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -312,39 +312,14 @@ describe("worker tunnel manager", () => {
 });
 
 describe("createWorkerSshRunner diagnostic tails", () => {
-  it.skipIf(process.platform === "win32")(
-    "keeps SSH tunnel failure stderr on a valid UTF-16 boundary",
-    async () => {
-      // STDERR_LIMIT is 4096. Payload length 4098 so raw `.slice(-4096)` starts on the
-      // low surrogate of 😀 (indexes: 0='a', 1=high, 2=low, 3..=b).
-      const retained = "b".repeat(4095);
-      const payload = `a😀${retained}`;
-      const runner = createWorkerSshRunner();
-      const child = runner.start(
-        [
-          process.execPath,
-          "-e",
-          `process.stderr.write(${JSON.stringify(payload)}); process.exit(1);`,
-        ],
-        { timeoutMs: 10_000, baseEnv: process.env },
-      );
+  it("keeps SSH tunnel failure stderr on a valid UTF-16 boundary", async () => {
+    const retained = "b".repeat(4095);
+    const child = createWorkerSshRunner().start(
+      [process.execPath, "-e", `process.stderr.write(${JSON.stringify(`a😀${retained}`)})`],
+      { timeoutMs: 10_000, baseEnv: process.env },
+    );
 
-      let message: string | undefined;
-      try {
-        await child.ready;
-      } catch (error) {
-        message = error instanceof Error ? error.message : String(error);
-      }
-      await child.exited;
-
-      expect(message).toBeDefined();
-      expect(message).toContain("Worker SSH tunnel failed:");
-      expect(message).toContain(retained);
-      expect(message).not.toContain("😀");
-      expect(message).not.toContain("\uFFFD");
-      const detail = message!.slice("Worker SSH tunnel failed: ".length);
-      expect(detail.charCodeAt(0)).toBe("b".charCodeAt(0));
-      expect(detail.charCodeAt(0)).toBeLessThan(0xd800);
-    },
-  );
+    await expect(child.ready).rejects.toThrow(`Worker SSH tunnel failed: ${retained}`);
+    await child.exited;
+  });
 });

--- a/src/gateway/worker-environments/tunnel.test.ts
+++ b/src/gateway/worker-environments/tunnel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { WorkerSshEndpoint } from "../../plugins/types.js";
 import type { CommandOptions, SpawnResult } from "../../process/exec.js";
 import {
+  createWorkerSshRunner,
   createWorkerTunnelManager,
   type WorkerSshProcess,
   type WorkerSshProcessExit,
@@ -308,4 +309,42 @@ describe("worker tunnel manager", () => {
     expect(manager.status("worker:replacement")).toBe("stopped");
     expect(fake.starts).toHaveLength(1);
   });
+});
+
+describe("createWorkerSshRunner diagnostic tails", () => {
+  it.skipIf(process.platform === "win32")(
+    "keeps SSH tunnel failure stderr on a valid UTF-16 boundary",
+    async () => {
+      // STDERR_LIMIT is 4096. Payload length 4098 so raw `.slice(-4096)` starts on the
+      // low surrogate of 😀 (indexes: 0='a', 1=high, 2=low, 3..=b).
+      const retained = "b".repeat(4095);
+      const payload = `a😀${retained}`;
+      const runner = createWorkerSshRunner();
+      const child = runner.start(
+        [
+          process.execPath,
+          "-e",
+          `process.stderr.write(${JSON.stringify(payload)}); process.exit(1);`,
+        ],
+        { timeoutMs: 10_000, baseEnv: process.env },
+      );
+
+      let message: string | undefined;
+      try {
+        await child.ready;
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+      await child.exited;
+
+      expect(message).toBeDefined();
+      expect(message).toContain("Worker SSH tunnel failed:");
+      expect(message).toContain(retained);
+      expect(message).not.toContain("😀");
+      expect(message).not.toContain("\uFFFD");
+      const detail = message!.slice("Worker SSH tunnel failed: ".length);
+      expect(detail.charCodeAt(0)).toBe("b".charCodeAt(0));
+      expect(detail.charCodeAt(0)).toBeLessThan(0xd800);
+    },
+  );
 });

--- a/src/gateway/worker-environments/tunnel.ts
+++ b/src/gateway/worker-environments/tunnel.ts
@@ -36,12 +36,6 @@ const REMOTE_SETUP_TIMEOUT_MS = 20_000;
 const WORKSPACE_TIMEOUT_MS = 10 * 60_000;
 const STOP_GRACE_MS = 1_500;
 const STDERR_LIMIT = 4_096;
-
-// Preserve the newest diagnostics without leaving a lone surrogate at the tail boundary.
-function appendBoundedDiagnosticTail(current: string, chunk: string): string {
-  const next = `${current}${chunk}`;
-  return next.length > STDERR_LIMIT ? sliceUtf16Safe(next, -STDERR_LIMIT) : next;
-}
 const DEFAULT_STABLE_CONNECTION_MS = 30_000;
 const DEFAULT_BACKOFF: BackoffPolicy = {
   initialMs: 250,
@@ -169,7 +163,7 @@ export function createWorkerSshRunner(): WorkerSshRunner {
         if (readySettled) {
           return;
         }
-        stdout = appendBoundedDiagnosticTail(stdout, chunk);
+        stdout = sliceUtf16Safe(`${stdout}${chunk}`, -STDERR_LIMIT);
         if (stdout.split(/\r?\n/u).includes(READY_MARKER)) {
           readySettled = true;
           resolveReady();
@@ -178,7 +172,7 @@ export function createWorkerSshRunner(): WorkerSshRunner {
       child.stderr.setEncoding("utf8");
       child.stderr.on("error", () => {});
       child.stderr.on("data", (chunk: string) => {
-        stderr = appendBoundedDiagnosticTail(stderr, chunk);
+        stderr = sliceUtf16Safe(`${stderr}${chunk}`, -STDERR_LIMIT);
       });
       child.once("error", settleReadyError);
       child.once("close", (code, signal) => {

--- a/src/gateway/worker-environments/tunnel.ts
+++ b/src/gateway/worker-environments/tunnel.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
 import { redactSensitiveText } from "../../logging/redact.js";
 import type { WorkerSshEndpoint } from "../../plugins/types.js";
@@ -35,6 +36,17 @@ const REMOTE_SETUP_TIMEOUT_MS = 20_000;
 const WORKSPACE_TIMEOUT_MS = 10 * 60_000;
 const STOP_GRACE_MS = 1_500;
 const STDERR_LIMIT = 4_096;
+
+// Remote SSH stderr/stdout can include emoji paths or locale text. Raw `.slice(-N)`
+// can start on a low surrogate; keep the rolling diagnostic tail UTF-16 safe so
+// processError() does not embed a lone surrogate in the operator-facing Error.
+function appendBoundedDiagnosticTail(current: string, chunk: string): string {
+  const next = `${current}${chunk}`;
+  if (next.length <= STDERR_LIMIT) {
+    return next;
+  }
+  return sliceUtf16Safe(next, Math.max(0, next.length - STDERR_LIMIT));
+}
 const DEFAULT_STABLE_CONNECTION_MS = 30_000;
 const DEFAULT_BACKOFF: BackoffPolicy = {
   initialMs: 250,
@@ -162,7 +174,7 @@ export function createWorkerSshRunner(): WorkerSshRunner {
         if (readySettled) {
           return;
         }
-        stdout = `${stdout}${chunk}`.slice(-STDERR_LIMIT);
+        stdout = appendBoundedDiagnosticTail(stdout, chunk);
         if (stdout.split(/\r?\n/u).includes(READY_MARKER)) {
           readySettled = true;
           resolveReady();
@@ -171,7 +183,7 @@ export function createWorkerSshRunner(): WorkerSshRunner {
       child.stderr.setEncoding("utf8");
       child.stderr.on("error", () => {});
       child.stderr.on("data", (chunk: string) => {
-        stderr = `${stderr}${chunk}`.slice(-STDERR_LIMIT);
+        stderr = appendBoundedDiagnosticTail(stderr, chunk);
       });
       child.once("error", settleReadyError);
       child.once("close", (code, signal) => {

--- a/src/gateway/worker-environments/tunnel.ts
+++ b/src/gateway/worker-environments/tunnel.ts
@@ -37,15 +37,10 @@ const WORKSPACE_TIMEOUT_MS = 10 * 60_000;
 const STOP_GRACE_MS = 1_500;
 const STDERR_LIMIT = 4_096;
 
-// Remote SSH stderr/stdout can include emoji paths or locale text. Raw `.slice(-N)`
-// can start on a low surrogate; keep the rolling diagnostic tail UTF-16 safe so
-// processError() does not embed a lone surrogate in the operator-facing Error.
+// Preserve the newest diagnostics without leaving a lone surrogate at the tail boundary.
 function appendBoundedDiagnosticTail(current: string, chunk: string): string {
   const next = `${current}${chunk}`;
-  if (next.length <= STDERR_LIMIT) {
-    return next;
-  }
-  return sliceUtf16Safe(next, Math.max(0, next.length - STDERR_LIMIT));
+  return next.length > STDERR_LIMIT ? sliceUtf16Safe(next, -STDERR_LIMIT) : next;
 }
 const DEFAULT_STABLE_CONNECTION_MS = 30_000;
 const DEFAULT_BACKOFF: BackoffPolicy = {


### PR DESCRIPTION
## What Problem This Solves

Worker SSH tunnel failures retain bounded stdout/stderr diagnostics before `processError()` exposes them to operators. Raw `.slice(-4096)` could begin the retained text on the low half of an emoji or another non-BMP character, producing malformed UTF-16 in the failure message.

This is the production `createWorkerSshRunner()` path used by the worker tunnel manager when SSH exits before its ready marker.

## Why This Change Was Made

Both output streams now share one small `appendBoundedDiagnosticTail` path backed by the repository's canonical `sliceUtf16Safe` helper. The 4096-code-unit cap, redaction, ready-marker behavior, reconnect policy, and success path are unchanged.

The regression invokes the real child-process runner and crosses the exact retention boundary. The maintainer refactor reduced the patch from 53 added lines to 23 while keeping the production boundary under test.

## User Impact

**Before:** A worker SSH failure could show a corrupted leading character when oversized remote output placed a surrogate pair across the retained-tail boundary.

**After:** The incomplete surrogate is discarded and the operator-facing diagnostic remains well-formed.

## Evidence

- Changed: `src/gateway/worker-environments/tunnel.ts`
- Regression: `src/gateway/worker-environments/tunnel.test.ts`
- Exact tested head: `f3bfd319b7c1a741976d1cf5f2a24c48858e59f0`
- Sanitized AWS Crabbox: `run_ff21a762ee41`, public network, no Tailscale, no instance profile, no credential hydration
- Command: `pnpm test src/gateway/worker-environments/tunnel.test.ts`
- Result: exit 0
- Fresh autoreview: no findings, correctness confidence 0.94
- Hosted exact-head CI: running

## Real behavior proof

- **Behavior addressed:** worker SSH failure details no longer split UTF-16 surrogate pairs at the bounded stdout/stderr tail.
- **Reachability:** `createWorkerTunnelManager` -> `createWorkerSshRunner().start(...)` -> child output handlers -> `appendBoundedDiagnosticTail` -> `processError(stderr)` -> rejected `ready` promise.
- **Boundary crossed:** real spawned child stderr into the operator-facing production error.
- **Fix classification:** root-cause fix.
- **Proof gap:** no live remote SSH worker was needed; forwarding and connection behavior are unchanged.

- [x] AI-assisted (Cursor and Codex)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
