### PR TITLE
improve(ui): search within Settings pages

### DIFF
--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -6,6 +6,7 @@ import {
   SIDEBAR_NAV_ROUTES,
   isPluginsHubRoute,
   navigationIconForRoute,
+  settingsSearchTextMatches,
   subtitleForRoute,
   titleForRoute,
 } from "./app-navigation.ts";
@@ -104,6 +105,14 @@ describe("navigationIconForRoute", () => {
     // TypeScript won't allow this normally, but runtime could receive unexpected values
     const unknownRouteId = "unknown" as RouteId;
     expect(navigationIconForRoute(unknownRouteId)).toBe("folder");
+  });
+});
+
+describe("settingsSearchTextMatches", () => {
+  it("uses locale-aware word prefixes for short queries", () => {
+    expect(settingsSearchTextMatches("CPU usage", "cp")).toBe(true);
+    expect(settingsSearchTextMatches("MCP", "cp")).toBe(false);
+    expect(settingsSearchTextMatches("外観設定", "設定")).toBe(true);
   });
 });
 

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -1,7 +1,7 @@
 // Control UI app navigation defines sidebar and settings presentation metadata.
 import type { RouteId } from "./app-route-paths.ts";
 import type { IconName } from "./components/icons.ts";
-import { t } from "./i18n/index.ts";
+import { i18n, t } from "./i18n/index.ts";
 import { normalizeLowercaseStringOrEmpty } from "./lib/string-coerce.ts";
 
 export type NavigationRouteId = RouteId;
@@ -86,6 +86,29 @@ export type SettingsSearchBlock = {
   hash: string;
 };
 
+let settingsSearchSegmenterLocale = "";
+let settingsSearchSegmenter: Intl.Segmenter | null = null;
+
+function settingsSearchHasWordPrefix(value: string, query: string): boolean {
+  const locale = i18n.getLocale();
+  if (settingsSearchSegmenterLocale !== locale) {
+    settingsSearchSegmenterLocale = locale;
+    settingsSearchSegmenter =
+      typeof Intl !== "undefined" && "Segmenter" in Intl
+        ? new Intl.Segmenter(locale, { granularity: "word" })
+        : null;
+  }
+  if (!settingsSearchSegmenter) {
+    return value.split(/[^\p{L}\p{N}]+/u).some((word) => word.startsWith(query));
+  }
+  for (const segment of settingsSearchSegmenter.segment(value)) {
+    if (segment.isWordLike !== false && segment.segment.startsWith(query)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function settingsSearchTextMatches(value: string, query: string): boolean {
   const candidate = normalizeLowercaseStringOrEmpty(value);
   const normalizedQuery = normalizeLowercaseStringOrEmpty(query);
@@ -95,7 +118,7 @@ export function settingsSearchTextMatches(value: string, query: string): boolean
   if (normalizedQuery.length > 2) {
     return candidate.includes(normalizedQuery);
   }
-  return candidate.split(/[^\p{L}\p{N}]+/u).some((word) => word.startsWith(normalizedQuery));
+  return settingsSearchHasWordPrefix(candidate, normalizedQuery);
 }
 
 // Grouping feeds the full-page settings sidebar (settings-sidebar.ts).

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -2,6 +2,7 @@
 import type { RouteId } from "./app-route-paths.ts";
 import type { IconName } from "./components/icons.ts";
 import { t } from "./i18n/index.ts";
+import { normalizeLowercaseStringOrEmpty } from "./lib/string-coerce.ts";
 
 export type NavigationRouteId = RouteId;
 
@@ -77,6 +78,25 @@ type SettingsNavigationGroup = {
   labelKey: string | null;
   routes: readonly NavigationRouteId[];
 };
+
+export type SettingsSearchBlock = {
+  routeId: RouteId;
+  label: string;
+  search?: string;
+  hash: string;
+};
+
+export function settingsSearchTextMatches(value: string, query: string): boolean {
+  const candidate = normalizeLowercaseStringOrEmpty(value);
+  const normalizedQuery = normalizeLowercaseStringOrEmpty(query);
+  if (!normalizedQuery) {
+    return false;
+  }
+  if (normalizedQuery.length > 2) {
+    return candidate.includes(normalizedQuery);
+  }
+  return candidate.split(/[^\p{L}\p{N}]+/u).some((word) => word.startsWith(normalizedQuery));
+}
 
 // Grouping feeds the full-page settings sidebar (settings-sidebar.ts).
 export const SETTINGS_NAVIGATION_GROUPS = [

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -53,7 +53,7 @@ type ShellSettingsSearchLoadState = {
   runtime: {
     context: ApplicationContext;
   };
-  handleSettingsSearchQueryChange: (query: string) => void;
+  handleSettingsSearchQueryChange: (query: string) => Promise<void>;
 };
 
 type TestWebKitWindow = Window & {
@@ -215,8 +215,7 @@ describe("OpenClaw shell settings search", () => {
       context: { runtimeConfig } as unknown as ApplicationContext,
     };
 
-    shell.handleSettingsSearchQueryChange("browser");
-    await Promise.resolve();
+    await shell.handleSettingsSearchQueryChange("browser");
 
     expect(runtimeConfig.ensureLoaded).toHaveBeenCalledOnce();
     expect(runtimeConfig.ensureSchemaLoaded).toHaveBeenCalledOnce();
@@ -244,17 +243,48 @@ describe("OpenClaw shell settings search", () => {
       context: { runtimeConfig: firstRuntimeConfig } as unknown as ApplicationContext,
     };
 
-    shell.handleSettingsSearchQueryChange("browser");
+    const load = shell.handleSettingsSearchQueryChange("browser");
     shell.runtime = {
       context: { runtimeConfig: secondRuntimeConfig } as unknown as ApplicationContext,
     };
     finishLoad?.();
-    await Promise.resolve();
+    await load;
 
     expect(firstRuntimeConfig.ensureLoaded).toHaveBeenCalledOnce();
     expect(firstRuntimeConfig.ensureSchemaLoaded).not.toHaveBeenCalled();
     expect(secondRuntimeConfig.ensureSchemaLoaded).not.toHaveBeenCalled();
   });
+
+  it.each(["config", "schema"] as const)(
+    "contains rejected %s loads within settings search",
+    async (failureStage) => {
+      const runtimeConfig = {
+        ensureLoaded: vi.fn(() =>
+          failureStage === "config"
+            ? Promise.reject(new Error("config unavailable"))
+            : Promise.resolve(),
+        ),
+        ensureSchemaLoaded: vi.fn(() =>
+          failureStage === "schema"
+            ? Promise.reject(new Error("schema unavailable"))
+            : Promise.resolve(),
+        ),
+      } as unknown as ApplicationContext["runtimeConfig"];
+      const shell = document.createElement(
+        "openclaw-app-shell",
+      ) as unknown as ShellSettingsSearchLoadState;
+      shell.runtime = {
+        context: { runtimeConfig } as unknown as ApplicationContext,
+      };
+
+      await expect(shell.handleSettingsSearchQueryChange("browser")).resolves.toBeUndefined();
+
+      expect(runtimeConfig.ensureLoaded).toHaveBeenCalledOnce();
+      expect(runtimeConfig.ensureSchemaLoaded).toHaveBeenCalledTimes(
+        failureStage === "schema" ? 1 : 0,
+      );
+    },
+  );
 });
 
 describe("OpenClaw shell keyboard shortcuts", () => {

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -49,6 +49,13 @@ type ShellNavigationState = {
   updated: () => void;
 };
 
+type ShellSettingsSearchLoadState = {
+  runtime: {
+    context: ApplicationContext;
+  };
+  handleSettingsSearchQueryChange: (query: string) => void;
+};
+
 type TestWebKitWindow = Window & {
   webkit?: {
     messageHandlers: {
@@ -192,6 +199,61 @@ describe("OpenClaw shell source initialization", () => {
     expect(secondAgents.ensureList).toHaveBeenCalledOnce();
     expect(firstRuntimeConfig.ensureLoaded).toHaveBeenCalledOnce();
     expect(secondRuntimeConfig.ensureLoaded).toHaveBeenCalledOnce();
+  });
+});
+
+describe("OpenClaw shell settings search", () => {
+  it("loads config and schema for a non-empty query", async () => {
+    const runtimeConfig = {
+      ensureLoaded: vi.fn(() => Promise.resolve()),
+      ensureSchemaLoaded: vi.fn(() => Promise.resolve()),
+    } as unknown as ApplicationContext["runtimeConfig"];
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellSettingsSearchLoadState;
+    shell.runtime = {
+      context: { runtimeConfig } as unknown as ApplicationContext,
+    };
+
+    shell.handleSettingsSearchQueryChange("browser");
+    await Promise.resolve();
+
+    expect(runtimeConfig.ensureLoaded).toHaveBeenCalledOnce();
+    expect(runtimeConfig.ensureSchemaLoaded).toHaveBeenCalledOnce();
+  });
+
+  it("does not load schema through a replaced runtime config capability", async () => {
+    let finishLoad: (() => void) | undefined;
+    const firstRuntimeConfig = {
+      ensureLoaded: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishLoad = resolve;
+          }),
+      ),
+      ensureSchemaLoaded: vi.fn(() => Promise.resolve()),
+    } as unknown as ApplicationContext["runtimeConfig"];
+    const secondRuntimeConfig = {
+      ensureLoaded: vi.fn(() => Promise.resolve()),
+      ensureSchemaLoaded: vi.fn(() => Promise.resolve()),
+    } as unknown as ApplicationContext["runtimeConfig"];
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellSettingsSearchLoadState;
+    shell.runtime = {
+      context: { runtimeConfig: firstRuntimeConfig } as unknown as ApplicationContext,
+    };
+
+    shell.handleSettingsSearchQueryChange("browser");
+    shell.runtime = {
+      context: { runtimeConfig: secondRuntimeConfig } as unknown as ApplicationContext,
+    };
+    finishLoad?.();
+    await Promise.resolve();
+
+    expect(firstRuntimeConfig.ensureLoaded).toHaveBeenCalledOnce();
+    expect(firstRuntimeConfig.ensureSchemaLoaded).not.toHaveBeenCalled();
+    expect(secondRuntimeConfig.ensureSchemaLoaded).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -1056,8 +1056,7 @@ class OpenClawShell extends OpenClawLightDomElement {
                 onExit: () => this.exitSettings(),
                 onNavigate: (routeId, options) => this.navigate(routeId, options),
                 onPreload: (routeId) => context.preload(routeId),
-                onSearchQueryChange: (nextQuery) =>
-                  this.handleSettingsSearchQueryChange(nextQuery),
+                onSearchQueryChange: (nextQuery) => this.handleSettingsSearchQueryChange(nextQuery),
                 preloadTimers: this.settingsPreloadTimers,
               })
             : html`<openclaw-app-sidebar

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -565,6 +565,19 @@ class OpenClawShell extends OpenClawLightDomElement {
     context.theme.setMode(event.detail.mode, event.detail.element);
   };
 
+  private handleSettingsSearchQueryChange(nextQuery: string) {
+    this.settingsSearchQuery = nextQuery;
+    const runtimeConfig = this.context?.runtimeConfig;
+    if (!runtimeConfig || !nextQuery.trim()) {
+      return;
+    }
+    void runtimeConfig.ensureLoaded().then(() => {
+      if (this.context?.runtimeConfig === runtimeConfig) {
+        void runtimeConfig.ensureSchemaLoaded();
+      }
+    });
+  }
+
   private chatNavigationOptions(options?: ApplicationNavigationOptions) {
     if (options) {
       return options;
@@ -1043,14 +1056,8 @@ class OpenClawShell extends OpenClawLightDomElement {
                 onExit: () => this.exitSettings(),
                 onNavigate: (routeId, options) => this.navigate(routeId, options),
                 onPreload: (routeId) => context.preload(routeId),
-                onSearchQueryChange: (nextQuery) => {
-                  this.settingsSearchQuery = nextQuery;
-                  if (nextQuery.trim()) {
-                    void context.runtimeConfig
-                      .ensureLoaded()
-                      .then(() => context.runtimeConfig.ensureSchemaLoaded());
-                  }
-                },
+                onSearchQueryChange: (nextQuery) =>
+                  this.handleSettingsSearchQueryChange(nextQuery),
                 preloadTimers: this.settingsPreloadTimers,
               })
             : html`<openclaw-app-sidebar

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -34,6 +34,7 @@ import { searchForSession } from "../lib/sessions/index.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import "../pages/approval/approval-page.ts";
+import { findSettingsSearchBlocks } from "../pages/config/settings-search.ts";
 import { renderDevicePairSetup } from "../pages/nodes/view-pairing.ts";
 import { pluginTabKey, pluginTabRefFromSearch } from "../pages/plugin/route.ts";
 import { bootstrapApplication, type ApplicationRuntime } from "./bootstrap.ts";
@@ -951,6 +952,13 @@ class OpenClawShell extends OpenClawLightDomElement {
         : null;
     const activePluginTabId = activePluginRef ? pluginTabKey(activePluginRef) : "";
     const settingsTakeover = isSettingsNavigationRoute(activeRoute);
+    const runtimeConfig = context.runtimeConfig.state;
+    const settingsSearchBlocks = findSettingsSearchBlocks({
+      query: this.settingsSearchQuery,
+      schema: runtimeConfig.configSchema,
+      value: runtimeConfig.configForm ?? runtimeConfig.configSnapshot?.config ?? null,
+      uiHints: runtimeConfig.configUiHints,
+    });
     const navDrawerOpen = this.navDrawerOpen && !this.onboarding;
     // Drawer navigation always opens expanded; the desktop collapse preference
     // stays persisted for when the viewport returns to the desktop layout.
@@ -1020,6 +1028,8 @@ class OpenClawShell extends OpenClawLightDomElement {
             ? renderSettingsSidebar({
                 basePath: context.basePath,
                 activeRouteId: activeRoute,
+                activeSearch: this.routeState.location?.search ?? "",
+                activeHash: this.routeState.location?.hash ?? "",
                 connected: gatewaySnapshot.connected,
                 version:
                   context.config.current.serverVersion ??
@@ -1029,11 +1039,17 @@ class OpenClawShell extends OpenClawLightDomElement {
                 updateRunning: overlaySnapshot.updateRunning,
                 onUpdate: () => void context.overlays.runUpdate(),
                 searchQuery: this.settingsSearchQuery,
+                searchBlockMatches: settingsSearchBlocks,
                 onExit: () => this.exitSettings(),
-                onNavigate: (routeId) => this.navigate(routeId),
+                onNavigate: (routeId, options) => this.navigate(routeId, options),
                 onPreload: (routeId) => context.preload(routeId),
                 onSearchQueryChange: (nextQuery) => {
                   this.settingsSearchQuery = nextQuery;
+                  if (nextQuery.trim()) {
+                    void context.runtimeConfig
+                      .ensureLoaded()
+                      .then(() => context.runtimeConfig.ensureSchemaLoaded());
+                  }
                 },
                 preloadTimers: this.settingsPreloadTimers,
               })

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -565,17 +565,20 @@ class OpenClawShell extends OpenClawLightDomElement {
     context.theme.setMode(event.detail.mode, event.detail.element);
   };
 
-  private handleSettingsSearchQueryChange(nextQuery: string) {
+  private async handleSettingsSearchQueryChange(nextQuery: string): Promise<void> {
     this.settingsSearchQuery = nextQuery;
     const runtimeConfig = this.context?.runtimeConfig;
     if (!runtimeConfig || !nextQuery.trim()) {
       return;
     }
-    void runtimeConfig.ensureLoaded().then(() => {
+    try {
+      await runtimeConfig.ensureLoaded();
       if (this.context?.runtimeConfig === runtimeConfig) {
-        void runtimeConfig.ensureSchemaLoaded();
+        await runtimeConfig.ensureSchemaLoaded();
       }
-    });
+    } catch {
+      // Runtime config state owns the visible load error; search stays usable.
+    }
   }
 
   private chatNavigationOptions(options?: ApplicationNavigationOptions) {
@@ -1056,7 +1059,9 @@ class OpenClawShell extends OpenClawLightDomElement {
                 onExit: () => this.exitSettings(),
                 onNavigate: (routeId, options) => this.navigate(routeId, options),
                 onPreload: (routeId) => context.preload(routeId),
-                onSearchQueryChange: (nextQuery) => this.handleSettingsSearchQueryChange(nextQuery),
+                onSearchQueryChange: (nextQuery) => {
+                  void this.handleSettingsSearchQueryChange(nextQuery);
+                },
                 preloadTimers: this.settingsPreloadTimers,
               })
             : html`<openclaw-app-sidebar

--- a/ui/src/components/config-form.meta.ts
+++ b/ui/src/components/config-form.meta.ts
@@ -1,0 +1,53 @@
+import { t } from "../i18n/index.ts";
+
+type ConfigSectionMeta = {
+  label: string;
+  description: string;
+};
+
+function createSectionMeta(key: string): ConfigSectionMeta {
+  return {
+    get label() {
+      return t(`configForm.sections.${key}.label`);
+    },
+    get description() {
+      return t(`configForm.sections.${key}.description`);
+    },
+  };
+}
+
+// Getters keep shared metadata responsive to runtime locale changes.
+export const SECTION_META: Record<string, ConfigSectionMeta> = {
+  env: createSectionMeta("env"),
+  update: createSectionMeta("update"),
+  agents: createSectionMeta("agents"),
+  auth: createSectionMeta("auth"),
+  channels: createSectionMeta("channels"),
+  messages: createSectionMeta("messages"),
+  commands: createSectionMeta("commands"),
+  hooks: createSectionMeta("hooks"),
+  skills: createSectionMeta("skills"),
+  tools: createSectionMeta("tools"),
+  gateway: createSectionMeta("gateway"),
+  wizard: createSectionMeta("wizard"),
+  meta: createSectionMeta("meta"),
+  logging: createSectionMeta("logging"),
+  browser: createSectionMeta("browser"),
+  ui: createSectionMeta("ui"),
+  models: createSectionMeta("models"),
+  bindings: createSectionMeta("bindings"),
+  broadcast: createSectionMeta("broadcast"),
+  audio: createSectionMeta("audio"),
+  session: createSectionMeta("session"),
+  cron: createSectionMeta("cron"),
+  web: createSectionMeta("web"),
+  discovery: createSectionMeta("discovery"),
+  canvasHost: createSectionMeta("canvasHost"),
+  talk: createSectionMeta("talk"),
+  plugins: createSectionMeta("plugins"),
+  diagnostics: createSectionMeta("diagnostics"),
+  cli: createSectionMeta("cli"),
+  secrets: createSectionMeta("secrets"),
+  acp: createSectionMeta("acp"),
+  mcp: createSectionMeta("mcp"),
+};

--- a/ui/src/components/config-form.node.ts
+++ b/ui/src/components/config-form.node.ts
@@ -6,19 +6,23 @@ import "../components/tooltip.ts";
 import { t } from "../i18n/index.ts";
 import { formatUnknownText } from "../lib/format.ts";
 import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalLowercaseString,
-} from "../lib/string-coerce.ts";
+  hasConfigSearchCriteria as hasSearchCriteria,
+  matchesNodeSearch,
+  matchesNodeSelf,
+  resolveConfigFieldMeta as resolveFieldMeta,
+  type ConfigSearchCriteria,
+} from "./config-form.search.ts";
 import {
   defaultValue,
   hasSensitiveConfigData,
   hintForPath,
-  humanize,
   pathKey,
   REDACTED_PLACEHOLDER,
   schemaType,
   type JsonSchema,
 } from "./config-form.shared.ts";
+
+export { matchesNodeSearch, parseConfigSearchQuery } from "./config-form.search.ts";
 
 const META_KEYS = new Set(["title", "description", "default", "nullable", "tags", "x-tags"]);
 
@@ -128,12 +132,6 @@ const icons = {
   `,
 };
 
-type FieldMeta = {
-  label: string;
-  help?: string;
-  tags: string[];
-};
-
 function isSecretRefObject(value: unknown): value is {
   source: string;
   id: string;
@@ -162,11 +160,6 @@ type SensitiveRenderState = {
   isRedacted: boolean;
   isRevealed: boolean;
   canReveal: boolean;
-};
-
-type ConfigSearchCriteria = {
-  text: string;
-  tags: string[];
 };
 
 function getSensitiveRenderState(params: SensitiveRenderParams): SensitiveRenderState {
@@ -212,212 +205,6 @@ function renderSensitiveToggleButton(params: {
       </button>
     </openclaw-tooltip>
   `;
-}
-
-function hasSearchCriteria(criteria: ConfigSearchCriteria | undefined): boolean {
-  return Boolean(criteria && (criteria.text.length > 0 || criteria.tags.length > 0));
-}
-
-export function parseConfigSearchQuery(query: string): ConfigSearchCriteria {
-  const tags: string[] = [];
-  const seen = new Set<string>();
-  const raw = query.trim();
-  const stripped = raw.replace(/(^|\s)tag:([^\s]+)/gi, (_, leading: string, token: string) => {
-    const normalized = normalizeLowercaseStringOrEmpty(token);
-    if (normalized && !seen.has(normalized)) {
-      seen.add(normalized);
-      tags.push(normalized);
-    }
-    return leading;
-  });
-  return {
-    text: normalizeLowercaseStringOrEmpty(stripped),
-    tags,
-  };
-}
-
-function normalizeTags(raw: unknown): string[] {
-  if (!Array.isArray(raw)) {
-    return [];
-  }
-  const seen = new Set<string>();
-  const tags: string[] = [];
-  for (const value of raw) {
-    if (typeof value !== "string") {
-      continue;
-    }
-    const tag = value.trim();
-    if (!tag) {
-      continue;
-    }
-    const key = normalizeLowercaseStringOrEmpty(tag);
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    tags.push(tag);
-  }
-  return tags;
-}
-
-function resolveFieldMeta(
-  path: Array<string | number>,
-  schema: JsonSchema,
-  hints: ConfigUiHints,
-): FieldMeta {
-  const hint = hintForPath(path, hints);
-  const label = hint?.label ?? schema.title ?? humanize(String(path.at(-1)));
-  const help = hint?.help ?? schema.description;
-  const schemaTags = normalizeTags(schema["x-tags"] ?? schema.tags);
-  const hintTags = normalizeTags(hint?.tags);
-  return {
-    label,
-    help,
-    tags: hintTags.length > 0 ? hintTags : schemaTags,
-  };
-}
-
-function matchesText(text: string, candidates: Array<string | undefined>): boolean {
-  if (!text) {
-    return true;
-  }
-  for (const candidate of candidates) {
-    if (normalizeOptionalLowercaseString(candidate)?.includes(text)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function matchesTags(filterTags: string[], fieldTags: string[]): boolean {
-  if (filterTags.length === 0) {
-    return true;
-  }
-  const normalized = new Set(fieldTags.map((tag) => normalizeLowercaseStringOrEmpty(tag)));
-  return filterTags.every((tag) => normalized.has(tag));
-}
-
-function matchesNodeSelf(params: {
-  schema: JsonSchema;
-  path: Array<string | number>;
-  hints: ConfigUiHints;
-  criteria: ConfigSearchCriteria;
-}): boolean {
-  const { schema, path, hints, criteria } = params;
-  if (!hasSearchCriteria(criteria)) {
-    return true;
-  }
-  const { label, help, tags } = resolveFieldMeta(path, schema, hints);
-  if (!matchesTags(criteria.tags, tags)) {
-    return false;
-  }
-
-  if (!criteria.text) {
-    return true;
-  }
-
-  const pathLabel = path
-    .filter((segment): segment is string => typeof segment === "string")
-    .join(".");
-  const enumText =
-    schema.enum && schema.enum.length > 0
-      ? schema.enum.map((value) => String(value)).join(" ")
-      : "";
-
-  return matchesText(criteria.text, [
-    label,
-    help,
-    schema.title,
-    schema.description,
-    pathLabel,
-    enumText,
-  ]);
-}
-
-export function matchesNodeSearch(params: {
-  schema: JsonSchema;
-  value: unknown;
-  path: Array<string | number>;
-  hints: ConfigUiHints;
-  criteria: ConfigSearchCriteria;
-}): boolean {
-  const { schema, value, path, hints, criteria } = params;
-  if (!hasSearchCriteria(criteria)) {
-    return true;
-  }
-  if (matchesNodeSelf({ schema, path, hints, criteria })) {
-    return true;
-  }
-
-  const type = schemaType(schema);
-  if (type === "object") {
-    const fallback = value ?? schema.default;
-    const obj =
-      fallback && typeof fallback === "object" && !Array.isArray(fallback)
-        ? (fallback as Record<string, unknown>)
-        : {};
-    const props = schema.properties ?? {};
-    for (const [propKey, node] of Object.entries(props)) {
-      if (
-        matchesNodeSearch({
-          schema: node,
-          value: obj[propKey],
-          path: [...path, propKey],
-          hints,
-          criteria,
-        })
-      ) {
-        return true;
-      }
-    }
-    const additional = schema.additionalProperties;
-    if (additional && typeof additional === "object") {
-      const reserved = new Set(Object.keys(props));
-      for (const [entryKey, entryValue] of Object.entries(obj)) {
-        if (reserved.has(entryKey)) {
-          continue;
-        }
-        if (
-          matchesNodeSearch({
-            schema: additional,
-            value: entryValue,
-            path: [...path, entryKey],
-            hints,
-            criteria,
-          })
-        ) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  if (type === "array") {
-    const itemsSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
-    if (!itemsSchema) {
-      return false;
-    }
-    const arr = Array.isArray(value) ? value : Array.isArray(schema.default) ? schema.default : [];
-    if (arr.length === 0) {
-      return false;
-    }
-    for (let idx = 0; idx < arr.length; idx += 1) {
-      if (
-        matchesNodeSearch({
-          schema: itemsSchema,
-          value: arr[idx],
-          path: [...path, idx],
-          hints,
-          criteria,
-        })
-      ) {
-        return true;
-      }
-    }
-  }
-
-  return false;
 }
 
 function renderTags(tags: string[]): TemplateResult | typeof nothing {

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -3,8 +3,9 @@ import { html, nothing } from "lit";
 import type { ConfigUiHints } from "../api/types.ts";
 import { icons } from "../components/icons.ts";
 import { t } from "../i18n/index.ts";
-import { normalizeLowercaseStringOrEmpty } from "../lib/string-coerce.ts";
-import { matchesNodeSearch, parseConfigSearchQuery, renderNode } from "./config-form.node.ts";
+import { SECTION_META } from "./config-form.meta.ts";
+import { renderNode } from "./config-form.node.ts";
+import { matchesConfigSectionSearch, parseConfigSearchQuery } from "./config-form.search.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 
 type ConfigFormProps = {
@@ -277,53 +278,6 @@ const sectionIcons = {
   `,
 };
 
-function createSectionMeta(key: string): { label: string; description: string } {
-  return {
-    get label() {
-      return t(`configForm.sections.${key}.label`);
-    },
-    get description() {
-      return t(`configForm.sections.${key}.description`);
-    },
-  };
-}
-
-// Getters keep exported metadata responsive to runtime locale changes.
-export const SECTION_META: Record<string, { label: string; description: string }> = {
-  env: createSectionMeta("env"),
-  update: createSectionMeta("update"),
-  agents: createSectionMeta("agents"),
-  auth: createSectionMeta("auth"),
-  channels: createSectionMeta("channels"),
-  messages: createSectionMeta("messages"),
-  commands: createSectionMeta("commands"),
-  hooks: createSectionMeta("hooks"),
-  skills: createSectionMeta("skills"),
-  tools: createSectionMeta("tools"),
-  gateway: createSectionMeta("gateway"),
-  wizard: createSectionMeta("wizard"),
-  meta: createSectionMeta("meta"),
-  logging: createSectionMeta("logging"),
-  browser: createSectionMeta("browser"),
-  ui: createSectionMeta("ui"),
-  models: createSectionMeta("models"),
-  bindings: createSectionMeta("bindings"),
-  broadcast: createSectionMeta("broadcast"),
-  audio: createSectionMeta("audio"),
-  session: createSectionMeta("session"),
-  cron: createSectionMeta("cron"),
-  web: createSectionMeta("web"),
-  discovery: createSectionMeta("discovery"),
-  canvasHost: createSectionMeta("canvasHost"),
-  talk: createSectionMeta("talk"),
-  plugins: createSectionMeta("plugins"),
-  diagnostics: createSectionMeta("diagnostics"),
-  cli: createSectionMeta("cli"),
-  secrets: createSectionMeta("secrets"),
-  acp: createSectionMeta("acp"),
-  mcp: createSectionMeta("mcp"),
-};
-
 function getSectionIcon(key: string) {
   return sectionIcons[key as keyof typeof sectionIcons] ?? sectionIcons.default;
 }
@@ -335,28 +289,15 @@ function matchesSearch(params: {
   uiHints: ConfigUiHints;
   query: string;
 }): boolean {
-  if (!params.query) {
-    return true;
-  }
-  const criteria = parseConfigSearchQuery(params.query);
-  const q = criteria.text;
   const meta = SECTION_META[params.key];
-  const sectionMetaMatches =
-    q &&
-    (normalizeLowercaseStringOrEmpty(params.key).includes(q) ||
-      (meta?.label ? normalizeLowercaseStringOrEmpty(meta.label).includes(q) : false) ||
-      (meta?.description ? normalizeLowercaseStringOrEmpty(meta.description).includes(q) : false));
-
-  if (sectionMetaMatches && criteria.tags.length === 0) {
-    return true;
-  }
-
-  return matchesNodeSearch({
+  return matchesConfigSectionSearch({
+    key: params.key,
     schema: params.schema,
     value: params.sectionValue,
-    path: [params.key],
     hints: params.uiHints,
-    criteria,
+    query: params.query,
+    label: meta?.label,
+    description: meta?.description,
   });
 }
 

--- a/ui/src/components/config-form.search.node.test.ts
+++ b/ui/src/components/config-form.search.node.test.ts
@@ -67,4 +67,27 @@ describe("config form search", () => {
     });
     expect(negative).toBe(false);
   });
+
+  it("searches array item schemas before entries exist", () => {
+    const matched = matchesNodeSearch({
+      schema: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            source: {
+              type: "string",
+              description: "Credential source for outgoing requests",
+            },
+          },
+        },
+      },
+      value: [],
+      path: ["headers"],
+      hints: {},
+      criteria: parseConfigSearchQuery("credential source"),
+    });
+
+    expect(matched).toBe(true);
+  });
 });

--- a/ui/src/components/config-form.search.node.test.ts
+++ b/ui/src/components/config-form.search.node.test.ts
@@ -90,4 +90,30 @@ describe("config form search", () => {
 
     expect(matched).toBe(true);
   });
+
+  it("searches additional-property schemas before entries exist", () => {
+    const matched = matchesNodeSearch({
+      schema: {
+        type: "object",
+        additionalProperties: {
+          type: "object",
+          properties: {
+            url: {
+              type: "string",
+            },
+          },
+        },
+      },
+      value: {},
+      path: ["servers"],
+      hints: {
+        "servers.*.url": {
+          help: "Endpoint used by the remote service",
+        },
+      },
+      criteria: parseConfigSearchQuery("remote service"),
+    });
+
+    expect(matched).toBe(true);
+  });
 });

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -1,8 +1,5 @@
 import type { ConfigUiHints } from "../api/types.ts";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalLowercaseString,
-} from "../lib/string-coerce.ts";
+import { normalizeLowercaseStringOrEmpty } from "../lib/string-coerce.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 
 export type ConfigSearchCriteria = {
@@ -15,6 +12,8 @@ export type ConfigFieldMeta = {
   help?: string;
   tags: string[];
 };
+
+export type ConfigSearchTextMatcher = (value: string, query: string) => boolean;
 
 export function hasConfigSearchCriteria(criteria: ConfigSearchCriteria | undefined): boolean {
   return Boolean(criteria && (criteria.text.length > 0 || criteria.tags.length > 0));
@@ -79,13 +78,19 @@ export function resolveConfigFieldMeta(
   };
 }
 
-function matchesText(text: string, candidates: Array<string | undefined>): boolean {
+function defaultTextMatcher(value: string, query: string): boolean {
+  return normalizeLowercaseStringOrEmpty(value).includes(normalizeLowercaseStringOrEmpty(query));
+}
+
+function matchesText(
+  text: string,
+  candidates: Array<string | undefined>,
+  textMatcher: ConfigSearchTextMatcher,
+): boolean {
   if (!text) {
     return true;
   }
-  return candidates.some((candidate) =>
-    normalizeOptionalLowercaseString(candidate)?.includes(text),
-  );
+  return candidates.some((candidate) => candidate !== undefined && textMatcher(candidate, text));
 }
 
 function matchesTags(filterTags: string[], fieldTags: string[]): boolean {
@@ -101,8 +106,9 @@ export function matchesNodeSelf(params: {
   path: Array<string | number>;
   hints: ConfigUiHints;
   criteria: ConfigSearchCriteria;
+  textMatcher?: ConfigSearchTextMatcher;
 }): boolean {
-  const { schema, path, hints, criteria } = params;
+  const { schema, path, hints, criteria, textMatcher = defaultTextMatcher } = params;
   if (!hasConfigSearchCriteria(criteria)) {
     return true;
   }
@@ -118,14 +124,11 @@ export function matchesNodeSelf(params: {
     .filter((segment): segment is string => typeof segment === "string")
     .join(".");
   const enumText = schema.enum?.map((value) => String(value)).join(" ") ?? "";
-  return matchesText(criteria.text, [
-    label,
-    help,
-    schema.title,
-    schema.description,
-    pathLabel,
-    enumText,
-  ]);
+  return matchesText(
+    criteria.text,
+    [label, help, schema.title, schema.description, pathLabel, enumText],
+    textMatcher,
+  );
 }
 
 export function matchesNodeSearch(params: {
@@ -134,12 +137,13 @@ export function matchesNodeSearch(params: {
   path: Array<string | number>;
   hints: ConfigUiHints;
   criteria: ConfigSearchCriteria;
+  textMatcher?: ConfigSearchTextMatcher;
 }): boolean {
-  const { schema, value, path, hints, criteria } = params;
+  const { schema, value, path, hints, criteria, textMatcher = defaultTextMatcher } = params;
   if (!hasConfigSearchCriteria(criteria)) {
     return true;
   }
-  if (matchesNodeSelf({ schema, path, hints, criteria })) {
+  if (matchesNodeSelf({ schema, path, hints, criteria, textMatcher })) {
     return true;
   }
 
@@ -159,6 +163,7 @@ export function matchesNodeSearch(params: {
           path: [...path, propertyKey],
           hints,
           criteria,
+          textMatcher,
         })
       ) {
         return true;
@@ -167,15 +172,26 @@ export function matchesNodeSearch(params: {
     const additional = schema.additionalProperties;
     if (additional && typeof additional === "object") {
       const reserved = new Set(Object.keys(properties));
-      for (const [entryKey, entryValue] of Object.entries(obj)) {
+      const dynamicEntries = Object.entries(obj).filter(([entryKey]) => !reserved.has(entryKey));
+      if (dynamicEntries.length === 0) {
+        return matchesNodeSearch({
+          schema: additional,
+          value: undefined,
+          path: [...path, "*"],
+          hints,
+          criteria,
+          textMatcher,
+        });
+      }
+      for (const [entryKey, entryValue] of dynamicEntries) {
         if (
-          !reserved.has(entryKey) &&
           matchesNodeSearch({
             schema: additional,
             value: entryValue,
             path: [...path, entryKey],
             hints,
             criteria,
+            textMatcher,
           })
         ) {
           return true;
@@ -200,6 +216,7 @@ export function matchesNodeSearch(params: {
       path: [...path, 0],
       hints,
       criteria,
+      textMatcher,
     });
   }
   return values.some((entry, index) =>
@@ -209,6 +226,7 @@ export function matchesNodeSearch(params: {
       path: [...path, index],
       hints,
       criteria,
+      textMatcher,
     }),
   );
 }
@@ -221,6 +239,7 @@ export function matchesConfigSectionSearch(params: {
   query: string;
   label?: string;
   description?: string;
+  textMatcher?: ConfigSearchTextMatcher;
 }): boolean {
   if (!params.query) {
     return true;
@@ -230,7 +249,9 @@ export function matchesConfigSectionSearch(params: {
     criteria.tags.length === 0 &&
     criteria.text.length > 0 &&
     [params.key, params.label, params.description].some((candidate) =>
-      normalizeOptionalLowercaseString(candidate)?.includes(criteria.text),
+      candidate !== undefined
+        ? (params.textMatcher ?? defaultTextMatcher)(candidate, criteria.text)
+        : false,
     );
   return (
     metadataMatches ||
@@ -240,6 +261,7 @@ export function matchesConfigSectionSearch(params: {
       path: [params.key],
       hints: params.hints,
       criteria,
+      textMatcher: params.textMatcher,
     })
   );
 }

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -193,6 +193,15 @@ export function matchesNodeSearch(params: {
     return false;
   }
   const values = Array.isArray(value) ? value : Array.isArray(schema.default) ? schema.default : [];
+  if (values.length === 0) {
+    return matchesNodeSearch({
+      schema: itemsSchema,
+      value: undefined,
+      path: [...path, 0],
+      hints,
+      criteria,
+    });
+  }
   return values.some((entry, index) =>
     matchesNodeSearch({
       schema: itemsSchema,

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -1,0 +1,236 @@
+import type { ConfigUiHints } from "../api/types.ts";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalLowercaseString,
+} from "../lib/string-coerce.ts";
+import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
+
+export type ConfigSearchCriteria = {
+  text: string;
+  tags: string[];
+};
+
+export type ConfigFieldMeta = {
+  label: string;
+  help?: string;
+  tags: string[];
+};
+
+export function hasConfigSearchCriteria(criteria: ConfigSearchCriteria | undefined): boolean {
+  return Boolean(criteria && (criteria.text.length > 0 || criteria.tags.length > 0));
+}
+
+export function parseConfigSearchQuery(query: string): ConfigSearchCriteria {
+  const tags: string[] = [];
+  const seen = new Set<string>();
+  const raw = query.trim();
+  const stripped = raw.replace(/(^|\s)tag:([^\s]+)/gi, (_, leading: string, token: string) => {
+    const normalized = normalizeLowercaseStringOrEmpty(token);
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized);
+      tags.push(normalized);
+    }
+    return leading;
+  });
+  return {
+    text: normalizeLowercaseStringOrEmpty(stripped),
+    tags,
+  };
+}
+
+function normalizeTags(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  for (const value of raw) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const tag = value.trim();
+    if (!tag) {
+      continue;
+    }
+    const key = normalizeLowercaseStringOrEmpty(tag);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    tags.push(tag);
+  }
+  return tags;
+}
+
+export function resolveConfigFieldMeta(
+  path: Array<string | number>,
+  schema: JsonSchema,
+  hints: ConfigUiHints,
+): ConfigFieldMeta {
+  const hint = hintForPath(path, hints);
+  const label = hint?.label ?? schema.title ?? humanize(String(path.at(-1)));
+  const help = hint?.help ?? schema.description;
+  const schemaTags = normalizeTags(schema["x-tags"] ?? schema.tags);
+  const hintTags = normalizeTags(hint?.tags);
+  return {
+    label,
+    help,
+    tags: hintTags.length > 0 ? hintTags : schemaTags,
+  };
+}
+
+function matchesText(text: string, candidates: Array<string | undefined>): boolean {
+  if (!text) {
+    return true;
+  }
+  return candidates.some((candidate) =>
+    normalizeOptionalLowercaseString(candidate)?.includes(text),
+  );
+}
+
+function matchesTags(filterTags: string[], fieldTags: string[]): boolean {
+  if (filterTags.length === 0) {
+    return true;
+  }
+  const normalized = new Set(fieldTags.map((tag) => normalizeLowercaseStringOrEmpty(tag)));
+  return filterTags.every((tag) => normalized.has(tag));
+}
+
+export function matchesNodeSelf(params: {
+  schema: JsonSchema;
+  path: Array<string | number>;
+  hints: ConfigUiHints;
+  criteria: ConfigSearchCriteria;
+}): boolean {
+  const { schema, path, hints, criteria } = params;
+  if (!hasConfigSearchCriteria(criteria)) {
+    return true;
+  }
+  const { label, help, tags } = resolveConfigFieldMeta(path, schema, hints);
+  if (!matchesTags(criteria.tags, tags)) {
+    return false;
+  }
+  if (!criteria.text) {
+    return true;
+  }
+
+  const pathLabel = path
+    .filter((segment): segment is string => typeof segment === "string")
+    .join(".");
+  const enumText = schema.enum?.map((value) => String(value)).join(" ") ?? "";
+  return matchesText(criteria.text, [
+    label,
+    help,
+    schema.title,
+    schema.description,
+    pathLabel,
+    enumText,
+  ]);
+}
+
+export function matchesNodeSearch(params: {
+  schema: JsonSchema;
+  value: unknown;
+  path: Array<string | number>;
+  hints: ConfigUiHints;
+  criteria: ConfigSearchCriteria;
+}): boolean {
+  const { schema, value, path, hints, criteria } = params;
+  if (!hasConfigSearchCriteria(criteria)) {
+    return true;
+  }
+  if (matchesNodeSelf({ schema, path, hints, criteria })) {
+    return true;
+  }
+
+  const type = schemaType(schema);
+  if (type === "object") {
+    const fallback = value ?? schema.default;
+    const obj =
+      fallback && typeof fallback === "object" && !Array.isArray(fallback)
+        ? (fallback as Record<string, unknown>)
+        : {};
+    const properties = schema.properties ?? {};
+    for (const [propertyKey, node] of Object.entries(properties)) {
+      if (
+        matchesNodeSearch({
+          schema: node,
+          value: obj[propertyKey],
+          path: [...path, propertyKey],
+          hints,
+          criteria,
+        })
+      ) {
+        return true;
+      }
+    }
+    const additional = schema.additionalProperties;
+    if (additional && typeof additional === "object") {
+      const reserved = new Set(Object.keys(properties));
+      for (const [entryKey, entryValue] of Object.entries(obj)) {
+        if (
+          !reserved.has(entryKey) &&
+          matchesNodeSearch({
+            schema: additional,
+            value: entryValue,
+            path: [...path, entryKey],
+            hints,
+            criteria,
+          })
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  if (type !== "array") {
+    return false;
+  }
+  const itemsSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
+  if (!itemsSchema) {
+    return false;
+  }
+  const values = Array.isArray(value) ? value : Array.isArray(schema.default) ? schema.default : [];
+  return values.some((entry, index) =>
+    matchesNodeSearch({
+      schema: itemsSchema,
+      value: entry,
+      path: [...path, index],
+      hints,
+      criteria,
+    }),
+  );
+}
+
+export function matchesConfigSectionSearch(params: {
+  key: string;
+  schema: JsonSchema;
+  value: unknown;
+  hints: ConfigUiHints;
+  query: string;
+  label?: string;
+  description?: string;
+}): boolean {
+  if (!params.query) {
+    return true;
+  }
+  const criteria = parseConfigSearchQuery(params.query);
+  const metadataMatches =
+    criteria.tags.length === 0 &&
+    criteria.text.length > 0 &&
+    [params.key, params.label, params.description].some((candidate) =>
+      normalizeOptionalLowercaseString(candidate)?.includes(criteria.text),
+    );
+  return (
+    metadataMatches ||
+    matchesNodeSearch({
+      schema: params.schema,
+      value: params.value,
+      path: [params.key],
+      hints: params.hints,
+      criteria,
+    })
+  );
+}

--- a/ui/src/components/config-form.ts
+++ b/ui/src/components/config-form.ts
@@ -1,5 +1,6 @@
 // Control UI view renders config form screen content.
-export { renderConfigForm, SECTION_META } from "./config-form.render.ts";
+export { renderConfigForm } from "./config-form.render.ts";
+export { SECTION_META } from "./config-form.meta.ts";
 export { analyzeConfigSchema, type ConfigSchemaAnalysis } from "./config-form.analyze.ts";
 export { renderNode } from "./config-form.node.ts";
 export { schemaType, type JsonSchema } from "./config-form.shared.ts";

--- a/ui/src/components/settings-sidebar.test.ts
+++ b/ui/src/components/settings-sidebar.test.ts
@@ -18,6 +18,90 @@ afterEach(() => {
 });
 
 describe("settings sidebar search", () => {
+  it("does not match the middle of a word for a short query", () => {
+    render(
+      renderSettingsSidebar({
+        basePath: "",
+        activeRouteId: "config",
+        connected: true,
+        version: "",
+        updateAvailable: null,
+        updateRunning: false,
+        onUpdate: vi.fn(),
+        searchQuery: "cp",
+        searchBlockMatches: [
+          {
+            routeId: "config",
+            label: "Gateway Host",
+            hash: "#settings-general-system",
+          },
+        ],
+        onExit: vi.fn(),
+        onNavigate: vi.fn(),
+        onSearchQueryChange: vi.fn(),
+        preloadTimers: new Map(),
+      }),
+      container,
+    );
+
+    const resultLabels = [
+      ...container.querySelectorAll(
+        ".settings-sidebar__item-label, .settings-sidebar__subitem-label",
+      ),
+    ].map((item) => item.textContent?.trim());
+    expect(resultLabels).toEqual(["General", "Gateway Host"]);
+  });
+
+  it("ranks matching pages before matching blocks and navigates to the block", () => {
+    const onNavigate = vi.fn();
+    render(
+      renderSettingsSidebar({
+        basePath: "",
+        activeRouteId: "config",
+        connected: true,
+        version: "",
+        updateAvailable: null,
+        updateRunning: false,
+        onUpdate: vi.fn(),
+        searchQuery: "mcp",
+        searchBlockMatches: [
+          {
+            routeId: "config",
+            label: "Automations",
+            hash: "#settings-general-automations",
+          },
+          {
+            routeId: "mcp",
+            label: "MCP",
+            search: "?section=mcp",
+            hash: "#config-section-mcp",
+          },
+        ],
+        onExit: vi.fn(),
+        onNavigate,
+        onSearchQueryChange: vi.fn(),
+        preloadTimers: new Map(),
+      }),
+      container,
+    );
+
+    const resultLabels = [
+      ...container.querySelectorAll(
+        ".settings-sidebar__item-label, .settings-sidebar__subitem-label",
+      ),
+    ].map((item) => item.textContent?.trim());
+    expect(resultLabels).toEqual(["MCP", "General", "Automations"]);
+    expect(container.querySelector(".settings-sidebar__item--active")).toBeNull();
+
+    const automations = container.querySelector<HTMLAnchorElement>(
+      '.settings-sidebar__subitem[href="/settings/general#settings-general-automations"]',
+    );
+    automations?.click();
+    expect(onNavigate).toHaveBeenCalledWith("config", {
+      hash: "#settings-general-automations",
+    });
+  });
+
   it("filters localized routes and groups while preserving navigation", () => {
     let searchQuery = "";
     const onNavigate = vi.fn();

--- a/ui/src/components/settings-sidebar.test.ts
+++ b/ui/src/components/settings-sidebar.test.ts
@@ -102,6 +102,52 @@ describe("settings sidebar search", () => {
     });
   });
 
+  it("keeps a precise block result when its owning page also matches", () => {
+    const onNavigate = vi.fn();
+    render(
+      renderSettingsSidebar({
+        basePath: "",
+        activeRouteId: "config",
+        connected: true,
+        version: "",
+        updateAvailable: null,
+        updateRunning: false,
+        onUpdate: vi.fn(),
+        searchQuery: "infrastructure",
+        searchBlockMatches: [
+          {
+            routeId: "infrastructure",
+            label: "Browser",
+            search: "?section=browser",
+            hash: "#config-section-browser",
+          },
+        ],
+        onExit: vi.fn(),
+        onNavigate,
+        onSearchQueryChange: vi.fn(),
+        preloadTimers: new Map(),
+      }),
+      container,
+    );
+
+    const resultLabels = [
+      ...container.querySelectorAll(
+        ".settings-sidebar__item-label, .settings-sidebar__subitem-label",
+      ),
+    ].map((item) => item.textContent?.trim());
+    expect(resultLabels).toEqual(["Infrastructure", "Browser"]);
+
+    container
+      .querySelector<HTMLAnchorElement>(
+        '.settings-sidebar__subitem[href="/settings/infrastructure?section=browser#config-section-browser"]',
+      )
+      ?.click();
+    expect(onNavigate).toHaveBeenCalledWith("infrastructure", {
+      search: "?section=browser",
+      hash: "#config-section-browser",
+    });
+  });
+
   it("filters localized routes and groups while preserving navigation", () => {
     let searchQuery = "";
     const onNavigate = vi.fn();

--- a/ui/src/components/settings-sidebar.ts
+++ b/ui/src/components/settings-sidebar.ts
@@ -7,10 +7,13 @@ import {
   scheduleRoutePreload,
   SETTINGS_NAVIGATION_GROUPS,
   settingsNavigationLabelForRoute,
+  settingsSearchTextMatches,
   subtitleForRoute,
   titleForRoute,
+  type SettingsSearchBlock,
 } from "../app-navigation.ts";
 import { pathForRoute, type RouteId } from "../app-route-paths.ts";
+import type { ApplicationNavigationOptions } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeLowercaseStringOrEmpty } from "../lib/string-coerce.ts";
 import { icons } from "./icons.ts";
@@ -19,14 +22,17 @@ import "./sidebar-update-card.ts";
 type SettingsSidebarProps = {
   basePath: string;
   activeRouteId: RouteId;
+  activeSearch?: string;
+  activeHash?: string;
   connected: boolean;
   version: string;
   updateAvailable: UpdateAvailable | null;
   updateRunning: boolean;
   onUpdate: () => void;
   searchQuery: string;
+  searchBlockMatches?: readonly SettingsSearchBlock[];
   onExit: () => void;
-  onNavigate: (routeId: RouteId) => void;
+  onNavigate: (routeId: RouteId, options?: ApplicationNavigationOptions) => void;
   onPreload?: (routeId: RouteId) => Promise<void> | void;
   onSearchQueryChange: (query: string) => void;
   preloadTimers: Map<EventTarget, ReturnType<typeof globalThis.setTimeout>>;
@@ -34,35 +40,77 @@ type SettingsSidebarProps = {
 
 type SettingsNavigationGroupView = {
   labelKey: string | null;
-  routes: readonly RouteId[];
+  items: readonly SettingsNavigationItemView[];
+};
+
+type SettingsNavigationItemView = {
+  routeId: RouteId;
+  blocks: readonly SettingsSearchBlock[];
 };
 
 function filterSettingsNavigationGroups(
   searchQuery: string,
+  blockMatches: readonly SettingsSearchBlock[],
 ): readonly SettingsNavigationGroupView[] {
   const query = normalizeLowercaseStringOrEmpty(searchQuery);
   if (!query) {
-    return SETTINGS_NAVIGATION_GROUPS;
+    return SETTINGS_NAVIGATION_GROUPS.map((group) => ({
+      labelKey: group.labelKey,
+      items: group.routes.map((routeId) => ({ routeId, blocks: [] })),
+    }));
   }
-  return SETTINGS_NAVIGATION_GROUPS.map((group) => {
-    const groupMatches = group.labelKey
-      ? normalizeLowercaseStringOrEmpty(t(group.labelKey)).includes(query)
-      : false;
-    const routes = groupMatches
-      ? group.routes
-      : group.routes.filter((routeId) =>
-          [
-            settingsNavigationLabelForRoute(routeId),
-            titleForRoute(routeId),
-            subtitleForRoute(routeId),
-          ].some((value) => normalizeLowercaseStringOrEmpty(value).includes(query)),
-        );
-    return { labelKey: group.labelKey, routes };
-  }).filter((group) => group.routes.length > 0);
+  const allRoutes = SETTINGS_NAVIGATION_GROUPS.flatMap((group) => group.routes);
+  const directRoutes = allRoutes.filter((routeId) =>
+    [
+      settingsNavigationLabelForRoute(routeId),
+      titleForRoute(routeId),
+      subtitleForRoute(routeId),
+    ].some((value) => settingsSearchTextMatches(value, query)),
+  );
+  const includedRoutes = new Set<RouteId>(directRoutes);
+  const groupRoutes = SETTINGS_NAVIGATION_GROUPS.flatMap((group) => {
+    const groupMatches = group.labelKey && settingsSearchTextMatches(t(group.labelKey), query);
+    if (!groupMatches) {
+      return [];
+    }
+    return group.routes.filter((routeId) => {
+      if (includedRoutes.has(routeId)) {
+        return false;
+      }
+      includedRoutes.add(routeId);
+      return true;
+    });
+  });
+  const blocksByRoute = new Map<RouteId, SettingsSearchBlock[]>();
+  for (const block of blockMatches) {
+    if (includedRoutes.has(block.routeId)) {
+      continue;
+    }
+    const routeBlocks = blocksByRoute.get(block.routeId) ?? [];
+    routeBlocks.push(block);
+    blocksByRoute.set(block.routeId, routeBlocks);
+  }
+  const pageRoutes = [...directRoutes, ...groupRoutes];
+  return [
+    ...(pageRoutes.length > 0
+      ? [
+          {
+            labelKey: null,
+            items: pageRoutes.map((routeId) => ({ routeId, blocks: [] })),
+          },
+        ]
+      : []),
+    ...allRoutes
+      .filter((routeId) => blocksByRoute.has(routeId))
+      .map((routeId) => ({
+        labelKey: null,
+        items: [{ routeId, blocks: blocksByRoute.get(routeId) ?? [] }],
+      })),
+  ];
 }
 
-function renderItem(props: SettingsSidebarProps, routeId: RouteId) {
-  const active = props.activeRouteId === routeId;
+function renderItem(props: SettingsSidebarProps, routeId: RouteId, label?: string) {
+  const active = !props.searchQuery && props.activeRouteId === routeId;
   return html`
     <a
       href=${pathForRoute(routeId, props.basePath)}
@@ -94,7 +142,43 @@ function renderItem(props: SettingsSidebarProps, routeId: RouteId) {
       <span class="settings-sidebar__item-icon" aria-hidden="true"
         >${icons[navigationIconForRoute(routeId)]}</span
       >
-      <span class="settings-sidebar__item-label">${settingsNavigationLabelForRoute(routeId)}</span>
+      <span class="settings-sidebar__item-label"
+        >${label ?? settingsNavigationLabelForRoute(routeId)}</span
+      >
+    </a>
+  `;
+}
+
+function renderBlockItem(props: SettingsSidebarProps, block: SettingsSearchBlock) {
+  const href = pathForRoute(block.routeId, props.basePath) + (block.search ?? "") + block.hash;
+  const active =
+    props.activeRouteId === block.routeId &&
+    props.activeHash === block.hash &&
+    (block.search === undefined || props.activeSearch === block.search);
+  return html`
+    <a
+      href=${href}
+      class="settings-sidebar__subitem ${active ? "settings-sidebar__subitem--active" : ""}"
+      aria-current=${active ? "location" : nothing}
+      @click=${(event: MouseEvent) => {
+        if (
+          event.defaultPrevented ||
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey
+        ) {
+          return;
+        }
+        event.preventDefault();
+        props.onNavigate(block.routeId, {
+          ...(block.search ? { search: block.search } : {}),
+          hash: block.hash,
+        });
+      }}
+    >
+      <span class="settings-sidebar__subitem-label">${block.label}</span>
     </a>
   `;
 }
@@ -103,7 +187,10 @@ export function renderSettingsSidebar(props: SettingsSidebarProps) {
   const gatewayStatus = t("chat.gatewayStatus", {
     status: props.connected ? t("common.online") : t("common.offline"),
   });
-  const navigationGroups = filterSettingsNavigationGroups(props.searchQuery);
+  const navigationGroups = filterSettingsNavigationGroups(
+    props.searchQuery,
+    props.searchBlockMatches ?? [],
+  );
   return html`
     <aside class="settings-sidebar">
       <header class="settings-sidebar__header">
@@ -164,7 +251,12 @@ export function renderSettingsSidebar(props: SettingsSidebarProps) {
                   ${group.labelKey
                     ? html`<div class="settings-sidebar__group-label">${t(group.labelKey)}</div>`
                     : nothing}
-                  ${group.routes.map((routeId) => renderItem(props, routeId))}
+                  ${group.items.map(
+                    (item) => html`
+                      ${renderItem(props, item.routeId)}
+                      ${item.blocks.map((block) => renderBlockItem(props, block))}
+                    `,
+                  )}
                 </div>
               `,
             )}

--- a/ui/src/components/settings-sidebar.ts
+++ b/ui/src/components/settings-sidebar.ts
@@ -48,6 +48,13 @@ type SettingsNavigationItemView = {
   blocks: readonly SettingsSearchBlock[];
 };
 
+function isRedundantRouteBlock(routeId: RouteId, block: SettingsSearchBlock): boolean {
+  const blockLabel = normalizeLowercaseStringOrEmpty(block.label);
+  return [settingsNavigationLabelForRoute(routeId), titleForRoute(routeId)].some(
+    (label) => normalizeLowercaseStringOrEmpty(label) === blockLabel,
+  );
+}
+
 function filterSettingsNavigationGroups(
   searchQuery: string,
   blockMatches: readonly SettingsSearchBlock[],
@@ -82,10 +89,13 @@ function filterSettingsNavigationGroups(
     });
   });
   const blocksByRoute = new Map<RouteId, SettingsSearchBlock[]>();
+  const seenBlocks = new Set<string>();
   for (const block of blockMatches) {
-    if (includedRoutes.has(block.routeId)) {
+    const blockKey = `${block.routeId}\u0000${block.search ?? ""}\u0000${block.hash}`;
+    if (seenBlocks.has(blockKey)) {
       continue;
     }
+    seenBlocks.add(blockKey);
     const routeBlocks = blocksByRoute.get(block.routeId) ?? [];
     routeBlocks.push(block);
     blocksByRoute.set(block.routeId, routeBlocks);
@@ -96,12 +106,17 @@ function filterSettingsNavigationGroups(
       ? [
           {
             labelKey: null,
-            items: pageRoutes.map((routeId) => ({ routeId, blocks: [] })),
+            items: pageRoutes.map((routeId) => ({
+              routeId,
+              blocks: (blocksByRoute.get(routeId) ?? []).filter(
+                (block) => !isRedundantRouteBlock(routeId, block),
+              ),
+            })),
           },
         ]
       : []),
     ...allRoutes
-      .filter((routeId) => blocksByRoute.has(routeId))
+      .filter((routeId) => !includedRoutes.has(routeId) && blocksByRoute.has(routeId))
       .map((routeId) => ({
         labelKey: null,
         items: [{ routeId, blocks: blocksByRoute.get(routeId) ?? [] }],

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -107,6 +107,32 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
     const video = page.video();
     await installMockGateway(page, {
       controlUiTabs: [{ group: "control", id: "logbook", label: "Logbook", pluginId: "logbook" }],
+      methodResponses: {
+        "config.get": {
+          config: {},
+          hash: "settings-search-e2e",
+        },
+        "config.schema": {
+          schema: {
+            type: "object",
+            properties: {
+              browser: {
+                type: "object",
+                title: "Browser",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                    title: "Enabled",
+                  },
+                },
+              },
+            },
+          },
+          uiHints: {},
+          version: "e2e",
+          generatedAt: "2026-07-12T00:00:00.000Z",
+        },
+      },
     });
 
     try {
@@ -249,6 +275,19 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
           "Appearance",
         ]);
       await captureSettingsSidebarProof(settingsSidebar, "01c-settings-search-group.png");
+      await holdUiProof(page);
+      await settingsSearch.fill("browser");
+      const browserResult = settingsSidebar.getByRole("link", {
+        name: "Browser",
+        exact: true,
+      });
+      await expect.poll(() => browserResult.isVisible()).toBe(true);
+      await browserResult.click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/infrastructure");
+      await expect.poll(() => new URL(page.url()).search).toBe("?section=browser");
+      await expect.poll(() => new URL(page.url()).hash).toBe("#config-section-browser");
+      await expect.poll(() => page.locator("#config-section-browser").isVisible()).toBe(true);
+      await captureSettingsSidebarProof(settingsSidebar, "01c-settings-search-deep-link.png");
       await holdUiProof(page);
       await settingsSearch.fill("does-not-exist");
       await expect.poll(() => settingsLinks.count()).toBe(0);

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -194,15 +194,60 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
           }),
         )
         .toBe(true);
+      await settingsSearch.fill("cp");
+      await expect
+        .poll(() =>
+          trimmedTextContents(
+            settingsSidebar.locator(
+              ".settings-sidebar__item-label, .settings-sidebar__subitem-label",
+            ),
+          ),
+        )
+        .toEqual(["General", "Gateway Host"]);
+      await settingsSearch.fill("mcp");
+      await expect
+        .poll(() =>
+          trimmedTextContents(
+            settingsSidebar.locator(
+              ".settings-sidebar__item-label, .settings-sidebar__subitem-label",
+            ),
+          ),
+        )
+        .toEqual(["MCP", "General", "Automations"]);
+      await settingsSidebar.getByRole("link", { name: "Automations" }).click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/general");
+      await expect.poll(() => new URL(page.url()).hash).toBe("#settings-general-automations");
+      await expect.poll(() => page.locator("#settings-general-automations").isVisible()).toBe(true);
+      await expect
+        .poll(() =>
+          settingsSidebar.getByRole("link", { name: "Automations" }).getAttribute("aria-current"),
+        )
+        .toBe("location");
+      await expect
+        .poll(() =>
+          settingsSidebar.getByRole("link", { name: "General" }).getAttribute("aria-current"),
+        )
+        .toBeNull();
       await settingsSearch.fill("  ThEmE  ");
-      await expect.poll(() => trimmedTextContents(settingsLinks)).toEqual(["Appearance"]);
+      await expect
+        .poll(() => trimmedTextContents(settingsLinks))
+        .toEqual(["Appearance", "General"]);
       await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/general");
       await captureSettingsSidebarProof(settingsSidebar, "01b-settings-search-filtered.png");
       await holdUiProof(page);
       await settingsSearch.fill("system");
       await expect
         .poll(() => trimmedTextContents(settingsLinks))
-        .toEqual(["Infrastructure", "Worktrees", "Debug", "Logs", "Activity", "About"]);
+        .toEqual([
+          "Infrastructure",
+          "Worktrees",
+          "Debug",
+          "Logs",
+          "Activity",
+          "About",
+          "General",
+          "Appearance",
+        ]);
       await captureSettingsSidebarProof(settingsSidebar, "01c-settings-search-group.png");
       await holdUiProof(page);
       await settingsSearch.fill("does-not-exist");
@@ -225,7 +270,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await settingsSearch.fill("channel");
       await captureSettingsSidebarProof(settingsSidebar, "01e-settings-search-route.png");
       await holdUiProof(page);
-      await settingsSidebar.getByRole("link", { name: "Channels" }).click();
+      await settingsSidebar.getByRole("link", { name: "Channels" }).first().click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/channels");
       await expect.poll(() => settingsSearch.inputValue()).toBe("channel");
       await captureSettingsSidebarProof(settingsSidebar, "01f-settings-search-navigated.png");

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -354,8 +354,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       : configSelectionFromSearch(this.pageId, globalThis.location?.search ?? "");
     this.selections = { ...this.selections, [this.pageId]: selection };
     const targetBlockId =
-      this.routeData?.targetBlockId ??
-      configTargetIdFromHash(globalThis.location?.hash ?? "");
+      this.routeData?.targetBlockId ?? configTargetIdFromHash(globalThis.location?.hash ?? "");
     this.pendingRouteTargetId = targetBlockId;
     if (this.pageId !== "config") {
       return;

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -25,6 +25,15 @@ import { i18n, isSupportedLocale, t, type Locale } from "../../i18n/index.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import {
+  AI_AGENTS_SECTION_KEYS,
+  AUTOMATION_SECTION_KEYS,
+  COMMUNICATION_SECTION_KEYS,
+  configSectionKeysForPage,
+  INFRASTRUCTURE_SECTION_KEYS,
+  SCOPED_CONFIG_SECTION_KEYS,
+  type ConfigPageId,
+} from "./config-sections.ts";
 import { renderMcp } from "./mcp.ts";
 import {
   renderQuickSettings,
@@ -38,14 +47,11 @@ import {
   type ConfigViewState,
 } from "./view.ts";
 
-export type ConfigPageId =
-  | "config"
-  | "communications"
-  | "appearance"
-  | "automation"
-  | "mcp"
-  | "infrastructure"
-  | "ai-agents";
+export type { ConfigPageId } from "./config-sections.ts";
+export type ConfigRouteData = {
+  section: string | null;
+  targetBlockId: string | null;
+};
 
 type ConfigFormMode = "form" | "raw";
 type ConfigSelection = { activeSection: string | null; activeSubsection: string | null };
@@ -60,42 +66,6 @@ const CONFIG_PAGE_I18N_KEYS = {
   "ai-agents": "aiAgents",
 } as const satisfies Record<ConfigPageId, string>;
 
-const COMMUNICATION_SECTION_KEYS = [
-  "messages",
-  "broadcast",
-  "__notifications__",
-  "talk",
-  "audio",
-  "channels",
-] as const;
-const APPEARANCE_SECTION_KEYS = ["__appearance__", "ui", "wizard"] as const;
-const AUTOMATION_SECTION_KEYS = ["commands", "hooks", "bindings", "cron", "approvals", "plugins"];
-const INFRASTRUCTURE_SECTION_KEYS = [
-  "gateway",
-  "web",
-  "browser",
-  "nodeHost",
-  "canvasHost",
-  "discovery",
-  "media",
-  "acp",
-  "mcp",
-] as const;
-const AI_AGENTS_SECTION_KEYS = [
-  "agents",
-  "models",
-  "skills",
-  "tools",
-  "memory",
-  "session",
-] as const;
-const SCOPED_CONFIG_SECTION_KEYS = new Set<string>([
-  ...COMMUNICATION_SECTION_KEYS,
-  ...APPEARANCE_SECTION_KEYS,
-  ...AUTOMATION_SECTION_KEYS,
-  ...INFRASTRUCTURE_SECTION_KEYS,
-  ...AI_AGENTS_SECTION_KEYS,
-]);
 const KNOWN_CHANNELS = [
   { id: "telegram", labelKey: "configPage.channels.telegram" },
   { id: "discord", labelKey: "configPage.channels.discord" },
@@ -150,18 +120,7 @@ function normalizeConfigSelection(
   activeSection: string | null,
   activeSubsection: string | null,
 ): ConfigSelection {
-  const sections: readonly string[] | null =
-    pageId === "communications"
-      ? COMMUNICATION_SECTION_KEYS
-      : pageId === "appearance"
-        ? APPEARANCE_SECTION_KEYS
-        : pageId === "automation"
-          ? AUTOMATION_SECTION_KEYS
-          : pageId === "mcp" || pageId === "infrastructure"
-            ? INFRASTRUCTURE_SECTION_KEYS
-            : pageId === "ai-agents"
-              ? AI_AGENTS_SECTION_KEYS
-              : null;
+  const sections = configSectionKeysForPage(pageId) ?? null;
   if (pageId === "config" && activeSection && SCOPED_CONFIG_SECTION_KEYS.has(activeSection)) {
     return { activeSection: null, activeSubsection: null };
   }
@@ -280,6 +239,7 @@ export class ConfigPage extends OpenClawLightDomElement {
   private context!: ApplicationContext;
 
   @property({ attribute: "page-id" }) pageId: ConfigPageId = "config";
+  @property({ attribute: false }) routeData: ConfigRouteData | null = null;
 
   @state() private settings = loadSettings();
   @state() private settingsMode: "quick" | "advanced" = "quick";
@@ -326,6 +286,7 @@ export class ConfigPage extends OpenClawLightDomElement {
   private systemInfoLoading = false;
   private systemInfoRequestId = 0;
   private systemInfoPollInterval: ReturnType<typeof globalThis.setInterval> | null = null;
+  private pendingRouteTargetId: string | null = null;
   private readonly subscriptions = new SubscriptionsController(this)
     .watch(
       () => this.context?.runtimeConfig,
@@ -360,11 +321,7 @@ export class ConfigPage extends OpenClawLightDomElement {
   override connectedCallback() {
     super.connectedCallback();
     this.settings = loadSettings();
-    const linkedSelection = configSelectionFromSearch(
-      this.pageId,
-      globalThis.location?.search ?? "",
-    );
-    this.selections = { ...this.selections, [this.pageId]: linkedSelection };
+    this.syncRouteData();
   }
 
   override disconnectedCallback() {
@@ -378,6 +335,12 @@ export class ConfigPage extends OpenClawLightDomElement {
     super.disconnectedCallback();
   }
 
+  override willUpdate(changed: PropertyValues) {
+    if (changed.has("pageId") || changed.has("routeData")) {
+      this.syncRouteData();
+    }
+  }
+
   override updated(changed: PropertyValues) {
     const pageChanged = changed.has("pageId") && changed.get("pageId") !== undefined;
     const modeChanged = changed.has("settingsMode") && changed.get("settingsMode") !== undefined;
@@ -385,6 +348,41 @@ export class ConfigPage extends OpenClawLightDomElement {
       this.invalidateSystemInfoRequest();
     }
     this.syncSystemInfoPolling();
+    this.scrollToPendingRouteTarget();
+  }
+
+  private syncRouteData() {
+    const selection = this.routeData
+      ? normalizeConfigSelection(this.pageId, this.routeData.section, null)
+      : configSelectionFromSearch(this.pageId, globalThis.location?.search ?? "");
+    this.selections = { ...this.selections, [this.pageId]: selection };
+    const targetBlockId =
+      this.routeData?.targetBlockId ??
+      (globalThis.location?.hash ? decodeURIComponent(globalThis.location.hash.slice(1)) : null);
+    this.pendingRouteTargetId = targetBlockId;
+    if (this.pageId !== "config") {
+      return;
+    }
+    if (this.routeData?.section) {
+      this.settingsMode = "advanced";
+    } else if (targetBlockId?.startsWith("settings-general-")) {
+      this.settingsMode = "quick";
+    }
+  }
+
+  private scrollToPendingRouteTarget() {
+    const targetId = this.pendingRouteTargetId;
+    if (!targetId) {
+      return;
+    }
+    const target = [...this.renderRoot.querySelectorAll<HTMLElement>("[id]")].find(
+      (element) => element.id === targetId,
+    );
+    if (!target) {
+      return;
+    }
+    target.scrollIntoView?.({ behavior: "smooth", block: "start" });
+    this.pendingRouteTargetId = null;
   }
 
   private isSystemInfoVisible(): boolean {
@@ -677,17 +675,7 @@ export class ConfigPage extends OpenClawLightDomElement {
   }
 
   private includeSections(): readonly string[] | undefined {
-    return this.pageId === "communications"
-      ? COMMUNICATION_SECTION_KEYS
-      : this.pageId === "appearance"
-        ? APPEARANCE_SECTION_KEYS
-        : this.pageId === "automation"
-          ? AUTOMATION_SECTION_KEYS
-          : this.pageId === "mcp" || this.pageId === "infrastructure"
-            ? INFRASTRUCTURE_SECTION_KEYS
-            : this.pageId === "ai-agents"
-              ? AI_AGENTS_SECTION_KEYS
-              : undefined;
+    return configSectionKeysForPage(this.pageId);
   }
 
   private isUpdateBusy(): boolean {

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -40,6 +40,7 @@ import {
   type QuickSettingsChannel,
   type QuickSettingsSecurity,
 } from "./quick.ts";
+import { configTargetIdFromHash, type ConfigRouteData } from "./route-data.ts";
 import {
   createConfigViewState,
   renderConfig,
@@ -48,10 +49,6 @@ import {
 } from "./view.ts";
 
 export type { ConfigPageId } from "./config-sections.ts";
-export type ConfigRouteData = {
-  section: string | null;
-  targetBlockId: string | null;
-};
 
 type ConfigFormMode = "form" | "raw";
 type ConfigSelection = { activeSection: string | null; activeSubsection: string | null };
@@ -358,7 +355,7 @@ export class ConfigPage extends OpenClawLightDomElement {
     this.selections = { ...this.selections, [this.pageId]: selection };
     const targetBlockId =
       this.routeData?.targetBlockId ??
-      (globalThis.location?.hash ? decodeURIComponent(globalThis.location.hash.slice(1)) : null);
+      configTargetIdFromHash(globalThis.location?.hash ?? "");
     this.pendingRouteTargetId = targetBlockId;
     if (this.pageId !== "config") {
       return;

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -398,11 +398,12 @@ export class ConfigPage extends OpenClawLightDomElement {
           this.runtimeConfigSource === runtimeConfig
             ? runtimeConfig.ensureSchemaLoaded()
             : undefined,
-        );
+        )
+        .catch(() => undefined);
       return;
     }
     if (!config.configSchema && !config.configSchemaLoading) {
-      void runtimeConfig.ensureSchemaLoaded();
+      void runtimeConfig.ensureSchemaLoaded().catch(() => undefined);
     }
   }
 

--- a/ui/src/pages/config/config-sections.ts
+++ b/ui/src/pages/config/config-sections.ts
@@ -1,0 +1,75 @@
+export type ConfigPageId =
+  | "config"
+  | "communications"
+  | "appearance"
+  | "automation"
+  | "mcp"
+  | "infrastructure"
+  | "ai-agents";
+
+export const COMMUNICATION_SECTION_KEYS = [
+  "messages",
+  "broadcast",
+  "__notifications__",
+  "talk",
+  "audio",
+  "channels",
+] as const;
+
+export const APPEARANCE_SECTION_KEYS = ["__appearance__", "ui", "wizard"] as const;
+
+export const AUTOMATION_SECTION_KEYS = [
+  "commands",
+  "hooks",
+  "bindings",
+  "cron",
+  "approvals",
+  "plugins",
+] as const;
+
+export const INFRASTRUCTURE_SECTION_KEYS = [
+  "gateway",
+  "web",
+  "browser",
+  "nodeHost",
+  "canvasHost",
+  "discovery",
+  "media",
+  "acp",
+  "mcp",
+] as const;
+
+export const AI_AGENTS_SECTION_KEYS = [
+  "agents",
+  "models",
+  "skills",
+  "tools",
+  "memory",
+  "session",
+] as const;
+
+export const SCOPED_CONFIG_SECTION_KEYS = new Set<string>([
+  ...COMMUNICATION_SECTION_KEYS,
+  ...APPEARANCE_SECTION_KEYS,
+  ...AUTOMATION_SECTION_KEYS,
+  ...INFRASTRUCTURE_SECTION_KEYS,
+  ...AI_AGENTS_SECTION_KEYS,
+]);
+
+export function configSectionKeysForPage(pageId: ConfigPageId): readonly string[] | undefined {
+  switch (pageId) {
+    case "communications":
+      return COMMUNICATION_SECTION_KEYS;
+    case "appearance":
+      return APPEARANCE_SECTION_KEYS;
+    case "automation":
+      return AUTOMATION_SECTION_KEYS;
+    case "mcp":
+    case "infrastructure":
+      return INFRASTRUCTURE_SECTION_KEYS;
+    case "ai-agents":
+      return AI_AGENTS_SECTION_KEYS;
+    case "config":
+      return undefined;
+  }
+}

--- a/ui/src/pages/config/config-sections.ts
+++ b/ui/src/pages/config/config-sections.ts
@@ -56,20 +56,16 @@ export const SCOPED_CONFIG_SECTION_KEYS = new Set<string>([
   ...AI_AGENTS_SECTION_KEYS,
 ]);
 
+const CONFIG_SECTION_KEYS_BY_PAGE = {
+  config: undefined,
+  communications: COMMUNICATION_SECTION_KEYS,
+  appearance: APPEARANCE_SECTION_KEYS,
+  automation: AUTOMATION_SECTION_KEYS,
+  mcp: INFRASTRUCTURE_SECTION_KEYS,
+  infrastructure: INFRASTRUCTURE_SECTION_KEYS,
+  "ai-agents": AI_AGENTS_SECTION_KEYS,
+} as const satisfies Record<ConfigPageId, readonly string[] | undefined>;
+
 export function configSectionKeysForPage(pageId: ConfigPageId): readonly string[] | undefined {
-  switch (pageId) {
-    case "communications":
-      return COMMUNICATION_SECTION_KEYS;
-    case "appearance":
-      return APPEARANCE_SECTION_KEYS;
-    case "automation":
-      return AUTOMATION_SECTION_KEYS;
-    case "mcp":
-    case "infrastructure":
-      return INFRASTRUCTURE_SECTION_KEYS;
-    case "ai-agents":
-      return AI_AGENTS_SECTION_KEYS;
-    case "config":
-      return undefined;
-  }
+  return CONFIG_SECTION_KEYS_BY_PAGE[pageId];
 }

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -31,6 +31,7 @@ import { formatBytes } from "../../lib/agents/display.ts";
 import { resolveAssistantTextAvatar, resolveChatAvatarRenderUrl } from "../../lib/avatar.ts";
 import { formatDurationHuman } from "../../lib/format.ts";
 import { normalizeOptionalString } from "../../lib/string-coerce.ts";
+import { GENERAL_SETTINGS_BLOCKS } from "./settings-search.ts";
 
 // ── Types ──
 
@@ -385,7 +386,7 @@ function renderModelCard(props: QuickSettingsProps) {
   const fastMode = formatFastModeValue(props.fastMode);
   const configBusy = isConfigBusy(props);
   return html`
-    <div class="qs-card qs-card--model">
+    <div id=${GENERAL_SETTINGS_BLOCKS.model.id} class="qs-card qs-card--model">
       ${renderCardHeader(icons.brain, t("quickSettings.model.title"))}
       <div class="qs-card__body">
         <div class="qs-row">
@@ -453,7 +454,7 @@ function renderChannelsCard(props: QuickSettingsProps) {
       : undefined;
 
   return html`
-    <div class="qs-card qs-card--channels">
+    <div id=${GENERAL_SETTINGS_BLOCKS.channels.id} class="qs-card qs-card--channels">
       ${renderCardHeader(icons.send, t("quickSettings.channels.title"), badge)}
       <div class="qs-card__body">
         ${props.channels.length === 0
@@ -487,7 +488,7 @@ function renderAutomationsCard(props: QuickSettingsProps) {
   const { cronJobCount, skillCount, mcpServerCount } = props.automation;
 
   return html`
-    <div class="qs-card qs-card--automations">
+    <div id=${GENERAL_SETTINGS_BLOCKS.automations.id} class="qs-card qs-card--automations">
       ${renderCardHeader(icons.zap, t("quickSettings.automation.title"))}
       <div class="qs-card__body">
         <div class="qs-row">
@@ -543,7 +544,7 @@ function renderSecurityCard(props: QuickSettingsProps) {
   const configBusy = isConfigBusy(props);
 
   return html`
-    <div class="qs-card qs-card--security">
+    <div id=${GENERAL_SETTINGS_BLOCKS.security.id} class="qs-card qs-card--security">
       ${renderCardHeader(
         icons.eye,
         t("quickSettings.security.title"),
@@ -768,7 +769,7 @@ function renderSystemCard(props: QuickSettingsProps) {
   const stats = info ? buildSystemStats(info) : buildSystemStatsPlaceholder();
 
   return html`
-    <div class="qs-card qs-card--system">
+    <div id=${GENERAL_SETTINGS_BLOCKS.system.id} class="qs-card qs-card--system">
       ${renderCardHeader(
         icons.monitor,
         t("quickSettings.system.gatewayHost"),
@@ -813,7 +814,7 @@ function renderAppearanceCard(props: QuickSettingsProps) {
     { id: "custom", label: importedThemeName },
   ];
   return html`
-    <div class="qs-card qs-card--appearance">
+    <div id=${GENERAL_SETTINGS_BLOCKS.appearance.id} class="qs-card qs-card--appearance">
       ${renderCardHeader(icons.spark, t("quickSettings.appearance.title"))}
       <div class="qs-card__body qs-appearance">
         <div class="qs-row qs-row--stacked">
@@ -994,7 +995,7 @@ function renderPersonalCard(props: QuickSettingsProps) {
         ? t("quickSettings.personal.configuredAvatar")
         : t("quickSettings.personal.fallbackLogo");
   return html`
-    <div class="qs-card qs-card--personal">
+    <div id=${GENERAL_SETTINGS_BLOCKS.personal.id} class="qs-card qs-card--personal">
       ${renderCardHeader(icons.image, t("quickSettings.personal.title"))}
       <div class="qs-card__body">
         <div class="qs-identity-grid">

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -31,7 +31,7 @@ import { formatBytes } from "../../lib/agents/display.ts";
 import { resolveAssistantTextAvatar, resolveChatAvatarRenderUrl } from "../../lib/avatar.ts";
 import { formatDurationHuman } from "../../lib/format.ts";
 import { normalizeOptionalString } from "../../lib/string-coerce.ts";
-import { GENERAL_SETTINGS_BLOCKS } from "./settings-search.ts";
+import { GENERAL_SETTINGS_TARGET_IDS } from "./settings-targets.ts";
 
 // ── Types ──
 
@@ -386,7 +386,7 @@ function renderModelCard(props: QuickSettingsProps) {
   const fastMode = formatFastModeValue(props.fastMode);
   const configBusy = isConfigBusy(props);
   return html`
-    <div id=${GENERAL_SETTINGS_BLOCKS.model.id} class="qs-card qs-card--model">
+    <div id=${GENERAL_SETTINGS_TARGET_IDS.model} class="qs-card qs-card--model">
       ${renderCardHeader(icons.brain, t("quickSettings.model.title"))}
       <div class="qs-card__body">
         <div class="qs-row">
@@ -454,7 +454,7 @@ function renderChannelsCard(props: QuickSettingsProps) {
       : undefined;
 
   return html`
-    <div id=${GENERAL_SETTINGS_BLOCKS.channels.id} class="qs-card qs-card--channels">
+    <div id=${GENERAL_SETTINGS_TARGET_IDS.channels} class="qs-card qs-card--channels">
       ${renderCardHeader(icons.send, t("quickSettings.channels.title"), badge)}
       <div class="qs-card__body">
         ${props.channels.length === 0
@@ -488,7 +488,7 @@ function renderAutomationsCard(props: QuickSettingsProps) {
   const { cronJobCount, skillCount, mcpServerCount } = props.automation;
 
   return html`
-    <div id=${GENERAL_SETTINGS_BLOCKS.automations.id} class="qs-card qs-card--automations">
+    <div id=${GENERAL_SETTINGS_TARGET_IDS.automations} class="qs-card qs-card--automations">
       ${renderCardHeader(icons.zap, t("quickSettings.automation.title"))}
       <div class="qs-card__body">
         <div class="qs-row">
@@ -544,7 +544,7 @@ function renderSecurityCard(props: QuickSettingsProps) {
   const configBusy = isConfigBusy(props);
 
   return html`
-    <div id=${GENERAL_SETTINGS_BLOCKS.security.id} class="qs-card qs-card--security">
+    <div id=${GENERAL_SETTINGS_TARGET_IDS.security} class="qs-card qs-card--security">
       ${renderCardHeader(
         icons.eye,
         t("quickSettings.security.title"),
@@ -769,7 +769,7 @@ function renderSystemCard(props: QuickSettingsProps) {
   const stats = info ? buildSystemStats(info) : buildSystemStatsPlaceholder();
 
   return html`
-    <div id=${GENERAL_SETTINGS_BLOCKS.system.id} class="qs-card qs-card--system">
+    <div id=${GENERAL_SETTINGS_TARGET_IDS.system} class="qs-card qs-card--system">
       ${renderCardHeader(
         icons.monitor,
         t("quickSettings.system.gatewayHost"),
@@ -814,7 +814,7 @@ function renderAppearanceCard(props: QuickSettingsProps) {
     { id: "custom", label: importedThemeName },
   ];
   return html`
-    <div id=${GENERAL_SETTINGS_BLOCKS.appearance.id} class="qs-card qs-card--appearance">
+    <div id=${GENERAL_SETTINGS_TARGET_IDS.appearance} class="qs-card qs-card--appearance">
       ${renderCardHeader(icons.spark, t("quickSettings.appearance.title"))}
       <div class="qs-card__body qs-appearance">
         <div class="qs-row qs-row--stacked">
@@ -995,7 +995,7 @@ function renderPersonalCard(props: QuickSettingsProps) {
         ? t("quickSettings.personal.configuredAvatar")
         : t("quickSettings.personal.fallbackLogo");
   return html`
-    <div id=${GENERAL_SETTINGS_BLOCKS.personal.id} class="qs-card qs-card--personal">
+    <div id=${GENERAL_SETTINGS_TARGET_IDS.personal} class="qs-card qs-card--personal">
       ${renderCardHeader(icons.image, t("quickSettings.personal.title"))}
       <div class="qs-card__body">
         <div class="qs-identity-grid">

--- a/ui/src/pages/config/route-data.test.ts
+++ b/ui/src/pages/config/route-data.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { configRouteData, configTargetIdFromHash } from "./route-data.ts";
+
+describe("config route data", () => {
+  it("normalizes the selected section and decodes the target block", () => {
+    expect(
+      configRouteData({
+        search: "?section=%20browser%20",
+        hash: "#config-section-browser%2Fprofiles",
+      }),
+    ).toEqual({
+      section: "browser",
+      targetBlockId: "config-section-browser/profiles",
+    });
+  });
+
+  it("ignores malformed target hashes", () => {
+    expect(configTargetIdFromHash("#%")).toBeNull();
+    expect(configRouteData({ search: "", hash: "#%" })).toEqual({
+      section: null,
+      targetBlockId: null,
+    });
+  });
+});

--- a/ui/src/pages/config/route-data.ts
+++ b/ui/src/pages/config/route-data.ts
@@ -16,9 +16,7 @@ export function configTargetIdFromHash(hash: string): string | null {
   }
 }
 
-export function configRouteData(
-  location: Pick<RouteLocation, "search" | "hash">,
-): ConfigRouteData {
+export function configRouteData(location: Pick<RouteLocation, "search" | "hash">): ConfigRouteData {
   const section = new URLSearchParams(location.search).get("section")?.trim() || null;
   return {
     section,

--- a/ui/src/pages/config/route-data.ts
+++ b/ui/src/pages/config/route-data.ts
@@ -1,0 +1,27 @@
+import type { RouteLocation } from "@openclaw/uirouter";
+
+export type ConfigRouteData = {
+  section: string | null;
+  targetBlockId: string | null;
+};
+
+export function configTargetIdFromHash(hash: string): string | null {
+  if (!hash) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(hash.slice(1));
+  } catch {
+    return null;
+  }
+}
+
+export function configRouteData(
+  location: Pick<RouteLocation, "search" | "hash">,
+): ConfigRouteData {
+  const section = new URLSearchParams(location.search).get("section")?.trim() || null;
+  return {
+    section,
+    targetBlockId: configTargetIdFromHash(location.hash),
+  };
+}

--- a/ui/src/pages/config/route.ts
+++ b/ui/src/pages/config/route.ts
@@ -2,13 +2,8 @@ import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import type { ApplicationContext } from "../../app/context.ts";
-import type { ConfigPageId, ConfigRouteData } from "./config-page.ts";
-
-function configRouteData(location: RouteLocation): ConfigRouteData {
-  const section = new URLSearchParams(location.search).get("section")?.trim() || null;
-  const targetBlockId = location.hash ? decodeURIComponent(location.hash.slice(1)) : null;
-  return { section, targetBlockId };
-}
+import type { ConfigPageId } from "./config-sections.ts";
+import { configRouteData, type ConfigRouteData } from "./route-data.ts";
 
 function loadConfigRoute(context: ApplicationContext, location: RouteLocation) {
   const primaryLoad = context.runtimeConfig.ensureLoaded();

--- a/ui/src/pages/config/route.ts
+++ b/ui/src/pages/config/route.ts
@@ -1,9 +1,16 @@
+import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import type { ApplicationContext } from "../../app/context.ts";
-import type { ConfigPageId } from "./config-page.ts";
+import type { ConfigPageId, ConfigRouteData } from "./config-page.ts";
 
-function loadConfigRoute(context: ApplicationContext) {
+function configRouteData(location: RouteLocation): ConfigRouteData {
+  const section = new URLSearchParams(location.search).get("section")?.trim() || null;
+  const targetBlockId = location.hash ? decodeURIComponent(location.hash.slice(1)) : null;
+  return { section, targetBlockId };
+}
+
+function loadConfigRoute(context: ApplicationContext, location: RouteLocation) {
   const primaryLoad = context.runtimeConfig.ensureLoaded();
   void primaryLoad.then(
     () => {
@@ -11,6 +18,7 @@ function loadConfigRoute(context: ApplicationContext) {
     },
     () => undefined,
   );
+  return configRouteData(location);
 }
 
 function configPage(id: ConfigPageId, path: string, aliases: readonly string[]) {
@@ -18,11 +26,15 @@ function configPage(id: ConfigPageId, path: string, aliases: readonly string[]) 
     id,
     path,
     aliases,
-    loader: (context: ApplicationContext) => loadConfigRoute(context),
+    loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
+      `${location.search}\u0000${location.hash}`,
+    loader: (context: ApplicationContext, { location }) => loadConfigRoute(context, location),
     component: () =>
       import("./config-page.ts").then(() => ({
         header: true,
-        render: () => html`<openclaw-config-page .pageId=${id}></openclaw-config-page>`,
+        render: (data: ConfigRouteData | undefined) => html`
+          <openclaw-config-page .pageId=${id} .routeData=${data ?? null}></openclaw-config-page>
+        `,
       })),
   });
 }

--- a/ui/src/pages/config/route.ts
+++ b/ui/src/pages/config/route.ts
@@ -7,12 +7,7 @@ import { configRouteData, type ConfigRouteData } from "./route-data.ts";
 
 function loadConfigRoute(context: ApplicationContext, location: RouteLocation) {
   const primaryLoad = context.runtimeConfig.ensureLoaded();
-  void primaryLoad.then(
-    () => {
-      void context.runtimeConfig.ensureSchemaLoaded();
-    },
-    () => undefined,
-  );
+  void primaryLoad.then(() => context.runtimeConfig.ensureSchemaLoaded()).catch(() => undefined);
   return configRouteData(location);
 }
 

--- a/ui/src/pages/config/settings-search.test.ts
+++ b/ui/src/pages/config/settings-search.test.ts
@@ -95,6 +95,37 @@ describe("findSettingsSearchBlocks", () => {
     ]);
   });
 
+  it("preserves nested schema matches for short prefix queries", () => {
+    const matches = findSettingsSearchBlocks({
+      query: "sa",
+      schema: {
+        type: "object",
+        properties: {
+          tools: {
+            type: "object",
+            properties: {
+              profile: {
+                type: "string",
+                description: "Controls sandbox access",
+              },
+            },
+          },
+        },
+      },
+      value: {},
+      uiHints: {},
+    });
+
+    expect(matches).toEqual([
+      {
+        routeId: "ai-agents",
+        label: "Tools",
+        search: "?section=tools",
+        hash: "#config-section-tools",
+      },
+    ]);
+  });
+
   it("searches and displays static settings blocks in the active locale", async () => {
     await i18n.setLocale("es");
 

--- a/ui/src/pages/config/settings-search.test.ts
+++ b/ui/src/pages/config/settings-search.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { i18n } from "../../i18n/index.ts";
 import { findSettingsSearchBlocks } from "./settings-search.ts";
+
+afterEach(async () => {
+  await i18n.setLocale("en");
+});
 
 describe("findSettingsSearchBlocks", () => {
   it("uses word prefixes instead of arbitrary substrings for short queries", () => {
@@ -87,6 +92,25 @@ describe("findSettingsSearchBlocks", () => {
         search: "?section=tools",
         hash: "#config-section-tools",
       },
+    ]);
+  });
+
+  it("searches and displays static settings blocks in the active locale", async () => {
+    await i18n.setLocale("es");
+
+    const matches = findSettingsSearchBlocks({
+      query: "apariencia",
+      schema: null,
+      value: null,
+      uiHints: {},
+    });
+
+    expect(matches).toEqual([
+      expect.objectContaining({
+        routeId: "config",
+        label: "Apariencia",
+        hash: "#settings-general-appearance",
+      }),
     ]);
   });
 

--- a/ui/src/pages/config/settings-search.test.ts
+++ b/ui/src/pages/config/settings-search.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { findSettingsSearchBlocks } from "./settings-search.ts";
+
+describe("findSettingsSearchBlocks", () => {
+  it("uses word prefixes instead of arbitrary substrings for short queries", () => {
+    const matches = findSettingsSearchBlocks({
+      query: "cp",
+      schema: {
+        type: "object",
+        properties: {
+          mcp: { type: "object", title: "MCP" },
+          acp: { type: "object", title: "ACP" },
+        },
+      },
+      value: {},
+      uiHints: {},
+    });
+
+    expect(matches).toEqual([
+      expect.objectContaining({
+        routeId: "config",
+        label: "Gateway Host",
+        hash: "#settings-general-system",
+      }),
+    ]);
+  });
+
+  it("matches visible quick-setting content and schema sections", () => {
+    const matches = findSettingsSearchBlocks({
+      query: "mcp",
+      schema: {
+        type: "object",
+        properties: {
+          mcp: {
+            type: "object",
+            properties: {
+              servers: { type: "object", title: "Servers" },
+            },
+          },
+        },
+      },
+      value: { mcp: { servers: {} } },
+      uiHints: {},
+    });
+
+    expect(matches).toEqual([
+      expect.objectContaining({
+        routeId: "config",
+        label: "Automations",
+        hash: "#settings-general-automations",
+      }),
+      expect.objectContaining({
+        routeId: "mcp",
+        label: "MCP",
+        search: "?section=mcp",
+        hash: "#config-section-mcp",
+      }),
+    ]);
+  });
+
+  it("maps a nested schema field to its owning settings page", () => {
+    const matches = findSettingsSearchBlocks({
+      query: "sandbox access",
+      schema: {
+        type: "object",
+        properties: {
+          tools: {
+            type: "object",
+            properties: {
+              profile: {
+                type: "string",
+                title: "Tool profile",
+                description: "Controls sandbox access",
+              },
+            },
+          },
+        },
+      },
+      value: {},
+      uiHints: {},
+    });
+
+    expect(matches).toEqual([
+      {
+        routeId: "ai-agents",
+        label: "Tools",
+        search: "?section=tools",
+        hash: "#config-section-tools",
+      },
+    ]);
+  });
+
+  it("does not create block results for an empty query", () => {
+    expect(
+      findSettingsSearchBlocks({
+        query: "  ",
+        schema: null,
+        value: null,
+        uiHints: {},
+      }),
+    ).toEqual([]);
+  });
+});

--- a/ui/src/pages/config/settings-search.ts
+++ b/ui/src/pages/config/settings-search.ts
@@ -263,24 +263,18 @@ export function findSettingsSearchBlocks(params: {
     return matches;
   }
   const value = params.value ?? {};
-  const usePrefixMatching =
-    criteria.tags.length === 0 && criteria.text.length > 0 && criteria.text.length <= 2;
   for (const [key, sectionSchema] of Object.entries(schema.properties)) {
     const meta = SECTION_META[key];
-    const matchesSection = usePrefixMatching
-      ? [key, meta?.label, meta?.description, sectionSchema.title, sectionSchema.description].some(
-          (candidate) =>
-            typeof candidate === "string" && settingsSearchTextMatches(candidate, criteria.text),
-        )
-      : matchesConfigSectionSearch({
-          key,
-          schema: sectionSchema,
-          value: value[key],
-          hints: params.uiHints,
-          query: params.query,
-          label: meta?.label,
-          description: meta?.description,
-        });
+    const matchesSection = matchesConfigSectionSearch({
+      key,
+      schema: sectionSchema,
+      value: value[key],
+      hints: params.uiHints,
+      query: params.query,
+      label: meta?.label,
+      description: meta?.description,
+      textMatcher: settingsSearchTextMatches,
+    });
     if (!matchesSection) {
       continue;
     }

--- a/ui/src/pages/config/settings-search.ts
+++ b/ui/src/pages/config/settings-search.ts
@@ -1,0 +1,201 @@
+import type { ConfigUiHints } from "../../api/types.ts";
+import { settingsSearchTextMatches, type SettingsSearchBlock } from "../../app-navigation.ts";
+import type { RouteId } from "../../app-route-paths.ts";
+import { SECTION_META } from "../../components/config-form.meta.ts";
+import {
+  matchesConfigSectionSearch,
+  parseConfigSearchQuery,
+} from "../../components/config-form.search.ts";
+import { schemaType, type JsonSchema } from "../../components/config-form.shared.ts";
+import {
+  AI_AGENTS_SECTION_KEYS,
+  APPEARANCE_SECTION_KEYS,
+  AUTOMATION_SECTION_KEYS,
+  COMMUNICATION_SECTION_KEYS,
+  INFRASTRUCTURE_SECTION_KEYS,
+} from "./config-sections.ts";
+
+type StaticSettingsBlock = SettingsSearchBlock & {
+  id: string;
+  searchText: string;
+};
+
+export const GENERAL_SETTINGS_BLOCKS = {
+  model: {
+    routeId: "config",
+    id: "settings-general-model",
+    label: "Model & Thinking",
+    hash: "#settings-general-model",
+    searchText: "model thinking fast mode auto standard",
+  },
+  channels: {
+    routeId: "config",
+    id: "settings-general-channels",
+    label: "Channels",
+    hash: "#settings-general-channels",
+    searchText: "channels telegram discord slack whatsapp signal imessage connected configure",
+  },
+  security: {
+    routeId: "config",
+    id: "settings-general-security",
+    label: "Security",
+    hash: "#settings-general-security",
+    searchText: "security gateway auth exec policy device auth browser tool profile",
+  },
+  system: {
+    routeId: "config",
+    id: "settings-general-system",
+    label: "Gateway Host",
+    hash: "#settings-general-system",
+    searchText: "gateway host system cpu memory disk uptime node address",
+  },
+  appearance: {
+    routeId: "config",
+    id: "settings-general-appearance",
+    label: "Appearance",
+    hash: "#settings-general-appearance",
+    searchText: "appearance theme mode text size lobster",
+  },
+  personal: {
+    routeId: "config",
+    id: "settings-general-personal",
+    label: "Personal",
+    hash: "#settings-general-personal",
+    searchText: "personal user assistant identity avatar image",
+  },
+  automations: {
+    routeId: "config",
+    id: "settings-general-automations",
+    label: "Automations",
+    hash: "#settings-general-automations",
+    searchText: "automations scheduled tasks cron skills mcp servers",
+  },
+} as const satisfies Record<string, StaticSettingsBlock>;
+
+export const APPEARANCE_SETTINGS_BLOCKS = {
+  theme: {
+    routeId: "appearance",
+    id: "settings-appearance-theme",
+    label: "Theme",
+    search: "?section=__appearance__",
+    hash: "#settings-appearance-theme",
+    searchText: "theme family import tweakcn light dark system",
+  },
+  textSize: {
+    routeId: "appearance",
+    id: "settings-appearance-text-size",
+    label: "Text size",
+    search: "?section=__appearance__",
+    hash: "#settings-appearance-text-size",
+    searchText: "text size scale small default large xl xxl",
+  },
+  connection: {
+    routeId: "appearance",
+    id: "settings-appearance-connection",
+    label: "Connection",
+    search: "?section=__appearance__",
+    hash: "#settings-appearance-connection",
+    searchText: "connection gateway status assistant version",
+  },
+} as const satisfies Record<string, StaticSettingsBlock>;
+
+export const COMMUNICATION_SETTINGS_BLOCKS = {
+  notifications: {
+    routeId: "communications",
+    id: "settings-communications-notifications",
+    label: "Push notifications",
+    search: "?section=__notifications__",
+    hash: "#settings-communications-notifications",
+    searchText: "push notifications browser permission subscription vapid gateway",
+  },
+} as const satisfies Record<string, StaticSettingsBlock>;
+
+const STATIC_SETTINGS_BLOCKS: readonly StaticSettingsBlock[] = [
+  ...Object.values(GENERAL_SETTINGS_BLOCKS),
+  ...Object.values(APPEARANCE_SETTINGS_BLOCKS),
+  ...Object.values(COMMUNICATION_SETTINGS_BLOCKS),
+];
+
+const COMMUNICATION_SECTIONS = new Set<string>(COMMUNICATION_SECTION_KEYS);
+const APPEARANCE_SECTIONS = new Set<string>(APPEARANCE_SECTION_KEYS);
+const AUTOMATION_SECTIONS = new Set<string>(AUTOMATION_SECTION_KEYS);
+const INFRASTRUCTURE_SECTIONS = new Set<string>(INFRASTRUCTURE_SECTION_KEYS);
+const AI_AGENTS_SECTIONS = new Set<string>(AI_AGENTS_SECTION_KEYS);
+
+function routeForConfigSection(key: string): RouteId {
+  if (key === "mcp") {
+    return "mcp";
+  }
+  if (COMMUNICATION_SECTIONS.has(key)) {
+    return "communications";
+  }
+  if (APPEARANCE_SECTIONS.has(key)) {
+    return "appearance";
+  }
+  if (AUTOMATION_SECTIONS.has(key)) {
+    return "automation";
+  }
+  if (INFRASTRUCTURE_SECTIONS.has(key)) {
+    return "infrastructure";
+  }
+  if (AI_AGENTS_SECTIONS.has(key)) {
+    return "ai-agents";
+  }
+  return "config";
+}
+
+export function findSettingsSearchBlocks(params: {
+  query: string;
+  schema: unknown;
+  value: Record<string, unknown> | null;
+  uiHints: ConfigUiHints;
+}): SettingsSearchBlock[] {
+  if (!params.query.trim()) {
+    return [];
+  }
+  const criteria = parseConfigSearchQuery(params.query);
+  const matches: SettingsSearchBlock[] =
+    criteria.tags.length === 0 && criteria.text
+      ? STATIC_SETTINGS_BLOCKS.filter((block) =>
+          settingsSearchTextMatches(`${block.label} ${block.searchText}`, criteria.text),
+        )
+      : [];
+  const schema =
+    params.schema && typeof params.schema === "object" && !Array.isArray(params.schema)
+      ? (params.schema as JsonSchema)
+      : null;
+  if (!schema || schemaType(schema) !== "object" || !schema.properties) {
+    return matches;
+  }
+  const value = params.value ?? {};
+  const usePrefixMatching =
+    criteria.tags.length === 0 && criteria.text.length > 0 && criteria.text.length <= 2;
+  for (const [key, sectionSchema] of Object.entries(schema.properties)) {
+    const meta = SECTION_META[key];
+    const matchesSection = usePrefixMatching
+      ? [key, meta?.label, meta?.description, sectionSchema.title, sectionSchema.description].some(
+          (candidate) =>
+            typeof candidate === "string" && settingsSearchTextMatches(candidate, criteria.text),
+        )
+      : matchesConfigSectionSearch({
+          key,
+          schema: sectionSchema,
+          value: value[key],
+          hints: params.uiHints,
+          query: params.query,
+          label: meta?.label,
+          description: meta?.description,
+        });
+    if (!matchesSection) {
+      continue;
+    }
+    const encodedKey = encodeURIComponent(key);
+    matches.push({
+      routeId: routeForConfigSection(key),
+      label: meta?.label ?? sectionSchema.title ?? key,
+      search: `?section=${encodedKey}`,
+      hash: `#config-section-${encodedKey}`,
+    });
+  }
+  return matches;
+}

--- a/ui/src/pages/config/settings-search.ts
+++ b/ui/src/pages/config/settings-search.ts
@@ -14,98 +14,91 @@ import {
   COMMUNICATION_SECTION_KEYS,
   INFRASTRUCTURE_SECTION_KEYS,
 } from "./config-sections.ts";
+import {
+  APPEARANCE_SETTINGS_TARGET_IDS,
+  COMMUNICATION_SETTINGS_TARGET_IDS,
+  GENERAL_SETTINGS_TARGET_IDS,
+} from "./settings-targets.ts";
 
 type StaticSettingsBlock = SettingsSearchBlock & {
-  id: string;
   searchText: string;
 };
 
-export const GENERAL_SETTINGS_BLOCKS = {
+const GENERAL_SETTINGS_BLOCKS = {
   model: {
     routeId: "config",
-    id: "settings-general-model",
     label: "Model & Thinking",
-    hash: "#settings-general-model",
+    hash: `#${GENERAL_SETTINGS_TARGET_IDS.model}`,
     searchText: "model thinking fast mode auto standard",
   },
   channels: {
     routeId: "config",
-    id: "settings-general-channels",
     label: "Channels",
-    hash: "#settings-general-channels",
+    hash: `#${GENERAL_SETTINGS_TARGET_IDS.channels}`,
     searchText: "channels telegram discord slack whatsapp signal imessage connected configure",
   },
   security: {
     routeId: "config",
-    id: "settings-general-security",
     label: "Security",
-    hash: "#settings-general-security",
+    hash: `#${GENERAL_SETTINGS_TARGET_IDS.security}`,
     searchText: "security gateway auth exec policy device auth browser tool profile",
   },
   system: {
     routeId: "config",
-    id: "settings-general-system",
     label: "Gateway Host",
-    hash: "#settings-general-system",
+    hash: `#${GENERAL_SETTINGS_TARGET_IDS.system}`,
     searchText: "gateway host system cpu memory disk uptime node address",
   },
   appearance: {
     routeId: "config",
-    id: "settings-general-appearance",
     label: "Appearance",
-    hash: "#settings-general-appearance",
+    hash: `#${GENERAL_SETTINGS_TARGET_IDS.appearance}`,
     searchText: "appearance theme mode text size lobster",
   },
   personal: {
     routeId: "config",
-    id: "settings-general-personal",
     label: "Personal",
-    hash: "#settings-general-personal",
+    hash: `#${GENERAL_SETTINGS_TARGET_IDS.personal}`,
     searchText: "personal user assistant identity avatar image",
   },
   automations: {
     routeId: "config",
-    id: "settings-general-automations",
     label: "Automations",
-    hash: "#settings-general-automations",
+    hash: `#${GENERAL_SETTINGS_TARGET_IDS.automations}`,
     searchText: "automations scheduled tasks cron skills mcp servers",
   },
 } as const satisfies Record<string, StaticSettingsBlock>;
 
-export const APPEARANCE_SETTINGS_BLOCKS = {
+const APPEARANCE_SETTINGS_BLOCKS = {
   theme: {
     routeId: "appearance",
-    id: "settings-appearance-theme",
     label: "Theme",
     search: "?section=__appearance__",
-    hash: "#settings-appearance-theme",
+    hash: `#${APPEARANCE_SETTINGS_TARGET_IDS.theme}`,
     searchText: "theme family import tweakcn light dark system",
   },
   textSize: {
     routeId: "appearance",
-    id: "settings-appearance-text-size",
     label: "Text size",
     search: "?section=__appearance__",
-    hash: "#settings-appearance-text-size",
+    hash: `#${APPEARANCE_SETTINGS_TARGET_IDS.textSize}`,
     searchText: "text size scale small default large xl xxl",
   },
   connection: {
     routeId: "appearance",
-    id: "settings-appearance-connection",
     label: "Connection",
     search: "?section=__appearance__",
-    hash: "#settings-appearance-connection",
+    hash: `#${APPEARANCE_SETTINGS_TARGET_IDS.connection}`,
     searchText: "connection gateway status assistant version",
   },
 } as const satisfies Record<string, StaticSettingsBlock>;
 
-export const COMMUNICATION_SETTINGS_BLOCKS = {
+const COMMUNICATION_SETTINGS_BLOCKS = {
   notifications: {
     routeId: "communications",
-    id: "settings-communications-notifications",
     label: "Push notifications",
     search: "?section=__notifications__",
-    hash: "#settings-communications-notifications",
+    hash: `#${COMMUNICATION_SETTINGS_TARGET_IDS.notifications}`,
     searchText: "push notifications browser permission subscription vapid gateway",
   },
 } as const satisfies Record<string, StaticSettingsBlock>;

--- a/ui/src/pages/config/settings-search.ts
+++ b/ui/src/pages/config/settings-search.ts
@@ -7,6 +7,7 @@ import {
   parseConfigSearchQuery,
 } from "../../components/config-form.search.ts";
 import { schemaType, type JsonSchema } from "../../components/config-form.shared.ts";
+import { t } from "../../i18n/index.ts";
 import {
   AI_AGENTS_SECTION_KEYS,
   APPEARANCE_SECTION_KEYS,
@@ -20,6 +21,12 @@ import {
   GENERAL_SETTINGS_TARGET_IDS,
 } from "./settings-targets.ts";
 
+type StaticSettingsBlockDescriptor = Omit<SettingsSearchBlock, "label"> & {
+  labelKey: string;
+  searchKeys: readonly string[];
+  aliases?: string;
+};
+
 type StaticSettingsBlock = SettingsSearchBlock & {
   searchText: string;
 };
@@ -27,83 +34,168 @@ type StaticSettingsBlock = SettingsSearchBlock & {
 const GENERAL_SETTINGS_BLOCKS = {
   model: {
     routeId: "config",
-    label: "Model & Thinking",
+    labelKey: "quickSettings.model.title",
     hash: `#${GENERAL_SETTINGS_TARGET_IDS.model}`,
-    searchText: "model thinking fast mode auto standard",
+    searchKeys: [
+      "quickSettings.model.model",
+      "quickSettings.model.thinking",
+      "quickSettings.model.fastMode",
+      "quickSettings.model.thinkingLevels.off",
+      "quickSettings.model.thinkingLevels.low",
+      "quickSettings.model.thinkingLevels.medium",
+      "quickSettings.model.thinkingLevels.high",
+      "quickSettings.model.fastModes.auto",
+      "quickSettings.model.fastModes.fast",
+      "quickSettings.model.fastModes.standard",
+    ],
   },
   channels: {
     routeId: "config",
-    label: "Channels",
+    labelKey: "quickSettings.channels.title",
     hash: `#${GENERAL_SETTINGS_TARGET_IDS.channels}`,
-    searchText: "channels telegram discord slack whatsapp signal imessage connected configure",
+    searchKeys: [
+      "quickSettings.channels.connectedCount",
+      "quickSettings.channels.empty",
+      "quickSettings.channels.connect",
+    ],
+    aliases: "telegram discord slack whatsapp signal imessage",
   },
   security: {
     routeId: "config",
-    label: "Security",
+    labelKey: "quickSettings.security.title",
     hash: `#${GENERAL_SETTINGS_TARGET_IDS.security}`,
-    searchText: "security gateway auth exec policy device auth browser tool profile",
+    searchKeys: [
+      "quickSettings.security.gatewayAuth",
+      "quickSettings.security.execPolicy",
+      "quickSettings.security.deviceAuth",
+      "quickSettings.security.browserEnabled",
+      "quickSettings.security.toolProfile",
+    ],
   },
   system: {
     routeId: "config",
-    label: "Gateway Host",
+    labelKey: "quickSettings.system.gatewayHost",
     hash: `#${GENERAL_SETTINGS_TARGET_IDS.system}`,
-    searchText: "gateway host system cpu memory disk uptime node address",
+    searchKeys: [
+      "quickSettings.system.cpu",
+      "quickSettings.system.memory",
+      "quickSettings.system.disk",
+      "quickSettings.system.loadAverage",
+      "quickSettings.system.runtime",
+    ],
+    aliases: "system uptime node address pid",
   },
   appearance: {
     routeId: "config",
-    label: "Appearance",
+    labelKey: "quickSettings.appearance.title",
     hash: `#${GENERAL_SETTINGS_TARGET_IDS.appearance}`,
-    searchText: "appearance theme mode text size lobster",
+    searchKeys: [
+      "quickSettings.appearance.theme",
+      "quickSettings.appearance.textSize",
+      "quickSettings.appearance.importedTheme",
+      "quickSettings.appearance.lobsterVisits",
+      "quickSettings.appearance.lobsterSounds",
+      "quickSettings.appearance.lobsterdex",
+    ],
+    aliases: "mode",
   },
   personal: {
     routeId: "config",
-    label: "Personal",
+    labelKey: "quickSettings.personal.title",
     hash: `#${GENERAL_SETTINGS_TARGET_IDS.personal}`,
-    searchText: "personal user assistant identity avatar image",
+    searchKeys: [
+      "quickSettings.personal.user",
+      "quickSettings.personal.assistant",
+      "quickSettings.personal.localIdentity",
+      "quickSettings.personal.assistantIdentity",
+      "quickSettings.personal.avatarText",
+      "quickSettings.personal.chooseImage",
+      "quickSettings.personal.browserOnly",
+    ],
+    aliases: "avatar image",
   },
   automations: {
     routeId: "config",
-    label: "Automations",
+    labelKey: "quickSettings.automation.title",
     hash: `#${GENERAL_SETTINGS_TARGET_IDS.automations}`,
-    searchText: "automations scheduled tasks cron skills mcp servers",
+    searchKeys: [
+      "quickSettings.automation.scheduledTask",
+      "quickSettings.automation.scheduledTasks",
+      "quickSettings.automation.installedSkill",
+      "quickSettings.automation.installedSkills",
+      "quickSettings.automation.mcpServer",
+      "quickSettings.automation.mcpServers",
+      "quickSettings.automation.manage",
+      "quickSettings.automation.browse",
+      "quickSettings.automation.configure",
+    ],
+    aliases: "cron",
   },
-} as const satisfies Record<string, StaticSettingsBlock>;
+} as const satisfies Record<string, StaticSettingsBlockDescriptor>;
 
 const APPEARANCE_SETTINGS_BLOCKS = {
   theme: {
     routeId: "appearance",
-    label: "Theme",
+    labelKey: "configView.appearance.theme",
     search: "?section=__appearance__",
     hash: `#${APPEARANCE_SETTINGS_TARGET_IDS.theme}`,
-    searchText: "theme family import tweakcn light dark system",
+    searchKeys: [
+      "configView.appearance.chooseTheme",
+      "configView.appearance.importedTheme",
+      "configView.appearance.import",
+      "configView.appearance.importFromTweakcn",
+      "configView.appearance.browseTweakcn",
+    ],
+    aliases: "tweakcn light dark system",
   },
   textSize: {
     routeId: "appearance",
-    label: "Text size",
+    labelKey: "configView.appearance.textSize",
     search: "?section=__appearance__",
     hash: `#${APPEARANCE_SETTINGS_TARGET_IDS.textSize}`,
-    searchText: "text size scale small default large xl xxl",
+    searchKeys: [
+      "configView.textSizes.small",
+      "configView.textSizes.default",
+      "configView.textSizes.large",
+      "configView.textSizes.xl",
+      "configView.textSizes.xxl",
+    ],
+    aliases: "scale",
   },
   connection: {
     routeId: "appearance",
-    label: "Connection",
+    labelKey: "configView.connection.title",
     search: "?section=__appearance__",
     hash: `#${APPEARANCE_SETTINGS_TARGET_IDS.connection}`,
-    searchText: "connection gateway status assistant version",
+    searchKeys: [
+      "configView.connection.gateway",
+      "configView.connection.status",
+      "configView.connection.assistant",
+    ],
+    aliases: "version",
   },
-} as const satisfies Record<string, StaticSettingsBlock>;
+} as const satisfies Record<string, StaticSettingsBlockDescriptor>;
 
 const COMMUNICATION_SETTINGS_BLOCKS = {
   notifications: {
     routeId: "communications",
-    label: "Push notifications",
+    labelKey: "configView.notifications.title",
     search: "?section=__notifications__",
     hash: `#${COMMUNICATION_SETTINGS_TARGET_IDS.notifications}`,
-    searchText: "push notifications browser permission subscription vapid gateway",
+    searchKeys: [
+      "configView.notifications.hint",
+      "configView.notifications.browserSupport",
+      "configView.notifications.permission",
+      "configView.notifications.status",
+      "configView.notifications.subscribed",
+      "configView.notifications.notSubscribed",
+      "configView.notifications.enable",
+    ],
+    aliases: "vapid gateway",
   },
-} as const satisfies Record<string, StaticSettingsBlock>;
+} as const satisfies Record<string, StaticSettingsBlockDescriptor>;
 
-const STATIC_SETTINGS_BLOCKS: readonly StaticSettingsBlock[] = [
+const STATIC_SETTINGS_BLOCKS: readonly StaticSettingsBlockDescriptor[] = [
   ...Object.values(GENERAL_SETTINGS_BLOCKS),
   ...Object.values(APPEARANCE_SETTINGS_BLOCKS),
   ...Object.values(COMMUNICATION_SETTINGS_BLOCKS),
@@ -114,6 +206,16 @@ const APPEARANCE_SECTIONS = new Set<string>(APPEARANCE_SECTION_KEYS);
 const AUTOMATION_SECTIONS = new Set<string>(AUTOMATION_SECTION_KEYS);
 const INFRASTRUCTURE_SECTIONS = new Set<string>(INFRASTRUCTURE_SECTION_KEYS);
 const AI_AGENTS_SECTIONS = new Set<string>(AI_AGENTS_SECTION_KEYS);
+
+function resolveStaticSettingsBlock(block: StaticSettingsBlockDescriptor): StaticSettingsBlock {
+  const { labelKey, searchKeys, aliases, ...destination } = block;
+  const label = t(labelKey);
+  return {
+    ...destination,
+    label,
+    searchText: [label, ...searchKeys.map((key) => t(key)), aliases ?? ""].join(" "),
+  };
+}
 
 function routeForConfigSection(key: string): RouteId {
   if (key === "mcp") {
@@ -149,8 +251,8 @@ export function findSettingsSearchBlocks(params: {
   const criteria = parseConfigSearchQuery(params.query);
   const matches: SettingsSearchBlock[] =
     criteria.tags.length === 0 && criteria.text
-      ? STATIC_SETTINGS_BLOCKS.filter((block) =>
-          settingsSearchTextMatches(`${block.label} ${block.searchText}`, criteria.text),
+      ? STATIC_SETTINGS_BLOCKS.map(resolveStaticSettingsBlock).filter((block) =>
+          settingsSearchTextMatches(block.searchText, criteria.text),
         )
       : [];
   const schema =

--- a/ui/src/pages/config/settings-targets.ts
+++ b/ui/src/pages/config/settings-targets.ts
@@ -1,0 +1,19 @@
+export const GENERAL_SETTINGS_TARGET_IDS = {
+  model: "settings-general-model",
+  channels: "settings-general-channels",
+  security: "settings-general-security",
+  system: "settings-general-system",
+  appearance: "settings-general-appearance",
+  personal: "settings-general-personal",
+  automations: "settings-general-automations",
+} as const;
+
+export const APPEARANCE_SETTINGS_TARGET_IDS = {
+  theme: "settings-appearance-theme",
+  textSize: "settings-appearance-text-size",
+  connection: "settings-appearance-connection",
+} as const;
+
+export const COMMUNICATION_SETTINGS_TARGET_IDS = {
+  notifications: "settings-communications-notifications",
+} as const;

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -25,7 +25,10 @@ import {
 } from "../../components/config-form.ts";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
-import { APPEARANCE_SETTINGS_BLOCKS, COMMUNICATION_SETTINGS_BLOCKS } from "./settings-search.ts";
+import {
+  APPEARANCE_SETTINGS_TARGET_IDS,
+  COMMUNICATION_SETTINGS_TARGET_IDS,
+} from "./settings-targets.ts";
 
 const TEXT_SCALE_LABELS: Record<TextScaleStop, string> = {
   90: "configView.textSizes.small",
@@ -866,7 +869,7 @@ function renderNotificationsSection(props: ConfigProps) {
     return html`
       <div class="settings-notifications">
         <section
-          id=${COMMUNICATION_SETTINGS_BLOCKS.notifications.id}
+          id=${COMMUNICATION_SETTINGS_TARGET_IDS.notifications}
           class="settings-notifications__card"
         >
           <div class="settings-notifications__header">
@@ -915,7 +918,7 @@ function renderNotificationsSection(props: ConfigProps) {
   return html`
     <div class="settings-notifications">
       <section
-        id=${COMMUNICATION_SETTINGS_BLOCKS.notifications.id}
+        id=${COMMUNICATION_SETTINGS_TARGET_IDS.notifications}
         class="settings-notifications__card"
       >
         <div class="settings-notifications__header">
@@ -1041,7 +1044,7 @@ function renderAppearanceSection(props: ConfigProps) {
   ];
   return html`
     <div class="settings-appearance">
-      <div id=${APPEARANCE_SETTINGS_BLOCKS.theme.id} class="settings-appearance__section">
+      <div id=${APPEARANCE_SETTINGS_TARGET_IDS.theme} class="settings-appearance__section">
         <h3 class="settings-appearance__heading">${t("configView.appearance.theme")}</h3>
         <p class="settings-appearance__hint">${t("configView.appearance.chooseTheme")}</p>
         <div class="settings-theme-grid">
@@ -1166,7 +1169,7 @@ function renderAppearanceSection(props: ConfigProps) {
             `}
       </div>
 
-      <div id=${APPEARANCE_SETTINGS_BLOCKS.textSize.id} class="settings-appearance__section">
+      <div id=${APPEARANCE_SETTINGS_TARGET_IDS.textSize} class="settings-appearance__section">
         <h3 class="settings-appearance__heading">${t("configView.appearance.textSize")}</h3>
         <div class="settings-text-scale">
           <div class="settings-text-scale__options">
@@ -1186,7 +1189,7 @@ function renderAppearanceSection(props: ConfigProps) {
         </div>
       </div>
 
-      <div id=${APPEARANCE_SETTINGS_BLOCKS.connection.id} class="settings-appearance__section">
+      <div id=${APPEARANCE_SETTINGS_TARGET_IDS.connection} class="settings-appearance__section">
         <h3 class="settings-appearance__heading">${t("configView.connection.title")}</h3>
         <div class="settings-info-grid">
           <div class="settings-info-row">

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -25,6 +25,7 @@ import {
 } from "../../components/config-form.ts";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
+import { APPEARANCE_SETTINGS_BLOCKS, COMMUNICATION_SETTINGS_BLOCKS } from "./settings-search.ts";
 
 const TEXT_SCALE_LABELS: Record<TextScaleStop, string> = {
   90: "configView.textSizes.small",
@@ -864,7 +865,10 @@ function renderNotificationsSection(props: ConfigProps) {
   if (!push) {
     return html`
       <div class="settings-notifications">
-        <section class="settings-notifications__card">
+        <section
+          id=${COMMUNICATION_SETTINGS_BLOCKS.notifications.id}
+          class="settings-notifications__card"
+        >
           <div class="settings-notifications__header">
             <span class="settings-notifications__icon">${getSectionIcon("__notifications__")}</span>
             <div class="settings-notifications__copy">
@@ -910,7 +914,10 @@ function renderNotificationsSection(props: ConfigProps) {
 
   return html`
     <div class="settings-notifications">
-      <section class="settings-notifications__card">
+      <section
+        id=${COMMUNICATION_SETTINGS_BLOCKS.notifications.id}
+        class="settings-notifications__card"
+      >
         <div class="settings-notifications__header">
           <span class="settings-notifications__icon">${getSectionIcon("__notifications__")}</span>
           <div class="settings-notifications__copy">
@@ -1034,7 +1041,7 @@ function renderAppearanceSection(props: ConfigProps) {
   ];
   return html`
     <div class="settings-appearance">
-      <div class="settings-appearance__section">
+      <div id=${APPEARANCE_SETTINGS_BLOCKS.theme.id} class="settings-appearance__section">
         <h3 class="settings-appearance__heading">${t("configView.appearance.theme")}</h3>
         <p class="settings-appearance__hint">${t("configView.appearance.chooseTheme")}</p>
         <div class="settings-theme-grid">
@@ -1159,7 +1166,7 @@ function renderAppearanceSection(props: ConfigProps) {
             `}
       </div>
 
-      <div class="settings-appearance__section">
+      <div id=${APPEARANCE_SETTINGS_BLOCKS.textSize.id} class="settings-appearance__section">
         <h3 class="settings-appearance__heading">${t("configView.appearance.textSize")}</h3>
         <div class="settings-text-scale">
           <div class="settings-text-scale__options">
@@ -1179,7 +1186,7 @@ function renderAppearanceSection(props: ConfigProps) {
         </div>
       </div>
 
-      <div class="settings-appearance__section">
+      <div id=${APPEARANCE_SETTINGS_BLOCKS.connection.id} class="settings-appearance__section">
         <h3 class="settings-appearance__heading">${t("configView.connection.title")}</h3>
         <div class="settings-info-grid">
           <div class="settings-info-row">

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -471,6 +471,41 @@ html.openclaw-native-nav .topbar .topbar-nav-toggle {
   text-overflow: ellipsis;
 }
 
+.settings-sidebar__subitem {
+  display: flex;
+  align-items: center;
+  min-height: 28px;
+  margin-inline-start: 24px;
+  padding: 0 9px;
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  cursor: default;
+  text-decoration: none;
+}
+
+.settings-sidebar__subitem:hover {
+  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+  text-decoration: none;
+}
+
+.settings-sidebar__subitem--active {
+  color: var(--text-strong);
+  background: color-mix(in srgb, var(--accent-subtle) 72%, transparent);
+}
+
+.settings-sidebar__subitem:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.settings-sidebar__subitem-label {
+  font-size: 12.5px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .settings-sidebar__footer {
   flex-shrink: 0;
   display: flex;


### PR DESCRIPTION
Related: #103138

## What Problem This Solves

The Settings sidebar search only matches top-level pages and group headings. Users still need to know which page owns a specific setting, so queries such as `avatar`, `MCP`, `CPU`, or `push notifications` cannot lead them to the relevant block.

## Why This Change Was Made

This PR extends the existing search with block metadata for Quick Settings and virtual sections, plus the existing recursive schema-field matcher for advanced configuration. Direct page matches stay first, nested results are grouped under the same localized page label used by the sidebar, and selecting a result opens and scrolls to the matching block.

One- and two-character queries use word-prefix matching instead of arbitrary substrings, so `cp` matches `CPU` without also matching `MCP` or `ACP`. Queries of three or more characters retain substring matching.

## User Impact

Users can search for the setting they remember instead of first guessing its page. Results preserve their page context, and deep links open the correct Quick Settings card, virtual section, or schema section.

## Evidence

- Focused Control UI tests: 71 passed.
- Control UI TypeScript check: `node scripts/run-tsgo.mjs -p tsconfig.ui.json --incremental false`.
- Mocked-Gateway sidebar E2E: 5 passed, including nested results, direct navigation, active-state behavior, and the short-query `cp` regression.
- `git diff --check origin/main...HEAD`.

### Proposed deep-search results

Gateway-related pages and matching blocks:

![Proposed Gateway search results](https://divine-crystal-bdsy.here.now/gateway.png)

MCP page plus the matching General block:

![Proposed MCP search results](https://divine-crystal-bdsy.here.now/mcp.png)

Avatar search routed to the Personal block:

![Proposed avatar search results](https://divine-crystal-bdsy.here.now/avatar.png)

This is AI-assisted work. The implementation was manually reviewed against the current Settings navigation, config schema search, route behavior, and focused automated proof.
