### PR TITLE
fix(discord): refresh model picker after default changes

### DIFF
--- a/extensions/discord/src/monitor/model-picker.state.ts
+++ b/extensions/discord/src/monitor/model-picker.state.ts
@@ -265,13 +265,15 @@ export function buildDiscordModelPickerCustomId(params: {
   }
   if (modelToken) {
     parts.push(`m=${modelToken}`);
-  } else if (modelIndex) {
-    // Legacy index-only state is accepted until the next render. New pending
-    // selections use the stable token so catalog reordering cannot retarget them.
-    parts.push(`mi=${String(modelIndex)}`);
-  }
-  if (recentSlot) {
-    parts.push(`rs=${String(recentSlot)}`);
+  } else {
+    // Legacy positional state is accepted until the next render. New model
+    // components use the stable token so catalog reordering cannot retarget them.
+    if (modelIndex) {
+      parts.push(`mi=${String(modelIndex)}`);
+    }
+    if (recentSlot) {
+      parts.push(`rs=${String(recentSlot)}`);
+    }
   }
   const providerBucket = params.providerBucket?.trim().toLowerCase();
   if (providerBucket) {

--- a/extensions/discord/src/monitor/model-picker.state.ts
+++ b/extensions/discord/src/monitor/model-picker.state.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements model picker.state behavior.
+import { createHash } from "node:crypto";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { ModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
@@ -56,6 +57,7 @@ export type DiscordModelPickerState = {
   page: number;
   providerPage?: number;
   modelIndex?: number;
+  modelToken?: string;
   recentSlot?: number;
   /**
    * Letter-range bucket label (e.g. "a-g") when the provider/model count
@@ -76,6 +78,14 @@ export const DISCORD_MODEL_PICKER_BUCKET_THRESHOLD = DISCORD_COMPONENT_MAX_SELEC
 
 /** Target items per alpha bucket. Discord caps selects at 25 options. */
 export const DISCORD_MODEL_PICKER_BUCKET_TARGET_SIZE = 20;
+const DISCORD_MODEL_PICKER_MODEL_TOKEN_PATTERN = /^[A-Za-z0-9_-]{8}$/u;
+
+export function createDiscordModelPickerModelToken(provider: string, model: string): string {
+  return createHash("sha256")
+    .update(JSON.stringify([normalizeProviderId(provider), model]), "utf8")
+    .digest("base64url")
+    .slice(0, 8);
+}
 
 export type DiscordModelPickerBucket = {
   /** Stable lowercase id, e.g. "a-g". Used in customId encoding. */
@@ -200,6 +210,7 @@ export function buildDiscordModelPickerCustomId(params: {
   page?: number;
   providerPage?: number;
   modelIndex?: number;
+  modelToken?: string;
   recentSlot?: number;
   providerBucket?: string;
   modelBucket?: string;
@@ -223,6 +234,10 @@ export function buildDiscordModelPickerCustomId(params: {
     typeof params.recentSlot === "number" && Number.isFinite(params.recentSlot)
       ? Math.max(1, Math.floor(params.recentSlot))
       : undefined;
+  const modelToken = params.modelToken?.trim();
+  if (modelToken && !DISCORD_MODEL_PICKER_MODEL_TOKEN_PATTERN.test(modelToken)) {
+    throw new Error("Discord model picker model token is invalid");
+  }
 
   const parts = [
     `${DISCORD_MODEL_PICKER_CUSTOM_ID_KEY}:c=${encodeCustomIdComponent(params.command)}`,
@@ -248,7 +263,11 @@ export function buildDiscordModelPickerCustomId(params: {
   if (providerPage) {
     parts.push(`pp=${String(providerPage)}`);
   }
-  if (modelIndex) {
+  if (modelToken) {
+    parts.push(`m=${modelToken}`);
+  } else if (modelIndex) {
+    // Legacy index-only state is accepted until the next render. New pending
+    // selections use the stable token so catalog reordering cannot retarget them.
     parts.push(`mi=${String(modelIndex)}`);
   }
   if (recentSlot) {
@@ -312,6 +331,10 @@ export function parseDiscordModelPickerData(data: ComponentData): DiscordModelPi
   const page = parseRawPage(data.g ?? data.pg);
   const providerPage = parseRawPositiveInt(data.pp);
   const modelIndex = parseRawPositiveInt(data.mi);
+  const modelTokenRaw = coerceString(data.m).trim();
+  const modelToken = DISCORD_MODEL_PICKER_MODEL_TOKEN_PATTERN.test(modelTokenRaw)
+    ? modelTokenRaw
+    : undefined;
   const recentSlot = parseRawPositiveInt(data.rs);
   const providerBucketRaw = decodeCustomIdComponent(coerceString(data.pb)).trim().toLowerCase();
   const modelBucketRaw = decodeCustomIdComponent(coerceString(data.mb)).trim().toLowerCase();
@@ -339,6 +362,7 @@ export function parseDiscordModelPickerData(data: ComponentData): DiscordModelPi
     page,
     ...(typeof providerPage === "number" ? { providerPage } : {}),
     ...(typeof modelIndex === "number" ? { modelIndex } : {}),
+    ...(modelToken ? { modelToken } : {}),
     ...(typeof recentSlot === "number" ? { recentSlot } : {}),
     ...(providerBucketRaw ? { providerBucket: providerBucketRaw } : {}),
     ...(modelBucketRaw ? { modelBucket: modelBucketRaw } : {}),

--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -1292,7 +1292,7 @@ describe("Discord model picker recents view", () => {
     });
     expect(rows).toHaveLength(4);
 
-    // First row: default model button (slot 1).
+    // First row: default model button.
     const defaultBtn = requireValue(
       rows[0]?.components?.[0],
       "recents view should render a default model button",
@@ -1304,9 +1304,10 @@ describe("Discord model picker recents view", () => {
     );
     expect(defaultState.action).toBe("submit");
     expect(defaultState.view).toBe("recents");
-    expect(defaultState.recentSlot).toBe(1);
+    expect(defaultState.recentSlot).toBeUndefined();
+    expect(defaultState.modelToken).toBe(createDiscordModelPickerModelToken("openai", "gpt-4.1"));
 
-    // Second row: first recent (slot 2).
+    // Second row: first recent.
     const recentBtn1 = requireValue(
       rows[1]?.components?.[0],
       "recents view should render first recent button",
@@ -1315,9 +1316,10 @@ describe("Discord model picker recents view", () => {
       parseDiscordModelPickerCustomId(recentBtn1.custom_id ?? ""),
       "first recent custom id should parse",
     );
-    expect(recentState1.recentSlot).toBe(2);
+    expect(recentState1.recentSlot).toBeUndefined();
+    expect(recentState1.modelToken).toBe(createDiscordModelPickerModelToken("openai", "gpt-4o"));
 
-    // Third row: second recent (slot 3).
+    // Third row: second recent.
     const recentBtn2 = requireValue(
       rows[2]?.components?.[0],
       "recents view should render second recent button",
@@ -1326,7 +1328,10 @@ describe("Discord model picker recents view", () => {
       parseDiscordModelPickerCustomId(recentBtn2.custom_id ?? ""),
       "second recent custom id should parse",
     );
-    expect(recentState2.recentSlot).toBe(3);
+    expect(recentState2.recentSlot).toBeUndefined();
+    expect(recentState2.modelToken).toBe(
+      createDiscordModelPickerModelToken("anthropic", "claude-sonnet-4-5"),
+    );
 
     // Fourth row (after divider): Back button.
     const backBtn = requireValue(

--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -11,6 +11,7 @@ import {
   DISCORD_MODEL_PICKER_PROVIDER_SINGLE_PAGE_MAX,
   buildDiscordModelPickerCustomId,
   computeAlphaBuckets,
+  createDiscordModelPickerModelToken,
   getDiscordModelPickerModelPage,
   getDiscordModelPickerProviderPage,
   findProviderBucketId,
@@ -276,6 +277,7 @@ describe("Discord model picker custom_id", () => {
   });
 
   it("keeps typical submit ids under Discord max length", () => {
+    const modelToken = createDiscordModelPickerModelToken("azure-openai-responses", "gpt-5.5");
     const customId = buildDiscordModelPickerCustomId({
       command: "models",
       action: "submit",
@@ -284,10 +286,14 @@ describe("Discord model picker custom_id", () => {
       page: 1,
       providerPage: 1,
       modelIndex: 10,
+      modelToken,
       userId: "12345678901234567890",
     });
 
     expect(customId.length).toBeLessThanOrEqual(DISCORD_CUSTOM_ID_MAX_CHARS);
+    const parsed = parseDiscordModelPickerCustomId(customId);
+    expect(parsed?.modelToken).toBe(modelToken);
+    expect(parsed?.modelIndex).toBeUndefined();
   });
 });
 
@@ -1033,7 +1039,8 @@ describe("Discord model picker rendering", () => {
     const submitState = parseDiscordModelPickerCustomId(navButtons[3]?.custom_id ?? "");
     expect(submitState?.action).toBe("submit");
     expect(submitState?.provider).toBe("openai");
-    expect(submitState?.modelIndex).toBe(3);
+    expect(submitState?.modelIndex).toBeUndefined();
+    expect(submitState?.modelToken).toBe(createDiscordModelPickerModelToken("openai", "o3"));
   });
 
   it("defaults the runtime picker to the first effective runtime choice", () => {
@@ -1093,7 +1100,8 @@ describe("Discord model picker rendering", () => {
     const submitState = parseDiscordModelPickerCustomId(navButtons.at(-1)?.custom_id ?? "");
     expect(submitState?.action).toBe("submit");
     expect(submitState?.runtime).toBeUndefined();
-    expect(submitState?.modelIndex).toBe(3);
+    expect(submitState?.modelIndex).toBeUndefined();
+    expect(submitState?.modelToken).toBe(createDiscordModelPickerModelToken("openai", "o3"));
   });
 
   it("carries only explicit runtime picker state into model submit ids", () => {

--- a/extensions/discord/src/monitor/model-picker.ts
+++ b/extensions/discord/src/monitor/model-picker.ts
@@ -3,6 +3,7 @@ export {
   buildDiscordModelPickerCustomId,
   buildDiscordModelPickerProviderItems,
   computeAlphaBuckets,
+  createDiscordModelPickerModelToken,
   findModelBucketId,
   findProviderBucketId,
   findProviderBucketLocation,

--- a/extensions/discord/src/monitor/model-picker.view.ts
+++ b/extensions/discord/src/monitor/model-picker.view.ts
@@ -900,6 +900,11 @@ function formatRecentsButtonLabel(modelRef: string, suffix?: string): string {
   return trimmed;
 }
 
+function createModelRefToken(modelRef: string): string | undefined {
+  const parsed = parseCurrentModelRef(modelRef);
+  return parsed ? createDiscordModelPickerModelToken(parsed.provider, parsed.model) : undefined;
+}
+
 export function renderDiscordModelPickerRecentsView(
   params: DiscordModelPickerRecentsViewParams,
 ): DiscordModelPickerRenderedView {
@@ -920,6 +925,7 @@ export function renderDiscordModelPickerRecentsView(
           action: "submit",
           view: "recents",
           recentSlot: 1,
+          modelToken: createModelRefToken(defaultModelRef),
           provider: params.provider,
           runtime: params.runtime,
           runtimeIndex: params.runtimeIndex,
@@ -944,6 +950,7 @@ export function renderDiscordModelPickerRecentsView(
             action: "submit",
             view: "recents",
             recentSlot: i + 2,
+            modelToken: createModelRefToken(modelRef),
             provider: params.provider,
             runtime: params.runtime,
             runtimeIndex: params.runtimeIndex,

--- a/extensions/discord/src/monitor/model-picker.view.ts
+++ b/extensions/discord/src/monitor/model-picker.view.ts
@@ -19,6 +19,7 @@ import {
 } from "../internal/discord.js";
 import {
   buildDiscordModelPickerCustomId,
+  createDiscordModelPickerModelToken,
   getDiscordModelPickerModelPage,
   getDiscordModelPickerProviderPage,
   normalizeModelPickerPage,
@@ -364,6 +365,7 @@ function buildPaginationRow(params: {
   runtimeIndex?: number;
   providerPage?: number;
   modelIndex?: number;
+  modelToken?: string;
   providerBucket?: string;
   modelBucket?: string;
 }): Row<Button> | null {
@@ -384,6 +386,7 @@ function buildPaginationRow(params: {
       page: Math.max(1, params.page - 1),
       providerPage: params.providerPage,
       modelIndex: params.modelIndex,
+      modelToken: params.modelToken,
       providerBucket: params.providerBucket,
       modelBucket: params.modelBucket,
       userId: params.userId,
@@ -409,6 +412,7 @@ function buildPaginationRow(params: {
       page: Math.min(params.totalPages, params.page + 1),
       providerPage: params.providerPage,
       modelIndex: params.modelIndex,
+      modelToken: params.modelToken,
       providerBucket: params.providerBucket,
       modelBucket: params.modelBucket,
       userId: params.userId,
@@ -436,6 +440,9 @@ function buildModelRows(params: {
 }): { rows: DiscordModelPickerRow[]; buttonRow: Row<Button> } {
   const parsedCurrentModel = parseCurrentModelRef(params.currentModel);
   const parsedPendingModel = parseCurrentModelRef(params.pendingModel);
+  const pendingModelToken = parsedPendingModel
+    ? createDiscordModelPickerModelToken(parsedPendingModel.provider, parsedPendingModel.model)
+    : undefined;
   const rows: DiscordModelPickerRow[] = [];
 
   const hasQuickModels = (params.quickModels ?? []).length > 0;
@@ -510,6 +517,7 @@ function buildModelRows(params: {
             page: params.modelPage.page,
             providerPage: providerPage.page,
             modelIndex: params.pendingModelIndex,
+            modelToken: pendingModelToken,
             ...(params.pendingModelIndex === undefined && activeModelBucket
               ? { modelBucket: activeModelBucket }
               : {}),
@@ -578,6 +586,7 @@ function buildModelRows(params: {
     ...compactRuntime,
     providerPage: providerPage.page,
     modelIndex: params.pendingModelIndex,
+    modelToken: pendingModelToken,
     // Model navigation derives providerBucket from provider on interaction;
     // carrying it here can exceed Discord's 100-char customId limit.
     modelBucket:
@@ -679,6 +688,7 @@ function buildModelRows(params: {
         page: params.modelPage.page,
         providerPage: providerPage.page,
         modelIndex: params.pendingModelIndex,
+        modelToken: pendingModelToken,
         userId: params.userId,
       }),
     }),

--- a/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
@@ -7,6 +7,7 @@ import {
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth-native";
 import type { ModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
+import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   Button,
@@ -299,20 +300,21 @@ export async function handleDiscordModelPickerInteraction(params: {
     deferredUpdate = true;
   }
 
+  const cfg = getRuntimeConfigSnapshot() ?? ctx.cfg;
   const route = await resolveDiscordModelPickerRoute({
     interaction,
-    cfg: ctx.cfg,
+    cfg,
     accountId: ctx.accountId,
     threadBindings: ctx.threadBindings,
   });
-  const pickerData = await loadDiscordModelPickerData(ctx.cfg, route.agentId);
+  const pickerData = await loadDiscordModelPickerData(cfg, route.agentId);
   const currentModelRef = resolveDiscordModelPickerCurrentModel({
-    cfg: ctx.cfg,
+    cfg,
     route,
     data: pickerData,
   });
   const currentRuntime = resolveDiscordModelPickerCurrentRuntime({
-    cfg: ctx.cfg,
+    cfg,
     route,
   });
   const allowedModelRefs = buildDiscordModelPickerAllowedModelRefs(pickerData);
@@ -627,7 +629,7 @@ export async function handleDiscordModelPickerInteraction(params: {
       interaction,
       selectionCommand,
       dispatchCommandInteraction: params.dispatchCommandInteraction,
-      cfg: ctx.cfg,
+      cfg,
       discordConfig: ctx.discordConfig,
       accountId: ctx.accountId,
       sessionPrefix: ctx.sessionPrefix,
@@ -643,7 +645,7 @@ export async function handleDiscordModelPickerInteraction(params: {
       settleMs: ctx.postApplySettleMs ?? 250,
       resolveCurrentModel: (currentRoute) =>
         resolveDiscordModelPickerCurrentModel({
-          cfg: ctx.cfg,
+          cfg,
           route: currentRoute,
           data: pickerData,
         }),

--- a/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
@@ -138,11 +138,20 @@ function resolveSubmittedModelRef(params: {
   if (params.parsed.action === "reset") {
     return `${params.data.resolvedDefault.provider}/${params.data.resolvedDefault.model}`;
   }
+  if (params.parsed.modelToken) {
+    return resolveDiscordModelPickerModelRefByToken(params.data, params.parsed.modelToken);
+  }
   if (params.parsed.action === "quick") {
+    if (params.requireModelToken) {
+      return null;
+    }
     const slot = params.parsed.recentSlot ?? 0;
     return slot >= 1 ? (params.quickModels[slot - 1] ?? null) : null;
   }
   if (params.parsed.view === "recents") {
+    if (params.requireModelToken) {
+      return null;
+    }
     const defaultModelRef = `${params.data.resolvedDefault.provider}/${params.data.resolvedDefault.model}`;
     const dedupedRecents = params.quickModels.filter((ref) => ref !== defaultModelRef);
     const slot = params.parsed.recentSlot ?? 0;
@@ -194,6 +203,21 @@ function listDiscordModelPickerProviderModels(
     return [];
   }
   return [...modelSet].toSorted();
+}
+
+function resolveDiscordModelPickerModelRefByToken(
+  data: Awaited<ReturnType<typeof loadDiscordModelPickerData>>,
+  modelToken: string,
+): string | null {
+  const matchingRefs: string[] = [];
+  for (const [provider, models] of data.byProvider) {
+    for (const model of models) {
+      if (createDiscordModelPickerModelToken(provider, model) === modelToken) {
+        matchingRefs.push(`${provider}/${model}`);
+      }
+    }
+  }
+  return matchingRefs.length === 1 ? (matchingRefs[0] ?? null) : null;
 }
 
 function resolveDiscordModelPickerModelIndex(params: {

--- a/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
+++ b/extensions/discord/src/monitor/native-command-model-picker-interaction.ts
@@ -20,6 +20,7 @@ import {
 import { readDiscordModelPickerRecentModels } from "./model-picker-preferences.js";
 import {
   DISCORD_MODEL_PICKER_CUSTOM_ID_KEY,
+  createDiscordModelPickerModelToken,
   findModelBucketId,
   findProviderBucketId,
   loadDiscordModelPickerData,
@@ -132,6 +133,7 @@ function resolveSubmittedModelRef(params: {
   data: ModelsProviderData;
   parsed: DiscordModelPickerState;
   quickModels: string[];
+  requireModelToken: boolean;
 }): string | null {
   if (params.parsed.action === "reset") {
     return `${params.data.resolvedDefault.provider}/${params.data.resolvedDefault.model}`;
@@ -151,10 +153,12 @@ function resolveSubmittedModelRef(params: {
   }
 
   const provider = params.parsed.provider;
-  const selectedModel = resolveDiscordModelPickerModelByIndex({
+  const selectedModel = resolveDiscordModelPickerModelSelection({
     data: params.data,
     provider: provider ?? "",
     modelIndex: params.parsed.modelIndex,
+    modelToken: params.parsed.modelToken,
+    requireModelToken: params.requireModelToken,
   });
   return provider && selectedModel ? `${provider}/${selectedModel}` : null;
 }
@@ -208,16 +212,24 @@ function resolveDiscordModelPickerModelIndex(params: {
   return index + 1;
 }
 
-function resolveDiscordModelPickerModelByIndex(params: {
+function resolveDiscordModelPickerModelSelection(params: {
   data: Awaited<ReturnType<typeof loadDiscordModelPickerData>>;
   provider: string;
   modelIndex?: number;
+  modelToken?: string;
+  requireModelToken?: boolean;
 }): string | null {
-  if (!params.modelIndex || params.modelIndex < 1) {
-    return null;
-  }
   const models = listDiscordModelPickerProviderModels(params.data, params.provider);
   if (!models.length) {
+    return null;
+  }
+  if (params.modelToken) {
+    const matchingModels = models.filter(
+      (model) => createDiscordModelPickerModelToken(params.provider, model) === params.modelToken,
+    );
+    return matchingModels.length === 1 ? (matchingModels[0] ?? null) : null;
+  }
+  if (params.requireModelToken || !params.modelIndex || params.modelIndex < 1) {
     return null;
   }
   return models[params.modelIndex - 1] ?? null;
@@ -301,6 +313,7 @@ export async function handleDiscordModelPickerInteraction(params: {
   }
 
   const cfg = getRuntimeConfigSnapshot() ?? ctx.cfg;
+  const requireModelToken = cfg !== ctx.cfg;
   const route = await resolveDiscordModelPickerRoute({
     interaction,
     cfg,
@@ -424,11 +437,20 @@ export async function handleDiscordModelPickerInteraction(params: {
       currentModelRef,
       data: pickerData,
     });
-    const pendingModel = resolveDiscordModelPickerModelByIndex({
+    const pendingModel = resolveDiscordModelPickerModelSelection({
       data: pickerData,
       provider,
       modelIndex: parsed.modelIndex,
+      modelToken: parsed.modelToken,
+      requireModelToken,
     });
+    if ((parsed.modelIndex || parsed.modelToken) && !pendingModel) {
+      await showNotice("That selection expired. Please choose a model again.");
+      return;
+    }
+    const pendingModelIndex = pendingModel
+      ? resolveDiscordModelPickerModelIndex({ data: pickerData, provider, model: pendingModel })
+      : undefined;
     const rendered = renderDiscordModelPickerModelsView({
       command: parsed.command,
       userId: parsed.userId,
@@ -441,7 +463,7 @@ export async function handleDiscordModelPickerInteraction(params: {
       currentModel: currentModelRef,
       currentRuntime,
       ...(pendingModel ? { pendingModel: `${provider}/${pendingModel}` } : {}),
-      pendingModelIndex: parsed.modelIndex,
+      pendingModelIndex: pendingModelIndex ?? undefined,
       pendingRuntime: resolvePendingRuntime({ data: pickerData, provider, parsed }),
       quickModels,
     });
@@ -549,12 +571,21 @@ export async function handleDiscordModelPickerInteraction(params: {
       await showNotice("Sorry, that provider isn't available anymore.");
       return;
     }
-    const selectedModel = resolveDiscordModelPickerModelByIndex({
+    const selectedModel = resolveDiscordModelPickerModelSelection({
       data: pickerData,
       provider,
       modelIndex: parsed.modelIndex,
+      modelToken: parsed.modelToken,
+      requireModelToken,
     });
+    if ((parsed.modelIndex || parsed.modelToken) && !selectedModel) {
+      await showNotice("That selection expired. Please choose a model again.");
+      return;
+    }
     const pendingModel = selectedModel ? `${provider}/${selectedModel}` : undefined;
+    const pendingModelIndex = selectedModel
+      ? resolveDiscordModelPickerModelIndex({ data: pickerData, provider, model: selectedModel })
+      : undefined;
     // Runtime select customId carries modelBucket only when no pending
     // model is set; otherwise derive from the pending model. As a final
     // fallback, derive from the user's current durable model so the
@@ -582,7 +613,7 @@ export async function handleDiscordModelPickerInteraction(params: {
       currentModel: currentModelRef,
       currentRuntime,
       ...(pendingModel ? { pendingModel } : {}),
-      pendingModelIndex: parsed.modelIndex,
+      pendingModelIndex: pendingModelIndex ?? undefined,
       pendingRuntime: selectedRuntime,
       quickModels,
     });
@@ -591,7 +622,12 @@ export async function handleDiscordModelPickerInteraction(params: {
   }
 
   if (parsed.action === "submit" || parsed.action === "reset" || parsed.action === "quick") {
-    const modelRef = resolveSubmittedModelRef({ data: pickerData, parsed, quickModels });
+    const modelRef = resolveSubmittedModelRef({
+      data: pickerData,
+      parsed,
+      quickModels,
+      requireModelToken,
+    });
     const parsedModelRef = modelRef ? splitDiscordModelRef(modelRef) : null;
     if (
       !parsedModelRef ||

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -293,6 +293,7 @@ describe("Discord model picker interactions", () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfigSnapshot").mockReturnValue(null);
+    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfigSourceSnapshot").mockReturnValue(null);
   });
 
   afterEach(async () => {
@@ -380,6 +381,9 @@ describe("Discord model picker interactions", () => {
       },
     } as OpenClawConfig;
     vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfigSnapshot").mockReturnValue(runtimeCfg);
+    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfigSourceSnapshot").mockReturnValue(
+      runtimeCfg,
+    );
 
     const staleData = createModelsProviderData({ openai: ["gpt-5.5"] });
     staleData.resolvedDefault = { provider: "openai", model: "gpt-5.5" };

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -424,6 +424,58 @@ describe("Discord model picker interactions", () => {
     ).toContain("✅ Model set to openai/gpt-5.6-terra.");
   });
 
+  it("keeps a pending model stable when hot reload reorders the catalog", async () => {
+    const context = createModelPickerContext();
+    const runtimeCfg = { ...context.cfg } as OpenClawConfig;
+    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfigSnapshot").mockReturnValue(runtimeCfg);
+    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfigSourceSnapshot").mockReturnValue(
+      runtimeCfg,
+    );
+
+    const runtimeData = createModelsProviderData({ openai: ["a", "aa", "b"] });
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(runtimeData);
+    mockModelCommandPipeline(createModelCommandDefinition());
+    const dispatchSpy = createDispatchSpy();
+
+    const submitInteraction = await runSubmitButton({
+      context,
+      data: {
+        cmd: "model",
+        act: "submit",
+        view: "models",
+        u: "owner",
+        p: "openai",
+        pg: "1",
+        m: modelPickerModule.createDiscordModelPickerModelToken("openai", "b"),
+      },
+      dispatchCommandInteraction: dispatchSpy,
+    });
+
+    expectDispatchedModelSelection({ dispatchSpy, model: "openai/b" });
+    expect(
+      JSON.stringify(firstMockArg(submitInteraction.followUp, "interaction.followUp")),
+    ).toContain("✅ Model set to openai/b.");
+
+    dispatchSpy.mockClear();
+    const legacyInteraction = await runSubmitButton({
+      context,
+      data: {
+        cmd: "model",
+        act: "submit",
+        view: "models",
+        u: "owner",
+        p: "openai",
+        pg: "1",
+        mi: "2",
+      },
+      dispatchCommandInteraction: dispatchSpy,
+    });
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(
+      JSON.stringify(firstMockArg(legacyInteraction.editReply, "interaction.editReply")),
+    ).toContain("selection expired");
+  });
+
   it("requires submit click before routing selected model through /model pipeline", async () => {
     const context = createModelPickerContext();
     const pickerData = createDefaultModelPickerData();

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "openclaw/plugin-sdk/command-auth-native";
 import type { ModelsProviderData } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import * as runtimeConfigSnapshotModule from "openclaw/plugin-sdk/runtime-config-snapshot";
 import * as globalsModule from "openclaw/plugin-sdk/runtime-env";
 import {
   loadSessionStore,
@@ -291,6 +292,7 @@ describe("Discord model picker interactions", () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-discord-model-picker-"));
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfigSnapshot").mockReturnValue(null);
   });
 
   afterEach(async () => {
@@ -353,6 +355,69 @@ describe("Discord model picker interactions", () => {
     expect(loadSpy).toHaveBeenCalledTimes(1);
     expect(interaction.editReply).toHaveBeenCalledTimes(1);
     expect(interaction.update).not.toHaveBeenCalled();
+  });
+
+  it("uses the hot-reloaded runtime config when old components reset to default", async () => {
+    const context = createModelPickerContext();
+    (context.cfg as { agents?: OpenClawConfig["agents"] }).agents = {
+      defaults: {
+        model: { primary: "openai/gpt-5.5" },
+        models: {
+          "openai/gpt-5.5": {},
+        },
+      },
+    };
+    const runtimeCfg = {
+      ...context.cfg,
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.6-terra" },
+          models: {
+            "openai/gpt-5.5": {},
+            "openai/gpt-5.6-terra": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfigSnapshot").mockReturnValue(runtimeCfg);
+
+    const staleData = createModelsProviderData({ openai: ["gpt-5.5"] });
+    staleData.resolvedDefault = { provider: "openai", model: "gpt-5.5" };
+    const runtimeData = createModelsProviderData({
+      openai: ["gpt-5.5", "gpt-5.6-terra"],
+    });
+    runtimeData.resolvedDefault = { provider: "openai", model: "gpt-5.6-terra" };
+    const loadSpy = vi
+      .spyOn(modelPickerModule, "loadDiscordModelPickerData")
+      .mockImplementation(async (cfg) => (cfg === runtimeCfg ? runtimeData : staleData));
+    const modelCommand = createModelCommandDefinition();
+    mockModelCommandPipeline(modelCommand);
+    const dispatchSpy = createDispatchSpy();
+
+    const resetInteraction = await runSubmitButton({
+      context,
+      data: {
+        cmd: "model",
+        act: "reset",
+        view: "models",
+        u: "owner",
+        pg: "1",
+      },
+      dispatchCommandInteraction: dispatchSpy,
+    });
+
+    expect(loadSpy).toHaveBeenCalledWith(runtimeCfg, "main");
+    expectDispatchedModelSelection({
+      dispatchSpy,
+      model: "openai/gpt-5.6-terra",
+    });
+    const dispatchCall = firstMockArg(dispatchSpy, "dispatchCommandInteraction") as
+      | Parameters<DispatchDiscordCommandInteraction>[0]
+      | undefined;
+    expect(dispatchCall?.cfg).toBe(runtimeCfg);
+    expect(
+      JSON.stringify(firstMockArg(resetInteraction.followUp, "interaction.followUp")),
+    ).toContain("✅ Model set to openai/gpt-5.6-terra.");
   });
 
   it("requires submit click before routing selected model through /model pipeline", async () => {

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -833,6 +833,56 @@ describe("Discord model picker interactions", () => {
     expectDispatchedModelSelection({ dispatchSpy, model: "openai/gpt-4o" });
   });
 
+  it("keeps a recent model stable when hot reload shifts its slot", async () => {
+    const context = createModelPickerContext();
+    const runtimeCfg = { ...context.cfg } as OpenClawConfig;
+    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfigSnapshot").mockReturnValue(runtimeCfg);
+    vi.spyOn(runtimeConfigSnapshotModule, "getRuntimeConfigSourceSnapshot").mockReturnValue(
+      runtimeCfg,
+    );
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(
+      createModelsProviderData({ openai: ["a", "b"] }),
+    );
+    vi.spyOn(modelPickerPreferencesModule, "readDiscordModelPickerRecentModels").mockResolvedValue([
+      "openai/a",
+      "openai/b",
+    ]);
+    mockModelCommandPipeline(createModelCommandDefinition());
+    const dispatchSpy = createDispatchSpy();
+
+    await runSubmitButton({
+      context,
+      data: {
+        cmd: "model",
+        act: "submit",
+        view: "recents",
+        u: "owner",
+        pg: "1",
+        m: modelPickerModule.createDiscordModelPickerModelToken("openai", "b"),
+      },
+      dispatchCommandInteraction: dispatchSpy,
+    });
+    expectDispatchedModelSelection({ dispatchSpy, model: "openai/b" });
+
+    dispatchSpy.mockClear();
+    const legacyInteraction = await runSubmitButton({
+      context,
+      data: {
+        cmd: "model",
+        act: "submit",
+        view: "recents",
+        u: "owner",
+        pg: "1",
+        rs: "1",
+      },
+      dispatchCommandInteraction: dispatchSpy,
+    });
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(
+      JSON.stringify(firstMockArg(legacyInteraction.editReply, "interaction.editReply")),
+    ).toContain("selection expired");
+  });
+
   it("does not decode compact recents runtime against another provider", async () => {
     const context = createModelPickerContext();
     const pickerData = createModelsProviderData({


### PR DESCRIPTION
## What Problem This Solves

Fixes #104614.

Discord model-picker components captured the channel startup config. After a hot reload changed the default or model catalog, old component clicks could reset or apply against stale data while `/status` and direct `/model` commands already used the active runtime config.

## Why This Change Was Made

The component handler now captures the active runtime config once per interaction and uses it consistently for routing, picker data, display, dispatch, and post-apply verification.

Model-bearing component state now carries a compact stable provider/model token instead of relying on catalog or recent-list positions. This prevents a hot reload from silently retargeting an old visible selection when models are inserted, removed, or reordered. Legacy positional components expire safely once the runtime config changes.

## User Impact

Users can change the default model or catalog without restarting Discord or the gateway. Existing current-format picker buttons keep selecting the model they display; stale legacy buttons ask the user to choose again instead of applying a different model.

## Evidence

- Fresh sanitized AWS Crabbox run `run_c7c34dfb462e` on exact reviewed head `102dec62f9416c2374422be2e31d5e66ea6117ab`: 72/72 focused Discord picker tests passed.
- After detecting and removing a malformed 100-file sync commit, the patch was rebuilt cleanly on current main at `7fc241d1a14340a6ba77b930f10ed711607ecaf3`. Stable patch id `f94c16dc97d295825b17b9a98900e17a3db2662d` matches the exact tested revision; the PR is again the intended six files.
- Fresh exact-final-head sanitized AWS Crabbox run `run_62769f71ce42`: 72/72 focused tests passed.
- Fresh Codex autoreview on the exact code bundle: clean, correctness confidence 0.91.
- Targeted `oxfmt` and `git diff --check` passed.
- Hosted CI is green on the final clean exact-tested head.
