### PR TITLE
fix(gateway): demote startup close transport races

### DIFF
--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -22,106 +22,109 @@ import {
 } from "./ws-connection.test-helpers.js";
 
 describe("attachGatewayWsConnectionHandler startup readiness", () => {
-  it("returns a retryable startup-unavailable connect response while sidecars are pending", async () => {
-    const sent: unknown[] = [];
-    const socket = createGatewayWsTestSocket({
-      closeEmits: true,
-      onSend: (data) => {
-        sent.push(JSON.parse(data));
-      },
-    });
-    const logWsControl = createGatewayWsTestLogger();
-
-    attachGatewayWsForTest({
-      attach: attachGatewayWsConnectionHandler,
-      socket,
-      options: {
-        resolvedAuth: { mode: "none", allowTailscale: false },
-        isStartupPending: () => true,
-        logWsControl: logWsControl as never,
-        buildRequestContext: () => createGatewayWsTestRequestContext() as never,
-      },
-    });
-    socket.emit(
-      "message",
-      JSON.stringify({
-        type: "req",
-        id: "connect-1",
-        method: "connect",
-        params: {
-          minProtocol: PROTOCOL_VERSION,
-          maxProtocol: PROTOCOL_VERSION,
-          client: {
-            id: GATEWAY_CLIENT_NAMES.CLI,
-            version: "dev",
-            platform: "test",
-            mode: GATEWAY_CLIENT_MODES.CLI,
-          },
-          role: "operator",
-          scopes: ["operator.read"],
-          caps: [],
+  it.each([GATEWAY_STARTUP_CLOSE_CODE, 1006])(
+    "keeps startup-unavailable close code %i at debug level",
+    async (observedCloseCode) => {
+      const sent: unknown[] = [];
+      const socket = createGatewayWsTestSocket({
+        onSend: (data) => {
+          sent.push(JSON.parse(data));
         },
-      }),
-    );
+      });
+      const logWsControl = createGatewayWsTestLogger();
 
-    await vi.waitFor(() => {
-      expect(
-        sent.some(
-          (frame) =>
-            typeof frame === "object" &&
-            frame !== null &&
-            (frame as { type?: unknown; id?: unknown; ok?: unknown }).type === "res" &&
-            (frame as { id?: unknown }).id === "connect-1",
-        ),
-      ).toBe(true);
-    });
-
-    const response = sent.find(
-      (frame) =>
-        typeof frame === "object" &&
-        frame !== null &&
-        (frame as { type?: unknown; id?: unknown }).type === "res" &&
-        (frame as { id?: unknown }).id === "connect-1",
-    ) as
-      | {
-          type?: unknown;
-          id?: unknown;
-          ok?: unknown;
-          error?: {
-            code?: unknown;
-            retryable?: unknown;
-            retryAfterMs?: unknown;
-            details?: unknown;
-          };
-        }
-      | undefined;
-    expect(response?.type).toBe("res");
-    expect(response?.id).toBe("connect-1");
-    expect(response?.ok).toBe(false);
-    expect(response?.error?.code).toBe("UNAVAILABLE");
-    expect(response?.error?.retryable).toBe(true);
-    expect(response?.error?.retryAfterMs).toBe(500);
-    expect(response?.error?.details).toEqual({ reason: GATEWAY_STARTUP_UNAVAILABLE_REASON });
-    await vi.waitFor(() => {
-      expect(socket.close).toHaveBeenCalledWith(
-        GATEWAY_STARTUP_CLOSE_CODE,
-        GATEWAY_STARTUP_CLOSE_REASON,
+      attachGatewayWsForTest({
+        attach: attachGatewayWsConnectionHandler,
+        socket,
+        options: {
+          resolvedAuth: { mode: "none", allowTailscale: false },
+          isStartupPending: () => true,
+          logWsControl: logWsControl as never,
+          buildRequestContext: () => createGatewayWsTestRequestContext() as never,
+        },
+      });
+      socket.emit(
+        "message",
+        JSON.stringify({
+          type: "req",
+          id: "connect-1",
+          method: "connect",
+          params: {
+            minProtocol: PROTOCOL_VERSION,
+            maxProtocol: PROTOCOL_VERSION,
+            client: {
+              id: GATEWAY_CLIENT_NAMES.CLI,
+              version: "dev",
+              platform: "test",
+              mode: GATEWAY_CLIENT_MODES.CLI,
+            },
+            role: "operator",
+            scopes: ["operator.read"],
+            caps: [],
+          },
+        }),
       );
-    });
-    expect(logWsControl.debug).toHaveBeenCalledWith(
-      expect.stringContaining("closed before connect"),
-      expect.objectContaining({
-        cause: GATEWAY_STARTUP_PENDING_CLOSE_CAUSE,
-        handshake: "failed",
-      }),
-    );
-    expect(logWsControl.debug).toHaveBeenCalledWith(
-      expect.stringContaining(`code=${GATEWAY_STARTUP_CLOSE_CODE}`),
-      expect.anything(),
-    );
-    expect(logWsControl.warn).not.toHaveBeenCalledWith(
-      expect.stringContaining("closed before connect"),
-      expect.anything(),
-    );
-  });
+
+      await vi.waitFor(() => {
+        expect(
+          sent.some(
+            (frame) =>
+              typeof frame === "object" &&
+              frame !== null &&
+              (frame as { type?: unknown; id?: unknown; ok?: unknown }).type === "res" &&
+              (frame as { id?: unknown }).id === "connect-1",
+          ),
+        ).toBe(true);
+      });
+
+      const response = sent.find(
+        (frame) =>
+          typeof frame === "object" &&
+          frame !== null &&
+          (frame as { type?: unknown; id?: unknown }).type === "res" &&
+          (frame as { id?: unknown }).id === "connect-1",
+      ) as
+        | {
+            type?: unknown;
+            id?: unknown;
+            ok?: unknown;
+            error?: {
+              code?: unknown;
+              retryable?: unknown;
+              retryAfterMs?: unknown;
+              details?: unknown;
+            };
+          }
+        | undefined;
+      expect(response?.type).toBe("res");
+      expect(response?.id).toBe("connect-1");
+      expect(response?.ok).toBe(false);
+      expect(response?.error?.code).toBe("UNAVAILABLE");
+      expect(response?.error?.retryable).toBe(true);
+      expect(response?.error?.retryAfterMs).toBe(500);
+      expect(response?.error?.details).toEqual({ reason: GATEWAY_STARTUP_UNAVAILABLE_REASON });
+      await vi.waitFor(() => {
+        expect(socket.close).toHaveBeenCalledWith(
+          GATEWAY_STARTUP_CLOSE_CODE,
+          GATEWAY_STARTUP_CLOSE_REASON,
+        );
+      });
+      socket.emit("close", observedCloseCode, Buffer.alloc(0));
+      expect(logWsControl.debug).toHaveBeenCalledWith(
+        expect.stringContaining("closed before connect"),
+        expect.objectContaining({
+          cause: GATEWAY_STARTUP_PENDING_CLOSE_CAUSE,
+          handshake: "failed",
+        }),
+      );
+      expect(logWsControl.debug).toHaveBeenCalledWith(
+        expect.stringContaining(`code=${observedCloseCode}`),
+        expect.anything(),
+      );
+      expect(logWsControl.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("closed before connect"),
+        expect.anything(),
+      );
+    },
+  );
 });

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -3,10 +3,7 @@ import { randomUUID } from "node:crypto";
 import type { Socket } from "node:net";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { RawData, WebSocket, WebSocketServer } from "ws";
-import {
-  GATEWAY_STARTUP_CLOSE_CODE,
-  GATEWAY_STARTUP_PENDING_CLOSE_CAUSE,
-} from "../../../packages/gateway-protocol/src/startup-unavailable.js";
+import { GATEWAY_STARTUP_PENDING_CLOSE_CAUSE } from "../../../packages/gateway-protocol/src/startup-unavailable.js";
 import { getRuntimeConfig } from "../../config/io.js";
 import { upsertPresence } from "../../infra/system-presence.js";
 import { logRejectedLargePayload } from "../../logging/diagnostic-payload.js";

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -464,8 +464,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         ...closeMeta,
       };
       if (!client) {
-        const isExpectedStartupRetryClose =
-          closeCause === GATEWAY_STARTUP_PENDING_CLOSE_CAUSE && code === GATEWAY_STARTUP_CLOSE_CODE;
+        const isExpectedStartupRetryClose = closeCause === GATEWAY_STARTUP_PENDING_CLOSE_CAUSE;
         const logFn =
           isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr) ||
           isExpectedStartupRetryClose ||


### PR DESCRIPTION
## What Problem This Solves

After #104610 landed, a managed restart still produced one warning when the Gateway had already classified a connect request as `startup-sidecars-pending`, but the local macOS client aborted with transport code 1006 before receiving the server's intended 1013 close.

## Why This Change Was Made

Treat the server-owned startup-pending close cause as authoritative regardless of which close code wins the transport race. Unclassified queued-frame closes remain warnings, preserving the safety fix added from review feedback in #104610.

## User Impact

Restart-window audits no longer report this final benign startup race. Unexpected pre-connect and queued-frame failures remain warning-level.

## Evidence

- Reproduced live on main after #104610: one `startup-sidecars-pending` warning with a parsed `connect` frame, close code 1006, and subsequently healthy Gateway/channels.
- Blacksmith Testbox `tbx_01kx97jgyxw89epdfdgebdzp9w`: both Gateway connection suites passed 64/64 assertions across eight Vitest projects.
- Autoreview: clean, no accepted/actionable findings.
- `git diff --check` passed.

Testbox run: https://github.com/openclaw/openclaw/actions/runs/29163828797
