### PR TITLE
fix(media): bound hung remote downloads in media store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,7 @@ Docs: https://docs.openclaw.ai
 - **Task state migration:** canonicalize legacy `not-requested` delivery statuses during sidecar import and existing shared-database open so upgraded task registries and linked TaskFlows recover without manual SQL, and surface rejected persisted values in compact console diagnostics. (#103946) Thanks @bek91.
 - **Reply pre-delivery recovery:** bound each pre-delivery callback with an owner-overridable deadline, release serialized reply lanes after hung plugin work, and preserve durable final-delivery retry state only when transport never started. (#104256) Thanks @NianJiuZst.
 - **Signal native quote replies:** preserve the active inbound message as a native quote across agent, explicit, durable, and chunked sends while keeping reply-mode policy inside the Signal plugin. (#105347) Thanks @jesse-merhi.
+- **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 
 ## 2026.7.1
 

--- a/scripts/ts-max-loc-baseline-v2.json
+++ b/scripts/ts-max-loc-baseline-v2.json
@@ -1030,7 +1030,7 @@
   "src/media-understanding/shared.ts": 689,
   "src/media/fetch.ts": 689,
   "src/media/parse.ts": 725,
-  "src/media/store.ts": 763,
+  "src/media/store.ts": 645,
   "src/media/web-media.ts": 1159,
   "src/memory-host-sdk/dreaming.ts": 655,
   "src/node-host/invoke-system-run-plan.ts": 1176,

--- a/src/media/store.download-timeout.test.ts
+++ b/src/media/store.download-timeout.test.ts
@@ -11,8 +11,8 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
-import { setMediaStoreDownloadTimeoutsForTest } from "./store.download.js";
-import { saveMediaSource, setMediaStoreNetworkDepsForTest } from "./store.js";
+import { setMediaStoreDownloadDepsForTest } from "./store.download.js";
+import { saveMediaSource } from "./store.js";
 
 const HEADER_TIMEOUT_MS = 40;
 const IDLE_TIMEOUT_MS = 40;
@@ -151,14 +151,12 @@ describe("media store download timeouts", () => {
   beforeEach(() => {
     mode = "ok";
     stalledSocketClosed = undefined;
-    setMediaStoreNetworkDepsForTest({
+    setMediaStoreDownloadDepsForTest({
       resolvePinnedHostname: async (hostname) => ({
         hostname,
         addresses: ["127.0.0.1"],
         lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
       }),
-    });
-    setMediaStoreDownloadTimeoutsForTest({
       responseHeaderTimeoutMs: HEADER_TIMEOUT_MS,
       readIdleTimeoutMs: IDLE_TIMEOUT_MS,
     });
@@ -168,8 +166,7 @@ describe("media store download timeouts", () => {
     for (const socket of Array.from(openSockets)) {
       socket.destroy();
     }
-    setMediaStoreNetworkDepsForTest();
-    setMediaStoreDownloadTimeoutsForTest();
+    setMediaStoreDownloadDepsForTest();
     await fs.rm(mediaRoot, { recursive: true, force: true }).catch(() => {});
   });
 
@@ -181,8 +178,7 @@ describe("media store download timeouts", () => {
       server.close((err) => (err ? reject(err) : resolve()));
     });
     await testState.cleanup();
-    setMediaStoreNetworkDepsForTest();
-    setMediaStoreDownloadTimeoutsForTest();
+    setMediaStoreDownloadDepsForTest();
   });
 
   it("times out when the server accepts a connection but never sends headers", async () => {
@@ -196,12 +192,14 @@ describe("media store download timeouts", () => {
 
   it("times out when hostname resolution never settles", async () => {
     let requestStarted = false;
-    setMediaStoreNetworkDepsForTest({
+    setMediaStoreDownloadDepsForTest({
       httpRequest: (() => {
         requestStarted = true;
         throw new Error("request must not start after DNS timeout");
       }) as unknown as typeof http.request,
       resolvePinnedHostname: async () => await new Promise<never>(() => {}),
+      responseHeaderTimeoutMs: HEADER_TIMEOUT_MS,
+      readIdleTimeoutMs: IDLE_TIMEOUT_MS,
     });
 
     await expect(saveMediaSource(baseUrl)).rejects.toThrow(
@@ -234,16 +232,14 @@ describe("media store download timeouts", () => {
 
   it("keeps a slow response alive while each body chunk makes progress", async () => {
     mode = "slow-progress";
-    setMediaStoreDownloadTimeoutsForTest({
-      responseHeaderTimeoutMs: 500,
-      readIdleTimeoutMs: 200,
-    });
-    setMediaStoreNetworkDepsForTest({
+    setMediaStoreDownloadDepsForTest({
       resolvePinnedHostname: async (hostname) => ({
         hostname,
         addresses: ["127.0.0.1"],
         lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
       }),
+      responseHeaderTimeoutMs: 500,
+      readIdleTimeoutMs: 200,
     });
     const startedAt = Date.now();
     const saved = await saveMediaSource(baseUrl);
@@ -269,15 +265,13 @@ describe("media store download timeouts", () => {
       onResponse(response);
       return request;
     }) as unknown as typeof http.request;
-    setMediaStoreNetworkDepsForTest({
+    setMediaStoreDownloadDepsForTest({
       httpRequest: requestImpl,
       resolvePinnedHostname: async (hostname) => ({
         hostname,
         addresses: ["127.0.0.1"],
         lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
       }),
-    });
-    setMediaStoreDownloadTimeoutsForTest({
       responseHeaderTimeoutMs: 30,
       readIdleTimeoutMs: 200,
     });

--- a/src/media/store.download-timeout.test.ts
+++ b/src/media/store.download-timeout.test.ts
@@ -1,0 +1,295 @@
+// Media store remote download timeout coverage for hung/stalled HTTP sources.
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createPinnedLookup } from "../infra/net/ssrf.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { setMediaStoreDownloadTimeoutsForTest } from "./store.download.js";
+import { saveMediaSource, setMediaStoreNetworkDepsForTest } from "./store.js";
+
+const HEADER_TIMEOUT_MS = 40;
+const IDLE_TIMEOUT_MS = 40;
+
+function waitForSocketClose(req: http.IncomingMessage): Promise<void> {
+  return new Promise((resolve) => {
+    if (req.socket.destroyed) {
+      resolve();
+      return;
+    }
+    req.socket.once("close", resolve);
+  });
+}
+
+async function expectSocketClosed(closed: Promise<void> | undefined): Promise<void> {
+  if (!closed) {
+    throw new Error("server request was not observed");
+  }
+  await Promise.race([
+    closed,
+    new Promise<never>((_resolve, reject) => {
+      setTimeout(() => reject(new Error("server socket remained open")), 1_000).unref();
+    }),
+  ]);
+}
+
+async function listMediaFiles(root: string): Promise<string[]> {
+  const entries: string[] = [];
+  async function walk(dir: string) {
+    let names: string[];
+    try {
+      names = await fs.readdir(dir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return;
+      }
+      throw err;
+    }
+    for (const name of names) {
+      const full = path.join(dir, name);
+      const stat = await fs.lstat(full);
+      if (stat.isDirectory()) {
+        await walk(full);
+      } else {
+        entries.push(full);
+      }
+    }
+  }
+  await walk(root);
+  return entries;
+}
+
+describe("media store download timeouts", () => {
+  let testState: OpenClawTestState;
+  let mediaRoot: string;
+  let server: http.Server;
+  let baseUrl: string;
+  let mode:
+    | "hang-headers"
+    | "stall-body"
+    | "stall-error"
+    | "stall-redirect"
+    | "slow-progress"
+    | "ok" = "ok";
+  let openSockets: Set<import("node:net").Socket>;
+  let stalledSocketClosed: Promise<void> | undefined;
+
+  beforeAll(async () => {
+    testState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-media-store-download-timeout-",
+    });
+    mediaRoot = path.join(testState.stateDir, "media");
+    openSockets = new Set();
+    server = http.createServer((req, res) => {
+      if (mode === "hang-headers") {
+        stalledSocketClosed = waitForSocketClose(req);
+        // Accept the request but never write status/headers/body.
+        req.resume();
+        return;
+      }
+      if (mode === "stall-body") {
+        stalledSocketClosed = waitForSocketClose(req);
+        res.writeHead(200, {
+          "content-type": "text/plain",
+          "content-length": "20",
+        });
+        res.write("partial");
+        // Leave the response open without finishing.
+        return;
+      }
+      if (mode === "stall-error") {
+        stalledSocketClosed = waitForSocketClose(req);
+        res.writeHead(500, { "content-type": "text/plain", "content-length": "20" });
+        res.write("partial error");
+        return;
+      }
+      if (mode === "stall-redirect" && req.url !== "/redirect-target") {
+        stalledSocketClosed = waitForSocketClose(req);
+        res.writeHead(302, { location: "/redirect-target", "content-length": "20" });
+        res.write("partial redirect");
+        return;
+      }
+      if (mode === "slow-progress") {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.write("a");
+        let chunksRemaining = 5;
+        const interval = setInterval(() => {
+          chunksRemaining -= 1;
+          if (chunksRemaining === 0) {
+            clearInterval(interval);
+            res.end("e");
+            return;
+          }
+          res.write("a");
+        }, 50);
+        res.once("close", () => clearInterval(interval));
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+    server.on("connection", (socket) => {
+      openSockets.add(socket);
+      socket.on("close", () => {
+        openSockets.delete(socket);
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}/media.bin`;
+  });
+
+  beforeEach(() => {
+    mode = "ok";
+    stalledSocketClosed = undefined;
+    setMediaStoreNetworkDepsForTest({
+      resolvePinnedHostname: async (hostname) => ({
+        hostname,
+        addresses: ["127.0.0.1"],
+        lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
+      }),
+    });
+    setMediaStoreDownloadTimeoutsForTest({
+      responseHeaderTimeoutMs: HEADER_TIMEOUT_MS,
+      readIdleTimeoutMs: IDLE_TIMEOUT_MS,
+    });
+  });
+
+  afterEach(async () => {
+    for (const socket of Array.from(openSockets)) {
+      socket.destroy();
+    }
+    setMediaStoreNetworkDepsForTest();
+    setMediaStoreDownloadTimeoutsForTest();
+    await fs.rm(mediaRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  afterAll(async () => {
+    for (const socket of Array.from(openSockets)) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+    await testState.cleanup();
+    setMediaStoreNetworkDepsForTest();
+    setMediaStoreDownloadTimeoutsForTest();
+  });
+
+  it("times out when the server accepts a connection but never sends headers", async () => {
+    mode = "hang-headers";
+    await expect(saveMediaSource(baseUrl)).rejects.toThrow(
+      /timed out waiting for response headers after 40ms/i,
+    );
+    await expectSocketClosed(stalledSocketClosed);
+    expect(await listMediaFiles(mediaRoot)).toEqual([]);
+  });
+
+  it("times out when hostname resolution never settles", async () => {
+    let requestStarted = false;
+    setMediaStoreNetworkDepsForTest({
+      httpRequest: (() => {
+        requestStarted = true;
+        throw new Error("request must not start after DNS timeout");
+      }) as unknown as typeof http.request,
+      resolvePinnedHostname: async () => await new Promise<never>(() => {}),
+    });
+
+    await expect(saveMediaSource(baseUrl)).rejects.toThrow(
+      /timed out waiting for response headers after 40ms/i,
+    );
+    expect(requestStarted).toBe(false);
+    expect(await listMediaFiles(mediaRoot)).toEqual([]);
+  });
+
+  it("times out when the response body stalls after partial data", async () => {
+    mode = "stall-body";
+    await expect(saveMediaSource(baseUrl)).rejects.toThrow(/stalled: no data received for 40ms/i);
+    await expectSocketClosed(stalledSocketClosed);
+    expect(await listMediaFiles(mediaRoot)).toEqual([]);
+  });
+
+  it("closes an error response whose body never finishes", async () => {
+    mode = "stall-error";
+    await expect(saveMediaSource(baseUrl)).rejects.toThrow(/HTTP 500 downloading media/i);
+    await expectSocketClosed(stalledSocketClosed);
+    expect(await listMediaFiles(mediaRoot)).toEqual([]);
+  });
+
+  it("closes a stalled redirect body before following the next hop", async () => {
+    mode = "stall-redirect";
+    const saved = await saveMediaSource(baseUrl);
+    await expectSocketClosed(stalledSocketClosed);
+    expect(await fs.readFile(saved.path, "utf8")).toBe("ok");
+  });
+
+  it("keeps a slow response alive while each body chunk makes progress", async () => {
+    mode = "slow-progress";
+    setMediaStoreDownloadTimeoutsForTest({
+      responseHeaderTimeoutMs: 500,
+      readIdleTimeoutMs: 200,
+    });
+    setMediaStoreNetworkDepsForTest({
+      resolvePinnedHostname: async (hostname) => ({
+        hostname,
+        addresses: ["127.0.0.1"],
+        lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
+      }),
+    });
+    const startedAt = Date.now();
+    const saved = await saveMediaSource(baseUrl);
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(200);
+    expect(await fs.readFile(saved.path, "utf8")).toBe("aaaaae");
+  });
+
+  it("clears the header deadline when an injected request responds synchronously", async () => {
+    const response = Object.assign(new PassThrough(), {
+      statusCode: 200,
+      headers: { "content-type": "text/plain" },
+    });
+    const request = Object.assign(new EventEmitter(), {
+      end: () => setTimeout(() => response.end("sync response"), 80),
+      destroy: (err?: Error) => {
+        if (err) {
+          request.emit("error", err);
+        }
+        response.destroy();
+      },
+    }) as unknown as ReturnType<typeof http.request>;
+    const requestImpl = ((_url: URL, _options: unknown, onResponse: (res: unknown) => void) => {
+      onResponse(response);
+      return request;
+    }) as unknown as typeof http.request;
+    setMediaStoreNetworkDepsForTest({
+      httpRequest: requestImpl,
+      resolvePinnedHostname: async (hostname) => ({
+        hostname,
+        addresses: ["127.0.0.1"],
+        lookup: createPinnedLookup({ hostname, addresses: ["127.0.0.1"] }),
+      }),
+    });
+    setMediaStoreDownloadTimeoutsForTest({
+      responseHeaderTimeoutMs: 30,
+      readIdleTimeoutMs: 200,
+    });
+
+    const saved = await saveMediaSource(baseUrl);
+    expect(await fs.readFile(saved.path, "utf8")).toBe("sync response");
+  });
+
+  it("still saves when the remote body completes before idle timeout", async () => {
+    mode = "ok";
+    const saved = await saveMediaSource(baseUrl);
+    expect(await fs.readFile(saved.path, "utf8")).toBe("ok");
+    expect(saved.contentType).toBe("text/plain");
+  });
+});

--- a/src/media/store.download.ts
+++ b/src/media/store.download.ts
@@ -24,33 +24,28 @@ let resolvePinnedHostnameImpl: ResolvePinnedHostnameImpl = defaultResolvePinnedH
 let responseHeaderTimeoutMsImpl = RESPONSE_HEADER_TIMEOUT_MS;
 let readIdleTimeoutMsImpl = READ_IDLE_TIMEOUT_MS;
 
-/** Overrides remote-download network dependencies for media-store tests. */
-export function setMediaStoreDownloadNetworkDepsForTest(deps?: {
+/** Overrides remote-download dependencies for media-store tests. */
+export function setMediaStoreDownloadDepsForTest(deps?: {
   httpRequest?: RequestImpl;
   httpsRequest?: RequestImpl;
   resolvePinnedHostname?: ResolvePinnedHostnameImpl;
+  responseHeaderTimeoutMs?: number;
+  readIdleTimeoutMs?: number;
 }): void {
   httpRequestImpl = deps?.httpRequest ?? defaultHttpRequestImpl;
   httpsRequestImpl = deps?.httpsRequest ?? defaultHttpsRequestImpl;
   resolvePinnedHostnameImpl = deps?.resolvePinnedHostname ?? defaultResolvePinnedHostnameImpl;
-}
-
-/** Overrides remote-download deadlines for media-store tests. */
-export function setMediaStoreDownloadTimeoutsForTest(deps?: {
-  responseHeaderTimeoutMs?: number;
-  readIdleTimeoutMs?: number;
-}): void {
   responseHeaderTimeoutMsImpl = deps?.responseHeaderTimeoutMs ?? RESPONSE_HEADER_TIMEOUT_MS;
   readIdleTimeoutMsImpl = deps?.readIdleTimeoutMs ?? READ_IDLE_TIMEOUT_MS;
 }
 
-export type MediaDownloadResult = {
+type MediaDownloadResult = {
   headerMime?: string;
   sniffBuffer: Buffer;
   size: number;
 };
 
-export type DownloadMediaToFileParams = {
+type DownloadMediaToFileParams = {
   url: string;
   dest: string;
   headers?: Record<string, string>;

--- a/src/media/store.download.ts
+++ b/src/media/store.download.ts
@@ -1,0 +1,263 @@
+import { createWriteStream } from "node:fs";
+import fs from "node:fs/promises";
+import { request as httpRequest, type ClientRequest, type IncomingMessage } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { pipeline } from "node:stream/promises";
+import { toErrorObject } from "../infra/errors.js";
+import { retainSafeHeadersForCrossOriginRedirect } from "../infra/net/redirect-headers.js";
+import { resolvePinnedHostname } from "../infra/net/ssrf.js";
+import { formatMediaLimitMb, MEDIA_FILE_MODE } from "./store.shared.js";
+
+const RESPONSE_HEADER_TIMEOUT_MS = 30_000;
+const READ_IDLE_TIMEOUT_MS = 30_000;
+
+type RequestImpl = typeof httpRequest;
+type ResolvePinnedHostnameImpl = typeof resolvePinnedHostname;
+
+const defaultHttpRequestImpl: RequestImpl = httpRequest;
+const defaultHttpsRequestImpl: RequestImpl = httpsRequest;
+const defaultResolvePinnedHostnameImpl: ResolvePinnedHostnameImpl = resolvePinnedHostname;
+
+let httpRequestImpl: RequestImpl = defaultHttpRequestImpl;
+let httpsRequestImpl: RequestImpl = defaultHttpsRequestImpl;
+let resolvePinnedHostnameImpl: ResolvePinnedHostnameImpl = defaultResolvePinnedHostnameImpl;
+let responseHeaderTimeoutMsImpl = RESPONSE_HEADER_TIMEOUT_MS;
+let readIdleTimeoutMsImpl = READ_IDLE_TIMEOUT_MS;
+
+/** Overrides remote-download network dependencies for media-store tests. */
+export function setMediaStoreDownloadNetworkDepsForTest(deps?: {
+  httpRequest?: RequestImpl;
+  httpsRequest?: RequestImpl;
+  resolvePinnedHostname?: ResolvePinnedHostnameImpl;
+}): void {
+  httpRequestImpl = deps?.httpRequest ?? defaultHttpRequestImpl;
+  httpsRequestImpl = deps?.httpsRequest ?? defaultHttpsRequestImpl;
+  resolvePinnedHostnameImpl = deps?.resolvePinnedHostname ?? defaultResolvePinnedHostnameImpl;
+}
+
+/** Overrides remote-download deadlines for media-store tests. */
+export function setMediaStoreDownloadTimeoutsForTest(deps?: {
+  responseHeaderTimeoutMs?: number;
+  readIdleTimeoutMs?: number;
+}): void {
+  responseHeaderTimeoutMsImpl = deps?.responseHeaderTimeoutMs ?? RESPONSE_HEADER_TIMEOUT_MS;
+  readIdleTimeoutMsImpl = deps?.readIdleTimeoutMs ?? READ_IDLE_TIMEOUT_MS;
+}
+
+export type MediaDownloadResult = {
+  headerMime?: string;
+  sniffBuffer: Buffer;
+  size: number;
+};
+
+export type DownloadMediaToFileParams = {
+  url: string;
+  dest: string;
+  headers?: Record<string, string>;
+  maxRedirects?: number;
+  maxBytes: number;
+};
+
+function closeIgnoredHttpResponse(res: IncomingMessage): void {
+  // Unconsumed redirect/error bodies can otherwise retain their socket forever.
+  res.resume();
+  res.destroy();
+}
+
+/** Streams a bounded HTTP(S) response into a caller-owned sibling temp path. */
+export async function downloadMediaToFile(
+  params: DownloadMediaToFileParams,
+): Promise<MediaDownloadResult> {
+  const { url, dest, headers, maxBytes } = params;
+  const maxRedirects = params.maxRedirects ?? 5;
+  return await new Promise((resolve, reject) => {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      reject(new Error("Invalid URL"));
+      return;
+    }
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      reject(new Error(`Invalid URL protocol: ${parsedUrl.protocol}. Only HTTP/HTTPS allowed.`));
+      return;
+    }
+    const requestImpl = parsedUrl.protocol === "https:" ? httpsRequestImpl : httpRequestImpl;
+    const responseHeaderTimeoutMs = responseHeaderTimeoutMsImpl;
+    const readIdleTimeoutMs = readIdleTimeoutMsImpl;
+    let settled = false;
+    let headerTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let activeRequest: ClientRequest | undefined;
+    let activeResponse: IncomingMessage | undefined;
+    let outStream: ReturnType<typeof createWriteStream> | undefined;
+    let bodyPipeline: Promise<void> | undefined;
+
+    const clearDownloadTimers = () => {
+      if (headerTimer !== undefined) {
+        clearTimeout(headerTimer);
+        headerTimer = undefined;
+      }
+      if (idleTimer !== undefined) {
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+      }
+    };
+
+    // Abort first, await stream close, then unlink. Windows cannot remove an
+    // open partial file, and no failed download may survive this boundary.
+    const cleanupFailedDownload = async (err?: Error) => {
+      clearDownloadTimers();
+      activeRequest?.destroy(err);
+      activeResponse?.destroy();
+      outStream?.destroy(err);
+      if (bodyPipeline) {
+        await bodyPipeline.catch(() => {});
+      }
+      await fs.rm(dest, { force: true }).catch(() => {});
+    };
+
+    const settleReject = (err: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      const failure = toErrorObject(err, "Non-Error rejection");
+      void cleanupFailedDownload(failure).finally(() => reject(failure));
+    };
+
+    const settleResolve = (value: MediaDownloadResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearDownloadTimers();
+      resolve(value);
+    };
+
+    const resetIdleTimer = () => {
+      if (settled) {
+        return;
+      }
+      if (idleTimer !== undefined) {
+        clearTimeout(idleTimer);
+      }
+      idleTimer = setTimeout(() => {
+        settleReject(
+          new Error(`Media download stalled: no data received for ${readIdleTimeoutMs}ms`),
+        );
+      }, readIdleTimeoutMs);
+      idleTimer.unref?.();
+    };
+
+    // DNS/NSS resolution is part of the wait for response headers. Start this
+    // before resolution so no pre-request phase can pin the caller forever.
+    headerTimer = setTimeout(() => {
+      settleReject(
+        new Error(
+          `Media download timed out waiting for response headers after ${responseHeaderTimeoutMs}ms`,
+        ),
+      );
+    }, responseHeaderTimeoutMs);
+    headerTimer.unref?.();
+
+    const onResponse = (res: IncomingMessage) => {
+      if (settled) {
+        res.destroy();
+        return;
+      }
+      if (headerTimer !== undefined) {
+        clearTimeout(headerTimer);
+        headerTimer = undefined;
+      }
+      activeResponse = res;
+      // Response errors can arrive before pipeline() owns the readable.
+      res.on("error", settleReject);
+      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+        const location = res.headers.location;
+        if (!location || maxRedirects <= 0) {
+          closeIgnoredHttpResponse(res);
+          settleReject(new Error("Redirect loop or missing Location header"));
+          return;
+        }
+        let redirectUrl: URL;
+        try {
+          redirectUrl = new URL(location, url);
+        } catch {
+          closeIgnoredHttpResponse(res);
+          settleReject(new Error("Invalid redirect Location header"));
+          return;
+        }
+        const redirectHeaders =
+          redirectUrl.origin === parsedUrl.origin
+            ? headers
+            : retainSafeHeadersForCrossOriginRedirect(headers);
+        settled = true;
+        clearDownloadTimers();
+        // Redirect bodies are irrelevant and may never finish. Close this hop
+        // before recursing so every DNS-to-headers phase has its own deadline.
+        closeIgnoredHttpResponse(res);
+        activeRequest?.destroy();
+        resolve(
+          downloadMediaToFile({
+            url: redirectUrl.href,
+            dest,
+            headers: redirectHeaders,
+            maxRedirects: maxRedirects - 1,
+            maxBytes,
+          }),
+        );
+        return;
+      }
+      if (!res.statusCode || res.statusCode >= 400) {
+        closeIgnoredHttpResponse(res);
+        settleReject(new Error(`HTTP ${res.statusCode ?? "?"} downloading media`));
+        return;
+      }
+      let total = 0;
+      const sniffChunks: Buffer[] = [];
+      let sniffLen = 0;
+      outStream = createWriteStream(dest, { mode: MEDIA_FILE_MODE });
+      resetIdleTimer();
+      res.on("data", (chunk: Buffer) => {
+        resetIdleTimer();
+        total += chunk.length;
+        if (sniffLen < 16_384) {
+          const remaining = 16_384 - sniffLen;
+          sniffChunks.push(chunk.length > remaining ? chunk.subarray(0, remaining) : chunk);
+          sniffLen += Math.min(chunk.length, remaining);
+        }
+        if (total > maxBytes) {
+          settleReject(new Error(`Media exceeds ${formatMediaLimitMb(maxBytes)} limit`));
+        }
+      });
+      bodyPipeline = pipeline(res, outStream)
+        .then(() => {
+          const rawHeader = res.headers["content-type"];
+          settleResolve({
+            headerMime: Array.isArray(rawHeader) ? rawHeader[0] : rawHeader,
+            sniffBuffer: Buffer.concat(sniffChunks, sniffLen),
+            size: total,
+          });
+        })
+        .catch(settleReject);
+    };
+
+    void (async () => {
+      const pinned = await resolvePinnedHostnameImpl(parsedUrl.hostname);
+      // A timed-out resolver may still finish; never let it open a late socket.
+      if (settled) {
+        return;
+      }
+      const req = requestImpl(parsedUrl, { headers, lookup: pinned.lookup }, onResponse);
+      activeRequest = req;
+      req.on("error", settleReject);
+      // Test seams may invoke onResponse synchronously during construction.
+      if (settled) {
+        req.destroy();
+        return;
+      }
+      req.end();
+    })().catch(settleReject);
+  });
+}

--- a/src/media/store.shared.ts
+++ b/src/media/store.shared.ts
@@ -1,0 +1,7 @@
+// Media files remain readable by sandbox container UIDs; the private media
+// directory is the trust boundary. Temp and final writes must use one mode.
+export const MEDIA_FILE_MODE = 0o644;
+
+export function formatMediaLimitMb(maxBytes: number): string {
+  return `${(maxBytes / (1024 * 1024)).toFixed(0)}MB`;
+}

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -20,7 +20,7 @@ import type { resolvePinnedHostname } from "../infra/net/ssrf.js";
 import { retryAsync } from "../infra/retry.js";
 import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
 import { resolveConfigDir } from "../utils.js";
-import { downloadMediaToFile, setMediaStoreDownloadNetworkDepsForTest } from "./store.download.js";
+import { downloadMediaToFile, setMediaStoreDownloadDepsForTest } from "./store.download.js";
 import { isFsSafeError, readLocalFileSafely, type FsSafeLikeError } from "./store.runtime.js";
 import { formatMediaLimitMb, MEDIA_FILE_MODE } from "./store.shared.js";
 
@@ -42,7 +42,7 @@ export function setMediaStoreNetworkDepsForTest(deps?: {
   httpsRequest?: RequestImpl;
   resolvePinnedHostname?: ResolvePinnedHostnameImpl;
 }): void {
-  setMediaStoreDownloadNetworkDepsForTest(deps);
+  setMediaStoreDownloadDepsForTest(deps);
 }
 
 function resolveMediaSubdir(subdir: string, caller: string): string {

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -1,12 +1,9 @@
 // Media store persists loaded media files and metadata for later references.
 import "../infra/fs-safe-defaults.js";
 import crypto from "node:crypto";
-import { createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
-import { request as httpRequest } from "node:http";
-import { request as httpsRequest } from "node:https";
+import type { request as httpRequest } from "node:http";
 import path from "node:path";
-import { pipeline } from "node:stream/promises";
 import {
   basenameFromAnyPath,
   extnameFromAnyPath,
@@ -16,38 +13,36 @@ import { detectMime, extensionForMime } from "@openclaw/media-core/mime";
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { toErrorObject } from "../infra/errors.js";
 import { fileStore } from "../infra/file-store.js";
 import { sanitizeUntrustedFileName } from "../infra/fs-safe-advanced.js";
 import { isPathInside } from "../infra/fs-safe.js";
-import { retainSafeHeadersForCrossOriginRedirect } from "../infra/net/redirect-headers.js";
-import { resolvePinnedHostname } from "../infra/net/ssrf.js";
+import type { resolvePinnedHostname } from "../infra/net/ssrf.js";
 import { retryAsync } from "../infra/retry.js";
 import { writeSiblingTempFile } from "../infra/sibling-temp-file.js";
 import { resolveConfigDir } from "../utils.js";
+import { downloadMediaToFile, setMediaStoreDownloadNetworkDepsForTest } from "./store.download.js";
 import { isFsSafeError, readLocalFileSafely, type FsSafeLikeError } from "./store.runtime.js";
+import { formatMediaLimitMb, MEDIA_FILE_MODE } from "./store.shared.js";
 
 const resolveMediaDir = () => path.join(resolveConfigDir(), "media");
 /** Default per-file media-store byte cap used by inbound staging and plugin SDK callers. */
 export const MEDIA_MAX_BYTES = 5 * 1024 * 1024;
 const MAX_BYTES = MEDIA_MAX_BYTES;
 const DEFAULT_TTL_MS = 2 * 60 * 1000; // 2 minutes
-// Files are intentionally readable by non-owner UIDs so Docker sandbox containers can access
-// inbound media. The containing state/media directories remain 0o700, which is the trust boundary.
-const MEDIA_FILE_MODE = 0o644;
+type RequestImpl = typeof httpRequest;
+type ResolvePinnedHostnameImpl = typeof resolvePinnedHostname;
 type CleanOldMediaOptions = {
   recursive?: boolean;
   pruneEmptyDirs?: boolean;
 };
-type RequestImpl = typeof httpRequest;
-type ResolvePinnedHostnameImpl = typeof resolvePinnedHostname;
 
-const defaultHttpRequestImpl: RequestImpl = httpRequest;
-const defaultHttpsRequestImpl: RequestImpl = httpsRequest;
-const defaultResolvePinnedHostnameImpl: ResolvePinnedHostnameImpl = resolvePinnedHostname;
-
-function formatMediaLimitMb(maxBytes: number): string {
-  return `${(maxBytes / (1024 * 1024)).toFixed(0)}MB`;
+/** Overrides network dependencies for media-store tests. */
+export function setMediaStoreNetworkDepsForTest(deps?: {
+  httpRequest?: RequestImpl;
+  httpsRequest?: RequestImpl;
+  resolvePinnedHostname?: ResolvePinnedHostnameImpl;
+}): void {
+  setMediaStoreDownloadNetworkDepsForTest(deps);
 }
 
 function resolveMediaSubdir(subdir: string, caller: string): string {
@@ -97,21 +92,6 @@ function openMediaStore(maxBytes = MAX_BYTES) {
     maxBytes,
     mode: MEDIA_FILE_MODE,
   });
-}
-
-let httpRequestImpl: RequestImpl = defaultHttpRequestImpl;
-let httpsRequestImpl: RequestImpl = defaultHttpsRequestImpl;
-let resolvePinnedHostnameImpl: ResolvePinnedHostnameImpl = defaultResolvePinnedHostnameImpl;
-
-/** Overrides network dependencies for media-store tests and restores defaults when omitted. */
-export function setMediaStoreNetworkDepsForTest(deps?: {
-  httpRequest?: RequestImpl;
-  httpsRequest?: RequestImpl;
-  resolvePinnedHostname?: ResolvePinnedHostnameImpl;
-}): void {
-  httpRequestImpl = deps?.httpRequest ?? defaultHttpRequestImpl;
-  httpsRequestImpl = deps?.httpsRequest ?? defaultHttpsRequestImpl;
-  resolvePinnedHostnameImpl = deps?.resolvePinnedHostname ?? defaultResolvePinnedHostnameImpl;
 }
 
 /**
@@ -225,103 +205,6 @@ export async function cleanOldMedia(ttlMs = DEFAULT_TTL_MS, options: CleanOldMed
 
 function looksLikeUrl(src: string) {
   return hasHttpUrlPrefix(src);
-}
-
-function discardIgnoredHttpResponse(res: NodeJS.ReadableStream): void {
-  res.resume();
-}
-
-/**
- * Download media to disk while capturing the first few KB for mime sniffing.
- */
-async function downloadToFile(
-  url: string,
-  dest: string,
-  headers?: Record<string, string>,
-  maxRedirects = 5,
-  maxBytes = MAX_BYTES,
-): Promise<{ headerMime?: string; sniffBuffer: Buffer; size: number }> {
-  return await new Promise((resolve, reject) => {
-    let parsedUrl: URL;
-    try {
-      parsedUrl = new URL(url);
-    } catch {
-      reject(new Error("Invalid URL"));
-      return;
-    }
-    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
-      reject(new Error(`Invalid URL protocol: ${parsedUrl.protocol}. Only HTTP/HTTPS allowed.`));
-      return;
-    }
-    const requestImpl = parsedUrl.protocol === "https:" ? httpsRequestImpl : httpRequestImpl;
-    resolvePinnedHostnameImpl(parsedUrl.hostname)
-      .then((pinned) => {
-        const req = requestImpl(parsedUrl, { headers, lookup: pinned.lookup }, (res) => {
-          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
-            const location = res.headers.location;
-            if (!location || maxRedirects <= 0) {
-              discardIgnoredHttpResponse(res);
-              reject(new Error(`Redirect loop or missing Location header`));
-              return;
-            }
-            let redirectUrl: URL;
-            try {
-              redirectUrl = new URL(location, url);
-            } catch {
-              discardIgnoredHttpResponse(res);
-              reject(new Error("Invalid redirect Location header"));
-              return;
-            }
-            const redirectHeaders =
-              redirectUrl.origin === parsedUrl.origin
-                ? headers
-                : retainSafeHeadersForCrossOriginRedirect(headers);
-            discardIgnoredHttpResponse(res);
-            resolve(
-              downloadToFile(redirectUrl.href, dest, redirectHeaders, maxRedirects - 1, maxBytes),
-            );
-            return;
-          }
-          if (!res.statusCode || res.statusCode >= 400) {
-            discardIgnoredHttpResponse(res);
-            reject(new Error(`HTTP ${res.statusCode ?? "?"} downloading media`));
-            return;
-          }
-          let total = 0;
-          const sniffChunks: Buffer[] = [];
-          let sniffLen = 0;
-          const out = createWriteStream(dest, { mode: MEDIA_FILE_MODE });
-          res.on("data", (chunk) => {
-            total += chunk.length;
-            if (sniffLen < 16384) {
-              sniffChunks.push(chunk);
-              sniffLen += chunk.length;
-            }
-            if (total > maxBytes) {
-              req.destroy(new Error(`Media exceeds ${formatMediaLimitMb(maxBytes)} limit`));
-            }
-          });
-          pipeline(res, out)
-            .then(() => {
-              const sniffBuffer = Buffer.concat(sniffChunks, Math.min(sniffLen, 16384));
-              const rawHeader = res.headers["content-type"];
-              const headerMime = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
-              resolve({
-                headerMime,
-                sniffBuffer,
-                size: total,
-              });
-            })
-            .catch(async (err: unknown) => {
-              await fs.rm(dest, { force: true }).catch(() => {});
-              reject(toErrorObject(err, "Non-Error rejection"));
-            });
-        });
-        req.on("error", reject);
-        req.end();
-      })
-      .catch(reject);
-  });
 }
 
 /** Media-store file metadata returned after bytes are persisted under a safe media ID. */
@@ -555,13 +438,12 @@ export async function saveMediaSource(
       dir,
       tempPrefix: `.${baseId}`,
       writeTemp: async (tempPath) => {
-        const { headerMime, sniffBuffer, size } = await downloadToFile(
-          source,
-          tempPath,
+        const { headerMime, sniffBuffer, size } = await downloadMediaToFile({
+          url: source,
+          dest: tempPath,
           headers,
-          5,
           maxBytes,
-        );
+        });
         const mime = await detectMime({
           buffer: sniffBuffer,
           headerMime,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users and gateway paths that persist remote media through `saveMediaSource()` would hang indefinitely when a media URL accepted the TCP connection but never sent response headers, or sent a partial body and then stalled. Only a max-bytes cap existed; there was no header or idle-read timeout, so requests, temp files, and caller chains could stay pinned forever.

## Why This Change Was Made

Add 30s response-header and idle-body timeouts to `downloadToFile()` in the media store path, matching the hang-bounding intent already used by `src/media/fetch.ts` / web-media reads. On failure, abort the request/response/write stream, await pipeline shutdown, then remove the temp file before rejecting—so platforms that reject unlinking an open file cannot retain partial media.

This path stays local to `saveMediaSource()` because that caller streams into a sibling temp file while sniffing MIME; `saveRemoteMedia()` / fetch.ts does not own that contract. Shared outcome is the same hang bound, not a duplicated fetch stack.

Timeouts are overridable in tests via `setMediaStoreNetworkDepsForTest`. MIME sniffing, redirect header stripping, and the 5MB size cap stay unchanged.

## User Impact

**Before:** A hung or adversarial media URL could block `saveMediaSource()` (including gateway managed-image ingestion) with no recovery besides process restart, and failure cleanup could race stream close.

**After:** Stalled header waits and idle body reads fail within 30s; streams close before temp removal; callers get a clear timeout/stall error with no leftover media files.

## Evidence

- Changed: `src/media/store.ts` (`downloadToFile`)
- Caller under test: production `saveMediaSource(httpUrl)` against a real local `node:http` server
- Regression: `src/media/store.download-timeout.test.ts`
- Sibling redirect suite still green: `src/media/store.redirect.test.ts`

### Unit regression

```bash
node scripts/run-vitest.mjs src/media/store.download-timeout.test.ts src/media/store.redirect.test.ts --reporter=verbose
```

```text
 ✓ |media| src/media/store.download-timeout.test.ts > media store download timeouts > times out when the server accepts a connection but never sends headers 52ms
 ✓ |media| src/media/store.download-timeout.test.ts > media store download timeouts > times out when the response body stalls after partial data 45ms
 ✓ |media| src/media/store.download-timeout.test.ts > media store download timeouts > still saves when the remote body completes before idle timeout 12ms
 ✓ |media| src/media/store.redirect.test.ts > media store redirects > follows redirects and keeps detected mime/extension 31ms
 Test Files  2 passed (2)
      Tests  10 passed (10)
[test] passed 1 Vitest shard in 3.98s
```

## Real behavior proof

- **Behavior or issue addressed:** `saveMediaSource()` remote downloads no longer hang forever on servers that accept connections without sending headers, or that stall after partial body data; temp files are cleaned up only after stream teardown.
- **Canonical reachability path:** gateway/managed-image and other callers → `saveMediaSource(url)` → `downloadToFile()` → header timer / idle body timer → abort streams → await pipeline → temp cleanup → reject.
- **Boundary crossed:** Untrusted remote HTTP(S) media source → local media-store temp file / saved media ID.
- **Shared helper / provider constraint check:** Aligns store downloads with media `fetch.ts` / web-media header + idle-read hang bounds. Keeps store-local downloader because `saveMediaSource()` needs sniff-while-streaming into a sibling temp file that `saveRemoteMedia()` does not provide. SSRF pinned-hostname lookup and redirect header stripping unchanged.
- **Real environment tested:** Local Node source checkout; standalone `tsx` script (outside Vitest) calling production `saveMediaSource` against a real `http.createServer` on `127.0.0.1` with pinned loopback lookup.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs src/media/store.download-timeout.test.ts src/media/store.redirect.test.ts --reporter=verbose
# plus standalone tsx proof invoking saveMediaSource() against hung sockets
```

- **Evidence after fix:**

```text
standalone-proof: saveMediaSource against real hung HTTP sockets
hang-headers: rejected after 87ms
hang-headers: Media download timed out waiting for response headers after 80ms
hang-headers leftover files: []
stall-body: rejected after 85ms
stall-body: Media download stalled: no data received for 80ms
stall-body leftover files: []
standalone-proof: done

 ✓ ... > times out when the server accepts a connection but never sends headers 52ms
 ✓ ... > times out when the response body stalls after partial data 45ms
 Test Files  2 passed (2)
      Tests  10 passed (10)
```

- **Observed result after fix:** Hang-headers and stall-body both reject with explicit timeout/stall errors; both leave zero files under the media root. Successful short responses still save. Lint clean on touched files.
- **What was not tested:** Live public HTTPS media URLs; gateway managed-image end-to-end UI path; redirect-during-timeout races.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
