### PR TITLE
test(ui): make stale chunk recovery coverage deterministic

### DIFF
--- a/ui/src/app/router-outlet.test.ts
+++ b/ui/src/app/router-outlet.test.ts
@@ -1,17 +1,8 @@
 import { createRouter, definePage, type Router } from "@openclaw/uirouter";
 import { html, type LitElement } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { retryStaleChunkReload, scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
+import { resetStaleChunkReloadStateForTest } from "./stale-chunk-reload.ts";
 import "./router-outlet.ts";
-
-vi.mock("./stale-chunk-reload.ts", async (importActual) => {
-  const actual = await importActual<typeof import("./stale-chunk-reload.ts")>();
-  return {
-    ...actual,
-    retryStaleChunkReload: vi.fn(async () => true),
-    scheduleStaleChunkReload: vi.fn(async () => false),
-  };
-});
 
 type RouteId = "page";
 type TestContext = { label: string };
@@ -57,7 +48,8 @@ async function settleOutlet(outlet: RouterOutletElement): Promise<void> {
 
 afterEach(() => {
   document.body.replaceChildren();
-  vi.clearAllMocks();
+  resetStaleChunkReloadStateForTest();
+  vi.unstubAllGlobals();
 });
 
 describe("openclaw-router-outlet", () => {
@@ -129,8 +121,10 @@ describe("openclaw-router-outlet", () => {
     router.stop();
   });
 
-  it("recovers stale-chunk import failures with a document reload instead of revalidate", async () => {
+  it("schedules stale-chunk recovery and falls back to revalidation while offline", async () => {
     let loadCount = 0;
+    const fetchMock = vi.fn(async () => new Response(null, { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({
       routes: [
         definePage({
@@ -155,13 +149,13 @@ describe("openclaw-router-outlet", () => {
     const alert = outlet.querySelector('[role="alert"]');
     expect(alert?.textContent).toContain("Importing a module script failed.");
     expect(alert?.textContent).toContain("Reload the page");
-    expect(vi.mocked(scheduleStaleChunkReload)).toHaveBeenCalled();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(loadCount).toBe(1);
 
     outlet.querySelector<HTMLButtonElement>("button")?.click();
-    await settleOutlet(outlet);
+    await vi.waitFor(() => expect(loadCount).toBe(2));
 
-    expect(vi.mocked(retryStaleChunkReload)).toHaveBeenCalledTimes(1);
-    expect(loadCount).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     outlet.remove();
     router.stop();
   });


### PR DESCRIPTION
## What Problem This Solves

Exact-head main CI failed in the UI shard because `router-outlet.test.ts` mocked an ESM dependency after the `openclaw-router-outlet` custom element could already have been registered against the real module. The test then asserted calls on a mock that the registered element did not use.

## Why This Change Was Made

Exercise the real stale-chunk recovery integration with a deterministic offline document probe. This verifies the automatic recovery probe, preserves the current route until retry, and proves retry falls back to router revalidation while the gateway is unreachable. The dedicated helper tests continue to cover the successful document-reload branch.

## User Impact

No runtime behavior change. Removes a full-suite-order-dependent release CI failure.

## Evidence

- Failing exact-head main job: https://github.com/openclaw/openclaw/actions/runs/29164822845/job/86576196403
- Focused Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29165100713 (`3 passed`)
- `git diff --check`
- Fresh autoreview: clean, no accepted/actionable findings
