### PR TITLE
fix(agents): keep full suite stable under load

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -4,6 +4,7 @@
  * system events, and process lifecycle behavior.
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayActiveWorkInspectors } from "../infra/gateway-active-work.js";
 import type { RunExit } from "../process/supervisor/types.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS } from "../utils/timer-delay.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -80,10 +81,29 @@ function createDeferred<T>() {
 }
 
 function prepareSuspension(requestId: string) {
+  // This test owns only the background-exec registry. Other process-global
+  // activity counters may legitimately stay busy in the non-isolated suite.
+  const inspect: GatewayActiveWorkInspectors = {
+    getQueueSize: () => 0,
+    getPendingReplies: () => 0,
+    getEmbeddedRuns: () => 0,
+    getBackgroundExecSessions: getActiveBackgroundExecSessionCount,
+    getCronRuns: () => 0,
+    getActiveTasks: () => 0,
+    getTaskBlockers: () => [],
+    getRootRequests: () => 0,
+    getSessionAdmissions: () => 0,
+    getSessionMutations: () => 0,
+    getChatRuns: () => 0,
+    getQueuedTurns: () => 0,
+    getTerminalPersistence: () => 0,
+    getTerminalSessions: () => 0,
+  };
   return prepareGatewaySuspend({
     requestId,
     pauseScheduling: vi.fn(),
     resumeScheduling: vi.fn(),
+    inspect,
   });
 }
 

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -22,6 +22,7 @@ type TestRunnerInternals = {
 const SHARED_TEST_SETUP = Symbol.for("openclaw.sharedTestSetup");
 const EMBEDDED_RUN_STATE = Symbol.for("openclaw.embeddedRunState");
 const REPLY_RUN_REGISTRY = Symbol.for("openclaw.replyRunRegistry");
+const DIAGNOSTIC_EVENTS_STATE = Symbol.for("openclaw.diagnosticEvents.state.v1");
 const nativeTimerGlobals = {
   setTimeout: globalThis.setTimeout,
   clearTimeout: globalThis.clearTimeout,
@@ -134,6 +135,13 @@ type ReplyRunStateForTest = {
   waitersByKey?: Map<unknown, Set<ReplyRunWaiter>>;
 };
 
+type DiagnosticEventsStateForTest = {
+  listeners?: Set<unknown>;
+  trustedListeners?: Set<unknown>;
+  toolExecutionListeners?: Set<unknown>;
+  asyncQueue?: unknown[];
+};
+
 function runCleanupActions(actions: CleanupAction[]): unknown {
   let firstError: unknown;
   for (const action of actions) {
@@ -207,6 +215,18 @@ function resetOpenClawGlobalRunState(): void {
   replyRunState?.waitersByKey?.clear();
 }
 
+function resetOpenClawGlobalDiagnosticState(): void {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const state = globalStore[DIAGNOSTIC_EVENTS_STATE] as DiagnosticEventsStateForTest | undefined;
+  // The dispatcher intentionally survives module reloads. Mirror isolate mode
+  // without duplicating its private state defaults in the test runner.
+  state?.listeners?.clear();
+  state?.trustedListeners?.clear();
+  state?.toolExecutionListeners?.clear();
+  state?.asyncQueue?.splice(0);
+  Reflect.deleteProperty(globalStore, DIAGNOSTIC_EVENTS_STATE);
+}
+
 export default class OpenClawNonIsolatedRunner extends TestRunner {
   override onCollectStart(file: RunnerTestFile) {
     super.onCollectStart(file);
@@ -252,6 +272,7 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     restoreSharedTestHomeAfterEnvUnstub(testHome);
     vi.clearAllMocks();
     resetOpenClawGlobalRunState();
+    resetOpenClawGlobalDiagnosticState();
     vi.resetModules();
     const internals = this as unknown as TestRunnerInternals;
     internals.moduleRunner?.mocker?.reset?.();


### PR DESCRIPTION
Closes #104679

AI-assisted: Codex implemented and reviewed this change.

## What Problem This Solves

Fixes an issue where maintainers running the full agents test suite on Linux would see intermittent false failures under load even though each affected file passed alone. The failures rotated among exec suspension finalization, tool-policy warning capture, and model-fallback diagnostic metadata assertions.

## Why This Change Was Made

The non-isolated runner now discards the process-global diagnostic dispatcher between files, matching isolate-mode state for enablement, listeners, and queued events. The exec finalization fixture also supplies a zero baseline for unrelated gateway activity inspectors so it measures only the background-exec registry it owns. Runtime behavior is unchanged.

## User Impact

No user-visible product behavior changes. Maintainers and CI agents get stable `src/agents` full-suite results without rerunning false negatives caused by prior test-file state.

## Evidence

- Before: Blacksmith Testbox `tbx_01kx9c7c6t0yeb3de64xbv7qjy` on clean current `main` failed 4/11,081 tests: all three exec-finalization cases plus model-fallback probe logging. Earlier captured runs also rotated into the two #47487 tool-policy warning assertions.
- Focused after: `corepack pnpm test src/agents/bash-tools.exec-runtime.test.ts src/agents/agent-tools.policy.test.ts src/agents/model-fallback.probe.test.ts` — 3 files, 88 tests passed.
- Full-suite after: `corepack pnpm test src/agents` — 588 files passed; 11,077 passed, 4 skipped.
- Changed gate: `corepack pnpm check:changed` on Blacksmith Testbox — formatting, core/root test types, core/script lint, and guards passed.
- Autoreview: clean; no accepted/actionable findings.
- Exact-head rerun attempt: two fresh Blacksmith leases were shut down during hydration step 5/10 before tests started. The successful full-suite run is patch-identical to this rebased commit and within the landing wrapper's 24-hour reuse window.
