### PR TITLE
fix(gateway): keep hook agent runs alive after request completion

### DIFF
--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -2,6 +2,12 @@
  * Hook endpoint trust tests for agent dispatch and gateway network config.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getActiveGatewayRootWorkCount,
+  isGatewaySubordinateWorkAdmissionClosed,
+  resetGatewayWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
+} from "../../process/gateway-work-admission.js";
 
 const enqueueSystemEventMock = vi.fn();
 const requestHeartbeatMock = vi.fn();
@@ -124,13 +130,47 @@ function logWarnMetaFor(message: string, predicate?: (meta: HookLogMeta) => bool
 
 describe("dispatchAgentHook trust handling", () => {
   beforeEach(() => {
+    resetGatewayWorkAdmission();
     vi.clearAllMocks();
     capturedDispatchAgentHook = undefined;
     createGatewayHooksRequestHandler(buildMinimalParams());
   });
 
   afterEach(() => {
+    resetGatewayWorkAdmission();
     vi.restoreAllMocks();
+  });
+
+  it("retains detached agent work after the hook request releases admission", async () => {
+    let continueRun = () => {};
+    let subordinateAdmissionClosed: boolean | undefined;
+    const runGate = new Promise<void>((resolve) => {
+      continueRun = resolve;
+    });
+    runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+      await runGate;
+      subordinateAdmissionClosed = isGatewaySubordinateWorkAdmissionClosed();
+      return { status: "ok", summary: "done", delivered: false };
+    });
+    const requestAdmission = tryBeginGatewayRootWorkAdmission();
+    expect(requestAdmission).not.toBeNull();
+
+    await requestAdmission?.run(async () => {
+      dispatchAgentHook(buildAgentPayload("Async hook"));
+      expect(getActiveGatewayRootWorkCount()).toBe(2);
+    });
+    requestAdmission?.release();
+
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+    continueRun();
+    await vi.waitFor(() =>
+      expect(logHooksInfoMock).toHaveBeenCalledWith(
+        "hook agent run completed without announcement",
+        expect.any(Object),
+      ),
+    );
+    expect(subordinateAdmissionClosed).toBe(false);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
 
   it("does not announce successful deliver:false hook results", async () => {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -20,6 +20,7 @@ import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeat } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";
 import type { HookAgentDispatchPayload, HooksConfigResolved } from "../hooks.js";
 import { createHooksRequestHandler, type HookClientIpConfig } from "./hooks-request-handler.js";
 
@@ -150,7 +151,7 @@ export function createGatewayHooksRequestHandler(params: {
     };
 
     let hookEventSessionKey: string | undefined;
-    void (async () => {
+    void runWithGatewayIndependentRootWorkContinuation(async () => {
       try {
         // Agent hooks run after the HTTP response path has returned, so failure
         // handling must record a system event instead of throwing to the caller.
@@ -222,7 +223,7 @@ export function createGatewayHooksRequestHandler(params: {
           });
         }
       }
-    })();
+    });
 
     return runId;
   };


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

AI-assisted: yes (Codex).

## What Problem This Solves

Fixes an issue where users triggering an agent through the Gateway hook endpoint would receive an accepted response, but the detached agent run could then fail with `GatewayDrainingError` after the HTTP request completed.

## Why This Change Was Made

The accepted hook run now reserves the existing independent root-work continuation before the request admission is released. This keeps the detached run tracked for suspension and restart while avoiding stale inherited request admission.

## User Impact

Accepted agent hooks continue running after the HTTP response instead of failing immediately because their request-scoped admission ended.

## Evidence

- AWS Crabbox run `run_0073b63b9181`: `corepack pnpm test src/gateway/server/hooks.agent-trust.test.ts src/process/gateway-work-admission.test.ts` — 53 tests passed across the gateway and process shards.
- AWS Crabbox run `run_fdf0398db9d3`: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — formatting, production/test typechecks, changed-file lint, and affected architecture guards passed.
- Added regression coverage that releases the request admission while the detached hook run is still active, verifies subordinate work remains admitted, and verifies the independent root is released after completion.
- Autoreview: GPT-5.6-sol, high reasoning, fast tier — no accepted/actionable findings (`patch is correct`, confidence 0.91).
