### PR TITLE
fix(realtime): add timeout to WebRTC offer requests

### DIFF
--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -4,7 +4,10 @@ import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
 } from "./realtime-talk-shared.ts";
-import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
+import {
+  REALTIME_WEBRTC_OFFER_TIMEOUT_MS,
+  WebRtcSdpRealtimeTalkTransport,
+} from "./realtime-talk-webrtc.ts";
 
 let getUserMedia: ReturnType<typeof vi.fn>;
 
@@ -174,6 +177,7 @@ function expectSpokenStatusMessage(events: SentRealtimeEvent[], message: string)
 describe("WebRtcSdpRealtimeTalkTransport", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   beforeEach(() => {
@@ -325,8 +329,48 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
         Authorization: "Bearer client-secret-123",
         "Content-Type": "application/sdp",
       },
+      signal: expect.any(AbortSignal),
     });
     transport.stop();
+  });
+
+  it("aborts stalled WebRTC SDP answer body reads after the offer timeout", async () => {
+    vi.useFakeTimers();
+    let offerSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      offerSignal = init?.signal ?? undefined;
+      return {
+        ok: true,
+        status: 200,
+        text: () =>
+          new Promise<string>((_, reject) => {
+            offerSignal?.addEventListener(
+              "abort",
+              () => reject(offerSignal?.reason ?? new Error("offer request aborted")),
+              { once: true },
+            );
+          }),
+      } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const transport = createOpenAiTransport();
+
+    const startResult = transport.start().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(offerSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(REALTIME_WEBRTC_OFFER_TIMEOUT_MS);
+
+    await expect(startResult).resolves.toMatchObject(
+      new Error(
+        `Realtime WebRTC offer request timed out after ${REALTIME_WEBRTC_OFFER_TIMEOUT_MS}ms`,
+      ),
+    );
+    expect(offerSignal?.aborted).toBe(true);
   });
 
   it("surfaces realtime provider errors from the OpenAI data channel", async () => {

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -382,7 +382,10 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
           new Promise<string>((_, reject) => {
             offerSignal?.addEventListener(
               "abort",
-              () => reject(offerSignal?.reason ?? new Error("offer request aborted")),
+              () => {
+                const reason = offerSignal?.reason;
+                reject(reason instanceof Error ? reason : new Error("offer request aborted"));
+              },
               { once: true },
             );
           }),

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -4,10 +4,7 @@ import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
 } from "./realtime-talk-shared.ts";
-import {
-  REALTIME_WEBRTC_OFFER_TIMEOUT_MS,
-  WebRtcSdpRealtimeTalkTransport,
-} from "./realtime-talk-webrtc.ts";
+import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
 
 let getUserMedia: ReturnType<typeof vi.fn>;
 
@@ -366,14 +363,60 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(offerSignal?.aborted).toBe(false);
 
-    await vi.advanceTimersByTimeAsync(REALTIME_WEBRTC_OFFER_TIMEOUT_MS);
+    await vi.runAllTimersAsync();
 
     await expect(startResult).resolves.toMatchObject(
-      new Error(
-        `Realtime WebRTC offer request timed out after ${REALTIME_WEBRTC_OFFER_TIMEOUT_MS}ms`,
-      ),
+      new Error("Realtime WebRTC offer request timed out after 30000ms"),
     );
     expect(offerSignal?.aborted).toBe(true);
+  });
+
+  it("aborts a pending WebRTC SDP answer body read when stopped", async () => {
+    let offerSignal: AbortSignal | undefined;
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      offerSignal = init?.signal ?? undefined;
+      return {
+        ok: true,
+        status: 200,
+        text: () =>
+          new Promise<string>((_, reject) => {
+            offerSignal?.addEventListener(
+              "abort",
+              () => reject(offerSignal?.reason ?? new Error("offer request aborted")),
+              { once: true },
+            );
+          }),
+      } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const transport = createOpenAiTransport();
+
+    const startResult = transport.start();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    transport.stop();
+
+    await expect(startResult).resolves.toBeUndefined();
+    expect(offerSignal?.aborted).toBe(true);
+  });
+
+  it("clears the WebRTC offer timeout after setup succeeds", async () => {
+    vi.useFakeTimers();
+    let offerSignal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        offerSignal = init?.signal ?? undefined;
+        return new Response("answer-sdp");
+      }) as unknown as typeof fetch,
+    );
+    const transport = createOpenAiTransport();
+
+    await transport.start();
+    await vi.runAllTimersAsync();
+
+    expect(offerSignal?.aborted).toBe(false);
+    transport.stop();
   });
 
   it("surfaces realtime provider errors from the OpenAI data channel", async () => {

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -346,7 +346,10 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
           new Promise<string>((_, reject) => {
             offerSignal?.addEventListener(
               "abort",
-              () => reject(offerSignal?.reason ?? new Error("offer request aborted")),
+              () => {
+                const reason = offerSignal?.reason;
+                reject(reason instanceof Error ? reason : new Error("offer request aborted"));
+              },
               { once: true },
             );
           }),

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -37,25 +37,12 @@ type ToolBuffer = {
 };
 
 const cancelledSetup = Symbol("cancelledSetup");
-export const REALTIME_WEBRTC_OFFER_TIMEOUT_MS = 30_000;
+const REALTIME_WEBRTC_OFFER_TIMEOUT_MS = 30_000;
 
-function createRealtimeWebRtcOfferTimeout(): {
-  signal: AbortSignal;
-  cleanup: () => void;
-} {
-  const controller = new AbortController();
-  const timer = globalThis.setTimeout(() => {
-    controller.abort(
-      new Error(
-        `Realtime WebRTC offer request timed out after ${REALTIME_WEBRTC_OFFER_TIMEOUT_MS}ms`,
-      ),
-    );
-  }, REALTIME_WEBRTC_OFFER_TIMEOUT_MS);
-  return {
-    signal: controller.signal,
-    cleanup: () => globalThis.clearTimeout(timer),
-  };
-}
+type PendingOfferRequest = {
+  controller: AbortController;
+  timeout: ReturnType<typeof globalThis.setTimeout>;
+};
 
 export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
   private peer: RTCPeerConnection | null = null;
@@ -68,6 +55,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
   private responseCreateInFlight = false;
   private responseCreatePending = false;
   private toolBuffers = new Map<string, ToolBuffer>();
+  private pendingOfferRequest: PendingOfferRequest | null = null;
   private readonly consultAbortControllers = new Set<AbortController>();
   private readonly emitTalkEvent: ReturnType<typeof createRealtimeTalkEventEmitter>;
 
@@ -165,7 +153,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     peer: RTCPeerConnection,
     offer: RTCSessionDescriptionInit,
   ): Promise<string | typeof cancelledSetup> {
-    const offerTimeout = createRealtimeWebRtcOfferTimeout();
+    const request = this.beginOfferRequest();
     try {
       const sdp = await this.awaitSetupStep(
         peer,
@@ -177,7 +165,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
             Authorization: `Bearer ${this.session.clientSecret}`,
             "Content-Type": "application/sdp",
           },
-          signal: offerTimeout.signal,
+          signal: request.controller.signal,
         }),
       );
       if (sdp === cancelledSetup) {
@@ -198,8 +186,44 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       }
       return answerSdp;
     } finally {
-      offerTimeout.cleanup();
+      this.finishOfferRequest(request);
     }
+  }
+
+  private beginOfferRequest(): PendingOfferRequest {
+    this.abortOfferRequest();
+    const controller = new AbortController();
+    const request = {
+      controller,
+      timeout: globalThis.setTimeout(() => {
+        controller.abort(
+          new Error(
+            `Realtime WebRTC offer request timed out after ${REALTIME_WEBRTC_OFFER_TIMEOUT_MS}ms`,
+          ),
+        );
+      }, REALTIME_WEBRTC_OFFER_TIMEOUT_MS),
+    };
+    this.pendingOfferRequest = request;
+    return request;
+  }
+
+  private finishOfferRequest(request: PendingOfferRequest): void {
+    globalThis.clearTimeout(request.timeout);
+    // A stopped transport may already have started a replacement request.
+    // Never let the old request's finally block detach the new lifecycle owner.
+    if (this.pendingOfferRequest === request) {
+      this.pendingOfferRequest = null;
+    }
+  }
+
+  private abortOfferRequest(): void {
+    const request = this.pendingOfferRequest;
+    if (!request) {
+      return;
+    }
+    this.pendingOfferRequest = null;
+    globalThis.clearTimeout(request.timeout);
+    request.controller.abort();
   }
 
   private isCurrentPeer(peer: RTCPeerConnection): boolean {
@@ -225,6 +249,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       this.emitTalkEvent({ type: "session.closed", final: true });
     }
     this.closed = true;
+    this.abortOfferRequest();
     this.channel?.close();
     this.channel = null;
     this.peer?.close();

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -37,6 +37,25 @@ type ToolBuffer = {
 };
 
 const cancelledSetup = Symbol("cancelledSetup");
+export const REALTIME_WEBRTC_OFFER_TIMEOUT_MS = 30_000;
+
+function createRealtimeWebRtcOfferTimeout(): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const timer = globalThis.setTimeout(() => {
+    controller.abort(
+      new Error(
+        `Realtime WebRTC offer request timed out after ${REALTIME_WEBRTC_OFFER_TIMEOUT_MS}ms`,
+      ),
+    );
+  }, REALTIME_WEBRTC_OFFER_TIMEOUT_MS);
+  return {
+    signal: controller.signal,
+    cleanup: () => globalThis.clearTimeout(timer),
+  };
+}
 
 export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
   private peer: RTCPeerConnection | null = null;
@@ -126,28 +145,7 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     if (!this.isCurrentPeer(peer)) {
       return;
     }
-    const sdp = await this.awaitSetupStep(
-      peer,
-      fetch(this.session.offerUrl ?? "https://api.openai.com/v1/realtime/calls", {
-        method: "POST",
-        body: offer.sdp,
-        headers: {
-          ...this.session.offerHeaders,
-          Authorization: `Bearer ${this.session.clientSecret}`,
-          "Content-Type": "application/sdp",
-        },
-      }),
-    );
-    if (sdp === cancelledSetup) {
-      return;
-    }
-    if (!this.isCurrentPeer(peer)) {
-      return;
-    }
-    if (!sdp.ok) {
-      throw new Error(`Realtime WebRTC setup failed (${sdp.status})`);
-    }
-    const answerSdp = await this.awaitSetupStep(peer, sdp.text());
+    const answerSdp = await this.readOfferAnswer(peer, offer);
     if (answerSdp === cancelledSetup) {
       return;
     }
@@ -161,6 +159,47 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
         sdp: answerSdp,
       }),
     );
+  }
+
+  private async readOfferAnswer(
+    peer: RTCPeerConnection,
+    offer: RTCSessionDescriptionInit,
+  ): Promise<string | typeof cancelledSetup> {
+    const offerTimeout = createRealtimeWebRtcOfferTimeout();
+    try {
+      const sdp = await this.awaitSetupStep(
+        peer,
+        fetch(this.session.offerUrl ?? "https://api.openai.com/v1/realtime/calls", {
+          method: "POST",
+          body: offer.sdp,
+          headers: {
+            ...this.session.offerHeaders,
+            Authorization: `Bearer ${this.session.clientSecret}`,
+            "Content-Type": "application/sdp",
+          },
+          signal: offerTimeout.signal,
+        }),
+      );
+      if (sdp === cancelledSetup) {
+        return cancelledSetup;
+      }
+      if (!this.isCurrentPeer(peer)) {
+        return cancelledSetup;
+      }
+      if (!sdp.ok) {
+        throw new Error(`Realtime WebRTC setup failed (${sdp.status})`);
+      }
+      const answerSdp = await this.awaitSetupStep(peer, sdp.text());
+      if (answerSdp === cancelledSetup) {
+        return cancelledSetup;
+      }
+      if (!this.isCurrentPeer(peer)) {
+        return cancelledSetup;
+      }
+      return answerSdp;
+    } finally {
+      offerTimeout.cleanup();
+    }
   }
 
   private isCurrentPeer(peer: RTCPeerConnection): boolean {


### PR DESCRIPTION
## What Problem This Solves

Realtime WebRTC voice setup could remain stuck forever if the SDP offer endpoint returned headers but never completed the answer body. Stopping Talk during that stall also left the request and its deadline alive until the timeout fired.

## Why This Change Was Made

The WebRTC transport now owns one pending offer request across both `fetch()` and response-body consumption. A 30-second deadline aborts a genuinely stalled exchange, while `stop()` clears that deadline and aborts the same request immediately. Identity-guarded cleanup prevents an older request from detaching a replacement request, and the timeout constant remains private instead of becoming a test-only production export.

This keeps cancellation at the transport that already owns the peer, microphone, media element, and stop lifecycle; it adds no configuration or cross-session policy.

## User Impact

- Stalled provider responses leave connecting state instead of hanging indefinitely.
- Pressing Stop during setup returns Talk to idle immediately and releases the request, peer, and microphone.
- Successful SDP setup cannot be invalidated later by a stale timeout.

## Evidence

Prepared head: `222677b2c30bbfae7f36860c2a141a4ebce6bb03`

- Blacksmith Testbox through Crabbox `tbx_01kxbr8kw8ywrht8vmmh244r1q`: `pnpm test ui/src/pages/chat/realtime-talk-webrtc.test.ts` passed 21/21; targeted `oxfmt --check` and `oxlint` passed.
- Source-blind full Control UI Chromium proof passed in 1.38s: Start Talk reached visible connecting state; Stop aborted the pending SDP answer before the deadline, closed one peer, stopped one microphone track, restored the Start voice input action, and left no voice error status.
- Maintained live OpenAI smoke passed on the patch-equivalent prepared head with `gpt-realtime-2.1`: backend Realtime bridge connected; browser WebRTC received an SDP answer containing audio, applied the remote description, and reached `connected`.
- Fresh autoreview passed with no accepted/actionable findings.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29203900475
- OpenAI API contract checked: the Realtime calls endpoint returns the SDP answer in the response body, so the deadline intentionally covers body consumption as well as initial response headers.

AI-assisted change.
