### PR TITLE
improve(ui): sit the split-view pane header beside the macOS window controls instead of reserving a titlebar band

### DIFF
--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -127,19 +127,6 @@ openclaw-chat-pane {
   }
 }
 
-/* Native macOS floats the traffic lights plus the titlebar accessory
-   (sidebar toggle, back/forward — DashboardWindowController) over the
-   top-left ~194px of the page. With the nav column collapsed the split view
-   is the window's top surface, so reserve the titlebar band above the pane
-   headers; this also keeps the header buttons clear of the AppKit drag
-   region (x 78-254, y < 46) that would swallow their clicks. Drawer widths
-   (<=1100px) reserve a 58px topbar row instead (layout.mobile.css). */
-@media (min-width: 1101px) {
-  html.openclaw-native-macos .shell--nav-collapsed .chat-split-view {
-    padding-top: var(--openclaw-native-titlebar-height, 50px);
-  }
-}
-
 .chat-pane__header {
   display: flex;
   flex: 0 0 auto;
@@ -177,4 +164,40 @@ openclaw-chat-pane {
   align-items: center;
   gap: 2px;
   flex: 0 0 auto;
+}
+
+/* Native macOS: with the nav column collapsed the top-left pane header is the
+   window's top surface, so its content shifts right of the floating window
+   chrome (Safari-style) instead of hiding under it. Traffic lights end at
+   x=78; newer apps (openclaw-native-nav) also float the titlebar accessory
+   (sidebar toggle + back/forward, DashboardWindowController) ending ~x=194.
+   Drawer widths (<=1100px) reserve a 58px topbar row instead
+   (layout.mobile.css). The first column's min-width grows by the extra inset
+   (90/204 minus the 12px base padding): the header's action row cannot
+   shrink, and the cell's overflow:hidden would clip the close/split buttons
+   at the 320px column minimum otherwise. */
+@media (min-width: 1101px) {
+  html.openclaw-native-macos .shell--nav-collapsed .chat-split-view__column:first-child {
+    min-width: 398px;
+  }
+
+  html.openclaw-native-macos
+    .shell--nav-collapsed
+    .chat-split-view__column:first-child
+    > .chat-split-view__cell:first-child
+    .chat-pane__header {
+    padding-left: 90px;
+  }
+
+  html.openclaw-native-nav .shell--nav-collapsed .chat-split-view__column:first-child {
+    min-width: 512px;
+  }
+
+  html.openclaw-native-nav
+    .shell--nav-collapsed
+    .chat-split-view__column:first-child
+    > .chat-split-view__cell:first-child
+    .chat-pane__header {
+    padding-left: 204px;
+  }
 }


### PR DESCRIPTION
Related: #104593

## What Problem This Solves

Reworks the macOS split-view titlebar clearance that landed in #104593. That fix reserved a 50px empty band across the whole window above the pane headers — it cleared the traffic lights, but wasted a full strip of vertical space on every split layout. Feedback: don't push the content down, move it right.

## Why This Change Was Made

Safari-style is the native convention: the header row stays the window's top surface and only its content shifts right of the floating window chrome. The rule now left-insets the **first column's first pane header** (the only header that can sit under the chrome) when the nav column is collapsed inside the Mac app at desktop widths:

- `html.openclaw-native-macos` (older apps, traffic lights only, ending x≈78): `padding-left: 90px`
- `html.openclaw-native-nav` (newer apps that also float the titlebar accessory — sidebar toggle + back/forward, ending x≈194 per `DashboardWindowController`): `padding-left: 204px`

The reserved-band rule from #104593 is deleted — one canonical clearance path. Drawer widths (≤1100px) keep their 58px topbar row (`layout.mobile.css`); other headers, plain browsers, and expanded-sidebar layouts (`NAV_WIDTH_MIN` 240 > 194) are untouched. The pane header row (48px since #104574) reads as the titlebar: its static title sits beside the native controls and the row still starts a native window drag.

## User Impact

macOS app users with a collapsed sidebar in chat split view get their full content height back: no empty strip above the panes, and the pane title is fully readable next to the window controls — like a native titlebar.

## Evidence

Mock control-UI with the Mac app's chrome injection simulated (classes/CSS from `DashboardWindowController.installNativeChromeScript`; traffic lights + accessory footprint overlaid):

| #104593 (reserved band) | This PR (right-shift) |
| --- | --- |
| ![band](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-pane-native-titlebar-band/band-before.png) | ![right shift](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-pane-native-titlebar-band/right-shift-after.png) |

Measured with the rules live in the mock:

- new app (`openclaw-native-nav`): first header `padding-left` 204px, header top y=0
- old app (`openclaw-native-macos` only): 90px
- plain browser: 12px (base, untouched)
- second column header and split-down lower cell: 12px (untouched)
- split-down case: only the top cell of the first column insets
