### PR TITLE
fix(ci): skip absent frozen-target protocol guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,8 @@ jobs:
             eventName === "workflow_dispatch" &&
             historicalTargetApproved &&
             checkoutRevision !== workflowRevision;
+          const frozenTarget =
+            eventName === "workflow_dispatch" && checkoutRevision !== workflowRevision;
 
           const nodeTestPlan = await import("./scripts/lib/ci-node-test-plan.mjs");
           const createNodeTestPlan =
@@ -444,7 +446,7 @@ jobs:
           const protocolCoverageRequested = runNode || runIosBuild || runAndroid;
           const runProtocolEventCoverage =
             protocolCoverageRequested &&
-            (!historicalTarget || existsSync("scripts/check-protocol-event-coverage.mjs"));
+            (!frozenTarget || existsSync("scripts/check-protocol-event-coverage.mjs"));
 
           const manifest = {
             docs_only: docsOnly,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -57,6 +57,7 @@ function runCiManifestFixture(options: {
   eventName?: "pull_request" | "workflow_dispatch";
   historicalCompatibility?: boolean;
   iosCapabilities?: boolean;
+  protocolCoverage?: boolean;
 }) {
   const root = mkdtempSync(path.join(tmpdir(), "openclaw-ci-manifest-"));
   try {
@@ -122,6 +123,9 @@ function runCiManifestFixture(options: {
       for (const name of ["install-swift-tools.sh", "lint-swift.sh", "format-swift.sh"]) {
         writeFileSync(path.join(root, "scripts", name), "#!/bin/sh\n");
       }
+    }
+    if (options.protocolCoverage ?? options.bundledPlanner) {
+      writeFileSync(path.join(root, "scripts", "check-protocol-event-coverage.mjs"), "");
     }
     const outputPath = path.join(root, "manifest.out");
     writeFileSync(outputPath, "", "utf8");
@@ -1635,6 +1639,7 @@ describe("ci workflow guards", () => {
     expect(current.outputs.run_native_i18n).toBe("true");
     expect(current.outputs.run_qa_smoke_ci).toBe("true");
     expect(current.outputs.run_channel_contracts_shards).toBe("true");
+    expect(current.outputs.run_protocol_event_coverage).toBe("true");
     expect(JSON.parse(current.outputs.checks_node_core_nondist_matrix).include).toContainEqual(
       expect.objectContaining({
         check_name: "bundled-node-plan",
@@ -1650,6 +1655,27 @@ describe("ci workflow guards", () => {
     expect(currentMissingIos.status, currentMissingIos.output).toBe(0);
     expect(currentMissingIos.outputs.historical_target).toBe("false");
     expect(currentMissingIos.outputs.run_ios_build).toBe("true");
+
+    const currentMissingProtocolCoverage = runCiManifestFixture({
+      bundledPlanner: true,
+      historicalCompatibility: false,
+      protocolCoverage: false,
+    });
+    expect(currentMissingProtocolCoverage.status, currentMissingProtocolCoverage.output).toBe(0);
+    expect(currentMissingProtocolCoverage.outputs.historical_target).toBe("false");
+    expect(currentMissingProtocolCoverage.outputs.run_protocol_event_coverage).toBe("false");
+
+    const pullRequestMissingProtocolCoverage = runCiManifestFixture({
+      bundledPlanner: true,
+      eventName: "pull_request",
+      protocolCoverage: false,
+    });
+    expect(
+      pullRequestMissingProtocolCoverage.status,
+      pullRequestMissingProtocolCoverage.output,
+    ).toBe(0);
+    expect(pullRequestMissingProtocolCoverage.outputs.historical_target).toBe("false");
+    expect(pullRequestMissingProtocolCoverage.outputs.run_protocol_event_coverage).toBe("true");
 
     const currentMissingPlanner = runCiManifestFixture({
       bundledPlanner: false,


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation uses trusted current-main workflow code against frozen candidate checkouts. The unpublished `extended-stable/2026.6.33` candidate predates `scripts/check-protocol-event-coverage.mjs`, but current CI unconditionally invoked that target-owned script and failed preflight before candidate tests could run.

## Why This Change Was Made

Treat a manually dispatched checkout whose revision differs from the trusted workflow revision as frozen for this capability probe. Skip protocol coverage only when that frozen checkout lacks the script. Current pull requests and same-revision dispatches remain fail-closed: the check stays required even if a patch deletes or renames the script.

## User Impact

No product runtime change. Restores exact-candidate release validation for older beta/LTS checkouts without allowing current CI changes to self-disable the protocol guard.

## Evidence

- LTS failure: https://github.com/openclaw/openclaw/actions/runs/29165952305/job/86578988126
- Focused Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29166161407 — 50/50 passed
- `git diff --check`
- Fresh autoreview: clean after fail-closed current-target regression coverage
