### PR TITLE
fix(ui): move language selector to general settings

### DIFF
--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -21,7 +21,7 @@ import {
 import { startThemeTransition } from "../../app/theme-transition.ts";
 import { resolveTheme, type ThemeMode, type ThemeName } from "../../app/theme.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
-import { t } from "../../i18n/index.ts";
+import { i18n, isSupportedLocale, t, type Locale } from "../../i18n/index.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
@@ -584,6 +584,11 @@ export class ConfigPage extends OpenClawLightDomElement {
     this.context.theme.refresh();
   }
 
+  private setLocale(locale: Locale) {
+    this.settings = patchSettings({ locale });
+    void i18n.setLocale(locale);
+  }
+
   private setTheme(
     theme: ThemeName,
     context?: Parameters<typeof startThemeTransition>[0]["context"],
@@ -815,6 +820,8 @@ export class ConfigPage extends OpenClawLightDomElement {
     const fastMode = agentsDefaults?.fastMode;
     const appConfig = this.context.config.current;
     return renderQuickSettings({
+      locale: isSupportedLocale(this.settings.locale) ? this.settings.locale : i18n.getLocale(),
+      onLocaleChange: (locale) => this.setLocale(locale),
       currentModel: model,
       thinkingLevel,
       fastMode: fastMode === "auto" || typeof fastMode === "boolean" ? fastMode : false,

--- a/ui/src/pages/config/quick.test.ts
+++ b/ui/src/pages/config/quick.test.ts
@@ -43,6 +43,8 @@ function expectStatByLabel(container: Element, text: string): HTMLElement {
 
 function createProps(overrides: Partial<QuickSettingsProps> = {}): QuickSettingsProps {
   return {
+    locale: "en",
+    onLocaleChange: vi.fn(),
     lobsterPetVisits: true,
     setLobsterPetVisits: () => {},
     lobsterPetSounds: false,
@@ -133,6 +135,7 @@ describe("renderQuickSettings", () => {
     render(renderQuickSettings(createProps()), container);
 
     expect(collectQuickSettingsCardKinds(container)).toEqual([
+      "qs-card--general",
       "qs-card--model",
       "qs-card--channels",
       "qs-card--security",
@@ -142,6 +145,23 @@ describe("renderQuickSettings", () => {
       "qs-card--automations",
     ]);
     expect(container.querySelectorAll(".qs-card--span-all")).toHaveLength(0);
+  });
+
+  it("changes the Control UI language from General settings", () => {
+    const onLocaleChange = vi.fn();
+    const container = document.createElement("div");
+
+    render(renderQuickSettings(createProps({ locale: "pt-BR", onLocaleChange })), container);
+
+    const row = expectRowByLabel(container, "Language");
+    const select = row.querySelector("select");
+    expect(select?.value).toBe("pt-BR");
+    if (!(select instanceof HTMLSelectElement)) {
+      throw new Error("Expected language selector");
+    }
+    select.value = "en";
+    select.dispatchEvent(new Event("change"));
+    expect(onLocaleChange).toHaveBeenCalledWith("en");
   });
 
   it("renders Gateway host identity and resources", () => {

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -26,7 +26,7 @@ import {
   canonicalLobsterLook,
   renderLobsterSvg,
 } from "../../components/lobster-pet.ts";
-import { t } from "../../i18n/index.ts";
+import { SUPPORTED_LOCALES, t, type Locale } from "../../i18n/index.ts";
 import { formatBytes } from "../../lib/agents/display.ts";
 import { resolveAssistantTextAvatar, resolveChatAvatarRenderUrl } from "../../lib/avatar.ts";
 import { formatDurationHuman } from "../../lib/format.ts";
@@ -56,6 +56,10 @@ export type QuickSettingsSecurity = {
 };
 
 export type QuickSettingsProps = {
+  // General
+  locale: Locale;
+  onLocaleChange: (locale: Locale) => void;
+
   // Model & Thinking
   currentModel: string;
   thinkingLevel: string;
@@ -336,6 +340,33 @@ function renderCardHeader(icon: TemplateResult, title: string, action?: Template
 
 function fastModeOptionValue(value: "auto" | "on" | "off"): FastMode {
   return value === "auto" ? "auto" : value === "on";
+}
+
+function renderGeneralCard(props: QuickSettingsProps) {
+  return html`
+    <div class="qs-card qs-card--general">
+      ${renderCardHeader(icons.globe, t("nav.settingsGeneral"))}
+      <div class="qs-card__body">
+        <label class="qs-row">
+          <span class="qs-row__label">${t("overview.access.language")}</span>
+          <select
+            class="cfg-select qs-select"
+            .value=${props.locale}
+            @change=${(event: Event) => {
+              props.onLocaleChange((event.target as HTMLSelectElement).value as Locale);
+            }}
+          >
+            ${SUPPORTED_LOCALES.map((locale) => {
+              const key = locale.replace(/-([a-zA-Z])/g, (_, character) => character.toUpperCase());
+              return html`<option value=${locale} ?selected=${props.locale === locale}>
+                ${t(`languages.${key}`)}
+              </option>`;
+            })}
+          </select>
+        </label>
+      </div>
+    </div>
+  `;
 }
 
 function renderModelCard(props: QuickSettingsProps) {
@@ -1070,9 +1101,10 @@ export function renderQuickSettings(props: QuickSettingsProps) {
   return html`
     <div class="qs-container">
       <div class="qs-grid">
-        ${renderModelCard(props)} ${renderChannelsCard(props)} ${renderSecurityCard(props)}
-        ${renderSystemCard(props)} ${renderAppearanceCard(props)} ${renderPersonalCard(props)}
-        ${renderAutomationsCard(props)} ${renderPendingChangesBar(props)}
+        ${renderGeneralCard(props)} ${renderModelCard(props)} ${renderChannelsCard(props)}
+        ${renderSecurityCard(props)} ${renderSystemCard(props)} ${renderAppearanceCard(props)}
+        ${renderPersonalCard(props)} ${renderAutomationsCard(props)}
+        ${renderPendingChangesBar(props)}
       </div>
 
       ${renderConnectionFooter(props)}

--- a/ui/src/pages/overview/overview-page.ts
+++ b/ui/src/pages/overview/overview-page.ts
@@ -310,27 +310,6 @@ class OverviewPage extends OpenClawLightDomElement {
     this.settings = { ...this.settings, ...patch };
   }
 
-  private updateLocale(locale: string) {
-    const gateway = this.context.gateway;
-    const navigation = this.context.navigation.snapshot;
-    const nextDraft = {
-      ...this.settings,
-      themeMode: this.context.theme.mode,
-      navCollapsed: navigation.navCollapsed,
-      sidebarPinnedRoutes: [...navigation.sidebarPinnedRoutes],
-      sidebarMoreExpanded: navigation.sidebarMoreExpanded,
-      locale,
-    };
-    this.settings = nextDraft;
-    patchSettings({
-      gatewayUrl: gateway.connection.gatewayUrl,
-      token: gateway.connection.token,
-      sessionKey: gateway.snapshot.sessionKey,
-      lastActiveSessionKey: gateway.snapshot.sessionKey,
-      locale,
-    });
-  }
-
   private connect() {
     const session = this.sessionKeyDirty
       ? {
@@ -482,7 +461,6 @@ class OverviewPage extends OpenClawLightDomElement {
         showGatewayToken: this.showGatewayToken,
         showGatewayPassword: this.showGatewayPassword,
         onConnectionChange: (patch) => this.updateConnectionDraft(patch),
-        onLocaleChange: (locale) => this.updateLocale(locale),
         onPasswordChange: (next) => (this.password = next),
         onSessionKeyChange: (sessionKey) => {
           this.sessionKeyDirty = true;

--- a/ui/src/pages/overview/overview-page.ts
+++ b/ui/src/pages/overview/overview-page.ts
@@ -16,12 +16,7 @@ import {
   type ApplicationGateway,
 } from "../../app/context.ts";
 import { hasOperatorReadAccess } from "../../app/operator-access.ts";
-import {
-  loadGatewaySessionSelection,
-  loadSettings,
-  patchSettings,
-  type UiSettings,
-} from "../../app/settings.ts";
+import { loadGatewaySessionSelection, loadSettings, type UiSettings } from "../../app/settings.ts";
 import { t } from "../../i18n/index.ts";
 import { isCronJobActiveFailure } from "../../lib/cron-status.ts";
 import { createInitialCronState, loadCronJobsPage, loadCronStatus } from "../../lib/cron/index.ts";

--- a/ui/src/pages/overview/view.render.test.ts
+++ b/ui/src/pages/overview/view.render.test.ts
@@ -2,8 +2,6 @@
 
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
-import { i18n } from "../../i18n/index.ts";
-import { getSafeLocalStorage } from "../../local-storage.ts";
 import { renderOverview } from "./view.ts";
 
 type OverviewProps = Parameters<typeof renderOverview>[0];
@@ -43,7 +41,6 @@ function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewPr
     showGatewayToken: false,
     showGatewayPassword: false,
     onConnectionChange: () => undefined,
-    onLocaleChange: () => undefined,
     onPasswordChange: () => undefined,
     onSessionKeyChange: () => undefined,
     onToggleGatewayTokenVisibility: () => undefined,
@@ -62,37 +59,6 @@ function compactText(node: Element | null): string | undefined {
 }
 
 describe("overview view rendering", () => {
-  it("keeps the persisted overview locale selected before i18n hydration finishes", async () => {
-    const container = document.createElement("div");
-    const props = createOverviewProps({
-      settings: {
-        ...createOverviewProps().settings,
-        locale: "zh-CN",
-      },
-    });
-
-    getSafeLocalStorage()?.clear();
-    await i18n.setLocale("en");
-
-    render(renderOverview(props), container);
-    await Promise.resolve();
-
-    let select = container.querySelector<HTMLSelectElement>("select");
-    expect(i18n.getLocale()).toBe("en");
-    expect(select?.value).toBe("zh-CN");
-    expect(select?.selectedOptions[0]?.textContent?.trim()).toBe("简体中文 (Simplified Chinese)");
-
-    await i18n.setLocale("zh-CN");
-    render(renderOverview(props), container);
-    await Promise.resolve();
-
-    select = container.querySelector<HTMLSelectElement>("select");
-    expect(select?.value).toBe("zh-CN");
-    expect(select?.selectedOptions[0]?.textContent?.trim()).toBe("简体中文 (简体中文)");
-
-    await i18n.setLocale("en");
-  });
-
   it("renders recent session names through the shared display resolver", async () => {
     const container = document.createElement("div");
     const props = createOverviewProps({

--- a/ui/src/pages/overview/view.ts
+++ b/ui/src/pages/overview/view.ts
@@ -15,7 +15,7 @@ import type { NavigationRouteId } from "../../app-navigation.ts";
 import { resolveGatewayTokenForUrlEdit, type UiSettings } from "../../app/settings.ts";
 import "../../components/tooltip.ts";
 import { icons } from "../../components/icons.ts";
-import { t, i18n, SUPPORTED_LOCALES, type Locale, isSupportedLocale } from "../../i18n/index.ts";
+import { t } from "../../i18n/index.ts";
 import { formatRelativeTimestamp, formatDurationHuman } from "../../lib/format.ts";
 import { renderOverviewAttention } from "./attention.ts";
 import { renderOverviewCards } from "./cards.ts";
@@ -41,7 +41,6 @@ type OverviewProps = {
   showGatewayToken: boolean;
   showGatewayPassword: boolean;
   onConnectionChange: (patch: Partial<Pick<UiSettings, "gatewayUrl" | "token">>) => void;
-  onLocaleChange: (locale: Locale) => void;
   onPasswordChange: (next: string) => void;
   onSessionKeyChange: (next: string) => void;
   onToggleGatewayTokenVisibility: () => void;
@@ -67,10 +66,6 @@ export function renderOverview(props: OverviewProps) {
     : t("common.na");
   const authMode = snapshot?.authMode;
   const isTrustedProxy = authMode === "trusted-proxy";
-
-  const currentLocale = isSupportedLocale(props.settings.locale)
-    ? props.settings.locale
-    : i18n.getLocale();
 
   return html`
     <section class="grid">
@@ -173,24 +168,6 @@ export function renderOverview(props: OverviewProps) {
                 props.onSessionKeyChange(v);
               }}
             />
-          </label>
-          <label class="field">
-            <span>${t("overview.access.language")}</span>
-            <select
-              .value=${currentLocale}
-              @change=${(e: Event) => {
-                const v = (e.target as HTMLSelectElement).value as Locale;
-                void i18n.setLocale(v);
-                props.onLocaleChange(v);
-              }}
-            >
-              ${SUPPORTED_LOCALES.map((loc) => {
-                const key = loc.replace(/-([a-zA-Z])/g, (_, c) => c.toUpperCase());
-                return html`<option value=${loc} ?selected=${currentLocale === loc}>
-                  ${t(`languages.${key}`)}
-                </option>`;
-              })}
-            </select>
           </label>
         </div>
         <div class="row" style="margin-top: 14px;">

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -135,6 +135,7 @@ openclaw-logs-page {
   grid-column: span 4;
 }
 
+.qs-card--general,
 .qs-card--appearance,
 .qs-card--system {
   grid-column: 1 / -1;
@@ -235,6 +236,13 @@ openclaw-logs-page {
   font-size: 0.8125rem;
   color: var(--muted);
   text-align: right;
+}
+
+.qs-select {
+  min-width: min(280px, 100%);
+  height: 38px;
+  background-color: var(--card);
+  font-size: inherit;
 }
 
 .qs-row__value--action {


### PR DESCRIPTION
## What Problem This Solves

The Control UI language selector currently lives in Overview alongside Gateway connection fields, while Settings > General does not expose the preference.

## Why This Change Was Made

This PR moves the existing locale selector and persistence behavior into a full-width General card in Settings. It reuses the existing Control UI select styling and removes the selector from Overview without changing the supported locale list.

## User Impact

Users can find and change the Control UI language under Settings > General, where a global interface preference is expected.

## Evidence

### Before on `origin/main`

Settings > General starts with Model & Thinking and has no language preference.

![Before: General settings without a language selector](https://ubuntu-valley-36rf.here.now/before.jpg)

### Proposed in this PR

Settings > General includes a full-width General card with the styled language selector.

![Proposed: language selector in General settings](https://ubuntu-valley-36rf.here.now/after.png)

Validated with:

- `node scripts/run-vitest.mjs ui/src/pages/config/quick.test.ts ui/src/pages/overview/view.render.test.ts` — 29 tests passed
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json --incremental --tsBuildInfoFile /tmp/settings-language-ui.tsbuildinfo`
- `node_modules/.bin/oxfmt --check ui/src/pages/config/config-page.ts ui/src/pages/config/quick.test.ts ui/src/pages/config/quick.ts ui/src/pages/overview/overview-page.ts ui/src/pages/overview/view.render.test.ts ui/src/pages/overview/view.ts ui/src/styles/config-quick.css`
- `git diff --check origin/main...HEAD`
- Mocked Control UI verification at `/overview` and `/settings/general`

AI-assisted: yes. I reviewed the diff and understand the changes.
