### PR TITLE
fix(release/2026.7.1): low-risk stable sweep — pairing authz, UTF-16 chunk safety, channel timeouts

### DIFF
--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -133,4 +133,24 @@ describe("createDiscordOpusPlaybackStream child stream errors", () => {
       expect(ffmpeg.kill).toHaveBeenCalledWith("SIGKILL");
     },
   );
+
+  it("bounds multibyte ffmpeg stderr by bytes without a replacement character", async () => {
+    const ffmpeg = createFakeFfmpeg();
+    spawnMock.mockReturnValue(ffmpeg);
+
+    const playback = createDiscordOpusPlaybackStream("input.mp3");
+    const errorSeen = new Promise<Error>((resolve) => {
+      playback.once("error", resolve);
+    });
+
+    ffmpeg.stderr.write("é".repeat(4095));
+    ffmpeg.stderr.write("😀");
+    ffmpeg.emit("close", 1, null);
+
+    const error = await errorSeen;
+    const stderrText = error.message.replace(/^ffmpeg exited with code 1: /, "");
+    expect(stderrText).toBe("é".repeat(4095));
+    expect(Buffer.byteLength(stderrText)).toBeLessThanOrEqual(8192);
+    expect(stderrText).not.toContain("\uFFFD");
+  });
 });

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -2,6 +2,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import { Transform, type Readable, type TransformCallback } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 import {
   Application,
   createDecoder as createLibopusDecoder,
@@ -108,7 +109,8 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
     windowsHide: true,
   });
   const opusStream = createDiscordOpusEncodeStream();
-  let stderr = "";
+  const stderr = Buffer.alloc(FFMPEG_ERROR_OUTPUT_BYTES);
+  let stderrBytes = 0;
   let ffmpegClosed = false;
   const killFfmpeg = (signal: NodeJS.Signals = "SIGTERM") => {
     if (!ffmpegClosed && !ffmpeg.killed) {
@@ -116,10 +118,9 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
     }
   };
 
-  ffmpeg.stderr.setEncoding("utf8");
-  ffmpeg.stderr.on("data", (chunk: string) => {
-    if (stderr.length < FFMPEG_ERROR_OUTPUT_BYTES) {
-      stderr = `${stderr}${chunk}`.slice(0, FFMPEG_ERROR_OUTPUT_BYTES);
+  ffmpeg.stderr.on("data", (chunk: Buffer) => {
+    if (stderrBytes < FFMPEG_ERROR_OUTPUT_BYTES) {
+      stderrBytes += chunk.copy(stderr, stderrBytes, 0, FFMPEG_ERROR_OUTPUT_BYTES - stderrBytes);
     }
   });
 
@@ -129,7 +130,9 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
   ffmpeg.once("close", (code, signal) => {
     ffmpegClosed = true;
     if (code && code !== 0) {
-      const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
+      // A byte cap can end inside a code point; omit that partial suffix instead of emitting U+FFFD.
+      const stderrText = new StringDecoder("utf8").write(stderr.subarray(0, stderrBytes)).trim();
+      const suffix = stderrText ? `: ${stderrText}` : "";
       opusStream.destroy(new Error(`ffmpeg exited with code ${code}${suffix}`));
       return;
     }

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type StreamingSessionStub = {
   active: boolean;
+  credentials: unknown;
   start: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
@@ -79,6 +80,7 @@ vi.mock("./streaming-card.js", () => {
     mergeStreamingText,
     FeishuStreamingSession: class {
       active = false;
+      credentials: unknown;
       start = vi.fn(async () => {
         this.active = true;
       });
@@ -92,7 +94,8 @@ vi.mock("./streaming-card.js", () => {
       });
       isActive = vi.fn(() => this.active);
 
-      constructor() {
+      constructor(_client: unknown, credentials: unknown) {
+        this.credentials = credentials;
         streamingInstances.push(this);
       }
     },
@@ -148,6 +151,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       config: {
         renderMode: "auto",
         streaming: true,
+        httpTimeoutMs: 45_000,
       },
     });
 
@@ -462,6 +466,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     await options.onIdle?.();
 
     expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].credentials).toMatchObject({ httpTimeoutMs: 45_000 });
     expect(streamingInstances[0].close).toHaveBeenCalledWith("plain text", {
       note: "Agent: agent",
     });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { resolveConfiguredHttpTimeoutMs } from "./client-timeout.js";
 import { createFeishuClient } from "./client.js";
 import { resolveFeishuIdentityEmoji } from "./identity-header.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
@@ -383,7 +384,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamingStartPromise = (async () => {
       const creds =
         account.appId && account.appSecret
-          ? { appId: account.appId, appSecret: account.appSecret, domain: account.domain }
+          ? {
+              appId: account.appId,
+              appSecret: account.appSecret,
+              domain: account.domain,
+              httpTimeoutMs: resolveConfiguredHttpTimeoutMs(account),
+            }
           : null;
       if (!creds) {
         return;

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -320,6 +320,68 @@ describe("FeishuStreamingSession", () => {
     );
   });
 
+  it("aborts a stalled Feishu tenant-token request after the configured timeout", async () => {
+    vi.useFakeTimers();
+    let authRequestReceived = false;
+    const deps: StreamingFetchDeps = {
+      fetchImpl: withFetchPreconnect(
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = new URL(input instanceof Request ? input.url : input.toString());
+          if (!url.pathname.includes("/auth/")) {
+            return jsonResponse({ code: 0, msg: "ok", data: { card_id: "card_should_not_reach" } });
+          }
+          authRequestReceived = true;
+          return await new Promise<Response>((_resolve, reject) => {
+            const signal = init?.signal;
+            if (!signal) {
+              reject(new Error("missing guarded fetch signal"));
+              return;
+            }
+            signal.addEventListener(
+              "abort",
+              () => {
+                const reason = signal.reason;
+                reject(
+                  reason instanceof Error
+                    ? reason
+                    : new Error("request aborted", { cause: reason }),
+                );
+              },
+              { once: true },
+            );
+          });
+        }),
+      ) as FeishuStreamingFetch,
+      lookupFn: hermeticPublicLookup,
+    };
+
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_stalled_token",
+        appSecret: "secret",
+        httpTimeoutMs: 25,
+      },
+      undefined,
+      deps,
+    );
+
+    const result = expect(session.start("chat_id", "open_id")).rejects.toSatisfy(
+      (error: unknown) => {
+        expect(error).toBeInstanceOf(Error);
+        const message = (error as Error).message;
+        expect(message).toMatch(/timed out/i);
+        return true;
+      },
+    );
+    await vi.advanceTimersByTimeAsync(26);
+    await result;
+    expect(authRequestReceived).toBe(true);
+    console.log(
+      "[feishu streaming-card stall proof] stalled tenant-token fetch honored configured timeout",
+    );
+  });
+
   it("rejects oversized streaming card-create JSON before buffering the full body", async () => {
     let streamState:
       | {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -10,13 +10,19 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { FEISHU_HTTP_TIMEOUT_MS } from "./client-timeout.js";
 import { getFeishuUserAgent } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { readFeishuJsonResponse } from "./json-response.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import type { FeishuDomain } from "./types.js";
 
-type Credentials = { appId: string; appSecret: string; domain?: FeishuDomain };
+type Credentials = {
+  appId: string;
+  appSecret: string;
+  domain?: FeishuDomain;
+  httpTimeoutMs?: number;
+};
 type CardState = {
   cardId: string;
   messageId: string;
@@ -124,6 +130,7 @@ async function getToken(creds: Credentials, deps?: FeishuStreamingDeps): Promise
     lookupFn: deps?.lookupFn,
     policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
     auditContext: "feishu.streaming-card.token",
+    timeoutMs: creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
   });
   let data: {
     code: number;
@@ -304,6 +311,7 @@ export class FeishuStreamingSession {
       lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.create",
+      timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
     });
     let createData: {
       code: number;
@@ -418,6 +426,7 @@ export class FeishuStreamingSession {
         lookupFn: this.lookupFn,
         policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
         auditContext: "feishu.streaming-card.update",
+        timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
       });
       await release();
       if (!response.ok) {
@@ -463,6 +472,7 @@ export class FeishuStreamingSession {
         lookupFn: this.lookupFn,
         policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
         auditContext: "feishu.streaming-card.replace",
+        timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
       });
       await release();
       if (!response.ok) {
@@ -571,6 +581,7 @@ export class FeishuStreamingSession {
       lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.note-update",
+      timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
     })
       .then(async ({ release }) => {
         await release();
@@ -637,6 +648,7 @@ export class FeishuStreamingSession {
       lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.close",
+      timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
     })
       .then(async ({ release }) => {
         await release();

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -281,6 +281,40 @@ describe("openrouter provider hooks", () => {
     expect(contribution?.dynamicSuffix).toContain("Final Fusion model: google/gemini-3.5-flash.");
   });
 
+  it("keeps bounded Fusion model IDs on valid UTF-16 boundaries", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const boundaryModelId = `${"a".repeat(255)}😀tail`;
+    const contribution = provider.resolveSystemPromptContribution?.({
+      provider: "openrouter",
+      modelId: "openrouter/fusion",
+      promptMode: "full",
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/fusion": {
+                params: {
+                  extraBody: {
+                    plugins: [
+                      {
+                        id: "fusion",
+                        analysis_models: [boundaryModelId],
+                        model: boundaryModelId,
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(contribution?.dynamicSuffix).toContain(`Analysis models: ${"a".repeat(255)}.`);
+    expect(contribution?.dynamicSuffix).toContain(`Final Fusion model: ${"a".repeat(255)}.`);
+  });
+
   it("describes Fusion config from the canonical OpenRouter model key", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
     const contribution = provider.resolveSystemPromptContribution?.({

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -15,6 +15,7 @@ import {
   getOpenRouterModelCapabilities,
   loadOpenRouterModelCapabilities,
 } from "openclaw/plugin-sdk/provider-stream-family";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { buildOpenRouterImageGenerationProvider } from "./image-generation-provider.js";
 import { openrouterMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { isOpenRouterMistralModelId, normalizeOpenRouterApiModelId } from "./models.js";
@@ -99,19 +100,21 @@ function sanitizePromptModelId(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
-  const normalized = Array.from(value)
-    .filter((char) => {
-      const codePoint = char.codePointAt(0) ?? 0;
-      return (
-        codePoint > 0x1f &&
-        (codePoint < 0x7f || codePoint > 0x9f) &&
-        codePoint !== 0x2028 &&
-        codePoint !== 0x2029
-      );
-    })
-    .join("")
-    .trim()
-    .slice(0, MAX_PROMPT_MODEL_ID_DISPLAY_CHARS);
+  const normalized = truncateUtf16Safe(
+    Array.from(value)
+      .filter((char) => {
+        const codePoint = char.codePointAt(0) ?? 0;
+        return (
+          codePoint > 0x1f &&
+          (codePoint < 0x7f || codePoint > 0x9f) &&
+          codePoint !== 0x2028 &&
+          codePoint !== 0x2029
+        );
+      })
+      .join("")
+      .trim(),
+    MAX_PROMPT_MODEL_ID_DISPLAY_CHARS,
+  );
   return normalized || undefined;
 }
 

--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -94,6 +94,38 @@ describe("EmbeddedBlockChunker", () => {
     expect(chunker.bufferedText).toBe("KLMNOP");
   });
 
+  it("keeps forced maxChars chunks valid at UTF-16 boundaries", () => {
+    const plainChunker = new EmbeddedBlockChunker({
+      minChars: 1,
+      maxChars: 20,
+      breakPreference: "paragraph",
+    });
+    plainChunker.append(`${"x".repeat(19)}😀tail`);
+
+    expect(drainChunks(plainChunker)).toEqual(["x".repeat(19)]);
+    expect(plainChunker.bufferedText).toBe("😀tail");
+
+    const tinyChunker = new EmbeddedBlockChunker({
+      minChars: 1,
+      maxChars: 1,
+      breakPreference: "paragraph",
+    });
+    tinyChunker.append("😀tail");
+
+    expect(drainChunks(tinyChunker)).toEqual(["😀", "t", "a", "i", "l"]);
+    expect(tinyChunker.bufferedText).toBe("");
+
+    const fencedChunker = new EmbeddedBlockChunker({
+      minChars: 10,
+      maxChars: 20,
+      breakPreference: "paragraph",
+    });
+    fencedChunker.append(`\`\`\`txt\n${"x".repeat(12)}😀tail`);
+
+    expect(drainChunks(fencedChunker)).toEqual([`\`\`\`txt\n${"x".repeat(12)}\n\`\`\`\n`]);
+    expect(fencedChunker.bufferedText).toBe("```txt\n😀tail");
+  });
+
   it("clamps long paragraphs to maxChars when flushOnParagraph is set", () => {
     const chunker = new EmbeddedBlockChunker({
       minChars: 1,

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -1,6 +1,8 @@
 /**
  * Splits streamed embedded-agent replies into Markdown-safe message chunks.
  */
+
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { FenceSpan } from "../../packages/markdown-core/src/fences.js";
 import {
   findFenceSpanAt,
@@ -379,13 +381,19 @@ export class EmbeddedBlockChunker {
     }
 
     if (buffer.length >= maxChars) {
-      if (isSafeFenceBreak(fenceSpans, offset + maxChars)) {
-        return { index: maxChars };
+      const firstCodePointWidth = (buffer.codePointAt(0) ?? 0) > 0xffff ? 2 : 1;
+      const forcedBreakIndex = sliceUtf16Safe(
+        buffer,
+        0,
+        Math.max(maxChars, firstCodePointWidth),
+      ).length;
+      if (isSafeFenceBreak(fenceSpans, offset + forcedBreakIndex)) {
+        return { index: forcedBreakIndex };
       }
-      const fence = findFenceSpanAt(fenceSpans, offset + maxChars);
+      const fence = findFenceSpanAt(fenceSpans, offset + forcedBreakIndex);
       if (fence) {
         const closeFenceStart = findFenceCloseLineStart(buffer, fence, offset);
-        if (closeFenceStart >= minChars && closeFenceStart < maxChars) {
+        if (closeFenceStart >= minChars && closeFenceStart < forcedBreakIndex) {
           return {
             index: closeFenceStart,
             fenceSplit: {
@@ -396,7 +404,7 @@ export class EmbeddedBlockChunker {
           };
         }
         return {
-          index: maxChars,
+          index: forcedBreakIndex,
           fenceSplit: {
             closeFenceLine: `${fence.indent}${fence.marker}`,
             reopenFenceLine: fence.openLine,
@@ -404,7 +412,7 @@ export class EmbeddedBlockChunker {
           },
         };
       }
-      return { index: maxChars };
+      return { index: forcedBreakIndex };
     }
 
     return { index: -1 };

--- a/src/infra/node-pairing-authz.test.ts
+++ b/src/infra/node-pairing-authz.test.ts
@@ -10,6 +10,13 @@ describe("resolveNodePairApprovalScopes", () => {
     ]);
   });
 
+  it("requires operator.admin for browser.proxy commands", () => {
+    expect(resolveNodePairApprovalScopes(["browser.proxy"])).toEqual([
+      "operator.pairing",
+      "operator.admin",
+    ]);
+  });
+
   it("requires operator.write for non-exec commands", () => {
     expect(resolveNodePairApprovalScopes(["canvas.present"])).toEqual([
       "operator.pairing",

--- a/src/infra/node-pairing-authz.ts
+++ b/src/infra/node-pairing-authz.ts
@@ -1,5 +1,5 @@
 // Maps node pairing command declarations to required operator scopes.
-import { NODE_SYSTEM_RUN_COMMANDS } from "./node-commands.js";
+import { NODE_BROWSER_PROXY_COMMAND, NODE_SYSTEM_RUN_COMMANDS } from "./node-commands.js";
 
 /** Operator scopes required to approve a pending node pairing surface. */
 export type NodeApprovalScope = "operator.pairing" | "operator.write" | "operator.admin";
@@ -8,13 +8,15 @@ const OPERATOR_PAIRING_SCOPE: NodeApprovalScope = "operator.pairing";
 const OPERATOR_WRITE_SCOPE: NodeApprovalScope = "operator.write";
 const OPERATOR_ADMIN_SCOPE: NodeApprovalScope = "operator.admin";
 
+const ADMIN_APPROVAL_COMMANDS = [...NODE_SYSTEM_RUN_COMMANDS, NODE_BROWSER_PROXY_COMMAND];
+
 /** Map declared node commands to the least operator scopes needed for approval. */
 export function resolveNodePairApprovalScopes(commands: unknown): NodeApprovalScope[] {
   const normalized = Array.isArray(commands)
     ? commands.filter((command): command is string => typeof command === "string")
     : [];
   if (
-    normalized.some((command) => NODE_SYSTEM_RUN_COMMANDS.some((allowed) => allowed === command))
+    normalized.some((command) => ADMIN_APPROVAL_COMMANDS.some((allowed) => allowed === command))
   ) {
     return [OPERATOR_PAIRING_SCOPE, OPERATOR_ADMIN_SCOPE];
   }


### PR DESCRIPTION
# What Problem This Solves

Follow-up to #104656 (merged): a curated sweep of small, isolated, user-visible or security fixes from `main` that are worth having in the 2026.7.1 stable cut. Each is a clean `-x` cherry-pick, patch-id-identical to its reviewed main original.

# Why This Change Was Made

- `68c18caca06c` fix(node-pairing): require operator.admin to approve browser.proxy nodes (#104491) — security tightening, +11/-2
- `92870e520063` fix(agents): preserve UTF-16 boundaries in block chunks (#104441) — streamed text no longer corrupts emoji/surrogate pairs at chunk boundaries
- `473df17bd726` fix(feishu): add 30 s request timeout to streaming-card API calls (#102948) — prevents indefinite hangs
- `03558dc00821` fix(openrouter): Fusion prompt corrupts boundary emoji in model IDs (#104433)
- `47751c117c17` fix(discord): bound ffmpeg stderr by bytes (#104230) — bounds memory on noisy media

Evaluated and dropped as not-clean backports (owning surface doesn't exist on this branch): #104464 (tool-title truncation lives in post-cut modules), #104608 (Telegram streamed-final pagination planner predates the fixed function here). #104555 was dropped from this sweep after it landed via #104656 with the release manager's "keep GPT-5.6 backport scoped" fixup; this PR does not re-add the descoped test blocks.

# User Impact

Browser-proxy node approval requires `operator.admin`; streamed messages stop corrupting emoji at chunk boundaries; Feishu streaming cards can no longer hang requests; OpenRouter model IDs with emoji render correctly; Discord ffmpeg stderr is memory-bounded.

# Evidence

- All five commits are merged on `main` with green CI and are patch-id-identical picks.
- Targeted Blacksmith Testbox run on this exact head over every test file the five fixes touch (`extensions/discord/src/voice/audio.test.ts`, `extensions/feishu/src/{reply-dispatcher,streaming-card}.test.ts`, `extensions/openrouter/index.test.ts`, `src/agents/embedded-agent-block-chunker.test.ts`, `src/infra/node-pairing-authz.test.ts`): all passed, `exit=0` (lease `tbx_01kx9a3j7k7dr1kh8490rffctv`). An earlier 374-test changed-selection run covered the sibling migration/GPT-5.6 stack.
- Live scenario proof for the sibling backport stack ran on the same Testbox: `doctor --fix` converged 30 orphaned legacy Codex binding sidecars in 26 s with 0 remaining, and fresh non-interactive onboarding persisted `agents.defaults.model.primary = "openai/gpt-5.6"`.
