### PR TITLE
fix(gateway): actively schedule launchd relaunch on supervisor restart

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -95,6 +95,7 @@ const restartGatewayProcessWithFreshPid = vi.fn<
     mode: "spawned" | "supervised" | "disabled" | "failed";
     pid?: number;
     detail?: string;
+    handoffSpawned?: Promise<boolean>;
   }
 >(() => ({ mode: "disabled" }));
 const respawnGatewayProcessForUpdate = vi.fn<
@@ -103,6 +104,7 @@ const respawnGatewayProcessForUpdate = vi.fn<
     pid?: number;
     detail?: string;
     child?: { kill: () => void };
+    handoffSpawned?: Promise<boolean>;
   }
 >(() => ({ mode: "disabled", detail: "OPENCLAW_NO_RESPAWN" }));
 const markUpdateRestartSentinelFailure = vi.fn<(reason: string) => Promise<null>>(
@@ -1665,6 +1667,7 @@ describe("runGatewayLoop", () => {
       process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
       restartGatewayProcessWithFreshPid.mockReturnValueOnce({
         mode: "supervised",
+        handoffSpawned: Promise.resolve(true),
       });
 
       await withIsolatedSignals(async ({ captureSignal }) => {
@@ -1694,6 +1697,45 @@ describe("runGatewayLoop", () => {
     }
   });
 
+  it("falls back in-process when the launchd restart handoff fails to spawn", async () => {
+    vi.clearAllMocks();
+    peekGatewaySigusr1RestartReason.mockReturnValue(undefined);
+    try {
+      setPlatform("darwin");
+      process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+      restartGatewayProcessWithFreshPid.mockReturnValueOnce({
+        mode: "supervised",
+        handoffSpawned: Promise.resolve(false),
+      });
+
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { start, runtime, exited } = await createSignaledLoopHarness();
+        const sigusr1 = captureSignal("SIGUSR1");
+        const sigint = captureSignal("SIGINT");
+
+        vi.useFakeTimers();
+        sigusr1();
+        await vi.advanceTimersByTimeAsync(1500);
+
+        expect(start).toHaveBeenCalledTimes(2);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        expect(acquireGatewayLock).toHaveBeenCalledTimes(2);
+        expect(gatewayLog.warn).toHaveBeenCalledWith(
+          "launchd restart handoff failed to spawn; falling back to in-process restart",
+        );
+
+        sigint();
+        await expect(exited).resolves.toBe(0);
+      });
+    } finally {
+      vi.useRealTimers();
+      delete process.env.OPENCLAW_LAUNCHD_LABEL;
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, "platform", originalPlatformDescriptor);
+      }
+    }
+  });
+
   it("carries SIGTERM restart intent reason into launchd supervised handoff", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ reason: "gateway.restart" });
@@ -1702,6 +1744,7 @@ describe("runGatewayLoop", () => {
       process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
       restartGatewayProcessWithFreshPid.mockReturnValueOnce({
         mode: "supervised",
+        handoffSpawned: Promise.resolve(true),
       });
 
       await withIsolatedSignals(async ({ captureSignal }) => {
@@ -1926,6 +1969,43 @@ describe("runGatewayLoop", () => {
       }
     },
   );
+
+  it("falls back in-process when a launchd update handoff fails to spawn", async () => {
+    vi.clearAllMocks();
+    peekGatewaySigusr1RestartReason.mockReturnValue("update.run");
+    respawnGatewayProcessForUpdate.mockReturnValueOnce({
+      mode: "supervised",
+      handoffSpawned: Promise.resolve(false),
+    });
+    try {
+      setPlatform("darwin");
+      process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { start, runtime, exited } = await createSignaledLoopHarness();
+        const sigusr1 = captureSignal("SIGUSR1");
+        const sigint = captureSignal("SIGINT");
+
+        vi.useFakeTimers();
+        sigusr1();
+        await vi.advanceTimersByTimeAsync(1500);
+
+        expect(start).toHaveBeenCalledTimes(2);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        expect(markUpdateRestartSentinelFailure).toHaveBeenCalledWith(
+          "restart-handoff-unavailable",
+        );
+
+        sigint();
+        await expect(exited).resolves.toBe(0);
+      });
+    } finally {
+      vi.useRealTimers();
+      delete process.env.OPENCLAW_LAUNCHD_LABEL;
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, "platform", originalPlatformDescriptor);
+      }
+    }
+  });
 
   it("keeps running when an external update restart handoff cannot be persisted", async () => {
     vi.clearAllMocks();

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -191,6 +191,19 @@ export async function runGatewayLoop(params: {
       return false;
     }
   };
+  const confirmLaunchdHandoff = async (respawn: {
+    handoffSpawned?: Promise<boolean>;
+  }): Promise<boolean> => {
+    const delay = new Promise<void>((resolve) => {
+      setTimeout(resolve, LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS);
+    });
+    const spawned = respawn.handoffSpawned
+      ? await Promise.race([respawn.handoffSpawned, delay.then(() => true)])
+      : false;
+    // Preserve the crash-loop throttle window even when spawn settles early.
+    await delay;
+    return spawned;
+  };
   const handleRestartAfterServerClose = async () => {
     await releaseLockIfHeld();
     const {
@@ -277,13 +290,25 @@ export async function runGatewayLoop(params: {
           restartResolver?.();
           return;
         }
-        activeRestartRequest = null;
         gatewayLog.info("restart mode: update process respawn (supervisor restart)");
-        if (supervisorMode === "launchd") {
-          await new Promise((resolve) => {
-            setTimeout(resolve, LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS);
-          });
+        if (supervisorMode === "launchd" && !(await confirmLaunchdHandoff(respawn))) {
+          gatewayLog.warn(
+            "launchd restart handoff failed to spawn; falling back to in-process restart",
+          );
+          await markUpdateRestartSentinelFailure("restart-handoff-unavailable").catch(
+            (err: unknown) => {
+              gatewayLog.warn(`failed to mark update restart handoff unavailable: ${String(err)}`);
+            },
+          );
+          if (!(await reacquireLockForInProcessRestart())) {
+            return;
+          }
+          activeRestartRequest = null;
+          shuttingDown = false;
+          restartResolver?.();
+          return;
         }
+        activeRestartRequest = null;
         exitProcess(0);
         return;
       }
@@ -349,15 +374,21 @@ export async function runGatewayLoop(params: {
           return;
         }
       }
-      activeRestartRequest = null;
       gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
-      if (supervisorMode === "launchd") {
-        // A short clean-exit pause keeps rapid SIGUSR1/config restarts from
-        // tripping launchd crash-loop throttling before KeepAlive relaunches.
-        await new Promise((resolve) => {
-          setTimeout(resolve, LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS);
-        });
+      if (supervisorMode === "launchd" && !(await confirmLaunchdHandoff(respawn))) {
+        await writeStabilityBundle("gateway.restart_handoff_spawn_failed");
+        gatewayLog.warn(
+          "launchd restart handoff failed to spawn; falling back to in-process restart",
+        );
+        if (!(await reacquireLockForInProcessRestart())) {
+          return;
+        }
+        activeRestartRequest = null;
+        shuttingDown = false;
+        restartResolver?.();
+        return;
       }
+      activeRestartRequest = null;
       exitProcess(0);
       return;
     }

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -40,7 +40,10 @@ function requireSpawnCall(callIndex = 0): SpawnCall {
   return [command, args as string[], options as SpawnCall[2]];
 }
 
-async function executeReloadHandoff(launchctlStub: string): Promise<{
+async function executeHandoff(
+  mode: "reload" | "start-after-exit",
+  launchctlStub: string,
+): Promise<{
   calls: string[];
   exitCode: number;
   log: string;
@@ -59,10 +62,10 @@ async function executeReloadHandoff(launchctlStub: string): Promise<{
     fs.writeFileSync(path.join(stubDir, "sleep"), "#!/bin/sh\nexit 0\n");
     fs.chmodSync(path.join(stubDir, "sleep"), 0o755);
 
-    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock, once: vi.fn() });
     scheduleDetachedLaunchdRestartHandoff({
       env: { HOME: home, OPENCLAW_PROFILE: "default" },
-      mode: "reload",
+      mode,
       waitForPid: noWaitPid,
     });
     const [, args] = requireSpawnCall();
@@ -115,7 +118,7 @@ async function executeReloadHandoff(launchctlStub: string): Promise<{
 afterEach(() => {
   spawnMock.mockReset();
   unrefMock.mockReset();
-  spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+  spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock, once: vi.fn() });
 });
 
 describe("scheduleDetachedLaunchdRestartHandoff", () => {
@@ -124,7 +127,7 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
       HOME: "/Users/test",
       OPENCLAW_PROFILE: "default",
     };
-    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock, once: vi.fn() });
 
     const result = scheduleDetachedLaunchdRestartHandoff({
       env,
@@ -132,7 +135,10 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
       waitForPid: 9876,
     });
 
-    expect(result).toEqual({ ok: true, value: 4242 });
+    expect(result).toEqual({
+      ok: true,
+      value: expect.any(Promise),
+    });
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const [, args] = requireSpawnCall();
     expect(args[0]).toBe("-c");
@@ -153,7 +159,7 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
   });
 
   it("uses the service target for start-after-exit mode", () => {
-    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock, once: vi.fn() });
 
     scheduleDetachedLaunchdRestartHandoff({
       env: {
@@ -164,17 +170,29 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     });
 
     const [, args] = requireSpawnCall();
-    expect(args[1]).toContain('if launchctl print "$service_target" >/dev/null 2>&1; then');
-    expect(args[1]).toContain("reason=launchd-auto-reload");
-    expect(args[1]).toContain("print_retry_count=$((print_retry_count - 1))");
-    expect(args[1]).toContain("sleep 0.2");
+    expect(args[1]).toContain('if launchctl kickstart "$service_target"; then');
     expect(args[1]).toContain('if launchctl bootstrap "$domain" "$plist_path"; then');
+    expect(args[1]).not.toContain('kickstart -k "$service_target"');
     expect(args[1]).not.toContain('if launchctl start "$label"; then');
     expect(args[1]).not.toContain('basename "$service_target"');
   });
 
+  it("kickstarts after exit without replacing a running KeepAlive process", async () => {
+    const result = await executeHandoff(
+      "start-after-exit",
+      'case "$1" in enable|kickstart) exit 0 ;; *) exit 1 ;; esac',
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.calls).toContain("enable gui/501/test.label");
+    expect(result.calls).toContain("kickstart gui/501/test.label");
+    expect(result.calls.some((call) => call.includes("kickstart -k"))).toBe(false);
+    expect(result.calls.some((call) => call.startsWith("bootstrap "))).toBe(false);
+    expect(result.log).toContain("restart done");
+  });
+
   it("outwaits launchd's stop window after bootout and retries bootstrap for reload mode", () => {
-    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock, once: vi.fn() });
 
     scheduleDetachedLaunchdRestartHandoff({
       env: {
@@ -205,7 +223,9 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
   });
 
   it("executes the generated reload handoff through a delayed launchd stop", async () => {
-    const result = await executeReloadHandoff(`
+    const result = await executeHandoff(
+      "reload",
+      `
 case "$1" in
   print)
     count_file="$LAUNCHCTL_STUB_DIR/print-count"
@@ -218,7 +238,8 @@ case "$1" in
     ;;
   bootstrap) exit 0 ;;
   *) exit 0 ;;
-esac`);
+esac`,
+    );
 
     expect(result.exitCode).toBe(0);
     expect(result.calls.filter((call) => call.startsWith("print "))).toHaveLength(21);
@@ -228,7 +249,9 @@ esac`);
   });
 
   it("retries bootstrap when the label disappears between print and kickstart", async () => {
-    const result = await executeReloadHandoff(`
+    const result = await executeHandoff(
+      "reload",
+      `
 case "$1" in
   print)
     count_file="$LAUNCHCTL_STUB_DIR/print-count"
@@ -250,7 +273,8 @@ case "$1" in
     ;;
   kickstart) exit 113 ;;
   *) exit 0 ;;
-esac`);
+esac`,
+    );
 
     expect(result.exitCode).toBe(0);
     expect(result.calls.filter((call) => call.startsWith("bootstrap "))).toHaveLength(2);
@@ -263,7 +287,8 @@ esac`);
     // A completed if with a false condition leaves $? at 0. Keep this
     // execution-level check so exhausted retries cannot report success while
     // the LaunchAgent remains deregistered.
-    const result = await executeReloadHandoff(
+    const result = await executeHandoff(
+      "reload",
       'case "$1" in bootstrap) exit 5 ;; print) exit 113 ;; *) exit 0 ;; esac',
     );
 
@@ -275,7 +300,7 @@ esac`);
   });
 
   it("sanitizes restart helper environment overrides before spawning", () => {
-    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock, once: vi.fn() });
 
     scheduleDetachedLaunchdRestartHandoff({
       env: {
@@ -310,5 +335,43 @@ esac`);
       });
     }).toThrow("Invalid launchd label: ../evil/label");
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("reports an asynchronous helper spawn failure", async () => {
+    const listeners = new Map<string, () => void>();
+    spawnMock.mockReturnValue({
+      pid: undefined,
+      unref: unrefMock,
+      once: vi.fn((event: string, listener: () => void) => {
+        listeners.set(event, listener);
+      }),
+    });
+
+    const result = scheduleDetachedLaunchdRestartHandoff({ mode: "start-after-exit" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    listeners.get("error")?.();
+    await expect(result.value).resolves.toBe(false);
+  });
+
+  it("reports a successfully spawned helper", async () => {
+    const listeners = new Map<string, () => void>();
+    spawnMock.mockReturnValue({
+      pid: 4242,
+      unref: unrefMock,
+      once: vi.fn((event: string, listener: () => void) => {
+        listeners.set(event, listener);
+      }),
+    });
+
+    const result = scheduleDetachedLaunchdRestartHandoff({ mode: "start-after-exit" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    listeners.get("spawn")?.();
+    await expect(result.value).resolves.toBe(true);
   });
 });

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -13,7 +13,7 @@ import { renderPosixRestartLogSetup } from "./restart-logs.js";
 
 type LaunchdRestartHandoffMode = "kickstart" | "reload" | "start-after-exit";
 
-type LaunchdRestartHandoffResult = Result<number | undefined, string>;
+type LaunchdRestartHandoffResult = Result<Promise<boolean>, string>;
 
 type LaunchdRestartTarget = {
   domain: string;
@@ -21,8 +21,6 @@ type LaunchdRestartTarget = {
   serviceTarget: string;
 };
 
-const START_AFTER_EXIT_PRINT_RETRY_COUNT = 15;
-const START_AFTER_EXIT_PRINT_RETRY_DELAY_SECONDS = 0.2;
 // The booted-out label stays registered until launchd finishes stopping the
 // old process. ExitTimeOut bounds that stop with SIGKILL, so the reload wait is
 // that ceiling plus teardown margin. A 3s poll could advance mid-stop and
@@ -204,31 +202,25 @@ exit "$status"
 `;
   }
 
-  const verifyLaunchdReload = `print_retry_count="${START_AFTER_EXIT_PRINT_RETRY_COUNT}"
-while [ "$print_retry_count" -gt 0 ]; do
-  if launchctl print "$service_target" >/dev/null 2>&1; then
-    printf '[%s] openclaw restart done source=handoff mode=${mode} reason=launchd-auto-reload interactive=0\\n' "$(date -u +%FT%TZ)" >&2
-    exit 0
-  fi
-  print_retry_count=$((print_retry_count - 1))
-  sleep ${START_AFTER_EXIT_PRINT_RETRY_DELAY_SECONDS}
-done
-`;
-
-  // Restart is explicit operator intent; undo any previous `launchctl disable`.
+  // Without -k, kickstart starts an inert service but leaves a KeepAlive
+  // replacement alone. This actively schedules relaunch without a second
+  // interruption when launchd wins the race after the caller exits.
   return `service_target="$1"
 domain="$2"
 plist_path="$3"
 ${waitForCallerPid}
-${verifyLaunchdReload}
 status=0
 launchctl enable "$service_target"
-if launchctl bootstrap "$domain" "$plist_path"; then
+if launchctl kickstart "$service_target"; then
   status=0
 else
   status=$?
-  launchctl kickstart -k "$service_target"
-  status=$?
+  if launchctl bootstrap "$domain" "$plist_path"; then
+    status=0
+  else
+    launchctl kickstart "$service_target"
+    status=$?
+  fi
 fi
 if [ "$status" -eq 0 ]; then
   printf '[%s] openclaw restart done source=handoff mode=${mode} interactive=0\\n' "$(date -u +%FT%TZ)" >&2
@@ -272,8 +264,14 @@ export function scheduleDetachedLaunchdRestartHandoff(params: {
         env: restartEnv,
       },
     );
+    // Node reports OS-level spawn failures asynchronously. The caller must
+    // confirm this before exiting or a failed handoff can strand the gateway.
+    const spawned = new Promise<boolean>((resolve) => {
+      child.once("spawn", () => resolve(true));
+      child.once("error", () => resolve(false));
+    });
     child.unref();
-    return ok(child.pid ?? undefined);
+    return ok(spawned);
   } catch (error) {
     return err(formatErrorMessage(error));
   }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -57,8 +57,8 @@ const state = vi.hoisted(() => ({
 }));
 const launchdRestartHandoffState = vi.hoisted(() => ({
   scheduleDetachedLaunchdRestartHandoff: vi.fn<
-    (_params: unknown) => { ok: true; value: number | undefined } | { ok: false; error: string }
-  >(() => ({ ok: true, value: 7331 })),
+    (_params: unknown) => { ok: true; value: Promise<boolean> } | { ok: false; error: string }
+  >(() => ({ ok: true, value: Promise.resolve(true) })),
 }));
 type CleanStaleGatewayProcessesOptions = {
   protectedPid?: number;
@@ -455,7 +455,7 @@ beforeEach(() => {
   launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReset();
   launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReturnValue({
     ok: true,
-    value: 7331,
+    value: Promise.resolve(true),
   });
   vi.clearAllMocks();
 });

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -6,6 +6,16 @@ import { SUPERVISOR_HINT_ENV_VARS } from "./supervisor-markers.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 const triggerOpenClawRestartMock = vi.hoisted(() => vi.fn());
+const scheduleLaunchdHandoffMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      ..._args: unknown[]
+    ): { ok: true; value: Promise<boolean> } | { ok: false; error: string } => ({
+      ok: true,
+      value: Promise.resolve(true),
+    }),
+  ),
+);
 const isContainerEnvironmentMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("node:child_process", async () => {
@@ -19,6 +29,10 @@ vi.mock("node:child_process", async () => {
 });
 vi.mock("./restart.js", () => ({
   triggerOpenClawRestart: (...args: unknown[]) => triggerOpenClawRestartMock(...args),
+}));
+vi.mock("../daemon/launchd-restart-handoff.js", () => ({
+  scheduleDetachedLaunchdRestartHandoff: (...args: unknown[]) =>
+    scheduleLaunchdHandoffMock(...args),
 }));
 vi.mock("./container-environment.js", () => ({
   isContainerEnvironment: () => isContainerEnvironmentMock(),
@@ -43,6 +57,11 @@ afterEach(() => {
   process.execArgv = [...originalExecArgv];
   spawnMock.mockClear();
   triggerOpenClawRestartMock.mockClear();
+  scheduleLaunchdHandoffMock.mockReset();
+  scheduleLaunchdHandoffMock.mockReturnValue({
+    ok: true,
+    value: Promise.resolve(true),
+  });
   isContainerEnvironmentMock.mockReset();
   isContainerEnvironmentMock.mockReturnValue(false);
   vi.restoreAllMocks();
@@ -63,14 +82,19 @@ function mockDetachedChild(pid: number) {
   };
 }
 
-function expectLaunchdSupervisedWithoutKickstart(params?: { launchJobLabel?: string }) {
+function expectLaunchdSupervisedWithHandoff(params?: { launchJobLabel?: string }) {
   setPlatform("darwin");
   if (params?.launchJobLabel) {
     process.env.LAUNCH_JOB_LABEL = params.launchJobLabel;
   }
   process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
   const result = restartGatewayProcessWithFreshPid();
-  expect(result).toEqual({ mode: "supervised" });
+  expect(result.mode).toBe("supervised");
+  expect(result.handoffSpawned).toBeInstanceOf(Promise);
+  expect(scheduleLaunchdHandoffMock).toHaveBeenCalledWith({
+    mode: "start-after-exit",
+    waitForPid: process.pid,
+  });
   expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
   expect(spawnMock).not.toHaveBeenCalled();
 }
@@ -96,9 +120,9 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("returns supervised when OpenClaw launchd markers are present on macOS (no kickstart)", () => {
+  it("actively schedules relaunch when OpenClaw launchd markers are present on macOS", () => {
     clearSupervisorHints();
-    expectLaunchdSupervisedWithoutKickstart({ launchJobLabel: "ai.openclaw.gateway" });
+    expectLaunchdSupervisedWithHandoff({ launchJobLabel: "ai.openclaw.gateway" });
   });
 
   it("returns supervised for a real gateway launchd job without the injected marker", () => {
@@ -109,6 +133,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     const result = restartGatewayProcessWithFreshPid();
 
     expect(result.mode).toBe("supervised");
+    expect(scheduleLaunchdHandoffMock).toHaveBeenCalledOnce();
     expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });
@@ -121,12 +146,25 @@ describe("restartGatewayProcessWithFreshPid", () => {
     const result = restartGatewayProcessWithFreshPid();
 
     expect(result.mode).toBe("supervised");
+    expect(scheduleLaunchdHandoffMock).toHaveBeenCalledOnce();
     expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("returns supervised on macOS when launchd label is set (no kickstart)", () => {
-    expectLaunchdSupervisedWithoutKickstart({ launchJobLabel: "ai.openclaw.gateway" });
+  it("returns supervised on macOS when launchd label is set", () => {
+    expectLaunchdSupervisedWithHandoff({ launchJobLabel: "ai.openclaw.gateway" });
+  });
+
+  it("returns failed when the launchd handoff cannot be scheduled", () => {
+    clearSupervisorHints();
+    setPlatform("darwin");
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    scheduleLaunchdHandoffMock.mockReturnValue({ ok: false, error: "spawn EPERM" });
+
+    expect(restartGatewayProcessWithFreshPid()).toEqual({
+      mode: "failed",
+      detail: "spawn EPERM",
+    });
   });
 
   it("launchd supervisor never returns failed regardless of triggerOpenClawRestart outcome", () => {
@@ -142,6 +180,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
     expect(result.mode).not.toBe("failed");
+    expect(scheduleLaunchdHandoffMock).toHaveBeenCalledOnce();
     expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
   });
 
@@ -153,6 +192,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     const result = restartGatewayProcessWithFreshPid();
 
     expect(result.mode).toBe("supervised");
+    expect(scheduleLaunchdHandoffMock).not.toHaveBeenCalled();
     expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });
@@ -192,7 +232,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when OPENCLAW_LAUNCHD_LABEL is set (stock launchd plist)", () => {
     clearSupervisorHints();
-    expectLaunchdSupervisedWithoutKickstart();
+    expectLaunchdSupervisedWithHandoff();
   });
 
   it("returns supervised when OPENCLAW_SYSTEMD_UNIT is set", () => {
@@ -312,6 +352,22 @@ describe("respawnGatewayProcessForUpdate", () => {
 
     expect(result).toEqual({ mode: "disabled", detail: "OPENCLAW_NO_RESPAWN" });
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("actively schedules launchd update relaunch before exiting", () => {
+    clearSupervisorHints();
+    setPlatform("darwin");
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    process.env.OPENCLAW_NO_RESPAWN = "1";
+
+    const result = respawnGatewayProcessForUpdate();
+
+    expect(result.mode).toBe("supervised");
+    expect(result.handoffSpawned).toBeInstanceOf(Promise);
+    expect(scheduleLaunchdHandoffMock).toHaveBeenCalledWith({
+      mode: "start-after-exit",
+      waitForPid: process.pid,
+    });
   });
 
   it("allows detached respawn on unmanaged Windows during updates", () => {

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -1,6 +1,7 @@
 // Respawns the gateway process when no supervisor handles restart.
 import { spawn, type ChildProcess } from "node:child_process";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { scheduleDetachedLaunchdRestartHandoff } from "../daemon/launchd-restart-handoff.js";
 import { isContainerEnvironment } from "./container-environment.js";
 import { formatErrorMessage } from "./errors.js";
 import { triggerOpenClawRestart } from "./restart.js";
@@ -12,6 +13,7 @@ type GatewayRespawnResult = {
   mode: RespawnMode;
   pid?: number;
   detail?: string;
+  handoffSpawned?: Promise<boolean>;
 };
 
 type GatewayUpdateRespawnResult = GatewayRespawnResult & {
@@ -60,6 +62,17 @@ function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
   return { child, pid: child.pid ?? undefined };
 }
 
+function scheduleLaunchdRestartAfterExit(): GatewayRespawnResult {
+  const handoff = scheduleDetachedLaunchdRestartHandoff({
+    mode: "start-after-exit",
+    waitForPid: process.pid,
+  });
+  if (!handoff.ok) {
+    return { mode: "failed", detail: handoff.error };
+  }
+  return { mode: "supervised", handoffSpawned: handoff.value };
+}
+
 /**
  * Attempt to restart this process with a fresh PID.
  * - supervised environments (launchd/systemd/schtasks): caller should exit and let supervisor restart
@@ -75,9 +88,9 @@ export function restartGatewayProcessWithFreshPid(
   }
   const supervisor = detectGatewayRespawnSupervisor(process.env);
   if (supervisor) {
-    // On macOS launchd, exit cleanly and let KeepAlive relaunch the service.
-    // Avoid detached kickstart/start handoffs here so restart timing stays tied
-    // to launchd's native supervision rather than a second helper process.
+    if (supervisor === "launchd") {
+      return scheduleLaunchdRestartAfterExit();
+    }
     if (supervisor === "schtasks") {
       const restart = triggerOpenClawRestart();
       if (!restart.ok) {
@@ -127,6 +140,9 @@ export function respawnGatewayProcessForUpdate(
   if (supervisor) {
     // Managed update handoffs require the original PID to exit before the
     // detached helper can mutate the install, even when respawn is disabled.
+    if (supervisor === "launchd") {
+      return scheduleLaunchdRestartAfterExit();
+    }
     if (supervisor === "schtasks") {
       const restart = triggerOpenClawRestart();
       if (!restart.ok) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #104538. A launchd-managed gateway could exit for an ordinary config or update restart and rely only on `KeepAlive`; in affected user launchd domains that left the gateway stopped until a manual `launchctl kickstart`.

## Why This Change Was Made

- Route both routine and update launchd restarts through the existing detached `start-after-exit` handoff.
- After the old gateway PID exits, use `launchctl kickstart` without `-k`. That actively starts an inert service while preserving an already-running KeepAlive replacement.
- Confirm Node's asynchronous child `spawn`/`error` outcome during the existing launchd throttle window. If the helper cannot spawn, keep the gateway reachable through the existing in-process fallback.

This replaces the contributor branch's separate polling mode with the existing handoff owner and also fixes the sibling update-restart path.

## User Impact

Routine configuration and update restarts no longer depend on launchd `KeepAlive` firing. Healthy KeepAlive relaunches are left running; inert jobs are actively started; a helper-spawn failure no longer causes the gateway to exit.

## Evidence

- `node scripts/run-vitest.mjs src/daemon/launchd-restart-handoff.test.ts src/infra/process-respawn.test.ts src/cli/gateway-cli/run-loop.test.ts src/daemon/launchd.test.ts` — 203 tests passed across three shards on exact rebased head `304d8cb9b7b`.
- `node scripts/check-changed.mjs -- <seven touched files>` — core and core-test typecheck, lint, format, import-cycle, dependency, API-baseline, database/state, and guard lanes passed. Blacksmith warmup timed out twice, so this used the documented trusted-source local fallback on Node 24.18.
- AutoReview on the launchd patch: clean, no accepted/actionable findings.
- Real macOS throwaway LaunchAgent: a second non-`-k` kickstart preserved PID 60272; after stopping it, the same command relaunched PID 60397. The job and plist were removed afterward.
- Initial hosted CI exposed an unrelated Gateway startup-probe timing flake twice (473 ms and 477 ms against a 400 ms deadline). Current `main` independently landed the equivalent stable signal-gap repair while this PR rebased, so the redundant local test commit was dropped. This PR again contains only the launchd bug fix.

Original fix by @ObliviateRickLin; replacement commit preserves `Co-authored-by: RickLin <83101411+ObliviateRickLin@users.noreply.github.com>`.
