### PR TITLE
fix(agents): stuck recovery must not abort replacement embedded runs

### DIFF
--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -29,8 +29,6 @@ export type EmbeddedAgentQueueHandle = {
   isAbortable?: () => boolean;
   isCompacting: () => boolean;
   supportsTranscriptCommitWait?: boolean;
-  /** True only when queueMessage preserves images supplied in its options. */
-  supportsQueueMessageImages?: boolean;
   cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
   abort: (reason?: "restart") => void;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
@@ -47,7 +45,14 @@ export type ActiveEmbeddedRunSnapshot = {
 
 export type EmbeddedRunWaiter = {
   resolve: (ended: boolean) => void;
-  timer?: NodeJS.Timeout;
+  timer: NodeJS.Timeout;
+  /**
+   * When set, the waiter tracks one captured run generation. It resolves once
+   * that handle is no longer the active registry occupant (clear, force-clear,
+   * or replace). Session-only waiters omit this and wait until the session has
+   * no active embedded handle.
+   */
+  handle?: EmbeddedAgentQueueHandle;
 };
 
 export type AbandonedEmbeddedRun = {

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -6,26 +6,30 @@ import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  testing as replyRunTesting,
   createReplyOperation,
   isReplyRunActiveForSessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
-import { testing as replyRunTesting } from "../../auto-reply/reply/reply-run-registry.test-support.js";
 import { setDiagnosticsEnabledForProcess } from "../../infra/diagnostic-events.js";
-import { resetDiagnosticRunActivityForTest } from "../../logging/diagnostic-run-activity.js";
-import { markDiagnosticToolStartedForTest } from "../../logging/diagnostic-run-activity.test-support.js";
+import {
+  markDiagnosticToolStartedForTest,
+  resetDiagnosticRunActivityForTest,
+} from "../../logging/diagnostic-run-activity.js";
 import {
   getDiagnosticSessionState,
   resetDiagnosticSessionStateForTest,
 } from "../../logging/diagnostic-session-state.js";
 import { diagnosticLogger } from "../../logging/diagnostic.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
-import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../../shared/number-coercion.js";
 import {
+  testing,
   abortAndDrainEmbeddedAgentRun,
   abortEmbeddedAgentRun,
   clearActiveEmbeddedRun,
   clearEmbeddedAgentRunAbortabilityForRunId,
+  clearEmbeddedRunAbandonment,
+  forceClearEmbeddedAgentRun,
   getActiveEmbeddedRunSnapshot,
   isEmbeddedAgentRunAbortableForRunId,
   isEmbeddedAgentRunAbortableForCompaction,
@@ -33,6 +37,7 @@ import {
   isEmbeddedRunAbandoned,
   formatEmbeddedAgentQueueFailureSummary,
   markActiveEmbeddedRunAbandoned,
+  markEmbeddedRunAbandoned,
   queueEmbeddedAgentMessageWithOutcome,
   queueEmbeddedAgentMessageWithOutcomeAsync,
   retainEmbeddedAgentRunAbortabilityForRunId,
@@ -44,7 +49,6 @@ import {
   waitForActiveEmbeddedRuns,
   waitForEmbeddedAgentRunEnd,
 } from "./runs.js";
-import { testing } from "./runs.test-support.js";
 
 type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
 
@@ -60,7 +64,6 @@ function createRunHandle(
       text: string,
       options?: Parameters<RunHandle["queueMessage"]>[1],
     ) => Promise<void>;
-    supportsQueueMessageImages?: boolean;
     supportsTranscriptCommitWait?: boolean;
   } = {},
 ): RunHandle {
@@ -76,7 +79,6 @@ function createRunHandle(
       ? { isAbortable: () => overrides.isAbortable !== false }
       : {}),
     isCompacting: () => overrides.isCompacting ?? false,
-    supportsQueueMessageImages: overrides.supportsQueueMessageImages,
     supportsTranscriptCommitWait: overrides.supportsTranscriptCommitWait,
     abort,
   };
@@ -465,40 +467,6 @@ describe("embedded-agent runner run registry", () => {
     });
   });
 
-  it("rejects images when the active run cannot preserve them", () => {
-    const queueMessage = vi.fn(async () => {});
-    setActiveEmbeddedRun("session-images", {
-      ...createRunHandle(),
-      queueMessage,
-    });
-
-    const outcome = queueEmbeddedAgentMessageWithOutcome("session-images", "inspect", {
-      images: [{ type: "image", data: "png", mimeType: "image/png" }],
-    });
-
-    expect(outcome).toEqual({
-      queued: false,
-      sessionId: "session-images",
-      reason: "image_input_unsupported",
-      gatewayHealth: "live",
-    });
-    expect(queueMessage).not.toHaveBeenCalled();
-
-    setActiveEmbeddedRun(
-      "session-images",
-      createRunHandle({ queueMessage, supportsQueueMessageImages: true }),
-    );
-
-    expect(
-      queueEmbeddedAgentMessageWithOutcome("session-images", "inspect", {
-        images: [{ type: "image", data: "png", mimeType: "image/png" }],
-      }).queued,
-    ).toBe(true);
-    expect(queueMessage).toHaveBeenCalledWith("inspect", {
-      images: [{ type: "image", data: "png", mimeType: "image/png" }],
-    });
-  });
-
   it("rejects message-tool-only steering for active runs created without that mode", () => {
     const queueMessage = vi.fn(async () => {});
     setActiveEmbeddedRun("session-automatic-source-reply", {
@@ -826,7 +794,7 @@ describe("embedded-agent runner run registry", () => {
     operation.setPhase("running");
     const recorder = createUserTurnTranscriptRecorder({
       input: { text: "visible group prompt", sender: { id: "user-42" } },
-      target: createTestUserTurnTranscriptTarget(),
+      target: { transcriptPath: "/tmp/unused-session.jsonl" },
     });
 
     const outcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
@@ -870,6 +838,82 @@ describe("embedded-agent runner run registry", () => {
     }
   });
 
+  it("does not abort or force-clear a replacement run after recovery captures the stale generation", async () => {
+    const debugSpy = vi.spyOn(diagnosticLogger, "debug").mockImplementation(() => undefined);
+    const staleAbort = vi.fn();
+    const replacementAbort = vi.fn();
+    const replacementHandle = createRunHandle({ abort: replacementAbort });
+    const staleHandle = createRunHandle({
+      abort: () => {
+        // During abort of the captured generation, install a replacement so
+        // later drain/force-clear steps must not cross into it.
+        setActiveEmbeddedRun("session-replaced-gen", replacementHandle, "agent:main:gen");
+        staleAbort();
+      },
+    });
+
+    setActiveEmbeddedRun("session-replaced-gen", staleHandle, "agent:main:gen");
+
+    const result = await abortAndDrainEmbeddedAgentRun({
+      sessionId: "session-replaced-gen",
+      sessionKey: "agent:main:gen",
+      settleMs: 50,
+      forceClear: true,
+      reason: "stuck_recovery",
+    });
+
+    expect(result).toEqual({ aborted: true, drained: true, forceCleared: false });
+    expect(staleAbort).toHaveBeenCalledTimes(1);
+    expect(replacementAbort).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunHandleActive("session-replaced-gen")).toBe(true);
+    expect(resolveActiveEmbeddedRunHandleSessionId("agent:main:gen")).toBe("session-replaced-gen");
+    // Generation-bound wait ends even though the session still has a live replacement.
+    await expect(waitForEmbeddedAgentRunEnd("session-replaced-gen", 50, staleHandle)).resolves.toBe(
+      true,
+    );
+    expect(
+      forceClearEmbeddedAgentRun(
+        "session-replaced-gen",
+        "agent:main:gen",
+        "stuck_recovery",
+        staleHandle,
+      ),
+    ).toBe(false);
+    expect(isEmbeddedAgentRunHandleActive("session-replaced-gen")).toBe(true);
+    expect(
+      debugSpy.mock.calls.some(([message]) => message.includes("run force-clear skipped")),
+    ).toBe(true);
+  });
+
+  it("skips force-clear and generation wait when the captured handle was already replaced", async () => {
+    const debugSpy = vi.spyOn(diagnosticLogger, "debug").mockImplementation(() => undefined);
+    const staleAbort = vi.fn();
+    const replacementAbort = vi.fn();
+    const staleHandle = createRunHandle({ abort: staleAbort });
+    const replacementHandle = createRunHandle({ abort: replacementAbort });
+
+    setActiveEmbeddedRun("session-pre-replaced", staleHandle, "agent:main:pre");
+    setActiveEmbeddedRun("session-pre-replaced", replacementHandle, "agent:main:pre");
+
+    await expect(
+      waitForEmbeddedAgentRunEnd("session-pre-replaced", 100, staleHandle),
+    ).resolves.toBe(true);
+    expect(
+      forceClearEmbeddedAgentRun(
+        "session-pre-replaced",
+        "agent:main:pre",
+        "stuck_recovery",
+        staleHandle,
+      ),
+    ).toBe(false);
+    expect(replacementAbort).not.toHaveBeenCalled();
+    expect(staleAbort).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunHandleActive("session-pre-replaced")).toBe(true);
+    expect(
+      debugSpy.mock.calls.some(([message]) => message.includes("run force-clear skipped")),
+    ).toBe(true);
+  });
+
   it("clamps oversized embedded run wait timers", async () => {
     vi.useFakeTimers();
     try {
@@ -886,64 +930,6 @@ describe("embedded-agent runner run registry", () => {
       await vi.runOnlyPendingTimersAsync();
       vi.useRealTimers();
     }
-  });
-
-  it("waits without a timer when no run-end timeout is requested", async () => {
-    vi.useFakeTimers();
-    try {
-      const handle = createRunHandle();
-      setActiveEmbeddedRun("session-unbounded", handle);
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-
-      const waitPromise = waitForEmbeddedAgentRunEnd("session-unbounded", null);
-
-      expect(setTimeoutSpy).not.toHaveBeenCalled();
-      clearActiveEmbeddedRun("session-unbounded", handle);
-      await expect(waitPromise).resolves.toBe(true);
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
-  });
-
-  it("waits for a reply-backed run without an embedded handle", async () => {
-    const operation = createReplyOperation({
-      sessionKey: "agent:main:reply-wait",
-      sessionId: "session-reply-wait",
-      resetTriggered: false,
-    });
-
-    const waitPromise = waitForEmbeddedAgentRunEnd("session-reply-wait", null);
-    let settled = false;
-    void waitPromise.then(() => {
-      settled = true;
-    });
-    await Promise.resolve();
-    expect(settled).toBe(false);
-
-    operation.complete();
-    await expect(waitPromise).resolves.toBe(true);
-  });
-
-  it("waits for a replacement run under the same session id", async () => {
-    const firstHandle = createRunHandle();
-    const replacementHandle = createRunHandle();
-    setActiveEmbeddedRun("session-replaced", firstHandle);
-
-    const waitPromise = waitForEmbeddedAgentRunEnd("session-replaced", null);
-    clearActiveEmbeddedRun("session-replaced", firstHandle);
-    setActiveEmbeddedRun("session-replaced", replacementHandle);
-    await Promise.resolve();
-
-    let settled = false;
-    void waitPromise.then(() => {
-      settled = true;
-    });
-    await Promise.resolve();
-    expect(settled).toBe(false);
-
-    clearActiveEmbeddedRun("session-replaced", replacementHandle);
-    await expect(waitPromise).resolves.toBe(true);
   });
 
   it("waits for active runs to drain", async () => {
@@ -1014,7 +1000,8 @@ describe("embedded-agent runner run registry", () => {
     );
     const handle = createRunHandle();
 
-    testing.resetActiveEmbeddedRuns();
+    runsA.testing.resetActiveEmbeddedRuns();
+    runsB.testing.resetActiveEmbeddedRuns();
 
     try {
       runsA.setActiveEmbeddedRun("session-shared", handle);
@@ -1023,7 +1010,8 @@ describe("embedded-agent runner run registry", () => {
       runsB.clearActiveEmbeddedRun("session-shared", handle);
       expect(runsA.isEmbeddedAgentRunActive("session-shared")).toBe(false);
     } finally {
-      testing.resetActiveEmbeddedRuns();
+      runsA.testing.resetActiveEmbeddedRuns();
+      runsB.testing.resetActiveEmbeddedRuns();
     }
   });
 
@@ -1050,37 +1038,29 @@ describe("embedded-agent runner run registry", () => {
     const sessionFile = "/tmp/openclaw-abandoned-session.jsonl";
     const handle = createRunHandle();
 
-    setActiveEmbeddedRun("session-timeout", handle, "agent:main:main", sessionFile);
-    expect(
-      markActiveEmbeddedRunAbandoned({
-        sessionId: "session-timeout",
-        handle,
-        sessionKey: "agent:main:main",
-        sessionFile,
-        reason: "timeout",
-      }),
-    ).toBe(true);
+    markEmbeddedRunAbandoned({
+      sessionId: "session-timeout",
+      sessionKey: "agent:main:main",
+      sessionFile,
+      reason: "timeout",
+    });
 
     expect(isEmbeddedRunAbandoned({ sessionId: "session-timeout" })).toBe(true);
     expect(isEmbeddedRunAbandoned({ sessionKey: "agent:main:main" })).toBe(true);
     expect(isEmbeddedRunAbandoned({ sessionFile })).toBe(true);
 
-    const nextHandle = createRunHandle();
-    setActiveEmbeddedRun("session-next", nextHandle, "agent:main:main", sessionFile);
+    setActiveEmbeddedRun("session-next", handle, "agent:main:main", sessionFile);
 
     expect(isEmbeddedRunAbandoned({ sessionId: "session-timeout" })).toBe(false);
     expect(isEmbeddedRunAbandoned({ sessionKey: "agent:main:main" })).toBe(false);
     expect(isEmbeddedRunAbandoned({ sessionFile })).toBe(false);
 
-    expect(
-      markActiveEmbeddedRunAbandoned({
-        sessionId: "session-next",
-        handle: nextHandle,
-        sessionKey: "agent:main:main",
-        reason: "timeout",
-      }),
-    ).toBe(true);
-    setActiveEmbeddedRun("session-third", createRunHandle(), "agent:main:main");
+    markEmbeddedRunAbandoned({
+      sessionId: "session-next",
+      sessionKey: "agent:main:main",
+      reason: "timeout",
+    });
+    clearEmbeddedRunAbandonment({ sessionId: "session-next" });
 
     expect(isEmbeddedRunAbandoned({ sessionKey: "agent:main:main" })).toBe(false);
   });

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -13,8 +13,6 @@ import {
   listActiveReplyRunSessionIds,
   queueReplyRunMessage,
   resolveReplyBackendQueueMessageMismatch,
-  resolveReplyRunPhaseForSessionId,
-  type ReplyOperationPhase,
   waitForReplyRunEndBySessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
 import {
@@ -55,16 +53,16 @@ export {
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
   resolveActiveEmbeddedRunSessionId,
+  type ActiveEmbeddedRunSnapshot,
   type EmbeddedAgentQueueHandle,
   type EmbeddedAgentQueueMessageOptions,
 } from "./run-state.js";
 
-type EmbeddedAgentQueueFailureReason =
+export type EmbeddedAgentQueueFailureReason =
   | "no_active_run"
   | "not_streaming"
   | "stale_run"
   | "compacting"
-  | "image_input_unsupported"
   | "source_reply_delivery_mode_mismatch"
   | "task_suggestion_delivery_mode_mismatch"
   | "transcript_commit_wait_unsupported"
@@ -198,7 +196,7 @@ function clearEmbeddedRunAbandonmentBySessionFile(sessionFile: string | undefine
   }
 }
 
-function clearEmbeddedRunAbandonment(params: {
+export function clearEmbeddedRunAbandonment(params: {
   sessionId?: string;
   sessionKey?: string;
   sessionFile?: string;
@@ -211,7 +209,7 @@ function clearEmbeddedRunAbandonment(params: {
   clearEmbeddedRunAbandonmentBySessionFile(params.sessionFile);
 }
 
-function markEmbeddedRunAbandoned(params: {
+export function markEmbeddedRunAbandoned(params: {
   sessionId: string;
   sessionKey?: string;
   sessionFile?: string;
@@ -295,6 +293,19 @@ function clearActiveRunSessionFiles(sessionId: string, sessionFile?: string): vo
       ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_FILE.delete(sessionFileKey);
     }
   }
+}
+
+/**
+ * @deprecated Use queueEmbeddedAgentMessageWithOutcomeAsync for delivery decisions.
+ * This boolean helper only reports immediate queue eligibility; it cannot surface
+ * async runtime rejection from the active run.
+ */
+export function queueEmbeddedAgentMessage(
+  sessionId: string,
+  text: string,
+  options?: EmbeddedAgentQueueMessageOptions,
+): boolean {
+  return queueEmbeddedAgentMessageWithOutcome(sessionId, text, options).queued;
 }
 
 /**
@@ -512,6 +523,34 @@ function prepareEmbeddedAgentQueueMessage(
  * - With a sessionId, aborts that single run.
  * - With no sessionId, supports targeted abort modes (for example, compacting runs only).
  */
+/**
+ * Abort one captured embedded-run generation. Skips when the registry no longer
+ * points at `handle` so stuck-recovery cannot cancel a replacement run.
+ */
+function abortEmbeddedAgentRunHandle(
+  sessionId: string,
+  handle: EmbeddedAgentQueueHandle,
+  reason?: "restart",
+): boolean {
+  const active = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  if (active !== handle) {
+    diag.debug(`abort failed: sessionId=${sessionId} reason=handle_mismatch`);
+    return false;
+  }
+  if (!isEmbeddedRunHandleAbortable(sessionId, handle)) {
+    diag.debug(`abort failed: sessionId=${sessionId} reason=not_abortable`);
+    return false;
+  }
+  diag.debug(`aborting run: sessionId=${sessionId}`);
+  try {
+    handle.abort(reason);
+  } catch (err) {
+    diag.warn(`abort failed: sessionId=${sessionId} err=${String(err)}`);
+    return false;
+  }
+  return true;
+}
+
 export function abortEmbeddedAgentRun(sessionId: string): boolean;
 export function abortEmbeddedAgentRun(
   sessionId: undefined,
@@ -522,6 +561,9 @@ export function abortEmbeddedAgentRun(
   opts?: { mode?: "all" | "compacting"; reason?: "restart" },
 ): boolean {
   if (typeof sessionId === "string" && sessionId.length > 0) {
+    // Administrative current-session abort: intentionally targets whatever is
+    // registered now (user abort, session reset, compaction). Generation-bound
+    // recovery uses abortEmbeddedAgentRunHandle via abortAndDrainEmbeddedAgentRun.
     const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
     if (!handle) {
       if (abortReplyRunBySessionId(sessionId)) {
@@ -530,18 +572,7 @@ export function abortEmbeddedAgentRun(
       diag.debug(`abort failed: sessionId=${sessionId} reason=no_active_run`);
       return false;
     }
-    if (!isEmbeddedRunHandleAbortable(sessionId, handle)) {
-      diag.debug(`abort failed: sessionId=${sessionId} reason=not_abortable`);
-      return false;
-    }
-    diag.debug(`aborting run: sessionId=${sessionId}`);
-    try {
-      handle.abort(opts?.reason);
-    } catch (err) {
-      diag.warn(`abort failed: sessionId=${sessionId} err=${String(err)}`);
-      return false;
-    }
-    return true;
+    return abortEmbeddedAgentRunHandle(sessionId, handle, opts?.reason);
   }
 
   const abortActiveEmbeddedRunHandles = (params: {
@@ -611,12 +642,6 @@ export function isEmbeddedAgentRunActive(sessionId: string): boolean {
     diag.debug(`run active check: sessionId=${sessionId} active=true`);
   }
   return active;
-}
-
-export function resolveEmbeddedAgentReplyRunPhase(
-  sessionId: string,
-): ReplyOperationPhase | undefined {
-  return resolveReplyRunPhaseForSessionId(sessionId);
 }
 
 export function isEmbeddedAgentRunHandleActive(sessionId: string): boolean {
@@ -714,22 +739,37 @@ export async function waitForActiveEmbeddedRuns(
   }
 }
 
-function waitForCurrentEmbeddedAgentRunEnd(
+/**
+ * Wait until the session has no active embedded run, or until a captured handle
+ * is no longer the active registry occupant when `handle` is provided.
+ */
+export function waitForEmbeddedAgentRunEnd(
   sessionId: string,
-  timeoutMs: number | null,
+  timeoutMs = 15_000,
+  handle?: EmbeddedAgentQueueHandle,
 ): Promise<boolean> {
-  if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
+  if (!sessionId) {
+    return Promise.resolve(true);
+  }
+  const active = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  if (handle !== undefined) {
+    // Generation-bound wait: the captured run is already gone when the session
+    // points elsewhere or is empty.
+    if (active !== handle) {
+      return Promise.resolve(true);
+    }
+  } else if (!active) {
     return waitForReplyRunEndBySessionId(sessionId, timeoutMs);
   }
-  const timeoutLabel = timeoutMs === null ? "none" : String(timeoutMs);
-  diag.debug(`waiting for run end: sessionId=${sessionId} timeoutMs=${timeoutLabel}`);
+  diag.debug(
+    `waiting for run end: sessionId=${sessionId} timeoutMs=${timeoutMs}${handle ? " generation=bound" : ""}`,
+  );
   return new Promise((resolve) => {
     const waiters = EMBEDDED_RUN_WAITERS.get(sessionId) ?? new Set();
     const waiter: EmbeddedRunWaiter = {
       resolve,
-    };
-    if (timeoutMs !== null) {
-      waiter.timer = setTimeout(
+      handle,
+      timer: setTimeout(
         () => {
           waiters.delete(waiter);
           if (waiters.size === 0) {
@@ -739,41 +779,13 @@ function waitForCurrentEmbeddedAgentRunEnd(
           resolve(false);
         },
         resolveTimerTimeoutMs(timeoutMs, 100, 100),
-      );
-    }
+      ),
+    };
     waiters.add(waiter);
     EMBEDDED_RUN_WAITERS.set(sessionId, waiters);
-    if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
-      waiters.delete(waiter);
-      if (waiters.size === 0) {
-        EMBEDDED_RUN_WAITERS.delete(sessionId);
-      }
-      if (waiter.timer) {
-        clearTimeout(waiter.timer);
-      }
-      resolve(true);
-    }
+    // Re-check after registration to close the clear/replace race.
+    notifyEmbeddedRunWaiters(sessionId);
   });
-}
-
-export async function waitForEmbeddedAgentRunEnd(
-  sessionId: string,
-  timeoutMs: number | null = 15_000,
-): Promise<boolean> {
-  if (!sessionId) {
-    return true;
-  }
-  const deadline = timeoutMs === null ? undefined : Date.now() + timeoutMs;
-  while (isEmbeddedAgentRunActive(sessionId)) {
-    const remainingMs = deadline === undefined ? null : deadline - Date.now();
-    if (remainingMs !== null && remainingMs <= 0) {
-      return false;
-    }
-    if (!(await waitForCurrentEmbeddedAgentRunEnd(sessionId, remainingMs))) {
-      return false;
-    }
-  }
-  return true;
 }
 
 export type AbortAndDrainEmbeddedAgentRunResult = {
@@ -782,6 +794,13 @@ export type AbortAndDrainEmbeddedAgentRunResult = {
   forceCleared: boolean;
 };
 
+/**
+ * Abort, wait, and optionally force-clear one run generation for a session.
+ *
+ * Captures the active handle at entry so later steps cannot act on a
+ * replacement registered under the same sessionId. Session-level and global
+ * abort APIs remain separate for intentional current-run cancellation.
+ */
 export async function abortAndDrainEmbeddedAgentRun(params: {
   sessionId: string;
   sessionKey?: string;
@@ -790,6 +809,8 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
   reason?: string;
 }): Promise<AbortAndDrainEmbeddedAgentRunResult> {
   const settleMs = params.settleMs ?? 15_000;
+  // Capture before any async gap; stuck recovery must not cross generations.
+  const capturedHandle = ACTIVE_EMBEDDED_RUNS.get(params.sessionId);
   // Recovery is a staleness expiry: stamp run_stalled on the reply operation
   // BEFORE any handle abort, or the run loop's abort handler re-enters
   // abortByUser and misattributes the watchdog kill to the user.
@@ -805,28 +826,67 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
     const drained = await waitForEmbeddedAgentRunEnd(params.sessionId, settleMs);
     return { aborted: true, drained, forceCleared: false };
   }
-  const aborted = abortEmbeddedAgentRun(params.sessionId) || expiredReplyRun;
-  const drained = aborted ? await waitForEmbeddedAgentRunEnd(params.sessionId, settleMs) : false;
+  const aborted = capturedHandle
+    ? abortEmbeddedAgentRunHandle(
+        params.sessionId,
+        capturedHandle,
+        params.reason === "restart" ? "restart" : undefined,
+      ) || expiredReplyRun
+    : abortEmbeddedAgentRun(params.sessionId) || expiredReplyRun;
+  const drained = aborted
+    ? await waitForEmbeddedAgentRunEnd(params.sessionId, settleMs, capturedHandle)
+    : false;
   const forceCleared =
     params.forceClear === true && (!aborted || !drained)
-      ? forceClearEmbeddedAgentRun(params.sessionId, params.sessionKey, params.reason)
+      ? forceClearEmbeddedAgentRun(
+          params.sessionId,
+          params.sessionKey,
+          params.reason,
+          capturedHandle,
+        )
       : false;
   return { aborted, drained, forceCleared };
 }
 
-function notifyEmbeddedRunEnded(sessionId: string) {
+/**
+ * Resolve waiters whose end condition is already true:
+ * - generation-bound: captured handle is no longer the active occupant
+ * - session-bound: session has no active embedded handle
+ */
+function notifyEmbeddedRunWaiters(sessionId: string) {
   const waiters = EMBEDDED_RUN_WAITERS.get(sessionId);
   if (!waiters || waiters.size === 0) {
     return;
   }
-  EMBEDDED_RUN_WAITERS.delete(sessionId);
-  diag.debug(`notifying waiters: sessionId=${sessionId} waiterCount=${waiters.size}`);
+  const active = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  const ready: EmbeddedRunWaiter[] = [];
   for (const waiter of waiters) {
-    if (waiter.timer) {
-      clearTimeout(waiter.timer);
+    if (waiter.handle !== undefined) {
+      if (active !== waiter.handle) {
+        ready.push(waiter);
+      }
+    } else if (active === undefined) {
+      ready.push(waiter);
     }
+  }
+  if (ready.length === 0) {
+    return;
+  }
+  diag.debug(
+    `notifying waiters: sessionId=${sessionId} waiterCount=${ready.length} remaining=${waiters.size - ready.length}`,
+  );
+  for (const waiter of ready) {
+    waiters.delete(waiter);
+    clearTimeout(waiter.timer);
     waiter.resolve(true);
   }
+  if (waiters.size === 0) {
+    EMBEDDED_RUN_WAITERS.delete(sessionId);
+  }
+}
+
+function notifyEmbeddedRunEnded(sessionId: string) {
+  notifyEmbeddedRunWaiters(sessionId);
 }
 
 export function setActiveEmbeddedRun(
@@ -858,6 +918,11 @@ export function setActiveEmbeddedRun(
   markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
   if (!sessionId.startsWith("probe-")) {
     diag.debug(`run registered: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);
+  }
+  // Replacement ends the previous generation for handle-bound waiters only;
+  // session-bound waiters keep waiting until the session is fully idle.
+  if (previousHandle && previousHandle !== handle) {
+    notifyEmbeddedRunWaiters(sessionId);
   }
 }
 
@@ -917,16 +982,27 @@ export function clearActiveEmbeddedRun(
   }
 }
 
-function forceClearEmbeddedAgentRun(
+export function forceClearEmbeddedAgentRun(
   sessionId: string,
   sessionKey?: string,
   reason = "stuck_recovery",
+  /**
+   * When provided, delete only if the registry still points at this captured
+   * generation. Omitting the handle keeps the administrative current-session
+   * force-clear path used by non-recovery callers.
+   */
+  handle?: EmbeddedAgentQueueHandle,
 ): boolean {
   let cleared = false;
-  const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
-  if (handle) {
+  const active = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  if (active) {
+    if (handle !== undefined && active !== handle) {
+      // A newer run owns the session; do not delete it or its reply ownership.
+      diag.debug(`run force-clear skipped: sessionId=${sessionId} reason=handle_mismatch`);
+      return false;
+    }
     ACTIVE_EMBEDDED_RUNS.delete(sessionId);
-    clearEmbeddedRunAbortability(handle);
+    clearEmbeddedRunAbortability(active);
     ACTIVE_EMBEDDED_RUN_SNAPSHOTS.delete(sessionId);
     clearActiveRunSessionKeys(sessionId, sessionKey);
     clearActiveRunSessionFiles(sessionId);
@@ -939,13 +1015,11 @@ function forceClearEmbeddedAgentRun(
   return forceClearReplyRunBySessionId(sessionId, cause) || cleared;
 }
 
-const testing = {
+export const testing = {
   resetActiveEmbeddedRuns() {
     for (const waiters of EMBEDDED_RUN_WAITERS.values()) {
       for (const waiter of waiters) {
-        if (waiter.timer) {
-          clearTimeout(waiter.timer);
-        }
+        clearTimeout(waiter.timer);
         waiter.resolve(true);
       }
     }
@@ -961,9 +1035,4 @@ const testing = {
     ABANDONED_EMBEDDED_RUN_SESSION_IDS_BY_FILE.clear();
   },
 };
-
-if (process.env.VITEST || process.env.NODE_ENV === "test") {
-  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.embeddedRunsTestApi")] =
-    testing;
-}
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
+export { testing as __testing };


### PR DESCRIPTION
Closes #104589

## What Problem This Solves

Fixes an issue where stuck-session recovery could abort or force-clear a **newer** embedded run that replaced an older generation under the same session ID. Operators saw redundant stuck-recovery cycles and healthy retries interrupted after a prior run failed to release cleanly.

## Why This Change Was Made

`abortAndDrainEmbeddedAgentRun` now captures the active handle at entry and binds abort, generation-aware drain wait, and optional force-clear to that generation. Administrative session-level and global abort APIs stay current-run cancellation paths. This matches ClawSweeper guidance to bind the full abort/wait/force-clear chain to one captured identity rather than only two guards.

## User Impact

Stuck recovery no longer cancels a healthy replacement run on the same session after a stale generation is selected. Normal user abort, restart, compaction, and session-reset cancellation behavior is unchanged.

## Evidence

Verification host: local macOS (Crabbox bypass)

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/runs.test.ts
# Test Files  1 passed (1)
# Tests  47 passed (47)

node scripts/run-vitest.mjs \
  src/logging/diagnostic-stuck-session-recovery.runtime.test.ts \
  src/logging/diagnostic-stuck-session-recovery.integration.test.ts
# Test Files  2 passed (2)
# Tests  31 passed (31)

pnpm check:changed -- \
  src/agents/embedded-agent-runner/runs.ts \
  src/agents/embedded-agent-runner/runs.test.ts \
  src/agents/embedded-agent-runner/run-state.ts
# typecheck core/core tests: ok
# format: ok after oxfmt
# lint core changed files: ok after removing unnecessary String() casts

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
  src/agents/embedded-agent-runner/run-state.ts \
  src/agents/embedded-agent-runner/runs.test.ts \
  src/agents/embedded-agent-runner/runs.ts
# Found 0 warnings and 0 errors.
```

New focused cases:

- `does not abort or force-clear a replacement run after recovery captures the stale generation`
- `skips force-clear and generation wait when the captured handle was already replaced`

## Real behavior proof

- Behavior addressed: stuck recovery must not abort/force-clear a replacement embedded run under the same session ID after selecting a stale generation.
- Environment: local macOS (darwin), Node v24.17.0, openclaw checkout branch `fix/104589-embedded-run-identity` @ `145ae17b36eecc011dd4c4a1e76bfef9943f123b`.
- Current-main contrast: on main, `abortAndDrainEmbeddedAgentRun` re-resolves the session ID for abort, session-only wait, and force-clear, so a mid-flight `setActiveEmbeddedRun` replacement can be aborted or deleted. `clearActiveEmbeddedRun` already used handle identity; abort/force-clear did not.
- **Runtime path exercised (not only unit assertions):** process-local registry + production `recoverStuckDiagnosticSession` → `abortAndDrainEmbeddedAgentRun` with `reason=stuck_recovery`, `forceClear=true`, `allowActiveAbort=true`. During the captured generation's `abort()`, a replacement handle was registered under the same `sessionId`/`sessionKey` (the race operators hit).
- Exact command after this patch (local one-shot harness; no network/credentials):
  ```bash
  OPENCLAW_LOG_LEVEL=debug node --import tsx /tmp/openclaw-pr-104654-proof/replacement-survives-stuck-recovery.mts
  ```
- Evidence after fix (captured 2026-07-11 20:39 UTC):
  - stale generation aborted once (`staleAbortCount=1`)
  - replacement never aborted (`replacementAbortCount=0`)
  - replacement still active under the session key after recovery
  - recovery outcome: `status=aborted aborted=true drained=true forceCleared=false released=0` in **41ms**
  - diagnostic log line: `stuck session recovery outcome: ... forceCleared=false`
- Terminal transcript (redacted: synthetic session ids only; no IPs/credentials/endpoints):

```text
=== openclaw PR #104654 real-behavior proof ===
host: darwin node=v24.17.0
cwd: /Users/wuqingxuan/openclaw
scenario: mid-abort replacement under same sessionId during stuck_recovery

[diagnostic:debug] session state: sessionId=proof-replacement-gen-session sessionKey=agent:main:proof-replacement-gen prev=idle new=processing reason="run_started" queueDepth=0
[31m[diagnostic][39m [90msession state: sessionId=proof-replacement-gen-session sessionKey=agent:main:proof-replacement-gen prev=idle new=processing reason="run_started" queueDepth=0[39m
[diagnostic:debug] run registered: sessionId=proof-replacement-gen-session totalActive=1
[31m[diagnostic][39m [90mrun registered: sessionId=proof-replacement-gen-session totalActive=1[39m
[diagnostic:debug] run handle active check: sessionId=proof-replacement-gen-session active=true
[31m[diagnostic][39m [90mrun handle active check: sessionId=proof-replacement-gen-session active=true[39m
[proof] before recovery: active=true keySessionId=proof-replacement-gen-session
[diagnostic:debug] run handle active check: sessionId=proof-replacement-gen-session active=true
[31m[diagnostic][39m [90mrun handle active check: sessionId=proof-replacement-gen-session active=true[39m
[diagnostic:debug] aborting run: sessionId=proof-replacement-gen-session
[31m[diagnostic][39m [90maborting run: sessionId=proof-replacement-gen-session[39m
[proof] stale.abort() called (count=1)
[proof] installing replacement run during stale abort
[diagnostic:debug] session state: sessionId=proof-replacement-gen-session sessionKey=agent:main:proof-replacement-gen prev=processing new=processing reason="run_replaced" queueDepth=0
[31m[diagnostic][39m [90msession state: sessionId=proof-replacement-gen-session sessionKey=agent:main:proof-replacement-gen prev=processing new=processing reason="run_replaced" queueDepth=0[39m
[diagnostic:debug] run registered: sessionId=proof-replacement-gen-session totalActive=1
[31m[diagnostic][39m [90mrun registered: sessionId=proof-replacement-gen-session totalActive=1[39m
[diagnostic:warn] stuck session recovery: sessionId=proof-replacement-gen-session sessionKey=agent:main:proof-replacement-gen age=720s action=abort_embedded_run aborted=true drained=true released=0
[31m[diagnostic][39m [33mstuck session recovery: sessionId=proof-replacement-gen-session sessionKey=agent:main:proof-replacement-gen age=720s action=abort_embedded_run aborted=true drained=true released=0[39m
[diagnostic:warn] stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=proof-replacement-gen-session sessionKey=agent:main:proof-replacement-gen activeSessionId=proof-replacement-gen-session activeWorkKind=embedded_run lane=session:agent:main:proof-replacement-gen aborted=true drained=true forceCleared=false released=0
[31m[diagnostic][39m [33mstuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=proof-replacement-gen-session sessionKey=agent:main:proof-replacement-gen activeSessionId=proof-replacement-gen-session activeWorkKind=embedded_run lane=session:agent:main:proof-replacement-gen aborted=true drained=true forceCleared=false released=0[39m
[diagnostic:debug] run handle active check: sessionId=proof-replacement-gen-session active=true
[31m[diagnostic][39m [90mrun handle active check: sessionId=proof-replacement-gen-session active=true[39m

=== results ===
{
  "elapsedMs": 41,
  "outcome": {
    "status": "aborted",
    "action": "abort_embedded_run",
    "sessionId": "proof-replacement-gen-session",
    "sessionKey": "agent:main:proof-replacement-gen",
    "activeSessionId": "proof-replacement-gen-session",
    "activeWorkKind": "embedded_run",
    "aborted": true,
    "drained": true,
    "forceCleared": false,
    "released": 0,
    "lane": "session:agent:main:proof-replacement-gen"
  }
}
{
  "staleAbortCount": 1,
  "replacementAbortCount": 0,
  "replacementStillActive": true,
  "keyMapsToSession": true,
  "forceClearSkippedLog": false,
  "recoveryOutcomeLog": true
}

PASS: stuck_recovery aborted the captured generation only; replacement remains active; forceCleared=false
```

- Focused regression re-check (same head):

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/runs.test.ts \
  -t "does not abort or force-clear a replacement run after recovery captures the stale generation"
RUN  v4.1.9
 ✓ |agents-core| src/agents/embedded-agent-runner/runs.test.ts (47 tests | 46 skipped)
 ✓ |agents-embedded-agent| src/agents/embedded-agent-runner/runs.test.ts (47 tests | 46 skipped)
 Test Files  2 passed (2)
      Tests  2 passed | 92 skipped (94)
```

- Control check: sibling unit cases still pass (`force-clears an aborted run that does not drain`, pre-replaced generation skip). Prior stuck-recovery runtime/integration suites (31 tests) remained green on the PR head.
- Observed result after fix: production stuck-session recovery acts only on the captured generation; a newer run registered under the same session survives abort/drain of the stale generation with `forceCleared=false`.
- What was not tested: multi-hour production watchdog under real multi-agent load and channel I/O; intentional current-session admin abort paths remain session-scoped by design.

## AI disclosure

This fix was authored with AI assistance (Grok). Human/operator review of the PR is still expected before merge.

