### PR TITLE
fix(gateway): avoid false warnings when local app disconnects during startup

### DIFF
--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -283,23 +283,26 @@ describe("attachGatewayWsConnectionHandler", () => {
     expect(context).toMatchObject({ phase: "ws_upgrade_started" });
   });
 
-  it("demotes local app startup aborts before the first frame", async () => {
-    const { socket, logWsControl } = await connectTestWs({
-      headers: { "user-agent": "OpenClaw/2607000290 CFNetwork/3860 Darwin/25" },
-      options: { isStartupPending: () => true },
-    });
+  it.each([1001, 1006])(
+    "demotes local app startup abort code %i before the first frame",
+    async (closeCode) => {
+      const { socket, logWsControl } = await connectTestWs({
+        headers: { "user-agent": "OpenClaw/2607000290 CFNetwork/3860 Darwin/25" },
+        options: { isStartupPending: () => true },
+      });
 
-    socket.emit("close", 1006, Buffer.alloc(0));
+      socket.emit("close", closeCode, Buffer.alloc(0));
 
-    expect(logWsControl.debug).toHaveBeenCalledWith(
-      expect.stringContaining("closed before connect"),
-      expect.objectContaining({ phase: "ws_upgrade_started" }),
-    );
-    expect(logWsControl.warn).not.toHaveBeenCalledWith(
-      expect.stringContaining("closed before connect"),
-      expect.anything(),
-    );
-  });
+      expect(logWsControl.debug).toHaveBeenCalledWith(
+        expect.stringContaining("closed before connect"),
+        expect.objectContaining({ phase: "ws_upgrade_started" }),
+      );
+      expect(logWsControl.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("closed before connect"),
+        expect.anything(),
+      );
+    },
+  );
 
   it("keeps queued local app startup frames at warning level", async () => {
     const logWsControl = createGatewayWsTestLogger();

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -426,7 +426,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
 
     const isExpectedLocalAppStartupAbort = (code: number) =>
       openedDuringStartup &&
-      code === 1006 &&
+      (code === 1001 || code === 1006) &&
       lastHandshakePhase === "ws_upgrade_started" &&
       !hasReceivedPreauthFrame &&
       lastFrameType === undefined &&


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators restarting the Gateway could see a warning that the local Mac app closed before connecting, even when the app cleanly disconnected during the startup window before sending any pre-auth frame.

## Why This Change Was Made

Treat WebSocket close code 1001 from the loopback OpenClaw app as the same expected startup abort as the existing 1006 case. The existing safeguards remain: startup must still be active, the handshake must still be at the upgrade phase, and no pre-auth frame may have been received or queued.

## User Impact

Gateway restart logs no longer report this clean local-app startup race as a warning. Unexpected pre-connect drops, including clients that sent or queued a frame, remain warning-level.

## Evidence

- Live restart log before the fix: loopback `OpenClaw/2607000290` closed with code 1001 after 9 ms at `ws_upgrade_started`, before any frame.
- Blacksmith Testbox `tbx_01kx9ar78brebczfmmmgdw94xe`: 68/68 tests passed across eight routed Gateway projects.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29165490589
- Autoreview: clean, no accepted or actionable findings.
