### PR TITLE
fix(sessions): preserve cancelled terminal outcome detail in the session state signal log

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -83,7 +83,7 @@ When route metadata is available, `session_status` also includes a visible `Rout
 
 ## Session state changes
 
-OpenClaw keeps a best-effort signal log for selected session state changes: direct human messages to child sessions, child-run completion or failure, child creation, goal changes, and compaction. The log contains metadata and one-line summaries, never message content. Its `stateVersion` is the session's signal-log head, not a transactional change-data-capture version; the session-store mutation and signal append use separate storage, so a failed append is logged without failing the originating turn.
+OpenClaw keeps a best-effort signal log for selected session state changes: direct human messages to child sessions, child-run completion or failure, child creation, goal changes, and compaction. Cancelled and timed-out child runs are recorded as failures, with the specific outcome (`cancelled`, `timeout`, or `error`) preserved in the event payload. The log contains metadata and one-line summaries, never message content. Its `stateVersion` is the session's signal-log head, not a transactional change-data-capture version; the session-store mutation and signal append use separate storage, so a failed append is logged without failing the originating turn.
 
 `sessions_list` includes `stateVersion` on rows with logged changes. `session_status` always returns `stateVersion` in structured details. Pass `changesSince: <previousStateVersion>` to retrieve up to 200 retained events after that version; this read does not acknowledge or advance parent notification cursors. A `historyGap: true` result means the requested version predates retained history, so refresh the whole session state instead of treating the response as an exact delta.
 

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -137,11 +137,28 @@ describe("AcpSessionManager", () => {
         mode: "prompt",
         requestId: "system-state-turn",
       });
+      runtimeState.runTurn.mockImplementationOnce(async function* () {
+        yield { type: "done" as const, status: "cancelled" as const };
+      });
+      await manager.runTurn({
+        provenance: "system",
+        cfg: baseCfg,
+        sessionKey: childSessionKey,
+        text: "cancelled turn",
+        mode: "prompt",
+        requestId: "cancelled-state-turn",
+      });
 
       expect(listSessionStateEventsSince(childSessionKey, "main", 0, 200).events).toMatchObject([
         { kind: "human_direct_message", runId: "human-state-turn" },
         { kind: "run_completed", runId: "human-state-turn" },
         { kind: "run_completed", runId: "system-state-turn" },
+        {
+          kind: "run_failed",
+          runId: "cancelled-state-turn",
+          summary: "child run cancelled",
+          payload: { outcome: "cancelled" },
+        },
       ]);
       closeOpenClawStateDatabaseForTest();
     });

--- a/src/acp/control-plane/manager.turn-runner.ts
+++ b/src/acp/control-plane/manager.turn-runner.ts
@@ -335,7 +335,7 @@ export async function runManagerTurn(params: {
                 childSessionKey: sessionKey,
                 runId: taskContext.runId,
                 requesterSessionKey: spawnedByWatcher,
-                outcomeStatus: turnOutcome.terminalStatus === "cancelled" ? "error" : "ok",
+                outcomeStatus: turnOutcome.terminalStatus === "cancelled" ? "cancelled" : "ok",
               });
             }
           }

--- a/src/sessions/session-state-events.test.ts
+++ b/src/sessions/session-state-events.test.ts
@@ -483,6 +483,12 @@ describe("session state events", () => {
       requesterSessionKey: watcher,
       outcomeStatus: "ok",
     });
+    recordSubagentTerminalState({
+      childSessionKey: child,
+      runId: "run-child-cancelled",
+      requesterSessionKey: watcher,
+      outcomeStatus: "cancelled",
+    });
     recordSessionGoalChanged({
       sessionKey: child,
       entry: {
@@ -504,10 +510,18 @@ describe("session state events", () => {
       sessionId: "session-child",
     });
 
-    expect(
-      listSessionStateEventsSince(child, "main", 0, 200, database).events.map(
-        (event) => event.kind,
-      ),
-    ).toEqual(["child_spawned", "run_completed", "goal_changed", "compacted"]);
+    const events = listSessionStateEventsSince(child, "main", 0, 200, database).events;
+    expect(events.map((event) => event.kind)).toEqual([
+      "child_spawned",
+      "run_completed",
+      "run_failed",
+      "goal_changed",
+      "compacted",
+    ]);
+    expect(events[2]).toMatchObject({
+      runId: "run-child-cancelled",
+      summary: "child run cancelled",
+      payload: { outcome: "cancelled" },
+    });
   });
 });

--- a/src/sessions/session-state-events.ts
+++ b/src/sessions/session-state-events.ts
@@ -859,13 +859,25 @@ export function recordSubagentSpawned(params: {
   });
 }
 
+type SubagentTerminalStatus = "ok" | "error" | "timeout" | "cancelled";
+
+const SUBAGENT_TERMINAL_SUMMARY: Record<SubagentTerminalStatus, string> = {
+  ok: "child run completed",
+  error: "child run failed",
+  timeout: "child run timed out",
+  cancelled: "child run cancelled",
+};
+
 /** Project an already-normalized subagent terminal outcome into the signal log. */
 export function recordSubagentTerminalState(params: {
   childSessionKey: string;
   runId: string;
   requesterSessionKey: string;
-  outcomeStatus: "ok" | "error" | "timeout";
+  outcomeStatus: SubagentTerminalStatus;
 }): void {
+  // Non-ok statuses share kind run_failed: the closed kind union mirrors the sibling
+  // SubagentRunOutcome status projection, which also folds cancel/timeout into error
+  // status. The precise outcome survives in payload for changesSince consumers.
   recordSessionStateEvent({
     sessionKey: params.childSessionKey,
     agentId: resolveAgentIdFromSessionKey(params.childSessionKey),
@@ -873,7 +885,8 @@ export function recordSubagentTerminalState(params: {
     actorType: "system",
     runId: params.runId,
     dedupeKey: `run-terminal:${params.runId}`,
-    summary: params.outcomeStatus === "ok" ? "child run completed" : "child run failed",
+    summary: SUBAGENT_TERMINAL_SUMMARY[params.outcomeStatus],
+    ...(params.outcomeStatus === "ok" ? {} : { payload: { outcome: params.outcomeStatus } }),
     watcherSessionKeys: [params.requesterSessionKey],
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #104636 (session state events + parent invalidation, issue #104565). Verification of the landed feature found that cancelled ACP child turns are projected into the signal log as a bare `run_failed` event with summary `child run failed` and no outcome detail: `manager.turn-runner.ts` collapsed `terminalStatus === "cancelled"` to `"error"` before calling `recordSubagentTerminalState`, and the projection had no way to carry the distinction. Timed-out runs had the same problem (kind carried it, the summary and payload did not).

For a parent doing `changesSince` reconciliation, "another actor cancelled the child's turn" and "the child crashed" are materially different signals — cancellation usually means someone intervened, which is exactly what this feature exists to surface.

## Why This Change Was Made

- `recordSubagentTerminalState` now accepts `outcomeStatus: "ok" | "error" | "timeout" | "cancelled"`, records an honest per-status summary (`child run cancelled` / `child run timed out` / `child run failed`), and preserves the precise outcome in the event payload (`payload.outcome`) for non-ok statuses.
- The ACP success path passes `"cancelled"` through instead of rederiving it into `"error"`.
- The event `kind` union is deliberately unchanged: non-ok statuses stay `run_failed`, mirroring the sibling `SubagentRunOutcome` status projection (which also folds cancel into error status upstream). The detail lives in the payload, so `NOTIFY_BY_KIND` materiality and all cursor behavior are untouched.
- Native subagent completions are unaffected: the registry's own outcome projection loses the cancel distinction before this seam, so its calls still pass `ok|error|timeout`.

Also reviewed and left as-is from the same verification pass: `sessions_list` omitting `stateVersion` on rows without logged changes is documented, intentional behavior.

## User Impact

Parents reconciling a child session via `session_status` `changesSince` now see whether a child ACP run was cancelled or timed out instead of a generic failure. No schema change, no new config, no notification-behavior change.

## Evidence

- Extended `src/sessions/session-state-events.test.ts` producer-helper test: cancelled projection asserts `kind: run_failed`, `summary: "child run cancelled"`, `payload: { outcome: "cancelled" }`.
- Extended `src/acp/control-plane/manager.test.ts` parented-turn test with a cancelled terminal turn (`done` event `status: "cancelled"`) asserting the projected event end to end.
- Docs: `docs/concepts/session-tool.md` notes cancelled/timed-out child runs record as failures with the specific outcome in the event payload.
- Autoreview (codex `gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings — "patch is correct (0.93)".
- `pnpm check:changed` (remote) + hosted CI on this PR.
