### PR TITLE
feat(fleet): stream tenant cell logs through the supervisor

### DIFF
--- a/docs/cli/fleet.md
+++ b/docs/cli/fleet.md
@@ -125,6 +125,21 @@ http://127.0.0.1:<host-port>/healthz
 
 The health result is `ok`, `failed`, or `skipped`. `/healthz` proves Gateway liveness, not full readiness of every configured channel or plugin. The probe is skipped when there is no usable local endpoint to check.
 
+## `fleet logs`
+
+Stream a cell's container logs directly to the terminal:
+
+```bash
+openclaw fleet logs acme
+openclaw fleet logs acme --follow
+openclaw fleet logs acme --tail 200
+openclaw fleet logs acme --since 10m
+```
+
+Fleet verifies the registered container's ownership labels before reading any logs, so it refuses a foreign container using the expected cell name. Press Ctrl-C to end `--follow` without treating the operator stop as a command failure.
+
+`fleet logs` has no `--json` mode because container logs are a raw stdout/stderr stream. For scripts, bound the output with `--tail` and use ordinary shell redirection or pipelines.
+
 ## `fleet start`, `fleet stop`, and `fleet restart`
 
 Control an existing cell with its recorded runtime:

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1510,6 +1510,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Create options
   - H2: fleet list
   - H2: fleet status
+  - H2: fleet logs
   - H2: fleet start, fleet stop, and fleet restart
   - H2: fleet upgrade
   - H2: fleet rm

--- a/src/cli/fleet-cli/commands.runtime.test.ts
+++ b/src/cli/fleet-cli/commands.runtime.test.ts
@@ -7,6 +7,7 @@ const mocks = await vi.hoisted(async () => {
     create: vi.fn(),
     list: vi.fn(),
     status: vi.fn(),
+    logs: vi.fn(),
     lifecycle: vi.fn(),
     upgrade: vi.fn(),
     remove: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock("../../fleet/service.runtime.js", () => ({
     create: mocks.create,
     list: mocks.list,
     status: mocks.status,
+    logs: mocks.logs,
     lifecycle: mocks.lifecycle,
     upgrade: mocks.upgrade,
     remove: mocks.remove,
@@ -28,6 +30,7 @@ vi.mock("../../fleet/service.runtime.js", () => ({
 import {
   runFleetCreateCommand,
   runFleetListCommand,
+  runFleetLogsCommand,
   runFleetRemoveCommand,
   runFleetStatusCommand,
 } from "./commands.runtime.js";
@@ -95,6 +98,16 @@ describe("fleet command output", () => {
     await runFleetListCommand({ json: true });
 
     expect(mocks.defaultRuntime.writeJson).toHaveBeenCalledWith({ cells });
+  });
+
+  it("delegates logs without adding formatted output", async () => {
+    const options = { tenant: "acme", follow: true, tail: 100, since: "10m" };
+
+    await runFleetLogsCommand(options);
+
+    expect(mocks.logs).toHaveBeenCalledWith(options);
+    expect(mocks.defaultRuntime.log).not.toHaveBeenCalled();
+    expect(mocks.defaultRuntime.writeJson).not.toHaveBeenCalled();
   });
 
   it("writes status JSON and describes retained data on removal", async () => {

--- a/src/cli/fleet-cli/commands.runtime.ts
+++ b/src/cli/fleet-cli/commands.runtime.ts
@@ -5,6 +5,7 @@ import {
   type FleetCreateOptions,
   type FleetHealthResult,
   type FleetLifecycleAction,
+  type FleetLogsOptions,
 } from "../../fleet/service.runtime.js";
 import { defaultRuntime } from "../../runtime.js";
 
@@ -84,6 +85,10 @@ export async function runFleetStatusCommand(options: {
   defaultRuntime.log(`Created: ${result.created}`);
   defaultRuntime.log(`Data: ${result.dataDir}`);
   defaultRuntime.log(`Health: ${formatHealth(result.health)}`);
+}
+
+export async function runFleetLogsCommand(options: FleetLogsOptions): Promise<void> {
+  await fleetService.logs(options);
 }
 
 export async function runFleetLifecycleCommand(options: {

--- a/src/cli/fleet-cli/register.test.ts
+++ b/src/cli/fleet-cli/register.test.ts
@@ -9,6 +9,7 @@ const mocks = await vi.hoisted(async () => {
     runFleetCreateCommand: vi.fn(),
     runFleetListCommand: vi.fn(),
     runFleetStatusCommand: vi.fn(),
+    runFleetLogsCommand: vi.fn(),
     runFleetLifecycleCommand: vi.fn(),
     runFleetUpgradeCommand: vi.fn(),
     runFleetRemoveCommand: vi.fn(),
@@ -23,6 +24,7 @@ vi.mock("./commands.runtime.js", () => ({
   runFleetCreateCommand: mocks.runFleetCreateCommand,
   runFleetListCommand: mocks.runFleetListCommand,
   runFleetStatusCommand: mocks.runFleetStatusCommand,
+  runFleetLogsCommand: mocks.runFleetLogsCommand,
   runFleetLifecycleCommand: mocks.runFleetLifecycleCommand,
   runFleetUpgradeCommand: mocks.runFleetUpgradeCommand,
   runFleetRemoveCommand: mocks.runFleetRemoveCommand,
@@ -117,6 +119,17 @@ describe("fleet cli", () => {
     expect(mocks.runFleetListCommand).toHaveBeenCalledWith({ json: true });
   });
 
+  it("normalizes logs options", async () => {
+    await runFleetCli(["logs", "acme", "--follow", "--tail", "100", "--since", "10m"]);
+
+    expect(mocks.runFleetLogsCommand).toHaveBeenCalledWith({
+      tenant: "acme",
+      follow: true,
+      tail: 100,
+      since: "10m",
+    });
+  });
+
   it("normalizes remove safety flags", async () => {
     await runFleetCli(["rm", "tenant-a", "--purge-data", "--force"]);
 
@@ -141,8 +154,13 @@ describe("fleet cli", () => {
       argv: ["create", "tenant-a", "--cpus", "0"],
       error: /--cpus must be a positive number/,
     },
-  ])("rejects invalid create options: $argv", async ({ argv, error }) => {
+    {
+      argv: ["logs", "tenant-a", "--tail", "1.5"],
+      error: /--tail must be a positive integer/,
+    },
+  ])("rejects invalid options: $argv", async ({ argv, error }) => {
     await expect(runFleetCli(argv)).rejects.toThrow(error);
     expect(mocks.runFleetCreateCommand).not.toHaveBeenCalled();
+    expect(mocks.runFleetLogsCommand).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/fleet-cli/register.ts
+++ b/src/cli/fleet-cli/register.ts
@@ -105,6 +105,20 @@ export function registerFleetCli(program: Command): void {
       await runtime.runFleetStatusCommand({ tenant, ...options });
     });
 
+  fleet
+    .command("logs")
+    .description("Stream tenant cell container logs")
+    .argument("<tenant>", "Tenant slug")
+    .option("--follow", "Follow log output", false)
+    .option("--tail <count>", "Number of lines to show", (value: string) =>
+      parseStrictPositiveIntOption(value, "--tail"),
+    )
+    .option("--since <value>", "Show logs since a duration or timestamp")
+    .action(async (tenant: string, options: { follow: boolean; tail?: number; since?: string }) => {
+      const runtime = await loadFleetRuntime();
+      await runtime.runFleetLogsCommand({ tenant, ...options });
+    });
+
   for (const action of ["start", "stop", "restart"] as const) {
     fleet
       .command(action)

--- a/src/fleet/containers.runtime.test.ts
+++ b/src/fleet/containers.runtime.test.ts
@@ -23,6 +23,7 @@ import {
   createFleetContainerRuntime,
   type CellContainerProfile,
   type FleetContainerCommandExecutor,
+  type FleetContainerStreamExecutor,
 } from "./containers.runtime.js";
 
 function successfulExecutor() {
@@ -389,6 +390,61 @@ describe("fleet container runtime", () => {
       ["rm", "--force", "cell-acme"],
       ["rm", "cell-acme"],
     ]);
+  });
+
+  it.each([
+    [{}, ["logs", "cell-acme"]],
+    [{ follow: true }, ["logs", "--follow", "cell-acme"]],
+    [{ tail: 200 }, ["logs", "--tail", "200", "cell-acme"]],
+    [{ since: "10m" }, ["logs", "--since", "10m", "cell-acme"]],
+    [
+      { follow: true, tail: 100, since: "2026-07-11T10:00:00Z" },
+      ["logs", "--follow", "--tail", "100", "--since", "2026-07-11T10:00:00Z", "cell-acme"],
+    ],
+  ] as const)("streams logs with exact argv for %o", async (options, expectedArgs) => {
+    const stream = vi.fn<FleetContainerStreamExecutor>(async () => ({ code: 0, signal: null }));
+    const runtime = createFleetContainerRuntime(successfulExecutor(), stream);
+
+    await expect(runtime.logs("podman", "cell-acme", options)).resolves.toBeUndefined();
+
+    expect(stream).toHaveBeenCalledWith("podman", expectedArgs);
+  });
+
+  it.each(["", "-1h", "10 m", "10m\n"])("rejects unsafe --since value %o", async (since) => {
+    const stream = vi.fn<FleetContainerStreamExecutor>(async () => ({ code: 0, signal: null }));
+    const runtime = createFleetContainerRuntime(successfulExecutor(), stream);
+
+    await expect(runtime.logs("docker", "cell-acme", { since })).rejects.toThrow(/--since/iu);
+    expect(stream).not.toHaveBeenCalled();
+  });
+
+  it("reports stream failures but accepts operator interrupt while following", async () => {
+    const stream = vi.fn<FleetContainerStreamExecutor>();
+    const runtime = createFleetContainerRuntime(successfulExecutor(), stream);
+    stream
+      .mockResolvedValueOnce({ code: 7, signal: null })
+      .mockResolvedValueOnce({ code: 130, signal: null })
+      .mockResolvedValueOnce({ code: 130, signal: null })
+      .mockResolvedValueOnce({ code: null, signal: "SIGTERM" })
+      .mockResolvedValueOnce({ code: null, signal: "SIGTERM" });
+
+    await expect(runtime.logs("podman", "cell-acme", {})).rejects.toThrow(
+      /podman logs failed with exit code 7/iu,
+    );
+    await expect(runtime.logs("podman", "cell-acme", { follow: true })).resolves.toBeUndefined();
+    await expect(runtime.logs("podman", "cell-acme", {})).rejects.toThrow(
+      /podman logs failed with exit code 130/iu,
+    );
+    // A forwarded termination signal ends a follow stream cleanly but fails a bounded read.
+    await expect(runtime.logs("podman", "cell-acme", { follow: true })).resolves.toBeUndefined();
+    await expect(runtime.logs("podman", "cell-acme", {})).rejects.toThrow(
+      /podman logs failed with signal SIGTERM/iu,
+    );
+    // Crash signals are never masked as operator stops, even while following.
+    stream.mockResolvedValueOnce({ code: null, signal: "SIGSEGV" });
+    await expect(runtime.logs("podman", "cell-acme", { follow: true })).rejects.toThrow(
+      /podman logs failed with signal SIGSEGV/iu,
+    );
   });
 
   it("creates and removes a labeled per-cell network", async () => {

--- a/src/fleet/containers.runtime.ts
+++ b/src/fleet/containers.runtime.ts
@@ -1,6 +1,8 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { attachChildProcessBridge } from "../process/child-process-bridge.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import {
   buildCellCreateArgs,
@@ -28,6 +30,33 @@ export type FleetContainerCommandExecutor = (
   args: string[],
   options: FleetContainerCommandOptions,
 ) => Promise<FleetContainerCommandResult>;
+
+export type FleetContainerStreamResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+// Mirrors the termination set attachChildProcessBridge forwards, plus SIGPIPE for a
+// downstream reader (e.g. `| head`) closing the inherited stdout mid-stream.
+const DELIBERATE_STREAM_STOP_SIGNALS = new Set<NodeJS.Signals>([
+  "SIGINT",
+  "SIGTERM",
+  "SIGHUP",
+  "SIGQUIT",
+  "SIGBREAK",
+  "SIGPIPE",
+]);
+
+export type FleetContainerStreamExecutor = (
+  runtime: FleetContainerRuntimeName,
+  args: string[],
+) => Promise<FleetContainerStreamResult>;
+
+export type FleetContainerLogsOptions = {
+  follow?: boolean;
+  tail?: number;
+  since?: string;
+};
 
 export type FleetContainerInspectResult =
   | {
@@ -379,6 +408,20 @@ const defaultFleetContainerCommandExecutor: FleetContainerCommandExecutor = asyn
   return normalized;
 };
 
+const defaultFleetContainerStreamExecutor: FleetContainerStreamExecutor = (runtime, args) =>
+  new Promise<FleetContainerStreamResult>((resolve, reject) => {
+    // Logs carry no environment or token arguments, so this narrow inherited-stdio seam needs no redaction.
+    const child = spawn(runtime, args, { stdio: ["ignore", "inherit", "inherit"] });
+    // Forward every termination signal (SIGINT/SIGTERM/SIGHUP/...), not just Ctrl-C:
+    // a supervisor signaling only the CLI PID must never orphan a follow stream that
+    // holds the inherited stdio descriptors. The bridge detaches itself on child exit.
+    attachChildProcessBridge(child);
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
+
 function isMissingContainerError(stderr: string): boolean {
   const normalized = stderr.toLowerCase();
   return (
@@ -407,8 +450,32 @@ function validateNetworkName(networkName: string): string {
   return normalized;
 }
 
+function buildLogsArgs(containerName: string, options: FleetContainerLogsOptions): string[] {
+  const args = ["logs"];
+  if (options.follow) {
+    args.push("--follow");
+  }
+  if (options.tail !== undefined) {
+    if (!Number.isSafeInteger(options.tail) || options.tail < 1) {
+      throw new Error("Fleet logs --tail must be a positive integer.");
+    }
+    args.push("--tail", String(options.tail));
+  }
+  if (options.since !== undefined) {
+    if (!options.since || options.since.startsWith("-") || /[\s\p{Cc}]/u.test(options.since)) {
+      throw new Error(
+        "Fleet logs --since must be non-empty, must not start with '-', and must not contain whitespace or control characters.",
+      );
+    }
+    args.push("--since", options.since);
+  }
+  args.push(containerName);
+  return args;
+}
+
 export function createFleetContainerRuntime(
   executor: FleetContainerCommandExecutor = defaultFleetContainerCommandExecutor,
+  streamExecutor: FleetContainerStreamExecutor = defaultFleetContainerStreamExecutor,
 ) {
   const execute = async (
     runtime: FleetContainerRuntimeName,
@@ -578,6 +645,30 @@ export function createFleetContainerRuntime(
 
     async restart(runtime: FleetContainerRuntimeName, containerName: string): Promise<void> {
       await execute(runtime, ["restart", containerName]);
+    },
+
+    async logs(
+      runtime: FleetContainerRuntimeName,
+      containerName: string,
+      options: FleetContainerLogsOptions,
+    ): Promise<void> {
+      const result = await streamExecutor(runtime, buildLogsArgs(containerName, options));
+      if (result.code === 0) {
+        return;
+      }
+      // A follow stream ended by a deliberate stop — a forwarded termination signal,
+      // a closed downstream pipe, or docker/podman's own Ctrl-C translation to 130 —
+      // is not a failure. Crash signals (SIGSEGV, SIGKILL, ...) stay errors.
+      const deliberateStop =
+        result.signal !== null && DELIBERATE_STREAM_STOP_SIGNALS.has(result.signal);
+      if (options.follow && (deliberateStop || result.code === 130)) {
+        return;
+      }
+      throw new Error(
+        `${runtime} logs failed with ${
+          result.signal ? `signal ${result.signal}` : `exit code ${result.code ?? 1}`
+        }.`,
+      );
     },
 
     async remove(

--- a/src/fleet/service-removal.runtime.test.ts
+++ b/src/fleet/service-removal.runtime.test.ts
@@ -75,6 +75,7 @@ function createContainerMock(
   const start = vi.fn<FleetContainerRuntime["start"]>(async () => undefined);
   const stop = vi.fn<FleetContainerRuntime["stop"]>(async () => undefined);
   const restart = vi.fn<FleetContainerRuntime["restart"]>(async () => undefined);
+  const logs = vi.fn<FleetContainerRuntime["logs"]>(async () => undefined);
   const remove = vi.fn<FleetContainerRuntime["remove"]>(async () => {
     inspect.mockResolvedValue({ kind: "missing", state: "missing" });
   });
@@ -91,6 +92,7 @@ function createContainerMock(
       start,
       stop,
       restart,
+      logs,
       remove,
     },
     assertLocal,
@@ -104,6 +106,7 @@ function createContainerMock(
     start,
     stop,
     restart,
+    logs,
     remove,
   };
 }

--- a/src/fleet/service.runtime.test.ts
+++ b/src/fleet/service.runtime.test.ts
@@ -76,6 +76,7 @@ function createContainerMock(
   const start = vi.fn<FleetContainerRuntime["start"]>(async () => undefined);
   const stop = vi.fn<FleetContainerRuntime["stop"]>(async () => undefined);
   const restart = vi.fn<FleetContainerRuntime["restart"]>(async () => undefined);
+  const logs = vi.fn<FleetContainerRuntime["logs"]>(async () => undefined);
   const remove = vi.fn<FleetContainerRuntime["remove"]>(async () => {
     inspect.mockResolvedValue({ kind: "missing", state: "missing" });
   });
@@ -92,6 +93,7 @@ function createContainerMock(
       start,
       stop,
       restart,
+      logs,
       remove,
     },
     assertLocal,
@@ -105,6 +107,7 @@ function createContainerMock(
     start,
     stop,
     restart,
+    logs,
     remove,
   };
 }
@@ -304,6 +307,53 @@ describe("fleet service", () => {
     await expect(service.lifecycle("acme", action)).resolves.toEqual({ tenant: "acme", action });
 
     expect(containers[action]).toHaveBeenCalledWith("docker", "openclaw-cell-acme");
+  });
+
+  it("streams logs only after proving container ownership", async () => {
+    const containers = createContainerMock();
+    const service = createFleetService({ env, containers: containers.runtime, now: () => 1000 });
+    await service.create({ tenant: "acme", gatewayToken: "token" });
+    containers.inspect.mockResolvedValue(runningInspection());
+
+    await expect(
+      service.logs({ tenant: "acme", follow: true, tail: 100, since: "10m" }),
+    ).resolves.toBeUndefined();
+
+    expect(containers.logs).toHaveBeenCalledWith("docker", "openclaw-cell-acme", {
+      follow: true,
+      tail: 100,
+      since: "10m",
+    });
+  });
+
+  it.each(["foreign", "missing", "unavailable"] as const)(
+    "refuses %s log inspection before streaming",
+    async (kind) => {
+      const inspection: FleetContainerInspectResult =
+        kind === "foreign"
+          ? runningInspection({ labels: {} })
+          : kind === "missing"
+            ? { kind: "missing", state: "missing" }
+            : { kind: "unavailable", state: "unknown", error: "daemon unavailable" };
+      const containers = createContainerMock();
+      const service = createFleetService({ env, containers: containers.runtime, now: () => 1000 });
+      await service.create({ tenant: "acme", gatewayToken: "token" });
+      containers.inspect.mockResolvedValue(inspection);
+
+      await expect(service.logs({ tenant: "acme" })).rejects.toThrow();
+      expect(containers.logs).not.toHaveBeenCalled();
+    },
+  );
+
+  it("refuses logs when the recorded runtime is unavailable", async () => {
+    const containers = createContainerMock();
+    const service = createFleetService({ env, containers: containers.runtime, now: () => 1000 });
+    await service.create({ tenant: "acme", gatewayToken: "token" });
+    containers.assertLocal.mockRejectedValue(new Error("daemon unavailable"));
+
+    await expect(service.logs({ tenant: "acme" })).rejects.toThrow(/daemon unavailable/iu);
+    expect(containers.inspect).not.toHaveBeenCalled();
+    expect(containers.logs).not.toHaveBeenCalled();
   });
 
   it("carries inspected environment and resources through upgrade", async () => {

--- a/src/fleet/service.runtime.ts
+++ b/src/fleet/service.runtime.ts
@@ -117,6 +117,13 @@ export type FleetStatusResult = {
 
 export type FleetLifecycleAction = "start" | "stop" | "restart";
 
+export type FleetLogsOptions = {
+  tenant: string;
+  follow?: boolean;
+  tail?: number;
+  since?: string;
+};
+
 export type FleetActionResult = {
   tenant: string;
   action: FleetLifecycleAction | "upgrade" | "rm";
@@ -402,6 +409,19 @@ export function createFleetService(options: FleetServiceOptions = {}) {
           await containers[action](record.runtime, record.containerName);
           return { tenant: record.tenantId, action };
         },
+      });
+    },
+
+    async logs(logOptions: FleetLogsOptions): Promise<void> {
+      const record = requireCell(env, validateTenantId(logOptions.tenant));
+      await containers.assertLocal(record.runtime);
+      const inspection = await containers.inspect(record.runtime, record.containerName);
+      // Ownership must be proven before inheriting stdio; never stream a foreign name-squatting container.
+      assertManagedInspection(record, inspection);
+      await containers.logs(record.runtime, record.containerName, {
+        follow: logOptions.follow,
+        tail: logOptions.tail,
+        since: logOptions.since,
       });
     },
 


### PR DESCRIPTION
## What Problem This Solves

Fleet (#104527) manages cell lifecycle but gives operators no way to see why a cell is unhealthy — the first diagnostic step after a failed `fleet status` health probe is container logs, and today that means bypassing the supervisor and its ownership checks with a hand-crafted `docker logs openclaw-cell-<tenant>`. Closes #104644.

## Why This Change Was Made

Adds `openclaw fleet logs <tenant> [--follow] [--tail <n>] [--since <value>]`:

- Ownership is proven before any output: registry lookup, local-runtime assertion, container inspection, and the same fleet-label ownership check the other commands use — a foreign container squatting on the cell name is refused, never streamed.
- Logs stream through a new narrow inherited-stdio seam (`docker|podman logs` via spawn, no capture cap, no timeout) rather than the existing captured executor, which is sized for short commands (4 MiB / 10 min). The seam carries no env or token argv, so no redaction machinery applies; commented at the seam.
- Ctrl-C semantics: SIGINT is forwarded to the child; signal termination maps to exit 130, which is treated as operator-initiated success only under `--follow` — a non-follow `logs` exiting 130 remains an error.
- Injection guards: `--tail` is a strict positive integer; `--since` must be non-empty, must not start with `-`, and must not contain whitespace/control characters (passed through verbatim otherwise, so both durations and timestamps work).
- No `--json` mode by design: logs are a raw stream; documented alongside `--tail` guidance for scripting.

Implementation was Codex-built from a frozen spec and reviewed line-by-line; one review finding (SIGINT forwarding) was fixed before this PR.

## User Impact

Operators diagnose cells without leaving the supervisor's ownership guarantees. Fleet remains experimental; no config surface changes, no new dependencies, no changes to existing commands.

## Evidence

- 138 focused tests green on Blacksmith Testbox (18 new: argv construction incl. injection rejections, ownership refusal before streaming, exit/SIGINT semantics, CLI parsing): https://github.com/openclaw/openclaw/actions/runs/29165510814
- `pnpm tsgo`, `pnpm check:test-types`, oxlint, scoped format: clean.
- Structured autoreview (Codex): the build pass fixed one SIGINT-forwarding finding; a fresh review then surfaced a real P2 — only SIGINT was forwarded, so a supervisor's SIGTERM/SIGHUP to the CLI PID could orphan a follow stream holding inherited descriptors. Fixed by adopting the repo's canonical `attachChildProcessBridge` (full termination-signal set, self-detaching) and an honest `{code, signal}` stream result. A further cycle narrowed follow-mode tolerance to deliberate-stop signals only (forwarded termination set + SIGPIPE + exit 130) so crash signals like SIGSEGV are never masked as operator stops, with regression coverage. Final review: clean, "no accepted/actionable findings" (0.93). One reviewer suggestion — editing CHANGELOG.md — was rejected per repo policy (changelog is release-only; release-note context lives in this PR body).
- Live proof on Linux (Blacksmith Testbox, run https://github.com/openclaw/openclaw/actions/runs/29165538971): full fleet scenario on real Docker (rootful) **and** Podman (rootless) with the real image — create, hardening inspect (docker reports `CapDrop=["ALL"]`; podman equivalently enumerates the dropped default capability set), `/healthz` ok on first probe, **`fleet logs --tail 5` streaming real gateway boot lines from inside both cells**, upgrade with token hash carry-over, `rm --purge-data` leaving zero containers/networks and purged data dirs. `ALL_SCENARIOS_PASSED`.
