### PR TITLE
feat: improve chat transcript alignment and readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI Talk controls:** keep voice, model, sensitivity, and other realtime defaults in Settings → Communications → Talk, and use the composer microphone caret to select any browser audio input. (#101046)
 - **Control UI session workspace shortcut:** expand or collapse the active Chat pane's session workspace rail with ⇧⌘B without changing the main app sidebar or the separate detail and Canvas preview panel. Thanks @shakkernerd.
 - **Control UI Settings shortcut:** open Settings with ⇧⌘, while leaving the browser-owned ⌘, shortcut unchanged. Thanks @shakkernerd.
+- **Control UI chat layout:** center the transcript on the composer axis, keep assistant and tool output left and user bubbles right within the same readable frame, and preserve custom message-width overrides. (#104474) Thanks @shakkernerd.
 - **Cron model selection:** choose an agent-turn model in Control UI Quick Create and show configured or default models in cron job rows and details. (#95341) Thanks @ly85206559.
 - **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards. (#100434)
 - **Logbook work journal:** add a disabled-by-default bundled plugin that turns paired-node screen snapshots into a private timeline, daily standup, and timeline-grounded Q&A in a plugin-contributed Control UI tab. (#99930)

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -553,7 +553,7 @@ See [Inferred commitments](/concepts/commitments).
       // toolTitles: false, // opt-in AI purpose titles for tool calls (spends utility-model tokens)
       // embedSandbox: "scripts", // strict | scripts | trusted
       // allowExternalEmbedUrls: false, // dangerous: allow absolute external http(s) embed URLs
-      // chatMessageMaxWidth: "min(1280px, 82%)", // optional grouped chat message max-width
+      // chatMessageMaxWidth: "min(1280px, 82%)", // optional centered chat transcript max-width
       // allowedOrigins: ["https://control.example.com"], // required for non-loopback Control UI
       // dangerouslyAllowHostHeaderOriginFallback: false, // dangerous Host-header origin fallback mode
       // allowInsecureAuth: false,
@@ -635,7 +635,7 @@ See [Inferred commitments](/concepts/commitments).
   Default `false`.
 - `controlUi.allowedOrigins`: explicit browser-origin allowlist for Gateway WebSocket connects. Required for public non-loopback browser origins. Private same-origin LAN/Tailnet UI loads from loopback, RFC1918/link-local, `.local`, `.ts.net`, or Tailscale CGNAT hosts are accepted without enabling Host-header fallback.
 - `controlUi.toolTitles`: opt in to AI-generated purpose titles for tool calls in Control UI chat. Default: `false` (tool rendering stays fully deterministic with no background model calls). When enabled, the `chat.toolTitles` method labels complex calls through standard utility-model routing — the agent's `utilityModel` (an operator decision that may send bounded tool arguments to the chosen provider, like every utility task), or the session provider's declared small-model default (OpenAI → `gpt-5.6-luna`, Anthropic → `claude-haiku-4-5`) — and caches results in the per-agent state database so repeat views never re-bill. `utilityModel: \"\"` disables titles like every other utility task; titles never fall back to the primary model.
-- `controlUi.chatMessageMaxWidth`: optional max-width for grouped Control UI chat messages. Accepts constrained CSS width values such as `960px`, `82%`, `min(1280px, 82%)`, and `calc(100% - 2rem)`.
+- `controlUi.chatMessageMaxWidth`: optional max-width for the centered Control UI chat transcript. Accepts constrained CSS width values such as `960px`, `82%`, `min(1280px, 82%)`, and `calc(100% - 2rem)`.
 - `controlUi.dangerouslyAllowHostHeaderOriginFallback`: dangerous mode that enables Host-header origin fallback for deployments that intentionally rely on Host-header origin policy.
 - `terminal.enabled`: opt in to the admin-scoped operator terminal. Default: `false`. The terminal starts a host PTY in the selected agent workspace, inherits the Gateway process environment, and is refused for agents with `sandbox.mode: "all"`. Enable it only for trusted operator deployments; changing it restarts the Gateway and updates the Control UI content security policy.
 - `terminal.shell`: optional shell executable. When unset, OpenClaw uses `$SHELL` on Unix and `%ComSpec%` on Windows.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -429,7 +429,7 @@ Absolute external `http(s)` embed URLs stay blocked by default. To let `[embed u
 
 ## Chat message width
 
-Grouped chat messages use a readable default max-width. Wide-monitor deployments can override it without patching bundled CSS by setting `gateway.controlUi.chatMessageMaxWidth`:
+The chat transcript uses a centered readable frame aligned with the composer. Assistant and tool output stay left-aligned while user bubbles stay right-aligned inside that frame. Wide-monitor deployments can override the transcript width without patching bundled CSS by setting `gateway.controlUi.chatMessageMaxWidth`:
 
 ```json5
 {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -608,7 +608,7 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.controlUi.allowExternalEmbedUrls":
     "DANGEROUS toggle that allows hosted embeds to load absolute external http(s) URLs. Keep this off unless your Control UI intentionally embeds trusted third-party pages; hosted /__openclaw__/canvas and /__openclaw__/a2ui documents do not need it.",
   "gateway.controlUi.chatMessageMaxWidth":
-    'Optional CSS max-width for grouped Control UI chat messages, for example "960px", "82%", or "min(1280px, 82%)". Values are validated against a constrained width grammar before reaching the browser.',
+    'Optional CSS max-width for the centered Control UI chat transcript, for example "960px", "82%", or "min(1280px, 82%)". Values are validated against a constrained width grammar before reaching the browser.',
   "gateway.controlUi.allowedOrigins":
     'Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com). Required for non-loopback Control UI deployments unless dangerous Host-header fallback is explicitly enabled. Setting ["*"] means allow any browser origin and should be avoided outside tightly controlled local testing.',
   "gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback":

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -46,6 +46,7 @@ type ControlRect = {
 
 type ChatFixtureOptions = {
   composerAttachment?: boolean;
+  direct?: boolean;
   sideResultBody?: string;
   singleAgent?: boolean;
   slashMenu?: boolean;
@@ -259,8 +260,8 @@ function chatHtml(opts: ChatFixtureOptions = {}) {
       <main class="content content--chat">
         <section class="card chat">
           <div class="chat-split-container">
-            <div class="chat-main">
-              <div class="chat-thread" role="log">
+            <div class="chat-main" style="flex: 1 1 100%">
+              <div class="chat-thread${opts.direct ? " chat-thread--direct" : ""}" role="log">
                 <div class="chat-thread-inner">
                   <div class="chat-group user">
                     <div class="chat-avatar user">V</div>
@@ -289,25 +290,23 @@ function chatHtml(opts: ChatFixtureOptions = {}) {
                   </div>
                 </div>
               </div>
-            </div>
-          </div>
-          ${
-            opts.sideResultBody !== undefined
-              ? `<section class="chat-side-result" role="status" aria-live="polite">
-                  <div class="chat-side-result__header">
-                    <div class="chat-side-result__label-row"><span class="chat-side-result__label">BTW</span><span class="chat-side-result__meta">Not saved to chat history</span></div>
-                    <button class="btn chat-side-result__dismiss">${iconSvg()}</button>
-                  </div>
-                  <div class="chat-side-result__question">What should I check next?</div>
-                  <div class="chat-side-result__body">${opts.sideResultBody}</div>
-                </section>`
-              : ""
-          }
-          <div class="agent-chat__composer-shell">
-            <div class="agent-chat__input">
               ${
-                opts.slashMenu
-                  ? `<div class="slash-menu" role="listbox" aria-label="Command suggestions">
+                opts.sideResultBody !== undefined
+                  ? `<section class="chat-side-result" role="status" aria-live="polite">
+                      <div class="chat-side-result__header">
+                        <div class="chat-side-result__label-row"><span class="chat-side-result__label">BTW</span><span class="chat-side-result__meta">Not saved to chat history</span></div>
+                        <button class="btn chat-side-result__dismiss">${iconSvg()}</button>
+                      </div>
+                      <div class="chat-side-result__question">What should I check next?</div>
+                      <div class="chat-side-result__body">${opts.sideResultBody}</div>
+                    </section>`
+                  : ""
+              }
+              <div class="agent-chat__composer-shell">
+                <div class="agent-chat__input">
+                  ${
+                    opts.slashMenu
+                      ? `<div class="slash-menu" role="listbox" aria-label="Command suggestions">
                       <div class="slash-menu-group">
                         <div class="slash-menu-group__label">Commands</div>
                         <div class="slash-menu-item slash-menu-item--active" role="option" aria-selected="true">
@@ -327,11 +326,11 @@ function chatHtml(opts: ChatFixtureOptions = {}) {
                         </div>
                       </div>
                     </div>`
-                  : ""
-              }
-              ${
-                opts.composerAttachment
-                  ? `<div class="chat-attachments-preview">
+                      : ""
+                  }
+                  ${
+                    opts.composerAttachment
+                      ? `<div class="chat-attachments-preview">
                       <div class="chat-attachment-thumb chat-attachment-thumb--file">
                         <div class="chat-attachment-file">
                           <span class="chat-attachment-file__icon">${iconSvg()}</span>
@@ -340,61 +339,63 @@ function chatHtml(opts: ChatFixtureOptions = {}) {
                         <button class="chat-attachment-remove" type="button" aria-label="Remove attachment">&times;</button>
                       </div>
                     </div>`
-                  : ""
-              }
-              <div class="agent-chat__composer-status-stack"> </div>
-              <div class="agent-chat__composer-input-row">
-                <details class="agent-chat__attach-menu">
-                  <summary class="agent-chat__input-btn agent-chat__input-btn--attach" aria-label="Add attachment">${iconSvg()}</summary>
-                  <div class="agent-chat__attach-menu-popover" role="menu">
-                    <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>Camera</span></button>
-                    <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>Photo</span></button>
-                    <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>File</span></button>
-                  </div>
-                </details>
-                <div class="agent-chat__composer-combobox">
-                  <textarea rows="1">Queued follow-up for the active operator session</textarea>
-                </div>
-                <div class="agent-chat__composer-actions">
-                  <button class="chat-send-btn chat-send-btn--voice" aria-label="Start voice input">${iconSvg()}</button>
-                </div>
-              </div>
-              <div class="agent-chat__composer-footer">
-                ${composerControlsHtml()}
-                <div class="agent-chat__composer-meta">
-                  <div class="context-usage">
-                    <details>
-                      <summary class="context-ring" role="status" aria-label="Session context usage: 46k/200k (23%)">
-                        <svg class="context-ring__dial" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
-                          <circle class="context-ring__track" cx="8" cy="8" r="6.5"></circle>
-                          <circle class="context-ring__fill" cx="8" cy="8" r="6.5"></circle>
-                        </svg>
-                      </summary>
-                      <section class="context-usage__popover">
-                        <div class="context-usage__section-label context-usage__plan-header">
-                          <span>Plan usage</span>
-                          <a class="context-usage__plan-link" href="/usage" data-chat-provider-usage="true">
-                            <span class="context-usage__plan-badge">Max (20x)</span>${iconSvg()}
-                          </a>
-                        </div>
-                        <div class="context-usage__limits">
-                          <div class="context-usage__limit">
-                            <div class="context-usage__limit-head">
-                              <span class="context-usage__limit-label">Weekly · all models</span>
-                              <span class="context-usage__limit-meta"><strong>72%</strong></span>
-                            </div>
-                            <div class="context-usage__limit-bar"><span style="width: 72%"></span></div>
-                          </div>
-                        </div>
-                      </section>
+                      : ""
+                  }
+                  <div class="agent-chat__composer-status-stack"> </div>
+                  <div class="agent-chat__composer-input-row">
+                    <details class="agent-chat__attach-menu">
+                      <summary class="agent-chat__input-btn agent-chat__input-btn--attach" aria-label="Add attachment">${iconSvg()}</summary>
+                      <div class="agent-chat__attach-menu-popover" role="menu">
+                        <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>Camera</span></button>
+                        <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>Photo</span></button>
+                        <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>File</span></button>
+                      </div>
                     </details>
+                    <div class="agent-chat__composer-combobox">
+                      <textarea rows="1">Queued follow-up for the active operator session</textarea>
+                    </div>
+                    <div class="agent-chat__composer-actions">
+                      <button class="chat-send-btn chat-send-btn--voice" aria-label="Start voice input">${iconSvg()}</button>
+                    </div>
                   </div>
-                  <div class="agent-chat__composer-progress">
-                    <span class="agent-chat__run-status agent-chat__run-status--in-progress">
-                      ${iconSvg()}<span class="agent-chat__run-status-label">In progress</span>
-                    </span>
+                  <div class="agent-chat__composer-footer">
+                    ${composerControlsHtml()}
+                    <div class="agent-chat__composer-meta">
+                      <div class="context-usage">
+                        <details>
+                          <summary class="context-ring" role="status" aria-label="Session context usage: 46k/200k (23%)">
+                            <svg class="context-ring__dial" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+                              <circle class="context-ring__track" cx="8" cy="8" r="6.5"></circle>
+                              <circle class="context-ring__fill" cx="8" cy="8" r="6.5"></circle>
+                            </svg>
+                          </summary>
+                          <section class="context-usage__popover">
+                            <div class="context-usage__section-label context-usage__plan-header">
+                              <span>Plan usage</span>
+                              <a class="context-usage__plan-link" href="/usage" data-chat-provider-usage="true">
+                                <span class="context-usage__plan-badge">Max (20x)</span>${iconSvg()}
+                              </a>
+                            </div>
+                            <div class="context-usage__limits">
+                              <div class="context-usage__limit">
+                                <div class="context-usage__limit-head">
+                                  <span class="context-usage__limit-label">Weekly · all models</span>
+                                  <span class="context-usage__limit-meta"><strong>72%</strong></span>
+                                </div>
+                                <div class="context-usage__limit-bar"><span style="width: 72%"></span></div>
+                              </div>
+                            </div>
+                          </section>
+                        </details>
+                      </div>
+                      <div class="agent-chat__composer-progress">
+                        <span class="agent-chat__run-status agent-chat__run-status--in-progress">
+                          ${iconSvg()}<span class="agent-chat__run-status-label">In progress</span>
+                        </span>
+                      </div>
+                      <span class="agent-chat__token-count">8</span>
+                    </div>
                   </div>
-                  <span class="agent-chat__token-count">8</span>
                 </div>
               </div>
             </div>
@@ -732,6 +733,32 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       }
     },
   );
+
+  it.each([
+    [1366, 900],
+    [1920, 1080],
+  ] as const)("centers direct messages on the composer axis at %sx%s", async (width, height) => {
+    const page = await openFixture(width, height, { direct: true });
+    try {
+      await expectNoHorizontalOverflow(page);
+      const [assistantLane, composer, thread, userLane] = await Promise.all([
+        getRect(page, ".chat-group.assistant .chat-group-messages"),
+        getRect(page, ".agent-chat__composer-shell"),
+        getRect(page, ".chat-thread-inner"),
+        getRect(page, ".chat-group.user .chat-group-messages"),
+      ]);
+
+      const threadCenter = thread.left + thread.width / 2;
+      const composerCenter = composer.left + composer.width / 2;
+      expect(Math.abs(threadCenter - composerCenter)).toBeLessThanOrEqual(1);
+      expect(Math.abs(thread.width - composer.width)).toBeLessThanOrEqual(1);
+      expect(thread.width).toBeCloseTo(768, 0);
+      expect(Math.abs(assistantLane.left - thread.left)).toBeLessThanOrEqual(1);
+      expect(Math.abs(userLane.right - thread.right)).toBeLessThanOrEqual(1);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
 
   it.each([
     [393, 852],

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -737,28 +737,53 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   it.each([
     [1366, 900],
     [1920, 1080],
-  ] as const)("centers direct messages on the composer axis at %sx%s", async (width, height) => {
-    const page = await openFixture(width, height, { direct: true });
-    try {
-      await expectNoHorizontalOverflow(page);
-      const [assistantLane, composer, thread, userLane] = await Promise.all([
-        getRect(page, ".chat-group.assistant .chat-group-messages"),
-        getRect(page, ".agent-chat__composer-shell"),
-        getRect(page, ".chat-thread-inner"),
-        getRect(page, ".chat-group.user .chat-group-messages"),
-      ]);
+  ] as const)(
+    "centers overflowing direct messages on the composer axis at %sx%s",
+    async (width, height) => {
+      const page = await openFixture(width, height, { direct: true });
+      try {
+        await page.evaluate(() => {
+          const thread = document.querySelector<HTMLElement>(".chat-thread");
+          const inner = document.querySelector<HTMLElement>(".chat-thread-inner");
+          if (!thread || !inner) {
+            throw new Error("Missing chat overflow fixture");
+          }
+          inner.style.minHeight = `${thread.clientHeight + 1}px`;
+        });
+        await expectNoHorizontalOverflow(page);
+        const [assistantLane, composer, thread, userLane, overflow] = await Promise.all([
+          getRect(page, ".chat-group.assistant .chat-group-messages"),
+          getRect(page, ".agent-chat__composer-shell"),
+          getRect(page, ".chat-thread-inner"),
+          getRect(page, ".chat-group.user .chat-group-messages"),
+          page.evaluate(() => {
+            const node = document.querySelector<HTMLElement>(".chat-thread");
+            if (!node) {
+              return null;
+            }
+            return {
+              clientHeight: node.clientHeight,
+              gutter: getComputedStyle(node).scrollbarGutter,
+              scrollHeight: node.scrollHeight,
+            };
+          }),
+        ]);
 
-      const threadCenter = thread.left + thread.width / 2;
-      const composerCenter = composer.left + composer.width / 2;
-      expect(Math.abs(threadCenter - composerCenter)).toBeLessThanOrEqual(1);
-      expect(Math.abs(thread.width - composer.width)).toBeLessThanOrEqual(1);
-      expect(thread.width).toBeCloseTo(768, 0);
-      expect(Math.abs(assistantLane.left - thread.left)).toBeLessThanOrEqual(1);
-      expect(Math.abs(userLane.right - thread.right)).toBeLessThanOrEqual(1);
-    } finally {
-      await closeBrowserPage(page);
-    }
-  });
+        expect(overflow).not.toBeNull();
+        expect(overflow?.scrollHeight).toBeGreaterThan(overflow?.clientHeight ?? 0);
+        expect(overflow?.gutter).toBe("stable both-edges");
+        const threadCenter = thread.left + thread.width / 2;
+        const composerCenter = composer.left + composer.width / 2;
+        expect(Math.abs(threadCenter - composerCenter)).toBeLessThanOrEqual(1);
+        expect(Math.abs(thread.width - composer.width)).toBeLessThanOrEqual(1);
+        expect(thread.width).toBeCloseTo(768, 0);
+        expect(Math.abs(assistantLane.left - thread.left)).toBeLessThanOrEqual(1);
+        expect(Math.abs(userLane.right - thread.right)).toBeLessThanOrEqual(1);
+      } finally {
+        await closeBrowserPage(page);
+      }
+    },
+  );
 
   it.each([
     [393, 852],

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -686,6 +686,19 @@ describe("chat compaction divider", () => {
   });
 });
 
+describe("chat conversation width", () => {
+  it("applies a configured width once to the centered transcript frame", () => {
+    const container = renderChatView({
+      chatMessageMaxWidth: "82%",
+      messages: [{ role: "assistant", content: "hello", timestamp: 1 }],
+    });
+    const chat = requireElement(container, ".chat", "chat");
+
+    expect(chat.style.getPropertyValue("--chat-thread-max-width")).toBe("82%");
+    expect(chat.style.getPropertyValue("--chat-message-max-width")).toBe("100%");
+  });
+});
+
 describe("direct thread avatar mode", () => {
   function sessionsListWithKind(sessionKey: string, kind: "direct" | "group" | "global") {
     return {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -692,10 +692,10 @@ describe("chat conversation width", () => {
       chatMessageMaxWidth: "82%",
       messages: [{ role: "assistant", content: "hello", timestamp: 1 }],
     });
-    const chat = requireElement(container, ".chat", "chat");
+    const chat = container.querySelector<HTMLElement>(".chat");
 
-    expect(chat.style.getPropertyValue("--chat-thread-max-width")).toBe("82%");
-    expect(chat.style.getPropertyValue("--chat-message-max-width")).toBe("100%");
+    expect(chat?.style.getPropertyValue("--chat-thread-max-width")).toBe("82%");
+    expect(chat?.style.getPropertyValue("--chat-message-max-width")).toBe("100%");
   });
 });
 

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -310,7 +310,12 @@ export function renderChat(props: ChatProps) {
       })}
       class="card chat"
       style=${styleMap(
-        props.chatMessageMaxWidth ? { "--chat-message-max-width": props.chatMessageMaxWidth } : {},
+        props.chatMessageMaxWidth
+          ? {
+              "--chat-thread-max-width": props.chatMessageMaxWidth,
+              "--chat-message-max-width": "100%",
+            }
+          : {},
       )}
       @drop=${(event: DragEvent) => {
         event.preventDefault();

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -326,7 +326,7 @@ img.chat-avatar {
 }
 
 .chat-thread--direct .chat-group {
-  margin-left: 8px;
+  margin-inline: 0;
 }
 
 .chat-thread--direct .chat-group.assistant .chat-group-messages {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -11,6 +11,8 @@ openclaw-chat-page {
 }
 
 .chat {
+  --chat-thread-max-width: 48rem;
+
   position: relative;
   display: flex;
   flex-direction: column;
@@ -99,6 +101,13 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 
 .chat-thread-inner > :first-child {
   margin-top: 0 !important;
+}
+
+.chat-thread-inner {
+  box-sizing: border-box;
+  width: calc(100% - 36px);
+  max-width: var(--chat-thread-max-width);
+  margin-inline: auto;
 }
 
 /* New messages indicator - floating pill above compose */

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -79,6 +79,8 @@ openclaw-chat-page {
   /* Grow, shrink, and use 0 base for proper scrolling */
   overflow-y: auto;
   overflow-x: hidden;
+  scrollbar-gutter: stable both-edges;
+  scrollbar-color: var(--muted-strong) transparent;
   /* The tall top inset is a titlebar band: it keeps the floating rail
      openers (.chat-floating-toggles, 28px at top 10px) clear of the first
      message and gives the native macOS app an empty strip that starts a
@@ -89,6 +91,14 @@ openclaw-chat-page {
   /* Allow shrinking for flex scroll behavior */
   border-radius: var(--radius-md);
   background: transparent;
+}
+
+:root .chat-thread::-webkit-scrollbar-thumb {
+  background: var(--muted-strong);
+}
+
+:root .chat-thread::-webkit-scrollbar-thumb:hover {
+  background: var(--text);
 }
 
 /* Split panes spend their top row on the pane header (which is both the


### PR DESCRIPTION
Closes #104474

## What Problem This Solves

Resolves a problem where chat content stretched across wide screens instead of aligning with the centered composer. Long transcripts could also shift when the scrollbar appeared, while the scrollbar itself lacked sufficient contrast.

## Why This Change Was Made

Center the transcript in the same readable-width frame as the composer while preserving left-aligned assistant and tool output and right-aligned user messages. Custom transcript widths remain supported, and symmetric scrollbar gutters prevent overflowing conversations from shifting off-axis.

## User Impact

Chat conversations are easier to read on wide screens, remain consistently aligned while scrolling, and use a more visible theme-aware scrollbar.

## Evidence

- 220 focused Chat UI tests passed on Blacksmith Testbox `tbx_01kx98damx7jrx3ffj0kckyjmr`.
- Browser coverage verifies centered alignment at 1366×900 and 1920×1080 with forced vertical overflow.
- Custom transcript-width mapping, direct-message alignment, light/dark responsive behavior, typechecks, lint, and changed-surface checks passed.
- Rebased onto current `origin/main`.
