### PR TITLE
fix(ci): validate frozen release candidates safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: ""
         type: string
+      release_candidate_ref:
+        description: Canonical release branch authorizing compatibility fallbacks for its exact head
+        required: false
+        default: ""
+        type: string
   push:
     branches: [main]
     paths-ignore:
@@ -107,6 +112,8 @@ jobs:
       run_check: ${{ steps.manifest.outputs.run_check }}
       run_check_additional: ${{ steps.manifest.outputs.run_check_additional }}
       run_check_docs: ${{ steps.manifest.outputs.run_check_docs }}
+      run_format_check: ${{ steps.manifest.outputs.run_format_check }}
+      compatibility_target: ${{ steps.manifest.outputs.compatibility_target }}
       run_control_ui_i18n: ${{ steps.manifest.outputs.run_control_ui_i18n }}
       run_ui_tests: ${{ steps.manifest.outputs.run_ui_tests }}
       run_native_i18n: ${{ steps.manifest.outputs.run_native_i18n }}
@@ -238,6 +245,26 @@ jobs:
           fi
           echo "eligible=true" >> "$GITHUB_OUTPUT"
 
+      - name: Validate release candidate target
+        id: release_candidate_target
+        if: inputs.release_candidate_ref != ''
+        env:
+          EXPECTED_SHA: ${{ steps.checkout_ref.outputs.sha }}
+          RELEASE_CANDIDATE_REF: ${{ inputs.release_candidate_ref }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_CANDIDATE_REF" =~ ^(release/[0-9]{4}\.[0-9]+\.[0-9]+|extended-stable/[0-9]{4}\.[0-9]+\.33)$ ]]; then
+            echo "release_candidate_ref must be a canonical OpenClaw release branch." >&2
+            exit 1
+          fi
+          remote="$(git remote get-url origin)"
+          branch_sha="$(git ls-remote --heads "$remote" "refs/heads/${RELEASE_CANDIDATE_REF}" | awk 'NR == 1 { print $1 }')"
+          if [[ "$branch_sha" != "$EXPECTED_SHA" ]]; then
+            echo "Release candidate branch ${RELEASE_CANDIDATE_REF} does not resolve to ${EXPECTED_SHA}." >&2
+            exit 1
+          fi
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+
       - name: Ensure preflight base commit
         if: github.event_name != 'workflow_dispatch'
         uses: ./.github/actions/ensure-base-commit
@@ -284,6 +311,7 @@ jobs:
           OPENCLAW_CI_RUN_NATIVE_I18N: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.changed_scope.outputs.run_native_i18n || 'false' }}
           OPENCLAW_CI_CHECKOUT_REVISION: ${{ steps.checkout_ref.outputs.sha }}
           OPENCLAW_CI_HISTORICAL_TARGET: ${{ steps.historical_target.outputs.eligible || 'false' }}
+          OPENCLAW_CI_RELEASE_CANDIDATE_TARGET: ${{ steps.release_candidate_target.outputs.eligible || 'false' }}
           OPENCLAW_CI_WORKFLOW_REVISION: ${{ github.sha }}
           OPENCLAW_CI_REPOSITORY: ${{ github.repository }}
           OPENCLAW_CI_EVENT_NAME: ${{ github.event_name }}
@@ -299,6 +327,11 @@ jobs:
             eventName === "workflow_dispatch" &&
             historicalTargetApproved &&
             checkoutRevision !== workflowRevision;
+          const releaseCandidateTarget =
+            eventName === "workflow_dispatch" &&
+            process.env.OPENCLAW_CI_RELEASE_CANDIDATE_TARGET === "true" &&
+            checkoutRevision !== workflowRevision;
+          const compatibilityTarget = historicalTarget || releaseCandidateTarget;
           const frozenTarget =
             eventName === "workflow_dispatch" && checkoutRevision !== workflowRevision;
 
@@ -306,7 +339,7 @@ jobs:
           const createNodeTestPlan =
             typeof nodeTestPlan.createNodeTestShardBundles === "function"
               ? nodeTestPlan.createNodeTestShardBundles
-              : historicalTarget
+              : compatibilityTarget
                 ? nodeTestPlan.createNodeTestShards
                 : undefined;
           if (typeof createNodeTestPlan !== "function") {
@@ -317,7 +350,7 @@ jobs:
             if (existsSync(path)) {
               return import(path);
             }
-            if (!historicalTarget) {
+            if (!compatibilityTarget) {
               throw new Error(`Current CI target does not provide ${path}`);
             }
             return {};
@@ -370,16 +403,19 @@ jobs:
           const runPluginContractShards = runNodeFull || runNodeFastPluginContracts;
           const runMacos =
             parseBoolean(process.env.OPENCLAW_CI_RUN_MACOS) && !docsOnly && isCanonicalRepository;
-          const supportsCurrentIosCi =
-            hasPackageScript("ios:build") &&
+          const supportsCurrentMacosSwiftCi =
             existsSync("scripts/install-swift-tools.sh") &&
             existsSync("scripts/lint-swift.sh") &&
             existsSync("scripts/format-swift.sh");
+          const supportsIosBuild = hasPackageScript("ios:build");
+          const supportsCurrentIosCi = supportsIosBuild && supportsCurrentMacosSwiftCi;
           const runIosBuild =
             parseBoolean(process.env.OPENCLAW_CI_RUN_IOS_BUILD) &&
             !docsOnly &&
             isCanonicalRepository &&
-            (!historicalTarget || supportsCurrentIosCi);
+            (!frozenTarget ||
+              supportsCurrentIosCi ||
+              (releaseCandidateTarget && supportsIosBuild));
           const runAndroid =
             parseBoolean(process.env.OPENCLAW_CI_RUN_ANDROID) && !docsOnly && isCanonicalRepository;
           const runWindows =
@@ -398,7 +434,13 @@ jobs:
           const runNativeI18n =
             parseBoolean(process.env.OPENCLAW_CI_RUN_NATIVE_I18N) &&
             !docsOnly &&
-            (!historicalTarget || supportsNativeI18n);
+            (!frozenTarget || supportsNativeI18n);
+          const targetWorkflow = existsSync(".github/workflows/ci.yml")
+            ? readFileSync(".github/workflows/ci.yml", "utf8")
+            : "";
+          const supportsFormatCheck =
+            targetWorkflow.split("pnpm format:check").length - 1 >= 2;
+          const runFormatCheck = !frozenTarget || supportsFormatCheck;
           const checksFastCoreTasks = [];
           if (runNodeFull) {
             checksFastCoreTasks.push(
@@ -418,7 +460,7 @@ jobs:
           const compactPullRequest = isCanonicalRepository && eventName === "pull_request";
           const runQaSmokeCi =
             runNodeFull &&
-            (!historicalTarget || existsSync("extensions/qa-lab/src/ci-smoke-plan.ts"));
+            (!compatibilityTarget || existsSync("extensions/qa-lab/src/ci-smoke-plan.ts"));
           const nodeTestShards = runNodeFull
             ? createNodeTestPlan({
                 includeReleaseOnlyPluginShards: false,
@@ -460,6 +502,7 @@ jobs:
             run_checks_fast_core: checksFastCoreTasks.length > 0,
             run_checks_fast: runNodeFull,
             historical_target: historicalTarget,
+            compatibility_target: compatibilityTarget,
             run_qa_smoke_ci: runQaSmokeCi,
             checks_fast_core_matrix: createMatrix(checksFastCoreTasks),
             run_plugin_contracts_shards: runPluginContractShards,
@@ -475,6 +518,7 @@ jobs:
             run_check: runNodeFull,
             run_check_additional: runNodeFull,
             run_check_docs: docsChanged && eventName !== "push",
+            run_format_check: runFormatCheck,
             run_control_ui_i18n: runControlUiI18n,
             run_ui_tests: runUiTests,
             run_native_i18n: runNativeI18n,
@@ -496,7 +540,8 @@ jobs:
             macos_node_matrix: createMatrix(
               runMacos ? [{ check_name: "macos-node", runtime: "node", task: "test" }] : [],
             ),
-            run_macos_swift: runMacos,
+            run_macos_swift:
+              runMacos && (!frozenTarget || compatibilityTarget || supportsCurrentMacosSwiftCi),
             run_ios_build: runIosBuild,
             run_android_job: runAndroid,
             run_protocol_event_coverage: runProtocolEventCoverage,
@@ -1083,11 +1128,15 @@ jobs:
         run: |
           node scripts/build-all.mjs qaRuntime
           pnpm ui:build
-          node scripts/package-openclaw-for-docker.mjs \
-            --allow-unreleased-changelog \
-            --skip-build \
-            --output-dir .artifacts/qa-e2e/smoke-ci-package \
+          package_args=(
+            --skip-build
+            --output-dir .artifacts/qa-e2e/smoke-ci-package
             --output-name openclaw-current.tgz
+          )
+          if grep -Fq -- '--allow-unreleased-changelog' scripts/package-openclaw-for-docker.mjs; then
+            package_args=(--allow-unreleased-changelog "${package_args[@]}")
+          fi
+          node scripts/package-openclaw-for-docker.mjs "${package_args[@]}"
 
       - name: Run smoke profile part
         env:
@@ -1421,7 +1470,8 @@ jobs:
 
       - name: Run check shard
         env:
-          HISTORICAL_TARGET: ${{ needs.preflight.outputs.historical_target }}
+          HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
+          FORMAT_CHECK: ${{ needs.preflight.outputs.run_format_check }}
           OPENCLAW_LOCAL_CHECK: "0"
           TASK: ${{ matrix.task }}
           PR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
@@ -1455,7 +1505,9 @@ jobs:
               ;;
             lint)
               pnpm lint --threads=8
-              pnpm format:check
+              if [ "$FORMAT_CHECK" = "true" ]; then
+                pnpm format:check
+              fi
               ;;
             dependencies)
               if pnpm run --silent 2>/dev/null | grep -q '^  deadcode:dependencies$'; then
@@ -1690,6 +1742,7 @@ jobs:
           install-bun: "false"
 
       - name: Check formatting
+        if: needs.preflight.outputs.run_format_check == 'true'
         run: pnpm format:check
 
       - name: Checkout ClawHub docs source
@@ -1987,7 +2040,7 @@ jobs:
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
     timeout-minutes: 20
     env:
-      HISTORICAL_TARGET: ${{ needs.preflight.outputs.historical_target }}
+      HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
     steps:
       - *platform_checkout_step
 

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -8,6 +8,11 @@ on:
         required: true
         default: main
         type: string
+      target_context_ref:
+        description: Optional canonical release branch context for an exact-SHA target
+        required: false
+        default: ""
+        type: string
       provider:
         description: Provider lane for cross-OS onboarding and the end-to-end agent turn
         required: false
@@ -154,6 +159,7 @@ jobs:
         id: resolve
         env:
           TARGET_REF: ${{ inputs.ref }}
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
         run: |
           bash workflow/scripts/github/resolve-openclaw-ref.sh \
             --ref "$TARGET_REF" \
@@ -381,6 +387,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_REF: ${{ inputs.ref }}
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
           PARENT_WORKFLOW_SHA: ${{ github.sha }}
@@ -548,6 +555,8 @@ jobs:
           args=(-f target_ref="$TARGET_SHA" -f include_android=true -f dispatch_id="$dispatch_id")
           if [[ "$TARGET_REF" =~ ^v[0-9]{4}\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
             args+=(-f historical_target_tag="$TARGET_REF")
+          elif [[ "$TARGET_CONTEXT_REF" =~ ^(release/[0-9]{4}\.[0-9]+\.[0-9]+|extended-stable/[0-9]{4}\.[0-9]+\.33)$ ]]; then
+            args+=(-f release_candidate_ref="$TARGET_CONTEXT_REF")
           fi
           dispatch_and_wait ci.yml "$dispatch_run_name" "${args[@]}"
 

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -9,7 +9,7 @@ on:
         default: main
         type: string
       target_context_ref:
-        description: Optional canonical release branch context for an exact-SHA target
+        description: Optional canonical release branch or tag context for an exact-SHA target
         required: false
         default: ""
         type: string
@@ -287,6 +287,7 @@ jobs:
           RUN_RELEASE_SOAK: ${{ inputs.run_release_soak || inputs.release_profile == 'stable' || inputs.release_profile == 'full' }}
           PROVIDER: ${{ inputs.provider }}
           MODE: ${{ inputs.mode }}
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
           CROSS_OS_SUITE_FILTER: ${{ inputs.cross_os_suite_filter }}
           RELEASE_PACKAGE_SPEC: ${{ inputs.release_package_spec }}
@@ -299,6 +300,7 @@ jobs:
           inputs_json="$(jq -nc \
             --arg provider "$PROVIDER" \
             --arg mode "$MODE" \
+            --arg targetContextRef "$TARGET_CONTEXT_REF" \
             --arg liveSuiteFilter "$LIVE_SUITE_FILTER" \
             --arg crossOsSuiteFilter "$CROSS_OS_SUITE_FILTER" \
             --arg releasePackageSpec "$RELEASE_PACKAGE_SPEC" \
@@ -307,6 +309,7 @@ jobs:
             '{
               provider: $provider,
               mode: $mode,
+              targetContextRef: $targetContextRef,
               liveSuiteFilter: $liveSuiteFilter,
               crossOsSuiteFilter: $crossOsSuiteFilter,
               releasePackageSpec: $releasePackageSpec,
@@ -555,6 +558,8 @@ jobs:
           args=(-f target_ref="$TARGET_SHA" -f include_android=true -f dispatch_id="$dispatch_id")
           if [[ "$TARGET_REF" =~ ^v[0-9]{4}\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
             args+=(-f historical_target_tag="$TARGET_REF")
+          elif [[ "$TARGET_CONTEXT_REF" =~ ^v[0-9]{4}\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?$ ]]; then
+            args+=(-f historical_target_tag="$TARGET_CONTEXT_REF")
           elif [[ "$TARGET_CONTEXT_REF" =~ ^(release/[0-9]{4}\.[0-9]+\.[0-9]+|extended-stable/[0-9]{4}\.[0-9]+\.33)$ ]]; then
             args+=(-f release_candidate_ref="$TARGET_CONTEXT_REF")
           fi
@@ -1897,6 +1902,7 @@ jobs:
           EVIDENCE_MANIFEST: ${{ needs.evidence_reuse.outputs.evidence_manifest }}
           PROVIDER: ${{ inputs.provider }}
           MODE: ${{ inputs.mode }}
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
           CROSS_OS_SUITE_FILTER: ${{ inputs.cross_os_suite_filter }}
           RELEASE_PACKAGE_SPEC: ${{ inputs.release_package_spec }}
@@ -1966,6 +1972,7 @@ jobs:
             --arg performanceConclusion "$PERFORMANCE_CONCLUSION" \
             --arg provider "$PROVIDER" \
             --arg mode "$MODE" \
+            --arg targetContextRef "$TARGET_CONTEXT_REF" \
             --arg liveSuiteFilter "$LIVE_SUITE_FILTER" \
             --arg crossOsSuiteFilter "$CROSS_OS_SUITE_FILTER" \
             --arg releasePackageSpec "$RELEASE_PACKAGE_SPEC" \
@@ -1988,6 +1995,7 @@ jobs:
               validationInputs: {
                 provider: $provider,
                 mode: $mode,
+                targetContextRef: $targetContextRef,
                 liveSuiteFilter: $liveSuiteFilter,
                 crossOsSuiteFilter: $crossOsSuiteFilter,
                 releasePackageSpec: $releasePackageSpec,

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1927,8 +1927,9 @@ jobs:
             --output-dir .artifacts/docker-e2e-package
             --output-name openclaw-current.tgz
           )
-          # Only current-tree QA callers opt in; release and package-candidate callers stay strict.
-          if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]]; then
+          # Frozen targets that predate the opt-in flag still strict-pack against their versioned changelog.
+          if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]] && \
+            grep -Fq -- '--allow-unreleased-changelog' scripts/package-openclaw-for-docker.mjs; then
             package_args+=(--allow-unreleased-changelog)
           fi
           node scripts/package-openclaw-for-docker.mjs "${package_args[@]}"

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -285,26 +285,35 @@ jobs:
           )"
           git -C .candidate fetch --force --no-tags origin \
             '+refs/heads/release/*:refs/remotes/origin/release/*'
+          git -C .candidate fetch --force --no-tags origin \
+            '+refs/heads/extended-stable/*:refs/remotes/origin/extended-stable/*'
           git -C .candidate fetch --force origin '+refs/tags/v*:refs/tags/v*'
 
           trusted_reason=""
+          trusted_release_branch=""
           if [[ "$compare_status" == "ahead" || "$compare_status" == "identical" ]]; then
             trusted_reason="main-ancestor"
           else
             normalized_ref="${TARGET_REF#refs/heads/}"
-            if [[ "$normalized_ref" =~ ^release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]]; then
+            if [[ "$normalized_ref" =~ ^(release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*|extended-stable/[0-9]{4}\.[1-9][0-9]*\.33)$ ]]; then
               [[ "$(git -C .candidate rev-parse "refs/remotes/origin/${normalized_ref}")" == "$candidate_sha" ]]
               trusted_reason="release-branch-head"
+              trusted_release_branch="$normalized_ref"
             elif [[ "$TARGET_REF" =~ ^refs/tags/v ]] || [[ "$TARGET_REF" =~ ^v ]]; then
               normalized_tag="${TARGET_REF#refs/tags/}"
               [[ "$(git -C .candidate rev-parse "refs/tags/${normalized_tag}^{commit}")" == "$candidate_sha" ]]
               trusted_reason="release-tag"
             elif [[ "$TARGET_REF" =~ ^[a-f0-9]{40}$ && "$TARGET_REF" == "$candidate_sha" ]]; then
-              if git -C .candidate for-each-ref \
-                --format='%(objectname)' \
-                refs/remotes/origin/release |
-                grep -Fxq "$candidate_sha"; then
+              matching_release_branches="$(
+                git -C .candidate for-each-ref \
+                  --format='%(objectname) %(refname:strip=3)' \
+                  refs/remotes/origin/release \
+                  refs/remotes/origin/extended-stable |
+                  awk -v sha="$candidate_sha" '$1 == sha { print $2 }'
+              )"
+              if [[ "$(wc -l <<<"$matching_release_branches" | tr -d ' ')" == "1" && -n "$matching_release_branches" ]]; then
                 trusted_reason="release-branch-head"
+                trusted_release_branch="$matching_release_branches"
               else
                 while IFS= read -r tag_ref; do
                   if [[ "$(git -C .candidate rev-parse "${tag_ref}^{commit}")" == "$candidate_sha" ]]; then
@@ -325,7 +334,7 @@ jobs:
             repository_name="${GITHUB_REPOSITORY#*/}"
             signature_json="$(
               gh api graphql \
-                -f query='query($owner:String!,$name:String!,$oid:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$oid){... on Commit{oid signature{isValid state signer{login}}}}}}' \
+                -f query='query($owner:String!,$name:String!,$oid:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$oid){... on Commit{oid signature{isValid state signer{login}} associatedPullRequests(first:10){nodes{state baseRefName baseRepository{nameWithOwner} mergeCommit{oid} mergedBy{login}}}}}}}' \
                 -f owner="$repository_owner" \
                 -f name="$repository_name" \
                 -f oid="$candidate_sha"
@@ -338,13 +347,31 @@ jobs:
                  .signature.signer.login' \
                 <<<"$signature_json"
             )"
+            permission_actor="$signer"
+            if [[ "$signer" == "web-flow" ]]; then
+              if [[ "$trusted_reason" != "release-branch-head" || -z "$trusted_release_branch" ]]; then
+                echo "GitHub web-flow candidates require an exact release branch head." >&2
+                exit 1
+              fi
+              permission_actor="$(
+                jq -er \
+                  --arg base "$trusted_release_branch" \
+                  --arg repo "$GITHUB_REPOSITORY" \
+                  --arg sha "$candidate_sha" \
+                  '[.data.repository.object.associatedPullRequests.nodes[] |
+                    select(.state == "MERGED" and .baseRefName == $base and
+                      .baseRepository.nameWithOwner == $repo and .mergeCommit.oid == $sha) |
+                    .mergedBy.login] | unique | select(length == 1) | .[0]' \
+                  <<<"$signature_json"
+              )"
+            fi
             role_name="$(
               gh api \
-                "repos/${GITHUB_REPOSITORY}/collaborators/${signer}/permission" \
+                "repos/${GITHUB_REPOSITORY}/collaborators/${permission_actor}/permission" \
                 --jq '.role_name'
             )"
             if [[ "$role_name" != "admin" && "$role_name" != "maintain" ]]; then
-              echo "Release candidate signer ${signer} lacks maintain/admin access." >&2
+              echo "Release candidate actor ${permission_actor} lacks maintain/admin access." >&2
               exit 1
             fi
           fi
@@ -940,26 +967,35 @@ jobs:
           )"
           git fetch --force --no-tags origin \
             '+refs/heads/release/*:refs/remotes/origin/release/*'
+          git fetch --force --no-tags origin \
+            '+refs/heads/extended-stable/*:refs/remotes/origin/extended-stable/*'
           git fetch --force origin '+refs/tags/v*:refs/tags/v*'
 
           trusted_reason=""
+          trusted_release_branch=""
           if [[ "$compare_status" == "ahead" || "$compare_status" == "identical" ]]; then
             trusted_reason="main-ancestor"
           else
             normalized_ref="${TARGET_REF#refs/heads/}"
-            if [[ "$normalized_ref" =~ ^release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]]; then
+            if [[ "$normalized_ref" =~ ^(release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*|extended-stable/[0-9]{4}\.[1-9][0-9]*\.33)$ ]]; then
               [[ "$(git rev-parse "refs/remotes/origin/${normalized_ref}")" == "$candidate_sha" ]]
               trusted_reason="release-branch-head"
+              trusted_release_branch="$normalized_ref"
             elif [[ "$TARGET_REF" =~ ^refs/tags/v ]] || [[ "$TARGET_REF" =~ ^v ]]; then
               normalized_tag="${TARGET_REF#refs/tags/}"
               [[ "$(git rev-parse "refs/tags/${normalized_tag}^{commit}")" == "$candidate_sha" ]]
               trusted_reason="release-tag"
             elif [[ "$TARGET_REF" =~ ^[a-f0-9]{40}$ && "$TARGET_REF" == "$candidate_sha" ]]; then
-              if git for-each-ref \
-                --format='%(objectname)' \
-                refs/remotes/origin/release |
-                grep -Fxq "$candidate_sha"; then
+              matching_release_branches="$(
+                git for-each-ref \
+                  --format='%(objectname) %(refname:strip=3)' \
+                  refs/remotes/origin/release \
+                  refs/remotes/origin/extended-stable |
+                  awk -v sha="$candidate_sha" '$1 == sha { print $2 }'
+              )"
+              if [[ "$(wc -l <<<"$matching_release_branches" | tr -d ' ')" == "1" && -n "$matching_release_branches" ]]; then
                 trusted_reason="release-branch-head"
+                trusted_release_branch="$matching_release_branches"
               else
                 while IFS= read -r tag_ref; do
                   if [[ "$(git rev-parse "${tag_ref}^{commit}")" == "$candidate_sha" ]]; then
@@ -977,7 +1013,7 @@ jobs:
             repository_name="${GITHUB_REPOSITORY#*/}"
             signature_json="$(
               gh api graphql \
-                -f query='query($owner:String!,$name:String!,$oid:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$oid){... on Commit{oid signature{isValid state signer{login}}}}}}' \
+                -f query='query($owner:String!,$name:String!,$oid:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$oid){... on Commit{oid signature{isValid state signer{login}} associatedPullRequests(first:10){nodes{state baseRefName baseRepository{nameWithOwner} mergeCommit{oid} mergedBy{login}}}}}}}' \
                 -f owner="$repository_owner" \
                 -f name="$repository_name" \
                 -f oid="$candidate_sha"
@@ -990,9 +1026,27 @@ jobs:
                  .signature.signer.login' \
                 <<<"$signature_json"
             )"
+            permission_actor="$signer"
+            if [[ "$signer" == "web-flow" ]]; then
+              if [[ "$trusted_reason" != "release-branch-head" || -z "$trusted_release_branch" ]]; then
+                echo "GitHub web-flow candidates require an exact release branch head." >&2
+                exit 1
+              fi
+              permission_actor="$(
+                jq -er \
+                  --arg base "$trusted_release_branch" \
+                  --arg repo "$GITHUB_REPOSITORY" \
+                  --arg sha "$candidate_sha" \
+                  '[.data.repository.object.associatedPullRequests.nodes[] |
+                    select(.state == "MERGED" and .baseRefName == $base and
+                      .baseRepository.nameWithOwner == $repo and .mergeCommit.oid == $sha) |
+                    .mergedBy.login] | unique | select(length == 1) | .[0]' \
+                  <<<"$signature_json"
+              )"
+            fi
             role_name="$(
               gh api \
-                "repos/${GITHUB_REPOSITORY}/collaborators/${signer}/permission" \
+                "repos/${GITHUB_REPOSITORY}/collaborators/${permission_actor}/permission" \
                 --jq '.role_name'
             )"
             [[ "$role_name" == "admin" || "$role_name" == "maintain" ]]

--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -351,7 +351,7 @@ jobs:
           OPENCLAW_EXTENSION_BATCH_PARALLEL: 2
           OPENCLAW_VITEST_MAX_WORKERS: 1
           OPENCLAW_EXTENSION_BATCH: ${{ matrix.extensions_csv }}
-        run: pnpm test:extensions:batch "$OPENCLAW_EXTENSION_BATCH" -- --exclude extensions/codex/src/app-server/run-attempt.test.ts
+        run: pnpm test:extensions:batch "$OPENCLAW_EXTENSION_BATCH" -- --retry=1 --exclude extensions/codex/src/app-server/run-attempt.test.ts
 
   plugin-prerelease-inspector:
     permissions:

--- a/scripts/full-release-validation-at-sha.d.mts
+++ b/scripts/full-release-validation-at-sha.d.mts
@@ -15,3 +15,7 @@ export function parseArgs(argv: unknown): {
 };
 export function releaseEvidenceVerificationArgs(parentRunId: unknown): string[];
 export function releaseEvidenceVerifierPath(worktreeRoot: unknown): string;
+export function resolveRemoteTargetRefSha(
+  targetRef: string,
+  executeGit?: (args: string[]) => string,
+): string;

--- a/scripts/full-release-validation-at-sha.d.mts
+++ b/scripts/full-release-validation-at-sha.d.mts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 export function parseArgs(argv: unknown): {
   sha: string;
+  targetRef: string;
   workflowSha: string;
   keepBranch: boolean;
   dryRun: boolean;

--- a/scripts/full-release-validation-at-sha.mjs
+++ b/scripts/full-release-validation-at-sha.mjs
@@ -7,6 +7,9 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const WORKFLOW = "full-release-validation.yml";
+const RELEASE_BRANCH_PATTERN =
+  /^(?:release\/[0-9]{4}\.[0-9]+\.[0-9]+|extended-stable\/[0-9]{4}\.[0-9]+\.33)$/u;
+const RELEASE_TAG_PATTERN = /^v[0-9]{4}\.[0-9]+\.[0-9]+(?:-(?:alpha|beta)\.[0-9]+)?$/u;
 const DEFAULT_INPUTS = {
   provider: "openai",
   mode: "both",
@@ -16,7 +19,7 @@ const DEFAULT_INPUTS = {
 };
 
 function usage() {
-  console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--target-ref <canonical-release-branch>] [--workflow-sha <trusted-main-ref>] [--keep-branch] [--dry-run] [-- -f key=value ...]
+  console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--target-ref <canonical-release-branch-or-tag>] [--workflow-sha <trusted-main-ref>] [--keep-branch] [--dry-run] [-- -f key=value ...]
 
 Creates a temporary remote branch pinned to trusted main release tooling,
 dispatches Full Release Validation with the target commit as its ref input,
@@ -137,22 +140,34 @@ export function parseArgs(argv) {
   }
   if (
     args.targetRef &&
-    !/^(?:release\/[0-9]{4}\.[0-9]+\.[0-9]+|extended-stable\/[0-9]{4}\.[0-9]+\.33)$/u.test(
-      args.targetRef,
-    )
+    !RELEASE_BRANCH_PATTERN.test(args.targetRef) &&
+    !RELEASE_TAG_PATTERN.test(args.targetRef)
   ) {
-    throw new Error("--target-ref must be a canonical OpenClaw release branch");
+    throw new Error("--target-ref must be a canonical OpenClaw release branch or tag");
   }
   return args;
+}
+
+export function resolveRemoteTargetRefSha(targetRef, executeGit = (args) => run("git", args)) {
+  if (RELEASE_BRANCH_PATTERN.test(targetRef)) {
+    return executeGit(["ls-remote", "--heads", "origin", `refs/heads/${targetRef}`]).split(
+      /\s+/u,
+    )[0];
+  }
+
+  const tagRef = `refs/tags/${targetRef}`;
+  const peeledSha = executeGit(["ls-remote", "--tags", "origin", `${tagRef}^{}`]).split(/\s+/u)[0];
+  if (peeledSha) {
+    return peeledSha;
+  }
+  return executeGit(["ls-remote", "--tags", "origin", tagRef]).split(/\s+/u)[0];
 }
 
 function verifyTargetRef(targetRef, targetSha) {
   if (!targetRef) {
     return targetSha;
   }
-  const remoteSha = run("git", ["ls-remote", "--heads", "origin", `refs/heads/${targetRef}`]).split(
-    /\s+/u,
-  )[0];
+  const remoteSha = resolveRemoteTargetRefSha(targetRef);
   if (remoteSha !== targetSha) {
     throw new Error(`Target ref ${targetRef} does not resolve to ${targetSha}`);
   }

--- a/scripts/full-release-validation-at-sha.mjs
+++ b/scripts/full-release-validation-at-sha.mjs
@@ -16,7 +16,7 @@ const DEFAULT_INPUTS = {
 };
 
 function usage() {
-  console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--workflow-sha <trusted-main-ref>] [--keep-branch] [--dry-run] [-- -f key=value ...]
+  console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--target-ref <canonical-release-branch>] [--workflow-sha <trusted-main-ref>] [--keep-branch] [--dry-run] [-- -f key=value ...]
 
 Creates a temporary remote branch pinned to trusted main release tooling,
 dispatches Full Release Validation with the target commit as its ref input,
@@ -60,6 +60,7 @@ function readOptionValue(argv, index, optionName) {
 export function parseArgs(argv) {
   const args = {
     sha: "",
+    targetRef: "",
     workflowSha: "",
     keepBranch: false,
     dryRun: false,
@@ -79,6 +80,11 @@ export function parseArgs(argv) {
     }
     if (arg === "--workflow-sha") {
       args.workflowSha = readOptionValue(argv, i, arg);
+      i += 1;
+      continue;
+    }
+    if (arg === "--target-ref") {
+      args.targetRef = readOptionValue(argv, i, arg);
       i += 1;
       continue;
     }
@@ -129,7 +135,28 @@ export function parseArgs(argv) {
   if (Object.hasOwn(args.inputs, "ref")) {
     throw new Error("SHA-pinned release validation reserves the ref input for --sha");
   }
+  if (
+    args.targetRef &&
+    !/^(?:release\/[0-9]{4}\.[0-9]+\.[0-9]+|extended-stable\/[0-9]{4}\.[0-9]+\.33)$/u.test(
+      args.targetRef,
+    )
+  ) {
+    throw new Error("--target-ref must be a canonical OpenClaw release branch");
+  }
   return args;
+}
+
+function verifyTargetRef(targetRef, targetSha) {
+  if (!targetRef) {
+    return targetSha;
+  }
+  const remoteSha = run("git", ["ls-remote", "--heads", "origin", `refs/heads/${targetRef}`]).split(
+    /\s+/u,
+  )[0];
+  if (remoteSha !== targetSha) {
+    throw new Error(`Target ref ${targetRef} does not resolve to ${targetSha}`);
+  }
+  return targetRef;
 }
 
 function resolveSha(requestedSha) {
@@ -234,11 +261,16 @@ function verifyReleaseEvidence(parentRunId, workflowSha) {
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const targetSha = resolveSha(args.sha);
+  const targetContextRef = verifyTargetRef(args.targetRef, targetSha);
   const workflowSha = resolveTrustedWorkflowSha(args.workflowSha);
   const shortSha = workflowSha.slice(0, 12);
   const branch = `release-ci/${shortSha}-${Date.now()}`;
   const remoteBranchRef = `refs/heads/${branch}`;
-  const dispatchInputs = { ref: targetSha, ...args.inputs };
+  const dispatchInputs = {
+    ref: targetSha,
+    ...(targetContextRef !== targetSha ? { target_context_ref: targetContextRef } : {}),
+    ...args.inputs,
+  };
 
   console.log(`Target SHA: ${targetSha}`);
   console.log(`Trusted workflow SHA: ${workflowSha}`);

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -57,7 +57,11 @@ function runCiManifestFixture(options: {
   eventName?: "pull_request" | "workflow_dispatch";
   historicalCompatibility?: boolean;
   iosCapabilities?: boolean;
+  iosBuildCapability?: boolean;
+  nativeI18nCapabilities?: boolean;
   protocolCoverage?: boolean;
+  formatCheck?: boolean;
+  releaseCandidateCompatibility?: boolean;
 }) {
   const root = mkdtempSync(path.join(tmpdir(), "openclaw-ci-manifest-"));
   try {
@@ -94,12 +98,18 @@ function runCiManifestFixture(options: {
       "utf8",
     );
     const iosCapabilities = options.iosCapabilities ?? options.bundledPlanner;
+    const iosBuildCapability = options.iosBuildCapability ?? iosCapabilities;
+    const nativeI18nCapabilities = options.nativeI18nCapabilities ?? options.bundledPlanner;
     const packageScripts = options.bundledPlanner
       ? {
-          "android:i18n:check": "true",
-          "apple:i18n:check": "true",
-          ...(iosCapabilities ? { "ios:build": "true" } : {}),
-          "native:i18n:check": "true",
+          ...(nativeI18nCapabilities
+            ? {
+                "android:i18n:check": "true",
+                "apple:i18n:check": "true",
+                "native:i18n:check": "true",
+              }
+            : {}),
+          ...(iosBuildCapability ? { "ios:build": "true" } : {}),
         }
       : {};
     writeFileSync(
@@ -127,6 +137,14 @@ function runCiManifestFixture(options: {
     if (options.protocolCoverage ?? options.bundledPlanner) {
       writeFileSync(path.join(root, "scripts", "check-protocol-event-coverage.mjs"), "");
     }
+    const targetWorkflow = path.join(root, ".github", "workflows", "ci.yml");
+    mkdirSync(path.dirname(targetWorkflow), { recursive: true });
+    writeFileSync(
+      targetWorkflow,
+      (options.formatCheck ?? options.bundledPlanner)
+        ? "pnpm format:check\npnpm format:check\n"
+        : "",
+    );
     const outputPath = path.join(root, "manifest.out");
     writeFileSync(outputPath, "", "utf8");
     const manifestStep = readCiWorkflow().jobs.preflight.steps.find(
@@ -147,6 +165,8 @@ function runCiManifestFixture(options: {
           (options.eventName ?? "workflow_dispatch") === "workflow_dispatch"
             ? "true"
             : "false",
+        OPENCLAW_CI_RELEASE_CANDIDATE_TARGET:
+          options.releaseCandidateCompatibility === true ? "true" : "false",
         OPENCLAW_CI_REPOSITORY: "openclaw/openclaw",
         OPENCLAW_CI_RUN_ANDROID: "true",
         OPENCLAW_CI_RUN_CONTROL_UI_I18N: "true",
@@ -1640,6 +1660,7 @@ describe("ci workflow guards", () => {
     expect(current.outputs.run_qa_smoke_ci).toBe("true");
     expect(current.outputs.run_channel_contracts_shards).toBe("true");
     expect(current.outputs.run_protocol_event_coverage).toBe("true");
+    expect(current.outputs.run_format_check).toBe("true");
     expect(JSON.parse(current.outputs.checks_node_core_nondist_matrix).include).toContainEqual(
       expect.objectContaining({
         check_name: "bundled-node-plan",
@@ -1655,6 +1676,59 @@ describe("ci workflow guards", () => {
     expect(currentMissingIos.status, currentMissingIos.output).toBe(0);
     expect(currentMissingIos.outputs.historical_target).toBe("false");
     expect(currentMissingIos.outputs.run_ios_build).toBe("true");
+    expect(currentMissingIos.outputs.run_macos_swift).toBe("true");
+
+    const frozenMissingCurrentCapabilities = runCiManifestFixture({
+      bundledPlanner: true,
+      historicalCompatibility: false,
+      iosCapabilities: false,
+      iosBuildCapability: true,
+      nativeI18nCapabilities: false,
+      protocolCoverage: false,
+      formatCheck: false,
+    });
+    expect(frozenMissingCurrentCapabilities.status, frozenMissingCurrentCapabilities.output).toBe(
+      0,
+    );
+    expect(frozenMissingCurrentCapabilities.outputs.historical_target).toBe("false");
+    expect(frozenMissingCurrentCapabilities.outputs.run_ios_build).toBe("false");
+    expect(frozenMissingCurrentCapabilities.outputs.run_macos_swift).toBe("false");
+    expect(frozenMissingCurrentCapabilities.outputs.run_native_i18n).toBe("false");
+    expect(frozenMissingCurrentCapabilities.outputs.run_protocol_event_coverage).toBe("false");
+    expect(frozenMissingCurrentCapabilities.outputs.run_format_check).toBe("false");
+
+    const releaseCandidateMissingSwiftWrappers = runCiManifestFixture({
+      bundledPlanner: true,
+      historicalCompatibility: false,
+      iosCapabilities: false,
+      iosBuildCapability: true,
+      releaseCandidateCompatibility: true,
+    });
+    expect(releaseCandidateMissingSwiftWrappers.status).toBe(0);
+    expect(releaseCandidateMissingSwiftWrappers.outputs.compatibility_target).toBe("true");
+    expect(releaseCandidateMissingSwiftWrappers.outputs.run_ios_build).toBe("true");
+    expect(releaseCandidateMissingSwiftWrappers.outputs.run_macos_swift).toBe("true");
+
+    const releaseCandidateMissingIosBuild = runCiManifestFixture({
+      bundledPlanner: true,
+      historicalCompatibility: false,
+      iosCapabilities: false,
+      iosBuildCapability: false,
+      releaseCandidateCompatibility: true,
+    });
+    expect(releaseCandidateMissingIosBuild.status).toBe(0);
+    expect(releaseCandidateMissingIosBuild.outputs.run_ios_build).toBe("false");
+
+    const legacyReleaseCandidate = runCiManifestFixture({
+      bundledPlanner: false,
+      historicalCompatibility: false,
+      releaseCandidateCompatibility: true,
+    });
+    expect(legacyReleaseCandidate.status, legacyReleaseCandidate.output).toBe(0);
+    expect(legacyReleaseCandidate.outputs.compatibility_target).toBe("true");
+    expect(
+      JSON.parse(legacyReleaseCandidate.outputs.checks_node_core_nondist_matrix).include,
+    ).toContainEqual(expect.objectContaining({ check_name: "legacy-node-plan" }));
 
     const currentMissingProtocolCoverage = runCiManifestFixture({
       bundledPlanner: true,
@@ -1702,6 +1776,12 @@ describe("ci workflow guards", () => {
     expect(historicalTargetStep.if).toBe("inputs.historical_target_tag != ''");
     expect(historicalTargetStep.run).toContain('git ls-remote --tags "$remote"');
     expect(historicalTargetStep.run).toContain('[[ "$tag_sha" != "$EXPECTED_SHA" ]]');
+    const releaseCandidateStep = workflow.jobs.preflight.steps.find(
+      (step: { name?: string }) => step.name === "Validate release candidate target",
+    );
+    expect(releaseCandidateStep.if).toBe("inputs.release_candidate_ref != ''");
+    expect(releaseCandidateStep.run).toContain('git ls-remote --heads "$remote"');
+    expect(releaseCandidateStep.run).toContain('[[ "$branch_sha" != "$EXPECTED_SHA" ]]');
     expect(workflow.jobs["qa-smoke-ci-profile"].if).toBe(
       "needs.preflight.outputs.run_qa_smoke_ci == 'true'",
     );
@@ -1716,7 +1796,7 @@ describe("ci workflow guards", () => {
     );
     expect(swiftInstall.run).toContain("brew install xcodegen swiftlint swiftformat");
     expect(workflow.jobs["macos-swift"].env.HISTORICAL_TARGET).toBe(
-      "${{ needs.preflight.outputs.historical_target }}",
+      "${{ needs.preflight.outputs.compatibility_target }}",
     );
     expect(swiftInstall.run).toContain('elif [[ "$HISTORICAL_TARGET" == "true" ]]');
     expect(swiftLint.run).toContain("swiftlint lint --config config/swiftlint.yml");
@@ -1726,7 +1806,7 @@ describe("ci workflow guards", () => {
       (step: { name?: string }) => step.name === "Run check shard",
     );
     expect(checkShard.env.HISTORICAL_TARGET).toBe(
-      "${{ needs.preflight.outputs.historical_target }}",
+      "${{ needs.preflight.outputs.compatibility_target }}",
     );
     expect(checkShard.run).toContain("pnpm tsgo:scripts");
     expect(checkShard.run).toContain("pnpm tsgo:strict-ratchet");
@@ -2468,6 +2548,8 @@ describe("ci workflow guards", () => {
     expect(smokeBuildStep.env.OPENCLAW_BUILD_PRIVATE_QA).toBe("1");
     expect(smokeBuildStep.run).toContain("--skip-build");
     expect(smokeBuildStep.run).toContain("--allow-unreleased-changelog");
+    expect(smokeBuildStep.run).toContain("grep -Fq");
+    expect(smokeBuildStep.run).toContain('"${package_args[@]}"');
     expect(workflow.jobs["qa-smoke-ci-artifacts"]).toBeUndefined();
     expect(workflow.jobs["qa-smoke-ci"]).toBeUndefined();
     expect(smokeProfileJob.needs).toEqual(["preflight"]);

--- a/test/scripts/find-reusable-release-validation.test.ts
+++ b/test/scripts/find-reusable-release-validation.test.ts
@@ -15,6 +15,7 @@ const VERIFIER_SHA = "c".repeat(40);
 const DEFAULT_INPUTS = {
   provider: "openai",
   mode: "both",
+  targetContextRef: "",
   liveSuiteFilter: "",
   crossOsSuiteFilter: "",
   releasePackageSpec: "",

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -16,6 +16,8 @@ describe("full-release-validation-at-sha", () => {
         "abc123",
         "--workflow-sha",
         "origin/main",
+        "--target-ref",
+        "release/2026.7.1",
         "--keep-branch",
         "--dry-run",
         "-f",
@@ -32,8 +34,15 @@ describe("full-release-validation-at-sha", () => {
         reuse_evidence: "true",
       },
       sha: "abc123",
+      targetRef: "release/2026.7.1",
       workflowSha: "origin/main",
     });
+  });
+
+  it("keeps branch context separate from the exact target SHA", () => {
+    const source = readFileSync("scripts/full-release-validation-at-sha.mjs", "utf8");
+    expect(source).toContain("ref: targetSha");
+    expect(source).toContain("target_context_ref: targetContextRef");
   });
 
   it("rejects missing option values", () => {
@@ -43,8 +52,18 @@ describe("full-release-validation-at-sha", () => {
       "--workflow-sha requires a value",
     );
     expect(() => parseArgs(["--workflow-sha", "-h"])).toThrow("--workflow-sha requires a value");
+    expect(() => parseArgs(["--target-ref", "--dry-run"])).toThrow("--target-ref requires a value");
     expect(() => parseArgs(["-f", "--dry-run"])).toThrow("-f requires a value");
     expect(() => parseArgs(["-f", "-h"])).toThrow("-f requires a value");
+  });
+
+  it("accepts only canonical release branch context", () => {
+    expect(parseArgs(["--target-ref", "extended-stable/2026.6.33"]).targetRef).toBe(
+      "extended-stable/2026.6.33",
+    );
+    expect(() => parseArgs(["--target-ref", "feature/not-release"])).toThrow(
+      "canonical OpenClaw release branch",
+    );
   });
 
   it("allows exact-target reuse to be disabled for a forced fresh run", () => {

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -6,6 +6,7 @@ import {
   parseArgs,
   releaseEvidenceVerificationArgs,
   releaseEvidenceVerifierPath,
+  resolveRemoteTargetRefSha,
 } from "../../scripts/full-release-validation-at-sha.mjs";
 
 describe("full-release-validation-at-sha", () => {
@@ -39,7 +40,7 @@ describe("full-release-validation-at-sha", () => {
     });
   });
 
-  it("keeps branch context separate from the exact target SHA", () => {
+  it("keeps release context separate from the exact target SHA", () => {
     const source = readFileSync("scripts/full-release-validation-at-sha.mjs", "utf8");
     expect(source).toContain("ref: targetSha");
     expect(source).toContain("target_context_ref: targetContextRef");
@@ -57,13 +58,40 @@ describe("full-release-validation-at-sha", () => {
     expect(() => parseArgs(["-f", "-h"])).toThrow("-f requires a value");
   });
 
-  it("accepts only canonical release branch context", () => {
+  it("accepts only canonical release branch or tag context", () => {
     expect(parseArgs(["--target-ref", "extended-stable/2026.6.33"]).targetRef).toBe(
       "extended-stable/2026.6.33",
     );
+    expect(parseArgs(["--target-ref", "v2026.7.1-beta.5"]).targetRef).toBe("v2026.7.1-beta.5");
+    expect(parseArgs(["--target-ref", "v2026.7.1"]).targetRef).toBe("v2026.7.1");
     expect(() => parseArgs(["--target-ref", "feature/not-release"])).toThrow(
-      "canonical OpenClaw release branch",
+      "canonical OpenClaw release branch or tag",
     );
+  });
+
+  it("resolves annotated release tags through their peeled commit", () => {
+    const calls: string[][] = [];
+    const sha = resolveRemoteTargetRefSha("v2026.7.1-beta.5", (args) => {
+      calls.push(args);
+      return `b6387afd6d2e0f43c2ae98d2d124dbc277f03cca\t${args.at(-1)}`;
+    });
+    expect(sha).toBe("b6387afd6d2e0f43c2ae98d2d124dbc277f03cca");
+    expect(calls).toEqual([["ls-remote", "--tags", "origin", "refs/tags/v2026.7.1-beta.5^{}"]]);
+  });
+
+  it("falls back to the direct ref for lightweight release tags", () => {
+    const calls: string[][] = [];
+    const sha = resolveRemoteTargetRefSha("v2026.7.1", (args) => {
+      calls.push(args);
+      return args.at(-1)?.endsWith("^{}")
+        ? ""
+        : "0123456789abcdef0123456789abcdef01234567\trefs/tags/v2026.7.1";
+    });
+    expect(sha).toBe("0123456789abcdef0123456789abcdef01234567");
+    expect(calls).toEqual([
+      ["ls-remote", "--tags", "origin", "refs/tags/v2026.7.1^{}"],
+      ["ls-remote", "--tags", "origin", "refs/tags/v2026.7.1"],
+    ]);
   });
 
   it("allows exact-target reuse to be disabled for a forced fresh run", () => {

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -207,6 +207,24 @@ function runAdvisoryStatus(overrides: Record<string, string> = {}) {
 }
 
 describe("release Telegram QA workflow", () => {
+  it("attributes GitHub web-flow release merges to their exact maintainer merger", () => {
+    const source = readFileSync(WORKFLOW_PATH, "utf8");
+
+    expect(source.match(/associatedPullRequests\(first:10\)/gu)).toHaveLength(2);
+    expect(source.match(/\.mergeCommit\.oid == \$sha/gu)).toHaveLength(2);
+    expect(source.match(/\.baseRefName == \$base/gu)).toHaveLength(2);
+    expect(source.match(/\.baseRepository\.nameWithOwner == \$repo/gu)).toHaveLength(2);
+    expect(source.match(/\.mergedBy\.login\] \| unique \| select\(length == 1\)/gu)).toHaveLength(
+      2,
+    );
+    expect(source.match(/collaborators\/\$\{permission_actor\}\/permission/gu)).toHaveLength(2);
+    expect(source.match(/refs\/remotes\/origin\/extended-stable/gu).length).toBeGreaterThanOrEqual(
+      2,
+    );
+    expect(source.match(/extended-stable\/\[0-9\]/gu).length).toBeGreaterThanOrEqual(2);
+    expect(source).not.toContain("collaborators/${signer}/permission");
+  });
+
   it("dispatches one accepted trusted-main child from release checks", () => {
     const releaseSource = readFileSync(RELEASE_CHECKS_PATH, "utf8");
     const reusableSource = readFileSync(WORKFLOW_PATH, "utf8");

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -218,10 +218,10 @@ describe("release Telegram QA workflow", () => {
       2,
     );
     expect(source.match(/collaborators\/\$\{permission_actor\}\/permission/gu)).toHaveLength(2);
-    expect(source.match(/refs\/remotes\/origin\/extended-stable/gu).length).toBeGreaterThanOrEqual(
-      2,
-    );
-    expect(source.match(/extended-stable\/\[0-9\]/gu).length).toBeGreaterThanOrEqual(2);
+    expect(
+      (source.match(/refs\/remotes\/origin\/extended-stable/gu) ?? []).length,
+    ).toBeGreaterThanOrEqual(2);
+    expect((source.match(/extended-stable\/\[0-9\]/gu) ?? []).length).toBeGreaterThanOrEqual(2);
     expect(source).not.toContain("collaborators/${signer}/permission");
   });
 

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -349,6 +349,13 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
       required: false,
       type: "string",
     });
+    expect(workflow.on.workflow_dispatch.inputs.release_candidate_ref).toEqual({
+      default: "",
+      description:
+        "Canonical release branch authorizing compatibility fallbacks for its exact head",
+      required: false,
+      type: "string",
+    });
     expect(manifestEnv).toEqual({
       OPENCLAW_CI_CHECKOUT_REVISION: "${{ steps.checkout_ref.outputs.sha }}",
       OPENCLAW_CI_DOCS_CHANGED:
@@ -357,6 +364,8 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
         "${{ github.event_name == 'workflow_dispatch' && 'false' || steps.docs_scope.outputs.docs_only }}",
       OPENCLAW_CI_EVENT_NAME: "${{ github.event_name }}",
       OPENCLAW_CI_HISTORICAL_TARGET: "${{ steps.historical_target.outputs.eligible || 'false' }}",
+      OPENCLAW_CI_RELEASE_CANDIDATE_TARGET:
+        "${{ steps.release_candidate_target.outputs.eligible || 'false' }}",
       OPENCLAW_CI_REPOSITORY: "${{ github.repository }}",
       OPENCLAW_CI_RUN_ANDROID:
         "${{ github.event_name == 'workflow_dispatch' && (inputs.release_gate || inputs.include_android) && 'true' || steps.changed_scope.outputs.run_android || 'false' }}",
@@ -402,6 +411,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
       ).run,
     ).toContain("pnpm deadcode:ci");
     expect(normalCiScript).toContain('args+=(-f historical_target_tag="$TARGET_REF")');
+    expect(normalCiScript).toContain('args+=(-f release_candidate_ref="$TARGET_CONTEXT_REF")');
     expect(normalCiScript).toContain('dispatch_and_wait ci.yml "$dispatch_run_name" "${args[@]}"');
     expect(normalCiScript).not.toContain("full_release_validation=true");
     expect(pluginPrereleaseScript).toContain(
@@ -471,6 +481,9 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
     expect(extensionShard.strategy.matrix).toBe(
       "${{ fromJson(needs.preflight.outputs.plugin_prerelease_extension_matrix) }}",
     );
+    expect(
+      extensionShard.steps.find((step: WorkflowStep) => step.name === "Run extension shard").run,
+    ).toContain("--retry=1");
     expect(inspector.name).toBe("plugin-prerelease-inspector");
     expect(inspector.needs).toEqual(["preflight"]);
     expect(inspector.if).toBe("needs.preflight.outputs.run_plugin_prerelease_suite == 'true'");

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -257,6 +257,10 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
     const dockerSuite = pluginWorkflow.jobs["plugin-prerelease-docker-suite"];
     const suite = pluginWorkflow.jobs["plugin-prerelease-suite"];
     const releaseWorkflow = readFullReleaseValidationWorkflow();
+    const releaseWorkflowSource = readFileSync(
+      ".github/workflows/full-release-validation.yml",
+      "utf8",
+    );
     const manifestScript = preflight.steps.find(
       (step: WorkflowStep) => step.name === "Build CI manifest",
     ).run;
@@ -411,7 +415,10 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
       ).run,
     ).toContain("pnpm deadcode:ci");
     expect(normalCiScript).toContain('args+=(-f historical_target_tag="$TARGET_REF")');
+    expect(normalCiScript).toContain('args+=(-f historical_target_tag="$TARGET_CONTEXT_REF")');
     expect(normalCiScript).toContain('args+=(-f release_candidate_ref="$TARGET_CONTEXT_REF")');
+    expect(releaseWorkflowSource).toContain('--arg targetContextRef "$TARGET_CONTEXT_REF"');
+    expect(releaseWorkflowSource).toContain("targetContextRef: $targetContextRef");
     expect(normalCiScript).toContain('dispatch_and_wait ci.yml "$dispatch_run_name" "${args[@]}"');
     expect(normalCiScript).not.toContain("full_release_validation=true");
     expect(pluginPrereleaseScript).toContain(

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -192,6 +192,7 @@ function rawManifest({
       packageAcceptancePackageSpec: "",
       provider: "openai",
       releasePackageSpec: "",
+      targetContextRef: "",
     },
     version,
     workflowName: "Full Release Validation",

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -186,6 +186,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
       "${{ inputs.allow_unreleased_changelog }}",
     );
     expect(packageStep!.run).toContain("package_args+=(--allow-unreleased-changelog)");
+    expect(packageStep!.run).toContain("grep -Fq");
   });
 
   it.each(PROFILE_EXPECTATIONS)(


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation used current workflow commands against frozen beta, July stable, and extended-stable candidates that predated those commands. This produced false failures in formatting, native i18n, Swift tooling, QA packaging, and Docker packaging. GitHub-generated release merge commits also failed Telegram provenance because the workflow permission-checked `web-flow` instead of the exact PR merger.

## Why This Change Was Made

- Capability-gate target-owned checks only for exact frozen targets; current PR/main remains fail-closed.
- Authenticate canonical `release/*` and `extended-stable/*` branch heads before enabling legacy planner and Swift fallbacks.
- Keep release validation pinned to the requested SHA while carrying verified branch context separately.
- Strict-pack older targets when their packager predates `--allow-unreleased-changelog`.
- Retry failed prerelease extension tests once; deterministic failures still fail twice.
- Resolve GitHub `web-flow` signatures through the unique exact merged PR and permission-check its merger.

## User Impact

Release validation can accurately exercise frozen beta, July stable, and LTS candidates without retroactively imposing newer tooling contracts or weakening current CI/security gates.

## Evidence

- Blacksmith Testbox run 29167099777: 110 workflow contract tests green after focused reruns.
- Targeted oxfmt check: all 11 changed workflow/script/test files clean.
- Exact GitHub GraphQL provenance probe for July commit `92ebc97e52574e8dfca50764670c0eb417094f9d`: unique merged PR and maintainer merger resolved.
- Fresh autoreview: clean; no accepted/actionable findings.
- `git diff --check`: clean.

Release failures addressed:

- LTS Full Release Validation 29166599380
- July Full Release Validation 29166667057
