### PR TITLE
fix(workboard): resolve parent dependency status via targeted lookups, not a full-corpus scan

### DIFF
--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -157,6 +157,82 @@ describe("WorkboardStore", () => {
     }
   });
 
+  it("computes active owner ids across boards via the sqlite fast path, matching the full-scan fallback", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-sqlite-owners-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    try {
+      const stores = createWorkboardSqliteStores({ dbPath });
+      const store = new WorkboardStore(stores.cards, {
+        boards: stores.boards,
+        subscriptions: stores.subscriptions,
+        attachments: stores.attachments,
+      });
+      await store.upsertBoard({ id: "board-a", name: "A" });
+      await store.upsertBoard({ id: "board-b", name: "B" });
+
+      // Claimed/running on board-a: consumes an owner slot for agent-1.
+      const claimedOnA = await store.create({
+        title: "Claimed on A",
+        boardId: "board-a",
+        status: "ready",
+      });
+      await store.claim(claimedOnA.id, { ownerId: "agent-1" });
+
+      // Ready (unclaimed) on board-b, same owner: dispatch must see agent-1 as busy
+      // even though this card lives on a different board than the running one.
+      const readyOnB = await store.create({
+        title: "Ready on B, same owner",
+        boardId: "board-b",
+        agentId: "agent-1",
+        status: "ready",
+      });
+
+      // Archived running card: must NOT count as an active owner slot.
+      const archived = await store.create({
+        title: "Archived running",
+        boardId: "board-a",
+        status: "ready",
+      });
+      await store.claim(archived.id, { ownerId: "agent-archived" });
+      await store.update(archived.id, { metadata: { archivedAt: Date.now() } });
+
+      // Bulk of unrelated triage-status cards (a different board), the case that
+      // made the original unscoped list() scan expensive. None should appear as
+      // active owners since none are running/claimed.
+      for (let i = 0; i < 25; i++) {
+        await store.create({ title: `Triage ${i}`, boardId: "triage-board", status: "triage" });
+      }
+
+      const activeOwnerIds = await store.listActiveOwnerIds();
+      expect(activeOwnerIds).toContain("agent-1");
+      expect(activeOwnerIds).not.toContain("agent-archived");
+      expect(activeOwnerIds.length).toBe(1);
+
+      // Cross-check the sqlite fast path against the generic list()-based fallback
+      // (what an in-memory/non-sqlite backend would compute) to prove they agree.
+      const fallbackStore = new WorkboardStore(
+        {
+          register: stores.cards.register.bind(stores.cards),
+          lookup: stores.cards.lookup.bind(stores.cards),
+          delete: stores.cards.delete.bind(stores.cards),
+          entries: stores.cards.entries.bind(stores.cards),
+        },
+        {
+          boards: stores.boards,
+          subscriptions: stores.subscriptions,
+          attachments: stores.attachments,
+        },
+      );
+      const fallbackOwnerIds = await fallbackStore.listActiveOwnerIds();
+      expect([...activeOwnerIds].sort()).toEqual([...fallbackOwnerIds].sort());
+
+      expect(readyOnB.metadata?.claim).toBeUndefined();
+      stores.close();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("uses rollback journaling on network-backed volumes", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-sqlite-network-"));
     const dbPath = path.join(dir, "workboard.sqlite");
@@ -1308,6 +1384,33 @@ describe("WorkboardStore", () => {
 
     const lateParent = await store.create({ title: "Late parent" });
     await expect(store.linkCards(lateParent.id, child.id)).rejects.toThrow(/active child/);
+  });
+
+  it("resolves parent dependency status with targeted lookups instead of a full-corpus scan", async () => {
+    const cardStore = createMemoryStore();
+    const entriesSpy = vi.spyOn(cardStore, "entries");
+    const store = new WorkboardStore(cardStore);
+
+    const parent = await store.create({ title: "Parent" });
+    const children = await Promise.all(
+      Array.from({ length: 8 }, (_, i) =>
+        store.create({ title: `Child ${i}`, status: "todo", parents: [parent.id] }),
+      ),
+    );
+
+    await store.complete(parent.id, { summary: "Parent done." });
+    entriesSpy.mockClear();
+    const dispatch = await store.dispatch();
+
+    expect(dispatch.promoted.map((card) => card.id).sort()).toEqual(
+      children.map((child) => child.id).sort(),
+    );
+    // Regression guard for the dependencyTargetStatus N+1: before the fix, every
+    // parented card being checked in this pass triggered its own additional
+    // unscoped list() call (an extra full-corpus scan per child, here 8 of them).
+    // Resolving parents via targeted get() calls keeps this flat regardless of
+    // how many dependent cards are promoted together.
+    expect(entriesSpy.mock.calls.length).toBeLessThanOrEqual(1);
   });
 
   it("rejects terminal children with incomplete dependency parents", async () => {

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -157,82 +157,6 @@ describe("WorkboardStore", () => {
     }
   });
 
-  it("computes active owner ids across boards via the sqlite fast path, matching the full-scan fallback", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-sqlite-owners-"));
-    const dbPath = path.join(dir, "workboard.sqlite");
-    try {
-      const stores = createWorkboardSqliteStores({ dbPath });
-      const store = new WorkboardStore(stores.cards, {
-        boards: stores.boards,
-        subscriptions: stores.subscriptions,
-        attachments: stores.attachments,
-      });
-      await store.upsertBoard({ id: "board-a", name: "A" });
-      await store.upsertBoard({ id: "board-b", name: "B" });
-
-      // Claimed/running on board-a: consumes an owner slot for agent-1.
-      const claimedOnA = await store.create({
-        title: "Claimed on A",
-        boardId: "board-a",
-        status: "ready",
-      });
-      await store.claim(claimedOnA.id, { ownerId: "agent-1" });
-
-      // Ready (unclaimed) on board-b, same owner: dispatch must see agent-1 as busy
-      // even though this card lives on a different board than the running one.
-      const readyOnB = await store.create({
-        title: "Ready on B, same owner",
-        boardId: "board-b",
-        agentId: "agent-1",
-        status: "ready",
-      });
-
-      // Archived running card: must NOT count as an active owner slot.
-      const archived = await store.create({
-        title: "Archived running",
-        boardId: "board-a",
-        status: "ready",
-      });
-      await store.claim(archived.id, { ownerId: "agent-archived" });
-      await store.update(archived.id, { metadata: { archivedAt: Date.now() } });
-
-      // Bulk of unrelated triage-status cards (a different board), the case that
-      // made the original unscoped list() scan expensive. None should appear as
-      // active owners since none are running/claimed.
-      for (let i = 0; i < 25; i++) {
-        await store.create({ title: `Triage ${i}`, boardId: "triage-board", status: "triage" });
-      }
-
-      const activeOwnerIds = await store.listActiveOwnerIds();
-      expect(activeOwnerIds).toContain("agent-1");
-      expect(activeOwnerIds).not.toContain("agent-archived");
-      expect(activeOwnerIds.length).toBe(1);
-
-      // Cross-check the sqlite fast path against the generic list()-based fallback
-      // (what an in-memory/non-sqlite backend would compute) to prove they agree.
-      const fallbackStore = new WorkboardStore(
-        {
-          register: stores.cards.register.bind(stores.cards),
-          lookup: stores.cards.lookup.bind(stores.cards),
-          delete: stores.cards.delete.bind(stores.cards),
-          entries: stores.cards.entries.bind(stores.cards),
-        },
-        {
-          boards: stores.boards,
-          subscriptions: stores.subscriptions,
-          attachments: stores.attachments,
-        },
-      );
-      const fallbackOwnerIds = await fallbackStore.listActiveOwnerIds();
-      expect([...activeOwnerIds].sort()).toEqual([...fallbackOwnerIds].sort());
-
-      expect(readyOnB.metadata?.claim).toBeUndefined();
-      stores.close();
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
   it("uses rollback journaling on network-backed volumes", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-sqlite-network-"));
     const dbPath = path.join(dir, "workboard.sqlite");
@@ -1402,8 +1326,9 @@ describe("WorkboardStore", () => {
     entriesSpy.mockClear();
     const dispatch = await store.dispatch();
 
-    expect(dispatch.promoted.map((card) => card.id).sort()).toEqual(
-      children.map((child) => child.id).sort(),
+    const idComparator = (left: string, right: string) => left.localeCompare(right);
+    expect(dispatch.promoted.map((card) => card.id).toSorted(idComparator)).toEqual(
+      children.map((child) => child.id).toSorted(idComparator),
     );
     // Regression guard for the dependencyTargetStatus N+1: before the fix, every
     // parented card being checked in this pass triggered its own additional

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -11,7 +11,6 @@ import type {
   PersistedWorkboardBoard,
   PersistedWorkboardCard,
   PersistedWorkboardNotificationSubscription,
-  WorkboardActiveOwnerQueryable,
   WorkboardKeyedStore,
 } from "./persistence-types.js";
 import { createWorkboardSqliteStores } from "./sqlite-store.js";
@@ -2354,34 +2353,6 @@ export class WorkboardStore {
       .map((entry) => entry.card)
       .filter((card) => !boardId || cardBoardId(card) === boardId)
       .toSorted(compareCards);
-  }
-
-  /**
-   * agentId (or undefined for unowned cards) of every card that currently
-   * consumes a dispatch "owner slot" — running, claimed, or with a running
-   * execution — across ALL boards, excluding archived cards. Used by
-   * dispatchAndStartWorkboardCards to enforce the cross-board same-owner
-   * exclusion without materializing the full corpus via list()/entries()
-   * when the underlying card store can answer this more cheaply (e.g. a
-   * single indexed SQL query instead of N+1 child-table reads per card).
-   * Falls back to a full list() scan for stores that don't implement the
-   * fast path (e.g. in-memory test stores), so behavior is unchanged there.
-   */
-  async listActiveOwnerIds(): Promise<Array<string | undefined>> {
-    const cardStore = this.store as WorkboardKeyedStore & Partial<WorkboardActiveOwnerQueryable>;
-    if (typeof cardStore.activeOwnerIds === "function") {
-      return await cardStore.activeOwnerIds();
-    }
-    const cards = await this.list();
-    return cards
-      .filter(
-        (card) =>
-          !card.metadata?.archivedAt &&
-          (card.status === "running" ||
-            Boolean(card.metadata?.claim) ||
-            card.execution?.status === "running"),
-      )
-      .map((card) => card.agentId);
   }
 
   async listBoards(): Promise<{ boards: WorkboardBoardSummary[] }> {

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -11,6 +11,7 @@ import type {
   PersistedWorkboardBoard,
   PersistedWorkboardCard,
   PersistedWorkboardNotificationSubscription,
+  WorkboardActiveOwnerQueryable,
   WorkboardKeyedStore,
 } from "./persistence-types.js";
 import { createWorkboardSqliteStores } from "./sqlite-store.js";
@@ -2355,6 +2356,34 @@ export class WorkboardStore {
       .toSorted(compareCards);
   }
 
+  /**
+   * agentId (or undefined for unowned cards) of every card that currently
+   * consumes a dispatch "owner slot" — running, claimed, or with a running
+   * execution — across ALL boards, excluding archived cards. Used by
+   * dispatchAndStartWorkboardCards to enforce the cross-board same-owner
+   * exclusion without materializing the full corpus via list()/entries()
+   * when the underlying card store can answer this more cheaply (e.g. a
+   * single indexed SQL query instead of N+1 child-table reads per card).
+   * Falls back to a full list() scan for stores that don't implement the
+   * fast path (e.g. in-memory test stores), so behavior is unchanged there.
+   */
+  async listActiveOwnerIds(): Promise<Array<string | undefined>> {
+    const cardStore = this.store as WorkboardKeyedStore & Partial<WorkboardActiveOwnerQueryable>;
+    if (typeof cardStore.activeOwnerIds === "function") {
+      return await cardStore.activeOwnerIds();
+    }
+    const cards = await this.list();
+    return cards
+      .filter(
+        (card) =>
+          !card.metadata?.archivedAt &&
+          (card.status === "running" ||
+            Boolean(card.metadata?.claim) ||
+            card.execution?.status === "running"),
+      )
+      .map((card) => card.agentId);
+  }
+
   async listBoards(): Promise<{ boards: WorkboardBoardSummary[] }> {
     const boards = new Map<string, WorkboardBoardSummary>();
     for (const entry of await this.boardStore.entries()) {
@@ -3010,8 +3039,8 @@ export class WorkboardStore {
       }
       return card.status === "scheduled" ? "ready" : card.status;
     }
-    const cards = new Map((await this.list()).map((entry) => [entry.id, entry]));
-    const parentsDone = parents.every((parentId) => cards.get(parentId)?.status === "done");
+    const parentCards = await Promise.all(parents.map((parentId) => this.get(parentId)));
+    const parentsDone = parentCards.every((parent) => parent?.status === "done");
     if (
       !parentsDone &&
       scheduledAt &&


### PR DESCRIPTION
Related: #101895

## What Problem This Solves

Workboard dispatch on boards with dependency-linked cards could stall for minutes as corpus size grew. Every dependency check rescanned and re-materialized every card, repeating full-corpus work for each parented card.

## Why This Change Was Made

Resolve only referenced parent cards through the indexed keyed-store lookup. Existing missing-parent, completion, scheduling, and promotion behavior stays unchanged. The separate cold cycle-detection path remains unchanged; no API, config, or storage contract changes.

## User Impact

Large Workboards dispatch promptly again. On the reporter's live roughly 5,770-card corpus, identical recurring dispatches fell from 154-160 seconds to 2.7-2.9 seconds, about 55x faster.

## Evidence

- CPU profile: 93.3% of samples were inside `dependencyTargetStatus -> list -> entries -> readCard` before the fix.
- Regression test: one completed parent plus eight children; all children promote and unscoped full-corpus `entries()` calls stay flat.
- Blacksmith Testbox `tbx_01kxdf8jbfyxn52hkqtjxjq0wq`: focused store tests passed 80/80; full `extensions/workboard/src` passed 111/111; `corepack pnpm check:changed` passed.
- Exact-head hosted code/test lanes passed at `191c84721a562befa5e030300fab6c72a758cc79`.
- The prior Real behavior proof check failed only because the PR body did not use these required template headings; this body now supplies them.
