### PR TITLE
fix: hide pinned session action until hover

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -6455,8 +6455,7 @@ details[open] > .ov-expandable-toggle::after {
    Shared by the sidebar recents list and the chat session picker. Rows read
    as plain text lines: the trailing aside stacks a relative time (or the run
    spinner) and the management actions in one grid cell, so hovering swaps
-   them without any layout shift. The pin action doubles as the pinned badge
-   and stays visible for pinned rows even without hover. */
+   them without any layout shift. */
 .session-row-host {
   position: relative;
 }
@@ -6578,20 +6577,8 @@ details[open] > .ov-expandable-toggle::after {
   }
 }
 
-/* Pinned badge: accent pin visible without hover. A live run wins the
-   trailing slot, so the badge only holds it while the session is idle;
-   both indicators share one grid cell and would overlap otherwise. */
 .session-row-host--pinned .session-action--pin {
   color: var(--accent);
-}
-
-.session-row-host--pinned:not(.session-row-host--running) .session-action--pin {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.session-row-host--pinned:not(.session-row-host--running) .session-row-trail {
-  opacity: 0;
 }
 
 .session-run-spinner {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with pinned Control UI conversations would see the pin action persistently displayed in the Pinned section, unlike the other session controls that appear only when the row is hovered or focused.

## Why This Change Was Made

This keeps pinned session rows using the same hover/focus action reveal behavior as the rest of the sidebar while preserving the accent color for the pin action when it appears. The existing pin button behavior is unchanged: clicking it on an already pinned session still sends `pinned: false`.

## User Impact

Pinned sessions now read like normal sidebar rows at rest, with the trailing time visible until the user hovers or focuses the row. Users can still unpin a session from the revealed pin action.

## Evidence

- `git diff --check origin/main...HEAD`
- `pnpm format:check -- ui/src/styles/components.css`
- Mock smoke: `curl -I http://127.0.0.1:53038/chat` returned `HTTP/1.1 200 OK`.
- Browser CSS proof on a pinned session row:
  - at rest: pin action `opacity: 0`, `pointer-events: none`; trail `opacity: 1`
  - forced hover state: pin action `opacity: 1`, `pointer-events: auto`; trail `opacity: 0`
