### PR TITLE
improve(tooling): unblock scripts/pr landings and clarify crabbox fast failures

### DIFF
--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -3441,6 +3441,11 @@ if (fullCheckout) {
   }
 }
 const childInvocation = spawnInvocation(binary, childArgs, childEnv, process.platform);
+// Fast-fail hint context: run --id reuse dies in under a second when the
+// lease hit its idle timeout, with only a bare nonzero exit from the binary.
+const reusedRunLeaseId = normalizedArgs[0] === "run" ? optionValue(normalizedArgs, "--id") : "";
+const childStartedAtMs = Date.now();
+const FAST_FAIL_HINT_WINDOW_MS = 15_000;
 const child = spawn(childInvocation.command, childInvocation.args, {
   cwd: childCwd,
   stdio: "inherit",
@@ -3503,7 +3508,17 @@ child.on("exit", (code, signal) => {
     process.exit(signalExitCodes.get(signal) ?? 1);
     return;
   }
-  process.exit(fullCheckoutAvailable ? (exitCode ?? 1) : 1);
+  const finalExitCode = fullCheckoutAvailable ? (exitCode ?? 1) : 1;
+  if (
+    finalExitCode !== 0 &&
+    reusedRunLeaseId &&
+    Date.now() - childStartedAtMs < FAST_FAIL_HINT_WINDOW_MS
+  ) {
+    console.error(
+      `[crabbox] run --id ${reusedRunLeaseId} failed fast; reusable leases expire after their idle timeout and rejected flags also exit immediately. Check the first error line above, verify the lease with \`node scripts/crabbox-wrapper.mjs list\`, or warm a fresh one with \`node scripts/crabbox-wrapper.mjs warmup\`.`,
+    );
+  }
+  process.exit(finalExitCode);
 });
 
 child.on("error", (error) => {

--- a/scripts/pr
+++ b/scripts/pr
@@ -18,11 +18,9 @@ if common_git_dir=$(git -C "$script_parent_dir" rev-parse --path-format=absolute
   canonical_self="$canonical_repo_root/scripts/$(basename "${BASH_SOURCE[0]}")"
   if [ "$script_self" != "$canonical_self" ] && [ -x "$canonical_self" ]; then
     if ! git -C "$script_parent_dir" diff --quiet HEAD -- \
-      ":(top)scripts/pr" ":(top)scripts/pr-lib" ":(top)scripts/lib/plain-gh.sh" ||
-      ! git -C "$canonical_repo_root" diff --quiet HEAD -- \
-        ":(top)scripts/pr" ":(top)scripts/pr-lib" ":(top)scripts/lib/plain-gh.sh"; then
-      echo "scripts/pr wrapper files have uncommitted changes in this worktree or the canonical checkout." >&2
-      echo "Refusing to silently substitute canonical wrapper code from: $canonical_repo_root" >&2
+      ":(top)scripts/pr" ":(top)scripts/pr-lib" ":(top)scripts/lib/plain-gh.sh"; then
+      echo "scripts/pr wrapper files have uncommitted changes in this worktree." >&2
+      echo "Refusing to run unreviewed wrapper code from: $script_parent_dir" >&2
       exit 1
     fi
     linked_wrapper_revision=$(
@@ -37,14 +35,34 @@ if common_git_dir=$(git -C "$script_parent_dir" rev-parse --path-format=absolute
         HEAD:scripts/pr-lib \
         HEAD:scripts/lib/plain-gh.sh 2>/dev/null || true
     )
+    canonical_wrapper_clean=1
+    if ! git -C "$canonical_repo_root" diff --quiet HEAD -- \
+      ":(top)scripts/pr" ":(top)scripts/pr-lib" ":(top)scripts/lib/plain-gh.sh"; then
+      canonical_wrapper_clean=0
+    fi
+    if [ -n "$linked_wrapper_revision" ] &&
+      [ "$linked_wrapper_revision" = "$canonical_wrapper_revision" ] &&
+      [ "$canonical_wrapper_clean" = "1" ]; then
+      exec "$canonical_self" "$@"
+    fi
+    # The canonical checkout can be parked on another branch or carry local
+    # edits (release trains move it); maintainer-controlled origin/main is the
+    # trust anchor then. Run THIS worktree's committed wrapper, without
+    # substitution, when it exactly matches origin/main.
+    anchor_wrapper_revision=$(
+      git -C "$script_parent_dir" rev-parse \
+        origin/main:scripts/pr \
+        origin/main:scripts/pr-lib \
+        origin/main:scripts/lib/plain-gh.sh 2>/dev/null || true
+    )
     if [ -z "$linked_wrapper_revision" ] ||
-      [ "$linked_wrapper_revision" != "$canonical_wrapper_revision" ]; then
-      echo "scripts/pr implementation differs between this worktree and the canonical checkout." >&2
+      [ -z "$anchor_wrapper_revision" ] ||
+      [ "$linked_wrapper_revision" != "$anchor_wrapper_revision" ]; then
+      echo "scripts/pr implementation differs between this worktree and the canonical checkout, and does not match origin/main." >&2
       echo "Refusing to silently substitute canonical wrapper code from: $canonical_repo_root" >&2
-      echo "Run scripts/pr from a trusted checkout with matching scripts/pr and scripts/pr-lib revisions." >&2
+      echo "Run scripts/pr from a checkout whose wrapper matches the canonical checkout or a fetched origin/main." >&2
       exit 1
     fi
-    exec "$canonical_self" "$@"
   fi
 fi
 

--- a/scripts/pr
+++ b/scripts/pr
@@ -49,11 +49,13 @@ if common_git_dir=$(git -C "$script_parent_dir" rev-parse --path-format=absolute
     # edits (release trains move it); maintainer-controlled origin/main is the
     # trust anchor then. Run THIS worktree's committed wrapper, without
     # substitution, when it exactly matches origin/main.
+    # refs/remotes/... explicitly: bare "origin/main" is a DWIM name that a
+    # local branch or tag named origin/main could shadow, spoofing the anchor.
     anchor_wrapper_revision=$(
       git -C "$script_parent_dir" rev-parse \
-        origin/main:scripts/pr \
-        origin/main:scripts/pr-lib \
-        origin/main:scripts/lib/plain-gh.sh 2>/dev/null || true
+        refs/remotes/origin/main:scripts/pr \
+        refs/remotes/origin/main:scripts/pr-lib \
+        refs/remotes/origin/main:scripts/lib/plain-gh.sh 2>/dev/null || true
     )
     if [ -z "$linked_wrapper_revision" ] ||
       [ -z "$anchor_wrapper_revision" ] ||

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -70,6 +70,10 @@ function writeFakeCrabbox(binDir: string, helpText: string): string {
       `  printf "%s" ${shellSingleQuote(helpText)}`,
       "  exit 0",
       "fi",
+      'if [ "$1" = "run" ] && [ -n "${OPENCLAW_FAKE_CRABBOX_RUN_STATUS:-}" ] && [ "$OPENCLAW_FAKE_CRABBOX_RUN_STATUS" != "0" ]; then',
+      '  printf "%s\\n" "fake run failure" >&2',
+      '  exit "$OPENCLAW_FAKE_CRABBOX_RUN_STATUS"',
+      "fi",
       'if [ "$1" = "config" ] && [ "$2" = "show" ]; then',
       '  for arg in "$@"; do',
       '    if [ "$arg" = "--json" ]; then',
@@ -201,6 +205,10 @@ function writeFakeCrabbox(binDir: string, helpText: string): string {
     'if (args[0] === "run" && args[1] === "--help") {',
     `  process.stdout.write(${JSON.stringify(helpText)});`,
     "  process.exit(0);",
+    "}",
+    'if (args[0] === "run" && Number.parseInt(process.env.OPENCLAW_FAKE_CRABBOX_RUN_STATUS || "0", 10) !== 0) {',
+    "  process.stderr.write('fake run failure\\n');",
+    "  process.exit(Number.parseInt(process.env.OPENCLAW_FAKE_CRABBOX_RUN_STATUS, 10));",
     "}",
     `require(${JSON.stringify(helperPath)});`,
   ].join("\n");
@@ -650,6 +658,30 @@ describe("scripts/crabbox-wrapper", () => {
 
     expect(result.status).toBe(0);
     expect(parseFakeCrabboxOutput(result).args).toContain("local-container");
+  });
+
+  it("hints at lease expiry when a reused-lease run fails fast", () => {
+    const result = runWrapper(
+      "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--provider", "local-container", "--id", "tbx_expired_fixture", "--", "echo ok"],
+      { env: { OPENCLAW_FAKE_CRABBOX_RUN_STATUS: "1" } },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "run --id tbx_expired_fixture failed fast; reusable leases expire after their idle timeout",
+    );
+  });
+
+  it("keeps failed runs without a reused lease free of the expiry hint", () => {
+    const result = runWrapper(
+      "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--provider", "local-container", "--", "echo ok"],
+      { env: { OPENCLAW_FAKE_CRABBOX_RUN_STATUS: "1" } },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).not.toContain("failed fast; reusable leases expire");
   });
 
   it("requires a current Crabbox binary for Blacksmith Testbox runs", () => {

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -95,13 +95,18 @@ describe("scripts/pr wrappers", () => {
     expect(dirtyLinkedResult.stderr).toContain("scripts/pr wrapper files have uncommitted changes");
     expect(git(linked, ["restore", "scripts/pr-lib/merge.sh"]).status).toBe(0);
 
+    // A dirty canonical checkout no longer blocks a linked worktree whose
+    // committed wrapper matches the origin/main trust anchor; without that
+    // anchor it must still refuse.
     writeFileSync(join(repo, "scripts", "pr-lib", "merge.sh"), "# dirty canonical\n");
     const dirtyResult = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
       cwd: linked,
       encoding: "utf8",
     });
     expect(dirtyResult.status).toBe(1);
-    expect(dirtyResult.stderr).toContain("scripts/pr wrapper files have uncommitted changes");
+    expect(dirtyResult.stderr).toContain(
+      "scripts/pr implementation differs between this worktree and the canonical checkout",
+    );
     expect(git(repo, ["restore", "scripts/pr-lib/merge.sh"]).status).toBe(0);
 
     writeFileSync(join(linked, "scripts", "pr-lib", "merge.sh"), "# linked\n");
@@ -116,8 +121,48 @@ describe("scripts/pr wrappers", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "scripts/pr implementation differs between this worktree and the canonical checkout.",
+      "scripts/pr implementation differs between this worktree and the canonical checkout",
     );
+  });
+
+  it("runs the local wrapper when it matches origin/main and the canonical checkout is parked elsewhere", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-pr-wrapper-anchor-"));
+    const repo = join(dir, "repo");
+    const linked = join(dir, "linked");
+    mkdirSync(join(repo, "scripts", "lib"), { recursive: true });
+    mkdirSync(join(repo, "scripts", "pr-lib"), { recursive: true });
+    writeFileSync(join(repo, "scripts", "pr"), readScript("scripts/pr"));
+    writeFileSync(join(repo, "scripts", "lib", "plain-gh.sh"), "# canonical\n");
+    writeFileSync(join(repo, "scripts", "pr-lib", "merge.sh"), "# canonical\n");
+    chmodSync(join(repo, "scripts", "pr"), 0o755);
+
+    const git = (cwd: string, args: string[]) =>
+      spawnSync("git", args, { cwd, encoding: "utf8", stdio: "pipe" });
+    expect(git(repo, ["init", "-b", "main"]).status).toBe(0);
+    expect(git(repo, ["config", "user.name", "OpenClaw Test"]).status).toBe(0);
+    expect(git(repo, ["config", "user.email", "test@example.invalid"]).status).toBe(0);
+    expect(git(repo, ["add", "scripts"]).status).toBe(0);
+    expect(git(repo, ["commit", "-m", "test: canonical wrapper"]).status).toBe(0);
+    // The linked worktree keeps main's wrapper; origin/main anchors trust.
+    expect(git(repo, ["update-ref", "refs/remotes/origin/main", "main"]).status).toBe(0);
+    expect(git(repo, ["worktree", "add", "-b", "feature", linked]).status).toBe(0);
+
+    // Park the canonical checkout on a release-style branch with a different
+    // wrapper revision, the exact contention that used to block landings.
+    expect(git(repo, ["switch", "-c", "release/test-train"]).status).toBe(0);
+    writeFileSync(join(repo, "scripts", "pr-lib", "merge.sh"), "# release drift\n");
+    expect(git(repo, ["add", "scripts/pr-lib/merge.sh"]).status).toBe(0);
+    expect(git(repo, ["commit", "-m", "test: release drift"]).status).toBe(0);
+
+    const result = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
+      cwd: linked,
+      encoding: "utf8",
+    });
+    rmSync(dir, { recursive: true, force: true });
+
+    expect(result.stderr).not.toContain("Refusing to silently substitute");
+    expect(result.stderr).not.toContain("scripts/pr implementation differs");
+    expect(result.stderr).not.toContain("uncommitted changes");
   });
 
   it("verifies local GitHub auth through GraphQL when REST quota is unavailable", () => {

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -158,11 +158,25 @@ describe("scripts/pr wrappers", () => {
       cwd: linked,
       encoding: "utf8",
     });
-    rmSync(dir, { recursive: true, force: true });
 
     expect(result.stderr).not.toContain("Refusing to silently substitute");
     expect(result.stderr).not.toContain("scripts/pr implementation differs");
     expect(result.stderr).not.toContain("uncommitted changes");
+
+    // A local branch literally named "origin/main" must not spoof the trust
+    // anchor: only the remote-tracking ref counts.
+    expect(git(repo, ["update-ref", "-d", "refs/remotes/origin/main"]).status).toBe(0);
+    expect(git(repo, ["update-ref", "refs/heads/origin/main", "main"]).status).toBe(0);
+    const spoofed = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
+      cwd: linked,
+      encoding: "utf8",
+    });
+    rmSync(dir, { recursive: true, force: true });
+
+    expect(spoofed.status).toBe(1);
+    expect(spoofed.stderr).toContain(
+      "scripts/pr implementation differs between this worktree and the canonical checkout",
+    );
   });
 
   it("verifies local GitHub auth through GraphQL when REST quota is unavailable", () => {


### PR DESCRIPTION
## What Problem This Solves

Two agent-workflow blockers surfaced during a 12-hour maintainer session. First, release trains park the shared canonical checkout on `release/*` branches; the `scripts/pr` wrapper trust guard then refuses to run from any linked worktree, hard-blocking every PR landing on the machine for the duration (~45 minutes in this case, worked around with a throwaway clone). Second, reused crabbox leases die at their idle timeout with a bare sub-second `exit 1` and no explanation, and rejected flags drown the actual error in a 200-line usage dump.

## Why This Change Was Made

`scripts/pr` now falls back to running the invoking worktree's own committed wrapper when its `scripts/pr` + `scripts/pr-lib` + `scripts/lib/plain-gh.sh` blobs exactly match the fetched `refs/remotes/origin/main` — the maintainer-controlled trust anchor. The explicit remote-tracking ref is deliberate: a local branch or tag literally named `origin/main` cannot spoof the anchor (review-caught DWIM hazard, regression-tested). A dirty canonical checkout now only blocks the exec-canonical substitution path, not the anchored local run; dirty worktree wrappers still refuse, and non-matching wrappers still refuse. The crabbox wrapper prints an actionable hint when a `run --id <lease>` invocation exits nonzero within 15 seconds, naming the idle-timeout cause and the `list`/`warmup` next steps.

## User Impact

Agents and maintainers can review, prepare, and merge PRs from linked worktrees while a release train (or any other agent) holds the canonical checkout, with no weakening of the wrapper trust model. Fast lease failures self-explain instead of requiring archaeology.

## Evidence

- `test/scripts/pr-wrappers.test.ts` + `test/scripts/crabbox-wrapper.test.ts` → 199/199 on Blacksmith Testbox, including new regression tests: anchor fallback runs locally when canonical is parked on a release-style branch, a spoofing `refs/heads/origin/main` is refused, dirty-canonical now falls through to the anchor check, the fast-fail hint fires for `run --id`, and a no-`--id` control stays hint-free.
- Codex autoreview, two rounds: round 1 caught the DWIM ref hazard (fixed by pinning `refs/remotes/origin/main`); round 2 clean ("patch is correct").
- `pnpm check:changed` → exit 0 (delegated, pearl-barnacle run).
- Sibling friction items from the same session, fixed elsewhere: the QA-smoke changelog pack gate was already fixed on main (#104162); autoreview single-pass exhaustive findings + Python 3.9 compat landed in openclaw/agent-skills#73. Deferred with reasons: pinned-ref worktree sync lives in the crabbox binary, not this repo; the compact-shard vi.mock flake is a separate test bug.