### PR TITLE
feat(macos): install transient app launches in Applications

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -31,8 +31,10 @@ final class AppState {
     @ObservationIgnored private let execApprovalsDefaultsAsyncResolver:
         @MainActor () async -> Result<ExecApprovalsResolvedDefaults, ExecApprovalsReadError>
     @ObservationIgnored private let execApprovalsReadRetryDelay: Duration
+    @ObservationIgnored let bundleLocationAllowsPersistentIntegration: Bool
     @ObservationIgnored private var execApprovalsReadRetryTask: Task<Void, Never>?
     @ObservationIgnored private var execApprovalsReadGeneration = 0
+    @ObservationIgnored private var isHydratingLaunchAtLogin = false
     private var isInitializing = true
     private var isApplyingRemoteTokenConfig = false
     private enum GatewayConfigSyncState: Equatable {
@@ -101,9 +103,23 @@ final class AppState {
 
     var launchAtLogin: Bool {
         didSet {
-            guard !self.isInitializing else { return }
+            guard Self.shouldPersistLaunchAtLoginChange(
+                isInitializing: self.isInitializing,
+                isHydrating: self.isHydratingLaunchAtLogin,
+                isEnabling: self.launchAtLogin,
+                bundleLocationAllowsPersistentIntegration: self.bundleLocationAllowsPersistentIntegration)
+            else { return }
             self.ifNotPreview { Task { AppStateStore.updateLaunchAtLogin(enabled: self.launchAtLogin) } }
         }
+    }
+
+    static func shouldPersistLaunchAtLoginChange(
+        isInitializing: Bool,
+        isHydrating: Bool,
+        isEnabling: Bool,
+        bundleLocationAllowsPersistentIntegration: Bool) -> Bool
+    {
+        !isInitializing && !isHydrating && (!isEnabling || bundleLocationAllowsPersistentIntegration)
     }
 
     var onboardingSeen: Bool {
@@ -343,6 +359,8 @@ final class AppState {
     {
         let isPreview = preview || ProcessInfo.processInfo.isRunningTests
         self.isPreview = isPreview
+        self.bundleLocationAllowsPersistentIntegration =
+            isPreview || ApplicationRelocator.currentBundleAllowsPersistentIntegration()
         self.execApprovalsDefaultsAsyncResolver = execApprovalsDefaultsAsyncResolver
         self.execApprovalsReadRetryDelay = execApprovalsReadRetryDelay
         if !isPreview {
@@ -463,7 +481,7 @@ final class AppState {
         if !self.isPreview {
             Task.detached(priority: .utility) { [weak self] in
                 let current = await LaunchAgentManager.status()
-                await MainActor.run { [weak self] in self?.launchAtLogin = current }
+                await MainActor.run { [weak self] in self?.hydrateLaunchAtLogin(current) }
             }
         }
 
@@ -489,6 +507,13 @@ final class AppState {
         if !self.isPreview {
             self.startConfigWatcher()
         }
+    }
+
+    private func hydrateLaunchAtLogin(_ enabled: Bool) {
+        // Reading launchd state must not rewrite a valid plist with this process's transient bundle path.
+        self.isHydratingLaunchAtLogin = true
+        self.launchAtLogin = enabled
+        self.isHydratingLaunchAtLogin = false
     }
 
     @MainActor

--- a/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
+++ b/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
@@ -1,0 +1,332 @@
+import AppKit
+import Foundation
+import OSLog
+import Security
+
+@MainActor
+enum ApplicationRelocator {
+    struct ApplicationIdentity: Equatable, Sendable {
+        let bundleIdentifier: String
+        let buildVersion: String
+    }
+
+    struct InstallCandidate: Equatable, Sendable {
+        let url: URL
+        let exists: Bool
+        let isWritable: Bool
+        let isTrusted: Bool
+        let identity: ApplicationIdentity?
+    }
+
+    struct Environment: Equatable, Sendable {
+        let bundleURL: URL
+        let homeDirectory: URL
+        let currentIdentity: ApplicationIdentity?
+        let candidates: [InstallCandidate]
+        let isReadOnlyVolume: Bool
+        let isDebugOrTesting: Bool
+    }
+
+    enum Recommendation: Equatable, Sendable {
+        case continueLaunch
+        case handOff(URL)
+        case offerInstall(destination: URL, replacing: Bool)
+        case cannotInstall
+    }
+
+    enum LaunchDisposition: Equatable, Sendable {
+        case continueLaunch(startUpdater: Bool)
+        case terminating
+    }
+
+    private static let logger = Logger(subsystem: "ai.openclaw", category: "app-relocation")
+
+    static func recommendation(for environment: Environment) -> Recommendation {
+        guard !environment.isDebugOrTesting,
+              self.isTransientLocation(
+                  environment.bundleURL,
+                  homeDirectory: environment.homeDirectory,
+                  isReadOnlyVolume: environment.isReadOnlyVolume)
+        else {
+            return .continueLaunch
+        }
+
+        if let currentIdentity = environment.currentIdentity {
+            for candidate in environment.candidates {
+                guard let installedIdentity = candidate.identity,
+                      candidate.isTrusted,
+                      installedIdentity.bundleIdentifier == currentIdentity.bundleIdentifier,
+                      self
+                          .compareBuild(installedIdentity.buildVersion, currentIdentity.buildVersion) !=
+                          .orderedAscending
+                else { continue }
+                return .handOff(candidate.url)
+            }
+
+            for candidate in environment.candidates {
+                guard candidate.isWritable,
+                      candidate.isTrusted,
+                      let installedIdentity = candidate.identity,
+                      installedIdentity.bundleIdentifier == currentIdentity.bundleIdentifier
+                else { continue }
+                return .offerInstall(destination: candidate.url, replacing: true)
+            }
+        }
+
+        if let destination = environment.candidates.first(where: { !$0.exists && $0.isWritable }) {
+            return .offerInstall(destination: destination.url, replacing: false)
+        }
+        return .cannotInstall
+    }
+
+    static func isTransientLocation(
+        _ bundleURL: URL,
+        homeDirectory: URL,
+        isReadOnlyVolume: Bool) -> Bool
+    {
+        let path = bundleURL.standardizedFileURL.path
+        let homePath = homeDirectory.standardizedFileURL.path
+        let stableRoots = ["/Applications", "\(homePath)/Applications"]
+        if stableRoots.contains(where: { self.isInside(path, root: $0) }) {
+            return false
+        }
+        if path.contains("/AppTranslocation/") {
+            return true
+        }
+        let transientRoots = ["\(homePath)/Downloads", "\(homePath)/Desktop"]
+        if transientRoots.contains(where: { self.isInside(path, root: $0) }) {
+            return true
+        }
+        return self.isInside(path, root: "/Volumes") && isReadOnlyVolume
+    }
+
+    static func handleLaunch(
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default,
+        processInfo: ProcessInfo = .processInfo) -> LaunchDisposition
+    {
+        let environment = self.currentEnvironment(
+            bundle: bundle,
+            fileManager: fileManager,
+            processInfo: processInfo)
+        switch self.recommendation(for: environment) {
+        case .continueLaunch:
+            return .continueLaunch(startUpdater: true)
+        case let .handOff(destination):
+            return self.relaunchAndTerminate(at: destination)
+        case let .offerInstall(destination, replacing):
+            guard self.confirmInstall(destination: destination, replacing: replacing) else {
+                return .continueLaunch(startUpdater: false)
+            }
+            do {
+                try self.install(
+                    source: environment.bundleURL,
+                    destination: destination,
+                    replacing: replacing,
+                    fileManager: fileManager)
+                return self.relaunchAndTerminate(at: destination)
+            } catch {
+                self.logger.error("Could not install app: \(error.localizedDescription, privacy: .public)")
+                self.showFailure(
+                    "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.")
+                return .continueLaunch(startUpdater: false)
+            }
+        case .cannotInstall:
+            self.showFailure(
+                "OpenClaw is running from a temporary location. Move it to Applications manually to enable updates and launch at login.")
+            return .continueLaunch(startUpdater: false)
+        }
+    }
+
+    static func currentBundleAllowsPersistentIntegration(
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default,
+        processInfo: ProcessInfo = .processInfo) -> Bool
+    {
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        if debugBuild || processInfo.isRunningTests || processInfo.isPreview {
+            return true
+        }
+
+        let bundleURL = bundle.bundleURL.standardizedFileURL
+        let isReadOnlyVolume = (try? bundleURL.resourceValues(forKeys: [.volumeIsReadOnlyKey]))?
+            .volumeIsReadOnly ?? false
+        return !self.isTransientLocation(
+            bundleURL,
+            homeDirectory: fileManager.homeDirectoryForCurrentUser,
+            isReadOnlyVolume: isReadOnlyVolume)
+    }
+
+    private static func currentEnvironment(
+        bundle: Bundle,
+        fileManager: FileManager,
+        processInfo: ProcessInfo) -> Environment
+    {
+        let bundleURL = bundle.bundleURL.standardizedFileURL
+        let homeDirectory = fileManager.homeDirectoryForCurrentUser.standardizedFileURL
+        let appName = bundleURL.lastPathComponent
+        let destinations = [
+            URL(fileURLWithPath: "/Applications").appendingPathComponent(appName),
+            homeDirectory.appendingPathComponent("Applications").appendingPathComponent(appName),
+        ]
+        let currentRequirement = self.designatedRequirement(for: bundleURL)
+        let candidates = destinations.map { destination in
+            let exists = fileManager.fileExists(atPath: destination.path)
+            let installedBundle = exists ? Bundle(url: destination) : nil
+            return InstallCandidate(
+                url: destination,
+                exists: exists,
+                isWritable: self.canWrite(destination: destination, fileManager: fileManager),
+                isTrusted: installedBundle.map {
+                    self.isTrustedInstalledApp($0, matching: currentRequirement, fileManager: fileManager)
+                } ?? false,
+                identity: installedBundle.flatMap(self.identity(for:)))
+        }
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        let isReadOnlyVolume = (try? bundleURL.resourceValues(forKeys: [.volumeIsReadOnlyKey]))?
+            .volumeIsReadOnly ?? false
+        return Environment(
+            bundleURL: bundleURL,
+            homeDirectory: homeDirectory,
+            currentIdentity: self.identity(for: bundle),
+            candidates: candidates,
+            isReadOnlyVolume: isReadOnlyVolume,
+            isDebugOrTesting: debugBuild || processInfo.isRunningTests || processInfo.isPreview)
+    }
+
+    private static func identity(for bundle: Bundle) -> ApplicationIdentity? {
+        guard let bundleIdentifier = bundle.bundleIdentifier,
+              let buildVersion = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        else { return nil }
+        return ApplicationIdentity(bundleIdentifier: bundleIdentifier, buildVersion: buildVersion)
+    }
+
+    private static func designatedRequirement(for bundleURL: URL) -> SecRequirement? {
+        var code: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(bundleURL as CFURL, SecCSFlags(), &code) == errSecSuccess,
+              let code
+        else { return nil }
+
+        var requirement: SecRequirement?
+        guard SecCodeCopyDesignatedRequirement(code, SecCSFlags(), &requirement) == errSecSuccess else { return nil }
+        return requirement
+    }
+
+    private static func isTrustedInstalledApp(
+        _ bundle: Bundle,
+        matching requirement: SecRequirement?,
+        fileManager: FileManager) -> Bool
+    {
+        guard let requirement,
+              let executableURL = bundle.executableURL,
+              fileManager.isExecutableFile(atPath: executableURL.path)
+        else { return false }
+
+        var code: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(bundle.bundleURL as CFURL, SecCSFlags(), &code) == errSecSuccess,
+              let code
+        else { return false }
+        return SecStaticCodeCheckValidity(
+            code,
+            SecCSFlags(rawValue: kSecCSCheckAllArchitectures),
+            requirement) == errSecSuccess
+    }
+
+    private static func canWrite(destination: URL, fileManager: FileManager) -> Bool {
+        var ancestor = destination.deletingLastPathComponent()
+        while !fileManager.fileExists(atPath: ancestor.path) {
+            let parent = ancestor.deletingLastPathComponent()
+            guard parent != ancestor else { return false }
+            ancestor = parent
+        }
+        return fileManager.isWritableFile(atPath: ancestor.path)
+    }
+
+    private static func install(
+        source: URL,
+        destination: URL,
+        replacing: Bool,
+        fileManager: FileManager) throws
+    {
+        let parent = destination.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        let staging = parent.appendingPathComponent(".\(destination.lastPathComponent).installing-\(UUID().uuidString)")
+        defer { try? fileManager.removeItem(at: staging) }
+        try fileManager.copyItem(at: source, to: staging)
+
+        if replacing {
+            let backupName = ".\(destination.lastPathComponent).backup-\(UUID().uuidString)"
+            _ = try fileManager.replaceItemAt(
+                destination,
+                withItemAt: staging,
+                backupItemName: backupName)
+            try? fileManager.removeItem(at: parent.appendingPathComponent(backupName))
+        } else {
+            try fileManager.moveItem(at: staging, to: destination)
+        }
+    }
+
+    private static func confirmInstall(destination: URL, replacing: Bool) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = replacing
+            ? "Replace the older OpenClaw in Applications?"
+            : "Install OpenClaw in Applications?"
+        alert.informativeText = replacing
+            ? "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications."
+            : "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: replacing ? "Replace and Relaunch" : "Install and Relaunch")
+        let cancel = alert.addButton(withTitle: "Not Now")
+        cancel.keyEquivalent = "\u{1b}"
+        NSApp.activate(ignoringOtherApps: true)
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private static func relaunchAndTerminate(at destination: URL) -> LaunchDisposition {
+        let helper = Process()
+        helper.executableURL = URL(fileURLWithPath: "/bin/sh")
+        helper.arguments = [
+            "-c",
+            "while /bin/kill -0 \"$2\" 2>/dev/null; do /bin/sleep 0.1; done; exec /usr/bin/open -n \"$1\"",
+            "openclaw-relocation",
+            destination.path,
+            String(ProcessInfo.processInfo.processIdentifier),
+        ]
+        do {
+            try helper.run()
+            NSApp.terminate(nil)
+            return .terminating
+        } catch {
+            self.logger.error("Could not schedule relaunch: \(error.localizedDescription, privacy: .public)")
+            self
+                .showFailure(
+                    "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.")
+            return .continueLaunch(startUpdater: false)
+        }
+    }
+
+    private static func showFailure(_ message: String) {
+        let alert = NSAlert()
+        alert.messageText = "Move OpenClaw to Applications"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private static func compareBuild(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        lhs.compare(rhs, options: .numeric)
+    }
+
+    private static func isInside(_ path: String, root: String) -> Bool {
+        path == root || path.hasPrefix(root + "/")
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -74,8 +74,11 @@ struct GeneralSettings: View {
             SettingsCardGroup("App") {
                 SettingsCardToggleRow(
                     title: "Launch at login",
-                    subtitle: "Automatically start OpenClaw after you sign in.",
+                    subtitle: self.state.bundleLocationAllowsPersistentIntegration
+                        ? "Automatically start OpenClaw after you sign in."
+                        : "Move OpenClaw to Applications before enabling launch at login.",
                     binding: self.$state.launchAtLogin)
+                    .disabled(!self.state.bundleLocationAllowsPersistentIntegration && !self.state.launchAtLogin)
 
                 SettingsCardToggleRow(
                     title: "Show Dock icon",

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -401,6 +401,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.terminate(nil)
             return
         }
+        switch ApplicationRelocator.handleLaunch() {
+        case .terminating:
+            return
+        case let .continueLaunch(startUpdater):
+            if startUpdater {
+                self.updaterController.start()
+            }
+        }
         // Remote startup can spawn an SSH child. Admit tunnel work only after the
         // singleton check so a short-lived handoff process cannot orphan that child.
         GatewayEndpointStore.admitPrimaryAppLaunch()
@@ -671,7 +679,12 @@ protocol UpdaterProviding: AnyObject {
     var automaticallyDownloadsUpdates: Bool { get set }
     var isAvailable: Bool { get }
     var updateStatus: UpdateStatus { get }
+    func start()
     func checkForUpdates(_ sender: Any?)
+}
+
+extension UpdaterProviding {
+    func start() {}
 }
 
 /// No-op updater used for debug/dev runs to suppress Sparkle dialogs.
@@ -704,12 +717,18 @@ final class SparkleUpdaterController: NSObject, UpdaterProviding {
         updaterDelegate: self,
         userDriverDelegate: nil)
     let updateStatus = UpdateStatus()
+    private var started = false
 
     init(savedAutoUpdate: Bool) {
         super.init()
         let updater = self.controller.updater
         updater.automaticallyChecksForUpdates = savedAutoUpdate
         updater.automaticallyDownloadsUpdates = savedAutoUpdate
+    }
+
+    func start() {
+        guard !self.started else { return }
+        self.started = true
         self.controller.startUpdater()
     }
 
@@ -724,10 +743,11 @@ final class SparkleUpdaterController: NSObject, UpdaterProviding {
     }
 
     var isAvailable: Bool {
-        true
+        self.started
     }
 
     func checkForUpdates(_ sender: Any?) {
+        guard self.started else { return }
         self.controller.checkForUpdates(sender)
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -932,9 +932,7 @@ extension OnboardingView {
                 }
                 self.skillsOverview
                 Toggle("Launch at login", isOn: self.$state.launchAtLogin)
-                    .onChange(of: self.state.launchAtLogin) { _, newValue in
-                        AppStateStore.updateLaunchAtLogin(enabled: newValue)
-                    }
+                    .disabled(!self.state.bundleLocationAllowsPersistentIntegration && !self.state.launchAtLogin)
             }
         }
         .task { await self.maybeLoadOnboardingSkills() }

--- a/apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite("Application Relocator Tests")
+@MainActor
+struct ApplicationRelocatorTests {
+    private let home = URL(fileURLWithPath: "/Users/tester")
+    private let current = ApplicationRelocator.ApplicationIdentity(
+        bundleIdentifier: "ai.openclaw.mac",
+        buildVersion: "100")
+
+    @Test
+    func `stable application locations continue normally`() {
+        let paths = [
+            "/Applications/OpenClaw.app",
+            "/Users/tester/Applications/OpenClaw.app",
+            "/Users/tester/Tools/OpenClaw.app",
+            "/Volumes/External/Apps/OpenClaw.app",
+        ]
+        for path in paths {
+            let recommendation = ApplicationRelocator.recommendation(
+                for: self.environment(path: path, readOnlyVolume: false))
+            #expect(recommendation == .continueLaunch)
+        }
+    }
+
+    @Test
+    func `debug and test builds never relocate`() {
+        let recommendation = ApplicationRelocator.recommendation(
+            for: self.environment(
+                path: "/Users/tester/Downloads/OpenClaw.app",
+                debugOrTesting: true))
+
+        #expect(recommendation == .continueLaunch)
+    }
+
+    @Test
+    func `transient copy offers system installation when available`() {
+        let destination = URL(fileURLWithPath: "/Applications/OpenClaw.app")
+        let recommendation = ApplicationRelocator.recommendation(
+            for: self.environment(
+                path: "/Users/tester/Downloads/OpenClaw.app",
+                candidates: [self.missing(destination, writable: true)]))
+
+        #expect(recommendation == .offerInstall(destination: destination, replacing: false))
+    }
+
+    @Test
+    func `read only mounted copy offers installation`() {
+        let destination = URL(fileURLWithPath: "/Applications/OpenClaw.app")
+        let recommendation = ApplicationRelocator.recommendation(
+            for: self.environment(
+                path: "/Volumes/OpenClaw/OpenClaw.app",
+                candidates: [self.missing(destination, writable: true)],
+                readOnlyVolume: true))
+
+        #expect(recommendation == .offerInstall(destination: destination, replacing: false))
+    }
+
+    @Test
+    func `translocated copy offers installation`() {
+        let destination = URL(fileURLWithPath: "/Applications/OpenClaw.app")
+        let recommendation = ApplicationRelocator.recommendation(
+            for: self.environment(
+                path: "/private/var/folders/x/AppTranslocation/y/d/OpenClaw.app",
+                candidates: [self.missing(destination, writable: true)]))
+
+        #expect(recommendation == .offerInstall(destination: destination, replacing: false))
+    }
+
+    @Test
+    func `equal or newer installed build receives handoff`() {
+        let destination = URL(fileURLWithPath: "/Applications/OpenClaw.app")
+        for build in ["100", "110"] {
+            let installed = ApplicationRelocator.ApplicationIdentity(
+                bundleIdentifier: self.current.bundleIdentifier,
+                buildVersion: build)
+            let recommendation = ApplicationRelocator.recommendation(
+                for: self.environment(
+                    path: "/Users/tester/Downloads/OpenClaw.app",
+                    candidates: [self.installed(destination, identity: installed)]))
+            #expect(recommendation == .handOff(destination))
+        }
+    }
+
+    @Test
+    func `older installed build can be replaced`() {
+        let destination = URL(fileURLWithPath: "/Applications/OpenClaw.app")
+        let installed = ApplicationRelocator.ApplicationIdentity(
+            bundleIdentifier: self.current.bundleIdentifier,
+            buildVersion: "90")
+        let recommendation = ApplicationRelocator.recommendation(
+            for: self.environment(
+                path: "/Users/tester/Downloads/OpenClaw.app",
+                candidates: [self.installed(destination, identity: installed)]))
+
+        #expect(recommendation == .offerInstall(destination: destination, replacing: true))
+    }
+
+    @Test
+    func `different same named app is never replaced`() {
+        let systemDestination = URL(fileURLWithPath: "/Applications/OpenClaw.app")
+        let userDestination = self.home.appendingPathComponent("Applications/OpenClaw.app")
+        let unrelated = ApplicationRelocator.ApplicationIdentity(
+            bundleIdentifier: "example.unrelated",
+            buildVersion: "999")
+        let recommendation = ApplicationRelocator.recommendation(
+            for: self.environment(
+                path: "/Users/tester/Desktop/OpenClaw.app",
+                candidates: [
+                    self.installed(systemDestination, identity: unrelated),
+                    self.missing(userDestination, writable: true),
+                ]))
+
+        #expect(recommendation == .offerInstall(destination: userDestination, replacing: false))
+    }
+
+    @Test
+    func `untrusted same identity app never receives handoff`() {
+        let systemDestination = URL(fileURLWithPath: "/Applications/OpenClaw.app")
+        let userDestination = self.home.appendingPathComponent("Applications/OpenClaw.app")
+        let recommendation = ApplicationRelocator.recommendation(
+            for: self.environment(
+                path: "/Users/tester/Downloads/OpenClaw.app",
+                candidates: [
+                    self.installed(systemDestination, identity: self.current, trusted: false),
+                    self.missing(userDestination, writable: true),
+                ]))
+
+        #expect(recommendation == .offerInstall(destination: userDestination, replacing: false))
+    }
+
+    @Test
+    func `unwritable destinations require manual installation`() {
+        let recommendation = ApplicationRelocator.recommendation(
+            for: self.environment(
+                path: "/Users/tester/Downloads/OpenClaw.app",
+                candidates: [
+                    self.missing(URL(fileURLWithPath: "/Applications/OpenClaw.app"), writable: false),
+                    self.missing(self.home.appendingPathComponent("Applications/OpenClaw.app"), writable: false),
+                ]))
+
+        #expect(recommendation == .cannotInstall)
+    }
+
+    @Test
+    func `launch at login hydration does not persist the current bundle path`() {
+        #expect(!AppState.shouldPersistLaunchAtLoginChange(
+            isInitializing: false,
+            isHydrating: true,
+            isEnabling: true,
+            bundleLocationAllowsPersistentIntegration: true))
+        #expect(!AppState.shouldPersistLaunchAtLoginChange(
+            isInitializing: false,
+            isHydrating: false,
+            isEnabling: true,
+            bundleLocationAllowsPersistentIntegration: false))
+        #expect(AppState.shouldPersistLaunchAtLoginChange(
+            isInitializing: false,
+            isHydrating: false,
+            isEnabling: false,
+            bundleLocationAllowsPersistentIntegration: false))
+    }
+
+    private func environment(
+        path: String,
+        candidates: [ApplicationRelocator.InstallCandidate] = [],
+        readOnlyVolume: Bool = false,
+        debugOrTesting: Bool = false) -> ApplicationRelocator.Environment
+    {
+        ApplicationRelocator.Environment(
+            bundleURL: URL(fileURLWithPath: path),
+            homeDirectory: self.home,
+            currentIdentity: self.current,
+            candidates: candidates,
+            isReadOnlyVolume: readOnlyVolume,
+            isDebugOrTesting: debugOrTesting)
+    }
+
+    private func missing(_ url: URL, writable: Bool) -> ApplicationRelocator.InstallCandidate {
+        ApplicationRelocator.InstallCandidate(
+            url: url,
+            exists: false,
+            isWritable: writable,
+            isTrusted: false,
+            identity: nil)
+    }
+
+    private func installed(
+        _ url: URL,
+        identity: ApplicationRelocator.ApplicationIdentity,
+        trusted: Bool = true) -> ApplicationRelocator.InstallCandidate
+    {
+        ApplicationRelocator.InstallCandidate(
+            url: url,
+            exists: true,
+            isWritable: true,
+            isTrusted: trusted,
+            identity: identity)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/UpdateOrchestrationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/UpdateOrchestrationTests.swift
@@ -17,6 +17,16 @@ struct UpdateOrchestrationTests {
         #expect(allowedSparkleChannels(forGatewayUpdateChannel: nil).isEmpty)
     }
 
+    #if canImport(Sparkle)
+    @Test func `Sparkle stays unavailable until launch relocation finishes`() {
+        let updater = SparkleUpdaterController(savedAutoUpdate: false)
+
+        #expect(!updater.isAvailable)
+        updater.checkForUpdates(nil)
+        #expect(!updater.isAvailable)
+    }
+    #endif
+
     @Test func `dashboard accepts only start update payloads`() {
         #expect(DashboardWindowController.isStartUpdateRequest(["type": "start-update"]))
         #expect(!DashboardWindowController.isStartUpdateRequest(["type": "update.run"]))


### PR DESCRIPTION
Closes #104645

## What Problem This Solves

Resolves a problem where users launching OpenClaw from a disk image, App Translocation, Downloads, or Desktop could keep running a temporary copy with unreliable updates and launch-at-login behavior. Reopening the original download after installation also needed a safe way to avoid another install prompt.

## Why This Change Was Made

Transient launches now offer a staged Applications install, hand off only to an equal-or-newer installed copy that matches the current app's code-signing requirement, and preserve stable custom install locations. Sparkle and path-based persistent integrations remain disabled while a transient copy continues running.

## User Impact

Downloaded and disk-image launches can install and reopen OpenClaw from Applications. Existing trusted installations receive the launch without repeated prompts; unrelated or untrusted same-named apps are never replaced or launched. Users who decline or cannot install can keep using the temporary copy, but updates and enabling launch at login stay unavailable until the app is moved.

## Evidence

- macOS Swift package build completed successfully.
- 11 relocation and launch-at-login regression scenarios passed.
- 10 updater orchestration scenarios passed.
- 17 General Settings and 20 onboarding smoke scenarios passed.
- Source-blind behavior contract passed all clauses and six anti-cheat probes.
- Fresh autoreview completed with no actionable findings.
- Full macOS Swift suite ran 1,171 tests; one unrelated concurrency test flaked only in the full parallel run, and its 18-test suite passed in isolation.
