### PR TITLE
fix(maint): reuse docs-only parent gate evidence

### DIFF
--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -9,6 +9,17 @@ run_hosted_prepare_gates() {
     echo "PR head changed before hosted gate verification (expected $current_head, got $remote_head). Re-run prepare-init."
     return 1
   fi
+  # A docs-only final commit may reuse its immutable parent; this covers
+  # release-owned cleanup without inferring PR identity from mutable branches.
+  if [ -z "$recent_sha" ]; then
+    local parent_sha
+    local parent_delta
+    if parent_sha=$(git rev-parse "${current_head}^" 2>/dev/null) &&
+      parent_delta=$(git diff --name-only "$parent_sha" "$current_head" 2>/dev/null) &&
+      file_list_is_docsish_only "$parent_delta"; then
+      recent_sha="$parent_sha"
+    fi
+  fi
 
   local repo
   repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -541,6 +541,39 @@ describe("prepare gate stamp transitions", () => {
     expect(result.stdout).toContain("ARG:--recent-sha\nARG:cafebabe");
   });
 
+  it.each([
+    ["CHANGELOG.md", true],
+    ["changed.ts", false],
+  ])("derives recent parent evidence for a %s commit: %s", (path, expected) => {
+    const { repoDir, headSha: parentSha } = makeRetryRepo();
+    writeFileSync(join(repoDir, path), "change\n");
+    spawnSync("git", ["add", path], { cwd: repoDir });
+    spawnSync(
+      "git",
+      ["-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "change"],
+      { cwd: repoDir },
+    );
+    const currentHead = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: repoDir,
+      encoding: "utf8",
+    }).stdout.trim();
+    const result = runGatesBash(
+      [
+        `gh() { if [ "$1" = pr ]; then printf '${currentHead}\\n'; else printf 'openclaw/openclaw\\n'; fi; }`,
+        "run_quiet_logged() { printf 'ARG:%s\\n' \"$@\"; }",
+        `run_hosted_prepare_gates 100606 ${currentHead} false`,
+      ].join("\n"),
+      { cwd: repoDir },
+    );
+
+    expect(result.status).toBe(0);
+    if (expected) {
+      expect(result.stdout).toContain(`ARG:--recent-sha\nARG:${parentSha}`);
+    } else {
+      expect(result.stdout).not.toContain("ARG:--recent-sha");
+    }
+  });
+
   it("clears remote stamps when fresh docs-only gates do not reuse prior proof", () => {
     const { repoDir } = makeRetryRepo();
     spawnSync("git", ["update-ref", "refs/remotes/origin/main", "HEAD"], { cwd: repoDir });

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../scripts/verify-pr-hosted-gates.mjs";
 
 const sha = "773ffd87a1e1e34451ad6e38fda37380c2569a50";
+const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
 const pr = 100606;
 const nowMs = Date.parse("2026-06-17T10:55:00Z");
 const BUILD_ARTIFACTS_WORKFLOW = "Blacksmith Build Artifacts Testbox";
@@ -128,7 +129,6 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it("accepts 13-hour green evidence from the recorded pre-rebase head", () => {
-    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     const evidence = collectHostedGateEvidence({
       sha,
       recentSha: previousSha,
@@ -153,7 +153,6 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it("accepts recent green evidence from an earlier head of the same PR", () => {
-    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     const evidence = collectHostedGateEvidence({
       sha,
       workflowRuns: [
@@ -177,7 +176,6 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it("requires recent evidence for scheduled gates observed on the target head", () => {
-    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     const targetArmRun = {
       ...successfulRun("Blacksmith ARM Testbox", 3, "2026-06-17T10:54:00Z"),
       status: "queued",
@@ -220,7 +218,6 @@ describe("verify-pr-hosted-gates", () => {
   it.each(["failure", "cancelled", "skipped"])(
     "does not reuse older green evidence after a current-head %s run",
     (conclusion) => {
-      const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
       expect(() =>
         collectHostedGateEvidence({
           sha,
@@ -241,7 +238,6 @@ describe("verify-pr-hosted-gates", () => {
   );
 
   it("does not reuse green evidence from another PR", () => {
-    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     expect(() =>
       collectHostedGateEvidence({
         sha,
@@ -262,7 +258,6 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it("requires the complete recent gate cohort from the recorded head", () => {
-    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     expect(() =>
       collectHostedGateEvidence({
         sha,
@@ -288,7 +283,6 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it("does not drop an applicable scheduled gate when its success is stale", () => {
-    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     expect(() =>
       collectHostedGateEvidence({
         sha,
@@ -313,7 +307,6 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it("does not reuse pre-rebase green evidence after a failed current-head manual gate", () => {
-    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     expect(() =>
       collectHostedGateEvidence({
         sha,
@@ -340,7 +333,6 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it("rejects stale or unrecorded fallback heads", () => {
-    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     const unrelatedSha = "ec159b0222cf4fa21b318317a7c5a29d52c846d2";
     const currentPending = {
       ...successfulRun("CI", 2, "2026-06-17T10:54:00Z"),
@@ -398,7 +390,6 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it("does not let a late failure from an obsolete head override a green target head", () => {
-    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     expect(
       collectHostedGateEvidence({
         sha,
@@ -728,7 +719,6 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it("queries the target and recorded pre-rebase SHAs", () => {
-    const previousSha = "8d86c44c6144f8f726a460914cddb8c9c201f119";
     expect(
       workflowRunQueryPaths("openclaw/openclaw", {
         sha,


### PR DESCRIPTION
## What Problem This Solves

The 24-hour hosted-gate policy could still wait for a fresh exact-head run after a maintainer added a docs-only final commit. This happened on #103445: the reviewed fork head was green, then release-note cleanup produced one child commit, while GitHub returned empty `pull_requests` arrays for the fork workflow runs.

## Why This Change Was Made

The prepare wrapper now passes the immediate parent as explicit recent evidence only when the complete parent-to-head delta is docs-classified. The parent relationship is immutable, and code-changing children remain exact-head only. Existing verified pre-rebase evidence keeps priority.

This deliberately avoids treating a mutable fork repository/branch pair as PR identity. GitHub's workflow-run API exposes branch, head SHA, and pull-request fields, but the observed fork runs omitted their associations even though the documented `exclude_pull_requests` default is false: https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository

## User Impact

Maintainer docs/changelog cleanup no longer forces another exact-head CI wait or rebase when the immutable parent already has a complete green hosted-gate cohort within 24 hours. Terminal failures on the current head still block, the 24-hour limit is unchanged, and any code delta still requires exact or separately verified evidence.

## Evidence

- Sanitized direct AWS Crabbox `run_41a19cc20fdb`: 40/40 hosted-gate verifier tests and 27/27 prepare-gate tests passed; full `check:changed` passed with zero warnings/errors.
- Source-blind temp-repo validation: docs-only child forwarded its parent through `--recent-sha`; an otherwise identical TypeScript child did not.
- Live #103445 lineage: `64b2e266f05c12fc1c9071c932eaf006251adff2..6d25173f1e2058dc5c8942e04a55f93bf3ba4da6` is one direct child touching only `CHANGELOG.md`.
- Live explicit-parent replay selected successful CI `29166217650` and Workflow Sanity `29166217651` from the fork parent despite both runs reporting `pull_requests: []`.
- Fresh structured autoreview: clean, confidence 0.93.

No root changelog entry: this is internal maintainer tooling, and root changelog generation is release-owned.
