### PR TITLE
fix(gemini): resolve search env secret refs

### DIFF
--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -12,10 +12,9 @@ import {
   MAX_SEARCH_COUNT,
   parseWebSearchTimeFilters,
   readCachedSearchPayload,
-  readConfiguredSecretString,
   readPositiveIntegerParam,
-  readProviderEnvValue,
   readStringParam,
+  resolveWebSearchProviderCredential,
   resolveCitationRedirectUrl,
   resolveSearchCacheTtlMs,
   resolveSearchCount,
@@ -26,6 +25,7 @@ import {
   writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
+import { coerceSecretRef } from "openclaw/plugin-sdk/secret-ref-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveGoogleApiClientHeaders } from "../google-api-client-header.js";
 import {
@@ -195,11 +195,20 @@ function resolveGeminiTimeRangeFilter(
 }
 
 function resolveGeminiRuntimeApiKey(gemini?: GeminiConfig): string | undefined {
-  return (
-    readConfiguredSecretString(gemini?.apiKey, "plugins.entries.google.config.webSearch.apiKey") ??
-    readProviderEnvValue(["GEMINI_API_KEY"]) ??
-    readConfiguredSecretString(gemini?.providerApiKey, "models.providers.google.apiKey")
-  );
+  const searchApiKey = resolveWebSearchProviderCredential({
+    credentialValue: gemini?.apiKey,
+    path: "plugins.entries.google.config.webSearch.apiKey",
+    envVars: ["GEMINI_API_KEY"],
+  });
+  if (searchApiKey || coerceSecretRef(gemini?.apiKey) !== null) {
+    return searchApiKey;
+  }
+
+  return resolveWebSearchProviderCredential({
+    credentialValue: gemini?.providerApiKey,
+    path: "models.providers.google.apiKey",
+    envVars: [],
+  });
 }
 
 function resolveGeminiWebSearchHeaders(gemini?: GeminiConfig): Record<string, string> | undefined {

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -509,6 +509,126 @@ describe("google web search provider", () => {
     });
   });
 
+  it("resolves configured Gemini env SecretRefs before GEMINI_API_KEY fallback", async () => {
+    await withEnvAsync(
+      {
+        GEMINI_API_KEY: "AIza-env-test",
+        GEMINI_SECRETREF_API_KEY: "AIza-ref-test",
+      },
+      async () => {
+        const mockFetch = installGeminiFetch();
+        const provider = createGeminiWebSearchProvider();
+        const tool = provider.createTool({
+          config: {
+            plugins: {
+              entries: {
+                google: {
+                  config: {
+                    webSearch: {
+                      apiKey: {
+                        source: "env",
+                        provider: "default",
+                        id: "GEMINI_SECRETREF_API_KEY",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          searchConfig: { provider: "gemini" },
+        });
+
+        await tool?.execute({ query: "OpenClaw Gemini SecretRef precedence" });
+
+        expect(getFetchHeaders(mockFetch)["x-goog-api-key"]).toBe("AIza-ref-test");
+      },
+    );
+  });
+
+  it("does not use fallback credentials when configured Gemini SecretRefs are unavailable", async () => {
+    await withEnvAsync(
+      {
+        GEMINI_API_KEY: "AIza-env-test",
+        MISSING_GEMINI_SECRETREF_API_KEY: "",
+      },
+      async () => {
+        const mockFetch = installGeminiFetch();
+        const provider = createGeminiWebSearchProvider();
+        const tool = provider.createTool({
+          config: {
+            plugins: {
+              entries: {
+                google: {
+                  config: {
+                    webSearch: {
+                      apiKey: {
+                        source: "env",
+                        provider: "default",
+                        id: "MISSING_GEMINI_SECRETREF_API_KEY",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            models: {
+              providers: {
+                google: createGoogleModelProviderConfig({
+                  apiKey: "AIza-provider-test",
+                }),
+              },
+            },
+          },
+          searchConfig: { provider: "gemini" },
+        });
+
+        await expect(
+          tool?.execute({ query: "OpenClaw Gemini missing SecretRef" }),
+        ).resolves.toEqual({
+          docs: "https://docs.openclaw.ai/tools/web",
+          error: "missing_gemini_api_key",
+          message:
+            "web_search (gemini) needs an API key. Set GEMINI_API_KEY in the Gateway environment, configure plugins.entries.google.config.webSearch.apiKey, or reuse models.providers.google.apiKey. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
+        });
+        expect(mockFetch).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("resolves Google model-provider env SecretRefs for Gemini search fallback", async () => {
+    await withEnvAsync(
+      {
+        GEMINI_API_KEY: undefined,
+        GOOGLE_PROVIDER_SECRETREF_API_KEY: "AIza-provider-ref-test",
+      },
+      async () => {
+        const mockFetch = installGeminiFetch();
+        const provider = createGeminiWebSearchProvider();
+        const tool = provider.createTool({
+          config: {
+            models: {
+              providers: {
+                google: createGoogleModelProviderConfig({
+                  apiKey: {
+                    source: "env",
+                    provider: "default",
+                    id: "GOOGLE_PROVIDER_SECRETREF_API_KEY",
+                  },
+                }),
+              },
+            },
+          },
+          searchConfig: { provider: "gemini" },
+        });
+
+        await tool?.execute({ query: "OpenClaw Gemini provider SecretRef fallback" });
+
+        expect(getFetchHeaders(mockFetch)["x-goog-api-key"]).toBe("AIza-provider-ref-test");
+      },
+    );
+  });
+
   it("routes Gemini web search through provider-level google.baseUrl as a fallback", async () => {
     const mockFetch = installGeminiFetch();
     const provider = createGeminiWebSearchProvider();


### PR DESCRIPTION
## What Problem This Solves

Gemini web_search runtime credential resolution treated configured SecretRefs differently from direct string keys. A configured `plugins.entries.google.config.webSearch.apiKey` env SecretRef could be skipped at runtime, allowing the ambient `GEMINI_API_KEY` fallback or the Google model-provider key to be used instead.

## Why This Change Was Made

The Gemini runtime already supports direct plugin search keys, ambient `GEMINI_API_KEY`, and model-provider key fallback. It should also honor the same SecretRef credential contract used by other web_search providers: configured env SecretRefs resolve to their referenced env value, and configured-but-unavailable SecretRefs fail closed instead of silently switching accounts.

## User Impact

Users who store the Gemini search API key as an env SecretRef now get the intended credential at request time. If that referenced secret is missing, Gemini web_search returns the existing missing-key diagnostic before any fetch is attempted instead of using another fallback key.

## Evidence

- Updated Gemini runtime credential resolution in `extensions/google/src/gemini-web-search-provider.runtime.ts`.
- Added focused regressions in `extensions/google/web-search-provider.test.ts` for:
  - configured Gemini env SecretRefs beating `GEMINI_API_KEY`
  - unavailable configured SecretRefs not falling back to env/provider credentials
  - Google model-provider env SecretRefs still working as fallback when no Gemini search key is configured
- [Exact-head secretless runtime proof](https://github.com/Leon-SK668/openclaw/actions/runs/29727758575) completed successfully against PR head `01c4cb3bcc942d2a3a8af91ecd3aa3b2a9c860f9`.

## Proof

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-gemini-secretref node scripts/run-vitest.mjs extensions/google/web-search-provider.test.ts`
- `node_modules/.bin/oxfmt --check extensions/google/src/gemini-web-search-provider.runtime.ts extensions/google/web-search-provider.test.ts`
- `node_modules/.bin/oxlint extensions/google/src/gemini-web-search-provider.runtime.ts extensions/google/web-search-provider.test.ts`
- `git diff --check`

### Exact-head secretless runtime proof

- Trusted harness commit `4412a20cc14f1f7785d9d660c463dec55de32abb` has clean trusted-main parent `a971188a6d0fa66514e7278ae9fdabc7571c7ead`; the workflow separately checked out exact PR head `01c4cb3bcc942d2a3a8af91ecd3aa3b2a9c860f9` with `contents: read` and `persist-credentials: false`, then installed locked dependencies under Node 24.15.0.
- The real Gemini provider entry traversed the production web guard and environment HTTP proxy over real sockets. A configured env SecretRef value won over distinct ambient and model-provider values, and a valid Gemini-shaped loopback response completed successfully.
- With the configured env reference missing while both fallback values remained present, the provider returned `missing_gemini_api_key` and neither proxy nor origin request count increased.
- Artifact: [`pr104672-gemini-secretref-exact-head-proof`](https://github.com/Leon-SK668/openclaw/actions/runs/29727758575/artifacts/8454970136), GitHub archive digest `sha256:4464c9a7606b301d6a3a55a31d2a502c9bc7a532e12fc5bfd9df1221baf88935`.
- Scope: this is secretless runtime routing, precedence, and fail-closed proof. It does not claim real Gemini vendor authentication or service acceptance.

### Current-Head Proof Binding After Rebase (2026-07-26)

Current head: `0620bb90ad49d699a0a0778e7a83d90a246de3e1`. Frozen rebase base: `0951d0dd307d5008276714679c62459293d3b619`.

No new runtime rerun is claimed here. The secretless runtime proof above remains applicable to the current head because:

- The proof diff (`64c82812a5e52f4a03d2b89b8132c068a048a81b...01c4cb3bcc942d2a3a8af91ecd3aa3b2a9c860f9`) and current diff (`0951d0dd307d5008276714679c62459293d3b619...0620bb90ad49d699a0a0778e7a83d90a246de3e1`) have the same stable patch-id: `d65916029207c3f47d54aefba20f426dae5e3f23`.
- Both diffs contain the same two files and the same `+136/-7` aggregate change: runtime `+16/-7` and tests `+120/-0`.
- The final metadata refresh changed only the commit SHA and committer date: `739d088567e6dca2adf0383ede511e528f424877` and `0620bb90ad49d699a0a0778e7a83d90a246de3e1` share tree `0f1e30b58595b26f84b46d8db6a1fe606dd7207f`, parent `0951d0dd307d5008276714679c62459293d3b619`, author, and commit message.

Current-head validation is green:

- CI: https://github.com/openclaw/openclaw/actions/runs/30194682447
- Workflow Sanity: https://github.com/openclaw/openclaw/actions/runs/30194682428

### Fresh Exact-Head Proof After 2026-08-05 Rebase

This proof supersedes the earlier-head binding above for current PR head `35f6e58015cad0956663092b57ae6b1ce81da24a`.

- [Secretless Actions run 30983604733](https://github.com/Leon-SK668/openclaw/actions/runs/30983604733) / [job 92233261828](https://github.com/Leon-SK668/openclaw/actions/runs/30983604733/job/92233261828) succeeded on Node 24.15.0 with a frozen-lockfile install.
- The real Gemini provider entry traversed the production web guard and a real loopback HTTP proxy/socket path. The configured env SecretRef won over distinct ambient `GEMINI_API_KEY` and model-provider credentials, and the Gemini-shaped response completed successfully.
- With the configured env SecretRef unavailable while both fallback credentials remained present, the provider returned `missing_gemini_api_key`; proxy and origin request counts did not increase.
- All recorded invariants were true: exact head, provider entry, proxy/origin sockets, request method/path/tool, configured credential precedence, fallback rejection, successful result, and fail-closed no-fetch behavior.
- [Artifact 8921159057](https://github.com/Leon-SK668/openclaw/actions/runs/30983604733/artifacts/8921159057), digest `sha256:97a52ffcb8d82683433880bee2dcf14723bd9f61c3beb0dccb2f77687cd3d434`, expires 2026-11-03.

Scope: secretless runtime routing, precedence, and fail-closed proof; it does not claim real Gemini vendor authentication or service acceptance.