### PR TITLE
fix: reconcile timed-out gateway message actions

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -211,6 +211,23 @@ describe("dynamic tool execution helpers", () => {
         config: undefined,
       }),
     ).toBe(CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS);
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-message-transport-timeout",
+          namespace: null,
+          tool: "message",
+          arguments: {
+            action: "send",
+            message: "long outbound update",
+            timeoutMs: 30_000,
+          },
+        },
+        config: undefined,
+      }),
+    ).toBe(CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS);
   });
 
   it("uses media image config and caps excessive dynamic tool timeouts", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -41,7 +41,7 @@ const CODEX_DYNAMIC_COMPUTER_COMPLETION_GRACE_MS = 30_000;
 /** Timeout for image-understanding style dynamic tool calls. */
 export const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
 /** Timeout for message-delivery dynamic tool calls. */
-export const CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS = 120_000;
+export const CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS = CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS;
 const LOG_FIELD_MAX_LENGTH = 160;
 
 type DynamicToolTimeoutDetails = {
@@ -478,6 +478,11 @@ export function resolveDynamicToolCallTimeoutMs(params: {
 }): number {
   if (params.call.tool === "computer") {
     return clampDynamicToolTimeoutMs(readComputerToolTimeoutMs(params.call.arguments));
+  }
+  // The message tool's `timeoutMs` is a Gateway transport budget. Its outer
+  // watchdog must also cover bounded same-key reconciliation after that timer.
+  if (params.call.tool === "message") {
+    return CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS;
   }
   return clampDynamicToolTimeoutMs(
     readDynamicToolCallTimeoutMs(params.call.arguments) ??

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -1245,7 +1245,7 @@ describe("runMessageAction plugin dispatch", () => {
         gateway: {
           clientName: "cli",
           mode: "cli",
-          timeoutMs: 30_000,
+          timeoutMs: 120_000,
         },
         dryRun: false,
       } satisfies Parameters<typeof runMessageAction>[0];
@@ -1261,6 +1261,7 @@ describe("runMessageAction plugin dispatch", () => {
         "second gateway least privilege call",
         1,
       );
+      expect(firstCall.timeoutMs).toBe(30_000);
       expect(secondCall).toMatchObject({
         ...firstCall,
         timeoutMs: null,

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -99,6 +99,7 @@ const mocks = vi.hoisted(() => ({
   materializeMessagePresentationFallback: vi.fn(),
   callGateway: vi.fn(),
   callGatewayLeastPrivilege: vi.fn(),
+  isGatewayTransportError: vi.fn(),
   randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
   maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
   prepareOutboundMirrorRoute: vi.fn(),
@@ -119,6 +120,7 @@ vi.mock("./outbound-send-service.js", () => ({
 vi.mock("./message.gateway.runtime.js", () => ({
   callGateway: mocks.callGateway,
   callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
+  isGatewayTransportError: mocks.isGatewayTransportError,
   randomIdempotencyKey: mocks.randomIdempotencyKey,
 }));
 
@@ -313,6 +315,11 @@ describe("runMessageAction plugin dispatch", () => {
     );
     mocks.callGateway.mockReset();
     mocks.callGatewayLeastPrivilege.mockReset();
+    mocks.isGatewayTransportError.mockReset();
+    mocks.isGatewayTransportError.mockImplementation(
+      (value: unknown) =>
+        value instanceof Error && (value as { kind?: unknown }).kind === "timeout",
+    );
     mocks.randomIdempotencyKey.mockClear();
     mocks.maybeApplyTtsToPayload.mockReset();
     mocks.maybeApplyTtsToPayload.mockImplementation(
@@ -1187,6 +1194,162 @@ describe("runMessageAction plugin dispatch", () => {
         },
         "result payload",
       );
+    });
+
+    it("keeps reconnecting a timed-out gateway send with the original idempotency key", async () => {
+      const handleActionResult = vi.fn(async () => jsonResult({ ok: true, local: true }));
+      const gatewayPlugin = createGatewayActionPlugin({
+        pluginId: "gatewaychat",
+        label: "Gateway Chat",
+        blurb: "Gateway Chat timeout reconciliation test plugin.",
+        actions: ["send"],
+        messaging: {
+          targetResolver: {
+            looksLikeId: () => true,
+          },
+        },
+        handleAction: handleActionResult,
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "gatewaychat",
+            source: "test",
+            plugin: gatewayPlugin,
+          },
+        ]),
+      );
+      const timeout = Object.assign(new Error("gateway timeout after 30000ms"), {
+        name: "GatewayTransportError",
+        kind: "timeout",
+      });
+      mocks.callGatewayLeastPrivilege
+        .mockRejectedValueOnce(timeout)
+        .mockRejectedValueOnce(timeout)
+        .mockResolvedValueOnce({ ok: true, messageId: "gw-send-late" });
+      const controller = new AbortController();
+
+      const result = await runMessageAction({
+        cfg: {
+          channels: {
+            gatewaychat: {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "gatewaychat",
+          target: "user-123",
+          message: "hello from agent",
+        },
+        gateway: {
+          clientName: "cli",
+          mode: "cli",
+          timeoutMs: 30_000,
+        },
+        abortSignal: controller.signal,
+        dryRun: false,
+      });
+
+      expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledTimes(3);
+      const firstCall = readMockCallArg(
+        mocks.callGatewayLeastPrivilege,
+        "first gateway least privilege call",
+      );
+      const secondCall = readMockCallArg(
+        mocks.callGatewayLeastPrivilege,
+        "second gateway least privilege call",
+        1,
+      );
+      const thirdCall = readMockCallArg(
+        mocks.callGatewayLeastPrivilege,
+        "third gateway least privilege call",
+        2,
+      );
+      expect(secondCall).toEqual({ ...firstCall, timeoutMs: 60_000 });
+      expect(thirdCall).toEqual(secondCall);
+      const gatewayParams = readRecordField(firstCall, "params", "gateway call params");
+      expectRecordFields(
+        gatewayParams,
+        {
+          channel: "gatewaychat",
+          action: "send",
+          idempotencyKey: "idem-gateway-action",
+        },
+        "gateway call params",
+      );
+      expect(handleActionResult).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        kind: "send",
+        channel: "gatewaychat",
+        action: "send",
+        handledBy: "plugin",
+        payload: { ok: true, messageId: "gw-send-late" },
+      });
+    });
+
+    it("does not reconnect a timed-out gateway send after cancellation", async () => {
+      const handleActionResult = vi.fn(async () => jsonResult({ ok: true, local: true }));
+      const gatewayPlugin = createGatewayActionPlugin({
+        pluginId: "gatewaychat",
+        label: "Gateway Chat",
+        blurb: "Gateway Chat cancellation test plugin.",
+        actions: ["send"],
+        messaging: {
+          targetResolver: {
+            looksLikeId: () => true,
+          },
+        },
+        handleAction: handleActionResult,
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "gatewaychat",
+            source: "test",
+            plugin: gatewayPlugin,
+          },
+        ]),
+      );
+      const controller = new AbortController();
+      const timeout = Object.assign(new Error("gateway timeout after 30000ms"), {
+        name: "GatewayTransportError",
+        kind: "timeout",
+      });
+      mocks.callGatewayLeastPrivilege
+        .mockRejectedValueOnce(timeout)
+        .mockImplementationOnce(async () => {
+          controller.abort();
+          throw timeout;
+        });
+
+      await expect(
+        runMessageAction({
+          cfg: {
+            channels: {
+              gatewaychat: {
+                enabled: true,
+              },
+            },
+          } as OpenClawConfig,
+          action: "send",
+          params: {
+            channel: "gatewaychat",
+            target: "user-123",
+            message: "hello from agent",
+          },
+          gateway: {
+            clientName: "cli",
+            mode: "cli",
+          },
+          abortSignal: controller.signal,
+          dryRun: false,
+        }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+
+      expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledTimes(2);
+      expect(handleActionResult).not.toHaveBeenCalled();
     });
 
     it("preserves gateway send receipts in broadcast results", async () => {

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -1196,98 +1196,107 @@ describe("runMessageAction plugin dispatch", () => {
       );
     });
 
-    it("keeps reconnecting a timed-out gateway send with the original idempotency key", async () => {
-      const handleActionResult = vi.fn(async () => jsonResult({ ok: true, local: true }));
-      const gatewayPlugin = createGatewayActionPlugin({
-        pluginId: "gatewaychat",
-        label: "Gateway Chat",
-        blurb: "Gateway Chat timeout reconciliation test plugin.",
-        actions: ["send"],
-        messaging: {
-          targetResolver: {
-            looksLikeId: () => true,
-          },
-        },
-        handleAction: handleActionResult,
-      });
-      setActivePluginRegistry(
-        createTestRegistry([
-          {
-            pluginId: "gatewaychat",
-            source: "test",
-            plugin: gatewayPlugin,
-          },
-        ]),
-      );
-      const timeout = Object.assign(new Error("gateway timeout after 30000ms"), {
-        name: "GatewayTransportError",
-        kind: "timeout",
-      });
-      mocks.callGatewayLeastPrivilege
-        .mockRejectedValueOnce(timeout)
-        .mockRejectedValueOnce(timeout)
-        .mockResolvedValueOnce({ ok: true, messageId: "gw-send-late" });
-      const controller = new AbortController();
-
-      const result = await runMessageAction({
-        cfg: {
-          channels: {
-            gatewaychat: {
-              enabled: true,
+    it.each([
+      ["a caller-owned deadline", true, null],
+      ["one bounded wait without a caller signal", false, 60_000],
+    ] as const)(
+      "reattaches a timed-out gateway send with %s and the original idempotency key",
+      async (_label, withAbortSignal, expectedTimeoutMs) => {
+        const handleActionResult = vi.fn(async () => jsonResult({ ok: true, local: true }));
+        const gatewayPlugin = createGatewayActionPlugin({
+          pluginId: "gatewaychat",
+          label: "Gateway Chat",
+          blurb: "Gateway Chat timeout reconciliation test plugin.",
+          actions: ["send"],
+          messaging: {
+            targetResolver: {
+              looksLikeId: () => true,
             },
           },
-        } as OpenClawConfig,
-        action: "send",
-        params: {
-          channel: "gatewaychat",
-          target: "user-123",
-          message: "hello from agent",
-        },
-        gateway: {
-          clientName: "cli",
-          mode: "cli",
-          timeoutMs: 30_000,
-        },
-        abortSignal: controller.signal,
-        dryRun: false,
-      });
+          handleAction: handleActionResult,
+        });
+        setActivePluginRegistry(
+          createTestRegistry([
+            {
+              pluginId: "gatewaychat",
+              source: "test",
+              plugin: gatewayPlugin,
+            },
+          ]),
+        );
+        const timeout = Object.assign(new Error("gateway timeout after 30000ms"), {
+          name: "GatewayTransportError",
+          kind: "timeout",
+        });
+        mocks.callGatewayLeastPrivilege
+          .mockRejectedValueOnce(timeout)
+          .mockResolvedValueOnce({ ok: true, messageId: "gw-send-late" });
+        const controller = new AbortController();
 
-      expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledTimes(3);
-      const firstCall = readMockCallArg(
-        mocks.callGatewayLeastPrivilege,
-        "first gateway least privilege call",
-      );
-      const secondCall = readMockCallArg(
-        mocks.callGatewayLeastPrivilege,
-        "second gateway least privilege call",
-        1,
-      );
-      const thirdCall = readMockCallArg(
-        mocks.callGatewayLeastPrivilege,
-        "third gateway least privilege call",
-        2,
-      );
-      expect(secondCall).toEqual({ ...firstCall, timeoutMs: 60_000 });
-      expect(thirdCall).toEqual(secondCall);
-      const gatewayParams = readRecordField(firstCall, "params", "gateway call params");
-      expectRecordFields(
-        gatewayParams,
-        {
+        const result = await runMessageAction({
+          cfg: {
+            channels: {
+              gatewaychat: {
+                enabled: true,
+              },
+            },
+          } as OpenClawConfig,
+          action: "send",
+          params: {
+            channel: "gatewaychat",
+            target: "user-123",
+            message: "hello from agent",
+          },
+          gateway: {
+            clientName: "cli",
+            mode: "cli",
+            timeoutMs: 30_000,
+          },
+          abortSignal: withAbortSignal ? controller.signal : undefined,
+          dryRun: false,
+        });
+
+        expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledTimes(2);
+        const firstCall = readMockCallArg(
+          mocks.callGatewayLeastPrivilege,
+          "first gateway least privilege call",
+        );
+        const secondCall = readMockCallArg(
+          mocks.callGatewayLeastPrivilege,
+          "second gateway least privilege call",
+          1,
+        );
+        expect(secondCall).toMatchObject({
+          ...firstCall,
+          timeoutMs: expectedTimeoutMs,
+          signal: withAbortSignal ? expect.any(AbortSignal) : undefined,
+        });
+        if (withAbortSignal) {
+          expect(secondCall.signal).toBeInstanceOf(AbortSignal);
+          expect(secondCall.signal).not.toBe(firstCall.signal);
+        } else {
+          expect(secondCall.signal).toBeUndefined();
+        }
+        const gatewayParams = readRecordField(firstCall, "params", "gateway call params");
+        expectRecordFields(
+          gatewayParams,
+          {
+            channel: "gatewaychat",
+            action: "send",
+            idempotencyKey: "idem-gateway-action",
+          },
+          "gateway call params",
+        );
+        expect(handleActionResult).not.toHaveBeenCalled();
+        expect(result).toMatchObject({
+          kind: "send",
           channel: "gatewaychat",
           action: "send",
-          idempotencyKey: "idem-gateway-action",
-        },
-        "gateway call params",
-      );
-      expect(handleActionResult).not.toHaveBeenCalled();
-      expect(result).toMatchObject({
-        kind: "send",
-        channel: "gatewaychat",
-        action: "send",
-        handledBy: "plugin",
-        payload: { ok: true, messageId: "gw-send-late" },
-      });
-    });
+          handledBy: "plugin",
+          payload: { ok: true, messageId: "gw-send-late" },
+        });
+      },
+    );
 
     it("does not reconnect a timed-out gateway send after cancellation", async () => {
       const handleActionResult = vi.fn(async () => jsonResult({ ok: true, local: true }));
@@ -1319,9 +1328,10 @@ describe("runMessageAction plugin dispatch", () => {
       });
       mocks.callGatewayLeastPrivilege
         .mockRejectedValueOnce(timeout)
-        .mockImplementationOnce(async () => {
+        .mockImplementationOnce(async (call: { signal?: AbortSignal }) => {
           controller.abort();
-          throw timeout;
+          expect(call.signal?.aborted).toBe(true);
+          throw Object.assign(new Error("gateway request aborted"), { name: "AbortError" });
         });
 
       await expect(

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -1196,107 +1196,122 @@ describe("runMessageAction plugin dispatch", () => {
       );
     });
 
-    it.each([
-      ["a caller-owned deadline", true, null],
-      ["one bounded wait without a caller signal", false, 60_000],
-    ] as const)(
-      "reattaches a timed-out gateway send with %s and the original idempotency key",
-      async (_label, withAbortSignal, expectedTimeoutMs) => {
-        const handleActionResult = vi.fn(async () => jsonResult({ ok: true, local: true }));
-        const gatewayPlugin = createGatewayActionPlugin({
-          pluginId: "gatewaychat",
-          label: "Gateway Chat",
-          blurb: "Gateway Chat timeout reconciliation test plugin.",
-          actions: ["send"],
-          messaging: {
-            targetResolver: {
-              looksLikeId: () => true,
-            },
+    it("reattaches a timed-out gateway send once with the original idempotency key", async () => {
+      const handleActionResult = vi.fn(async () => jsonResult({ ok: true, local: true }));
+      const gatewayPlugin = createGatewayActionPlugin({
+        pluginId: "gatewaychat",
+        label: "Gateway Chat",
+        blurb: "Gateway Chat timeout reconciliation test plugin.",
+        actions: ["send"],
+        messaging: {
+          targetResolver: {
+            looksLikeId: () => true,
           },
-          handleAction: handleActionResult,
-        });
-        setActivePluginRegistry(
-          createTestRegistry([
-            {
-              pluginId: "gatewaychat",
-              source: "test",
-              plugin: gatewayPlugin,
-            },
-          ]),
-        );
-        const timeout = Object.assign(new Error("gateway timeout after 30000ms"), {
-          name: "GatewayTransportError",
-          kind: "timeout",
-        });
-        mocks.callGatewayLeastPrivilege
-          .mockRejectedValueOnce(timeout)
-          .mockResolvedValueOnce({ ok: true, messageId: "gw-send-late" });
-        const controller = new AbortController();
-
-        const result = await runMessageAction({
-          cfg: {
-            channels: {
-              gatewaychat: {
-                enabled: true,
-              },
-            },
-          } as OpenClawConfig,
-          action: "send",
-          params: {
-            channel: "gatewaychat",
-            target: "user-123",
-            message: "hello from agent",
-          },
-          gateway: {
-            clientName: "cli",
-            mode: "cli",
-            timeoutMs: 30_000,
-          },
-          abortSignal: withAbortSignal ? controller.signal : undefined,
-          dryRun: false,
-        });
-
-        expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledTimes(2);
-        const firstCall = readMockCallArg(
-          mocks.callGatewayLeastPrivilege,
-          "first gateway least privilege call",
-        );
-        const secondCall = readMockCallArg(
-          mocks.callGatewayLeastPrivilege,
-          "second gateway least privilege call",
-          1,
-        );
-        expect(secondCall).toMatchObject({
-          ...firstCall,
-          timeoutMs: expectedTimeoutMs,
-          signal: withAbortSignal ? expect.any(AbortSignal) : undefined,
-        });
-        if (withAbortSignal) {
-          expect(secondCall.signal).toBeInstanceOf(AbortSignal);
-          expect(secondCall.signal).not.toBe(firstCall.signal);
-        } else {
-          expect(secondCall.signal).toBeUndefined();
-        }
-        const gatewayParams = readRecordField(firstCall, "params", "gateway call params");
-        expectRecordFields(
-          gatewayParams,
+        },
+        handleAction: handleActionResult,
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
           {
-            channel: "gatewaychat",
-            action: "send",
-            idempotencyKey: "idem-gateway-action",
+            pluginId: "gatewaychat",
+            source: "test",
+            plugin: gatewayPlugin,
           },
-          "gateway call params",
-        );
-        expect(handleActionResult).not.toHaveBeenCalled();
-        expect(result).toMatchObject({
-          kind: "send",
+        ]),
+      );
+      const timeout = Object.assign(new Error("gateway timeout after 30000ms"), {
+        name: "GatewayTransportError",
+        kind: "timeout",
+      });
+      mocks.callGatewayLeastPrivilege
+        .mockRejectedValueOnce(timeout)
+        .mockResolvedValueOnce({ ok: true, messageId: "gw-send-late" });
+      const controller = new AbortController();
+
+      const actionInput = {
+        cfg: {
+          channels: {
+            gatewaychat: {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "gatewaychat",
+          target: "user-123",
+          message: "hello from agent",
+        },
+        gateway: {
+          clientName: "cli",
+          mode: "cli",
+          timeoutMs: 30_000,
+        },
+        dryRun: false,
+      } satisfies Parameters<typeof runMessageAction>[0];
+      const result = await runMessageAction({ ...actionInput, abortSignal: controller.signal });
+
+      expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledTimes(2);
+      const firstCall = readMockCallArg(
+        mocks.callGatewayLeastPrivilege,
+        "first gateway least privilege call",
+      );
+      const secondCall = readMockCallArg(
+        mocks.callGatewayLeastPrivilege,
+        "second gateway least privilege call",
+        1,
+      );
+      expect(secondCall).toMatchObject({
+        ...firstCall,
+        timeoutMs: null,
+        signal: expect.any(AbortSignal),
+      });
+      expect(secondCall.signal).toBeInstanceOf(AbortSignal);
+      expect(secondCall.signal).not.toBe(firstCall.signal);
+      const gatewayParams = readRecordField(firstCall, "params", "gateway call params");
+      expectRecordFields(
+        gatewayParams,
+        {
           channel: "gatewaychat",
           action: "send",
-          handledBy: "plugin",
-          payload: { ok: true, messageId: "gw-send-late" },
-        });
-      },
-    );
+          idempotencyKey: "idem-gateway-action",
+        },
+        "gateway call params",
+      );
+      expect(handleActionResult).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        kind: "send",
+        channel: "gatewaychat",
+        action: "send",
+        handledBy: "plugin",
+        payload: { ok: true, messageId: "gw-send-late" },
+      });
+
+      mocks.callGatewayLeastPrivilege.mockReset();
+      mocks.callGatewayLeastPrivilege
+        .mockRejectedValueOnce(timeout)
+        .mockResolvedValueOnce({ ok: true, messageId: "gw-send-bounded" });
+
+      const boundedResult = await runMessageAction(actionInput);
+
+      expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledTimes(2);
+      const boundedReconciliationCall = readMockCallArg(
+        mocks.callGatewayLeastPrivilege,
+        "bounded gateway reconciliation call",
+        1,
+      );
+      expect(boundedReconciliationCall).toMatchObject({ timeoutMs: 60_000, signal: undefined });
+      const boundedParams = readRecordField(
+        boundedReconciliationCall,
+        "params",
+        "bounded gateway reconciliation params",
+      );
+      expect(boundedParams.idempotencyKey).toBe("idem-gateway-action");
+      expect(boundedResult).toMatchObject({
+        kind: "send",
+        payload: { ok: true, messageId: "gw-send-bounded" },
+      });
+    });
 
     it("does not reconnect a timed-out gateway send after cancellation", async () => {
       const handleActionResult = vi.fn(async () => jsonResult({ ok: true, local: true }));

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -221,6 +221,7 @@ function resolveGatewayActionOptions(gateway?: MessageActionRunnerGateway) {
 
 const MESSAGE_ACTION_RECONCILIATION_TIMEOUT_MS = 60_000;
 const MESSAGE_ACTION_RECONCILIATION_MAX_MS = 9 * 60_000;
+const MESSAGE_ACTION_INITIAL_SEND_TIMEOUT_MAX_MS = 30_000;
 
 async function callGatewayMessageAction<T>(params: {
   gateway?: MessageActionRunnerGateway;
@@ -231,12 +232,18 @@ async function callGatewayMessageAction<T>(params: {
     await loadMessageActionGatewayRuntime();
   const gateway = resolveGatewayActionOptions(params.gateway);
   const agentRuntimeIdentityToken = await params.gateway?.resolveAgentRuntimeIdentityToken?.();
+  // A timed-out send is reattached with the same idempotency key. Cap only the
+  // initial wait so the 9-minute join remains inside Codex's 10-minute tool envelope.
+  const timeoutMs =
+    params.actionParams.action === "send"
+      ? Math.min(gateway.timeoutMs, MESSAGE_ACTION_INITIAL_SEND_TIMEOUT_MAX_MS)
+      : gateway.timeoutMs;
   const call = {
     url: gateway.url,
     token: gateway.token,
     method: "message.action",
     params: params.actionParams,
-    timeoutMs: gateway.timeoutMs,
+    timeoutMs,
     signal: params.abortSignal,
     clientName: gateway.clientName,
     clientDisplayName: gateway.clientDisplayName,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -219,24 +219,58 @@ function resolveGatewayActionOptions(gateway?: MessageActionRunnerGateway) {
   return resolveOutboundMessageGatewayOptions(gateway);
 }
 
+const MESSAGE_ACTION_RECONCILIATION_TIMEOUT_MS = 60_000;
+
 async function callGatewayMessageAction<T>(params: {
   gateway?: MessageActionRunnerGateway;
   actionParams: Record<string, unknown>;
+  abortSignal?: AbortSignal;
 }): Promise<T> {
-  const { callGatewayLeastPrivilege } = await loadMessageActionGatewayRuntime();
+  const { callGatewayLeastPrivilege, isGatewayTransportError } =
+    await loadMessageActionGatewayRuntime();
   const gateway = resolveGatewayActionOptions(params.gateway);
   const agentRuntimeIdentityToken = await params.gateway?.resolveAgentRuntimeIdentityToken?.();
-  return await callGatewayLeastPrivilege<T>({
+  const call = {
     url: gateway.url,
     token: gateway.token,
     method: "message.action",
     params: params.actionParams,
     timeoutMs: gateway.timeoutMs,
+    signal: params.abortSignal,
     clientName: gateway.clientName,
     clientDisplayName: gateway.clientDisplayName,
     mode: gateway.mode,
     agentRuntimeIdentityToken,
-  });
+  };
+  try {
+    return await callGatewayLeastPrivilege<T>(call);
+  } catch (error) {
+    if (!isGatewayTransportError(error) || error.kind !== "timeout") {
+      throw error;
+    }
+    throwIfAborted(params.abortSignal);
+  }
+
+  const reconciliationCall = {
+    ...call,
+    timeoutMs: Math.max(call.timeoutMs, MESSAGE_ACTION_RECONCILIATION_TIMEOUT_MS),
+  };
+  // A caller-side timeout does not cancel Gateway work. When the caller owns a
+  // cancellation lifecycle, keep reattaching with the same idempotency key so
+  // a late delivery is not shown to the model as a failure it may resend.
+  for (;;) {
+    try {
+      return await callGatewayLeastPrivilege<T>(reconciliationCall);
+    } catch (error) {
+      if (!isGatewayTransportError(error) || error.kind !== "timeout") {
+        throw error;
+      }
+      if (!params.abortSignal) {
+        throw error;
+      }
+      throwIfAborted(params.abortSignal);
+    }
+  }
 }
 
 async function resolveGatewayActionIdempotencyKey(idempotencyKey?: string): Promise<string> {
@@ -690,6 +724,7 @@ async function runGatewayPluginMessageActionOrNull(params: {
   );
   const payload = await callGatewayMessageAction<unknown>({
     gateway: params.gateway,
+    abortSignal: params.input.abortSignal,
     actionParams: {
       channel: params.channel,
       action: params.action,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -220,6 +220,7 @@ function resolveGatewayActionOptions(gateway?: MessageActionRunnerGateway) {
 }
 
 const MESSAGE_ACTION_RECONCILIATION_TIMEOUT_MS = 60_000;
+const MESSAGE_ACTION_RECONCILIATION_MAX_MS = 9 * 60_000;
 
 async function callGatewayMessageAction<T>(params: {
   gateway?: MessageActionRunnerGateway;
@@ -245,32 +246,35 @@ async function callGatewayMessageAction<T>(params: {
   try {
     return await callGatewayLeastPrivilege<T>(call);
   } catch (error) {
-    if (!isGatewayTransportError(error) || error.kind !== "timeout") {
+    if (
+      !isGatewayTransportError(error) ||
+      error.kind !== "timeout" ||
+      params.actionParams.action !== "send"
+    ) {
       throw error;
     }
     throwIfAborted(params.abortSignal);
   }
 
+  const reconciliationSignal = params.abortSignal
+    ? AbortSignal.any([
+        params.abortSignal,
+        AbortSignal.timeout(MESSAGE_ACTION_RECONCILIATION_MAX_MS),
+      ])
+    : undefined;
   const reconciliationCall = {
     ...call,
-    timeoutMs: Math.max(call.timeoutMs, MESSAGE_ACTION_RECONCILIATION_TIMEOUT_MS),
+    // `null` keeps startup bounded but removes the per-request timer after
+    // hello. The dedicated signal bounds a joined in-flight action without
+    // reconnecting every minute or inheriting the run's much longer lifetime.
+    timeoutMs: params.abortSignal
+      ? null
+      : Math.max(call.timeoutMs, MESSAGE_ACTION_RECONCILIATION_TIMEOUT_MS),
+    signal: reconciliationSignal,
   };
-  // A caller-side timeout does not cancel Gateway work. When the caller owns a
-  // cancellation lifecycle, keep reattaching with the same idempotency key so
-  // a late delivery is not shown to the model as a failure it may resend.
-  for (;;) {
-    try {
-      return await callGatewayLeastPrivilege<T>(reconciliationCall);
-    } catch (error) {
-      if (!isGatewayTransportError(error) || error.kind !== "timeout") {
-        throw error;
-      }
-      if (!params.abortSignal) {
-        throw error;
-      }
-      throwIfAborted(params.abortSignal);
-    }
-  }
+  // A caller-side timeout does not cancel Gateway work. Reattach once with the
+  // unchanged idempotency key so the live Gateway can join the original work.
+  return await callGatewayLeastPrivilege<T>(reconciliationCall);
 }
 
 async function resolveGatewayActionIdempotencyKey(idempotencyKey?: string): Promise<string> {

--- a/src/infra/outbound/message.gateway.runtime.ts
+++ b/src/infra/outbound/message.gateway.runtime.ts
@@ -2,5 +2,6 @@
 export {
   callGateway,
   callGatewayLeastPrivilege,
+  isGatewayTransportError,
   randomIdempotencyKey,
 } from "../../gateway/call.js";


### PR DESCRIPTION
Related: #80177
Related: #102179

## What Problem This Solves

Fixes duplicate channel replies when a Gateway-backed `message(action=send)` exceeds the client deadline but succeeds later. The model can otherwise see a tool failure, compose a paraphrased retry, and make both deliveries visible. This was observed on Telegram after upgrading from an OpenClaw 2026.6.10 control window to the 2026.7.1 beta line.

## Why This Change Was Made

On `GatewayTransportError(kind="timeout")` only, `send` reattaches once to the unchanged `message.action` payload and idempotency key. The Gateway already joins same-key in-flight work and caches its completed result, so reconciliation observes the original action instead of dispatching another one.

For agent calls with an abort signal, the reattachment has its own nine-minute deadline and still respects caller cancellation. The initial `send` wait is capped at 30 seconds, keeping transport plus reconciliation inside Codex's ten-minute outer watchdog even when a larger `timeoutMs` is supplied. Calls without a cancellation lifecycle use one bounded 60-second fallback attempt. There is no unbounded retry loop, non-`send` actions are unchanged, and definitive errors still return immediately.

This is intentionally a process-local mitigation: it relies on the live Gateway's in-flight join/cache and does not claim exactly-once delivery across Gateway restarts.

## User Impact

Agents wait for the original delivery result instead of treating an ambiguous client timeout as an immediate send failure. This closes the timeout -> late success -> paraphrased duplicate path without lengthening normal sends or changing channel configuration.

## Evidence

- Sanitized production evidence in the related items shows a first `message(action=send)` timing out after 30 seconds, the Gateway later recording the Telegram send as successful, and a paraphrased second send following.
- Focused regression coverage verifies a timed-out send reattaches exactly once with the same idempotency key, caller cancellation prevents reattachment, no-signal calls remain bounded, and a configured 120-second transport timeout is capped to preserve the total deadline.
- `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.plugin-dispatch.test.ts extensions/codex/src/app-server/dynamic-tool-execution.test.ts -- --reporter=dot` — 37/37 outbound and 26/26 Codex tests passed.
- `node scripts/run-vitest.mjs src/gateway/server-methods/send.test.ts` — 138/138 passed, including the same-key in-flight join contract.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings (0.89 confidence on the final timeout-cap patch).
- A redacted current-head Telegram live-proof request has been submitted to Mantis and remains pending.
- AI-assisted. No private message content, chat identifiers, or credentials are included.
