### PR TITLE
fix(macos): remove duplicate sidebar toggle buttons in the Mac app dashboard

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -668,8 +668,8 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             style.id = "openclaw-native-macos-chrome";
             style.textContent = \(Self.jsStringLiteral(css));
             // openclaw-native-nav advertises the titlebar sidebar toggle so a
-            // matching Control UI hides its floating expand button; older web
-            // bundles ignore the class and keep their own fallback control.
+            // matching Control UI hides its in-page expand/collapse buttons;
+            // older web bundles ignore the class and keep their own controls.
             document.documentElement.classList.add("openclaw-native-macos", "openclaw-native-nav");
             document.head.appendChild(style);
           } catch {}

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -594,25 +594,35 @@ class OpenClawShell extends OpenClawLightDomElement {
     });
     if (nextNavCollapsed) {
       void this.updateComplete.then(() => {
-        this.querySelector<HTMLElement>(".shell-nav-expand")?.focus();
+        this.restoreFocusTo(this.querySelector<HTMLElement>(".shell-nav-expand"));
       });
     }
+  }
+
+  /** Focus a restoration target, falling back to the content anchor. The
+   * in-page sidebar toggles are display:none when the Mac app hosts the
+   * toggle in its titlebar (openclaw-native-nav, DashboardWindowController),
+   * so focus must not strand on the body or inside an offscreen drawer. */
+  private restoreFocusTo(target: HTMLElement | null | undefined) {
+    const resolved =
+      target?.isConnected && target.checkVisibility()
+        ? target
+        : this.querySelector<HTMLElement>(".content");
+    resolved?.focus();
   }
 
   private closeNavDrawer(options: { restoreFocus?: boolean } = {}) {
     if (this.navDrawerOpen) {
       this.dismissSidebarTransientMenus();
     }
-    const focusTarget = options.restoreFocus ? this.navDrawerTrigger : null;
+    const trigger = options.restoreFocus ? this.navDrawerTrigger : null;
     this.navDrawerOpen = false;
     this.navDrawerTrigger = null;
-    if (!(focusTarget instanceof HTMLElement) || !focusTarget.isConnected) {
+    if (!options.restoreFocus) {
       return;
     }
     requestAnimationFrame(() => {
-      if (focusTarget.isConnected) {
-        focusTarget.focus();
-      }
+      this.restoreFocusTo(trigger instanceof HTMLElement ? trigger : null);
     });
   }
 
@@ -641,7 +651,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.requestUpdate();
     if (dismissedHiddenMenus) {
       void this.updateComplete.then(() => {
-        this.querySelector<HTMLElement>(".topbar-nav-toggle")?.focus();
+        this.restoreFocusTo(this.querySelector<HTMLElement>(".topbar-nav-toggle"));
       });
     }
   };
@@ -1015,6 +1025,7 @@ class OpenClawShell extends OpenClawLightDomElement {
           "workboard"
             ? "content--workboard"
             : ""}"
+          tabindex="-1"
         >
           ${gatewaySnapshot.connected
             ? nothing

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -442,7 +442,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
           ${this.renderSearch()}
           <openclaw-tooltip .content=${`${collapseLabel} (⌘B)`}>
             <button
-              class="sidebar-brand__icon"
+              class="sidebar-brand__icon sidebar-brand__collapse"
               type="button"
               @click=${() => this.onToggleSidebar?.()}
               aria-label=${collapseLabel}

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -1,0 +1,135 @@
+// The macOS app hosts a native titlebar sidebar toggle and stamps
+// `openclaw-native-nav` on the document root (DashboardWindowController);
+// the web UI must then hide its own expand/collapse buttons or every state
+// shows two toggles. Plain browsers keep the web controls.
+import { chromium, type Browser, type BrowserContext } from "playwright";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+let context: BrowserContext | undefined;
+
+describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  afterEach(async () => {
+    await context?.close();
+    context = undefined;
+  });
+
+  async function openPage(options: { nativeNav: boolean; width?: number }) {
+    context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: options.width ?? 1280 },
+    });
+    const page = await context.newPage();
+    if (options.nativeNav) {
+      // Mirrors the WKUserScript in DashboardWindowController.installNativeChromeScript,
+      // which runs at document end. Playwright init scripts fire before
+      // document.documentElement exists, so defer until the DOM is parsed.
+      await page.addInitScript(() => {
+        const stamp = () =>
+          document.documentElement.classList.add("openclaw-native-macos", "openclaw-native-nav");
+        if (document.documentElement) {
+          stamp();
+        } else {
+          document.addEventListener("DOMContentLoaded", stamp);
+        }
+      });
+    }
+    await installMockGateway(page);
+    const response = await page.goto(server.baseUrl);
+    expect(response?.status()).toBe(200);
+    // The brand row only becomes visible on desktop widths; drawer widths keep
+    // the sidebar hidden, so wait for DOM attachment instead of visibility.
+    await page.locator(".sidebar-brand").waitFor({ state: "attached" });
+    return page;
+  }
+
+  it("keeps the web expand/collapse controls in plain browsers", async () => {
+    const page = await openPage({ nativeNav: false });
+
+    const collapse = page.locator(".sidebar-brand__collapse");
+    await expect.poll(() => collapse.isVisible()).toBe(true);
+    await collapse.click();
+
+    const expand = page.locator(".shell-nav-expand");
+    await expect.poll(() => expand.isVisible()).toBe(true);
+    await expand.click();
+    await expect.poll(() => collapse.isVisible()).toBe(true);
+  });
+
+  it("hides both web toggles when the native titlebar toggle is present", async () => {
+    const page = await openPage({ nativeNav: true });
+
+    await expect.poll(() => page.locator(".sidebar-brand__collapse").isVisible()).toBe(false);
+
+    // Collapse through the native titlebar path; the floating expand control
+    // must stay hidden (the titlebar button is the only expand affordance).
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent("openclaw:native-toggle-sidebar"));
+    });
+    await expect
+      .poll(() => page.locator(".shell").getAttribute("class"))
+      .toContain("shell--nav-collapsed");
+    await expect.poll(() => page.locator(".shell-nav-expand").isVisible()).toBe(false);
+    // With the in-page expand control hidden, collapse anchors keyboard focus
+    // on the content column instead of stranding it on the body.
+    await expect
+      .poll(() => page.evaluate(() => document.activeElement?.classList.contains("content")))
+      .toBe(true);
+  });
+
+  it("keeps the drawer hamburger at narrow widths in plain browsers", async () => {
+    const page = await openPage({ nativeNav: false, width: 900 });
+    await expect.poll(() => page.locator(".topbar-nav-toggle").isVisible()).toBe(true);
+  });
+
+  it("hides the drawer hamburger at narrow widths when the native toggle is present", async () => {
+    const page = await openPage({ nativeNav: true, width: 900 });
+    // The native titlebar toggle drives the drawer via the window event, so
+    // the web hamburger would be a duplicate control.
+    await expect.poll(() => page.locator(".topbar-nav-toggle").isVisible()).toBe(false);
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent("openclaw:native-toggle-sidebar"));
+    });
+    await expect
+      .poll(() => page.locator(".shell").getAttribute("class"))
+      .toContain("shell--nav-drawer-open");
+    // Closing through the native toggle restores focus to the content anchor,
+    // not the hidden hamburger the drawer recorded as its trigger.
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent("openclaw:native-toggle-sidebar"));
+    });
+    await expect
+      .poll(() => page.locator(".shell").getAttribute("class"))
+      .not.toContain("shell--nav-drawer-open");
+    await expect
+      .poll(() => page.evaluate(() => document.activeElement?.classList.contains("content")))
+      .toBe(true);
+  });
+});

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -106,19 +106,15 @@ html.openclaw-native-macos .shell-nav-expand {
 }
 
 /* Newer Mac apps host a native sidebar toggle in the titlebar next to
-   back/forward and add openclaw-native-nav; visually retire the floating
-   duplicate but keep it focusable: collapse focus restoration targets it
-   (app-host.ts) and keyboard/screen-reader users still need an in-page
-   expand control, so it reveals itself on keyboard focus like a skip link.
-   Older apps only add openclaw-native-macos and keep it visible. */
-html.openclaw-native-nav .shell-nav-expand {
-  opacity: 0;
-  pointer-events: none;
-}
-
-html.openclaw-native-nav .shell-nav-expand:focus-visible {
-  opacity: 1;
-  pointer-events: auto;
+   back/forward and add openclaw-native-nav; the in-page toggles (desktop
+   collapse/expand plus the drawer hamburger below 1100px) would duplicate
+   it, so they disappear entirely (⌘B and the accessible titlebar button
+   cover keyboard/screen-reader use). Older apps only add
+   openclaw-native-macos and keep the web controls visible. */
+html.openclaw-native-nav .shell-nav-expand,
+html.openclaw-native-nav .sidebar-brand__collapse,
+html.openclaw-native-nav .topbar .topbar-nav-toggle {
+  display: none;
 }
 
 .shell--onboarding {
@@ -2019,6 +2015,12 @@ openclaw-session-menu[popover] {
   transition:
     margin-bottom 0.16s ease,
     margin-right 0.16s ease;
+}
+
+/* Programmatic focus anchor (tabindex="-1") used when collapsing the sidebar
+   with no visible in-page expand control; skip-link-style, so no ring. */
+.content:focus {
+  outline: none;
 }
 
 .content > * + * {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS app dashboard showed two sidebar toggle buttons in every navigation state: the native titlebar toggle (next to the traffic lights) plus the Control UI's own controls — the collapse button in the sidebar brand row, the floating expand button while collapsed, and the drawer hamburger at narrow widths. The floating expand button also popped visible after using the titlebar toggle because collapse focus restoration force-revealed the "retired" control through its focus-visible escape hatch.

## Why This Change Was Made

The Mac app already stamps `openclaw-native-nav` on the document root to advertise its titlebar toggle (`DashboardWindowController.installNativeChromeScript`), but the Control UI only soft-hid the floating expand button (opacity 0, focusable), and never hid the brand-row collapse button or the narrow-width hamburger. In the Mac app the titlebar button should be the only sidebar toggle; plain browsers and older app builds (which only stamp `openclaw-native-macos`) keep the web controls.

## User Impact

- macOS app: exactly one sidebar toggle (the native titlebar button) in expanded, collapsed, and narrow drawer layouts; Cmd+B still works.
- Keyboard/screen-reader users in the app: collapsing or closing the drawer anchors focus on the content column instead of stranding it on the body, on a hidden control, or inside the offscreen drawer (shared `restoreFocusTo` fallback, also used by the resize-dismiss path).
- Web and older Mac apps: unchanged; the in-page toggles stay visible and keep the existing focus behavior.

## Evidence

- New Playwright e2e `ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts` (4 tests) covers plain-browser vs native-nav at desktop and narrow widths, including drawer toggling through the `openclaw:native-toggle-sidebar` event and focus anchoring after collapse/close.
- Remote proof (Testbox through Crabbox): focused e2e green on `tbx_01kx9csvwet4p9h7jbgpjfwnrt`; final combined `pnpm check:changed` + focused e2e run green on `tbx_01kx9dw3pfcx8nz14wnjq66815` (exit 0, patch-identical content pre-rebase).
- Codex autoreview (gpt-5.6-sol, xhigh) iterated to clean: "no accepted/actionable findings"; earlier rounds surfaced the narrow-width hamburger duplicate and the three focus-restoration regressions, all fixed here.
