### PR TITLE
fix: ignore missing channel secrets in doctor preview

### DIFF
--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -143,7 +143,36 @@ vi.mock("../secrets/channel-contract-api.js", () => ({
 }));
 
 vi.mock("../channels/plugins/read-only.js", () => ({
-  listReadOnlyChannelPluginsForConfig: vi.fn(() => []),
+  listReadOnlyChannelPluginsForConfig: vi.fn((config: {
+    channels?: Record<string, { accounts?: Record<string, unknown>; defaultAccount?: string }>;
+  }) => {
+    const plugins = [] as Array<{
+      id: string;
+      config: {
+        listAccountIds: (cfg: typeof config) => string[];
+        defaultAccountId: (cfg: typeof config) => string | undefined;
+      };
+    }>;
+    if (config?.channels?.discord) {
+      plugins.push({
+        id: "discord",
+        config: {
+          listAccountIds: (cfg) => Object.keys(cfg.channels?.discord?.accounts ?? {}),
+          defaultAccountId: (cfg) => cfg.channels?.discord?.defaultAccount,
+        },
+      });
+    }
+    if (config?.channels?.matrix) {
+      plugins.push({
+        id: "matrix",
+        config: {
+          listAccountIds: (cfg) => Object.keys(cfg.channels?.matrix?.accounts ?? {}),
+          defaultAccountId: (cfg) => cfg.channels?.matrix?.defaultAccount,
+        },
+      });
+    }
+    return plugins;
+  }),
 }));
 
 vi.mock("../plugins/web-fetch-providers.runtime.js", () => ({

--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -6,6 +6,9 @@ const REGISTRY_IDS = [
   "agents.list[].memorySearch.remote.apiKey",
   "channels.discord.token",
   "channels.discord.accounts.*.token",
+  "channels.matrix.accessToken",
+  "channels.matrix.password",
+  "channels.matrix.accounts.default.accessToken",
   "channels.telegram.botToken",
   "gateway.auth.token",
   "gateway.auth.password",
@@ -94,6 +97,53 @@ vi.mock("../secrets/target-registry.js", () => ({
     }
     return out;
   }),
+}));
+
+vi.mock("../secrets/channel-contract-api.js", () => ({
+  loadChannelSecretContractApi: vi.fn(({ channelId }: { channelId: string }) => {
+    if (channelId === "discord") {
+      return {
+        secretTargetRegistryEntries: [
+          {
+            id: "channels.discord.token",
+            configFile: "openclaw.json",
+            pathPattern: "channels.discord.token",
+          },
+          {
+            id: "channels.discord.accounts.*.token",
+            configFile: "openclaw.json",
+            pathPattern: "channels.discord.accounts.*.token",
+          },
+        ],
+      };
+    }
+    if (channelId === "matrix") {
+      return {
+        secretTargetRegistryEntries: [
+          {
+            id: "channels.matrix.accessToken",
+            configFile: "openclaw.json",
+            pathPattern: "channels.matrix.accessToken",
+          },
+          {
+            id: "channels.matrix.password",
+            configFile: "openclaw.json",
+            pathPattern: "channels.matrix.password",
+          },
+          {
+            id: "channels.matrix.accounts.*.accessToken",
+            configFile: "openclaw.json",
+            pathPattern: "channels.matrix.accounts.*.accessToken",
+          },
+        ],
+      };
+    }
+    return { secretTargetRegistryEntries: [] };
+  }),
+}));
+
+vi.mock("../channels/plugins/read-only.js", () => ({
+  listReadOnlyChannelPluginsForConfig: vi.fn(() => []),
 }));
 
 vi.mock("../plugins/web-fetch-providers.runtime.js", () => ({
@@ -245,6 +295,7 @@ import {
   getCapabilityWebFetchCommandSecretTargetIds,
   getCapabilityWebSearchCommandSecretTargets,
   getCapabilityWebSearchCommandSecretTargetIds,
+  getConfiguredChannelsCommandSecretTargetIds,
   getModelsCommandSecretTargetIds,
   getQrRemoteCommandSecretTargetIds,
   getScopedChannelsCommandSecretTargets,
@@ -286,6 +337,25 @@ describe("command secret target ids", () => {
     expect(ids.has("agents.defaults.memorySearch.remote.apiKey")).toBe(true);
     expect(ids.has("agents.list[].memorySearch.remote.apiKey")).toBe(true);
     expect(ids.has("channels.discord.token")).toBe(false);
+  });
+
+  it("includes only configured channel secret targets for doctor preview scans", () => {
+    const ids = getConfiguredChannelsCommandSecretTargetIds({
+      channels: {
+        matrix: {
+          enabled: false,
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+        },
+        discord: {
+          token: { source: "env", provider: "default", id: "DISCORD_TOKEN" },
+        },
+      },
+    } as never);
+
+    expect(ids).toEqual(new Set(["channels.discord.token"]));
+    expect(ids.has("channels.matrix.accessToken")).toBe(false);
+    expect(ids.has("channels.matrix.password")).toBe(false);
   });
 
   it("scopes capability web search commands to search credential surfaces only", () => {

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -752,7 +752,7 @@ function getConfiguredChannelSecretTargetIds(
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
-  const targetIds = new Set<string>();
+  const candidateTargetIds = new Set<string>();
   const channels = config.channels;
   if (channels && typeof channels === "object" && !Array.isArray(channels)) {
     for (const channelId of Object.keys(channels)) {
@@ -762,7 +762,7 @@ function getConfiguredChannelSecretTargetIds(
       const contract = loadChannelSecretContractApi({ channelId, config, env });
       for (const entry of contract?.secretTargetRegistryEntries ?? []) {
         if (isScopedChannelSecretTargetEntry({ entry, pluginChannelId: channelId })) {
-          targetIds.add(entry.id);
+          candidateTargetIds.add(entry.id);
         }
       }
     }
@@ -773,11 +773,15 @@ function getConfiguredChannelSecretTargetIds(
   })) {
     for (const entry of plugin.secrets?.secretTargetRegistryEntries ?? []) {
       if (isScopedChannelSecretTargetEntry({ entry, pluginChannelId: plugin.id })) {
-        targetIds.add(entry.id);
+        candidateTargetIds.add(entry.id);
       }
     }
   }
-  return [...targetIds].toSorted((left, right) => left.localeCompare(right));
+  return [
+    ...new Set(
+      discoverConfigSecretTargetsByIds(config, candidateTargetIds).map((target) => target.entry.id),
+    ),
+  ].toSorted((left, right) => left.localeCompare(right));
 }
 
 function buildCommandSecretTargets(): CommandSecretTargets {


### PR DESCRIPTION
## Summary
- filter configured channel secret targets through discovered config paths before doctor preview scans them
- add a regression test that keeps disabled Matrix channel secret ids out of preview scans
- update the channel plugin test mock so default-account scoping still works after rebasing onto current main

## Test plan
- openclaw doctor --non-interactive --no-color
- openclaw doctor --fix --non-interactive --no-color
- node scripts/run-vitest.mjs src/cli/command-secret-targets.test.ts