### PR TITLE
fix(agents): make indexed access explicit across src/agents (NUIA phase 3a)

### DIFF
--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -196,7 +196,12 @@ function parseLspMessages(buffer: Buffer): { messages: unknown[]; remaining: Buf
       continue;
     }
 
-    const contentLength = Number.parseInt(match[1], 10);
+    const contentLengthText = match.at(1);
+    if (contentLengthText === undefined) {
+      remaining = remaining.subarray(headerEnd + headerSeparator.length);
+      continue;
+    }
+    const contentLength = Number.parseInt(contentLengthText, 10);
     const bodyStart = headerEnd + headerSeparator.length;
     const bodyEnd = bodyStart + contentLength;
 

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -94,14 +94,14 @@ function toJsonAgentToolResult(params: {
 }
 
 function requireStringArg(input: unknown, key: string): string {
-  if (
-    !input ||
-    typeof input !== "object" ||
-    typeof (input as Record<string, unknown>)[key] !== "string"
-  ) {
+  if (!input || typeof input !== "object") {
     throw new Error(`${key} is required`);
   }
-  return (input as Record<string, string>)[key];
+  const value = Reflect.get(input, key);
+  if (typeof value !== "string") {
+    throw new Error(`${key} is required`);
+  }
+  return value;
 }
 
 function optionalStringRecordArg(input: unknown, key: string): Record<string, string> | undefined {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2686,6 +2686,9 @@ async function agentCommandInternal(
 
           if (combinedPayload) {
             const entry = sessionStore[sessionKey] ?? sessionEntry;
+            if (!entry) {
+              throw new Error("Cannot persist pending delivery without a session entry");
+            }
             const next: SessionEntry = {
               ...entry,
               pendingFinalDelivery: true,
@@ -2754,6 +2757,9 @@ async function agentCommandInternal(
           !sessionReboundDuringRun
         ) {
           const entry = sessionStore[sessionKey] ?? sessionEntry;
+          if (!entry) {
+            throw new Error("Cannot clear pending delivery without a session entry");
+          }
           const noPendingTextForThisRun =
             opts.deliver === true &&
             pendingFinalDeliveryTextForThisRun === undefined &&

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -671,8 +671,8 @@ function splitPreservedRecentTurns(params: {
   }
   const conversationIndexes: number[] = [];
   const userIndexes: number[] = [];
-  for (let i = 0; i < params.messages.length; i += 1) {
-    const role = (params.messages[i] as { role?: unknown }).role;
+  for (const [i, message] of params.messages.entries()) {
+    const role = message.role;
     if (role === "user" || role === "assistant") {
       conversationIndexes.push(i);
       if (role === "user") {
@@ -714,11 +714,10 @@ function splitPreservedRecentTurns(params: {
     return { summarizableMessages: params.messages, preservedMessages: [] };
   }
   const preservedToolCallIds = new Set<string>();
-  for (let i = 0; i < params.messages.length; i += 1) {
+  for (const [i, message] of params.messages.entries()) {
     if (!preservedIndexSet.has(i)) {
       continue;
     }
-    const message = params.messages[i];
     if (message.role !== "assistant") {
       continue;
     }
@@ -736,14 +735,13 @@ function splitPreservedRecentTurns(params: {
       }
     }
     if (preservedStartIndex >= 0) {
-      for (let i = preservedStartIndex; i < params.messages.length; i += 1) {
-        const message = params.messages[i];
+      for (const [offset, message] of params.messages.slice(preservedStartIndex).entries()) {
         if (message.role !== "toolResult") {
           continue;
         }
         const toolResultId = extractToolResultId(message);
         if (toolResultId && preservedToolCallIds.has(toolResultId)) {
-          preservedIndexSet.add(i);
+          preservedIndexSet.add(preservedStartIndex + offset);
         }
       }
     }
@@ -817,8 +815,7 @@ function formatSplitTurnContextSection(messages: AgentMessage[]): string {
 }
 
 function extractLatestUserAsk(messages: AgentMessage[]): string | null {
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const message = messages[i];
+  for (const message of messages.toReversed()) {
     if (message.role !== "user") {
       continue;
     }

--- a/src/agents/agent-hooks/context-pruning/pruner.ts
+++ b/src/agents/agent-hooks/context-pruning/pruner.ts
@@ -88,7 +88,10 @@ function takeHeadFromJoinedText(parts: string[], maxChars: number): string {
   }
   let remaining = maxChars;
   let out = "";
-  for (let i = 0; i < parts.length && remaining > 0; i++) {
+  for (const [i, p] of parts.entries()) {
+    if (remaining <= 0) {
+      break;
+    }
     if (i > 0) {
       out += "\n";
       remaining -= 1;
@@ -96,7 +99,6 @@ function takeHeadFromJoinedText(parts: string[], maxChars: number): string {
         break;
       }
     }
-    const p = parts[i];
     if (p.length <= remaining) {
       out += p;
       remaining -= p.length;
@@ -114,8 +116,10 @@ function takeTailFromJoinedText(parts: string[], maxChars: number): string {
   }
   let remaining = maxChars;
   const out: string[] = [];
-  for (let i = parts.length - 1; i >= 0 && remaining > 0; i--) {
-    const p = parts[i];
+  for (const [reverseIndex, p] of parts.toReversed().entries()) {
+    if (remaining <= 0) {
+      break;
+    }
     if (p.length <= remaining) {
       out.push(p);
       remaining -= p.length;
@@ -123,7 +127,7 @@ function takeTailFromJoinedText(parts: string[], maxChars: number): string {
       out.push(sliceUtf16Safe(p, -remaining));
       break;
     }
-    if (remaining > 0 && i > 0) {
+    if (remaining > 0 && reverseIndex < parts.length - 1) {
       out.push("\n");
       remaining -= 1;
     }

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -601,8 +601,7 @@ export function resolveAgentIdsByWorkspacePath(
   const ids = listAgentIds(cfg);
   const matches: Array<{ id: string; workspaceDir: string; order: number }> = [];
 
-  for (let index = 0; index < ids.length; index += 1) {
-    const id = ids[index];
+  for (const [index, id] of ids.entries()) {
     const workspaceDir = normalizePathForComparison(resolveAgentWorkspaceDir(cfg, id));
     if (!isPathInside(workspaceDir, normalizedWorkspacePath)) {
       continue;

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -410,6 +410,9 @@ function convertAnthropicMessages(
     : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);
   for (let i = 0; i < transformedMessages.length; i += 1) {
     const msg = transformedMessages[i];
+    if (!msg) {
+      continue;
+    }
     if (msg.role === "user") {
       const isRuntimeContextCarrier = msg.runtimeContextCarrier === true;
       if (typeof msg.content === "string") {
@@ -564,11 +567,11 @@ function convertAnthropicMessages(
         },
       ];
       let j = i + 1;
-      while (j < transformedMessages.length && transformedMessages[j].role === "toolResult") {
-        const nextMsg = transformedMessages[j] as Extract<
-          Context["messages"][number],
-          { role: "toolResult" }
-        >;
+      while (j < transformedMessages.length) {
+        const nextMsg = transformedMessages.at(j);
+        if (nextMsg?.role !== "toolResult") {
+          break;
+        }
         toolResults.push({
           type: "tool_result",
           tool_use_id: nextMsg.toolCallId,
@@ -1467,8 +1470,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               costModel = { ...model, cost: CLAUDE_FABLE_5_FALLBACK_MODEL_COST };
               calculateCost(costModel, output.usage);
               eventSink.push({ type: "start", partial: output as never });
-              for (let i = 0; i < output.content.length; i += 1) {
-                const block = output.content[i];
+              for (const [i, block] of output.content.entries()) {
                 if (block.type !== "text") {
                   continue;
                 }

--- a/src/agents/api-key-rotation.ts
+++ b/src/agents/api-key-rotation.ts
@@ -56,8 +56,7 @@ export async function executeWithApiKeyRotation<T>(
 
   let lastError: unknown;
   const transientRetry = resolveTransientProviderRetryOptions(params.transientRetry);
-  keyLoop: for (let apiKeyIndex = 0; apiKeyIndex < keys.length; apiKeyIndex += 1) {
-    const apiKey = keys[apiKeyIndex];
+  keyLoop: for (const [apiKeyIndex, apiKey] of keys.entries()) {
     const maxOperationAttempts = resolveTransientProviderAttempts(transientRetry);
     for (let attemptNumber = 1; attemptNumber <= maxOperationAttempts; attemptNumber += 1) {
       try {

--- a/src/agents/apply-patch-paths.ts
+++ b/src/agents/apply-patch-paths.ts
@@ -149,11 +149,14 @@ export function extractApplyPatchTargetPaths(
   const paths: string[] = [];
   const seen = new Set<string>();
   for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index];
+    const line = lines.at(index);
+    if (line === undefined) {
+      break;
+    }
     const addPath = readMarkerPath(line, ADD_FILE_MARKER);
     if (addPath !== undefined) {
       pushPath(paths, seen, addPath, options);
-      while (index + 1 < lines.length && lines[index + 1].startsWith("+")) {
+      while (index + 1 < lines.length && lines.at(index + 1)?.startsWith("+")) {
         index += 1;
       }
       continue;
@@ -170,20 +173,24 @@ export function extractApplyPatchTargetPaths(
       // sub-marker that names the new path. Skip leading blank lines so
       // human-edited patches with extra spacing still pick it up.
       let lookahead = index + 1;
-      while (lookahead < lines.length && lines[lookahead].trim() === "") {
+      while (lookahead < lines.length && lines.at(lookahead)?.trim() === "") {
         lookahead += 1;
       }
-      const movePath = readMarkerPath(lines[lookahead], MOVE_TO_MARKER);
+      const movePath = readMarkerPath(lines.at(lookahead), MOVE_TO_MARKER);
       if (movePath !== undefined) {
         pushPath(paths, seen, movePath, options);
         lookahead += 1;
       }
       while (lookahead < lines.length) {
-        if (lines[lookahead].trim() === "") {
+        const lookaheadLine = lines.at(lookahead);
+        if (lookaheadLine === undefined) {
+          break;
+        }
+        if (lookaheadLine.trim() === "") {
           lookahead += 1;
           continue;
         }
-        if (lines[lookahead].startsWith("***")) {
+        if (lookaheadLine.startsWith("***")) {
           break;
         }
         lookahead += 1;

--- a/src/agents/apply-patch-update.ts
+++ b/src/agents/apply-patch-update.ts
@@ -111,8 +111,8 @@ function applyReplacements(
         result.splice(startIndex, 1);
       }
     }
-    for (let i = 0; i < newLines.length; i += 1) {
-      result.splice(startIndex + i, 0, newLines[i]);
+    for (const [i, line] of newLines.entries()) {
+      result.splice(startIndex + i, 0, line);
     }
   }
   return result;
@@ -171,7 +171,9 @@ function linesMatch(
   normalize: (value: string) => string,
 ): boolean {
   for (let idx = 0; idx < pattern.length; idx += 1) {
-    if (normalize(lines[start + idx]) !== normalize(pattern[idx])) {
+    const line = lines.at(start + idx);
+    const expected = pattern.at(idx);
+    if (line === undefined || expected === undefined || normalize(line) !== normalize(expected)) {
       return false;
     }
   }

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -539,7 +539,10 @@ function parseOneHunk(lines: string[], lineNumber: number): { hunk: Hunk; consum
   if (lines.length === 0) {
     throw new Error(`Invalid patch hunk at line ${lineNumber}: empty hunk`);
   }
-  const firstLine = lines[0].trim();
+  const firstLine = lines.at(0)?.trim();
+  if (firstLine === undefined) {
+    throw new Error(`Invalid patch hunk at line ${lineNumber}: empty hunk`);
+  }
   if (firstLine.startsWith(ADD_FILE_MARKER)) {
     const targetPath = firstLine.slice(ADD_FILE_MARKER.length);
     let contents = "";
@@ -581,12 +584,16 @@ function parseOneHunk(lines: string[], lineNumber: number): { hunk: Hunk; consum
 
     const chunks: UpdateFileChunk[] = [];
     while (remaining.length > 0) {
-      if (remaining[0].trim() === "") {
+      const firstRemaining = remaining.at(0);
+      if (firstRemaining === undefined) {
+        break;
+      }
+      if (firstRemaining.trim() === "") {
         remaining = remaining.slice(1);
         consumed += 1;
         continue;
       }
-      if (remaining[0].startsWith("***")) {
+      if (firstRemaining.startsWith("***")) {
         break;
       }
       const { chunk, consumed: chunkLines } = parseUpdateFileChunk(
@@ -634,14 +641,15 @@ function parseUpdateFileChunk(
 
   let changeContext: string | undefined;
   let startIndex = 0;
-  if (lines[0] === EMPTY_CHANGE_CONTEXT_MARKER) {
+  const firstLine = lines.at(0);
+  if (firstLine === EMPTY_CHANGE_CONTEXT_MARKER) {
     startIndex = 1;
-  } else if (lines[0].startsWith(CHANGE_CONTEXT_MARKER)) {
-    changeContext = lines[0].slice(CHANGE_CONTEXT_MARKER.length);
+  } else if (firstLine?.startsWith(CHANGE_CONTEXT_MARKER)) {
+    changeContext = firstLine.slice(CHANGE_CONTEXT_MARKER.length);
     startIndex = 1;
   } else if (!allowMissingContext) {
     throw new Error(
-      `Invalid patch hunk at line ${lineNumber}: Expected update hunk to start with a @@ context marker, got: '${lines[0]}'`,
+      `Invalid patch hunk at line ${lineNumber}: Expected update hunk to start with a @@ context marker, got: '${firstLine}'`,
     );
   }
 

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -630,7 +630,7 @@ export function mergeAuthProfileStores(
                 profiles[profileId] || !removedRuntimeExternalProfileIds.has(profileId),
             ),
           ])
-          .filter(([, profileIds]) => profileIds.length > 0),
+          .filter(([, profileIds]) => Array.isArray(profileIds) && profileIds.length > 0),
       )
     : undefined;
   const mergedLastGood = mergeRecord(base.lastGood, override.lastGood);

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -241,7 +241,7 @@ export async function resolveSessionAuthProfileOverride(params: {
     }
     for (let offset = 1; offset <= order.length; offset += 1) {
       const candidate = order[(startIndex + offset) % order.length];
-      if (!isProfileInCooldown(store, candidate)) {
+      if (candidate && !isProfileInCooldown(store, candidate)) {
         return candidate;
       }
     }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -422,7 +422,7 @@ function pruneAuthProfileStoreReferences(
             provider,
             profileIds.filter((profileId) => keptOrderProfileIds.has(profileId)),
           ])
-          .filter(([, profileIds]) => profileIds.length > 0),
+          .filter(([, profileIds]) => Array.isArray(profileIds) && profileIds.length > 0),
       )
     : undefined;
   store.lastGood = store.lastGood

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -324,9 +324,12 @@ function capPendingBuffer(buffer: string[], pendingCharsInput: number, cap: numb
   }
   if (buffer.length && pendingChars > cap) {
     const overflow = pendingChars - cap;
-    const previousLength = buffer[0].length;
-    buffer[0] = sliceUtf16Safe(buffer[0], overflow);
-    pendingChars -= previousLength - buffer[0].length;
+    const firstChunk = buffer.at(0);
+    if (firstChunk !== undefined) {
+      const trimmedChunk = sliceUtf16Safe(firstChunk, overflow);
+      buffer[0] = trimmedChunk;
+      pendingChars -= firstChunk.length - trimmedChunk.length;
+    }
   }
   return pendingChars;
 }

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -709,7 +709,7 @@ export async function processGatewayAllowlist(
       allowlistEval.segments.length === 1 &&
       (autoReviewSegment?.raw === undefined ||
         autoReviewSegment.raw.trim() === params.command.trim())
-        ? autoReviewSegment.argv
+        ? autoReviewSegment?.argv
         : undefined;
     const autoReviewHasBoundCommand = analysisOk && autoReviewArgv !== undefined;
     // A model approval is valid only for the executable resolved during review;

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -665,9 +665,9 @@ export async function analyzeNodeApprovalRequirement(params: {
     }),
     autoReviewArgv:
       autoReviewBindingEval.segments.length === 1 &&
-      (autoReviewBindingEval.segments[0]?.raw === undefined ||
-        autoReviewBindingEval.segments[0].raw.trim() === autoReviewBindingCommand.trim())
-        ? autoReviewBindingEval.segments[0].argv
+      (autoReviewBindingEval.segments.at(0)?.raw === undefined ||
+        autoReviewBindingEval.segments.at(0)?.raw.trim() === autoReviewBindingCommand.trim())
+        ? autoReviewBindingEval.segments.at(0)?.argv
         : undefined,
   };
 }

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -397,7 +397,7 @@ function stripPreflightEnvPrefix(argv: string[]): string[] {
     return argv;
   }
   let idx = 0;
-  while (idx < argv.length && isShellEnvAssignmentToken(argv[idx])) {
+  while (idx < argv.length && isShellEnvAssignmentToken(argv.at(idx) ?? "")) {
     idx += 1;
   }
   if (!isEnvExecutableToken(argv[idx])) {
@@ -405,7 +405,10 @@ function stripPreflightEnvPrefix(argv: string[]): string[] {
   }
   idx += 1;
   while (idx < argv.length) {
-    const token = argv[idx];
+    const token = argv.at(idx);
+    if (token === undefined) {
+      break;
+    }
     if (token === "--") {
       idx += 1;
       break;
@@ -418,7 +421,8 @@ function stripPreflightEnvPrefix(argv: string[]): string[] {
       break;
     }
     idx += 1;
-    const option = token.split("=", 1)[0];
+    const equalsIndex = token.indexOf("=");
+    const option = token.includes("=") ? token.slice(0, equalsIndex) : token;
     if (
       PREFLIGHT_ENV_OPTIONS_WITH_VALUES.has(option) &&
       !token.includes("=") &&
@@ -433,10 +437,13 @@ function stripPreflightEnvPrefix(argv: string[]): string[] {
 function findFirstPythonScriptArg(tokens: string[]): string | null {
   const optionsWithSeparateValue = new Set(["-W", "-X", "-Q", "--check-hash-based-pycs"]);
   for (let i = 0; i < tokens.length; i += 1) {
-    const token = tokens[i];
+    const token = tokens.at(i);
+    if (token === undefined) {
+      break;
+    }
     if (token === "--") {
-      const next = tokens[i + 1];
-      return normalizeLowercaseStringOrEmpty(next).endsWith(".py") ? next : null;
+      const next = tokens.at(i + 1);
+      return next && normalizeLowercaseStringOrEmpty(next).endsWith(".py") ? next : null;
     }
     if (token === "-") {
       return null;
@@ -465,11 +472,14 @@ function findNodeScriptArgs(tokens: string[]): string[] {
   let entryScript: string | null = null;
   let hasInlineEvalOrPrint = false;
   for (let i = 0; i < tokens.length; i += 1) {
-    const token = tokens[i];
+    const token = tokens.at(i);
+    if (token === undefined) {
+      break;
+    }
     if (token === "--") {
       if (!hasInlineEvalOrPrint && !entryScript) {
-        const next = tokens[i + 1];
-        if (normalizeLowercaseStringOrEmpty(next).endsWith(".js")) {
+        const next = tokens.at(i + 1);
+        if (next && normalizeLowercaseStringOrEmpty(next).endsWith(".js")) {
           entryScript = next;
         }
       }
@@ -491,8 +501,8 @@ function findNodeScriptArgs(tokens: string[]): string[] {
       continue;
     }
     if (optionsWithSeparateValue.has(token)) {
-      const next = tokens[i + 1];
-      if (normalizeLowercaseStringOrEmpty(next).endsWith(".js")) {
+      const next = tokens.at(i + 1);
+      if (next && normalizeLowercaseStringOrEmpty(next).endsWith(".js")) {
         preloadScripts.push(next);
       }
       i += 1;
@@ -537,10 +547,13 @@ function extractInterpreterScriptTargetFromArgv(
     return null;
   }
   let commandIdx = 0;
-  while (commandIdx < argv.length && /^[A-Za-z_][A-Za-z0-9_]*=.*$/u.test(argv[commandIdx])) {
+  while (
+    commandIdx < argv.length &&
+    /^[A-Za-z_][A-Za-z0-9_]*=.*$/u.test(argv.at(commandIdx) ?? "")
+  ) {
     commandIdx += 1;
   }
-  const executable = normalizeOptionalLowercaseString(argv[commandIdx]);
+  const executable = normalizeOptionalLowercaseString(argv.at(commandIdx));
   if (!executable) {
     return null;
   }
@@ -956,16 +969,19 @@ function extractShellWrappedCommandPayload(
   }
   const shortOptionsWithSeparateValue = new Set(["-O", "-o"]);
   for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i];
+    const arg = args.at(i);
+    if (arg === undefined) {
+      break;
+    }
     if (arg === "--") {
       return null;
     }
     if (arg === "-c") {
-      return args[i + 1] ?? null;
+      return args.at(i + 1) ?? null;
     }
     if (/^-[A-Za-z]+$/u.test(arg)) {
       if (arg.includes("c")) {
-        return args[i + 1] ?? null;
+        return args.at(i + 1) ?? null;
       }
       if (shortOptionsWithSeparateValue.has(arg)) {
         i += 1;
@@ -974,7 +990,7 @@ function extractShellWrappedCommandPayload(
     }
     if (/^--[A-Za-z0-9][A-Za-z0-9-]*(?:=.*)?$/u.test(arg)) {
       if (!arg.includes("=")) {
-        const next = args[i + 1];
+        const next = args.at(i + 1);
         if (next && next !== "--" && !next.startsWith("-")) {
           i += 1;
         }

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -193,6 +193,9 @@ export function deriveSessionName(command: string): string | undefined {
     return undefined;
   }
   const verb = tokens[0];
+  if (!verb) {
+    return "";
+  }
   let target = tokens.slice(1).find((t) => !t.startsWith("-"));
   if (!target) {
     target = tokens[1];

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -250,8 +250,12 @@ function decodeJwtExpiryMs(token: string): number | null {
   if (parts.length < 2) {
     return null;
   }
+  const encodedPayload = parts.at(1);
+  if (!encodedPayload) {
+    return null;
+  }
   try {
-    const payloadRaw = Buffer.from(parts[1], "base64url").toString("utf8");
+    const payloadRaw = Buffer.from(encodedPayload, "base64url").toString("utf8");
     const payload = JSON.parse(payloadRaw) as { exp?: unknown };
     if (typeof payload.exp !== "number" || !Number.isFinite(payload.exp) || payload.exp <= 0) {
       return null;
@@ -267,8 +271,12 @@ function decodeJwtIdentityClaims(token: string): { sub?: string; email?: string 
   if (parts.length < 2) {
     return {};
   }
+  const encodedPayload = parts.at(1);
+  if (!encodedPayload) {
+    return {};
+  }
   try {
-    const payloadRaw = Buffer.from(parts[1], "base64url").toString("utf8");
+    const payloadRaw = Buffer.from(encodedPayload, "base64url").toString("utf8");
     const payload = JSON.parse(payloadRaw) as { sub?: unknown; email?: unknown };
     const sub = typeof payload.sub === "string" && payload.sub ? payload.sub : undefined;
     const email = typeof payload.email === "string" && payload.email ? payload.email : undefined;

--- a/src/agents/cli-runner/bundle-mcp-adapter-shared.ts
+++ b/src/agents/cli-runner/bundle-mcp-adapter-shared.ts
@@ -28,12 +28,14 @@ export function decodeHeaderEnvPlaceholder(
   value: string,
 ): { envVar: string; bearer: boolean } | null {
   const bearerMatch = /^Bearer \${([A-Z0-9_]+)}$/.exec(value);
-  if (bearerMatch) {
-    return { envVar: bearerMatch[1], bearer: true };
+  const bearerEnvVar = bearerMatch?.at(1);
+  if (bearerEnvVar) {
+    return { envVar: bearerEnvVar, bearer: true };
   }
   const envMatch = /^\${([A-Z0-9_]+)}$/.exec(value);
-  if (envMatch) {
-    return { envVar: envMatch[1], bearer: false };
+  const envVar = envMatch?.at(1);
+  if (envVar) {
+    return { envVar, bearer: false };
   }
   return null;
 }

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -118,7 +118,8 @@ function resolveOpenClawMcpEnvTemplates(value: unknown, env?: Record<string, str
   }
   if (typeof value === "string") {
     return value.replace(OPENCLAW_MCP_ENV_TEMPLATE_PATTERN, (match, name: string) => {
-      return Object.hasOwn(env, name) ? env[name] : match;
+      const replacement = env[name];
+      return Object.hasOwn(env, name) && replacement !== undefined ? replacement : match;
     });
   }
   if (Array.isArray(value)) {

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -1135,8 +1135,9 @@ export async function executePreparedCliRun(
               const candidates = cliLoopbackCalls.filter((candidate) =>
                 matchesCliLoopbackCall(previous.toolName, previous.args, candidate.current),
               );
-              if (candidates.length === 1 && !candidates[0]?.ambiguous) {
-                candidates[0].current = current;
+              const candidate = candidates.at(0);
+              if (candidates.length === 1 && candidate && !candidate.ambiguous) {
+                candidate.current = current;
               } else if (candidates.length > 0) {
                 markCliLoopbackCallsAmbiguous(candidates);
               }

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -131,9 +131,11 @@ export function splitMessagesByTokenShare(
     return true;
   };
 
-  for (let index = 0; index < messages.length; index += 1) {
-    const message = messages[index];
-    const messageTokens = perMessageTokens[index];
+  for (const [index, message] of messages.entries()) {
+    const messageTokens = perMessageTokens.at(index);
+    if (messageTokens === undefined) {
+      throw new Error("Compaction token estimates are out of sync with messages");
+    }
 
     if (
       pendingToolCallIds.size === 0 &&
@@ -214,9 +216,11 @@ export function chunkMessagesByMaxTokens(
   let currentChunk: AgentMessage[] = [];
   let currentTokens = 0;
 
-  for (let index = 0; index < messages.length; index += 1) {
-    const message = messages[index];
-    const messageTokens = perMessageTokens[index];
+  for (const [index, message] of messages.entries()) {
+    const messageTokens = perMessageTokens.at(index);
+    if (messageTokens === undefined) {
+      throw new Error("Compaction token estimates are out of sync with messages");
+    }
     if (currentChunk.length > 0 && currentTokens + messageTokens > effectiveMax) {
       chunks.push(currentChunk);
       currentChunk = [];
@@ -298,9 +302,11 @@ export function buildOversizedFallbackPlan(params: {
   const perMessageTokens = estimatePerMessageTokens(params.messages);
   const oversizedThreshold = params.contextWindow * 0.5;
 
-  for (let index = 0; index < params.messages.length; index += 1) {
-    const msg = params.messages[index];
-    const tokens = perMessageTokens[index];
+  for (const [index, msg] of params.messages.entries()) {
+    const tokens = perMessageTokens.at(index);
+    if (tokens === undefined) {
+      throw new Error("Compaction token estimates are out of sync with messages");
+    }
     if (tokens * SAFETY_MARGIN > oversizedThreshold) {
       const role = (msg as { role?: string }).role ?? "message";
       oversizedNotes.push(
@@ -373,6 +379,9 @@ export function pruneHistoryForContextShare(params: {
       break;
     }
     const [dropped, ...rest] = chunks;
+    if (!dropped) {
+      break;
+    }
     const flatRest = rest.flat();
 
     // After dropping a chunk, repair tool_use/tool_result pairing to handle

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -408,7 +408,11 @@ export async function summarizeInStages(params: {
   }
 
   if (partialSummaries.length === 1) {
-    return partialSummaries[0];
+    const summary = partialSummaries.at(0);
+    if (summary === undefined) {
+      throw new Error("Compaction summary plan produced no summary");
+    }
+    return summary;
   }
 
   // Capture once so timestamps are strictly monotonic across
@@ -417,7 +421,10 @@ export async function summarizeInStages(params: {
   const summaryMessages: AgentMessage[] = partialSummaries.map((summary, index) => {
     // serializeConversation preserves content but not timestamps, so chronology
     // must be explicit in the text consumed by the merge model.
-    const chunk = plan.chunks[index];
+    const chunk = plan.chunks.at(index);
+    if (!chunk) {
+      throw new Error(`Compaction summary plan is missing chunk ${index}`);
+    }
     const timeRange = extractChunkTimeRange(chunk);
     const label =
       index === 0

--- a/src/agents/configured-provider-fallback.ts
+++ b/src/agents/configured-provider-fallback.ts
@@ -22,8 +22,8 @@ export function resolveConfiguredProviderFallback(params: {
   const defaultProviderConfig = configuredProviders[params.defaultProvider];
   const defaultModel = params.defaultModel?.trim();
   const defaultProviderHasDefaultModel =
-    Boolean(defaultProviderConfig) &&
-    Boolean(defaultModel) &&
+    defaultProviderConfig !== undefined &&
+    defaultModel !== undefined &&
     Array.isArray(defaultProviderConfig.models) &&
     defaultProviderConfig.models.some((model) => model?.id === defaultModel);
   if (defaultProviderConfig && (!defaultModel || defaultProviderHasDefaultModel)) {

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -269,7 +269,7 @@ export class EmbeddedBlockChunker {
     }
 
     const nextStart =
-      absoluteBreakIdx < source.length && /\s/.test(source[absoluteBreakIdx])
+      absoluteBreakIdx < source.length && /\s/.test(source.charAt(absoluteBreakIdx))
         ? absoluteBreakIdx + 1
         : absoluteBreakIdx;
     return { start: skipLeadingNewlines(source, nextStart), reopenFence: undefined };
@@ -375,7 +375,7 @@ export class EmbeddedBlockChunker {
     }
 
     for (let i = window.length - 1; i >= minChars; i--) {
-      if (/\s/.test(window[i]) && isSafeFenceBreak(fenceSpans, offset + i)) {
+      if (/\s/.test(window.charAt(i)) && isSafeFenceBreak(fenceSpans, offset + i)) {
         return { index: i };
       }
     }

--- a/src/agents/embedded-agent-helpers/openai.ts
+++ b/src/agents/embedded-agent-helpers/openai.ts
@@ -454,10 +454,13 @@ export function downgradeOpenAIReasoningBlocks(
     type AssistantContentBlock = (typeof assistantMsg.content)[number];
 
     const nextContent: AssistantContentBlock[] = [];
-    for (let i = 0; i < assistantMsg.content.length; i++) {
-      const block = assistantMsg.content[i];
-      if (!block || typeof block !== "object") {
-        nextContent.push(block as AssistantContentBlock);
+    for (const [i, block] of assistantMsg.content.entries()) {
+      if (!block) {
+        changed = true;
+        continue;
+      }
+      if (typeof block !== "object") {
+        nextContent.push(block);
         continue;
       }
       const record = block as OpenAIThinkingBlock;

--- a/src/agents/embedded-agent-helpers/turns.ts
+++ b/src/agents/embedded-agent-helpers/turns.ts
@@ -172,9 +172,11 @@ function collectFutureToolResultIds(messages: AgentMessage[], startIndex: number
 function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[] {
   const result: AgentMessage[] = [];
 
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i];
-    if (!msg || typeof msg !== "object") {
+  for (const [i, msg] of messages.entries()) {
+    if (!msg) {
+      continue;
+    }
+    if (typeof msg !== "object") {
       result.push(msg);
       continue;
     }

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -406,7 +406,8 @@ function selectTopContributors(
   for (const contributor of contributors) {
     let insertAt = selected.length;
     for (let index = 0; index < selected.length; index += 1) {
-      if (contributor.chars > selected[index].chars) {
+      const selectedContributor = selected.at(index);
+      if (selectedContributor && contributor.chars > selectedContributor.chars) {
         insertAt = index;
         break;
       }

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -235,8 +235,7 @@ function buildSuccessorEntries(params: {
 
   const entryById = new Map<string, SessionEntry>();
   const originalIndexById = new Map<string, number>();
-  for (let index = 0; index < allEntries.length; index += 1) {
-    const entry = allEntries[index];
+  for (const [index, entry] of allEntries.entries()) {
     entryById.set(entry.id, entry);
     originalIndexById.set(entry.id, index);
   }

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -929,7 +929,9 @@ function normalizeDeepSeekV4CandidateId(modelId: unknown): string | undefined {
   if (typeof modelId !== "string") {
     return undefined;
   }
-  const withoutSuffix = modelId.trim().toLowerCase().split(":", 1)[0];
+  const normalized = modelId.trim().toLowerCase();
+  const suffixIndex = normalized.indexOf(":");
+  const withoutSuffix = suffixIndex === -1 ? normalized : normalized.slice(0, suffixIndex);
   return withoutSuffix.split("/").pop();
 }
 

--- a/src/agents/embedded-agent-runner/history.ts
+++ b/src/agents/embedded-agent-runner/history.ts
@@ -33,7 +33,7 @@ export function limitHistoryTurns(
   // that buildSessionContext places at index 0 to carry pre-compaction context.
   let conversationStart = 0;
   while (conversationStart < messages.length) {
-    const role = messages[conversationStart].role;
+    const role = messages.at(conversationStart)?.role;
     if (role === "user" || role === "assistant") {
       break;
     }
@@ -48,8 +48,8 @@ export function limitHistoryTurns(
   let userCount = 0;
   let lastUserIndex = tail.length;
 
-  for (let i = tail.length - 1; i >= 0; i--) {
-    if (tail[i].role === "user") {
+  for (const [i, message] of Array.from(tail.entries()).toReversed()) {
+    if (message.role === "user") {
       userCount++;
       if (userCount > limit) {
         return [...messages.slice(0, conversationStart), ...tail.slice(lastUserIndex)];

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -110,6 +110,7 @@ function classifyGenericExternalRunFailurePayload(params: {
     payload?.isReasoning === true ||
     typeof text !== "string" ||
     text.trim() !== GENERIC_EXTERNAL_RUN_FAILURE_TEXT ||
+    !payload ||
     hasNonTextVisiblePayloadContent(payload)
   ) {
     return null;

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.ts
@@ -288,11 +288,14 @@ function shouldCloseSmartQuotedValueAt(
 }
 
 function decodeSmartQuotedJsonStringEscapes(value: string): string {
-  return value.replace(/\\(?:(["\\/bfnrt])|u([0-9a-fA-F]{4}))/g, (_match, escaped, hex) =>
-    typeof hex === "string"
-      ? String.fromCharCode(Number.parseInt(hex, 16))
-      : TOOLCALL_REPAIR_JSON_STRING_ESCAPES[escaped as string],
-  );
+  return value.replace(/\\(?:(["\\/bfnrt])|u([0-9a-fA-F]{4}))/g, (match, escaped, hex) => {
+    if (typeof hex === "string") {
+      return String.fromCharCode(Number.parseInt(hex, 16));
+    }
+    return typeof escaped === "string"
+      ? (TOOLCALL_REPAIR_JSON_STRING_ESCAPES[escaped] ?? match)
+      : match;
+  });
 }
 
 function readSmartQuotedValue(

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
@@ -369,9 +369,12 @@ function sanitizeReplayToolCallInputs(
   const preservedThinkingToolCallIds = new Set<string>();
   const priorToolCallIds = new Set<string>();
 
-  for (let index = 0; index < messages.length; index += 1) {
-    const message = messages[index];
-    if (!message || typeof message !== "object" || message.role !== "assistant") {
+  for (const [index, message] of messages.entries()) {
+    if (!message) {
+      changed = true;
+      continue;
+    }
+    if (typeof message !== "object" || message.role !== "assistant") {
       out.push(message);
       continue;
     }
@@ -507,9 +510,12 @@ function sanitizeAnthropicReplayToolResults(
   const disallowEmbeddedUserToolResultsForSignedThinkingReplay =
     options?.disallowEmbeddedUserToolResultsForSignedThinkingReplay === true;
 
-  for (let index = 0; index < messages.length; index += 1) {
-    const message = messages[index];
-    if (!message || typeof message !== "object" || message.role !== "user") {
+  for (const [index, message] of messages.entries()) {
+    if (!message) {
+      changed = true;
+      continue;
+    }
+    if (typeof message !== "object" || message.role !== "user") {
       out.push(message);
       continue;
     }

--- a/src/agents/embedded-agent-runner/run/history-image-prune.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.ts
@@ -61,7 +61,7 @@ function resolvePruneBeforeIndex(messages: AgentMessage[]): number {
   if (completedTurnStarts.length <= PRESERVE_RECENT_COMPLETED_TURNS) {
     return -1;
   }
-  return completedTurnStarts[completedTurnStarts.length - PRESERVE_RECENT_COMPLETED_TURNS];
+  return completedTurnStarts.at(-PRESERVE_RECENT_COMPLETED_TURNS) ?? -1;
 }
 
 function pruneHistoryMediaReferenceText(text: string): string {

--- a/src/agents/embedded-agent-runner/run/images.ts
+++ b/src/agents/embedded-agent-runner/run/images.ts
@@ -146,9 +146,7 @@ export function mergePromptAttachmentImages(params: {
         promptImages.push(image);
       }
     }
-    while (inlineIndex < existingImages.length) {
-      promptImages.push(existingImages[inlineIndex++]);
-    }
+    promptImages.push(...existingImages.slice(inlineIndex));
     while (offloadedIndex < offloadedImages.length) {
       const image = offloadedImages[offloadedIndex++];
       if (image) {
@@ -251,9 +249,13 @@ function extractTrailingAttachmentMediaUris(prompt: string, count: number): stri
     uris.push(match[1]);
   }
   for (let left = 0, right = uris.length - 1; left < right; left += 1, right -= 1) {
-    const uri = uris[left];
-    uris[left] = uris[right];
-    uris[right] = uri;
+    const leftUri = uris.at(left);
+    const rightUri = uris.at(right);
+    if (leftUri === undefined || rightUri === undefined) {
+      break;
+    }
+    uris[left] = rightUri;
+    uris[right] = leftUri;
   }
   return uris;
 }
@@ -374,6 +376,9 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
   let match: RegExpExecArray | null;
   while ((match = MEDIA_ATTACHED_PATTERN.exec(prompt)) !== null) {
     const content = match[1];
+    if (content === undefined) {
+      continue;
+    }
 
     // Skip "[media attached: N files]" header lines
     if (/^\d+\s+files?$/i.test(content.trim())) {
@@ -384,8 +389,9 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     // This must be tested before the extension-based path regex because the
     // URI has no file extension suffix in its base form.
     const mediaUriMatch = content.match(MEDIA_URI_REGEX);
-    if (mediaUriMatch && !mediaUriMatch[1].includes("\0")) {
-      const uri = `media://inbound/${mediaUriMatch[1]}`;
+    const mediaId = mediaUriMatch?.at(1);
+    if (mediaId && !mediaId.includes("\0")) {
+      const uri = `media://inbound/${mediaId}`;
       const dedupeKey = normalizeRefForDedupe(uri);
       if (!seen.has(dedupeKey)) {
         seen.add(dedupeKey);

--- a/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/tool-media-payloads.ts
@@ -34,7 +34,10 @@ export function mergeAttemptToolMediaPayloads(params: {
   const payloads = params.payloads?.length ? [...params.payloads] : [];
   const payloadIndex = payloads.findIndex((payload) => !payload.isReasoning);
   if (payloadIndex >= 0) {
-    const payload = payloads[payloadIndex];
+    const payload = payloads.at(payloadIndex);
+    if (!payload) {
+      return payloads;
+    }
     if (
       params.sourceReplyDeliveryMode === "message_tool_only" &&
       getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -261,7 +261,8 @@ export function stripInvalidThinkingSignatures(
   let latestAssistantIndex = -1;
   if (preserveLatestAssistant) {
     for (let i = messages.length - 1; i >= 0; i -= 1) {
-      if (isAssistantMessageWithContent(messages[i])) {
+      const message = messages.at(i);
+      if (message && isAssistantMessageWithContent(message)) {
         latestAssistantIndex = i;
         break;
       }
@@ -271,8 +272,7 @@ export function stripInvalidThinkingSignatures(
   let touched = false;
   const out: AgentMessage[] = [];
 
-  for (let i = 0; i < messages.length; i += 1) {
-    const message = messages[i];
+  for (const [i, message] of messages.entries()) {
     if (!isAssistantMessageWithContent(message)) {
       out.push(message);
       continue;
@@ -324,7 +324,8 @@ export function stripInvalidThinkingSignatures(
 export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
   let latestAssistantIndex = -1;
   for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (isAssistantMessageWithContent(messages[i])) {
+    const message = messages.at(i);
+    if (message && isAssistantMessageWithContent(message)) {
       latestAssistantIndex = i;
       break;
     }
@@ -332,8 +333,7 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
 
   let touched = false;
   const out: AgentMessage[] = [];
-  for (let i = 0; i < messages.length; i += 1) {
-    const msg = messages[i];
+  for (const [i, msg] of messages.entries()) {
     if (!isAssistantMessageWithContent(msg)) {
       out.push(msg);
       continue;
@@ -367,8 +367,9 @@ function shouldPreserveCurrentToolTurnReasoning(
   index: number,
   latestUserIndex: number,
 ): boolean {
-  const message = messages[index];
+  const message = messages.at(index);
   if (
+    !message ||
     index < latestUserIndex ||
     !isAssistantMessageWithContent(message) ||
     !hasAssistantToolCall(message)
@@ -377,7 +378,7 @@ function shouldPreserveCurrentToolTurnReasoning(
   }
 
   for (let i = index - 1; i >= 0; i -= 1) {
-    const role = (messages[i] as { role?: unknown })?.role;
+    const role = messages.at(i)?.role;
     if (role === "user") {
       break;
     }
@@ -387,9 +388,9 @@ function shouldPreserveCurrentToolTurnReasoning(
   }
 
   for (let i = index + 1; i < messages.length; i += 1) {
-    const next = messages[i];
-    const role = (next as { role?: unknown })?.role;
-    if (isToolResultMessage(next)) {
+    const next = messages.at(i);
+    const role = next?.role;
+    if (next && isToolResultMessage(next)) {
       return true;
     }
     if (role === "user") {
@@ -403,7 +404,8 @@ function shouldPreserveCurrentToolTurnReasoning(
 export function shouldPreserveLatestAssistantThinking(messages: AgentMessage[]): boolean {
   let latestAssistantIndex = -1;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (isAssistantMessageWithContent(messages[index])) {
+    const message = messages.at(index);
+    if (message && isAssistantMessageWithContent(message)) {
       latestAssistantIndex = index;
       break;
     }
@@ -417,7 +419,7 @@ export function shouldPreserveLatestAssistantThinking(messages: AgentMessage[]):
 
   let latestUserIndex = -1;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if ((messages[index] as { role?: unknown })?.role === "user") {
+    if (messages.at(index)?.role === "user") {
       latestUserIndex = index;
       break;
     }
@@ -457,7 +459,7 @@ function stripAllThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
 export function dropReasoningFromHistory(messages: AgentMessage[]): AgentMessage[] {
   let latestUserIndex = -1;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if ((messages[index] as { role?: unknown })?.role === "user") {
+    if (messages.at(index)?.role === "user") {
       latestUserIndex = index;
       break;
     }
@@ -465,8 +467,7 @@ export function dropReasoningFromHistory(messages: AgentMessage[]): AgentMessage
 
   let touched = false;
   const out: AgentMessage[] = [];
-  for (let index = 0; index < messages.length; index += 1) {
-    const message = messages[index];
+  for (const [index, message] of messages.entries()) {
     if (!isAssistantMessageWithContent(message)) {
       out.push(message);
       continue;

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -42,8 +42,7 @@ function findTranscriptRewriteMatches(
   const matchedIndices: number[] = [];
   let bytesFreed = 0;
 
-  for (let index = 0; index < branch.length; index++) {
-    const entry = branch[index];
+  for (const [index, entry] of branch.entries()) {
     if (entry.type !== "message") {
       continue;
     }
@@ -221,11 +220,11 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
     };
   }
 
-  const firstMatchedEntry = branch[matchedIndices[0]] as
-    | Extract<SessionBranchEntry, { type: "message" }>
-    | undefined;
+  const firstMatchedIndex = matchedIndices.at(0);
+  const firstMatchedEntry =
+    firstMatchedIndex === undefined ? undefined : branch.at(firstMatchedIndex);
   // matchedIndices only contains indices of branch "message" entries.
-  if (!firstMatchedEntry) {
+  if (!firstMatchedEntry || firstMatchedEntry.type !== "message") {
     return {
       changed: false,
       bytesFreed: 0,
@@ -244,8 +243,7 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
   // re-running persistence hooks or size truncation on replayed messages.
   const appendMessage = getRawSessionAppendMessage(params.sessionManager);
   const rewrittenEntryIds = new Map<string, string>();
-  for (let index = matchedIndices[0]; index < branch.length; index++) {
-    const entry = branch[index];
+  for (const entry of branch.slice(firstMatchedIndex)) {
     const replacement = entry.type === "message" ? replacementsById.get(entry.id) : undefined;
     const newEntryId =
       replacement === undefined
@@ -360,10 +358,10 @@ export function rewriteTranscriptEntriesInState(params: {
     };
   }
 
-  const firstMatchedEntry = branch[matchedIndices[0]] as
-    | Extract<SessionBranchEntry, { type: "message" }>
-    | undefined;
-  if (!firstMatchedEntry) {
+  const firstMatchedIndex = matchedIndices.at(0);
+  const firstMatchedEntry =
+    firstMatchedIndex === undefined ? undefined : branch.at(firstMatchedIndex);
+  if (!firstMatchedEntry || firstMatchedEntry.type !== "message") {
     return {
       changed: false,
       bytesFreed: 0,
@@ -376,7 +374,7 @@ export function rewriteTranscriptEntriesInState(params: {
   if (params.allowedRewriteSuffixEntryIds) {
     const allowedIds = new Set(params.allowedRewriteSuffixEntryIds);
     const hasUnexpectedSuffixEntry = branch
-      .slice(matchedIndices[0])
+      .slice(firstMatchedIndex)
       .some((entry) => typeof entry.id === "string" && !allowedIds.has(entry.id));
     if (hasUnexpectedSuffixEntry) {
       return {
@@ -397,8 +395,7 @@ export function rewriteTranscriptEntriesInState(params: {
 
   const appendedEntries: TranscriptPersistedEntry[] = [];
   const rewrittenEntryIds = new Map<string, string>();
-  for (let index = matchedIndices[0]; index < branch.length; index++) {
-    const entry = branch[index];
+  for (const entry of branch.slice(firstMatchedIndex)) {
     const replacement = entry.type === "message" ? replacementsById.get(entry.id) : undefined;
     const newEntry =
       replacement === undefined

--- a/src/agents/embedded-agent-utils.ts
+++ b/src/agents/embedded-agent-utils.ts
@@ -384,8 +384,11 @@ export function extractThinkingFromTaggedStream(text: string): string {
     return "";
   }
   const closeMatches = [...text.matchAll(THINKING_TAG_CLOSE_GLOBAL_RE)];
-  const lastOpen = openMatches[openMatches.length - 1];
-  const lastClose = closeMatches[closeMatches.length - 1];
+  const lastOpen = openMatches.at(-1);
+  const lastClose = closeMatches.at(-1);
+  if (!lastOpen) {
+    return "";
+  }
   if (lastClose && (lastClose.index ?? -1) > (lastOpen.index ?? -1)) {
     return closed;
   }

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -1770,7 +1770,10 @@ function updateJsonHash(hash: ReturnType<typeof createHash>, value: JsonValue): 
   for (const key of keys) {
     hash.update(JSON.stringify(key));
     hash.update(":");
-    updateJsonHash(hash, value[key]);
+    const item = value[key];
+    if (item !== undefined) {
+      updateJsonHash(hash, item);
+    }
     hash.update(",");
   }
   if (truncated) {
@@ -1784,7 +1787,10 @@ function updateJsonHash(hash: ReturnType<typeof createHash>, value: JsonValue): 
       }
       hash.update(JSON.stringify(key));
       hash.update(":");
-      updateJsonHash(hash, value[key]);
+      const item = value[key];
+      if (item !== undefined) {
+        updateJsonHash(hash, item);
+      }
       hash.update(",");
     }
   }
@@ -1909,7 +1915,10 @@ function snapshotJsonValue(value: JsonValue, state: { remainingStringLength: num
   const snapshot: Record<string, JsonValue> = {};
   const keys = Object.keys(value);
   for (const key of keys.slice(0, MAX_NATIVE_HOOK_RELAY_HISTORY_OBJECT_KEYS)) {
-    snapshot[snapshotString(key, state)] = snapshotJsonValue(value[key], state);
+    const item = value[key];
+    if (item !== undefined) {
+      snapshot[snapshotString(key, state)] = snapshotJsonValue(item, state);
+    }
   }
   if (keys.length > MAX_NATIVE_HOOK_RELAY_HISTORY_OBJECT_KEYS) {
     snapshot["[truncated]"] = keys.length - MAX_NATIVE_HOOK_RELAY_HISTORY_OBJECT_KEYS;

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -191,6 +191,9 @@ export function mergeIdentityMarkdownContent(
 
     if (matchingIndexes.length > 0) {
       const [firstIndex, ...duplicateIndexes] = matchingIndexes;
+      if (firstIndex === undefined) {
+        continue;
+      }
       nextLines[firstIndex] = buildIdentityLine(label, value);
       for (const duplicateIndex of duplicateIndexes.toReversed()) {
         nextLines.splice(duplicateIndex, 1);

--- a/src/agents/live-cache-regression-runner.ts
+++ b/src/agents/live-cache-regression-runner.ts
@@ -127,7 +127,10 @@ async function resolveLiveCacheProviderPool(params: {
     } else {
       params.regressions.push(warning);
     }
-    params.summary[error.provider].skipped = true;
+    const providerSummary = params.summary[error.provider];
+    if (providerSummary) {
+      providerSummary.skipped = true;
+    }
     logLiveCache(warning);
     return undefined;
   }
@@ -762,6 +765,11 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
     anthropic: {},
     openai: {},
   };
+  const openaiSummary = summary.openai;
+  const anthropicSummary = summary.anthropic;
+  if (!openaiSummary || !anthropicSummary) {
+    throw new Error("Live cache summary providers were not initialized");
+  }
   const openai = await resolveLiveCacheProviderPool({
     config: {
       provider: "openai",
@@ -801,7 +809,7 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
       logLiveCache(
         `openai ${lane} best ${formatUsage(openaiResult.best?.usage ?? {})} rate=${openaiResult.best?.hitRate.toFixed(3) ?? "0.000"}`,
       );
-      summary.openai[lane] = {
+      openaiSummary[lane] = {
         best: openaiResult.best?.usage,
         hitRate: openaiResult.best?.hitRate,
         attempts: openaiAttempt.attempts,
@@ -809,11 +817,11 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
       };
       appendBaselineFindings({ regressions, warnings }, openaiAttempt.findings);
     } else {
-      summary.openai[lane] = { skipped: true };
+      openaiSummary[lane] = { skipped: true };
     }
 
     if (!anthropic) {
-      summary.anthropic[lane] = { skipped: true };
+      anthropicSummary[lane] = { skipped: true };
       continue;
     }
     const { attempt: anthropicAttempt } = await runAnthropicCacheLane({
@@ -825,7 +833,7 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
       warnings,
     });
     if (!anthropicAttempt) {
-      summary.anthropic[lane] = { skipped: true };
+      anthropicSummary[lane] = { skipped: true };
       continue;
     }
     const anthropicResult = anthropicAttempt.result;
@@ -835,7 +843,7 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
     logLiveCache(
       `anthropic ${lane} best ${formatUsage(anthropicResult.best?.usage ?? {})} rate=${anthropicResult.best?.hitRate.toFixed(3) ?? "0.000"}`,
     );
-    summary.anthropic[lane] = {
+    anthropicSummary[lane] = {
       best: anthropicResult.best?.usage,
       hitRate: anthropicResult.best?.hitRate,
       attempts: anthropicAttempt.attempts,
@@ -853,7 +861,7 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
     : undefined;
   if (disabled) {
     logLiveCache(`anthropic disabled ${formatUsage(disabled.disabled?.usage ?? {})}`);
-    summary.anthropic.disabled = {
+    anthropicSummary.disabled = {
       disabled: disabled.disabled?.usage,
     };
     assertAgainstBaseline({
@@ -864,7 +872,7 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
       warnings,
     });
   } else {
-    summary.anthropic.disabled = { skipped: true };
+    anthropicSummary.disabled = { skipped: true };
   }
 
   logLiveCache(`cache regression summary ${JSON.stringify(summary)}`);

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -671,7 +671,9 @@ function isPrivateIpv4Host(host: string): boolean {
     return false;
   }
   const [a, b] = octets;
-  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
+  return (
+    a === 10 || (a === 172 && b !== undefined && b >= 16 && b <= 31) || (a === 192 && b === 168)
+  );
 }
 
 function hasExplicitProviderApiKeyConfig(providerConfig: ModelProviderConfig): boolean {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -221,7 +221,10 @@ function mergeCatalogEntries(models: ModelCatalogEntry[], entries: ModelCatalogE
       indexByKey.set(key, models.length - 1);
       continue;
     }
-    models[existingIndex] = overlayCatalogMetadata(models[existingIndex], entry);
+    const existing = models.at(existingIndex);
+    if (existing) {
+      models[existingIndex] = overlayCatalogMetadata(existing, entry);
+    }
   }
 }
 

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -704,10 +704,9 @@ function findLiveSessionModelSwitchRedirectIndex(params: {
   currentIndex: number;
 }): number | null {
   const targetKey = modelKey(params.error.provider, params.error.model);
-  for (let i = params.currentIndex + 1; i < params.candidates.length; i += 1) {
-    const candidate = params.candidates[i];
+  for (const [offset, candidate] of params.candidates.slice(params.currentIndex + 1).entries()) {
     if (modelKey(candidate.provider, candidate.model) === targetKey) {
-      return i;
+      return params.currentIndex + 1 + offset;
     }
   }
   return null;
@@ -1503,7 +1502,10 @@ async function runWithModelFallbackInternal<T>(
   const requestedCandidate = candidates[0];
 
   for (let i = 0; i < candidates.length; i += 1) {
-    const candidate = candidates[i];
+    const candidate = candidates.at(i);
+    if (!candidate) {
+      throw new Error(`Missing model fallback candidate at index ${i}`);
+    }
     const candidateHarnessAuth = await resolveModelFallbackCandidateHarnessAuthPrecheck({
       cfg: params.cfg,
       agentId: params.agentId,
@@ -2032,8 +2034,7 @@ export async function runWithImageModelFallback<T>(params: {
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
 
-  for (let i = 0; i < candidates.length; i += 1) {
-    const candidate = candidates[i];
+  for (const [i, candidate] of candidates.entries()) {
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -429,7 +429,11 @@ async function mapWithConcurrency<T, R>(
       if (current >= items.length) {
         return;
       }
-      results[current] = await fn(items[current], current);
+      const item = items.at(current);
+      if (item === undefined) {
+        return;
+      }
+      results[current] = await fn(item, current);
       completed += 1;
       opts?.onProgress?.(completed, items.length);
     }

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -78,10 +78,10 @@ function normalizeProviderModelsForConfig(
       const existingIndex = seenById.get(id);
       if (existingIndex !== undefined) {
         mutated = true;
-        nextModels[existingIndex] = mergeNormalizedProviderModel(
-          nextModels[existingIndex],
-          normalizedModel,
-        );
+        const existing = nextModels.at(existingIndex);
+        if (existing) {
+          nextModels[existingIndex] = mergeNormalizedProviderModel(existing, normalizedModel);
+        }
         continue;
       }
       seenById.set(id, nextModels.length);

--- a/src/agents/modes/interactive/components/diff.ts
+++ b/src/agents/modes/interactive/components/diff.ts
@@ -15,7 +15,10 @@ function parseDiffLine(line: string): { prefix: string; lineNum: string; content
   if (!match) {
     return null;
   }
-  return { prefix: match[1], lineNum: match[2], content: match[3] };
+  const [, prefix, lineNum, content] = match;
+  return prefix !== undefined && lineNum !== undefined && content !== undefined
+    ? { prefix, lineNum, content }
+    : null;
 }
 
 /**
@@ -92,7 +95,10 @@ export function renderDiff(diffText: string, _options: RenderDiffOptions = {}): 
 
   let i = 0;
   while (i < lines.length) {
-    const line = lines[i];
+    const line = lines.at(i);
+    if (line === undefined) {
+      break;
+    }
     const parsed = parseDiffLine(line);
 
     if (!parsed) {
@@ -105,7 +111,8 @@ export function renderDiff(diffText: string, _options: RenderDiffOptions = {}): 
       // Collect consecutive removed lines
       const removedLines: { lineNum: string; content: string }[] = [];
       while (i < lines.length) {
-        const p = parseDiffLine(lines[i]);
+        const currentLine = lines.at(i);
+        const p = currentLine === undefined ? null : parseDiffLine(currentLine);
         if (!p || p.prefix !== "-") {
           break;
         }
@@ -116,7 +123,8 @@ export function renderDiff(diffText: string, _options: RenderDiffOptions = {}): 
       // Collect consecutive added lines
       const addedLines: { lineNum: string; content: string }[] = [];
       while (i < lines.length) {
-        const p = parseDiffLine(lines[i]);
+        const currentLine = lines.at(i);
+        const p = currentLine === undefined ? null : parseDiffLine(currentLine);
         if (!p || p.prefix !== "+") {
           break;
         }
@@ -129,6 +137,9 @@ export function renderDiff(diffText: string, _options: RenderDiffOptions = {}): 
       if (removedLines.length === 1 && addedLines.length === 1) {
         const removed = removedLines[0];
         const added = addedLines[0];
+        if (!removed || !added) {
+          continue;
+        }
 
         const { removedLine, addedLine } = renderIntraLineDiff(
           replaceTabs(removed.content),

--- a/src/agents/modes/interactive/theme/theme.ts
+++ b/src/agents/modes/interactive/theme/theme.ts
@@ -186,8 +186,8 @@ const GRAY_VALUES = Array.from({ length: 24 }, (_, i) => 8 + i * 10);
 function findClosestCubeIndex(value: number): number {
   let minDist = Infinity;
   let minIdx = 0;
-  for (let i = 0; i < CUBE_VALUES.length; i++) {
-    const dist = Math.abs(value - CUBE_VALUES[i]);
+  for (const [i, cubeValue] of CUBE_VALUES.entries()) {
+    const dist = Math.abs(value - cubeValue);
     if (dist < minDist) {
       minDist = dist;
       minIdx = i;
@@ -199,8 +199,8 @@ function findClosestCubeIndex(value: number): number {
 function findClosestGrayIndex(gray: number): number {
   let minDist = Infinity;
   let minIdx = 0;
-  for (let i = 0; i < GRAY_VALUES.length; i++) {
-    const dist = Math.abs(gray - GRAY_VALUES[i]);
+  for (const [i, grayValue] of GRAY_VALUES.entries()) {
+    const dist = Math.abs(gray - grayValue);
     if (dist < minDist) {
       minDist = dist;
       minIdx = i;
@@ -232,6 +232,9 @@ function rgbTo256(r: number, g: number, b: number): number {
   const cubeR = CUBE_VALUES[rIdx];
   const cubeG = CUBE_VALUES[gIdx];
   const cubeB = CUBE_VALUES[bIdx];
+  if (cubeR === undefined || cubeG === undefined || cubeB === undefined) {
+    throw new Error("Invalid 256-color cube index");
+  }
   const cubeIndex = 16 + 36 * rIdx + 6 * gIdx + bIdx;
   const cubeDist = colorDistance(r, g, b, cubeR, cubeG, cubeB);
 
@@ -239,6 +242,9 @@ function rgbTo256(r: number, g: number, b: number): number {
   const gray = Math.round(0.299 * r + 0.587 * g + 0.114 * b);
   const grayIdx = findClosestGrayIndex(gray);
   const grayValue = GRAY_VALUES[grayIdx];
+  if (grayValue === undefined) {
+    throw new Error("Invalid 256-color grayscale index");
+  }
   const grayIndex = 232 + grayIdx;
   const grayDist = colorDistance(r, g, b, grayValue, grayValue, grayValue);
 
@@ -313,7 +319,11 @@ function resolveVarRefs(
     throw new Error(`Variable reference not found: ${value}`);
   }
   visited.add(value);
-  return resolveVarRefs(vars[value], vars, visited);
+  const resolved = vars[value];
+  if (resolved === undefined) {
+    throw new Error(`Variable reference not found: ${value}`);
+  }
+  return resolveVarRefs(resolved, vars, visited);
 }
 
 function resolveThemeColors<T extends Record<string, ColorValue>>(
@@ -515,7 +525,10 @@ function parseThemeJsonContent(label: string, content: string): ThemeJson {
 function loadThemeJson(name: string): ThemeJson {
   const builtinThemes = getBuiltinThemes();
   if (name in builtinThemes) {
-    return builtinThemes[name];
+    const builtinTheme = builtinThemes[name];
+    if (builtinTheme) {
+      return builtinTheme;
+    }
   }
   const registeredTheme = registeredThemes.get(name);
   if (registeredTheme?.sourcePath) {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1147,7 +1147,9 @@ function convertResponsesMessages(
     if (!id.includes("|")) {
       return normalizeIdPart(id);
     }
-    const [callId, itemId] = id.split("|");
+    const separatorIndex = id.indexOf("|");
+    const callId = id.slice(0, separatorIndex);
+    const itemId = id.slice(separatorIndex + 1);
     const normalizedCallId = normalizeIdPart(callId);
     const isForeignToolCall = source.provider !== model.provider || source.api !== model.api;
     let normalizedItemId = isForeignToolCall
@@ -1278,7 +1280,9 @@ function convertResponsesMessages(
           output.push(messageItem as ResponseInputItem);
           previousReplayItemWasReasoning = false;
         } else if (block.type === "toolCall") {
-          const [callId, itemIdRaw] = block.id.split("|");
+          const separatorIndex = block.id.indexOf("|");
+          const callId = separatorIndex === -1 ? block.id : block.id.slice(0, separatorIndex);
+          const itemIdRaw = separatorIndex === -1 ? undefined : block.id.slice(separatorIndex + 1);
           const itemId =
             shouldReplayResponsesItemIds && !(isDifferentModel && itemIdRaw?.startsWith("fc_"))
               ? itemIdRaw
@@ -1305,7 +1309,9 @@ function convertResponsesMessages(
       const hasText = sanitizedTextResult.trim().length > 0;
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const hasImages = msg.content.some((item) => item.type === "image");
-      const [callId] = msg.toolCallId.split("|");
+      const separatorIndex = msg.toolCallId.indexOf("|");
+      const callId =
+        separatorIndex === -1 ? msg.toolCallId : msg.toolCallId.slice(0, separatorIndex);
       messages.push({
         type: "function_call_output",
         call_id: callId,
@@ -1538,13 +1544,16 @@ async function processResponsesStream(
     const compatible = uniqueCandidates.filter((state) => !identitiesConflict(state, identity));
     const matches = compatible.filter((state) => sharesIdentity(state, identity));
     if (matches.length === 1) {
-      return adoptToolCallIdentity(matches[0], identity);
+      const match = matches.at(0);
+      return match ? adoptToolCallIdentity(match, identity) : undefined;
     }
     // Only a sole active call may adopt an identity it did not already know.
     // Parallel calls require a positive match so missing indices stay fail-closed.
-    return uniqueCandidates.length === 1 && compatible.length === 1 && matches.length === 0
-      ? adoptToolCallIdentity(compatible[0], identity)
-      : undefined;
+    if (uniqueCandidates.length !== 1 || compatible.length !== 1 || matches.length !== 0) {
+      return undefined;
+    }
+    const candidate = compatible.at(0);
+    return candidate ? adoptToolCallIdentity(candidate, identity) : undefined;
   };
   const resolveStreamingToolCall = (
     event: Record<string, unknown>,

--- a/src/agents/payload-redaction.ts
+++ b/src/agents/payload-redaction.ts
@@ -110,9 +110,13 @@ function visitDiagnosticPayload(
     }
 
     if (shouldRedactImageData(record)) {
+      const imageData = record.data;
+      if (typeof imageData !== "string") {
+        return out;
+      }
       out.data = REDACTED_IMAGE_DATA;
-      out.bytes = estimateBase64DecodedBytes(record.data);
-      out.sha256 = digestBase64Payload(record.data);
+      out.bytes = estimateBase64DecodedBytes(imageData);
+      out.sha256 = digestBase64Payload(imageData);
     }
     return out;
   };

--- a/src/agents/plugin-model-catalog.ts
+++ b/src/agents/plugin-model-catalog.ts
@@ -56,6 +56,9 @@ export function decodePluginModelCatalogRelativePathPluginId(
     return undefined;
   }
   const encodedPluginId = relativePath.split(/[\\/]/)[1];
+  if (!encodedPluginId) {
+    return undefined;
+  }
   try {
     return decodeURIComponent(encodedPluginId);
   } catch {

--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -537,7 +537,11 @@ function appendLocalServiceOutputTail(
     return redacted;
   }
   let start = bytes.byteLength - LOCAL_SERVICE_OUTPUT_TAIL_MAX_BYTES;
-  while (start < bytes.byteLength && (bytes[start] & 0xc0) === 0x80) {
+  while (start < bytes.byteLength) {
+    const byte = bytes.at(start);
+    if (byte === undefined || (byte & 0xc0) !== 0x80) {
+      break;
+    }
     start += 1;
   }
   return bytes.subarray(start).toString("utf8");

--- a/src/agents/pty-keys.ts
+++ b/src/agents/pty-keys.ts
@@ -188,7 +188,7 @@ function encodeKeyToken(
   }
 
   if (token.length === 2 && token.startsWith("^")) {
-    const ctrl = toCtrlChar(token[1]);
+    const ctrl = toCtrlChar(token.charAt(1));
     if (ctrl) {
       return ctrl;
     }

--- a/src/agents/sandbox/ssh.ts
+++ b/src/agents/sandbox/ssh.ts
@@ -115,7 +115,7 @@ function assertValidExecRemoteCommand(command: string): void {
     if (!frame) {
       throw new Error("Malformed SSH/OpenShell exec command: parser state underflow.");
     }
-    const char = command[index];
+    const char = command.charAt(index);
 
     if (frame.escaping) {
       frame.escaping = false;
@@ -250,12 +250,15 @@ function assertValidExecRemoteCommand(command: string): void {
     throw new Error("Malformed SSH/OpenShell exec command: trailing backslash escape.");
   }
   if (pendingHeredocs.length > 0) {
+    const pending = pendingHeredocs.at(0);
+    if (!pending) {
+      throw new Error("Malformed SSH/OpenShell exec command: parser state underflow.");
+    }
     throw new Error(
-      `Malformed SSH/OpenShell exec command: unterminated here-doc ${pendingHeredocs[0].delimiter}.`,
+      `Malformed SSH/OpenShell exec command: unterminated here-doc ${pending.delimiter}.`,
     );
   }
-  for (let index = frames.length - 1; index >= 0; index -= 1) {
-    const frame = frames[index];
+  for (const frame of frames.toReversed()) {
     if (frame.quote === "single") {
       throw new Error("Malformed SSH/OpenShell exec command: unclosed single quote.");
     }
@@ -389,10 +392,11 @@ function readPlaceholderToken(command: string, index: number): string | null {
 
 function hasRedirectionTargetAfter(command: string, index: number): boolean {
   let cursor = index;
-  while (command[cursor] === " " || command[cursor] === "\t") {
+  while (command.charAt(cursor) === " " || command.charAt(cursor) === "\t") {
     cursor += 1;
   }
-  return command[cursor] !== undefined && !/[;&|()<>\r\n]/.test(command[cursor]);
+  const next = command.charAt(cursor);
+  return next !== "" && !/[;&|()<>\r\n]/.test(next);
 }
 
 function isLikelyGeneratedWorkflowPlaceholder(command: string, index: number): boolean {
@@ -672,9 +676,13 @@ export async function runSshSandboxCommand(
     remoteCommand: params.remoteCommand,
     tty: params.tty,
   });
+  const [executable, ...args] = argv;
+  if (!executable) {
+    throw new Error("SSH command argv is empty");
+  }
   const sshEnv = sanitizeEnvVars(process.env).allowed;
   return await new Promise<SandboxBackendCommandResult>((resolve, reject) => {
-    const child = spawn(argv[0], argv.slice(1), {
+    const child = spawn(executable, args, {
       stdio: ["pipe", "pipe", "pipe"],
       env: sshEnv,
       signal: params.signal,
@@ -798,13 +806,17 @@ export async function uploadDirectoryToSshTarget(params: {
     session: params.session,
     remoteCommand,
   });
+  const [sshExecutable, ...sshArgs] = sshArgv;
+  if (!sshExecutable) {
+    throw new Error("SSH command argv is empty");
+  }
   const sshEnv = sanitizeEnvVars(process.env).allowed;
   await new Promise<void>((resolve, reject) => {
     const tar = spawn("tar", ["-C", params.localDir, "-cf", "-", "."], {
       stdio: ["ignore", "pipe", "pipe"],
       signal: params.signal,
     });
-    const ssh = spawn(sshArgv[0], sshArgv.slice(1), {
+    const ssh = spawn(sshExecutable, sshArgs, {
       stdio: ["pipe", "pipe", "pipe"],
       env: sshEnv,
       signal: params.signal,

--- a/src/agents/sandbox/test-args.ts
+++ b/src/agents/sandbox/test-args.ts
@@ -14,9 +14,10 @@ export function findDockerArgsCall(calls: unknown[][], command: string): string[
 /** Collects every value passed after a repeated Docker flag. */
 export function collectDockerFlagValues(args: string[], flag: string): string[] {
   const values: string[] = [];
-  for (let i = 0; i < args.length; i += 1) {
-    if (args[i] === flag && typeof args[i + 1] === "string") {
-      values.push(args[i + 1]);
+  for (const [i, arg] of args.entries()) {
+    const value = args.at(i + 1);
+    if (arg === flag && value !== undefined) {
+      values.push(value);
     }
   }
   return values;

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -75,8 +75,17 @@ function isExpectedCompactionAppend(entryId: string, appendedText: string): bool
     return false;
   }
   try {
-    const entry = JSON.parse(lines[0]) as { type?: unknown; id?: unknown };
-    return entry.type === "compaction" && entry.id === entryId;
+    const line = lines.at(0);
+    if (!line) {
+      return false;
+    }
+    const entry: unknown = JSON.parse(line);
+    return (
+      typeof entry === "object" &&
+      entry !== null &&
+      Reflect.get(entry, "type") === "compaction" &&
+      Reflect.get(entry, "id") === entryId
+    );
   } catch {
     return false;
   }
@@ -768,7 +777,11 @@ export function installSessionToolResultGuard(
         }
         return undefined;
       }
-      nextMessage = sanitized[0];
+      const sanitizedMessage = sanitized.at(0);
+      if (!sanitizedMessage) {
+        return undefined;
+      }
+      nextMessage = sanitizedMessage;
     }
     const nextRole = (nextMessage as { role?: unknown }).role;
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -269,6 +269,9 @@ function normalizeLegacyToolResultId(
     return message;
   }
   const [toolCall] = toolCalls;
+  if (!toolCall) {
+    return message;
+  }
   const toolResultName = normalizeOptionalString((message as { toolName?: unknown }).toolName);
   const toolCallName = normalizeOptionalString(toolCall.name);
   if (toolResultName && toolCallName && toolResultName !== toolCallName) {
@@ -365,10 +368,9 @@ function repairToolCallInputs(
   const preservedThinkingToolCallIds = new Set<string>();
   const priorToolCallIds = new Set<string>();
 
-  for (let index = 0; index < messages.length; index += 1) {
-    const msg = messages[index];
+  for (const [index, msg] of messages.entries()) {
     if (!msg || typeof msg !== "object") {
-      out.push(msg);
+      changed = true;
       continue;
     }
 
@@ -633,9 +635,9 @@ export function repairToolUseResultPairing(
   };
 
   for (let i = 0; i < messages.length; i += 1) {
-    const msg = messages[i];
+    const msg = messages.at(i);
     if (!msg || typeof msg !== "object") {
-      out.push(msg);
+      changed = true;
       continue;
     }
 
@@ -675,9 +677,9 @@ export function repairToolUseResultPairing(
 
     let j = i + 1;
     for (; j < messages.length; j += 1) {
-      const next = messages[j];
+      const next = messages.at(j);
       if (!next || typeof next !== "object") {
-        remainder.push(next);
+        changed = true;
         continue;
       }
 

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -177,11 +177,15 @@ export function parseSkillBlock(text: string): ParsedSkillBlock | null {
   if (!match) {
     return null;
   }
+  const [, name, location, content, userMessage] = match;
+  if (name === undefined || location === undefined || content === undefined) {
+    return null;
+  }
   return {
-    name: match[1],
-    location: match[2],
-    content: match[3],
-    userMessage: match[4]?.trim() || undefined,
+    name,
+    location,
+    content,
+    userMessage: userMessage?.trim() || undefined,
   };
 }
 
@@ -682,8 +686,7 @@ export class AgentSession {
       return false;
     }
 
-    for (let i = event.messages.length - 1; i >= 0; i--) {
-      const message = event.messages[i];
+    for (const message of event.messages.toReversed()) {
       if (message.role === "assistant") {
         return this.isRetryableError(message);
       }
@@ -707,8 +710,7 @@ export class AgentSession {
   /** Find the last assistant message in agent state (including aborted ones) */
   private findLastAssistantMessage(): AssistantMessage | undefined {
     const messages = this.agent.state.messages;
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
+    for (const msg of messages.toReversed()) {
       if (msg.role === "assistant") {
         return msg;
       }
@@ -1682,7 +1684,10 @@ export class AgentSession {
     const len = scopedModels.length;
     const nextIndex =
       direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
-    const next = scopedModels[nextIndex];
+    const next = scopedModels.at(nextIndex);
+    if (!next) {
+      throw new Error("Scoped model cycle produced an invalid index");
+    }
     const thinkingLevel = this.getThinkingLevelForModelSwitch(next.thinkingLevel);
 
     // Apply model
@@ -1718,7 +1723,10 @@ export class AgentSession {
     const len = availableModels.length;
     const nextIndex =
       direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
-    const nextModel = availableModels[nextIndex];
+    const nextModel = availableModels.at(nextIndex);
+    if (!nextModel) {
+      throw new Error("Available model cycle produced an invalid index");
+    }
 
     const thinkingLevel = this.getThinkingLevelForModelSwitch();
     this.agent.state.model = nextModel;
@@ -1778,7 +1786,10 @@ export class AgentSession {
     const levels = this.getAvailableThinkingLevels();
     const currentIndex = levels.indexOf(this.thinkingLevel);
     const nextIndex = (currentIndex + 1) % levels.length;
-    const nextLevel = levels[nextIndex];
+    const nextLevel = levels.at(nextIndex);
+    if (!nextLevel) {
+      return undefined;
+    }
 
     this.setThinkingLevel(nextLevel);
     return nextLevel;
@@ -2099,7 +2110,7 @@ export class AgentSession {
       // Remove the error message from agent state (it IS saved to session for history,
       // but we don't want it in context for the retry)
       const messages = this.agent.state.messages;
-      if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
+      if (messages.at(-1)?.role === "assistant") {
         this.agent.state.messages = messages.slice(0, -1);
       }
       return await this.runAutoCompaction("overflow", true);
@@ -2118,10 +2129,10 @@ export class AgentSession {
       // Verify the usage source is post-compaction. Kept pre-compaction messages
       // have stale usage reflecting the old (larger) context and would falsely
       // trigger compaction right after one just finished.
-      const usageMsg = messages[estimate.lastUsageIndex];
+      const usageMsg = messages.at(estimate.lastUsageIndex);
       if (
         compactionEntry &&
-        usageMsg.role === "assistant" &&
+        usageMsg?.role === "assistant" &&
         usageMsg.timestamp <= new Date(compactionEntry.timestamp).getTime()
       ) {
         return false;
@@ -2684,7 +2695,7 @@ export class AgentSession {
 
     // Remove error message from agent state (keep in session for history)
     const messages = this.agent.state.messages;
-    if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
+    if (messages.at(-1)?.role === "assistant") {
       this.agent.state.messages = messages.slice(0, -1);
     }
 
@@ -3181,8 +3192,7 @@ export class AgentSession {
       // Check if there's a valid assistant usage after the compaction boundary
       const compactionIndex = branchEntries.lastIndexOf(latestCompaction);
       let hasPostCompactionUsage = false;
-      for (let i = branchEntries.length - 1; i > compactionIndex; i--) {
-        const entry = branchEntries[i];
+      for (const entry of branchEntries.slice(compactionIndex + 1).toReversed()) {
         if (entry.type === "message" && entry.message.role === "assistant") {
           const assistant = entry.message;
           if (assistant.stopReason !== "aborted" && assistant.stopReason !== "error") {

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -141,7 +141,10 @@ function buildFallbackModel(
     return undefined;
   }
 
-  const baseModel = providerModels[0];
+  const baseModel = providerModels.at(0);
+  if (!baseModel) {
+    return undefined;
+  }
 
   return {
     ...baseModel,
@@ -523,10 +526,13 @@ export async function findInitialModel(options: {
 
   // 2. Use first model from scoped models (skip if continuing/resuming)
   if (scopedModels.length > 0 && !isContinuing) {
+    const scopedModel = scopedModels.at(0);
+    if (!scopedModel) {
+      throw new Error("Scoped model list became empty during selection");
+    }
     return {
-      model: scopedModels[0].model,
-      thinkingLevel:
-        scopedModels[0].thinkingLevel ?? defaultThinkingLevel ?? DEFAULT_THINKING_LEVEL,
+      model: scopedModel.model,
+      thinkingLevel: scopedModel.thinkingLevel ?? defaultThinkingLevel ?? DEFAULT_THINKING_LEVEL,
       fallbackMessage: undefined,
     };
   }

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -379,18 +379,17 @@ export async function createAgentSession(
                   ? { type: "text" as const, text: "Image reading is disabled." }
                   : c,
               )
-              .filter(
-                (c, i, arr) =>
-                  // Dedupe consecutive "Image reading is disabled." texts
-                  !(
-                    c.type === "text" &&
-                    c.text === "Image reading is disabled." &&
-                    i > 0 &&
-                    arr[i - 1].type === "text" &&
-                    (arr[i - 1] as { type: "text"; text: string }).text ===
-                      "Image reading is disabled."
-                  ),
-              );
+              .filter((c, i, arr) => {
+                const previous = arr.at(i - 1);
+                // Dedupe consecutive "Image reading is disabled." texts
+                return !(
+                  c.type === "text" &&
+                  c.text === "Image reading is disabled." &&
+                  i > 0 &&
+                  previous?.type === "text" &&
+                  previous.text === "Image reading is disabled."
+                );
+              });
             return Object.assign({}, msg, { content: filteredContent });
           }
         }

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -354,9 +354,9 @@ export function parseSessionEntries(content: string): FileEntry[] {
 }
 
 export function getLatestCompactionEntry(entries: SessionEntry[]): CompactionEntry | null {
-  for (let i = entries.length - 1; i >= 0; i--) {
-    if (entries[i].type === "compaction") {
-      return entries[i] as CompactionEntry;
+  for (const entry of entries.toReversed()) {
+    if (entry.type === "compaction") {
+      return entry;
     }
   }
   return null;
@@ -590,7 +590,7 @@ function hasCacheableSessionHeader(entries: FileEntry[]): boolean {
     return true;
   }
   const header = entries[0];
-  if (header.type !== "session" || typeof (header as { id?: unknown }).id !== "string") {
+  if (!header || header.type !== "session" || typeof header.id !== "string") {
     return false;
   }
 
@@ -901,8 +901,9 @@ function revalidateLoadedSessionFile(
 // mutations from leaking back into the cache).
 function copyFileEntries(entries: readonly FileEntry[]): FileEntry[] {
   const copy = entries.slice();
-  if (copy.length > 0 && copy[0].type === "session" && Object.isFrozen(copy[0])) {
-    copy[0] = cloneFileEntry(copy[0]);
+  const header = copy.at(0);
+  if (header?.type === "session" && Object.isFrozen(header)) {
+    copy[0] = cloneFileEntry(header);
   }
   return copy;
 }
@@ -1319,7 +1320,7 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
       return null;
     }
     const header = entries[0];
-    if (header.type !== "session") {
+    if (!header || header.type !== "session") {
       return null;
     }
 
@@ -2507,8 +2508,7 @@ export class SessionManager {
     // Walk entries in reverse to find the latest session_info entry.
     // Empty names explicitly clear the session title.
     const entries = this.getEntries();
-    for (let i = entries.length - 1; i >= 0; i--) {
-      const entry = entries[i];
+    for (const entry of entries.toReversed()) {
       if (entry.type === "session_info") {
         return entry.name?.trim() || undefined;
       }

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -125,7 +125,11 @@ function getReplacementLineRange(lines: LineSpan[], replacement: TextReplacement
   }
 
   let endLine = startLine;
-  while (endLine < lines.length && lines[endLine].end < replacementEnd) {
+  while (endLine < lines.length) {
+    const line = lines.at(endLine);
+    if (!line || line.end >= replacementEnd) {
+      break;
+    }
     endLine++;
   }
   if (endLine >= lines.length) {
@@ -136,8 +140,7 @@ function getReplacementLineRange(lines: LineSpan[], replacement: TextReplacement
 
 function applyReplacements(content: string, replacements: TextReplacement[], offset = 0): string {
   let result = content;
-  for (let i = replacements.length - 1; i >= 0; i--) {
-    const replacement = replacements[i];
+  for (const replacement of replacements.toReversed()) {
     const matchIndex = replacement.matchIndex - offset;
     result =
       result.slice(0, matchIndex) +
@@ -185,8 +188,13 @@ function applyReplacementsPreservingUnchangedLines(
   let result = "";
   for (const group of groups) {
     result += originalLines.slice(originalLineIndex, group.startLine).join("");
-    const groupStartOffset = baseLines[group.startLine].start;
-    const groupEndOffset = baseLines[group.endLine - 1].end;
+    const firstLine = baseLines.at(group.startLine);
+    const lastLine = baseLines.at(group.endLine - 1);
+    if (!firstLine || !lastLine) {
+      throw new Error("Replacement group is outside the base content.");
+    }
+    const groupStartOffset = firstLine.start;
+    const groupEndOffset = lastLine.end;
     result += applyReplacements(
       baseContent.slice(groupStartOffset, groupEndOffset),
       group.replacements,
@@ -274,8 +282,8 @@ function truncateCandidateText(text: string, maxChars: number): string {
   }
   const cut =
     maxChars > 0 &&
-    /[\uD800-\uDBFF]/.test(text[maxChars - 1]) &&
-    /[\uDC00-\uDFFF]/.test(text[maxChars])
+    /[\uD800-\uDBFF]/.test(text.charAt(maxChars - 1)) &&
+    /[\uDC00-\uDFFF]/.test(text.charAt(maxChars))
       ? maxChars - 1
       : maxChars;
   return text.slice(0, cut);
@@ -319,7 +327,7 @@ function describeIndentation(line: string): string {
 function firstDifferenceIndex(left: string, right: string): number {
   const sharedLength = Math.min(left.length, right.length);
   for (let index = 0; index < sharedLength; index++) {
-    if (left[index] !== right[index]) {
+    if (left.charAt(index) !== right.charAt(index)) {
       return index;
     }
   }
@@ -461,8 +469,8 @@ export function applyEditsToNormalizedContent(
     newText: normalizeToLF(edit.newText),
   }));
 
-  for (let i = 0; i < normalizedEdits.length; i++) {
-    if (normalizedEdits[i].oldText.length === 0) {
+  for (const [i, edit] of normalizedEdits.entries()) {
+    if (edit.oldText.length === 0) {
       throw getEmptyOldTextError(path, i, normalizedEdits.length);
     }
   }
@@ -476,8 +484,7 @@ export function applyEditsToNormalizedContent(
     : normalizedContent;
 
   const matchedEdits: MatchedEdit[] = [];
-  for (let i = 0; i < normalizedEdits.length; i++) {
-    const edit = normalizedEdits[i];
+  for (const [i, edit] of normalizedEdits.entries()) {
     const matchResult = fuzzyFindText(replacementBaseContent, edit.oldText);
     if (!matchResult.found) {
       throw getNotFoundError(path, i, normalizedEdits.length, normalizedContent, edit.oldText);
@@ -498,8 +505,11 @@ export function applyEditsToNormalizedContent(
 
   matchedEdits.sort((a, b) => a.matchIndex - b.matchIndex);
   for (let i = 1; i < matchedEdits.length; i++) {
-    const previous = matchedEdits[i - 1];
-    const current = matchedEdits[i];
+    const previous = matchedEdits.at(i - 1);
+    const current = matchedEdits.at(i);
+    if (!previous || !current) {
+      continue;
+    }
     if (previous.matchIndex + previous.matchLength > current.matchIndex) {
       throw new Error(
         `edits[${previous.editIndex}] and edits[${current.editIndex}] overlap in ${path}. Merge them into one edit or target disjoint regions.`,
@@ -558,8 +568,7 @@ export function generateDiffString(
   let lastWasChange = false;
   let firstChangedLine: number | undefined;
 
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
+  for (const [i, part] of parts.entries()) {
     const raw = part.value.split("\n");
     if (raw[raw.length - 1] === "") {
       raw.pop();
@@ -587,7 +596,8 @@ export function generateDiffString(
       lastWasChange = true;
     } else {
       // Context lines - only show a few before/after changes
-      const nextPartIsChange = i < parts.length - 1 && (parts[i + 1].added || parts[i + 1].removed);
+      const nextPart = parts.at(i + 1);
+      const nextPartIsChange = Boolean(nextPart?.added || nextPart?.removed);
       const hasLeadingChange = lastWasChange;
       const hasTrailingChange = nextPartIsChange;
 

--- a/src/agents/sessions/tools/output-accumulator.ts
+++ b/src/agents/sessions/tools/output-accumulator.ts
@@ -200,12 +200,16 @@ export class OutputAccumulator {
     }
 
     let start = buffer.length - this.maxRollingBytes;
-    while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) {
+    while (start < buffer.length) {
+      const byte = buffer.at(start);
+      if (byte === undefined || (byte & 0xc0) !== 0x80) {
+        break;
+      }
       start++;
     }
 
     this.tailStartsAtLineBoundary =
-      start === 0 ? this.tailStartsAtLineBoundary : buffer[start - 1] === 0x0a;
+      start === 0 ? this.tailStartsAtLineBoundary : buffer.at(start - 1) === 0x0a;
     this.tailText = buffer.subarray(start).toString("utf-8");
     this.tailBytes = byteLength(this.tailText);
   }

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -360,7 +360,11 @@ export function createReadToolDefinition(
               let outputText: string;
               if (truncation.firstLineExceedsLimit) {
                 // First line alone exceeds the byte limit. Point the model at a bash fallback.
-                const firstLineSize = formatSize(Buffer.byteLength(allLines[startLine], "utf-8"));
+                const firstLine = allLines.at(startLine);
+                if (firstLine === undefined) {
+                  throw new Error("Requested line is outside the file.");
+                }
+                const firstLineSize = formatSize(Buffer.byteLength(firstLine, "utf-8"));
                 outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${quotePosixShellArg(path)} | head -c ${DEFAULT_MAX_BYTES}]`;
                 details = { truncation };
               } else if (truncation.truncated) {

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -183,14 +183,19 @@ function updateWriteHighlightCacheIncremental(
 
   const segments = deltaNormalized.split("\n");
   const lastIndex = cache.normalizedLines.length - 1;
-  cache.normalizedLines[lastIndex] += segments[0];
+  const firstSegment = segments.at(0);
+  const currentLastLine = cache.normalizedLines.at(lastIndex);
+  if (firstSegment === undefined || currentLastLine === undefined) {
+    return rebuildWriteHighlightCacheFull(rawPath, fileContent);
+  }
+  cache.normalizedLines[lastIndex] = currentLastLine + firstSegment;
   cache.highlightedLines[lastIndex] = highlightSingleLine(
     cache.normalizedLines[lastIndex],
     cache.lang,
   );
-  for (let i = 1; i < segments.length; i++) {
-    cache.normalizedLines.push(segments[i]);
-    cache.highlightedLines.push(highlightSingleLine(segments[i], cache.lang));
+  for (const segment of segments.slice(1)) {
+    cache.normalizedLines.push(segment);
+    cache.highlightedLines.push(highlightSingleLine(segment, cache.lang));
   }
   refreshWriteHighlightPrefix(cache);
   return cache;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -831,7 +831,10 @@ function resolveRequesterBoundConversationRef(params: {
     return undefined;
   }
   if (activeBindings.length === 1) {
-    const conversation = activeBindings[0].conversation;
+    const conversation = activeBindings.at(0)?.conversation;
+    if (!conversation) {
+      return undefined;
+    }
     return {
       conversationId: conversation.conversationId,
       ...(conversation.parentConversationId
@@ -847,7 +850,10 @@ function resolveRequesterBoundConversationRef(params: {
           normalizeOptionalString(params.fallback?.parentConversationId),
     );
     if (matched.length === 1) {
-      const conversation = matched[0].conversation;
+      const conversation = matched.at(0)?.conversation;
+      if (!conversation) {
+        return undefined;
+      }
       return {
         conversationId: conversation.conversationId,
         ...(conversation.parentConversationId

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -702,7 +702,7 @@ function resolveDetailFromKeys(
     return undefined;
   }
   if (entries.length === 1) {
-    return entries[0].value;
+    return entries.at(0)?.value;
   }
 
   const seen = new Set<string>();

--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -205,7 +205,7 @@ export function trimLeadingEnv(words: string[]): string[] {
     return words.slice(index);
   }
 
-  while (index < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index])) {
+  while (index < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words.at(index) ?? "")) {
     index += 1;
   }
   return words.slice(index);
@@ -331,7 +331,7 @@ export function scanTopLevelChars(
   let pendingHeredocs: HeredocMarker[] = [];
 
   for (let i = 0; i < command.length; i += 1) {
-    const char = command[i];
+    const char = command.charAt(i);
 
     if (escaped) {
       escaped = false;

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -90,8 +90,9 @@ function summarizeKnownExec(words: string[]): string {
       stash: "stash git changes",
     };
 
-    if (sub && map[sub]) {
-      return map[sub];
+    const mappedSummary = sub ? map[sub] : undefined;
+    if (mappedSummary) {
+      return mappedSummary;
     }
     if (!sub || sub.startsWith("/") || sub.startsWith("~") || sub.includes("/")) {
       return gitCwd ? `run git command in ${gitCwd}` : "run git command";
@@ -484,7 +485,10 @@ function summarizeExecCommand(command: string): ExecSummary | undefined {
   }
 
   const summaries = stages.map((stage) => summarizePipeline(stage));
-  const text = summaries.length === 1 ? summaries[0] : summaries.join(" → ");
+  const text = summaries.length === 1 ? summaries.at(0) : summaries.join(" → ");
+  if (!text) {
+    return undefined;
+  }
   const allGeneric = summaries.every((summary) => isGenericSummary(summary));
 
   return { text, chdirPath, allGeneric };

--- a/src/agents/tool-schema-projection.ts
+++ b/src/agents/tool-schema-projection.ts
@@ -38,9 +38,12 @@ type RuntimeToolEntryRead<TTool extends Pick<AnyAgentTool, "name" | "parameters"
 
 type ToolSchemaInspectionMode = "runtime" | "provider-normalizable";
 
-function unreadableRuntimeToolEntry(
-  toolIndex: number,
-): RuntimeToolEntryRead<Pick<AnyAgentTool, "name" | "parameters">> {
+function unreadableRuntimeToolEntry<
+  TTool extends Pick<AnyAgentTool, "name" | "parameters"> = Pick<
+    AnyAgentTool,
+    "name" | "parameters"
+  >,
+>(toolIndex: number): RuntimeToolEntryRead<TTool> {
   return {
     ok: false,
     diagnostic: {
@@ -58,14 +61,19 @@ function readRuntimeToolEntries<TTool extends Pick<AnyAgentTool, "name" | "param
   try {
     length = tools.length;
   } catch {
-    return [unreadableRuntimeToolEntry(0) as RuntimeToolEntryRead<TTool>];
+    return [unreadableRuntimeToolEntry<TTool>(0)];
   }
   const entries: RuntimeToolEntryRead<TTool>[] = [];
   for (let toolIndex = 0; toolIndex < length; toolIndex += 1) {
     try {
-      entries.push({ ok: true, tool: tools[toolIndex], toolIndex });
+      const tool = tools.at(toolIndex);
+      entries.push(
+        tool === undefined
+          ? unreadableRuntimeToolEntry<TTool>(toolIndex)
+          : { ok: true, tool, toolIndex },
+      );
     } catch {
-      entries.push(unreadableRuntimeToolEntry(toolIndex) as RuntimeToolEntryRead<TTool>);
+      entries.push(unreadableRuntimeToolEntry<TTool>(toolIndex));
     }
   }
   return entries;

--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -119,8 +119,10 @@ export function buildReadableToolsByName(
   }
   for (let index = 0; index < toolCount; index += 1) {
     try {
-      const tool = tools[index];
-      toolsByName.set(tool.name, tool);
+      const tool = tools.at(index);
+      if (tool) {
+        toolsByName.set(tool.name, tool);
+      }
     } catch {
       // Unreadable entries are reported by the schema projection diagnostics.
     }

--- a/src/agents/tools/computer-tool.ts
+++ b/src/agents/tools/computer-tool.ts
@@ -368,7 +368,10 @@ async function resolveComputerNode(
     return match;
   }
   if (eligible.length === 1) {
-    return eligible[0];
+    const node = eligible.at(0);
+    if (node) {
+      return node;
+    }
   }
   if (eligible.length === 0) {
     throw new Error(
@@ -500,7 +503,10 @@ function computerFrameImageIdentity(
   if (images.length !== 1) {
     return undefined;
   }
-  const image = images[0];
+  const image = images.at(0);
+  if (!image) {
+    return undefined;
+  }
   return crypto
     .createHash("sha256")
     .update(JSON.stringify([image.mimeType, image.data]))

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -366,7 +366,9 @@ function isAllowedGatewayConfigPath(path: string): boolean {
       return false;
     }
     for (let i = 0; i < patternSegments.length; i += 1) {
-      if (!pathSegmentMatches(patternSegments[i], pathSegments[i])) {
+      const patternSegment = patternSegments.at(i);
+      const pathSegment = pathSegments.at(i);
+      if (!patternSegment || !pathSegment || !pathSegmentMatches(patternSegment, pathSegment)) {
         return false;
       }
     }

--- a/src/agents/tools/image-tool.helpers.ts
+++ b/src/agents/tools/image-tool.helpers.ts
@@ -213,7 +213,7 @@ function resolveProviderlessConfiguredImageModelRef(params: {
     return ref;
   }
   if (matches.length === 1) {
-    return matches[0];
+    return matches.at(0) ?? ref;
   }
   throw new Error(
     `Ambiguous image model "${ref}". Configure a provider-prefixed ref such as ${matches

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -700,7 +700,10 @@ async function runImagePrompt(params: {
       const describeImage =
         imageProvider?.describeImage ?? imageToolProviderDeps.describeImageWithModel;
       if (params.images.length === 1) {
-        const image = params.images[0];
+        const image = params.images.at(0);
+        if (!image) {
+          throw new Error("Image input disappeared during model execution");
+        }
         const described = await describeImage({
           buffer: image.buffer,
           fileName: "image-1",
@@ -1071,22 +1074,20 @@ export function createImageTool(options?: {
         workspaceDir: options?.workspaceDir,
       });
 
-      const imageDetails =
-        loadedImages.length === 1
-          ? {
-              image: loadedImages[0].resolvedImage,
-              ...(loadedImages[0].rewrittenFrom
-                ? { rewrittenFrom: loadedImages[0].rewrittenFrom }
-                : {}),
-            }
-          : {
-              images: loadedImages.map((img) =>
-                Object.assign(
-                  { image: img.resolvedImage },
-                  img.rewrittenFrom ? { rewrittenFrom: img.rewrittenFrom } : {},
-                ),
+      const singleImage = loadedImages.length === 1 ? loadedImages.at(0) : undefined;
+      const imageDetails = singleImage
+        ? {
+            image: singleImage.resolvedImage,
+            ...(singleImage.rewrittenFrom ? { rewrittenFrom: singleImage.rewrittenFrom } : {}),
+          }
+        : {
+            images: loadedImages.map((img) =>
+              Object.assign(
+                { image: img.resolvedImage },
+                img.rewrittenFrom ? { rewrittenFrom: img.rewrittenFrom } : {},
               ),
-            };
+            ),
+          };
 
       return buildTextToolResult(result, imageDetails);
     },

--- a/src/agents/tools/media-generate-tool-actions-shared.ts
+++ b/src/agents/tools/media-generate-tool-actions-shared.ts
@@ -106,7 +106,10 @@ export function createMediaGenerateProviderListActionResult<
   );
 
   const lines = providerDetails.flatMap((details, index) => {
-    const provider = params.providers[index];
+    const provider = params.providers.at(index);
+    if (!provider) {
+      return [];
+    }
     const authHints = getProviderEnvVars(provider.id);
     const capabilities = params.summarizeCapabilities(provider);
     const modelLine = details.models.length > 0 ? details.models.join(", ") : "unknown";

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -767,6 +767,9 @@ function buildPollSchema() {
   };
   for (const name of SHARED_POLL_CREATION_PARAM_NAMES) {
     const def = POLL_CREATION_PARAM_DEFS[name];
+    if (!def) {
+      continue;
+    }
     switch (def.kind) {
       case "string":
         props[name] = Type.Optional(Type.String());

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -110,14 +110,14 @@ export function selectDefaultNodeFromList(
   const connected = withCapability.filter((n) => n.connected);
   const candidates = connected.length > 0 ? connected : withCapability;
   if (candidates.length === 1) {
-    return candidates[0];
+    return candidates.at(0) ?? null;
   }
 
   const preferLocalMac = options.preferLocalMac ?? true;
   if (preferLocalMac) {
     const local = candidates.filter(isLocalMacNode);
     if (local.length === 1) {
-      return local[0];
+      return local.at(0) ?? null;
     }
   }
 

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -273,8 +273,12 @@ export async function geminiAnalyzePdf(params: {
     throw new Error("Gemini PDF returned no candidates.");
   }
 
-  const textParts = candidates[0].content?.parts?.filter((p) => typeof p.text === "string") ?? [];
-  const text = textParts.map((p) => p.text!).join("");
+  const candidate = candidates.at(0);
+  if (!candidate) {
+    throw new Error("Gemini PDF returned no candidates.");
+  }
+  const textParts = candidate.content?.parts?.filter((part) => typeof part.text === "string") ?? [];
+  const text = textParts.map((part) => part.text).join("");
 
   if (!text.trim()) {
     throw new Error("Gemini PDF returned no text.");

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -109,8 +109,7 @@ function buildPdfExtractionContext(
   > = [];
 
   // Add extracted text and images
-  for (let i = 0; i < extractions.length; i++) {
-    const extraction = extractions[i];
+  for (const [i, extraction] of extractions.entries()) {
     if (extraction.text.trim()) {
       const label = extractions.length > 1 ? `[PDF ${i + 1} text]\n` : "[PDF text]\n";
       content.push({ type: "text", text: label + extraction.text });
@@ -540,22 +539,20 @@ export function createPdfTool(options?: {
         getExtractions,
       });
 
-      const pdfDetails =
-        loadedPdfs.length === 1
-          ? {
-              pdf: loadedPdfs[0].resolvedPath,
-              ...(loadedPdfs[0].rewrittenFrom
-                ? { rewrittenFrom: loadedPdfs[0].rewrittenFrom }
-                : {}),
-            }
-          : {
-              pdfs: loadedPdfs.map((p) =>
-                Object.assign(
-                  { pdf: p.resolvedPath },
-                  p.rewrittenFrom ? { rewrittenFrom: p.rewrittenFrom } : {},
-                ),
+      const singlePdf = loadedPdfs.length === 1 ? loadedPdfs.at(0) : undefined;
+      const pdfDetails = singlePdf
+        ? {
+            pdf: singlePdf.resolvedPath,
+            ...(singlePdf.rewrittenFrom ? { rewrittenFrom: singlePdf.rewrittenFrom } : {}),
+          }
+        : {
+            pdfs: loadedPdfs.map((p) =>
+              Object.assign(
+                { pdf: p.resolvedPath },
+                p.rewrittenFrom ? { rewrittenFrom: p.rewrittenFrom } : {},
               ),
-            };
+            ),
+          };
 
       return buildTextToolResult(result, { native: result.native, ...pdfDetails });
     },

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -158,8 +158,10 @@ export function deriveChannel(params: {
     return lastChannel;
   }
   const parts = params.key.split(":").filter(Boolean);
-  if (parts.length >= 3 && (parts[1] === "group" || parts[1] === "channel")) {
-    return parts[0];
+  const scope = parts.at(1);
+  const keyChannel = parts.at(0);
+  if (parts.length >= 3 && keyChannel && (scope === "group" || scope === "channel")) {
+    return keyChannel;
   }
   return "unknown";
 }

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -428,7 +428,10 @@ export function createSessionsListTool(opts?: {
             if (next >= titleTargets.length) {
               return;
             }
-            const target = titleTargets[next];
+            const target = titleTargets.at(next);
+            if (!target) {
+              return;
+            }
             const fields = await readSessionTitleFieldsFromTranscriptAsync({
               agentId: target.agentId,
               sessionEntry: target.sessionEntry,
@@ -460,7 +463,10 @@ export function createSessionsListTool(opts?: {
             if (next >= historyTargets.length) {
               return;
             }
-            const target = historyTargets[next];
+            const target = historyTargets.at(next);
+            if (!target) {
+              return;
+            }
             const history = await gatewayCall<{ messages: Array<unknown> }>({
               method: "chat.history",
               params: { sessionKey: target.resolvedKey, limit: messageLimit },

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -1133,8 +1133,9 @@ export function createVideoGenerateTool(options?: {
       // Attach roles to the loaded image assets (positional, by index into images[]).
       for (let i = 0; i < loadedReferenceImages.length; i++) {
         const role = imageRoles[i];
-        if (role) {
-          loadedReferenceImages[i].sourceAsset.role = role;
+        const asset = loadedReferenceImages.at(i);
+        if (role && asset) {
+          asset.sourceAsset.role = role;
         }
       }
       const loadedReferenceVideos = await loadReferenceAssets({
@@ -1146,8 +1147,9 @@ export function createVideoGenerateTool(options?: {
       });
       for (let i = 0; i < loadedReferenceVideos.length; i++) {
         const role = videoRoles[i];
-        if (role) {
-          loadedReferenceVideos[i].sourceAsset.role = role;
+        const asset = loadedReferenceVideos.at(i);
+        if (role && asset) {
+          asset.sourceAsset.role = role;
         }
       }
       const loadedReferenceAudios = await loadReferenceAssets({
@@ -1159,8 +1161,9 @@ export function createVideoGenerateTool(options?: {
       });
       for (let i = 0; i < loadedReferenceAudios.length; i++) {
         const role = audioRoles[i];
-        if (role) {
-          loadedReferenceAudios[i].sourceAsset.role = role;
+        const asset = loadedReferenceAudios.at(i);
+        if (role && asset) {
+          asset.sourceAsset.role = role;
         }
       }
       validateVideoGenerationCapabilities({

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -161,7 +161,7 @@ function findTagEnd(html: string, start: number): TagEndResult {
   let afterEquals = false;
   let rawTextStartInQuote: number | undefined;
   for (let i = start + 1; i < html.length; i += 1) {
-    const ch = html[i];
+    const ch = html.charAt(i);
     if (quote) {
       if (rawTextStartInQuote === undefined && readRawTextOpenTagName(html, i)) {
         rawTextStartInQuote = i;
@@ -198,7 +198,7 @@ function isSelfClosingTagRaw(raw: string): boolean {
   if (!trimmed.endsWith("/")) {
     return false;
   }
-  const beforeSlash = trimmed[trimmed.length - 2];
+  const beforeSlash = trimmed.charAt(trimmed.length - 2);
   const tagBody = trimmed.slice(0, -1);
   let hasAttributeSeparator = false;
   for (const ch of tagBody) {
@@ -250,13 +250,13 @@ function readTagToken(html: string, start: number): ReadTagResult | null {
   }
 
   let pos = start + 1;
-  while (pos < end && isAsciiWhitespace(html[pos])) {
+  while (pos < end && isAsciiWhitespace(html.charAt(pos))) {
     pos += 1;
   }
   const closing = html[pos] === "/";
   if (closing) {
     pos += 1;
-    while (pos < end && isAsciiWhitespace(html[pos])) {
+    while (pos < end && isAsciiWhitespace(html.charAt(pos))) {
       pos += 1;
     }
   }
@@ -269,7 +269,7 @@ function readTagToken(html: string, start: number): ReadTagResult | null {
   }
 
   const nameStart = pos;
-  while (pos < end && isTagNameChar(html[pos])) {
+  while (pos < end && isTagNameChar(html.charAt(pos))) {
     pos += 1;
   }
   if (pos === nameStart || !isTagNameStartChar(html[nameStart] ?? "")) {
@@ -301,15 +301,18 @@ function readTagToken(html: string, start: number): ReadTagResult | null {
 function readAttributeValue(rawTag: string, name: string): string | undefined {
   const target = name.toLowerCase();
   let pos = 0;
-  while (pos < rawTag.length && !isAsciiWhitespace(rawTag[pos])) {
+  while (pos < rawTag.length && !isAsciiWhitespace(rawTag.charAt(pos))) {
     pos += 1;
   }
   while (pos < rawTag.length) {
-    while (pos < rawTag.length && (isAsciiWhitespace(rawTag[pos]) || rawTag[pos] === "/")) {
+    while (
+      pos < rawTag.length &&
+      (isAsciiWhitespace(rawTag.charAt(pos)) || rawTag.charAt(pos) === "/")
+    ) {
       pos += 1;
     }
     const attrStart = pos;
-    while (pos < rawTag.length && isTagNameChar(rawTag[pos])) {
+    while (pos < rawTag.length && isTagNameChar(rawTag.charAt(pos))) {
       pos += 1;
     }
     if (pos === attrStart) {
@@ -317,13 +320,13 @@ function readAttributeValue(rawTag: string, name: string): string | undefined {
       continue;
     }
     const attrName = rawTag.slice(attrStart, pos).toLowerCase();
-    while (pos < rawTag.length && isAsciiWhitespace(rawTag[pos])) {
+    while (pos < rawTag.length && isAsciiWhitespace(rawTag.charAt(pos))) {
       pos += 1;
     }
     let value = "";
     if (rawTag[pos] === "=") {
       pos += 1;
-      while (pos < rawTag.length && isAsciiWhitespace(rawTag[pos])) {
+      while (pos < rawTag.length && isAsciiWhitespace(rawTag.charAt(pos))) {
         pos += 1;
       }
       const quote = rawTag[pos];
@@ -341,7 +344,7 @@ function readAttributeValue(rawTag: string, name: string): string | undefined {
         const valueStart = pos;
         while (
           pos < rawTag.length &&
-          !isAsciiWhitespace(rawTag[pos]) &&
+          !isAsciiWhitespace(rawTag.charAt(pos)) &&
           rawTag[pos] !== '"' &&
           rawTag[pos] !== "'" &&
           rawTag[pos] !== "=" &&
@@ -363,8 +366,8 @@ function readAttributeValue(rawTag: string, name: string): string | undefined {
 
 function skipUnsupportedAttribute(rawTag: string, start: number): number {
   let pos = start;
-  while (pos < rawTag.length && !isAsciiWhitespace(rawTag[pos])) {
-    const quote = rawTag[pos];
+  while (pos < rawTag.length && !isAsciiWhitespace(rawTag.charAt(pos))) {
+    const quote = rawTag.charAt(pos);
     if (quote === '"' || quote === "'") {
       const valueEnd = rawTag.indexOf(quote, pos + 1);
       pos = valueEnd === -1 ? rawTag.length : valueEnd + 1;

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -56,29 +56,32 @@ function isStyleHidden(style: string): boolean {
   for (const [prop, pattern] of HIDDEN_STYLE_PATTERNS) {
     const escapedProp = prop.replace(/-/g, "\\-");
     const match = style.match(new RegExp(`(?:^|;)\\s*${escapedProp}\\s*:\\s*([^;]+)`, "i"));
-    if (match && pattern.test(match[1])) {
+    const value = match?.at(1);
+    if (value && pattern.test(value)) {
       return true;
     }
   }
 
   // clip-path: none is not hidden, but positive percentage inset() clipping hides content.
   const clipPath = style.match(/(?:^|;)\s*clip-path\s*:\s*([^;]+)/i);
-  if (clipPath && !/^\s*none\s*$/i.test(clipPath[1])) {
-    if (/inset\s*\(\s*(?:0*\.\d+|[1-9]\d*(?:\.\d+)?)%/i.test(clipPath[1])) {
+  const clipPathValue = clipPath?.at(1);
+  if (clipPathValue && !/^\s*none\s*$/i.test(clipPathValue)) {
+    if (/inset\s*\(\s*(?:0*\.\d+|[1-9]\d*(?:\.\d+)?)%/i.test(clipPathValue)) {
       return true;
     }
   }
 
   // transform: scale(0)
   const transform = style.match(/(?:^|;)\s*transform\s*:\s*([^;]+)/i);
-  if (transform) {
-    if (/scale\s*\(\s*0\s*\)/i.test(transform[1])) {
+  const transformValue = transform?.at(1);
+  if (transformValue) {
+    if (/scale\s*\(\s*0\s*\)/i.test(transformValue)) {
       return true;
     }
-    if (/translateX\s*\(\s*-\d{4,}px\s*\)/i.test(transform[1])) {
+    if (/translateX\s*\(\s*-\d{4,}px\s*\)/i.test(transformValue)) {
       return true;
     }
-    if (/translateY\s*\(\s*-\d{4,}px\s*\)/i.test(transform[1])) {
+    if (/translateY\s*\(\s*-\d{4,}px\s*\)/i.test(transformValue)) {
       return true;
     }
   }
@@ -89,11 +92,11 @@ function isStyleHidden(style: string): boolean {
   const overflow = style.match(/(?:^|;)\s*overflow\s*:\s*([^;]+)/i);
   if (
     width &&
-    /^\s*0(px)?\s*$/i.test(width[1]) &&
+    /^\s*0(px)?\s*$/i.test(width.at(1) ?? "") &&
     height &&
-    /^\s*0(px)?\s*$/i.test(height[1]) &&
+    /^\s*0(px)?\s*$/i.test(height.at(1) ?? "") &&
     overflow &&
-    /^\s*hidden\s*$/i.test(overflow[1])
+    /^\s*hidden\s*$/i.test(overflow.at(1) ?? "")
   ) {
     return true;
   }
@@ -101,10 +104,10 @@ function isStyleHidden(style: string): boolean {
   // Offscreen positioning: left/top far negative
   const left = style.match(/(?:^|;)\s*left\s*:\s*([^;]+)/i);
   const top = style.match(/(?:^|;)\s*top\s*:\s*([^;]+)/i);
-  if (left && /^\s*-\d{4,}px\s*$/i.test(left[1])) {
+  if (left && /^\s*-\d{4,}px\s*$/i.test(left.at(1) ?? "")) {
     return true;
   }
-  if (top && /^\s*-\d{4,}px\s*$/i.test(top[1])) {
+  if (top && /^\s*-\d{4,}px\s*$/i.test(top.at(1) ?? "")) {
     return true;
   }
 

--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -220,7 +220,7 @@ function isValidIsoDate(value: string): boolean {
     return false;
   }
   const [year, month, day] = value.split("-").map((part) => Number.parseInt(part, 10));
-  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+  if (year === undefined || month === undefined || day === undefined) {
     return false;
   }
 
@@ -236,6 +236,9 @@ export function isoToPerplexityDate(iso: string): string | undefined {
     return undefined;
   }
   const [, year, month, day] = match;
+  if (year === undefined || month === undefined || day === undefined) {
+    return undefined;
+  }
   return `${Number.parseInt(month, 10)}/${Number.parseInt(day, 10)}/${year}`;
 }
 
@@ -248,6 +251,9 @@ export function normalizeToIsoDate(value: string): string | undefined {
   const match = trimmed.match(PERPLEXITY_DATE_PATTERN);
   if (match) {
     const [, month, day, year] = match;
+    if (year === undefined || month === undefined || day === undefined) {
+      return undefined;
+    }
     const iso = `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
     return isValidIsoDate(iso) ? iso : undefined;
   }
@@ -314,17 +320,19 @@ export function normalizeFreshness(
 
   const lower = normalizeLowercaseStringOrEmpty(trimmed);
   if (BRAVE_FRESHNESS_SHORTCUTS.has(lower)) {
-    return provider === "brave" ? lower : FRESHNESS_TO_RECENCY[lower];
+    const recency = FRESHNESS_TO_RECENCY[lower];
+    return provider === "brave" ? lower : recency;
   }
   if (PERPLEXITY_RECENCY_VALUES.has(lower)) {
-    return provider === "perplexity" ? lower : RECENCY_TO_FRESHNESS[lower];
+    const freshness = RECENCY_TO_FRESHNESS[lower];
+    return provider === "perplexity" ? lower : freshness;
   }
   if (provider === "brave") {
     const match = trimmed.match(BRAVE_FRESHNESS_RANGE);
     if (match) {
       const [, start, end] = match;
       // Brave accepts explicit ISO ranges; Perplexity only supports recency buckets here.
-      if (isValidIsoDate(start) && isValidIsoDate(end) && start <= end) {
+      if (start && end && isValidIsoDate(start) && isValidIsoDate(end) && start <= end) {
         return `${start}to${end}`;
       }
     }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -873,6 +873,9 @@ export async function ensureAgentWorkspace(params?: {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
   const dir = resolveUserPath(rawDir);
   const [attestationPath, ...legacyAttestationPaths] = resolveWorkspaceAttestationPaths(dir);
+  if (!attestationPath) {
+    throw new Error("Workspace attestation path could not be resolved");
+  }
   const attestationPaths = [attestationPath, ...legacyAttestationPaths];
   const recentAttestationPath = await findRecentWorkspaceAttestationPath(attestationPaths);
 


### PR DESCRIPTION
Related: #104600

## What Problem This Solves

Phase 3a of the `noUncheckedIndexedAccess` adoption (#104600): `src/agents/**` — the runtime's hottest surface (model fallback, provider stream transports, bash execution phases, sandbox SSH, session management) — carried 517 unchecked-index errors, the largest single concentration in the repo.

## Why This Change Was Made

Pure burn-down (no lane/config changes; `src/` gates later via the core-lane flag flip): all 517 errors fixed across 91 files, repo-wide count 1,186 → 669. Dominant patterns: indexed loops to iteration/`.entries()`, `.at()`/`charAt` boundaries, destructuring, regex/split guards, explicit invariant failures — including one rewrite that deleted a pre-existing `as Extract<...>` cast because the guard provides discriminated narrowing naturally.

Hot-path equivalence was the review bar: Anthropic/OpenAI stream parsers keep event ordering and payloads byte-identical (restructuring only; guards sit on malformed-parser boundaries, not per-token paths); bash host phases preserve argv ordering, approval binding, and option consumption; SSH spawns identical argv; model fallback retains its intentionally mutable live-switch candidate index.

Cleanup-mandate finds, each verified:
- `agent-command.ts`: two sites spread `...entry` where the entry could be `undefined`, silently persisting an empty `SessionEntry` (`{...undefined}` → `{}`) — now fail loudly with context (latent state-corruption bug).
- Transcript normalization/repair: sparse/undefined messages are dropped and marked changed instead of propagating into runtime arrays.
- Malformed JWT/regex/split/JSON/LSP/compaction-plan/line-range inputs take explicit existing failure paths or clearer local errors.
- `tool-schema-projection.ts`: generalized the existing unreadable-entry constructor, deleting repeated casts.
- Codex's own review pass caught and fixed an introduced `.at(-1)` wraparound in image-placeholder deduplication before handoff.

## User Impact

No behavior change on healthy paths; corrupted-state and malformed-input paths fail with clear local errors instead of silent propagation.

## Evidence

- `tsgo -p tsconfig.core.json --noUncheckedIndexedAccess`: `src/agents` 0 errors (was 517); repo 669 (was 1,186). Normal core and core-test lanes fresh-clean.
- Blacksmith Testbox: full `pnpm check`, `pnpm check:test-types`, and the complete `pnpm test src/agents` suite (11,068/11,076 passing). The 4 failures are pre-existing load-dependent flakes, proven with a control run: detached clean `origin/main` (cc4425eb4c3) fails the same `bash-tools.exec-runtime` suspension tests identically (plus two `agent-tools.policy` tests this branch run didn't hit), and both flaky files pass solo-remote on this branch (2/2 files green). Flake cluster filed as follow-up work.
- `node scripts/run-oxlint.mjs src` clean; oxfmt clean on all 91 files.
- Fresh autoreview on the final tree with no accepted findings.
- LOC +706/−396: boundary guards and named retrievals across 517 sites; no new helpers, no compat paths.
