### PR TITLE
fix(release/2026.7.1): backport tool-result compaction fix stack (#99495/#102610 + #99756 + UTF-16 safety)

### DIFF
--- a/src/agents/cache-trace.ts
+++ b/src/agents/cache-trace.ts
@@ -119,7 +119,7 @@ function digest(value: unknown): string {
   return crypto.createHash("sha256").update(serialized).digest("hex");
 }
 
-function summarizeMessages(messages: AgentMessage[]): {
+export function summarizeMessages(messages: AgentMessage[]): {
   messageCount: number;
   messageRoles: Array<string | undefined>;
   messageFingerprints: string[];

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { streamOpenAICompletions, streamOpenAIResponses } from "@openclaw/ai/internal/openai";
 /**
  * Cache-stability gate for the prompt-cache bust fix (issue #3658).
@@ -22,6 +25,13 @@ import { describe, expect, it } from "vitest";
 import { stripInboundMetadata } from "../../../auto-reply/reply/strip-inbound-meta.js";
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
 import type { Context, Model } from "../../../llm/types.js";
+import {
+  appendUserTurnTranscriptMessage,
+  createUserTurnTranscriptRecorder,
+  mergePreparedUserTurnMessageForRuntime,
+  type UserTurnInput,
+} from "../../../sessions/user-turn-transcript.js";
+import { summarizeMessages } from "../../cache-trace.js";
 import {
   OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
   relocateCurrentRuntimeContextCarrierToTail,
@@ -355,6 +365,95 @@ describe("prompt-cache byte-identity (issue #3658)", () => {
     // Metadata stripped, then stamped from the message's own timestamp.
     const expectedStrippedBare = stripInboundMetadata(stored); // "What is 2+2?"
     expect(output[0]?.content).toBe(`${EXPECTED_PREFIX_TURN1}${expectedStrippedBare}`);
+  });
+});
+
+describe("append-only late media (issue #99495)", () => {
+  it("keeps every sent fingerprint stable and appends one late-media turn", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-99495-boundary-"));
+    const transcriptPath = path.join(dir, "session.jsonl");
+    const admittedInput = {
+      text: "describe this",
+      timestamp: TS_TURN1,
+      idempotencyKey: "cache-99495:user",
+    };
+    let resolveMedia!: (input: UserTurnInput) => void;
+    let markResolverStarted!: () => void;
+    const resolverStarted = new Promise<void>((resolve) => {
+      markResolverStarted = resolve;
+    });
+    const mediaInput = new Promise<UserTurnInput>((resolve) => {
+      resolveMedia = resolve;
+    });
+    try {
+      const recorder = createUserTurnTranscriptRecorder({
+        input: admittedInput,
+        resolveInput: async () => {
+          markResolverStarted();
+          return await mediaInput;
+        },
+        target: { transcriptPath, sessionId: "session-99495", sessionKey: "main", cwd: dir },
+      });
+      const persistence = recorder.persistFallback();
+      await resolverStarted;
+      await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        input: admittedInput,
+        sessionId: "session-99495",
+        sessionKey: "main",
+        cwd: dir,
+      });
+      recorder.markRuntimePersisted(recorder.message);
+      const admittedRuntimeMessage = mergePreparedUserTurnMessageForRuntime({
+        runtimeMessage: currentUserMsg(admittedInput.text, admittedInput.timestamp),
+        preparedMessage: recorder.message,
+      });
+      const sent = normalizeMessagesForLlmBoundary([admittedRuntimeMessage], { timezone: TZ });
+      recorder.markSentToProvider?.();
+      resolveMedia({
+        ...admittedInput,
+        media: [{ path: path.join(dir, "image.png"), contentType: "image/png" }],
+      });
+      await persistence;
+      const persisted = fs
+        .readFileSync(transcriptPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { message?: AgentMsg })
+        .flatMap((entry) => (entry.message ? [entry.message] : []));
+      const next = normalizeMessagesForLlmBoundary(persisted, { timezone: TZ });
+      const sentSummary = summarizeMessages(sent);
+      const nextSummary = summarizeMessages(next);
+
+      expect(nextSummary.messageCount).toBe(sentSummary.messageCount + 1);
+      expect(nextSummary.messageFingerprints.slice(0, sentSummary.messageCount)).toEqual(
+        sentSummary.messageFingerprints,
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps media inline when resolution finishes before serialization", async () => {
+    const prepared = createUserTurnTranscriptRecorder({
+      input: { text: "describe this", timestamp: TS_TURN1 },
+      resolveInput: async () => ({
+        text: "describe this",
+        timestamp: TS_TURN1,
+        media: [{ path: "media://inbound/image.jpg", contentType: "image/jpeg" }],
+      }),
+      target: { transcriptPath: "/unused/session.jsonl" },
+    });
+    const resolved = await prepared.resolveMessage();
+    const merged = mergePreparedUserTurnMessageForRuntime({
+      runtimeMessage: currentUserMsg("describe this", TS_TURN1),
+      preparedMessage: resolved,
+    });
+    prepared.markSentToProvider?.();
+    const summary = summarizeMessages(normalizeMessagesForLlmBoundary([merged], { timezone: TZ }));
+
+    expect(summary.messageCount).toBe(1);
+    expect(merged).toMatchObject({ MediaPath: "media://inbound/image.jpg" });
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -321,6 +321,12 @@ import {
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
 import {
+  cloneToolResultPromptProjectionState,
+  getEmbeddedSessionPromptState,
+  hasSessionUserTurnBeenSent,
+  markSessionUserTurnsSent,
+} from "../session-prompt-state.js";
+import {
   describeEmbeddedAgentStreamStrategy,
   resetEmbeddedAgentBaseStreamFnCacheForTest,
   resolveEmbeddedAgentApiKey,
@@ -347,9 +353,7 @@ import {
 import {
   resolveLiveToolResultMaxChars,
   resolveLiveToolResultAggregateMaxChars,
-  createToolResultPromptProjectionState,
   truncateOversizedToolResultsInMessages,
-  type ToolResultPromptProjectionState,
   truncateOversizedToolResultsInSessionManager,
 } from "../tool-result-truncation.js";
 import { splitSdkTools } from "../tool-split.js";
@@ -2656,8 +2660,10 @@ export async function runEmbeddedAttempt(
           );
       }
       let prePromptMessageCount = activeSession.messages.length;
-      const toolResultPromptProjectionState: ToolResultPromptProjectionState =
-        createToolResultPromptProjectionState();
+      // Session-owned projections survive attempt teardown so already-sent tool results
+      // cannot rewrite the provider prompt-cache tail between turns (#99495).
+      const sessionPromptState = getEmbeddedSessionPromptState(params.sessionId);
+      const toolResultPromptProjectionState = sessionPromptState.toolResults;
       let contextEngineAfterTurnCheckpoint: number | null = null;
       let unwindowedContextEngineMessagesForPrecheck: AgentMessage[] | undefined;
       let contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]> =
@@ -4363,7 +4369,7 @@ export async function runEmbeddedAttempt(
             contextTokenBudget,
             promptToolResultMaxChars,
             promptToolResultAggregateMaxChars,
-            toolResultPromptProjectionState,
+            cloneToolResultPromptProjectionState(toolResultPromptProjectionState),
           );
           const promptHistoryChanged =
             promptToolResultTruncation.messages !== activeSession.messages;
@@ -4989,9 +4995,21 @@ export async function runEmbeddedAttempt(
                     promptToolResultAggregateMaxChars,
                     toolResultPromptProjectionState,
                   );
-                  return providerPromptHistoryTruncation.messages !== messages
-                    ? providerPromptHistoryTruncation.messages
-                    : messages;
+                  const providerMessages =
+                    providerPromptHistoryTruncation.messages !== messages
+                      ? providerPromptHistoryTruncation.messages
+                      : messages;
+                  // This provider-dispatch transform marks the current turn sent so late
+                  // media appends instead of rewriting its prompt-cache slot (#99495).
+                  markSessionUserTurnsSent(sessionPromptState, providerMessages);
+                  const recorder = params.userTurnTranscriptRecorder;
+                  if (
+                    recorder &&
+                    hasSessionUserTurnBeenSent(sessionPromptState, recorder.message) !== false
+                  ) {
+                    recorder.markSentToProvider?.();
+                  }
+                  return providerMessages;
                 },
               );
               activeSession.agent.streamFn = providerPromptStreamFn;

--- a/src/agents/embedded-agent-runner/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/session-prompt-state.ts
@@ -1,0 +1,107 @@
+/** Process-local prompt projection state owned by an embedded session lifecycle. */
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import type { AgentMessage } from "../runtime/index.js";
+
+export type ToolResultPromptProjectionState = {
+  replacements: Map<string, AgentMessage>;
+  frozen: Set<string>;
+  ambiguousBaseKeys: Set<string>;
+  sourceTextByKey: Map<string, string[]>;
+};
+
+export type EmbeddedSessionPromptState = {
+  toolResults: ToolResultPromptProjectionState;
+  sentUserTurnIds: Set<string>;
+};
+
+const MAX_SESSION_PROMPT_STATES = 64;
+const SESSION_PROMPT_STATES_KEY = Symbol.for("openclaw.embeddedSessionPromptStates");
+const sessionPromptStates = resolveGlobalSingleton(
+  SESSION_PROMPT_STATES_KEY,
+  () => new Map<string, EmbeddedSessionPromptState>(),
+);
+
+function createSessionPromptState(): EmbeddedSessionPromptState {
+  return {
+    toolResults: {
+      replacements: new Map<string, AgentMessage>(),
+      frozen: new Set<string>(),
+      ambiguousBaseKeys: new Set<string>(),
+      sourceTextByKey: new Map<string, string[]>(),
+    },
+    sentUserTurnIds: new Set<string>(),
+  };
+}
+
+export function cloneToolResultPromptProjectionState(
+  state: ToolResultPromptProjectionState,
+): ToolResultPromptProjectionState {
+  return {
+    replacements: new Map(state.replacements),
+    frozen: new Set(state.frozen),
+    ambiguousBaseKeys: new Set(state.ambiguousBaseKeys),
+    sourceTextByKey: new Map(state.sourceTextByKey),
+  };
+}
+
+export function getEmbeddedSessionPromptState(sessionId: string): EmbeddedSessionPromptState {
+  const existing = sessionPromptStates.get(sessionId);
+  if (existing) {
+    sessionPromptStates.delete(sessionId);
+    sessionPromptStates.set(sessionId, existing);
+    return existing;
+  }
+  const created = createSessionPromptState();
+  sessionPromptStates.set(sessionId, created);
+  while (sessionPromptStates.size > MAX_SESSION_PROMPT_STATES) {
+    const oldest = sessionPromptStates.keys().next().value;
+    if (typeof oldest !== "string") {
+      break;
+    }
+    sessionPromptStates.delete(oldest);
+  }
+  return created;
+}
+
+export function clearEmbeddedSessionPromptStates(sessionIds: Iterable<string | undefined>): void {
+  for (const sessionId of sessionIds) {
+    const normalized = sessionId?.trim();
+    if (normalized) {
+      sessionPromptStates.delete(normalized);
+    }
+  }
+}
+
+export function markSessionUserTurnsSent(
+  state: EmbeddedSessionPromptState,
+  messages: AgentMessage[],
+): void {
+  for (const message of messages) {
+    if (message.role !== "user") {
+      continue;
+    }
+    const idempotencyKey = (message as { idempotencyKey?: unknown }).idempotencyKey;
+    if (typeof idempotencyKey === "string" && idempotencyKey.length > 0) {
+      state.sentUserTurnIds.add(idempotencyKey);
+    }
+  }
+}
+
+export function hasSessionUserTurnBeenSent(
+  state: EmbeddedSessionPromptState,
+  message: AgentMessage | undefined,
+): boolean | undefined {
+  if (!message || message.role !== "user") {
+    return undefined;
+  }
+  const idempotencyKey = (message as { idempotencyKey?: unknown }).idempotencyKey;
+  return typeof idempotencyKey === "string" && idempotencyKey.length > 0
+    ? state.sentUserTurnIds.has(idempotencyKey)
+    : undefined;
+}
+
+export const testing = {
+  reset() {
+    sessionPromptStates.clear();
+  },
+};

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -166,6 +166,32 @@ describe("truncateToolResultText", () => {
     expect(result).toContain("[custom-truncated]");
     expect(result.length).toBeGreaterThan(250);
   });
+
+  it("keeps direct and suffix-only cuts on complete code points", () => {
+    expect(
+      truncateToolResultText("aaa😀z", 5, {
+        suffix: "!",
+        minKeepChars: 0,
+      }),
+    ).toBe("aaa!");
+    expect(
+      truncateToolResultText("abcdef", 1, {
+        suffix: "😀",
+        minKeepChars: 0,
+      }),
+    ).toBe("");
+  });
+
+  it("keeps both head and tail cuts on complete code points", () => {
+    const marker = "\n\n⚠️ [... middle content omitted — showing head and tail ...]\n\n";
+    const text = `${"a".repeat(6)}😀${"m".repeat(100)}😀${"x".repeat(22)} Error`;
+    expect(
+      truncateToolResultText(text, 100, {
+        suffix: "!",
+        minKeepChars: 1,
+      }),
+    ).toBe(`${"a".repeat(6)}${marker}${"x".repeat(22)} Error!`);
+  });
 });
 
 describe("getToolResultTextLength", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -7,9 +7,11 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { convertToLlm } from "../../../packages/agent-core/src/harness/messages.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
+import { buildRuntimeContextCustomMessage } from "./run/runtime-context-prompt.js";
 import {
   getEmbeddedSessionPromptState,
   testing as sessionPromptStateTesting,
@@ -722,6 +724,206 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(freshResult?.role).toBe("toolResult");
     expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
     expect(totalChars).toBeLessThanOrEqual(32_000);
+  });
+
+  it("preserves fresh tool results through a trailing runtime context carrier", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const history: AgentMessage[] = [];
+    for (let index = 0; index < 50; index++) {
+      history.push(makeAssistantMessage(`call ${index}`));
+      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
+    }
+    history.push(makeUserMessage("run echo with extra context"));
+
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    expect(first.truncatedCount).toBeGreaterThan(0);
+
+    const freshOutput = "OC99756_EXEC_MARKER_".padEnd(4_000, "x");
+    const runtimeContextMessage = buildRuntimeContextCustomMessage("runtime context refresh");
+    if (!runtimeContextMessage) {
+      throw new Error("expected runtime context message");
+    }
+    const providerMessages = convertToLlm([
+      ...history,
+      makeAssistantMessage("running exec"),
+      makeToolResult(freshOutput, "fresh_exec"),
+      runtimeContextMessage,
+    ] as AgentMessage[]) as AgentMessage[];
+    const providerCarrier = providerMessages.at(-1) as
+      | (AgentMessage & { runtimeContextCarrier?: boolean })
+      | undefined;
+    expect(providerCarrier?.runtimeContextCarrier).toBe(true);
+
+    const second = truncateOversizedToolResultsInMessages(
+      providerMessages,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+
+    const freshResult = second.messages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "fresh_exec",
+    );
+    const historicalResults = second.messages.filter(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId.startsWith("history_"),
+    );
+    const firstHistoricalLengths = new Map(
+      first.messages.flatMap((message) =>
+        message.role === "toolResult" && message.toolCallId.startsWith("history_")
+          ? [[message.toolCallId, getToolResultTextLength(message)] as const]
+          : [],
+      ),
+    );
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
+    expect(
+      historicalResults.some(
+        (message) =>
+          getToolResultTextLength(message) <
+          (firstHistoricalLengths.get(message.toolCallId) ?? Number.POSITIVE_INFINITY),
+      ),
+    ).toBe(true);
+    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(second.aggregatePressureEngaged).toBe(true);
+    expect(totalChars).toBeLessThanOrEqual(32_000);
+  });
+
+  it("preserves multiple fresh tool results before queued steering", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const history: AgentMessage[] = [];
+    for (let index = 0; index < 50; index++) {
+      history.push(makeAssistantMessage(`call ${index}`));
+      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
+    }
+    history.push(makeUserMessage("run several commands"));
+
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    expect(first.truncatedCount).toBeGreaterThan(0);
+
+    const freshOutputs = [
+      "OC99241_SHORT_SENTINEL_".padEnd(234, "s"),
+      "OC99241_LONG_SENTINEL_".padEnd(4_000, "l"),
+    ];
+    const second = truncateOversizedToolResultsInMessages(
+      [
+        ...history,
+        makeAssistantMessage("running tools"),
+        makeToolResult(freshOutputs[0]!, "fresh_short"),
+        makeToolResult(freshOutputs[1]!, "fresh_long"),
+        makeUserMessage("queued steering after tool execution"),
+      ],
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+
+    const freshResults = second.messages.filter(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId.startsWith("fresh_"),
+    );
+    const historicalResults = second.messages.filter(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId.startsWith("history_"),
+    );
+    const firstHistoricalLengths = new Map(
+      first.messages.flatMap((message) =>
+        message.role === "toolResult" && message.toolCallId.startsWith("history_")
+          ? [[message.toolCallId, getToolResultTextLength(message)] as const]
+          : [],
+      ),
+    );
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+
+    expect(freshResults.map(getFirstToolResultText)).toEqual(freshOutputs);
+    expect(
+      historicalResults.some(
+        (message) =>
+          getToolResultTextLength(message) <
+          (firstHistoricalLengths.get(message.toolCallId) ?? Number.POSITIVE_INFINITY),
+      ),
+    ).toBe(true);
+    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(second.aggregatePressureEngaged).toBe(true);
+    expect(totalChars).toBeLessThanOrEqual(32_000);
+  });
+
+  it("shrinks deferred fresh results when frozen history cannot satisfy the hard cap", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const history: AgentMessage[] = [
+      makeToolResult("a".repeat(4_000), "history_a"),
+      makeToolResult("b".repeat(4_000), "history_b"),
+      makeUserMessage("establish a frozen projection baseline"),
+    ];
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      1_000_000,
+      8_000,
+      100,
+      projectionState,
+    );
+    expect(first.aggregatePressureEngaged).toBe(true);
+
+    const freshOutput = "OC99241_HARD_CAP_SENTINEL_".padEnd(4_000, "f");
+    const runtimeContextMessage = buildRuntimeContextCustomMessage("hard-cap runtime context");
+    if (!runtimeContextMessage) {
+      throw new Error("expected runtime context message");
+    }
+    const providerMessages = convertToLlm([
+      ...history,
+      makeToolResult(freshOutput, "fresh_hard_cap"),
+      runtimeContextMessage,
+    ] as AgentMessage[]) as AgentMessage[];
+    expect(
+      (providerMessages.at(-1) as { runtimeContextCarrier?: boolean } | undefined)
+        ?.runtimeContextCarrier,
+    ).toBe(true);
+    const second = truncateOversizedToolResultsInMessages(
+      providerMessages,
+      1_000_000,
+      8_000,
+      100,
+      projectionState,
+    );
+    const freshResult = second.messages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "fresh_hard_cap",
+    );
+    const freshText = freshResult ? getFirstToolResultText(freshResult) : "";
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+
+    expect(freshText.length).toBeGreaterThan(0);
+    expect(freshText.length).toBeLessThan(freshOutput.length);
+    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(second.aggregatePressureEngaged).toBe(true);
+    expect(totalChars).toBeLessThanOrEqual(100);
   });
 
   it("caps oversized fresh trailing tool results without clearing them for aggregate recovery", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -10,6 +10,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
+import {
+  getEmbeddedSessionPromptState,
+  testing as sessionPromptStateTesting,
+} from "./session-prompt-state.js";
 
 let truncateToolResultText: typeof import("./tool-result-truncation.js").truncateToolResultText;
 let truncateToolResultMessage: typeof import("./tool-result-truncation.js").truncateToolResultMessage;
@@ -57,6 +61,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  sessionPromptStateTesting.reset();
   if (tmpDir) {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     tmpDir = undefined;
@@ -644,6 +649,43 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(lastText && getToolResultTextLength(lastText)).toBeLessThanOrEqual(12_000);
   });
 
+  it("keeps #99495 historical bytes stable across attempts sharing session state", () => {
+    const state = getEmbeddedSessionPromptState("session-99495").toolResults;
+    const history = [
+      makeToolResult("a".repeat(4_000), "history_1"),
+      makeToolResult("b".repeat(4_000), "history_2"),
+    ];
+    const first = truncateOversizedToolResultsInMessages(history, 128_000, 5_000, 20_000, state);
+    const secondAttemptState = getEmbeddedSessionPromptState("session-99495").toolResults;
+    const second = truncateOversizedToolResultsInMessages(
+      [...history, makeToolResult("c".repeat(12_000), "current")],
+      128_000,
+      5_000,
+      20_000,
+      secondAttemptState,
+    );
+
+    expect(secondAttemptState).toBe(state);
+    expect(second.messages.slice(0, history.length)).toEqual(first.messages);
+  });
+
+  it("shrinks #99495 frozen bytes monotonically only under a tighter hard cap", () => {
+    const state = getEmbeddedSessionPromptState("session-99495-shrink").toolResults;
+    const history = [
+      makeToolResult("a".repeat(8_000), "history_1"),
+      makeToolResult("b".repeat(8_000), "history_2"),
+    ];
+    const first = truncateOversizedToolResultsInMessages(history, 128_000, 6_000, 20_000, state);
+    const shrunk = truncateOversizedToolResultsInMessages(history, 128_000, 3_000, 20_000, state);
+    const relaxed = truncateOversizedToolResultsInMessages(history, 128_000, 7_000, 20_000, state);
+    const lengths = (messages: AgentMessage[]) => messages.map(getToolResultTextLength);
+
+    expect(
+      lengths(shrunk.messages).every((length, index) => length <= lengths(first.messages)[index]!),
+    ).toBe(true);
+    expect(relaxed.messages).toEqual(shrunk.messages);
+  });
+
   it("preserves fresh trailing tool results when aggregate history is already saturated", () => {
     const projectionState = createToolResultPromptProjectionState();
     const history: AgentMessage[] = [];
@@ -978,7 +1020,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     ).toBeLessThan(15_000);
   });
 
-  it("does not reuse ambiguous projections across filtered history", () => {
+  it("freezes #99495 ambiguous-key projections across filtered history", () => {
     const projectionState = createToolResultPromptProjectionState();
     const duplicate = (text: string) => ({
       role: "toolResult" as const,
@@ -1004,7 +1046,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
 
     expect(first.messages[0]).not.toEqual(first.messages[1]);
-    expect(filtered.messages[0]).toEqual(duplicate("b".repeat(100)));
+    expect(filtered.messages[0]).toEqual(first.messages[1]);
   });
 });
 

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -3,6 +3,7 @@
  */
 import { existsSync } from "node:fs";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { TextContent } from "../../llm/types.js";
@@ -139,11 +140,12 @@ function appendBoundedTruncationSuffix(params: {
       return finalText;
     }
     if (keptText.length === 0) {
-      return finalText.slice(0, params.maxChars);
+      return truncateUtf16Safe(finalText, params.maxChars);
     }
     const overflow = finalText.length - params.maxChars;
-    const nextKeptText = keptText.slice(0, Math.max(0, keptText.length - overflow));
-    keptText = nextKeptText.length < keptText.length ? nextKeptText : keptText.slice(0, -1);
+    const nextKeptText = sliceUtf16Safe(keptText, 0, Math.max(0, keptText.length - overflow));
+    keptText =
+      nextKeptText.length < keptText.length ? nextKeptText : sliceUtf16Safe(keptText, 0, -1);
   }
 }
 
@@ -158,8 +160,8 @@ const MIDDLE_OMISSION_MARKER =
  * which should be preserved during truncation.
  */
 function hasImportantTail(text: string): boolean {
-  // Check last ~2000 chars for error-like patterns
-  const tail = normalizeLowercaseStringOrEmpty(text.slice(-2000));
+  // Check last ~2000 chars for error-like patterns without splitting a surrogate pair.
+  const tail = normalizeLowercaseStringOrEmpty(sliceUtf16Safe(text, -2000));
   return (
     /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code)\b/.test(tail) ||
     // JSON closing — if the output is JSON, the tail has closing structure
@@ -213,7 +215,8 @@ export function truncateToolResultText(
         tailStart = tailNewline + 1;
       }
 
-      const keptText = text.slice(0, headCut) + MIDDLE_OMISSION_MARKER + text.slice(tailStart);
+      const keptText =
+        sliceUtf16Safe(text, 0, headCut) + MIDDLE_OMISSION_MARKER + sliceUtf16Safe(text, tailStart);
       return appendBoundedTruncationSuffix({
         keptText,
         originalTextLength: text.length,
@@ -229,7 +232,7 @@ export function truncateToolResultText(
   if (lastNewline > budget * 0.8) {
     cutPoint = lastNewline;
   }
-  const keptText = text.slice(0, cutPoint);
+  const keptText = sliceUtf16Safe(text, 0, cutPoint);
   return appendBoundedTruncationSuffix({
     keptText,
     originalTextLength: text.length,

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -1,6 +1,7 @@
 /**
  * Truncates oversized tool-result content in messages and transcripts.
  */
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -19,6 +20,7 @@ import { SessionManager } from "../sessions/index.js";
 import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
+import type { ToolResultPromptProjectionState } from "./session-prompt-state.js";
 import {
   persistTranscriptStateMutation,
   readTranscriptFileState,
@@ -666,12 +668,7 @@ type ToolResultReplacement = {
   message: AgentMessage;
 };
 
-export type ToolResultPromptProjectionState = {
-  replacements: Map<string, AgentMessage>;
-  frozen: Set<string>;
-  ambiguousBaseKeys: Set<string>;
-  sourceTextByKey: Map<string, string[]>;
-};
+export type { ToolResultPromptProjectionState } from "./session-prompt-state.js";
 
 export function createToolResultPromptProjectionState(): ToolResultPromptProjectionState {
   return {
@@ -712,16 +709,27 @@ function getToolResultProjectionKeys(
     }
   }
   const occurrences = new Map<string, number>();
-  return baseKeys.map((baseKey) => {
-    if (!baseKey) {
+  return baseKeys.map((baseKey, index) => {
+    if (baseKey && !projectionState.ambiguousBaseKeys.has(baseKey)) {
+      return baseKey;
+    }
+    const message = messages[index];
+    if (!message || message.role !== "toolResult") {
       return undefined;
     }
-    if (projectionState.ambiguousBaseKeys.has(baseKey)) {
-      return undefined;
-    }
-    const occurrence = occurrences.get(baseKey) ?? 0;
-    occurrences.set(baseKey, occurrence + 1);
-    return `${baseKey}:${occurrence}`;
+    // Ambiguous/missing tool ids still need a stable frozen identity; otherwise
+    // each request rewrites their prompt-cache tail projection (#99495).
+    const messageId = (message as { id?: unknown }).id;
+    const sourceIdentity =
+      typeof messageId === "string" && messageId.length > 0
+        ? `id:${messageId}`
+        : `text:${createHash("sha256")
+            .update(JSON.stringify(getToolResultTextBlocks(message)))
+            .digest("base64url")}`;
+    const fallbackBase = `fallback:${baseKey ?? "tool"}:${sourceIdentity}`;
+    const occurrence = occurrences.get(fallbackBase) ?? 0;
+    occurrences.set(fallbackBase, occurrence + 1);
+    return `${fallbackBase}:${occurrence}`;
   });
 }
 
@@ -846,9 +854,9 @@ function buildAggregateToolResultReplacements(params: {
     });
   const recoveryCandidates = [
     ...aggregateRecoveryCandidates.filter((item) => item.aggregateEligible),
-    ...(protectedEntryIds.size > 0
-      ? aggregateRecoveryCandidates.filter((item) => !item.aggregateEligible)
-      : []),
+    // Frozen bytes move only after fresh output is exhausted and the hard aggregate
+    // guard still overflows; starting from the frozen projection makes this shrink-only.
+    ...aggregateRecoveryCandidates.filter((item) => !item.aggregateEligible),
   ];
 
   // Spend aggregate reduction on older entries first so fresh tool output stays intact.

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -553,6 +553,7 @@ export function truncateOversizedToolResultsInMessages(
   const projectionKeys = projectionState
     ? getToolResultProjectionKeys(messages, projectionState)
     : [];
+  const hasFrozenProjectionBaseline = (projectionState?.frozen.size ?? 0) > 0;
   const branch = messages.map((message, index) => {
     const projectionKey = projectionKeys[index];
     const projectedMessage = projectionKey
@@ -576,6 +577,13 @@ export function truncateOversizedToolResultsInMessages(
         !projectionKey ||
         !projectionState?.frozen.has(projectionKey) ||
         (projectedMessage !== undefined && mergedMessage === message),
+      // Steering and follow-up messages can follow fresh tool results before dispatch.
+      // Reduce frozen history first so message position cannot make fresh output disappear.
+      deferAggregateRecovery:
+        projectionKey !== undefined &&
+        projectionState !== undefined &&
+        hasFrozenProjectionBaseline &&
+        !projectionState.frozen.has(projectionKey),
     };
   });
   const plan = buildToolResultReplacementPlan({
@@ -661,6 +669,7 @@ type ToolResultBranchEntry = {
   type: string;
   message?: AgentMessage;
   aggregateEligible?: boolean;
+  deferAggregateRecovery?: boolean;
 };
 
 type ToolResultReplacement = {
@@ -808,7 +817,13 @@ function buildAggregateToolResultReplacements(params: {
       (
         item,
       ): item is {
-        entry: { id: string; type: string; message: AgentMessage; aggregateEligible?: boolean };
+        entry: {
+          id: string;
+          type: string;
+          message: AgentMessage;
+          aggregateEligible?: boolean;
+          deferAggregateRecovery?: boolean;
+        };
         index: number;
       } =>
         item.entry.type === "message" &&
@@ -822,7 +837,8 @@ function buildAggregateToolResultReplacements(params: {
       spillSourceMessage: params.spillSourceBranch?.[item.index]?.message ?? item.entry.message,
       textLength: getToolResultTextLength(item.entry.message),
       aggregateEligible: item.entry.aggregateEligible !== false,
-      protectedFromAggregateRecovery: protectedEntryIds.has(item.entry.id),
+      deferredByFreshProjection: item.entry.deferAggregateRecovery === true,
+      protectedByTrailingBatch: protectedEntryIds.has(item.entry.id),
     }))
     .filter((item) => item.textLength > 0);
 
@@ -845,7 +861,7 @@ function buildAggregateToolResultReplacements(params: {
   let remainingReduction = totalChars - params.aggregateBudgetChars;
   const replacements: Array<{ entryId: string; message: AgentMessage }> = [];
   const aggregateRecoveryCandidates = candidates
-    .filter((item) => !item.protectedFromAggregateRecovery)
+    .filter((item) => !item.deferredByFreshProjection && !item.protectedByTrailingBatch)
     .toSorted((a, b) => {
       if (a.index !== b.index) {
         return a.index - b.index;
@@ -854,9 +870,12 @@ function buildAggregateToolResultReplacements(params: {
     });
   const recoveryCandidates = [
     ...aggregateRecoveryCandidates.filter((item) => item.aggregateEligible),
-    // Frozen bytes move only after fresh output is exhausted and the hard aggregate
-    // guard still overflows; starting from the frozen projection makes this shrink-only.
+    // Start from frozen projections before touching deferred fresh results. Reusing their
+    // projected text keeps this shrink-only and preserves prompt-cache stability.
     ...aggregateRecoveryCandidates.filter((item) => !item.aggregateEligible),
+    ...candidates.filter(
+      (item) => item.deferredByFreshProjection && !item.protectedByTrailingBatch,
+    ),
   ];
 
   // Spend aggregate reduction on older entries first so fresh tool output stays intact.

--- a/src/auto-reply/reply/session-reset-cleanup.test.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.test.ts
@@ -1,6 +1,10 @@
 // Tests session reset cleanup for stale files and persisted state.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  getEmbeddedSessionPromptState,
+  testing as sessionPromptStateTesting,
+} from "../../agents/embedded-agent-runner/session-prompt-state.js";
+import {
   enqueueSystemEvent,
   peekSystemEvents,
   resetSystemEventsForTest,
@@ -14,12 +18,22 @@ import {
 import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 
 afterEach(() => {
+  sessionPromptStateTesting.reset();
   replyRunTesting.resetReplyRunRegistry();
   resetDiagnosticRunActivityForTest();
   resetSystemEventsForTest();
 });
 
 describe("clearSessionResetRuntimeState", () => {
+  it("disposes prompt projections with the archived session", () => {
+    const state = getEmbeddedSessionPromptState("old-session");
+    state.sentUserTurnIds.add("sent-user-turn");
+
+    clearSessionResetRuntimeState(["old-session"]);
+
+    expect(getEmbeddedSessionPromptState("old-session")).not.toBe(state);
+  });
+
   it("clears reset queues and drains system events for normalized keys", () => {
     enqueueSystemEvent("stale alpha", { sessionKey: "alpha" });
     enqueueSystemEvent("stale beta", { sessionKey: "beta" });

--- a/src/auto-reply/reply/session-reset-cleanup.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.ts
@@ -1,4 +1,5 @@
 /** Clears reset-related queues and system events for session keys. */
+import { clearEmbeddedSessionPromptStates } from "../../agents/embedded-agent-runner/session-prompt-state.js";
 import { drainSystemEventEntries } from "../../infra/system-events.js";
 import { clearSessionQueues, type ClearSessionQueueResult } from "./queue/cleanup.js";
 import { clearReplyRunForResetBySessionId } from "./reply-run-registry.js";
@@ -13,6 +14,7 @@ export function clearSessionResetRuntimeState(
   keys: Array<string | undefined>,
   opts?: { activeReplySessionId?: string },
 ): ClearSessionResetRuntimeStateResult {
+  clearEmbeddedSessionPromptStates(keys);
   const cleared = clearSessionQueues(keys);
   let systemEventsCleared = 0;
 

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -17,6 +17,7 @@ import {
   mergePreparedUserTurnMessageForRuntime,
   persistUserTurnTranscript,
   resolvePersistedUserTurnText,
+  type UserTurnInput,
 } from "./user-turn-transcript.js";
 
 describe("user turn transcript persistence", () => {
@@ -713,6 +714,101 @@ describe("user turn transcript persistence", () => {
           content: "describe this",
           MediaPath: path.join(dir, "image.png"),
           MediaType: "image/png",
+        }),
+      ]);
+    });
+
+    it("appends #99495 media that resolves after the admitted turn reached the provider", async () => {
+      const dir = createTempDir("openclaw-user-turn-recorder-late-media-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+      const admittedInput = {
+        text: "describe this",
+        timestamp: 123,
+        idempotencyKey: "chat-run-late:user",
+      };
+      let resolveMedia!: (input: UserTurnInput) => void;
+      let markResolverStarted!: () => void;
+      const resolverStarted = new Promise<void>((resolve) => {
+        markResolverStarted = resolve;
+      });
+      const mediaInput = new Promise<UserTurnInput>((resolve) => {
+        resolveMedia = resolve;
+      });
+      const recorder = createUserTurnTranscriptRecorder({
+        input: admittedInput,
+        resolveInput: async () => {
+          markResolverStarted();
+          return await mediaInput;
+        },
+        target: {
+          transcriptPath,
+          sessionId: "session-1",
+          sessionKey: "main",
+          cwd: dir,
+        },
+      });
+      const persistence = recorder.persistFallback();
+      await resolverStarted;
+      await appendUserTurnTranscriptMessage({
+        transcriptPath,
+        input: admittedInput,
+        sessionId: "session-1",
+        sessionKey: "main",
+        cwd: dir,
+      });
+      recorder.markRuntimePersisted(recorder.message);
+      recorder.markSentToProvider?.();
+      resolveMedia({
+        ...admittedInput,
+        media: [{ path: path.join(dir, "image.png"), contentType: "image/png" }],
+      });
+
+      await persistence;
+
+      expect(readTranscriptMessages(transcriptPath)).toEqual([
+        expect.objectContaining({
+          content: "describe this",
+          idempotencyKey: "chat-run-late:user",
+        }),
+        expect.objectContaining({
+          content: `[media attached: ${path.join(dir, "image.png")}]`,
+          idempotencyKey: "chat-run-late:user:late-media",
+          MediaPath: path.join(dir, "image.png"),
+        }),
+      ]);
+    });
+
+    it("keeps #99495 media inline when it resolves before first serialization", async () => {
+      const dir = createTempDir("openclaw-user-turn-recorder-early-media-");
+      const transcriptPath = path.join(dir, "session.jsonl");
+      const recorder = createUserTurnTranscriptRecorder({
+        input: {
+          text: "describe this",
+          timestamp: 123,
+          idempotencyKey: "chat-run-early:user",
+        },
+        resolveInput: async () => ({
+          text: "describe this",
+          timestamp: 123,
+          idempotencyKey: "chat-run-early:user",
+          media: [{ path: path.join(dir, "image.png"), contentType: "image/png" }],
+        }),
+        target: {
+          transcriptPath,
+          sessionId: "session-1",
+          sessionKey: "main",
+          cwd: dir,
+        },
+      });
+
+      await recorder.persistFallback();
+      recorder.markSentToProvider?.();
+
+      expect(readTranscriptMessages(transcriptPath)).toEqual([
+        expect.objectContaining({
+          content: "describe this",
+          idempotencyKey: "chat-run-early:user",
+          MediaPath: path.join(dir, "image.png"),
         }),
       ]);
     });

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -301,6 +301,54 @@ function isUserMessage(message: AgentMessage): message is PersistedUserTurnMessa
   return (message as { role?: unknown }).role === "user";
 }
 
+function buildLateResolvedMediaMessage(params: {
+  admittedMessage?: PersistedUserTurnMessage;
+  resolvedMessage: PersistedUserTurnMessage;
+}): PersistedUserTurnMessage | undefined {
+  const admittedMedia = buildPersistedUserTurnMediaInputsFromFields(params.admittedMessage);
+  const resolvedMedia = buildPersistedUserTurnMediaInputsFromFields(params.resolvedMessage);
+  if (
+    resolvedMedia.length === 0 ||
+    JSON.stringify(resolvedMedia) === JSON.stringify(admittedMedia)
+  ) {
+    return undefined;
+  }
+  const resolved = params.resolvedMessage as unknown as Record<string, unknown>;
+  const admittedContent = params.admittedMessage?.content;
+  const resolvedContent = params.resolvedMessage.content;
+  const mediaOnlyText = resolvedMedia
+    .map((media) => media.path ?? media.url)
+    .filter((value): value is string => Boolean(value))
+    .map((value) => `[media attached: ${value}]`)
+    .join("\n");
+  const content =
+    typeof resolvedContent === "string" && resolvedContent === admittedContent
+      ? mediaOnlyText
+      : Array.isArray(resolvedContent) && typeof admittedContent === "string"
+        ? (() => {
+            const mediaContent = resolvedContent.filter(
+              (block) =>
+                !block ||
+                typeof block !== "object" ||
+                (block as { type?: unknown; text?: unknown }).type !== "text" ||
+                (block as { text?: unknown }).text !== admittedContent,
+            );
+            return mediaContent.length > 0
+              ? mediaContent
+              : [{ type: "text" as const, text: mediaOnlyText }];
+          })()
+        : resolvedContent;
+  const idempotencyKey =
+    typeof resolved.idempotencyKey === "string" && resolved.idempotencyKey.length > 0
+      ? `${resolved.idempotencyKey}:late-media`
+      : `late-media:${typeof resolved.timestamp === "number" ? resolved.timestamp : Date.now()}`;
+  return {
+    ...resolved,
+    content,
+    idempotencyKey,
+  } as unknown as PersistedUserTurnMessage;
+}
+
 function isBeforeAgentRunBlockedMessage(message: AgentMessage): boolean {
   const marker = (message as { __openclaw?: { beforeAgentRunBlocked?: unknown } })["__openclaw"]
     ?.beforeAgentRunBlocked;
@@ -567,6 +615,9 @@ export function createUserTurnTranscriptRecorder(
   let selfPersistencePromise: Promise<UserTurnTranscriptPersistResult | undefined> | undefined;
   let resolvedMessagePromise: Promise<PersistedUserTurnMessage | undefined> | undefined;
   let persistedMessageNotified = false;
+  let runtimePersistedMessage: PersistedUserTurnMessage | undefined;
+  let sentToProvider = false;
+  let resolvedBeforeProvider = false;
 
   const handlePersistenceError = (error: unknown) => {
     if (params.onPersistenceError) {
@@ -593,12 +644,13 @@ export function createUserTurnTranscriptRecorder(
       resolvedMessagePromise = (async () => {
         try {
           const resolvedInput = await params.resolveInput?.();
-          return (
+          const resolvedMessage =
             resolvePersistedUserTurnMessage({
               message: params.message,
               input: resolvedInput ?? params.input,
-            }) ?? message
-          );
+            }) ?? message;
+          resolvedBeforeProvider = !sentToProvider;
+          return resolvedMessage;
         } catch (error) {
           handlePersistenceError(error);
           return message;
@@ -640,9 +692,6 @@ export function createUserTurnTranscriptRecorder(
     target?: UserTurnTranscriptTargetResolver;
     updateMode?: UserTurnTranscriptUpdateMode;
   }): Promise<UserTurnTranscriptPersistResult | undefined> => {
-    if (persisted) {
-      return persistedResult;
-    }
     if (options.skipWhenBlocked && blocked) {
       return undefined;
     }
@@ -653,9 +702,6 @@ export function createUserTurnTranscriptRecorder(
       // Approved persistence waits for runtime-owned writes first to avoid
       // duplicate user turns when the harness already persisted the message.
       await waitForRuntimePersistence();
-      if (persisted) {
-        return persistedResult;
-      }
     }
     if (selfPersistencePromise) {
       return await selfPersistencePromise;
@@ -670,19 +716,54 @@ export function createUserTurnTranscriptRecorder(
         return undefined;
       }
       const updateMode = options.updateMode ?? params.updateMode ?? "inline";
-      const result = isUserTurnTranscriptFileTarget(target)
-        ? await appendFileTargetUserTurnTranscript({
-            target,
-            message: resolvedMessage,
-            updateMode,
-            beforeMessageWrite: params.beforeMessageWrite,
-          })
-        : await persistUserTurnTranscript({
-            ...target,
-            message: resolvedMessage,
-            updateMode,
-            ...(params.beforeMessageWrite ? { beforeMessageWrite: params.beforeMessageWrite } : {}),
-          });
+      const persistMessage = async (
+        candidate: PersistedUserTurnMessage,
+        candidateUpdateMode: UserTurnTranscriptUpdateMode,
+      ) =>
+        isUserTurnTranscriptFileTarget(target)
+          ? await appendFileTargetUserTurnTranscript({
+              target,
+              message: candidate,
+              updateMode: candidateUpdateMode,
+              beforeMessageWrite: params.beforeMessageWrite,
+            })
+          : await persistUserTurnTranscript({
+              ...target,
+              message: candidate,
+              updateMode: candidateUpdateMode,
+              ...(params.beforeMessageWrite
+                ? { beforeMessageWrite: params.beforeMessageWrite }
+                : {}),
+            });
+      const lateMediaMessage =
+        sentToProvider && !resolvedBeforeProvider
+          ? buildLateResolvedMediaMessage({
+              admittedMessage: runtimePersistedMessage ?? message,
+              resolvedMessage,
+            })
+          : undefined;
+      if (lateMediaMessage) {
+        // The admitted bytes already crossed the LLM boundary. Persisting media as a
+        // second turn preserves that prefix; inline replacement would thrash cache tail (#99495).
+        if (!persisted && message) {
+          const admittedResult = await persistMessage(message, updateMode);
+          if (admittedResult) {
+            persisted = true;
+            persistedResult = admittedResult;
+            notifyMessagePersisted(admittedResult.message);
+          }
+        }
+        const appendedMedia = await persistMessage(lateMediaMessage, "none");
+        if (appendedMedia) {
+          persisted = true;
+          persistedResult = appendedMedia;
+        }
+        return appendedMedia;
+      }
+      if (persisted) {
+        return persistedResult;
+      }
+      const result = await persistMessage(resolvedMessage, updateMode);
       if (result) {
         persisted = true;
         persistedResult = result;
@@ -701,11 +782,15 @@ export function createUserTurnTranscriptRecorder(
   return {
     message,
     resolveMessage: resolveMessageForPersistence,
+    markSentToProvider: () => {
+      sentToProvider = true;
+    },
     markRuntimePersistencePending: (pending) => {
       runtimePersistencePromise = pending;
     },
     markRuntimePersisted: (persistedMessage) => {
       persisted = true;
+      runtimePersistedMessage = persistedMessage;
       if (persistedMessage && persistedResult) {
         persistedResult = {
           ...persistedResult,

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -78,6 +78,7 @@ export type UserTurnTranscriptTargetResolver =
 export type UserTurnTranscriptRecorder = {
   readonly message: PersistedUserTurnMessage | undefined;
   resolveMessage: () => Promise<PersistedUserTurnMessage | undefined>;
+  markSentToProvider?: () => void;
   markRuntimePersistencePending: (pending: Promise<void>) => void;
   markRuntimePersisted: (message?: PersistedUserTurnMessage) => void;
   markBlocked: () => void;


### PR DESCRIPTION
# What Problem This Solves

The most-complained-about beta bug in Discord: tool-result text disappearing in long-running sessions under context pressure ("That tool result compaction bug is really hurting productivity. Sessions become unusable after a while" — pintst in #general/#users-helping-users; snowzlm flagged it twice today in #clawtributors as "huge impact, especially on long-running sessions"). The complete fix is a three-commit stack on `main` that `release/2026.7.1` is missing.

# Why This Change Was Made

Exact `-x` cherry-picks, all patch-id-identical to their reviewed `main` originals, in dependency order:

- `9e75ce9dd1e1` fix(agents): keep tool-result truncation UTF-16 safe (#102087) — same UTF-16 family as #104684; truncation can no longer split surrogate pairs
- `fd34019b4da5` fix(agents): keep prompt history append-only mid-session (#99495) (#102610) — snowzlm's original fix; mid-session history rewrites no longer break append-only prompt state (also the direct prerequisite: it owns the recovery-candidate ordering #99756 builds on)
- `abd6cbbae1b1` fix: preserve tool-result text across media fallback and context pressure (#99756) — merged tonight (19:35Z); defers aggregate recovery away from fresh tool results so message position cannot make fresh output disappear

All three applied conflict-free once ordered; picking #99756 alone conflicts because #102610 owns its context.

# User Impact

Long-running sessions stop losing fresh tool output under context pressure, truncation no longer corrupts emoji/surrogate pairs, and prompt history stays append-only mid-session (prompt-cache stability). This is the fix pair users are explicitly waiting on for stable.

# Evidence

- All three commits merged on `main` with green CI; picks verified patch-id-identical.
- Targeted Blacksmith Testbox runs on this exact head over every touched suite (`tool-result-truncation.test.ts`, `attempt.llm-boundary.cache-stability.test.ts`, `session-reset-cleanup.test.ts`, `user-turn-transcript.test.ts`): 96 tests passed, `exit=0` (lease `tbx_01kx9fetr0pxhkjryy44njv40f`).
- Thanks @snowzlm for the fix pair and the persistence.
