### PR TITLE
refactor(qqbot): canonicalize the live group gate and delete the dead duplicate

### DIFF
--- a/extensions/qqbot/src/engine/gateway/stages/group-gate-stage.ts
+++ b/extensions/qqbot/src/engine/gateway/stages/group-gate-stage.ts
@@ -1,13 +1,12 @@
 // Qqbot plugin module implements group gate stage behavior.
 import type { HistoryPort } from "../../adapter/history.port.js";
 import type { QQBotInboundAccess } from "../../adapter/index.js";
-import type { MentionGatePort } from "../../adapter/mention-gate.port.js";
 import { classifyCoreCommandForGroup } from "../../commands/command-visibility.js";
 import { DEFAULT_GROUP_PROMPT, resolveGroupSettings } from "../../config/group.js";
 import { resolveGroupActivation } from "../../group/activation.js";
 import { toAttachmentSummaries, type HistoryEntry } from "../../group/history.js";
 import { detectWasMentioned, hasAnyMention, resolveImplicitMention } from "../../group/mention.js";
-import type { GroupMessageGateResult } from "../../group/message-gating.js";
+import { resolveGroupMessageGate } from "../../group/message-gating.js";
 import { getRefIndex } from "../../ref/store.js";
 import type { InboundContext, InboundGroupInfo, InboundPipelineDeps } from "../inbound-context.js";
 import { isMergedTurn, type QueuedMessage } from "../message-queue.js";
@@ -74,7 +73,7 @@ export function runGroupGateStage(input: GroupGateStageInput): GroupGateStageRes
   const commandAuthorized =
     deps.allowTextCommands !== false && input.access.commandAccess.authorized;
 
-  const gate = resolveGateWithPort({
+  const gate = resolveGroupMessageGate({
     mentionGatePort: deps.adapters.mentionGate,
     ignoreOtherMentions,
     hasAnyMention: anyMention,
@@ -134,69 +133,6 @@ export function runGroupGateStage(input: GroupGateStageInput): GroupGateStageRes
   }
 
   return { kind: "skip", groupInfo, skipReason: gate.action };
-}
-
-function resolveGateWithPort(params: {
-  mentionGatePort: MentionGatePort;
-  ignoreOtherMentions: boolean;
-  hasAnyMention: boolean;
-  wasMentioned: boolean;
-  implicitMention: boolean;
-  allowTextCommands: boolean;
-  isControlCommand: boolean;
-  commandAuthorized: boolean;
-  requireMention: boolean;
-}): GroupMessageGateResult {
-  if (
-    params.ignoreOtherMentions &&
-    params.hasAnyMention &&
-    !params.wasMentioned &&
-    !params.implicitMention
-  ) {
-    return {
-      action: "drop_other_mention",
-      effectiveWasMentioned: false,
-      shouldBypassMention: false,
-    };
-  }
-
-  const decision = params.mentionGatePort.resolveInboundMentionDecision({
-    facts: {
-      canDetectMention: true,
-      wasMentioned: params.wasMentioned,
-      hasAnyMention: params.hasAnyMention,
-      implicitMentionKinds: params.implicitMention ? ["reply_to_bot"] : [],
-    },
-    policy: {
-      isGroup: true,
-      requireMention: params.requireMention,
-      allowTextCommands: params.allowTextCommands,
-      hasControlCommand: params.isControlCommand,
-      commandAuthorized: params.commandAuthorized,
-    },
-  });
-
-  if (params.allowTextCommands && params.isControlCommand && !params.commandAuthorized) {
-    return {
-      action: "block_unauthorized_command",
-      effectiveWasMentioned: false,
-      shouldBypassMention: false,
-    };
-  }
-
-  if (decision.shouldSkip) {
-    return {
-      action: "skip_no_mention",
-      effectiveWasMentioned: decision.effectiveWasMentioned,
-      shouldBypassMention: decision.shouldBypassMention,
-    };
-  }
-
-  return {
-    action: "pass",
-    effectiveWasMentioned: decision.effectiveWasMentioned,
-    shouldBypassMention: decision.shouldBypassMention,
-  };
 }
 
 function recordGroupHistory(params: {

--- a/extensions/qqbot/src/engine/group/message-gating.test.ts
+++ b/extensions/qqbot/src/engine/group/message-gating.test.ts
@@ -1,14 +1,21 @@
 // Qqbot tests cover message gating plugin behavior.
+import { resolveInboundMentionDecision } from "openclaw/plugin-sdk/channel-mention-gating";
 import { describe, expect, it } from "vitest";
+import type { MentionGatePort } from "../adapter/mention-gate.port.js";
 import {
   resolveGroupMessageGate,
   type GroupMessageGateInput,
   type GroupMessageGateResult,
 } from "./message-gating.js";
 
+// Real SDK-backed port so these tests prove gate parity against the canonical
+// mention decision engine, not a stub.
+const mentionGatePort: MentionGatePort = { resolveInboundMentionDecision };
+
 // Compose a full input so each test can override just the interesting axis.
 function input(overrides: Partial<GroupMessageGateInput>): GroupMessageGateInput {
   return {
+    mentionGatePort,
     ignoreOtherMentions: false,
     hasAnyMention: false,
     wasMentioned: false,
@@ -17,7 +24,6 @@ function input(overrides: Partial<GroupMessageGateInput>): GroupMessageGateInput
     isControlCommand: false,
     commandAuthorized: false,
     requireMention: true,
-    canDetectMention: true,
     ...overrides,
   };
 }
@@ -113,13 +119,6 @@ describe("engine/group/message-gating", () => {
 
     it("passes through when requireMention is off", () => {
       const result = resolveGroupMessageGate(input({ requireMention: false }));
-      expectAction(result, "pass");
-    });
-
-    it("passes through when mention cannot be detected (DMs)", () => {
-      const result = resolveGroupMessageGate(
-        input({ requireMention: true, canDetectMention: false }),
-      );
       expectAction(result, "pass");
     });
   });

--- a/extensions/qqbot/src/engine/group/message-gating.ts
+++ b/extensions/qqbot/src/engine/group/message-gating.ts
@@ -1,4 +1,6 @@
 // Qqbot plugin module implements message gating behavior.
+import type { MentionGatePort } from "../adapter/mention-gate.port.js";
+
 type GroupMessageGateAction =
   | "drop_other_mention"
   | "block_unauthorized_command"
@@ -12,6 +14,7 @@ export interface GroupMessageGateResult {
 }
 
 export interface GroupMessageGateInput {
+  mentionGatePort: MentionGatePort;
   ignoreOtherMentions: boolean;
   hasAnyMention: boolean;
   wasMentioned: boolean;
@@ -20,46 +23,19 @@ export interface GroupMessageGateInput {
   isControlCommand: boolean;
   commandAuthorized: boolean;
   requireMention: boolean;
-  canDetectMention: boolean;
 }
 
-function resolveMentionGating(input: {
-  requireMention: boolean;
-  canDetectMention: boolean;
-  wasMentioned: boolean;
-  implicitMention: boolean;
-  shouldBypassMention: boolean;
-}): { effectiveWasMentioned: boolean; shouldSkip: boolean } {
-  const effectiveWasMentioned =
-    input.wasMentioned || input.implicitMention || input.shouldBypassMention;
-  const shouldSkip = input.requireMention && input.canDetectMention && !effectiveWasMentioned;
-  return { effectiveWasMentioned, shouldSkip };
-}
-
-function resolveCommandBypass(input: {
-  requireMention: boolean;
-  wasMentioned: boolean;
-  hasAnyMention: boolean;
-  allowTextCommands: boolean;
-  commandAuthorized: boolean;
-  isControlCommand: boolean;
-}): boolean {
-  return (
-    input.requireMention &&
-    !input.wasMentioned &&
-    !input.hasAnyMention &&
-    input.allowTextCommands &&
-    input.commandAuthorized &&
-    input.isControlCommand
-  );
-}
-
-export function resolveGroupMessageGate(input: GroupMessageGateInput): GroupMessageGateResult {
+/**
+ * Group gate Layer 1 (ignoreOtherMentions) is QQ-specific and decided here;
+ * Layer 2+3 (command gating + mention gating + command bypass) delegate to the
+ * mention gate port backed by the SDK's `resolveInboundMentionDecision`.
+ */
+export function resolveGroupMessageGate(params: GroupMessageGateInput): GroupMessageGateResult {
   if (
-    input.ignoreOtherMentions &&
-    input.hasAnyMention &&
-    !input.wasMentioned &&
-    !input.implicitMention
+    params.ignoreOtherMentions &&
+    params.hasAnyMention &&
+    !params.wasMentioned &&
+    !params.implicitMention
   ) {
     return {
       action: "drop_other_mention",
@@ -68,7 +44,23 @@ export function resolveGroupMessageGate(input: GroupMessageGateInput): GroupMess
     };
   }
 
-  if (input.allowTextCommands && input.isControlCommand && !input.commandAuthorized) {
+  const decision = params.mentionGatePort.resolveInboundMentionDecision({
+    facts: {
+      canDetectMention: true,
+      wasMentioned: params.wasMentioned,
+      hasAnyMention: params.hasAnyMention,
+      implicitMentionKinds: params.implicitMention ? ["reply_to_bot"] : [],
+    },
+    policy: {
+      isGroup: true,
+      requireMention: params.requireMention,
+      allowTextCommands: params.allowTextCommands,
+      hasControlCommand: params.isControlCommand,
+      commandAuthorized: params.commandAuthorized,
+    },
+  });
+
+  if (params.allowTextCommands && params.isControlCommand && !params.commandAuthorized) {
     return {
       action: "block_unauthorized_command",
       effectiveWasMentioned: false,
@@ -76,34 +68,17 @@ export function resolveGroupMessageGate(input: GroupMessageGateInput): GroupMess
     };
   }
 
-  const shouldBypassMention = resolveCommandBypass({
-    requireMention: input.requireMention,
-    wasMentioned: input.wasMentioned,
-    hasAnyMention: input.hasAnyMention,
-    allowTextCommands: input.allowTextCommands,
-    commandAuthorized: input.commandAuthorized,
-    isControlCommand: input.isControlCommand,
-  });
-
-  const mentionGate = resolveMentionGating({
-    requireMention: input.requireMention,
-    canDetectMention: input.canDetectMention,
-    wasMentioned: input.wasMentioned,
-    implicitMention: input.implicitMention,
-    shouldBypassMention,
-  });
-
-  if (mentionGate.shouldSkip) {
+  if (decision.shouldSkip) {
     return {
       action: "skip_no_mention",
-      effectiveWasMentioned: mentionGate.effectiveWasMentioned,
-      shouldBypassMention,
+      effectiveWasMentioned: decision.effectiveWasMentioned,
+      shouldBypassMention: decision.shouldBypassMention,
     };
   }
 
   return {
     action: "pass",
-    effectiveWasMentioned: mentionGate.effectiveWasMentioned,
-    shouldBypassMention,
+    effectiveWasMentioned: decision.effectiveWasMentioned,
+    shouldBypassMention: decision.shouldBypassMention,
   };
 }


### PR DESCRIPTION
Related: #104318

## What Problem This Solves

Phase-2 audit of the old allowlist/ingress lineage: which internal callers still bypass the canonical message-access gate engine, and which of those can migrate mechanically versus need a product decision.

## Why This Change Was Made

The audit found the deprecated ingress projections have zero live runtime consumers (main pre-drained them), so the deletable surface here was qqbot's dead duplicated group gate: the stale copy plus local mention/command-bypass helpers had zero production callers while the live port-backed gate lived in a stage file — the live gate is now the single canonical `resolveGroupMessageGate` and the dead path is gone (net −90 LOC). Parity is pinned by 16 admission-outcome tests against the live path with a real SDK mention-decision port. Four remaining old-lineage clusters are deliberately NOT migrated — each has a genuine semantic delta vs the engine, documented in this PR for product decisions: telegram's `chatExplicitlyAllowed` (explicit group entry + empty sender allowlist ⇒ allowed, ordered before command/event gates), slack DM auth's `open && allowFrom("*")` fast-path with name/slug matching before pairing, slack `reactionMode` policy (unmodeled by the event gate), slack bot-room authorization via live `conversations.members` presence.

## User Impact

None — dead code removal with admission outcomes pinned unchanged.

## Evidence

- Testbox `tbx_01kx991xbcq59vqvyx1b9nse4v`: src/channels + src/plugin-sdk + src/auto-reply + qqbot suites + full `pnpm check:changed`, exit 0; repo-wide `oxfmt --check` green up front (`tbx_01kx98cmhxmp9qpx0h6vtqftbd`).
- 16-case admission parity suite (drop/block/skip/pass) on the canonical gate.
- Autoreview (codex gpt-5.6-sol, xhigh): clean (0.98).
