### PR TITLE
fix(ui): let settings config pages grow with content

### DIFF
--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -1,6 +1,7 @@
 // Control UI tests cover config behavior.
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures.js";
 import type { ThemeMode, ThemeName } from "../../app/theme.ts";
 import { createConfigViewState, renderConfig, type ConfigProps } from "./view.ts";
 
@@ -62,6 +63,17 @@ describe("config view", () => {
     setTextScale: vi.fn(),
     gatewayUrl: "",
     assistantName: "OpenClaw",
+  });
+
+  it("lets config pages grow with their content instead of creating an inner viewport", () => {
+    const configCss = readStyleSheet("ui/src/styles/config.css");
+    const layoutRules = configCss.match(/\.config-layout\s*\{[^}]*\}/gu) ?? [];
+
+    expect(layoutRules.length).toBeGreaterThan(0);
+    for (const rule of layoutRules) {
+      expect(rule).not.toMatch(/\bheight\s*:/u);
+      expect(rule).not.toMatch(/\bmax-height\s*:/u);
+    }
   });
 
   function findActionButtons(container: HTMLElement): {

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover config behavior.
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
-import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures.js";
+import "../../styles.css";
 import type { ThemeMode, ThemeName } from "../../app/theme.ts";
 import { createConfigViewState, renderConfig, type ConfigProps } from "./view.ts";
 
@@ -65,14 +65,23 @@ describe("config view", () => {
     assistantName: "OpenClaw",
   });
 
-  it("lets config pages grow with their content instead of creating an inner viewport", () => {
-    const configCss = readStyleSheet("ui/src/styles/config.css");
-    const layoutRules = configCss.match(/\.config-layout\s*\{[^}]*\}/gu) ?? [];
+  it("lets config pages grow with their content instead of creating an inner viewport", async () => {
+    const { container } = renderConfigView({
+      activeSection: "__appearance__",
+      includeSections: ["__appearance__"],
+      customThemeImportExpanded: true,
+    });
+    document.body.append(container);
 
-    expect(layoutRules.length).toBeGreaterThan(0);
-    for (const rule of layoutRules) {
-      expect(rule).not.toMatch(/\bheight\s*:/u);
-      expect(rule).not.toMatch(/\bmax-height\s*:/u);
+    try {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+
+      const content = queryRequired(container, ".config-content", HTMLElement);
+      expect(content.scrollHeight - content.clientHeight).toBeLessThanOrEqual(1);
+    } finally {
+      container.remove();
     }
   });
 

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -7,7 +7,6 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 0;
-  height: calc(100vh - 160px);
   margin: 12px 0 0;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
@@ -2200,8 +2199,6 @@
 
 @media (max-width: 768px) {
   .config-layout {
-    height: calc(100vh - 100px);
-    height: calc(100dvh - 100px);
     margin: 8px 0 0;
     border-radius: var(--radius-md);
   }


### PR DESCRIPTION
## What Problem This Solves

Settings config pages that use the shared `.config-layout` panel could create an inner page-like viewport because the panel had fixed `100vh`/`100dvh` heights. In `/settings/appearance`, this showed up as the settings panel scrolling inside the page instead of letting the settings workspace grow with its content.

## Why This Change Was Made

This PR removes the fixed desktop and mobile heights from `.config-layout`, so the shared config panel sizes to its content. The regular settings page scroll container remains responsible for page scrolling.

It also adds a focused regression test that fails if `.config-layout` gets a `height` or `max-height` again.

## User Impact

In this PR, the affected settings config pages no longer create an extra vertical scroll area inside the config panel:

- `/settings/communications`
- `/settings/appearance`
- `/settings/automation`
- `/settings/mcp`
- `/settings/infrastructure`
- `/settings/ai-agents`

`/settings/general` was checked and does not use the shared `.config-layout` surface.

## Evidence

Focused validation:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/config/view.browser.test.ts`
- Result: 29 tests passed
- `git diff --check`
- `/chat` mock responded with HTTP 200 at `http://127.0.0.1:5187/chat`

Screenshots were captured from the local mock at a `1836x1376` viewport.

### `/settings/communications`

Before:

![Before /settings/communications](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/1fa8a8bfc28226724e5cee360f624b8c5f839aa4/openclaw-settings-before-communications.svg)

After:

![After /settings/communications](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/9d23db14c58d56402469de9afa0e375ccbb022fa/openclaw-settings-after-communications.svg)

### `/settings/appearance`

Before:

![Before /settings/appearance](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/aa05f6d88b8b9333287dbe385cbddeec8824d366/openclaw-settings-before-appearance.svg)

After:

![After /settings/appearance](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/7458ce0393e1c17a16c4d6b74587635e579f1a99/openclaw-settings-after-appearance.svg)

### `/settings/automation`

Before:

![Before /settings/automation](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/b6bc8a8d7a001f8aa9fa1b6c1e487abfb599a2b9/openclaw-settings-before-automation.svg)

After:

![After /settings/automation](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/fa957cc86263bca289d8e41a4e53bd0f7e2cc6ef/openclaw-settings-after-automation.svg)

### `/settings/mcp`

Before:

![Before /settings/mcp](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/7ae124200e5722e7e1ce3bf8046ff19bf731ae97/openclaw-settings-before-mcp.svg)

After:

![After /settings/mcp](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/d0ccadec71d54a6574fff44d00131a2cd417a03a/openclaw-settings-after-mcp.svg)

### `/settings/infrastructure`

Before:

![Before /settings/infrastructure](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/ba392bb0f78c56098b737bc6b6b51d1e69078a50/openclaw-settings-before-infrastructure.svg)

After:

![After /settings/infrastructure](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/95333d58cdc3a01b815d34b84ca4824d2dbde3bf/openclaw-settings-after-infrastructure.svg)

### `/settings/ai-agents`

Before:

![Before /settings/ai-agents](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/cc020e4c73e9355aa5d339bd9aa948540c3d7100/openclaw-settings-before-ai-agents.svg)

After:

![After /settings/ai-agents](https://gist.githubusercontent.com/vyctorbrzezowski/3bdb5e6edad3aa3a2b5d7125d2f44c92/raw/3d372875e3ad44ea9206f5770841a24b97edaf63/openclaw-settings-after-ai-agents.svg)
