### PR TITLE
fix(minimax): resolve search env secret refs

### DIFF
--- a/extensions/minimax/src/minimax-web-search-provider.runtime.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.runtime.ts
@@ -10,9 +10,7 @@ import {
   formatCliCommand,
   mergeScopedSearchConfig,
   readCachedSearchPayload,
-  readConfiguredSecretString,
   readPositiveIntegerParam,
-  readProviderEnvValue,
   readStringParam,
   MAX_SEARCH_COUNT,
   resolveProviderWebSearchPluginConfig,
@@ -20,6 +18,7 @@ import {
   resolveSearchCount,
   resolveSearchTimeoutSeconds,
   resolveSiteName,
+  resolveWebSearchProviderCredential,
   withTrustedWebSearchEndpoint,
   wrapWebContent,
   writeCachedSearchPayload,
@@ -56,12 +55,11 @@ type MiniMaxSearchResponse = {
 };
 
 function resolveMiniMaxApiKey(searchConfig?: SearchConfigRecord): string | undefined {
-  return (
-    readConfiguredSecretString(
-      searchConfig?.apiKey,
-      "plugins.entries.minimax.config.webSearch.apiKey",
-    ) ?? readProviderEnvValue([...MINIMAX_TOKEN_PLAN_ENV_VARS, "MINIMAX_API_KEY"])
-  );
+  return resolveWebSearchProviderCredential({
+    credentialValue: searchConfig?.apiKey,
+    path: "plugins.entries.minimax.config.webSearch.apiKey",
+    envVars: [...MINIMAX_TOKEN_PLAN_ENV_VARS, "MINIMAX_API_KEY"],
+  });
 }
 
 function isMiniMaxCnHost(value: string | undefined): boolean {

--- a/extensions/minimax/src/minimax-web-search-provider.test.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.test.ts
@@ -25,6 +25,8 @@ describe("minimax web search provider", () => {
   const originalCodingApiKey = process.env.MINIMAX_CODING_API_KEY;
   const originalOauthToken = process.env.MINIMAX_OAUTH_TOKEN;
   const originalApiKey = process.env.MINIMAX_API_KEY;
+  const originalSecretRefApiKey = process.env.MINIMAX_SECRETREF_API_KEY;
+  const originalMissingSecretRefApiKey = process.env.MISSING_MINIMAX_SECRETREF_API_KEY;
 
   beforeEach(() => {
     delete process.env.MINIMAX_API_HOST;
@@ -32,6 +34,8 @@ describe("minimax web search provider", () => {
     delete process.env.MINIMAX_CODING_API_KEY;
     delete process.env.MINIMAX_OAUTH_TOKEN;
     delete process.env.MINIMAX_API_KEY;
+    delete process.env.MINIMAX_SECRETREF_API_KEY;
+    delete process.env.MISSING_MINIMAX_SECRETREF_API_KEY;
   });
 
   afterEach(() => {
@@ -40,6 +44,8 @@ describe("minimax web search provider", () => {
     restoreEnvValue("MINIMAX_CODING_API_KEY", originalCodingApiKey);
     restoreEnvValue("MINIMAX_OAUTH_TOKEN", originalOauthToken);
     restoreEnvValue("MINIMAX_API_KEY", originalApiKey);
+    restoreEnvValue("MINIMAX_SECRETREF_API_KEY", originalSecretRefApiKey);
+    restoreEnvValue("MISSING_MINIMAX_SECRETREF_API_KEY", originalMissingSecretRefApiKey);
   });
 
   describe("resolveMiniMaxRegion", () => {

--- a/extensions/minimax/src/minimax-web-search-provider.test.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.test.ts
@@ -143,6 +143,45 @@ describe("minimax web search provider", () => {
       expect(resolveMiniMaxApiKey({ apiKey: "configured-key" })).toBe("configured-key");
     });
 
+    it("resolves configured env SecretRefs before MiniMax token-plan fallbacks", () => {
+      process.env.MINIMAX_CODE_PLAN_KEY = "token-plan-fallback";
+      process.env.MINIMAX_SECRETREF_API_KEY = "secretref-token-plan-key";
+      expect(
+        resolveMiniMaxApiKey({
+          apiKey: {
+            source: "env",
+            provider: "default",
+            id: "MINIMAX_SECRETREF_API_KEY",
+          },
+        }),
+      ).toBe("secretref-token-plan-key");
+    });
+
+    it("does not use MiniMax token-plan fallbacks when configured SecretRefs are unavailable", () => {
+      process.env.MINIMAX_CODE_PLAN_KEY = "token-plan-fallback";
+      process.env.MINIMAX_API_KEY = "legacy-fallback";
+      process.env.MISSING_MINIMAX_SECRETREF_API_KEY = "";
+
+      expect(
+        resolveMiniMaxApiKey({
+          apiKey: {
+            source: "env",
+            provider: "default",
+            id: "MISSING_MINIMAX_SECRETREF_API_KEY",
+          },
+        }),
+      ).toBeUndefined();
+      expect(
+        resolveMiniMaxApiKey({
+          apiKey: {
+            source: "file",
+            provider: "vault",
+            id: "/minimax/api-key",
+          },
+        }),
+      ).toBeUndefined();
+    });
+
     it("accepts MINIMAX_CODING_API_KEY as a token-plan alias", () => {
       process.env.MINIMAX_CODING_API_KEY = "coding-key";
       expect(resolveMiniMaxApiKey()).toBe("coding-key");


### PR DESCRIPTION
## What Problem This Solves

`extensions/minimax/src/minimax-web-search-provider.runtime.ts` read MiniMax web-search credentials with `readConfiguredSecretString(...) ?? MINIMAX_*` env fallback. That path accepts direct strings, but an env SecretRef in `tools.web.search.apiKey` stays unresolved instead of reading the referenced environment variable.

## Why This Change Was Made

MiniMax web search already has several documented Token Plan/OAuth env fallbacks. A configured SecretRef should be resolved before those ambient fallbacks, and an unavailable SecretRef should fail closed instead of silently selecting `MINIMAX_CODE_PLAN_KEY`, `MINIMAX_CODING_API_KEY`, `MINIMAX_OAUTH_TOKEN`, or `MINIMAX_API_KEY`.

## User Impact

Users can keep MiniMax web-search keys in env-backed SecretRefs without storing raw credentials in config. If the referenced env var is absent, the tool reports the normal missing-key state rather than sending requests with an unrelated ambient MiniMax token.

## Evidence

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/minimax/src/minimax-web-search-provider.test.ts -- --reporter=verbose` passed, 1 file / 21 tests.
- `node_modules/.bin/oxfmt --check --threads=1 extensions/minimax/src/minimax-web-search-provider.test.ts` passed.
- `node_modules/.bin/oxlint extensions/minimax/src/minimax-web-search-provider.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine claude` reported no accepted/actionable findings.
- Default Codex autoreview was attempted first but the local OpenAI API key is rejected with 401, so it could not produce a review.

## Proof

The regression tests cover direct configured keys, the documented MiniMax env fallback order, configured env SecretRef precedence over Token Plan fallbacks, and missing env/file SecretRefs returning no key without live credentials.

Current head also restores `MINIMAX_SECRETREF_API_KEY` and `MISSING_MINIMAX_SECRETREF_API_KEY` in test cleanup, addressing the prior ClawSweeper env-isolation finding.

No `MINIMAX_API_KEY` or MiniMax Token Plan credential is available in this environment, so exact-head live MiniMax provider proof remains unavailable here.
