### PR TITLE
feat(openai): recognize GPT-Live realtime models and fail closed with guidance

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -829,6 +829,20 @@ compatibility fallback when the shared
     smaller, lower-cost Realtime 2.1 variant.
 
     <Note>
+    **GPT-Live (upcoming).** OpenAI's full-duplex `gpt-live-1` and
+    `gpt-live-1-mini` models replaced ChatGPT voice mode in July 2026; the
+    developer API is rolling out to early-access organizations. OpenClaw
+    recognizes the model family but does not run it yet: GPT-Live sessions are
+    WebRTC-only, own their turn-taking (no VAD), and delegate agent work
+    through a handoff event protocol that OpenClaw's realtime transports do
+    not implement yet. Configuring a `gpt-live-*` model fails closed with
+    guidance on both the WebSocket bridge and Talk browser sessions instead of
+    silently connecting audio without agent access. API access is also gated
+    per OpenAI organization during early access. Keep `gpt-realtime-2.1` (the
+    default) until GPT-Live support lands.
+    </Note>
+
+    <Note>
     Backend OpenAI realtime bridges use the GA Realtime WebSocket session
     shape, which does not accept `session.temperature`. Azure OpenAI
     deployments remain available via `azureEndpoint` and `azureDeployment` and

--- a/extensions/openai/realtime-quicksilver.test.ts
+++ b/extensions/openai/realtime-quicksilver.test.ts
@@ -57,7 +57,10 @@ describe("openai realtime voice provider with gpt-live models", () => {
       providerConfig: { apiKey: "test-key" },
       model: "gpt-realtime-2.1",
     });
-    expect(session?.offerUrl).toBe("https://api.openai.com/v1/realtime/calls");
+    expect(session).toMatchObject({
+      transport: "webrtc",
+      offerUrl: "https://api.openai.com/v1/realtime/calls",
+    });
     expect(mintSecretMock.mock.calls[0]?.[0]?.session).toMatchObject({
       type: "realtime",
       model: "gpt-realtime-2.1",

--- a/extensions/openai/realtime-quicksilver.test.ts
+++ b/extensions/openai/realtime-quicksilver.test.ts
@@ -1,0 +1,86 @@
+// Openai tests cover GPT-Live (quicksilver) realtime voice gating.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isOpenAIGptLiveModel,
+  OPENAI_GPT_LIVE_BRIDGE_UNSUPPORTED_MESSAGE,
+  OPENAI_GPT_LIVE_BROWSER_SESSION_UNSUPPORTED_MESSAGE,
+} from "./realtime-quicksilver.js";
+import { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";
+
+const mintSecretMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./realtime-provider-shared.js", async () => {
+  const actual = await vi.importActual<typeof import("./realtime-provider-shared.js")>(
+    "./realtime-provider-shared.js",
+  );
+  return {
+    ...actual,
+    createOpenAIRealtimeClientSecret: mintSecretMock,
+  };
+});
+
+describe("openai gpt-live model detection", () => {
+  it("matches the gpt-live model family", () => {
+    expect(isOpenAIGptLiveModel("gpt-live-1")).toBe(true);
+    expect(isOpenAIGptLiveModel("gpt-live-1-mini")).toBe(true);
+    expect(isOpenAIGptLiveModel(" GPT-Live-1 ")).toBe(true);
+    expect(isOpenAIGptLiveModel("gpt-live")).toBe(true);
+  });
+
+  it("rejects non-live models and prefix lookalikes", () => {
+    expect(isOpenAIGptLiveModel(undefined)).toBe(false);
+    expect(isOpenAIGptLiveModel("gpt-realtime-2.1")).toBe(false);
+    expect(isOpenAIGptLiveModel("gpt-liveish")).toBe(false);
+  });
+});
+
+describe("openai realtime voice provider with gpt-live models", () => {
+  beforeEach(() => {
+    mintSecretMock.mockReset();
+    mintSecretMock.mockResolvedValue({ value: "ek_test", expiresAt: 1234 });
+  });
+
+  it("fails closed for gpt-live browser sessions with guidance", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    await expect(
+      provider.createBrowserSession?.({
+        providerConfig: { apiKey: "test-key" },
+        model: "gpt-live-1",
+      }),
+    ).rejects.toThrow(OPENAI_GPT_LIVE_BROWSER_SESSION_UNSUPPORTED_MESSAGE);
+    expect(mintSecretMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps GA realtime browser sessions working", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const session = await provider.createBrowserSession?.({
+      providerConfig: { apiKey: "test-key" },
+      model: "gpt-realtime-2.1",
+    });
+    expect(session?.offerUrl).toBe("https://api.openai.com/v1/realtime/calls");
+    expect(mintSecretMock.mock.calls[0]?.[0]?.session).toMatchObject({
+      type: "realtime",
+      model: "gpt-realtime-2.1",
+    });
+  });
+
+  it("rejects gpt-live models on the realtime WebSocket bridge", () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const callbacks = {
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    };
+    expect(() =>
+      provider.createBridge({
+        ...callbacks,
+        providerConfig: { apiKey: "test-key", model: "gpt-live-1" },
+      }),
+    ).toThrow(OPENAI_GPT_LIVE_BRIDGE_UNSUPPORTED_MESSAGE);
+    expect(() =>
+      provider.createBridge({
+        ...callbacks,
+        providerConfig: { apiKey: "test-key", model: "gpt-realtime-2.1" },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/extensions/openai/realtime-quicksilver.ts
+++ b/extensions/openai/realtime-quicksilver.ts
@@ -1,0 +1,31 @@
+// GPT-Live (OpenAI "quicksilver" session type) gating for realtime voice.
+//
+// GPT-Live models (gpt-live-1, gpt-live-1-mini) are full-duplex quicksilver
+// sessions: WebRTC-only (the API rejects websocket session creation with
+// "Quicksilver sessions require WebRTC", probed 2026-07-11), no client
+// turn_detection or tools, and agent delegation happens via
+// conversation.handoff.* events instead of GA function-call events. The Talk
+// browser client only speaks the GA Realtime protocol today, so routing
+// GPT-Live into it would connect audio while agent consult silently never
+// fires. Both transports fail closed with guidance until the handoff protocol
+// is implemented (wire shape reference: openai/codex codex-rs realtime v1);
+// the API is also org-gated until OpenAI opens GPT-Live access.
+
+const OPENAI_GPT_LIVE_MODEL_PREFIX = "gpt-live";
+
+export const OPENAI_GPT_LIVE_BRIDGE_UNSUPPORTED_MESSAGE =
+  "GPT-Live models are not supported on the realtime WebSocket bridge: OpenAI requires WebRTC for quicksilver sessions. Set a gpt-realtime model for this transport.";
+
+export const OPENAI_GPT_LIVE_BROWSER_SESSION_UNSUPPORTED_MESSAGE =
+  "GPT-Live models are not supported for Talk browser sessions yet: quicksilver sessions delegate through conversation.handoff events that the Talk client does not implement. Set a gpt-realtime model until GPT-Live support lands.";
+
+export function isOpenAIGptLiveModel(model: string | undefined): boolean {
+  if (!model) {
+    return false;
+  }
+  const normalized = model.trim().toLowerCase();
+  return (
+    normalized === OPENAI_GPT_LIVE_MODEL_PREFIX ||
+    normalized.startsWith(`${OPENAI_GPT_LIVE_MODEL_PREFIX}-`)
+  );
+}

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -41,6 +41,11 @@ import {
   resolveOpenAIProviderConfigRecord,
   trimToUndefined,
 } from "./realtime-provider-shared.js";
+import {
+  isOpenAIGptLiveModel,
+  OPENAI_GPT_LIVE_BRIDGE_UNSUPPORTED_MESSAGE,
+  OPENAI_GPT_LIVE_BROWSER_SESSION_UNSUPPORTED_MESSAGE,
+} from "./realtime-quicksilver.js";
 
 type OpenAIRealtimeVoice =
   | "alloy"
@@ -1456,6 +1461,9 @@ async function createOpenAIRealtimeBrowserSession(
   }
 
   const model = req.model ?? config.model ?? OPENAI_REALTIME_DEFAULT_MODEL;
+  if (isOpenAIGptLiveModel(model)) {
+    throw new Error(OPENAI_GPT_LIVE_BROWSER_SESSION_UNSUPPORTED_MESSAGE);
+  }
   const auth = await requireOpenAIRealtimePlatformAuth({
     configuredApiKey: config.apiKey,
     cfg: req.cfg,
@@ -1550,6 +1558,9 @@ export function buildOpenAIRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin 
     },
     createBridge: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
+      if (isOpenAIGptLiveModel(config.model)) {
+        throw new Error(OPENAI_GPT_LIVE_BRIDGE_UNSUPPORTED_MESSAGE);
+      }
       return new OpenAIRealtimeVoiceBridge({
         ...req,
         apiKey: config.apiKey,


### PR DESCRIPTION
Related: #104683

## What Problem This Solves

OpenAI's GPT-Live models (`gpt-live-1`, `gpt-live-1-mini`, launched 2026-07-08 as the new ChatGPT voice mode) are rolling out to early-access API organizations. Configuring one in OpenClaw today produces silent misbehavior: the realtime WebSocket bridge fails with an opaque provider `invalid_model` error, and a Talk browser session would mint a GA-shaped session for a model whose full-duplex protocol the Talk client does not speak - audio could connect while agent consult silently never fires.

## Why This Change Was Made

First slice of GPT-Live support (#104683): the `openai` realtime voice provider now recognizes the `gpt-live` model family and fails closed with actionable guidance on both transports. The WebSocket bridge explains that OpenAI requires WebRTC for these sessions (live-probed: the API rejects websocket creation with "GPT-Live sessions require WebRTC"); Talk browser sessions explain that GPT-Live delegates agent work through a `conversation.handoff.*` event protocol the Talk client does not implement yet. Full session support (GPT-Live WebRTC calls plus the handoff delegation adapter in the Talk client) is deliberately not shipped here: the API is org-entitlement-gated (HTTP 403 "Voice session access denied"), so a handoff adapter cannot be live-verified yet. Wire-shape reference for the follow-up is documented in the issue (openai/codex codex-rs realtime v1). No new config surface; the default model stays `gpt-realtime-2.1`.

## User Impact

Users who configure `gpt-live-1` (or any `GPT-Live` model) for OpenAI realtime voice now get a clear configuration error stating what to use instead (`gpt-realtime` models) and why, instead of opaque provider errors or a voice session without agent access. GA realtime behavior is unchanged. Docs describe GPT-Live status and the plan.

## Evidence

- Live API probe (2026-07-11, two orgs, codex-shaped requests):
  - WS `wss://api.openai.com/v1/realtime?model=...` fails with `invalid_intent` "GPT-Live sessions require WebRTC." - the WebRTC-only gate the bridge error now explains.
  - Plain WS `?model=gpt-live-1` fails with `invalid_model` - GA sessions cannot carry GPT-Live.
  - `POST /v1/realtime/calls` (multipart SDP + GPT-Live session JSON) is accepted by the endpoint (call id allocated) and fails only on org entitlement: HTTP 403 "Voice session access denied", identically for a `gpt-realtime-1.5` control - confirming full support cannot be verified until OpenAI enables the org.
- Talk client protocol gap verified in source: `ui/src/pages/chat/realtime-talk-webrtc.ts` handles GA `response.function_call_arguments.*` tool events only; no `conversation.handoff.*` handling exists.
- Focused tests: `extensions/openai/realtime-gpt-live.test.ts` (model-family detection, browser-session fail-closed, WS-bridge fail-closed, GA sessions unchanged) - passed on AWS Crabbox (AWS Crabbox cbx_81f87f6c236c, run_66a3ac1c2835, 5/5 passed).
- Codex autoreview (gpt-5.6-sol, xhigh) flagged the original approach (routing GPT-Live into the GA browser transport) as incorrect for exactly this protocol gap; this PR ships the reviewer-endorsed fail-closed alternative.

