### PR TITLE
fix(mcp): timeout flags treat hexadecimal input as seconds

### DIFF
--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -161,6 +161,44 @@ describe("mcp cli", () => {
     });
   });
 
+  it("rejects hexadecimal MCP timeout options before writing configuration", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async (home) => {
+      const workspaceDir = await createWorkspace();
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await expect(
+        runMcpCommand([
+          "mcp",
+          "add",
+          "docs",
+          "--url",
+          "https://mcp.example.com/mcp",
+          "--timeout",
+          "0x10",
+          "--no-probe",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+      expect(lastErrorLine()).toBe("--timeout must be a positive number.");
+      await expect(fs.readFile(configPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
+      await runMcpCommand(["mcp", "set", "docs", '{"url":"https://mcp.example.com","timeout":12}']);
+      mockError.mockClear();
+
+      await expect(
+        runMcpCommand(["mcp", "configure", "docs", "--connect-timeout", "0x3"]),
+      ).rejects.toThrow("__exit__:1");
+      expect(lastErrorLine()).toBe("--connect-timeout must be a positive number.");
+
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "show", "docs", "--json"]);
+      expect(JSON.parse(lastLogLine())).toEqual({
+        url: "https://mcp.example.com",
+        timeout: 12,
+      });
+    });
+  });
+
   it("labels listed MCP servers as OpenClaw-managed", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -2,6 +2,7 @@
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringifiedOptionalString,
@@ -83,8 +84,8 @@ function parsePositiveNumberOption(value: string | undefined, label: string): nu
   if (value === undefined) {
     return undefined;
   }
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  const parsed = parseStrictFiniteNumber(value);
+  if (parsed === undefined || parsed <= 0) {
     fail(`${label} must be a positive number.`);
   }
   return parsed;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators using `openclaw mcp add` or `openclaw mcp configure`
could pass hexadecimal timeout strings such as `0x10` and have them silently saved
as 16 seconds, even though the CLI exposes these options as positive numbers of
seconds.

## Why This Change Was Made

The MCP CLI now validates `--timeout` and `--connect-timeout` with OpenClaw's shared
strict finite-number token parser before either configuration command can write.
This is the common owner for both flags in both commands, so the fix rejects
non-decimal syntax at the input boundary instead of adding a downstream config or
runtime special case.

Positive decimal and scientific-notation values remain supported. Direct JSON MCP
configuration, timeout field names and aliases, schema validation, defaults, and
runtime seconds-to-milliseconds conversion are unchanged.

## User Impact

Operators now receive a clear validation error for hexadecimal timeout input, and
an invalid `mcp add` or `mcp configure` command leaves configuration unchanged.
Valid decimal timeout values continue to persist and resolve to the same runtime
budgets.

## Evidence

- Stock pinned main (`702ba19e3aba`) accepted
  `--timeout 0x10 --connect-timeout 0x3`; `mcp show` then reported `timeout: 16`
  and `connectTimeout: 3`.
- Current-head production CLI-handler proof used an isolated real config writer and
  runtime status resolver:

  ```json
  {
    "invalidAddRejectedBeforeWrite": true,
    "invalidConfigureRejectedWithoutMutation": true,
    "decimalTimeoutSeconds": 12,
    "decimalConnectTimeoutSeconds": 3,
    "resolvedRequestTimeoutMs": 12000,
    "resolvedConnectionTimeoutMs": 3000
  }
  ```

- Full owning CLI test file: 1 file passed, 25 tests passed. The regression covers
  `mcp add --timeout 0x10` failing before the first config write and
  `mcp configure --connect-timeout 0x3` preserving an existing server config.
- `node scripts/run-oxlint.mjs src/cli/mcp-cli.ts src/cli/mcp-cli.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm exec oxfmt --check --threads=1 src/cli/mcp-cli.ts src/cli/mcp-cli.test.ts`
- `pnpm build`

Impact-surface review traced raw Commander values through the MCP config writers and
the runtime timeout resolver, and checked sibling CLI numeric parsers. Gateway or
external MCP connectivity is not applicable to this bug because the affected path
is local CLI parsing before probe or dispatch. A fresh open-PR search found no PR
covering hexadecimal MCP timeout parsing; the open MCP OAuth timeout work applies
already-configured budgets to network requests and does not overlap this behavior.

Fix classification: root cause fix. No schema, default, migration, protocol, or
provider behavior changes.
