### PR TITLE
fix(browser): budget sequential action watchdogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Browser action watchdogs:** budget composite waits and nested batches across every sequential phase so direct, CLI, and paired-node browser actions can finish without disabling transport timeout protection. (#104457)
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Browser action watchdogs:** budget composite waits and nested batches across every sequential phase so direct, CLI, and paired-node browser actions can finish without disabling transport timeout protection. (#104457)
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/extensions/browser/src/browser-tool.actions.ts
+++ b/extensions/browser/src/browser-tool.actions.ts
@@ -29,6 +29,7 @@ import {
   resolveRuntimeImageSanitization,
   wrapExternalContent,
 } from "./browser-tool.runtime.js";
+import { resolveBrowserActRequestTimeoutMs } from "./browser/act-policy.js";
 import {
   DEFAULT_BROWSER_ACTION_TIMEOUT_MS,
   DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS,
@@ -47,7 +48,6 @@ const browserToolActionDeps = {
   imageResultFromFile,
 };
 
-const BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS = 5_000;
 const BROWSER_DOWNLOAD_REQUEST_TIMEOUT_SLACK_MS = 5_000;
 
 type BrowserActRequest = Parameters<typeof browserAct>[1];
@@ -128,20 +128,7 @@ function withConfiguredActTimeout(
 }
 
 function resolveActProxyTimeoutMs(request: BrowserActRequest): number | undefined {
-  const candidateTimeouts: number[] = [];
-  const explicitTimeout = normalizePositiveTimeoutMs(
-    (request as BrowserActRequestWithTimeout).timeoutMs,
-  );
-  if (explicitTimeout !== undefined) {
-    candidateTimeouts.push(explicitTimeout + BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS);
-  }
-  if (request.kind === "wait") {
-    const waitDuration = normalizeNonNegativeDurationMs(request.timeMs);
-    if (waitDuration !== undefined) {
-      candidateTimeouts.push(waitDuration + BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS);
-    }
-  }
-  return candidateTimeouts.length ? Math.max(...candidateTimeouts) : undefined;
+  return resolveBrowserActRequestTimeoutMs(request);
 }
 
 export const testing = {

--- a/extensions/browser/src/browser-tool.schema.test.ts
+++ b/extensions/browser/src/browser-tool.schema.test.ts
@@ -46,4 +46,14 @@ describe("browser tool schema", () => {
     expect(properties.kind.enum).toContain("scrollIntoView");
     expect(requestProperties.kind.enum).toContain("scrollIntoView");
   });
+
+  it("exposes batch actions on nested and flattened act params", () => {
+    const properties = BrowserToolSchema.properties as BrowserSchemaRecord;
+    const requestProperties = properties.request.properties as BrowserSchemaRecord;
+
+    expect(properties.kind.enum).toContain("batch");
+    expect(properties.actions).toBeDefined();
+    expect(requestProperties.kind.enum).toContain("batch");
+    expect(requestProperties.actions).toBeDefined();
+  });
 });

--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -15,6 +15,7 @@ import { Type } from "typebox";
 import { ACT_MAX_VIEWPORT_DIMENSION } from "./browser/act-policy.js";
 
 const BROWSER_ACT_KINDS = [
+  "batch",
   "click",
   "clickCoords",
   "type",
@@ -72,6 +73,9 @@ const BrowserActSchema = Type.Object({
   // Common fields
   targetId: Type.Optional(Type.String({ description: TAB_REFERENCE_DESCRIPTION })),
   ref: Type.Optional(Type.String()),
+  // batch - permissive children keep the provider schema flat; runtime validates each action.
+  actions: Type.Optional(Type.Array(Type.Object({}, { additionalProperties: true }))),
+  stopOnError: Type.Optional(Type.Boolean()),
   // click
   doubleClick: Type.Optional(Type.Boolean()),
   button: Type.Optional(Type.String()),
@@ -149,6 +153,8 @@ export const BrowserToolSchema = Type.Object({
   promptText: Type.Optional(Type.String()),
   // Legacy flattened act params (preferred: request={...})
   kind: Type.Optional(stringEnum(BROWSER_ACT_KINDS)),
+  actions: Type.Optional(Type.Array(Type.Object({}, { additionalProperties: true }))),
+  stopOnError: Type.Optional(Type.Boolean()),
   doubleClick: Type.Optional(Type.Boolean()),
   button: Type.Optional(Type.String()),
   modifiers: Type.Optional(Type.Array(Type.String())),

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -474,6 +474,7 @@ function nodeInvokeCall(callIndex: number): {
   request: {
     nodeId?: string;
     command?: string;
+    timeoutMs?: number;
     params?: {
       method?: string;
       path?: string;
@@ -491,6 +492,7 @@ function nodeInvokeCall(callIndex: number): {
   const request = mockCallArg<{
     nodeId?: string;
     command?: string;
+    timeoutMs?: number;
     params?: {
       method?: string;
       path?: string;
@@ -1909,14 +1911,20 @@ describe("browser tool act compatibility", () => {
     await tool.execute?.("call-1", {
       action: "act",
       target: "node",
-      request: { kind: "wait", timeMs: 20_000 },
+      request: { kind: "wait", timeMs: 20_000, text: "ready" },
     });
 
     const { options, request } = lastNodeInvokeCall();
-    expect(options.timeoutMs).toBe(55_000);
+    expect(options.timeoutMs).toBe(75_000);
+    expect(request.timeoutMs).toBe(75_000);
     expect(request.params?.path).toBe("/act");
-    expect(request.params?.body).toEqual({ kind: "wait", timeMs: 20_000, timeoutMs: 45_000 });
-    expect(request.params?.timeoutMs).toBe(45_000 + 5_000);
+    expect(request.params?.body).toEqual({
+      kind: "wait",
+      timeMs: 20_000,
+      text: "ready",
+      timeoutMs: 45_000,
+    });
+    expect(request.params?.timeoutMs).toBe(70_000);
   });
 
   it("honors string act request timeouts when sizing node proxy calls", async () => {
@@ -1925,18 +1933,47 @@ describe("browser tool act compatibility", () => {
     await tool.execute?.("call-1", {
       action: "act",
       target: "node",
-      request: { kind: "wait", timeMs: "20000", timeoutMs: "45000" },
+      request: { kind: "wait", timeMs: "20000", text: "ready", timeoutMs: "45000" },
     });
 
     const { options, request } = lastNodeInvokeCall();
-    expect(options.timeoutMs).toBe(55_000);
+    expect(options.timeoutMs).toBe(75_000);
     expect(request.params?.path).toBe("/act");
     expect(request.params?.body).toEqual({
       kind: "wait",
       timeMs: "20000",
+      text: "ready",
       timeoutMs: "45000",
     });
-    expect(request.params?.timeoutMs).toBe(50_000);
+    expect(request.params?.timeoutMs).toBe(70_000);
+  });
+
+  it("sizes node proxy calls for recursively nested batch execution", async () => {
+    mockSingleBrowserProxyNode();
+    const tool = createBrowserTool();
+
+    await tool.execute?.("call-1", {
+      action: "act",
+      target: "node",
+      request: {
+        kind: "batch",
+        actions: [
+          { kind: "wait", timeMs: 30_000 },
+          {
+            kind: "batch",
+            actions: [
+              { kind: "wait", timeMs: 30_000 },
+              { kind: "wait", timeMs: 30_000 },
+            ],
+          },
+        ],
+      },
+    });
+
+    const { options, request } = lastNodeInvokeCall();
+    expect(request.params?.timeoutMs).toBe(95_000);
+    expect(request.timeoutMs).toBe(100_000);
+    expect(options.timeoutMs).toBe(100_000);
   });
 
   it("rejects fractional act request timeouts before node proxy calls", async () => {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -198,6 +198,8 @@ const SCREENSHOT_SHARE_UNAVAILABLE =
 
 const LEGACY_BROWSER_ACT_REQUEST_KEYS = [
   "kind",
+  "actions",
+  "stopOnError",
   "targetId",
   "ref",
   "doubleClick",
@@ -381,6 +383,9 @@ async function callBrowserProxy(params: {
     {
       nodeId: params.nodeId,
       command: "browser.proxy",
+      // node.invoke owns a separate watchdog from browser.proxy. Keep both
+      // bounded, with enough outer slack for the proxy result to cross back.
+      timeoutMs: gatewayTimeoutMs,
       params: {
         method: params.method,
         path: params.path,

--- a/extensions/browser/src/browser/act-policy.test.ts
+++ b/extensions/browser/src/browser/act-policy.test.ts
@@ -1,0 +1,187 @@
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  resolveBrowserActExecutionBudgetMs,
+  resolveBrowserActRequestTimeoutMs,
+} from "./act-policy.js";
+import type { BrowserActRequest } from "./client-actions.types.js";
+
+describe("browser action execution budgets", () => {
+  it("sums the delay and every sequential wait condition", () => {
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "wait",
+        timeMs: 10_000,
+        text: "ready",
+        textGone: "loading",
+        selector: "#result",
+        url: "**/done",
+        loadState: "networkidle",
+        fn: "() => true",
+        timeoutMs: 20_000,
+      }),
+    ).toBe(130_000);
+  });
+
+  it("normalizes each condition timeout before multiplication", () => {
+    const wait = {
+      kind: "wait",
+      text: "ready",
+      textGone: "loading",
+      selector: "#result",
+      url: "**/done",
+      loadState: "load",
+      fn: "() => true",
+    } as const;
+
+    expect(resolveBrowserActExecutionBudgetMs({ ...wait, timeoutMs: 1 })).toBe(3_000);
+    expect(resolveBrowserActExecutionBudgetMs({ ...wait, timeoutMs: Number.MAX_VALUE })).toBe(
+      720_000,
+    );
+  });
+
+  it("matches runtime normalization for whitespace-only wait conditions", () => {
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "wait",
+        timeMs: 0,
+        text: " ",
+        textGone: " ",
+        selector: "",
+        url: " ",
+        fn: " ",
+      }),
+    ).toBe(40_000);
+    expect(resolveBrowserActRequestTimeoutMs({ kind: "wait", timeMs: 0 })).toBe(5_000);
+  });
+
+  it("recursively sums nested batch children in execution order", () => {
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "batch",
+        actions: [
+          { kind: "wait", timeMs: 30_000 },
+          {
+            kind: "batch",
+            actions: [
+              { kind: "wait", timeMs: 30_000 },
+              { kind: "wait", timeMs: 30_000 },
+            ],
+          },
+        ],
+      }),
+    ).toBe(90_000);
+  });
+
+  it("keeps leaf defaults and adds outer slack once", () => {
+    expect(resolveBrowserActExecutionBudgetMs({ kind: "click", ref: "1" })).toBe(60_000);
+    expect(resolveBrowserActRequestTimeoutMs({ kind: "click", ref: "1", timeoutMs: 45_000 })).toBe(
+      50_250,
+    );
+  });
+
+  it("budgets sequential leaf phases and bounded delays", () => {
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "fill",
+        fields: [
+          { ref: "first", type: "text" },
+          { ref: "second", type: "text" },
+        ],
+        timeoutMs: 20_000,
+      }),
+    ).toBe(40_500);
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "type",
+        ref: "field",
+        text: "value",
+        slowly: true,
+        submit: true,
+        timeoutMs: 20_000,
+      }),
+    ).toBe(60_250);
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "click",
+        ref: "button",
+        delayMs: 5_000,
+        timeoutMs: 20_000,
+      }),
+    ).toBe(45_250);
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "clickCoords",
+        x: 10,
+        y: 20,
+        doubleClick: true,
+        delayMs: 5_000,
+        timeoutMs: 20_000,
+      }),
+    ).toBe(35_250);
+  });
+
+  it("preserves the prior whole-request floor for batches", () => {
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "batch",
+        actions: [
+          {
+            kind: "fill",
+            fields: [
+              { ref: "first", type: "text" },
+              { ref: "second", type: "text" },
+            ],
+            timeoutMs: 20_000,
+          },
+        ],
+      }),
+    ).toBe(60_000);
+  });
+
+  it("budgets the wider scrollIntoView locator timeout", () => {
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "batch",
+        actions: Array.from({ length: 4 }, () => ({
+          kind: "scrollIntoView" as const,
+          ref: "result",
+        })),
+      }),
+    ).toBe(81_000);
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "scrollIntoView",
+        ref: "result",
+        timeoutMs: 120_000,
+      }),
+    ).toBe(120_250);
+  });
+
+  it("leaves malformed model batch validation to the browser route", () => {
+    expect(
+      resolveBrowserActExecutionBudgetMs({
+        kind: "batch",
+        requests: [],
+        actions: [{ kind: "wait", selector: 1 }, { kind: "unknown" }, null],
+      } as unknown as BrowserActRequest),
+    ).toBe(60_000);
+  });
+
+  it("saturates aggregate and slack arithmetic at the timer limit", () => {
+    const actions: BrowserActRequest[] = Array.from({ length: 3_000 }, () => ({
+      kind: "wait",
+      text: "ready",
+      textGone: "loading",
+      selector: "#result",
+      url: "**/done",
+      loadState: "load",
+      fn: "() => true",
+      timeoutMs: 120_000,
+    }));
+    const batch = { kind: "batch", actions } as const;
+
+    expect(resolveBrowserActExecutionBudgetMs(batch)).toBe(MAX_TIMER_TIMEOUT_MS);
+    expect(resolveBrowserActRequestTimeoutMs(batch)).toBe(MAX_TIMER_TIMEOUT_MS);
+  });
+});

--- a/extensions/browser/src/browser/act-policy.ts
+++ b/extensions/browser/src/browser/act-policy.ts
@@ -4,6 +4,16 @@
  * Shared by the tool schema and runtime action handlers so model-facing limits
  * and browser-control enforcement stay aligned.
  */
+import {
+  addTimerTimeoutGraceMs,
+  clampPositiveTimerTimeoutMs,
+  MAX_TIMER_TIMEOUT_MS,
+  parseStrictInteger,
+  resolveTimerTimeoutMs,
+} from "openclaw/plugin-sdk/number-runtime";
+import type { BrowserActRequest } from "./client-actions.types.js";
+import { DEFAULT_BROWSER_ACTION_TIMEOUT_MS } from "./constants.js";
+
 /** Maximum number of actions accepted in a batched browser action request. */
 export const ACT_MAX_BATCH_ACTIONS = 100;
 /** Maximum nested action depth accepted by recursive browser actions. */
@@ -20,6 +30,11 @@ const ACT_MAX_INTERACTION_TIMEOUT_MS = 60_000;
 const ACT_MAX_WAIT_TIMEOUT_MS = 120_000;
 const ACT_DEFAULT_INTERACTION_TIMEOUT_MS = 8_000;
 const ACT_DEFAULT_WAIT_TIMEOUT_MS = 20_000;
+
+/** Grace between the runtime's action budget and an outer transport watchdog. */
+export const BROWSER_ACTION_TRANSPORT_SLACK_MS = 5_000;
+/** Post-action window that keeps navigation policy interception active. */
+export const BROWSER_ACTION_NAVIGATION_GRACE_MS = 250;
 
 export function normalizeActBoundedNonNegativeMs(
   value: number | undefined,
@@ -55,4 +70,158 @@ export function resolveActWaitTimeoutMs(timeoutMs?: number): number {
       ? Math.floor(timeoutMs)
       : ACT_DEFAULT_WAIT_TIMEOUT_MS;
   return Math.max(ACT_MIN_TIMEOUT_MS, Math.min(ACT_MAX_WAIT_TIMEOUT_MS, normalized));
+}
+
+function parseTimerInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.floor(value)
+    : parseStrictInteger(value);
+}
+
+function resolveNonNegativeTimerMs(value: unknown): number {
+  const parsed = parseTimerInteger(value);
+  return parsed !== undefined && parsed >= 0 ? resolveTimerTimeoutMs(parsed, 0, 0) : 0;
+}
+
+function addExecutionBudgetMs(totalMs: number, nextMs: number): number {
+  return Math.min(MAX_TIMER_TIMEOUT_MS, totalMs + nextMs);
+}
+
+function multiplyExecutionBudgetMs(durationMs: number, count: number): number {
+  return Math.min(MAX_TIMER_TIMEOUT_MS, durationMs * count);
+}
+
+function resolveInteractionTimeoutMs(request: BrowserActRequest): number {
+  return resolveActInteractionTimeoutMs(
+    parseTimerInteger("timeoutMs" in request ? request.timeoutMs : undefined),
+  );
+}
+
+function addNavigationGraceMs(durationMs: number, count = 1): number {
+  return addExecutionBudgetMs(
+    durationMs,
+    multiplyExecutionBudgetMs(BROWSER_ACTION_NAVIGATION_GRACE_MS, count),
+  );
+}
+
+function isActionObject(value: unknown): value is BrowserActRequest {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveLeafExecutionBudgetMs(
+  request: Exclude<BrowserActRequest, { kind: "batch" | "wait" }>,
+): number {
+  switch (request.kind) {
+    case "click": {
+      const timeoutMs = resolveInteractionTimeoutMs(request);
+      const delayMs = Math.min(ACT_MAX_CLICK_DELAY_MS, resolveNonNegativeTimerMs(request.delayMs));
+      const actionMs = delayMs > 0 ? addExecutionBudgetMs(timeoutMs * 2, delayMs) : timeoutMs;
+      return addNavigationGraceMs(actionMs);
+    }
+    case "clickCoords": {
+      const delayMs = Math.min(ACT_MAX_CLICK_DELAY_MS, resolveNonNegativeTimerMs(request.delayMs));
+      const explicitTimeoutMs =
+        clampPositiveTimerTimeoutMs(parseTimerInteger(request.timeoutMs)) ?? 0;
+      return addNavigationGraceMs(
+        addExecutionBudgetMs(
+          explicitTimeoutMs,
+          multiplyExecutionBudgetMs(delayMs, request.doubleClick ? 3 : 1),
+        ),
+      );
+    }
+    case "type": {
+      const phaseCount = (request.slowly ? 2 : 1) + (request.submit ? 1 : 0);
+      return addNavigationGraceMs(
+        multiplyExecutionBudgetMs(resolveInteractionTimeoutMs(request), phaseCount),
+      );
+    }
+    case "press":
+      return addNavigationGraceMs(resolveNonNegativeTimerMs(request.delayMs));
+    case "fill": {
+      const fields = Array.isArray(request.fields) ? request.fields : [];
+      const fieldCount = fields.filter(
+        (field) =>
+          Boolean(field) &&
+          typeof field === "object" &&
+          typeof field.ref === "string" &&
+          Boolean(field.ref.trim()),
+      ).length;
+      return addNavigationGraceMs(
+        multiplyExecutionBudgetMs(resolveInteractionTimeoutMs(request), fieldCount),
+        fieldCount,
+      );
+    }
+    case "evaluate":
+      return addNavigationGraceMs(resolveActWaitTimeoutMs(parseTimerInteger(request.timeoutMs)));
+    case "scrollIntoView":
+      return addNavigationGraceMs(resolveActWaitTimeoutMs(parseTimerInteger(request.timeoutMs)));
+    case "hover":
+    case "drag":
+    case "select":
+      return addNavigationGraceMs(resolveInteractionTimeoutMs(request));
+    case "resize":
+    case "close":
+      return 0;
+  }
+  return 0;
+}
+
+function resolveExecutionBudgetMs(request: BrowserActRequest): number {
+  if (request.kind === "batch") {
+    // Model-facing schemas keep child actions permissive for provider compatibility.
+    // Budget valid entries only; the browser route remains the validation owner.
+    const actions = Array.isArray(request.actions) ? request.actions.filter(isActionObject) : [];
+    return actions.reduce(
+      (totalMs, action) => addExecutionBudgetMs(totalMs, resolveExecutionBudgetMs(action)),
+      0,
+    );
+  }
+  if (request.kind !== "wait") {
+    return resolveLeafExecutionBudgetMs(request);
+  }
+  // Text locators accept whitespace as content; selector, URL, and function
+  // waits normalize it away. Keep this in lockstep with waitForViaPlaywright.
+  const conditionCount = [
+    Boolean(request.text),
+    Boolean(request.textGone),
+    typeof request.selector === "string" && Boolean(request.selector.trim()),
+    typeof request.url === "string" && Boolean(request.url.trim()),
+    Boolean(request.loadState),
+    typeof request.fn === "string" && Boolean(request.fn.trim()),
+  ].filter(Boolean).length;
+  const timeoutMs = resolveActWaitTimeoutMs(parseTimerInteger(request.timeoutMs));
+  return addExecutionBudgetMs(
+    resolveNonNegativeTimerMs(request.timeMs),
+    multiplyExecutionBudgetMs(timeoutMs, conditionCount),
+  );
+}
+
+/**
+ * Resolve the runtime budget before an outer transport watchdog is armed.
+ * Wait phases and batch children execute serially, so maxima would abort valid work midway.
+ */
+export function resolveBrowserActExecutionBudgetMs(request: BrowserActRequest): number {
+  const executionBudgetMs = resolveExecutionBudgetMs(request);
+  if (request.kind === "wait") {
+    return executionBudgetMs;
+  }
+  const explicitTimeoutMs =
+    request.kind === "batch"
+      ? undefined
+      : clampPositiveTimerTimeoutMs(
+          parseTimerInteger("timeoutMs" in request ? request.timeoutMs : undefined),
+        );
+  return explicitTimeoutMs === undefined
+    ? Math.max(DEFAULT_BROWSER_ACTION_TIMEOUT_MS, executionBudgetMs)
+    : executionBudgetMs;
+}
+
+/** Add action transport slack once after the full sequential runtime budget is known. */
+export function resolveBrowserActRequestTimeoutMs(request: BrowserActRequest): number {
+  return (
+    addTimerTimeoutGraceMs(
+      resolveBrowserActExecutionBudgetMs(request),
+      BROWSER_ACTION_TRANSPORT_SLACK_MS,
+    ) ?? 1
+  );
 }

--- a/extensions/browser/src/browser/client-actions-core.ts
+++ b/extensions/browser/src/browser/client-actions-core.ts
@@ -9,6 +9,10 @@ import {
   clampPositiveTimerTimeoutMs,
   resolveTimerTimeoutMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import {
+  BROWSER_ACTION_TRANSPORT_SLACK_MS,
+  resolveBrowserActRequestTimeoutMs,
+} from "./act-policy.js";
 import type {
   BrowserActionOk,
   BrowserActionPathResult,
@@ -18,7 +22,6 @@ import { buildProfileQuery, withBaseUrl } from "./client-actions-url.js";
 import type { BrowserActRequest } from "./client-actions.types.js";
 import { fetchBrowserJson } from "./client-fetch.js";
 import {
-  DEFAULT_BROWSER_ACTION_TIMEOUT_MS,
   DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS,
   DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS,
 } from "./constants.js";
@@ -38,36 +41,17 @@ type BrowserActResponse = {
   downloads?: BrowserDownloadResult[];
 };
 
-const BROWSER_REQUEST_TIMEOUT_SLACK_MS = 5_000;
-
 type BrowserDownloadActionResult = BrowserActionTabResult & { download: BrowserDownloadResult };
 
 function normalizePositiveTimeoutMs(value: unknown): number | undefined {
   return clampPositiveTimerTimeoutMs(value);
 }
 
-function resolveBrowserActRequestTimeoutMs(req: BrowserActRequest): number {
-  const explicitTimeout = normalizePositiveTimeoutMs((req as { timeoutMs?: unknown }).timeoutMs);
-  const candidateTimeouts =
-    explicitTimeout === undefined
-      ? [DEFAULT_BROWSER_ACTION_TIMEOUT_MS]
-      : [addTimerTimeoutGraceMs(explicitTimeout, BROWSER_REQUEST_TIMEOUT_SLACK_MS) ?? 1];
-  if (req.kind === "wait") {
-    const waitDuration = normalizePositiveTimeoutMs(req.timeMs);
-    if (waitDuration !== undefined) {
-      candidateTimeouts.push(
-        addTimerTimeoutGraceMs(waitDuration, BROWSER_REQUEST_TIMEOUT_SLACK_MS) ?? 1,
-      );
-    }
-  }
-  return Math.max(...candidateTimeouts);
-}
-
 function resolveBrowserOperationRequestTimeoutMs(timeoutMs: unknown): number {
   const operationTimeoutMs =
     normalizePositiveTimeoutMs(timeoutMs) ?? DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS;
   // Let the browser operation report its own timeout/error before the client watchdog fires.
-  return addTimerTimeoutGraceMs(operationTimeoutMs, BROWSER_REQUEST_TIMEOUT_SLACK_MS) ?? 1;
+  return addTimerTimeoutGraceMs(operationTimeoutMs, BROWSER_ACTION_TRANSPORT_SLACK_MS) ?? 1;
 }
 
 async function postDownloadRequest(

--- a/extensions/browser/src/browser/client.test.ts
+++ b/extensions/browser/src/browser/client.test.ts
@@ -422,14 +422,37 @@ describe("browser client", () => {
     await browserAct("http://127.0.0.1:18791", { kind: "click", ref: "1" });
     await browserAct("http://127.0.0.1:18791", {
       kind: "wait",
-      timeMs: 70_000,
+      timeMs: 10_000,
+      text: "ready",
+      timeoutMs: 20_000,
     });
     await browserAct("http://127.0.0.1:18791", {
       kind: "wait",
+      text: "ready",
       timeoutMs: 45_000,
     });
+    await browserAct("http://127.0.0.1:18791", {
+      kind: "batch",
+      actions: [
+        { kind: "wait", timeMs: 30_000 },
+        {
+          kind: "batch",
+          actions: [
+            { kind: "wait", timeMs: 30_000 },
+            { kind: "wait", timeMs: 30_000 },
+          ],
+        },
+      ],
+    });
+    await browserAct(
+      "http://127.0.0.1:18791",
+      { kind: "wait", timeMs: 30_000 },
+      { timeoutMs: 12_345 },
+    );
 
-    expect(calls.map((call) => call.init?.timeoutMs)).toEqual([60_000, 75_000, 50_000]);
+    expect(calls.map((call) => call.init?.timeoutMs)).toEqual([
+      65_000, 35_000, 50_000, 95_000, 12_345,
+    ]);
   });
 
   it("clamps oversized browser action timeouts before forwarding", async () => {
@@ -444,14 +467,21 @@ describe("browser client", () => {
 
     await browserAct("http://127.0.0.1:18791", {
       kind: "wait",
+      text: "ready",
       timeoutMs: Number.MAX_SAFE_INTEGER,
     });
+    await browserAct(
+      "http://127.0.0.1:18791",
+      { kind: "wait", text: "ready" },
+      { timeoutMs: Number.MAX_SAFE_INTEGER },
+    );
     await browserScreenshotAction("http://127.0.0.1:18791", {
       timeoutMs: Number.MAX_SAFE_INTEGER,
     });
 
-    const act = calls.find((call) => call.url.endsWith("/act"));
-    expect(act?.init?.timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
+    const actCalls = calls.filter((call) => call.url.endsWith("/act"));
+    expect(actCalls[0]?.init?.timeoutMs).toBe(125_000);
+    expect(actCalls[1]?.init?.timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
     const screenshot = calls.find((call) => call.url.endsWith("/screenshot"));
     expect(screenshot?.init?.timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
     const screenshotBody = JSON.parse(

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -11,6 +11,7 @@ import {
   ACT_MAX_BATCH_DEPTH,
   ACT_MAX_CLICK_DELAY_MS,
   ACT_MAX_WAIT_TIME_MS,
+  BROWSER_ACTION_NAVIGATION_GRACE_MS,
   resolveActInteractionTimeoutMs,
   resolveActWaitTimeoutMs,
 } from "./act-policy.js";
@@ -62,7 +63,6 @@ type TargetOpts = {
   targetId?: string;
 };
 
-const INTERACTION_NAVIGATION_GRACE_MS = 250;
 const ACT_DOWNLOAD_MAX_DRAIN_MS = 1_000;
 
 function interactionNavigationPolicy(
@@ -276,7 +276,7 @@ function observeDelayedInteractionNavigation(
         mainFrameNavigated: didCrossDocumentUrlChange(page, previousUrl),
         subframes,
       });
-    }, INTERACTION_NAVIGATION_GRACE_MS);
+    }, BROWSER_ACTION_NAVIGATION_GRACE_MS);
     const cleanup = () => {
       clearTimeout(timeout);
       // Call off directly on page (not via a cached reference) to preserve
@@ -363,7 +363,7 @@ function scheduleDelayedInteractionNavigationGuard(
           subframes,
         },
       }).then(() => settle(), settle);
-    }, INTERACTION_NAVIGATION_GRACE_MS);
+    }, BROWSER_ACTION_NAVIGATION_GRACE_MS);
     const cleanup = () => {
       clearTimeout(timeout);
       page.off!("framenavigated", onFrameNavigated);
@@ -571,7 +571,7 @@ async function awaitNavigationGuardedInteraction<T>(
           // The canonical post-check can settle on the first safe navigation.
           // Keep request interception for the full grace after the raw action.
           const elapsedMs = Math.max(0, Date.now() - actionSettledAtMs);
-          const remainingMs = Math.max(0, INTERACTION_NAVIGATION_GRACE_MS - elapsedMs);
+          const remainingMs = Math.max(0, BROWSER_ACTION_NAVIGATION_GRACE_MS - elapsedMs);
           if (remainingMs > 0) {
             await new Promise<void>((resolve) => {
               setTimeout(resolve, remainingMs);
@@ -1869,13 +1869,13 @@ export async function executeActViaPlaywright(
     },
   });
   const downloadGraceMs = actionNeedsStandaloneDownloadGrace(opts.action, navigationPolicy)
-    ? INTERACTION_NAVIGATION_GRACE_MS
+    ? BROWSER_ACTION_NAVIGATION_GRACE_MS
     : 0;
   const drainDownloads = async (firstEventGraceMs = downloadGraceMs) =>
     await downloadCapture.drain({
       firstEventGraceMs,
       maxWaitMs: ACT_DOWNLOAD_MAX_DRAIN_MS,
-      quietMs: INTERACTION_NAVIGATION_GRACE_MS,
+      quietMs: BROWSER_ACTION_NAVIGATION_GRACE_MS,
     });
   const dialogAbort = createObservedDialogAbortSignalForPage({
     page,
@@ -1917,7 +1917,7 @@ export async function executeActViaPlaywright(
     try {
       const failureGraceMs =
         dialogAbort.signal.aborted && actionUsesNavigationRequestGuard(opts.action)
-          ? INTERACTION_NAVIGATION_GRACE_MS
+          ? BROWSER_ACTION_NAVIGATION_GRACE_MS
           : downloadGraceMs;
       await drainDownloads(failureGraceMs);
     } catch (downloadErr) {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
@@ -113,7 +113,39 @@ describe("browser action input wait command", () => {
     const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
       | { timeoutMs?: number }
       | undefined;
-    expect(options?.timeoutMs).toBeGreaterThan(21000);
+    expect(options?.timeoutMs).toBe(26_000);
+  });
+
+  it("budgets every supplied wait condition before adding transport slack", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "wait",
+        "#result",
+        "--time",
+        "1000",
+        "--text",
+        "Ready",
+        "--text-gone",
+        "Loading",
+        "--url",
+        "**/done",
+        "--load",
+        "networkidle",
+        "--fn",
+        "() => true",
+        "--timeout-ms",
+        "2000",
+      ],
+      { from: "user" },
+    );
+
+    const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
+      | { timeoutMs?: number }
+      | undefined;
+    expect(options?.timeoutMs).toBe(18_000);
   });
 
   it("rejects non-decimal wait numeric options before sending the wait request", async () => {

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
@@ -3,6 +3,8 @@
  */
 import type { Command } from "commander";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveBrowserActExecutionBudgetMs } from "../../browser/act-policy.js";
+import type { BrowserActRequest } from "../../browser/client-actions.types.js";
 import {
   BROWSER_TAB_REFERENCE_HELP,
   parseBrowserNonNegativeIntegerOption,
@@ -17,7 +19,6 @@ import {
   resolveBrowserActionContext,
 } from "./shared.js";
 
-const DEFAULT_WAIT_CONDITION_TIMEOUT_MS = 20000;
 type BrowserWaitLoadState = "load" | "domcontentloaded" | "networkidle";
 
 function parseBrowserWaitLoadState(value: unknown): BrowserWaitLoadState | undefined {
@@ -97,26 +98,23 @@ export function registerBrowserFormWaitEvalCommands(
         const textGone = normalizeOptionalString(opts.textGone);
         const url = normalizeOptionalString(opts.url);
         const fn = normalizeOptionalString(opts.fn);
-        const waitConditionCount = [text, textGone, sel, url, load, fn].filter(Boolean).length;
-        const outerTimeoutBaseMs =
-          (timeMs ?? 0) + waitConditionCount * (timeoutMs ?? DEFAULT_WAIT_CONDITION_TIMEOUT_MS) ||
-          undefined;
+        const request: BrowserActRequest = {
+          kind: "wait",
+          timeMs,
+          text,
+          textGone,
+          selector: sel,
+          url,
+          loadState: load,
+          fn,
+          targetId: normalizeOptionalString(opts.targetId),
+          timeoutMs,
+        };
         const result = await callBrowserAct<{ result?: unknown }>({
           parent,
           profile,
-          body: {
-            kind: "wait",
-            timeMs,
-            text,
-            textGone,
-            selector: sel,
-            url,
-            loadState: load,
-            fn,
-            targetId: normalizeOptionalString(opts.targetId),
-            timeoutMs,
-          },
-          timeoutMs: outerTimeoutBaseMs,
+          body: request,
+          timeoutMs: resolveBrowserActExecutionBudgetMs(request),
         });
         logBrowserActionResult(parent, result, "wait complete");
       } catch (err) {

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
@@ -3,6 +3,8 @@
  */
 import fs from "node:fs/promises";
 import type { Command } from "commander";
+import { addTimerTimeoutGraceMs } from "openclaw/plugin-sdk/number-runtime";
+import { BROWSER_ACTION_TRANSPORT_SLACK_MS } from "../../browser/act-policy.js";
 import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
 import {
   danger,
@@ -17,14 +19,15 @@ type BrowserActionContext = {
   profile: string | undefined;
 };
 
-const BROWSER_ACTION_TIMEOUT_SLACK_MS = 5000;
 const DEFAULT_BROWSER_ACTION_TIMEOUT_MS = 20000;
 
 /** Adds gateway slack to a Browser action timeout so route work can finish cleanly. */
 export function withBrowserActionTimeoutSlack(timeoutMs: number | undefined): number {
   return (
-    Math.max(1, Math.floor(timeoutMs ?? DEFAULT_BROWSER_ACTION_TIMEOUT_MS)) +
-    BROWSER_ACTION_TIMEOUT_SLACK_MS
+    addTimerTimeoutGraceMs(
+      timeoutMs ?? DEFAULT_BROWSER_ACTION_TIMEOUT_MS,
+      BROWSER_ACTION_TRANSPORT_SLACK_MS,
+    ) ?? 1
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Composite browser waits and nested batches execute their phases serially, but direct, CLI, browser-proxy, and node-invoke watchdogs were sized from one phase, a maximum, or a fixed 20/30/60 second deadline. Valid work could be aborted midway and a retry could repeat already-completed page side effects. The agent tool also omitted `batch`/`actions` from its model-facing schema, and malformed permissive batch input could crash timeout calculation before the browser route returned its normal validation error.

Closes #104457.

## Why This Change Was Made

One recursive, saturating action-budget policy now mirrors the actual sequential runtime phases, including per-action Playwright timeouts, bounded delays, navigation grace, composite wait conditions, nested batches, and the wider scroll/evaluate timeout contract. Direct requests, CLI waits, browser proxy calls, and paired-node calls reuse that owner; the computed deadline is propagated through both `browser.proxy` and the separate `node.invoke` watchdog. Explicit caller timeout overrides remain authoritative, the existing whole-request floor remains, and transport watchdogs stay enabled.

The flat provider-compatible agent schema now advertises `batch`, `actions`, and `stopOnError` without introducing recursive JSON Schema. Runtime budgeting tolerates malformed permissive children long enough for the browser route to return its canonical validation error.

## User Impact

Long composite waits and nested batches can finish once across host, CLI, and paired-node browser automation instead of failing at an unrelated outer deadline. Genuine Playwright locator errors still surface, and invalid batch input now returns an actionable validation error rather than a JavaScript `.reduce()` crash. This does not parallelize actions, remove timeout protection, widen browser/navigation permissions, or change the per-agent trust boundary.

## Evidence

- Blacksmith Testbox-through-Crabbox `tbx_01kx9742wgnqkm9m5v1yqjaaqd`: 140/140 focused browser tests.
- Same Testbox: changed typecheck, lint, format, database-first, media, sidecar, and import-cycle gates passed.
- Real isolated Gateway + `openai/gpt-5.4` + managed browser:
  - composite 8s + condition/function wait returned `COMPOSITE_SUCCESS Budget Proof` (`cc3b1457-7973-45b7-95f3-7d8f24e5e907`; 3 Browser calls, 0 failures, no fallback);
  - 63s nested host batch returned ordered `DIRECT_BATCH A,B,C,D` (`e483fc58-9107-49f6-b7c7-cf7e77565b39`; 2 Browser calls, 0 failures);
  - 63s paired-node batch crossed the former 30s node-invoke deadline and returned ordered `NODE_BATCH A,B,C,D` (`e8f206d5-6181-4aa9-8596-598b8058873a`; 2 Browser calls, 0 failures);
  - impossible locator after an 8s delay returned Playwright's 7s locator timeout at 16.071s, not a generic transport timeout;
  - malformed `{kind:"batch",requests:[]}` returned `actions are required`, not a runtime crash.
- Official Playwright 1.61.1 source inspected for locator/action/wait timeout and mouse delay sequencing.
- Fresh autoreview: clean, no accepted/actionable findings (0.91 overall confidence).

AI-assisted implementation and review. No agent transcript attached.
