### PR TITLE
fix(qqbot): share passive reply budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **QQ Bot reply budgets:** count typing, channel sends, and gateway static-final delivery against one five-request passive-reply budget, then use the existing proactive fallback instead of letting long turns hit QQ error `22009`.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **QQ Bot reply budgets:** count typing, channel sends, and gateway static-final delivery against one five-request passive-reply budget, then use the existing proactive fallback instead of letting long turns hit QQ error `22009`.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/extensions/qqbot/src/__traces__/budget-exhaustion.trace.jsonl
+++ b/extensions/qqbot/src/__traces__/budget-exhaustion.trace.jsonl
@@ -6,13 +6,13 @@
 {"seq":6,"at":20000,"dir":"in","kind":"tool-progress","data":{"name":"message","phase":"result"}}
 {"seq":7,"at":20000,"dir":"out","kind":"POST /v2/users/user-openid-trace/messages","data":{"payload":{"content":"Reply 1 via message tool","msg_id":"qq-msg-budget-exhaustion","msg_seq":5,"msg_type":0},"result":{"id":"wire-msg-5","timestamp":"2026-01-01T00:00:00.000Z"}}}
 {"seq":8,"at":20000,"dir":"in","kind":"tool-progress","data":{"name":"message","phase":"result"}}
-{"seq":9,"at":20000,"dir":"out","kind":"POST /v2/users/user-openid-trace/messages","data":{"payload":{"content":"Reply 2 via message tool","msg_id":"qq-msg-budget-exhaustion","msg_seq":6,"msg_type":0},"result":{"id":"wire-msg-6","timestamp":"2026-01-01T00:00:00.000Z"}}}
+{"seq":9,"at":20000,"dir":"out","kind":"POST /v2/users/user-openid-trace/messages","data":{"payload":{"content":"Reply 2 via message tool","msg_type":0},"result":{"id":"wire-msg-6","timestamp":"2026-01-01T00:00:00.000Z"}}}
 {"seq":10,"at":20000,"dir":"in","kind":"tool-progress","data":{"name":"message","phase":"result"}}
-{"seq":11,"at":20000,"dir":"out","kind":"POST /v2/users/user-openid-trace/messages","data":{"payload":{"content":"Reply 3 via message tool","msg_id":"qq-msg-budget-exhaustion","msg_seq":7,"msg_type":0},"result":{"id":"wire-msg-7","timestamp":"2026-01-01T00:00:00.000Z"}}}
+{"seq":11,"at":20000,"dir":"out","kind":"POST /v2/users/user-openid-trace/messages","data":{"payload":{"content":"Reply 3 via message tool","msg_type":0},"result":{"id":"wire-msg-7","timestamp":"2026-01-01T00:00:00.000Z"}}}
 {"seq":12,"at":20000,"dir":"in","kind":"tool-progress","data":{"name":"message","phase":"result"}}
-{"seq":13,"at":20000,"dir":"out","kind":"POST /v2/users/user-openid-trace/messages","data":{"payload":{"content":"Reply 4 via message tool","msg_id":"qq-msg-budget-exhaustion","msg_seq":8,"msg_type":0},"result":{"id":"wire-msg-8","timestamp":"2026-01-01T00:00:00.000Z"}}}
+{"seq":13,"at":20000,"dir":"out","kind":"POST /v2/users/user-openid-trace/messages","data":{"payload":{"content":"Reply 4 via message tool","msg_type":0},"result":{"id":"wire-msg-8","timestamp":"2026-01-01T00:00:00.000Z"}}}
 {"seq":14,"at":20000,"dir":"in","kind":"tool-progress","data":{"name":"message","phase":"result"}}
 {"seq":15,"at":20000,"dir":"out","kind":"POST /v2/users/user-openid-trace/messages","data":{"payload":{"content":"Reply 5 via message tool","msg_type":0},"result":{"id":"wire-msg-9","timestamp":"2026-01-01T00:00:00.000Z"}}}
 {"seq":16,"at":20000,"dir":"in","kind":"final","data":{"text":"Budget check complete."}}
-{"seq":17,"at":20000,"dir":"out","kind":"POST /v2/users/user-openid-trace/messages","data":{"payload":{"content":"Budget check complete.","msg_id":"qq-msg-budget-exhaustion","msg_seq":9,"msg_type":0},"result":{"id":"wire-msg-10","timestamp":"2026-01-01T00:00:00.000Z"}}}
+{"seq":17,"at":20000,"dir":"out","kind":"POST /v2/users/user-openid-trace/messages","data":{"payload":{"content":"Budget check complete.","msg_type":0},"result":{"id":"wire-msg-10","timestamp":"2026-01-01T00:00:00.000Z"}}}
 {"seq":18,"at":20000,"dir":"in","kind":"idle"}

--- a/extensions/qqbot/src/delivery-trace.test.ts
+++ b/extensions/qqbot/src/delivery-trace.test.ts
@@ -6,9 +6,9 @@
 // reply budget accounting (engine/gateway/typing-keepalive.ts +
 // gateway.ts startTypingForEvent), the static block-deliver pipeline
 // (engine/gateway/outbound-dispatch.ts deliver wiring →
-// engine/messaging/outbound-deliver.ts), and the budget-limited channel
-// outbound send path (engine/messaging/outbound.ts sendText with
-// ReplyLimiter proactive fallback) — against a recording ApiClient mock, so
+// engine/messaging/outbound-deliver.ts), and the common budget-limited sender
+// path (engine/messaging/sender.ts text/media sends with ReplyLimiter proactive
+// fallback) — against a recording ApiClient mock, so
 // OUT events are the raw QQ Open Platform HTTP calls. Every wire call that
 // carries `msg_id` + `msg_seq` spends QQ's ≤5-per-msg_id passive reply
 // budget; typing renewals count against it, which is the point of this
@@ -22,10 +22,6 @@
 //   that re-sends the accumulated partial text unchanged (abortStreaming only
 //   runs when finalization throws, and performFlush/finalize have no dirty
 //   check against the last sent chunk).
-// - The gateway deliver/static-final path sends passive replies via
-//   sender.sendText directly and never consults the ReplyLimiter; only the
-//   channel outbound path (outbound.ts sendText) has the proactive fallback,
-//   so typing spends + tool sends + final can exceed QQ's server budget.
 // Refresh goldens with OPENCLAW_TRACE_UPDATE=1 (see delivery-trace harness docs).
 import {
   deliveryTraceScenarios,
@@ -37,7 +33,7 @@ import {
   type WireRecorder,
 } from "openclaw/plugin-sdk/channel-contract-testing";
 import { chunkMarkdownText } from "openclaw/plugin-sdk/reply-runtime";
-import { describe, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { TYPING_INPUT_SECOND, TypingKeepAlive } from "./engine/gateway/typing-keepalive.js";
 import { createQQBotMarkdownChunker } from "./engine/messaging/markdown-table-chunking.js";
 import {
@@ -46,6 +42,7 @@ import {
   TEXT_CHUNK_LIMIT,
   type DeliverDeps,
 } from "./engine/messaging/outbound-deliver.js";
+import { checkMessageReplyLimit, claimMessageReply } from "./engine/messaging/outbound-reply.js";
 import {
   sendDocument,
   sendMedia as sendOutboundMedia,
@@ -256,8 +253,8 @@ function setupQqbotTrace(recorder: WireRecorder, msgId: string) {
   // Replica of the outbound-dispatch.ts block-deliver wiring for a visible
   // final payload (silent/media-only gates and group-skip branches are not
   // exercised by these scripts). Deliver-first finals lock the controller and
-  // fall back to the static passive send path — which never consults the
-  // ReplyLimiter (AS-IS budget wart pinned by the budget-exhaustion golden).
+  // fall back to the static sender path, which shares the same passive budget
+  // and proactive fallback as channel outbound sends.
   const deliverFinal = async (payload: {
     text?: string;
     mediaUrls?: string[];
@@ -302,8 +299,8 @@ function setupQqbotTrace(recorder: WireRecorder, msgId: string) {
 
   // tool-progress "result" steps stand in for message-tool sends replying to
   // the same inbound message. Those ride the channel outbound seam
-  // (channel.ts sendText → outbound.ts sendText), the only path that consults
-  // the ReplyLimiter (4 passive replies per msg_id, then proactive fallback).
+  // (channel.ts sendText → outbound.ts sendText → sender.ts sendText), which
+  // shares one five-request budget with typing and static final delivery.
   let toolSendCount = 0;
   const sendViaChannelOutbound = async () => {
     toolSendCount += 1;
@@ -321,6 +318,10 @@ function setupQqbotTrace(recorder: WireRecorder, msgId: string) {
         // Replica of gateway.ts startTypingForEvent: initial input_notify
         // (first budget spend), then the keepalive loop with
         // TYPING_RENEWAL_LIMIT renewals reserving one reply for the final.
+        const passive = claimMessageReply(msgId, 1);
+        if (!passive.allowed) {
+          break;
+        }
         await sendInputNotify({
           openid: OPENID,
           creds: accountToCreds(account),
@@ -400,10 +401,9 @@ const QQBOT_TRACE_SCENARIOS: readonly DeliveryTraceScenario[] = [
   qqbotScenario("streaming-happy-c2c", deliveryTraceScenarios["streaming-happy"].steps),
   // Budget lifecycle against one msg_id: initial input_notify plus exactly
   // TYPING_RENEWAL_LIMIT (3) renewals, then a renewal-free tick proving the
-  // reserved final reply; five message-tool sends where the ReplyLimiter
-  // allows 4 passive replies and falls back to a proactive body (no
-  // msg_id/msg_seq) for the fifth; and a static final that still sends
-  // passively because the deliver path never consults the limiter (AS-IS).
+  // reserved final reply; five message-tool sends where only the first can
+  // claim the fifth passive slot; then a static final. Every later text send
+  // falls back to a proactive body without msg_id/msg_seq.
   qqbotScenario("budget-exhaustion", [
     { kind: "reply-start" },
     { kind: "advance", ms: 5000 },
@@ -435,20 +435,40 @@ const QQBOT_TRACE_SCENARIOS: readonly DeliveryTraceScenario[] = [
   ]),
 ];
 
+const EXPECTED_REPLY_BUDGET_REMAINING: Readonly<Record<string, number>> = {
+  "streaming-happy-c2c": 3,
+  "budget-exhaustion": 0,
+  "media-interrupt": 1,
+};
+
 describe("qqbot delivery trace goldens", () => {
   for (const scenario of QQBOT_TRACE_SCENARIOS) {
-    it(`records ${scenario.name}`, async () => {
+    const scenarioName = scenario.name;
+    it(`records ${scenarioName}`, async () => {
+      const msgId = `qq-msg-${scenarioName}`;
       try {
         const events = await runDeliveryTraceScenario({
           scenario,
           // Distinct msg_id per scenario keeps the module-global ReplyLimiter
           // and upload caches from leaking budget state across scenarios.
-          setup: (recorder) => setupQqbotTrace(recorder, `qq-msg-${scenario.name}`),
+          setup: (recorder) => setupQqbotTrace(recorder, msgId),
         });
         expectDeliveryTraceMatchesGolden({
-          goldenUrl: new URL(`./__traces__/${scenario.name}.trace.jsonl`, import.meta.url),
+          goldenUrl: new URL(`./__traces__/${scenarioName}.trace.jsonl`, import.meta.url),
           events,
         });
+        const expectedRemaining = EXPECTED_REPLY_BUDGET_REMAINING[scenarioName];
+        if (expectedRemaining !== undefined) {
+          const finalOffsetMs = events.at(-1)?.at ?? 0;
+          vi.useFakeTimers({ now: Date.UTC(2026, 0, 1) + finalOffsetMs });
+          try {
+            // Each stream session and media message consumes one shared slot;
+            // uploads and later chunks within a session do not.
+            expect(checkMessageReplyLimit(msgId).remaining).toBe(expectedRemaining);
+          } finally {
+            vi.useRealTimers();
+          }
+        }
       } finally {
         wire.recorder = null;
       }

--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -9,6 +9,7 @@ import { initCommands } from "../commands/slash-commands-impl.js";
 import { resolveGroupCommandLevelFromAccountConfig } from "../config/group.js";
 import { createNodeSessionStoreReader } from "../group/activation.js";
 import type { HistoryEntry } from "../group/history.js";
+import { claimMessageReply } from "../messaging/outbound-reply.js";
 import { setOutboundAudioPort } from "../messaging/outbound.js";
 import {
   clearTokenCache,
@@ -288,6 +289,13 @@ async function startTypingForEvent(
     const creds = accountToCreds(account);
     const rawNotifyFn = createRawInputNotifyFn(account.appId);
     const sendNotifyAndStartKeepAlive = async () => {
+      // Typing and text share QQ's five passive calls. Keep one slot for the
+      // final reply. The claim stays inside this retried closure so each wire
+      // attempt consumes its own slot.
+      const passive = claimMessageReply(event.messageId, 1);
+      if (!passive.allowed) {
+        return { keepAlive: null };
+      }
       const resp = await senderSendInputNotify({
         openid: event.senderId,
         creds,

--- a/extensions/qqbot/src/engine/gateway/typing-keepalive.test.ts
+++ b/extensions/qqbot/src/engine/gateway/typing-keepalive.test.ts
@@ -1,6 +1,13 @@
 // Qqbot tests cover typing keepalive plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReplyLimiter } from "../messaging/reply-limiter.js";
 import { TypingKeepAlive, TYPING_INPUT_SECOND, TYPING_RENEWAL_LIMIT } from "./typing-keepalive.js";
+
+function createTypingClaim(messageId: string) {
+  const limiter = new ReplyLimiter({ limit: 5 });
+  limiter.record(messageId); // Initial input_notify.
+  return (id: string, reserve: number) => limiter.claim(id, reserve);
+}
 
 describe("TypingKeepAlive", () => {
   afterEach(() => {
@@ -17,6 +24,8 @@ describe("TypingKeepAlive", () => {
       sendInputNotify,
       "openid-1",
       "msg-1",
+      undefined,
+      createTypingClaim("msg-1"),
     );
 
     keepAlive.start();
@@ -43,6 +52,8 @@ describe("TypingKeepAlive", () => {
       sendInputNotify,
       "openid-1",
       "msg-1",
+      undefined,
+      createTypingClaim("msg-1"),
     );
 
     keepAlive.start();
@@ -67,16 +78,18 @@ describe("TypingKeepAlive", () => {
       sendInputNotify,
       "openid-1",
       "msg-1",
+      undefined,
+      createTypingClaim("msg-1"),
     );
 
     keepAlive.start();
 
-    // First tick: the failed attempt and its token-refresh retry both spend budget.
+    // First tick: the failed attempt and its token-refresh retry both claim the shared budget.
     await vi.advanceTimersByTimeAsync(5_000);
     expect(clearCache).toHaveBeenCalledTimes(1);
     expect(sendInputNotify).toHaveBeenCalledTimes(2);
 
-    // Only one renewal remains before the reserved final-reply slot.
+    // Only one renewal attempt remains before the reserved final-reply slot.
     await vi.advanceTimersByTimeAsync(20_000);
     expect(sendInputNotify).toHaveBeenCalledTimes(TYPING_RENEWAL_LIMIT);
   });
@@ -96,6 +109,8 @@ describe("TypingKeepAlive", () => {
       sendInputNotify,
       "openid-1",
       "msg-1",
+      undefined,
+      createTypingClaim("msg-1"),
     );
 
     keepAlive.start();

--- a/extensions/qqbot/src/engine/gateway/typing-keepalive.ts
+++ b/extensions/qqbot/src/engine/gateway/typing-keepalive.ts
@@ -6,6 +6,8 @@
  */
 
 import { createTypingKeepaliveLoop } from "openclaw/plugin-sdk/channel-outbound";
+import { claimMessageReply } from "../messaging/outbound-reply.js";
+import type { ReplyLimitResult } from "../messaging/reply-limiter.js";
 import { formatErrorMessage } from "../utils/format.js";
 
 /** Function that sends a typing indicator to one user. */
@@ -26,7 +28,6 @@ export const TYPING_RENEWAL_LIMIT =
   QQ_C2C_PASSIVE_REPLY_LIMIT - INITIAL_TYPING_NOTIFY_COUNT - FINAL_REPLY_RESERVE_COUNT;
 
 export class TypingKeepAlive {
-  private renewalsRemaining = TYPING_RENEWAL_LIMIT;
   private stopped = false;
   // Core loop owns the interval and in-flight tick suppression; budget
   // accounting in sendAttempt() decides when it must stop for good.
@@ -40,8 +41,12 @@ export class TypingKeepAlive {
     private readonly clearCache: () => void,
     private readonly sendInputNotify: SendInputNotifyFn,
     private readonly openid: string,
-    private readonly msgId: string | undefined,
+    private readonly msgId: string,
     private readonly log?: { debug?: (msg: string) => void },
+    private readonly claimPassiveReply: (
+      messageId: string,
+      reserve: number,
+    ) => ReplyLimitResult = claimMessageReply,
   ) {}
 
   /** Start periodic keep-alive sends. */
@@ -77,19 +82,23 @@ export class TypingKeepAlive {
   }
 
   private async sendAttempt(token: string): Promise<void> {
-    if (this.stopped || this.renewalsRemaining <= 0) {
-      this.stop();
+    if (this.stopped) {
       return;
     }
 
-    // Count attempts, not successes (token-refresh retries included): a failed
-    // call may still consume QQ's msg_id budget, so keep FINAL_REPLY_RESERVE_COUNT safe.
-    this.renewalsRemaining--;
+    // Claim before every wire attempt: a failed request may still have consumed
+    // QQ's msg_id budget, while the final text slot must remain available.
+    const claim = this.claimPassiveReply(this.msgId, FINAL_REPLY_RESERVE_COUNT);
+    if (!claim.allowed) {
+      this.log?.debug?.(`Typing keep-alive budget exhausted for ${this.openid}`);
+      this.stop();
+      return;
+    }
     try {
       await this.sendInputNotify(token, this.openid, this.msgId, TYPING_INPUT_SECOND);
       this.log?.debug?.(`Typing keep-alive sent to ${this.openid}`);
     } finally {
-      if (this.renewalsRemaining <= 0) {
+      if (claim.remaining <= FINAL_REPLY_RESERVE_COUNT) {
         this.log?.debug?.(`Typing keep-alive budget exhausted for ${this.openid}`);
         this.stop();
       }

--- a/extensions/qqbot/src/engine/messaging/outbound-reply.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-reply.ts
@@ -6,7 +6,7 @@ const replyLimiter = new ReplyLimiter();
 
 export type { ReplyLimitResult };
 
-export const MESSAGE_REPLY_LIMIT = 4;
+export const MESSAGE_REPLY_LIMIT = 5;
 
 export function checkMessageReplyLimit(messageId: string): ReplyLimitResult {
   return replyLimiter.checkLimit(messageId);
@@ -17,6 +17,17 @@ export function recordMessageReply(messageId: string): void {
   debugLog(
     `[qqbot] recordMessageReply: ${messageId}, count=${replyLimiter.getStats().totalReplies}`,
   );
+}
+
+/** Reserve one slot before a passive request so concurrent sends share one budget. */
+export function claimMessageReply(messageId: string, reserve = 0): ReplyLimitResult {
+  const result = replyLimiter.claim(messageId, reserve);
+  if (result.allowed) {
+    debugLog(
+      `[qqbot] claimMessageReply: ${messageId}, remaining=${result.remaining}/${MESSAGE_REPLY_LIMIT}`,
+    );
+  }
+  return result;
 }
 
 export function getMessageReplyStats(): { trackedMessages: number; totalReplies: number } {

--- a/extensions/qqbot/src/engine/messaging/outbound.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound.ts
@@ -60,11 +60,6 @@ import {
   sendVideoMsg,
   sendVoice,
 } from "./outbound-media-send.js";
-import {
-  checkMessageReplyLimit,
-  MESSAGE_REPLY_LIMIT,
-  recordMessageReply,
-} from "./outbound-reply.js";
 import type {
   MediaOutboundContext,
   MediaTargetContext,
@@ -94,8 +89,8 @@ const mediaPathDecodeLog = {
  */
 export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
   const { to, account } = ctx;
-  let { text, replyToId } = ctx;
-  let fallbackToProactive = false;
+  const { replyToId } = ctx;
+  let { text } = ctx;
 
   initApiConfig(account.appId, { markdownSupport: account.markdownSupport });
 
@@ -107,32 +102,6 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
       2,
     ),
   );
-
-  if (replyToId) {
-    const limitCheck = checkMessageReplyLimit(replyToId);
-
-    if (!limitCheck.allowed) {
-      if (limitCheck.shouldFallbackToProactive) {
-        debugWarn(
-          `[qqbot] sendText: passive reply unavailable, falling back to proactive send - ${limitCheck.message}`,
-        );
-        fallbackToProactive = true;
-        replyToId = null;
-      } else {
-        debugError(
-          `[qqbot] sendText: passive reply was blocked without a fallback path - ${limitCheck.message}`,
-        );
-        return {
-          channel: "qqbot",
-          error: limitCheck.message,
-        };
-      }
-    } else {
-      debugLog(
-        `[qqbot] sendText: remaining passive replies for ${replyToId}: ${limitCheck.remaining}/${MESSAGE_REPLY_LIMIT}`,
-      );
-    }
-  }
 
   text = normalizeMediaTags(text);
 
@@ -223,9 +192,6 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
           const result = await senderSendText(deliveryTarget, item.content, creds, {
             msgId: replyToId ?? undefined,
           });
-          if (replyToId) {
-            recordMessageReply(replyToId);
-          }
           lastResult = {
             channel: "qqbot",
             messageId: result.id,
@@ -277,13 +243,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
         error: "Proactive messages require non-empty content (--message cannot be empty)",
       };
     }
-    if (fallbackToProactive) {
-      debugLog(
-        `[qqbot] sendText: [fallback] sending proactive message to ${to}, length=${text.length}`,
-      );
-    } else {
-      debugLog(`[qqbot] sendText: sending proactive message to ${to}, length=${text.length}`);
-    }
+    debugLog(`[qqbot] sendText: sending proactive message to ${to}, length=${text.length}`);
   }
 
   if (!account.appId || !account.clientSecret) {
@@ -302,9 +262,6 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
     const result = await senderSendText(deliveryTarget, text, creds, {
       msgId: replyToId ?? undefined,
     });
-    if (replyToId) {
-      recordMessageReply(replyToId);
-    }
     return {
       channel: "qqbot",
       messageId: result.id,

--- a/extensions/qqbot/src/engine/messaging/reply-limiter.test.ts
+++ b/extensions/qqbot/src/engine/messaging/reply-limiter.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReplyLimiter } from "./reply-limiter.js";
+
+describe("ReplyLimiter", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shares five atomic claims while typing reserves the final reply", () => {
+    const limiter = new ReplyLimiter({ limit: 5 });
+
+    expect(limiter.claim("msg-1", 1)).toMatchObject({ allowed: true, remaining: 4 });
+    expect(limiter.claim("msg-1", 1)).toMatchObject({ allowed: true, remaining: 3 });
+    expect(limiter.claim("msg-1", 1)).toMatchObject({ allowed: true, remaining: 2 });
+    expect(limiter.claim("msg-1", 1)).toMatchObject({ allowed: true, remaining: 1 });
+    expect(limiter.claim("msg-1", 1)).toMatchObject({
+      allowed: false,
+      remaining: 1,
+      fallbackReason: "limit_exceeded",
+    });
+
+    expect(limiter.claim("msg-1")).toMatchObject({ allowed: true, remaining: 0 });
+    expect(limiter.claim("msg-1")).toMatchObject({
+      allowed: false,
+      remaining: 0,
+      fallbackReason: "limit_exceeded",
+    });
+    expect(limiter.getStats()).toEqual({ trackedMessages: 1, totalReplies: 5 });
+  });
+
+  it("does not reopen an expired passive reply window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const limiter = new ReplyLimiter({ ttlMs: 60_000 });
+    expect(limiter.claim("msg-1").allowed).toBe(true);
+
+    vi.setSystemTime(60_001);
+    expect(limiter.claim("msg-1")).toMatchObject({
+      allowed: false,
+      remaining: 0,
+      fallbackReason: "expired",
+    });
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/reply-limiter.ts
+++ b/extensions/qqbot/src/engine/messaging/reply-limiter.ts
@@ -2,7 +2,7 @@
  * Passive reply limiter — enforce per-message reply count and TTL limits.
  *
  * QQ Bot restricts how many passive replies can be sent in response to a
- * single inbound message (4 per hour by default). This module tracks reply
+ * single inbound message (5 per hour by default). This module tracks reply
  * counts and determines whether the next reply should be passive or
  * fall back to proactive mode.
  *
@@ -12,7 +12,7 @@
 
 /** Configuration for the reply limiter. */
 interface ReplyLimiterConfig {
-  /** Maximum passive replies per message. Defaults to 4. */
+  /** Maximum passive replies per message. Defaults to 5. */
   limit?: number;
   /** TTL in milliseconds for the passive reply window. Defaults to 1 hour. */
   ttlMs?: number;
@@ -39,7 +39,7 @@ interface ReplyRecord {
   firstReplyAt: number;
 }
 
-const DEFAULT_LIMIT = 4;
+const DEFAULT_LIMIT = 5;
 const DEFAULT_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_MAX_TRACKED = 10_000;
 
@@ -48,12 +48,11 @@ const DEFAULT_MAX_TRACKED = 10_000;
  *
  * Usage:
  * ```ts
- * const limiter = new ReplyLimiter({ limit: 4, ttlMs: 3600000 });
- * const check = limiter.checkLimit(messageId);
- * if (check.allowed) {
+ * const limiter = new ReplyLimiter({ limit: 5, ttlMs: 3600000 });
+ * const claim = limiter.claim(messageId);
+ * if (claim.allowed) {
  *   await sendPassiveReply(...);
- *   limiter.record(messageId);
- * } else if (check.shouldFallbackToProactive) {
+ * } else if (claim.shouldFallbackToProactive) {
  *   await sendProactiveMessage(...);
  * }
  * ```
@@ -70,18 +69,27 @@ export class ReplyLimiter {
     this.maxTracked = config?.maxTrackedMessages ?? DEFAULT_MAX_TRACKED;
   }
 
-  /** Check whether a passive reply is allowed for the given message. */
-  checkLimit(messageId: string): ReplyLimitResult {
+  /** Check whether a passive reply is allowed while leaving `reserve` slots unused. */
+  checkLimit(messageId: string, reserve = 0): ReplyLimitResult {
     const now = Date.now();
     this.evictIfNeeded(now);
 
     const record = this.tracker.get(messageId);
 
     if (!record) {
+      if (this.limit > reserve) {
+        return {
+          allowed: true,
+          remaining: this.limit,
+          shouldFallbackToProactive: false,
+        };
+      }
       return {
-        allowed: true,
+        allowed: false,
         remaining: this.limit,
-        shouldFallbackToProactive: false,
+        shouldFallbackToProactive: true,
+        fallbackReason: "limit_exceeded",
+        message: `Passive reply budget reserved (${reserve} of ${this.limit} remaining); sending proactively instead`,
       };
     }
 
@@ -95,14 +103,17 @@ export class ReplyLimiter {
       };
     }
 
-    const remaining = this.limit - record.count;
-    if (remaining <= 0) {
+    const remaining = this.limit - (record?.count ?? 0);
+    if (remaining <= reserve) {
       return {
         allowed: false,
-        remaining: 0,
+        remaining,
         shouldFallbackToProactive: true,
         fallbackReason: "limit_exceeded",
-        message: `Passive reply limit reached (${this.limit} per hour); sending proactively instead`,
+        message:
+          reserve > 0
+            ? `Passive reply budget reserved (${reserve} of ${this.limit} remaining); sending proactively instead`
+            : `Passive reply limit reached (${this.limit} per hour); sending proactively instead`,
       };
     }
 
@@ -111,6 +122,16 @@ export class ReplyLimiter {
       remaining,
       shouldFallbackToProactive: false,
     };
+  }
+
+  /** Atomically reserve one passive-reply slot before starting the request. */
+  claim(messageId: string, reserve = 0): ReplyLimitResult {
+    const check = this.checkLimit(messageId, reserve);
+    if (!check.allowed) {
+      return check;
+    }
+    this.record(messageId);
+    return { ...check, remaining: check.remaining - 1 };
   }
 
   /** Record one passive reply against a message. */

--- a/extensions/qqbot/src/engine/messaging/sender.ts
+++ b/extensions/qqbot/src/engine/messaging/sender.ts
@@ -48,6 +48,7 @@ import { debugLog, debugError, debugWarn } from "../utils/log.js";
 import { sanitizeFileName } from "../utils/string-normalize.js";
 import { computeFileHash, getCachedFileInfo, setCachedFileInfo } from "../utils/upload-cache.js";
 import { normalizeSource, type MediaSource, type RawMediaSource } from "./media-source.js";
+import { claimMessageReply } from "./outbound-reply.js";
 
 // ============ Re-exported types ============
 
@@ -386,16 +387,30 @@ export async function sendText(
   creds: AccountCreds,
   opts?: { msgId?: string; messageReference?: string; forcePlainText?: boolean },
 ): Promise<MessageResponse> {
-  const api = resolveAccount(creds.appId).messageApi;
+  const ctx = resolveAccount(creds.appId);
+  const api = ctx.messageApi;
   const c: Credentials = { appId: creds.appId, clientSecret: creds.clientSecret };
+  let msgId = opts?.msgId;
+
+  // MessageApi issues one POST. Higher-level token retries re-enter sendText,
+  // so every retry and target type claims another slot before reaching the wire.
+  if (msgId) {
+    const passive = claimMessageReply(msgId);
+    if (!passive.allowed) {
+      ctx.logger.warn?.(
+        `Passive reply unavailable for ${target.type}; falling back to a send without msg_id: ${passive.message}`,
+      );
+      msgId = undefined;
+    }
+  }
 
   if (target.type === "c2c" || target.type === "group") {
     const scope: ChatScope = target.type;
-    if (opts?.msgId) {
+    if (msgId) {
       return api.sendMessage(scope, target.id, content, c, {
-        msgId: opts.msgId,
-        messageReference: opts.messageReference,
-        forcePlainText: opts.forcePlainText,
+        msgId,
+        messageReference: opts?.messageReference,
+        forcePlainText: opts?.forcePlainText,
       });
     }
     return api.sendProactiveMessage(scope, target.id, content, c, {
@@ -404,10 +419,10 @@ export async function sendText(
   }
 
   if (target.type === "dm") {
-    return api.sendDmMessage({ guildId: target.id, content, creds: c, msgId: opts?.msgId });
+    return api.sendDmMessage({ guildId: target.id, content, creds: c, msgId });
   }
 
-  return api.sendChannelMessage({ channelId: target.id, content, creds: c, msgId: opts?.msgId });
+  return api.sendChannelMessage({ channelId: target.id, content, creds: c, msgId });
 }
 
 // ============ Input notify ============
@@ -615,13 +630,26 @@ async function sendMediaInternal(
     // and file APIs ignore it.
     const msgContent = opts.kind === "image" || opts.kind === "video" ? opts.content : undefined;
 
+    // Uploads do not spend the reply budget; the following message POST does.
+    // Claim here so every media path and retry shares the text/typing ledger.
+    let msgId = opts.msgId;
+    if (msgId) {
+      const passive = claimMessageReply(msgId);
+      if (!passive.allowed) {
+        ctx.logger.warn?.(
+          `Passive media reply unavailable for ${scope}; falling back to proactive send: ${passive.message}`,
+        );
+        msgId = undefined;
+      }
+    }
+
     const result = await ctx.mediaApi.sendMediaMessage(
       scope,
       opts.target.id,
       uploadResult.file_info,
       c,
       {
-        msgId: opts.msgId,
+        msgId,
         content: msgContent,
       },
     );

--- a/extensions/qqbot/src/engine/messaging/streaming-c2c.ts
+++ b/extensions/qqbot/src/engine/messaging/streaming-c2c.ts
@@ -25,6 +25,7 @@ import {
   type MessageResponse,
 } from "../types.js";
 import { normalizeMediaTags } from "../utils/media-tags.js";
+import { claimMessageReply } from "./outbound-reply.js";
 import type { OutboundMediaAccessContext } from "./outbound-types.js";
 import type { MediaTargetContext } from "./outbound.js";
 import { getMessageApi } from "./sender.js";
@@ -1000,6 +1001,14 @@ export class StreamingController {
         return;
       }
       const firstText = safeText;
+      // A stream session is one passive reply: claim once before its first
+      // POST, then reuse the same msg_seq for all later chunks in the session.
+      const passive = claimMessageReply(this.deps.replyToMsgId);
+      if (!passive.allowed) {
+        this.logWarn(`stream budget unavailable; falling back to static delivery`);
+        this.transition("aborted", "doStartStreaming", "passive_budget_exhausted");
+        return;
+      }
       const resp = await this.sendStreamChunk(
         firstText,
         StreamInputState.GENERATING,


### PR DESCRIPTION
Related: #104318

## What Problem This Solves

QQ permits at most five passive calls for one inbound `msg_id`. The delivery trace added in #104582 exposed nine passive calls during a long qqbot turn because gateway static-final delivery bypassed the outbound-only `ReplyLimiter`, while typing kept a separate 1+3 budget. Tencent documents the over-limit response as `22009 msg limit exceed`.

## Why This Change Was Made

Move passive-budget ownership to the common sender boundary and add an atomic pre-request claim. Initial typing, keepalive retries, static/channel text, media message posts, and each new C2C stream session now share one five-call ledger. Typing reserves the final slot; once the ledger is exhausted, message sends omit `msg_id` and use the existing proactive path. The old outbound-only check/record path is removed so calls cannot double-count or bypass accounting.

The budget-exhaustion golden is intentionally updated: four typing calls plus the first tool reply are passive; later tool replies and static final are proactive.

## User Impact

Long qqbot turns no longer attempt a sixth passive send that QQ rejects. They continue through the supported proactive fallback instead. Media uploads themselves do not consume budget; their message POST does.

## Evidence

- Tencent contract: [C2C passive replies allow five calls per `msg_id` in 60 minutes; over-limit error is `22009`](https://github.com/tencent-connect/bot-docs/blob/main/docs/develop/api-v2/server-inter/message/send-receive/send.md).
- Testbox `tbx_01kx94h86xw98ta3wfth5d27yf`: `pnpm test extensions/qqbot/src` — 77 files, 699 tests passed.
- Same Testbox: path-scoped `pnpm check:changed` — production/test `tsgo`, oxlint, format, import-cycle, dependency, changelog, and repository policy checks passed.
- Source-blind behavior contract: 10 outbound calls, exactly 5 passive calls (4 typing + 1 text), 5 proactive text calls; anti-cheat mutation adding `msg_id` to final fails the invariant.
- Fresh autoreview: clean, no accepted or actionable findings.

No configured QQBot account/inbound `msg_id` was available for a live credentialed rejection test. The server-side boundary is therefore established from Tencent's current primary contract plus the deterministic raw-request trace, not a production rejection log.
