### PR TITLE
improve(ui): sidebar session selection reads as filled pill instead of accent border

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1272,13 +1272,11 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   min-width: 0;
   min-height: 34px;
   padding-right: 4px;
-  border: 1px solid transparent;
   border-radius: var(--radius-md);
   color: var(--muted);
   cursor: default;
   transition:
     background var(--duration-fast) ease,
-    border-color var(--duration-fast) ease,
     color var(--duration-fast) ease;
 }
 
@@ -1287,17 +1285,18 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   color: var(--text);
 }
 
+/* Selection is a filled neutral pill (hover fill, one step stronger), not an
+   accent border: 1px accent outlines read as focus/error chrome on the
+   red-leaning themes. Derive from --text so it holds in light + dark. */
 .sidebar-recent-session--active {
-  background: color-mix(in srgb, var(--accent-subtle) 68%, transparent);
-  border-color: color-mix(in srgb, var(--accent) 16%, transparent);
+  background: color-mix(in srgb, var(--text) 10%, transparent);
   color: var(--text-strong);
 }
 
-/* Multi-select highlight: stronger border than --active so a selection stays
-   readable when it includes the active row. */
+/* Multi-select is an accent wash so it stays distinguishable by hue from the
+   neutral --active fill when a selection includes the active row. */
 .sidebar-recent-session--selected {
-  background: color-mix(in srgb, var(--accent-subtle) 52%, transparent);
-  border-color: color-mix(in srgb, var(--accent) 42%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
   color: var(--text-strong);
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1287,15 +1287,17 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 
 /* Selection is a filled neutral pill (hover fill, one step stronger), not an
    accent border: 1px accent outlines read as focus/error chrome on the
-   red-leaning themes. Derive from --text so it holds in light + dark. */
-.sidebar-recent-session--active {
+   red-leaning themes. Derive from --text so it holds in light + dark.
+   Doubled class outranks .sidebar-recent-session:hover so the selection fill
+   does not degrade to the weaker hover fill while the row is under pointer. */
+.sidebar-recent-session.sidebar-recent-session--active {
   background: color-mix(in srgb, var(--text) 10%, transparent);
   color: var(--text-strong);
 }
 
 /* Multi-select is an accent wash so it stays distinguishable by hue from the
    neutral --active fill when a selection includes the active row. */
-.sidebar-recent-session--selected {
+.sidebar-recent-session.sidebar-recent-session--selected {
   background: color-mix(in srgb, var(--accent) 14%, transparent);
   color: var(--text-strong);
 }


### PR DESCRIPTION
## What Problem This Solves

The active/selected session rows in the Control UI sidebar (Sessions list and the Codex sessions sidebar) were highlighted with a 1px accent-colored border around an accent-tinted background. On the red-leaning themes this reads as focus/error chrome rather than selection: a thin pink/red outline around the current session row, visually heavier than the neutral hover state and out of step with how modern app sidebars (Claude.ai, Linear) mark the current item.

## Why This Change Was Made

Selection should read as "this row is where you are," not "this row needs attention." The redesign drops borders entirely and uses filled pills:

- **Active row**: a neutral fill derived from `--text` (`color-mix(in srgb, var(--text) 10%, transparent)`) — one step stronger than hover, theme-agnostic, works in light and dark across all five themes.
- **Multi-select rows**: a borderless accent wash (`color-mix(in srgb, var(--accent) 14%, transparent)`) so a selection stays distinguishable by hue from the neutral active fill, preserving the old contract that a selection containing the active row remains readable.
- The now-unused `border: 1px solid transparent` base and its `border-color` transition are deleted.

Both the app sidebar (`ui/src/components/app-sidebar.ts`) and the plugin Codex sidebar (`ui/src/pages/plugin/codex-sidebar.ts`) render these classes, so one CSS change covers both surfaces. No markup or class-name changes.

## User Impact

The current session in the sidebar now shows as a clean neutral filled pill instead of an accent-bordered box; multi-selected sessions show a soft accent wash. Hover, drag, and draft-row styling are unchanged.

## Evidence

Before/after, rendered from the real `ui/src/styles` stylesheets with the exact `app-sidebar.ts` row markup. Rows top to bottom: default, hover, active session, multi-selected session, default.

**Light theme**

![Session selection before/after, light theme](https://gist.githubusercontent.com/steipete/ad90bf341a3fdb7c773822bcfdf9ffd4/raw/aad483d78acc27fb0153e5d7a82b0fb796f2f70a/session-selection-light.png)

**Dark theme**

![Session selection before/after, dark theme](https://gist.githubusercontent.com/steipete/ad90bf341a3fdb7c773822bcfdf9ffd4/raw/aad483d78acc27fb0153e5d7a82b0fb796f2f70a/session-selection-dark.png)

The change is CSS-only in `ui/src/styles/layout.css` (7 insertions, 8 deletions); no class names used by `app-sidebar.ts`, `codex-sidebar.ts`, or the e2e/unit tests changed. The usual Crabbox artifact publishing path was unavailable (coordinator reports `artifact_upload_unavailable`), so assets are hosted on a gist.
