### PR TITLE
fix: Slack drops attachments delivered via message_changed file_share events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Slack delayed file uploads:** deliver newly finalized file sets from `message_changed` events exactly once across persistent and in-memory dedupe, including Enterprise Grid and Slack Connect placeholders, while leaving ordinary edits passive. (#104703) Thanks @dreuvenrsg.
 - **Session retry classification:** stop permanent provider errors whose identifiers or payload details merely contain 429/5xx digit sequences from re-sending full context, and share bounded rate-limit-window parsing across retry paths. (#105258) Thanks @destire-mio.
 - **LINE directive templates:** suppress confirms and buttons with blank required fields or unlabeled actions while preserving valid titleless buttons and surrounding reply text. (#105520) Thanks @edenfunf.
 - **SQLite maintenance schema validation:** reject current-version global and agent databases with missing or drifted canonical tables, constraints, indexes, triggers, or table options before compaction, while accepting supported additive-migration layouts.

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -155,12 +155,12 @@ export type SlackMonitorContext = {
   logger: ReturnType<typeof getChildLogger>;
   markMessageSeen: (
     channelId: string | undefined,
-    ts?: string,
+    deliveryId?: string,
     eventScope?: SlackEventScope,
   ) => boolean;
   releaseSeenMessage: (
     channelId: string | undefined,
-    ts?: string,
+    deliveryId?: string,
     eventScope?: SlackEventScope,
   ) => void;
   shouldDropMismatchedSlackEvent: (body: unknown) => boolean;
@@ -336,24 +336,24 @@ export function createSlackMonitorContext(params: {
 
   const markMessageSeen = (
     channelId: string | undefined,
-    ts?: string,
+    deliveryId?: string,
     eventScope?: SlackEventScope,
   ) => {
-    if (!channelId || !ts) {
+    if (!channelId || !deliveryId) {
       return false;
     }
-    return seenMessages.check(scopedKey(`${channelId}:${ts}`, eventScope));
+    return seenMessages.check(scopedKey(`${channelId}:${deliveryId}`, eventScope));
   };
 
   const releaseSeenMessage = (
     channelId: string | undefined,
-    ts?: string,
+    deliveryId?: string,
     eventScope?: SlackEventScope,
   ) => {
-    if (!channelId || !ts) {
+    if (!channelId || !deliveryId) {
       return;
     }
-    seenMessages.delete(scopedKey(`${channelId}:${ts}`, eventScope));
+    seenMessages.delete(scopedKey(`${channelId}:${deliveryId}`, eventScope));
   };
 
   const assistantContextKey = (channelId: string, threadTs: string, eventScope?: SlackEventScope) =>

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -410,6 +410,104 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).toHaveBeenCalledTimes(calls);
   });
 
+  function makeFileShareChangedEvent(overrides?: {
+    user?: string;
+    files?: Array<{ id: string; name?: string }>;
+    previousFiles?: Array<{ id: string; name?: string }>;
+    text?: string;
+    previousText?: string;
+  }) {
+    const user = overrides?.user ?? "U1";
+    return {
+      type: "message",
+      subtype: "message_changed",
+      channel: "C123",
+      channel_type: "channel",
+      message: {
+        type: "message",
+        subtype: "file_share",
+        ts: "123.456",
+        user,
+        text: overrides?.text ?? "please review these",
+        files: overrides?.files ?? [
+          { id: "F1", name: "packing-slip-1.pdf" },
+          { id: "F2", name: "packing-slip-2.pdf" },
+        ],
+      },
+      previous_message: {
+        ts: "123.456",
+        user,
+        text: overrides?.previousText ?? "please review these",
+        files: overrides?.previousFiles ?? [{ id: "F1", name: "packing-slip-1.pdf" }],
+      },
+      event_ts: "123.999",
+    };
+  }
+
+  it("promotes a user file_share message_changed with new files into the message pipeline", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent(),
+      body: {},
+    });
+
+    expect(messageQueueMock).not.toHaveBeenCalled();
+    expect(handleSlackMessage).toHaveBeenCalledTimes(1);
+    const [promoted] = handleSlackMessage.mock.calls[0] as unknown as [
+      { ts?: string; channel?: string; user?: string; files?: Array<{ id: string }> },
+    ];
+    expect(promoted).toMatchObject({
+      type: "message",
+      subtype: "file_share",
+      channel: "C123",
+      user: "U1",
+      ts: "123.456",
+    });
+    expect(promoted.files?.map((file) => file.id)).toEqual(["F1", "F2"]);
+  });
+
+  it("keeps plain message_changed edits on the system-event path (no re-triggered replies)", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: {
+        type: "message",
+        subtype: "message_changed",
+        channel: "D1",
+        message: { ts: "123.456", user: "U1", text: "edited words" },
+        previous_message: { ts: "123.456", user: "U1", text: "original words" },
+        event_ts: "123.999",
+      },
+      body: {},
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(messageQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not promote a file_share message_changed when the file set is unchanged", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({
+        files: [{ id: "F1", name: "packing-slip-1.pdf" }],
+        previousFiles: [{ id: "F1", name: "packing-slip-1.pdf" }],
+      }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(messageQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not promote self-attributed file_share message_changed events", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({ user: "U_BOT" }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+  });
+
   it("passes regular message events to the message handler", async () => {
     const { handleSlackMessage } = await invokeRegisteredHandler({
       eventName: "message",

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -492,7 +492,12 @@ describe("registerSlackMessageEvents", () => {
   function makeFileShareChangedEvent(overrides?: {
     user?: string;
     files?: Array<{ id: string; name?: string; mode?: string; file_access?: string }>;
-    previousFiles?: Array<{ id: string; name?: string; mode?: string; file_access?: string }>;
+    previousFiles?: Array<{
+      id: string;
+      name?: string;
+      mode?: string;
+      file_access?: string;
+    }> | null;
     text?: string;
     previousText?: string;
     subtype?: "file_share" | null;
@@ -528,7 +533,11 @@ describe("registerSlackMessageEvents", () => {
         ts: "123.456",
         user,
         text: overrides?.previousText ?? "please review these",
-        files: overrides?.previousFiles ?? [{ id: "F1", name: "packing-slip-1.pdf" }],
+        ...(overrides?.previousFiles === null
+          ? {}
+          : {
+              files: overrides?.previousFiles ?? [{ id: "F1", name: "packing-slip-1.pdf" }],
+            }),
       },
       event_ts: "123.999",
     };
@@ -716,6 +725,25 @@ describe("registerSlackMessageEvents", () => {
     expect(promoted).toMatchObject({
       files: [{ id: "F1", mode: "file_access", file_access: "check_file_info" }],
     });
+  });
+
+  it("promotes new media when a valid previous message had no media fields", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({ previousFiles: null }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+  });
+
+  it("does not promote media when the previous message snapshot is unavailable", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    const event: Record<string, unknown> = makeFileShareChangedEvent();
+    delete event.previous_message;
+    await requireMessageHandler(handler)({ event, body: {} });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
   });
 
   it("keeps plain message_changed edits on the system-event path (no re-triggered replies)", async () => {

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -498,13 +498,18 @@ describe("registerSlackMessageEvents", () => {
     subtype?: "file_share" | null;
     botId?: string;
     username?: string;
+    channel?: string;
+    channelType?: "im" | "mpim" | "channel" | "group" | null;
+    parentUserId?: string;
   }) {
     const user = overrides?.user ?? "U1";
     return {
       type: "message",
       subtype: "message_changed",
-      channel: "C123",
-      channel_type: "channel",
+      channel: overrides?.channel ?? "C123",
+      ...(overrides?.channelType === null
+        ? {}
+        : { channel_type: overrides?.channelType ?? "channel" }),
       message: {
         type: "message",
         ...(overrides?.subtype === null ? {} : { subtype: overrides?.subtype ?? "file_share" }),
@@ -512,6 +517,7 @@ describe("registerSlackMessageEvents", () => {
         user,
         ...(overrides?.botId ? { bot_id: overrides.botId } : {}),
         ...(overrides?.username ? { username: overrides.username } : {}),
+        ...(overrides?.parentUserId ? { parent_user_id: overrides.parentUserId } : {}),
         text: overrides?.text ?? "please review these",
         files: overrides?.files ?? [
           { id: "F1", name: "packing-slip-1.pdf" },
@@ -654,6 +660,43 @@ describe("registerSlackMessageEvents", () => {
       bot_id: "B_OTHER",
       username: "file integration",
     });
+  });
+
+  it("preserves cached conversation type and parent routing on promotion", async () => {
+    const harness = createSlackSystemEventTestHarness({ dmPolicy: "open" });
+    harness.ctx.rememberSlackChannelType("C0MPDM42", "mpim");
+    const handleSlackMessage = vi.fn(async () => {});
+    registerSlackMessageEvents({ ctx: harness.ctx, handleSlackMessage });
+
+    await requireMessageHandler(harness.getHandler("message") as MessageHandler | null)({
+      event: makeFileShareChangedEvent({
+        channel: "C0MPDM42",
+        channelType: null,
+        parentUserId: "U_PARENT",
+      }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    const [promoted] = handleSlackMessage.mock.calls[0] as unknown as [
+      { channel_type?: string; parent_user_id?: string },
+    ];
+    expect(promoted).toMatchObject({
+      channel_type: "mpim",
+      parent_user_id: "U_PARENT",
+    });
+  });
+
+  it("leaves an omitted uncached conversation type unresolved", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({ channel: "C0SHARED", channelType: null }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    const [promoted] = handleSlackMessage.mock.calls[0] as unknown as [{ channel_type?: string }];
+    expect(promoted.channel_type).toBeUndefined();
   });
 
   it("promotes a Slack Connect file-access placeholder for files.info hydration", async () => {

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -7,10 +7,18 @@ import {
   type SlackSystemEventTestOverrides,
 } from "./system-event-test-harness.js";
 
-const { messageQueueMock, messageAllowMock, inboundInfoSpy } = vi.hoisted(() => ({
+const {
+  messageQueueMock,
+  messageAllowMock,
+  inboundInfoSpy,
+  prepareSlackMessageMock,
+  dispatchPreparedSlackMessageMock,
+} = vi.hoisted(() => ({
   messageQueueMock: vi.fn(),
   messageAllowMock: vi.fn(),
   inboundInfoSpy: vi.fn(),
+  prepareSlackMessageMock: vi.fn(),
+  dispatchPreparedSlackMessageMock: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
@@ -54,9 +62,15 @@ vi.mock("openclaw/plugin-sdk/text-chunking", () => ({
   sanitizeAssistantVisibleText: (text: string) => text,
   stripReasoningTagsFromText: (text: string) => text,
 }));
+vi.mock("../message-handler/pipeline.runtime.js", () => ({
+  prepareSlackMessage: (...args: unknown[]) => prepareSlackMessageMock(...args),
+  dispatchPreparedSlackMessage: (...args: unknown[]) => dispatchPreparedSlackMessageMock(...args),
+}));
 
 let registerSlackMessageEvents: typeof import("./messages.js").registerSlackMessageEvents;
 let formatSlackInboundLogLine: typeof import("./messages.js").formatSlackInboundLogLine;
+let createSlackMessageHandler: typeof import("../message-handler.js").createSlackMessageHandler;
+let clearSlackInboundDeliveryStateForTest: typeof import("../inbound-delivery-state.js").clearSlackInboundDeliveryStateForTest;
 
 function inboundLogLines(): string[] {
   return inboundInfoSpy.mock.calls
@@ -106,6 +120,63 @@ function createEnterpriseHandlers(eventName: RegisteredEventName) {
   };
 }
 
+function createEnterpriseFullHandler() {
+  const harness = createSlackSystemEventTestHarness({ dmPolicy: "open" });
+  harness.ctx.installationIdentity = {
+    kind: "enterprise",
+    apiAppId: "A_TEST",
+    enterpriseId: "E_TEST",
+  };
+  (harness.ctx.app as unknown as { client: object }).client = {};
+  const seen = new Set<string>();
+  const scopedSeenKey = (
+    channelId: string | undefined,
+    deliveryId: string | undefined,
+    eventScope?: { teamId?: string },
+  ) =>
+    channelId && deliveryId
+      ? `${eventScope?.teamId ? `${eventScope.teamId}:` : ""}${channelId}:${deliveryId}`
+      : undefined;
+  Object.assign(harness.ctx, {
+    accountId: "default",
+    cfg: {},
+    markMessageSeen: (
+      channelId: string | undefined,
+      deliveryId: string | undefined,
+      eventScope?: { teamId?: string },
+    ) => {
+      const key = scopedSeenKey(channelId, deliveryId, eventScope);
+      if (!key) {
+        return false;
+      }
+      if (seen.has(key)) {
+        return true;
+      }
+      seen.add(key);
+      return false;
+    },
+    releaseSeenMessage: (
+      channelId: string | undefined,
+      deliveryId: string | undefined,
+      eventScope?: { teamId?: string },
+    ) => {
+      const key = scopedSeenKey(channelId, deliveryId, eventScope);
+      if (key) {
+        seen.delete(key);
+      }
+    },
+  });
+  const handleSlackMessage = createSlackMessageHandler({
+    ctx: harness.ctx,
+    account: { accountId: "default" } as Parameters<typeof createSlackMessageHandler>[0]["account"],
+  });
+  registerSlackMessageEvents({ ctx: harness.ctx, handleSlackMessage });
+  return {
+    handler: requireMessageHandler(harness.getHandler("message") as MessageHandler | null),
+    clearSeen: () => seen.clear(),
+  };
+}
+
 function requireMessageHandler(handler: MessageHandler | null): MessageHandler {
   if (!handler) {
     throw new Error("expected Slack message event handler");
@@ -120,11 +191,19 @@ function resetMessageMocks(): void {
 
 beforeAll(async () => {
   ({ registerSlackMessageEvents, formatSlackInboundLogLine } = await import("./messages.js"));
+  ({ createSlackMessageHandler } = await import("../message-handler.js"));
+  ({ clearSlackInboundDeliveryStateForTest } = await import("../inbound-delivery-state.js"));
 });
 
 beforeEach(() => {
   resetMessageMocks();
   inboundInfoSpy.mockClear();
+  prepareSlackMessageMock.mockReset().mockImplementation(async (params) => ({
+    ctxPayload: {},
+    message: (params as { message?: unknown }).message,
+  }));
+  dispatchPreparedSlackMessageMock.mockReset().mockResolvedValue(undefined);
+  clearSlackInboundDeliveryStateForTest();
 });
 
 function makeChangedEvent(overrides?: { channel?: string; user?: string }) {
@@ -412,10 +491,11 @@ describe("registerSlackMessageEvents", () => {
 
   function makeFileShareChangedEvent(overrides?: {
     user?: string;
-    files?: Array<{ id: string; name?: string }>;
-    previousFiles?: Array<{ id: string; name?: string }>;
+    files?: Array<{ id: string; name?: string; mode?: string; file_access?: string }>;
+    previousFiles?: Array<{ id: string; name?: string; mode?: string; file_access?: string }>;
     text?: string;
     previousText?: string;
+    subtype?: "file_share" | null;
   }) {
     const user = overrides?.user ?? "U1";
     return {
@@ -425,7 +505,7 @@ describe("registerSlackMessageEvents", () => {
       channel_type: "channel",
       message: {
         type: "message",
-        subtype: "file_share",
+        ...(overrides?.subtype === null ? {} : { subtype: overrides?.subtype ?? "file_share" }),
         ts: "123.456",
         user,
         text: overrides?.text ?? "please review these",
@@ -443,6 +523,76 @@ describe("registerSlackMessageEvents", () => {
       event_ts: "123.999",
     };
   }
+
+  async function runEnterpriseFileFinalizationScenario() {
+    const { handler, clearSeen } = createEnterpriseFullHandler();
+    const listenerClient = { id: "listener-client" };
+    const eventContext = {
+      body: { api_app_id: "A_TEST" },
+      context: { isEnterpriseInstall: true, enterpriseId: "E_TEST", teamId: "T111" },
+      client: listenerClient,
+    };
+    const initial = {
+      type: "message",
+      subtype: "file_share",
+      channel: "C123",
+      channel_type: "channel",
+      user: "U123",
+      text: "please review these",
+      files: [{ id: "F1", url_private: "https://files.slack.com/file-1" }],
+      ts: "123.456",
+      event_ts: "123.456",
+    };
+    const finalized = {
+      type: "message",
+      subtype: "message_changed",
+      hidden: true,
+      channel: "C123",
+      channel_type: "channel",
+      ts: "123.999",
+      event_ts: "123.999",
+      message: {
+        ...initial,
+        files: [
+          { id: "F1", url_private: "https://files.slack.com/file-1" },
+          { id: "F2", url_private: "https://files.slack.com/file-2" },
+        ],
+      },
+      previous_message: initial,
+    };
+
+    await handler({ event: initial, ...eventContext });
+    await handler({ event: finalized, ...eventContext });
+
+    expect(prepareSlackMessageMock).toHaveBeenCalledTimes(2);
+    expect(prepareSlackMessageMock.mock.calls[1]?.[0]).toMatchObject({
+      message: {
+        subtype: "file_share",
+        ts: "123.456",
+        files: [{ id: "F1" }, { id: "F2" }],
+      },
+    });
+    expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(2);
+    return { handler, clearSeen, eventContext, finalized };
+  }
+
+  it("delivers an Enterprise file finalization and persistently suppresses its replay", async () => {
+    const scenario = await runEnterpriseFileFinalizationScenario();
+    scenario.clearSeen();
+
+    await scenario.handler({ event: scenario.finalized, ...scenario.eventContext });
+
+    expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("delivers an Enterprise file finalization and suppresses its in-memory replay", async () => {
+    const scenario = await runEnterpriseFileFinalizationScenario();
+    clearSlackInboundDeliveryStateForTest();
+
+    await scenario.handler({ event: scenario.finalized, ...scenario.eventContext });
+
+    expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(2);
+  });
 
   it("promotes a user file_share message_changed with new files into the message pipeline", async () => {
     const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
@@ -464,6 +614,40 @@ describe("registerSlackMessageEvents", () => {
       ts: "123.456",
     });
     expect(promoted.files?.map((file) => file.id)).toEqual(["F1", "F2"]);
+  });
+
+  it("promotes a subtype-less generic message when Slack finalizes its files", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({ subtype: null }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    const [promoted] = handleSlackMessage.mock.calls[0] as unknown as [
+      { subtype?: string; files?: Array<{ id: string }> },
+    ];
+    expect(promoted.subtype).toBeUndefined();
+    expect(promoted.files?.map((file) => file.id)).toEqual(["F1", "F2"]);
+  });
+
+  it("promotes a Slack Connect file-access placeholder for files.info hydration", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({
+        files: [{ id: "F1", mode: "file_access", file_access: "check_file_info" }],
+        previousFiles: [],
+      }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    const [promoted] = handleSlackMessage.mock.calls[0] as unknown as [
+      { files?: Array<Record<string, unknown>> },
+    ];
+    expect(promoted).toMatchObject({
+      files: [{ id: "F1", mode: "file_access", file_access: "check_file_info" }],
+    });
   });
 
   it("keeps plain message_changed edits on the system-event path (no re-triggered replies)", async () => {
@@ -490,6 +674,22 @@ describe("registerSlackMessageEvents", () => {
       event: makeFileShareChangedEvent({
         files: [{ id: "F1", name: "packing-slip-1.pdf" }],
         previousFiles: [{ id: "F1", name: "packing-slip-1.pdf" }],
+      }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(messageQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not promote a file_share caption edit when its media is unchanged", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({
+        files: [{ id: "F1", name: "packing-slip-1.pdf" }],
+        previousFiles: [{ id: "F1", name: "packing-slip-1.pdf" }],
+        text: "edited caption",
+        previousText: "original caption",
       }),
       body: {},
     });

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -496,6 +496,8 @@ describe("registerSlackMessageEvents", () => {
     text?: string;
     previousText?: string;
     subtype?: "file_share" | null;
+    botId?: string;
+    username?: string;
   }) {
     const user = overrides?.user ?? "U1";
     return {
@@ -508,6 +510,8 @@ describe("registerSlackMessageEvents", () => {
         ...(overrides?.subtype === null ? {} : { subtype: overrides?.subtype ?? "file_share" }),
         ts: "123.456",
         user,
+        ...(overrides?.botId ? { bot_id: overrides.botId } : {}),
+        ...(overrides?.username ? { username: overrides.username } : {}),
         text: overrides?.text ?? "please review these",
         files: overrides?.files ?? [
           { id: "F1", name: "packing-slip-1.pdf" },
@@ -631,6 +635,27 @@ describe("registerSlackMessageEvents", () => {
     expect(promoted.files?.map((file) => file.id)).toEqual(["F1", "F2"]);
   });
 
+  it("preserves bot attribution on a promoted subtype-less file finalization", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({
+        subtype: null,
+        botId: "B_OTHER",
+        username: "file integration",
+      }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    const [promoted] = handleSlackMessage.mock.calls[0] as unknown as [
+      { bot_id?: string; username?: string },
+    ];
+    expect(promoted).toMatchObject({
+      bot_id: "B_OTHER",
+      username: "file integration",
+    });
+  });
+
   it("promotes a Slack Connect file-access placeholder for files.info hydration", async () => {
     const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
     await requireMessageHandler(handler)({
@@ -690,6 +715,23 @@ describe("registerSlackMessageEvents", () => {
         previousFiles: [{ id: "F1", name: "packing-slip-1.pdf" }],
         text: "edited caption",
         previousText: "original caption",
+      }),
+      body: {},
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(messageQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not promote a file_share message_changed when media was only removed", async () => {
+    const { handler, handleSlackMessage } = createHandlers("message", { dmPolicy: "open" });
+    await requireMessageHandler(handler)({
+      event: makeFileShareChangedEvent({
+        files: [{ id: "F1", name: "packing-slip-1.pdf" }],
+        previousFiles: [
+          { id: "F1", name: "packing-slip-1.pdf" },
+          { id: "F2", name: "packing-slip-2.pdf" },
+        ],
       }),
       body: {},
     });

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -160,6 +160,98 @@ function resolveAssistantMessageChangedInbound(params: {
   };
 }
 
+function slackFileKeyList(value: unknown): string {
+  if (!Array.isArray(value)) {
+    return "";
+  }
+  return value
+    .map((file) => {
+      const record = asRecord(file);
+      return asString(record?.id) ?? asString(record?.name) ?? "";
+    })
+    .filter(Boolean)
+    .join(",");
+}
+
+/**
+ * Slack finalizes file uploads asynchronously: a message posted with (multiple)
+ * attachments can reach the app with an incomplete file set — or none at all —
+ * and the complete upload only lands later as a `message_changed` event whose
+ * inner message carries subtype `file_share`. Treating those purely as edit
+ * notifications silently drops the user's documents.
+ *
+ * Promote a user-authored `message_changed` back into the regular message
+ * pipeline only when it actually delivers new content: the file set differs
+ * from `previous_message`, or text appeared where there was none, or the text
+ * changed alongside attached files. Plain edits keep flowing to the
+ * system-event path so replies are not re-triggered (see #28834), and the
+ * downstream seen-message dedupe still applies to the promoted event's
+ * original `ts`.
+ */
+function resolveFileShareMessageChangedInbound(params: {
+  event: SlackMessageEvent;
+  ctx: SlackMonitorContext;
+}): SlackMessageEvent | undefined {
+  if (params.event.subtype !== "message_changed") {
+    return undefined;
+  }
+  const changed = params.event as SlackMessageChangedEvent;
+  const next = asRecord(changed.message) as SlackAssistantMessageRecord | undefined;
+  if (!next) {
+    return undefined;
+  }
+  if (isSelfAttributedMessageChange({ event: changed, message: next, ctx: params.ctx })) {
+    return undefined;
+  }
+  const nextType = asString((next as { type?: unknown }).type);
+  if (nextType && nextType !== "message") {
+    return undefined;
+  }
+  const nextSubtype = asString((next as { subtype?: unknown }).subtype);
+  if (nextSubtype && nextSubtype !== "file_share") {
+    return undefined;
+  }
+  const senderId = asString(next.user);
+  if (!senderId || !isSlackUserId(senderId)) {
+    return undefined;
+  }
+  const nextText = asString(next.text)?.trim() ?? "";
+  const nextFiles = Array.isArray(next.files) ? next.files : [];
+  const nextAttachments = Array.isArray(next.attachments) ? next.attachments : [];
+  if (!nextText && nextFiles.length === 0 && nextAttachments.length === 0) {
+    return undefined;
+  }
+  const previous = asRecord(changed.previous_message) as SlackAssistantMessageRecord | undefined;
+  const prevText = asString(previous?.text)?.trim() ?? "";
+  const deliversNewContent =
+    slackFileKeyList(next.files) !== slackFileKeyList(previous?.files) ||
+    (!prevText && Boolean(nextText)) ||
+    (prevText !== nextText && nextFiles.length > 0);
+  if (!deliversNewContent) {
+    return undefined;
+  }
+  const channelType = normalizeSlackChannelType(
+    asString((changed as SlackMessageChangedEvent & { channel_type?: unknown }).channel_type),
+    changed.channel,
+  );
+  return {
+    type: "message",
+    ...(nextSubtype ? { subtype: nextSubtype } : {}),
+    channel: changed.channel ?? params.event.channel,
+    ...(channelType ? { channel_type: channelType } : {}),
+    user: senderId,
+    text: asString(next.text),
+    ts: asString(next.ts) ?? asString(changed.event_ts),
+    thread_ts: asString(next.thread_ts),
+    event_ts: changed.event_ts,
+    files: Array.isArray(next.files) ? (next.files as SlackMessageEvent["files"]) : undefined,
+    attachments: Array.isArray(next.attachments)
+      ? (next.attachments as SlackMessageEvent["attachments"])
+      : undefined,
+    blocks: Array.isArray(next.blocks) ? (next.blocks as SlackMessageEvent["blocks"]) : undefined,
+  };
+}
+
 export function registerSlackMessageEvents(params: {
   ctx: SlackMonitorContext;
   handleSlackMessage: SlackMessageHandler;
@@ -239,6 +331,21 @@ export function registerSlackMessageEvents(params: {
           ctx,
         })
       ) {
+        return;
+      }
+
+      // A message_changed carrying a user's file_share payload is Slack
+      // delivering the (multi-)file upload, not an edit — route it through the
+      // regular message pipeline so the attachments reach the agent.
+      const fileShareChangedInbound = resolveFileShareMessageChangedInbound({
+        event: message,
+        ctx,
+      });
+      if (fileShareChangedInbound) {
+        await handleSlackMessage(fileShareChangedInbound, {
+          source: "message",
+          ...(eventScope ? { eventScope, awaitDispatch: true } : {}),
+        });
         return;
       }
 

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -18,7 +18,7 @@ import type { SlackMonitorContext } from "../context.js";
 import { resolveSlackEventScope, type SlackEventScope } from "../event-scope.js";
 import {
   buildSlackInboundContentVersion,
-  hasSlackInboundDeliverableMedia,
+  hasNewSlackInboundDeliverableMedia,
   withSlackInboundContentVersion,
 } from "../inbound-delivery-identity.js";
 import type { SlackMessageHandler } from "../message-handler.js";
@@ -44,6 +44,7 @@ export function formatSlackInboundLogLine(params: {
 
 type SlackAssistantMessageRecord = {
   bot_id?: unknown;
+  username?: unknown;
   user?: unknown;
   text?: unknown;
   ts?: unknown;
@@ -173,7 +174,7 @@ function resolveAssistantMessageChangedInbound(params: {
  * notifications silently drops the user's documents.
  *
  * Promote a user-authored `message_changed` back into the regular message
- * pipeline only when its nested `file_share` carries a new media version.
+ * pipeline only when its nested `file_share` adds deliverable media.
  * Plain edits keep flowing to the system-event path so replies are not
  * re-triggered (see #28834).
  */
@@ -204,14 +205,11 @@ function resolveFileShareMessageChangedInbound(params: {
   if (!senderId || !isSlackUserId(senderId)) {
     return undefined;
   }
-  if (!hasSlackInboundDeliverableMedia(next)) {
-    return undefined;
-  }
   const previous = asRecord(changed.previous_message) as SlackAssistantMessageRecord | undefined;
-  const contentVersion = buildSlackInboundContentVersion(next);
-  if (contentVersion === buildSlackInboundContentVersion(previous ?? {})) {
+  if (!hasNewSlackInboundDeliverableMedia(next, previous ?? {})) {
     return undefined;
   }
+  const contentVersion = buildSlackInboundContentVersion(next);
   const channelType = normalizeSlackChannelType(
     asString((changed as SlackMessageChangedEvent & { channel_type?: unknown }).channel_type),
     changed.channel,
@@ -223,6 +221,8 @@ function resolveFileShareMessageChangedInbound(params: {
       channel: changed.channel ?? params.event.channel,
       ...(channelType ? { channel_type: channelType } : {}),
       user: senderId,
+      bot_id: asString(next.bot_id),
+      username: asString(next.username),
       text: asString(next.text),
       ts: asString(next.ts) ?? asString(changed.event_ts),
       thread_ts: asString(next.thread_ts),

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -49,6 +49,7 @@ type SlackAssistantMessageRecord = {
   text?: unknown;
   ts?: unknown;
   thread_ts?: unknown;
+  parent_user_id?: unknown;
   files?: unknown;
   attachments?: unknown;
   assistant_thread?: unknown;
@@ -181,6 +182,7 @@ function resolveAssistantMessageChangedInbound(params: {
 function resolveFileShareMessageChangedInbound(params: {
   event: SlackMessageEvent;
   ctx: SlackMonitorContext;
+  eventScope?: SlackEventScope;
 }): SlackMessageEvent | undefined {
   if (params.event.subtype !== "message_changed") {
     return undefined;
@@ -210,10 +212,7 @@ function resolveFileShareMessageChangedInbound(params: {
     return undefined;
   }
   const contentVersion = buildSlackInboundContentVersion(next);
-  const channelType = normalizeSlackChannelType(
-    asString((changed as SlackMessageChangedEvent & { channel_type?: unknown }).channel_type),
-    changed.channel,
-  );
+  const channelType = params.ctx.recallSlackChannelType(changed.channel, params.eventScope);
   return withSlackInboundContentVersion(
     {
       type: "message",
@@ -226,6 +225,7 @@ function resolveFileShareMessageChangedInbound(params: {
       text: asString(next.text),
       ts: asString(next.ts) ?? asString(changed.event_ts),
       thread_ts: asString(next.thread_ts),
+      parent_user_id: asString(next.parent_user_id),
       event_ts: changed.event_ts,
       files: Array.isArray(next.files) ? (next.files as SlackMessageEvent["files"]) : undefined,
       attachments: Array.isArray(next.attachments)
@@ -321,6 +321,7 @@ export function registerSlackMessageEvents(params: {
       const fileShareChangedInbound = resolveFileShareMessageChangedInbound({
         event: message,
         ctx,
+        eventScope: eventScope ?? undefined,
       });
       if (fileShareChangedInbound) {
         await handleSlackMessage(fileShareChangedInbound, {

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -208,7 +208,16 @@ function resolveFileShareMessageChangedInbound(params: {
     return undefined;
   }
   const previous = asRecord(changed.previous_message) as SlackAssistantMessageRecord | undefined;
-  if (!hasNewSlackInboundDeliverableMedia(next, previous ?? {})) {
+  const messageTs = asString(next.ts);
+  if (
+    !previous ||
+    !messageTs ||
+    asString(previous.ts) !== messageTs ||
+    asString(previous.user) !== senderId
+  ) {
+    return undefined;
+  }
+  if (!hasNewSlackInboundDeliverableMedia(next, previous)) {
     return undefined;
   }
   const contentVersion = buildSlackInboundContentVersion(next);
@@ -223,7 +232,7 @@ function resolveFileShareMessageChangedInbound(params: {
       bot_id: asString(next.bot_id),
       username: asString(next.username),
       text: asString(next.text),
-      ts: asString(next.ts) ?? asString(changed.event_ts),
+      ts: messageTs,
       thread_ts: asString(next.thread_ts),
       parent_user_id: asString(next.parent_user_id),
       event_ts: changed.event_ts,

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -16,6 +16,11 @@ import type { SlackAppMentionEvent, SlackMessageEvent } from "../../types.js";
 import { normalizeSlackChannelType } from "../channel-type.js";
 import type { SlackMonitorContext } from "../context.js";
 import { resolveSlackEventScope, type SlackEventScope } from "../event-scope.js";
+import {
+  buildSlackInboundContentVersion,
+  hasSlackInboundDeliverableMedia,
+  withSlackInboundContentVersion,
+} from "../inbound-delivery-identity.js";
 import type { SlackMessageHandler } from "../message-handler.js";
 import type { SlackMessageChangedEvent } from "../types.js";
 import { resolveSlackMessageSubtypeHandler } from "./message-subtype-handlers.js";
@@ -160,19 +165,6 @@ function resolveAssistantMessageChangedInbound(params: {
   };
 }
 
-function slackFileKeyList(value: unknown): string {
-  if (!Array.isArray(value)) {
-    return "";
-  }
-  return value
-    .map((file) => {
-      const record = asRecord(file);
-      return asString(record?.id) ?? asString(record?.name) ?? "";
-    })
-    .filter(Boolean)
-    .join(",");
-}
-
 /**
  * Slack finalizes file uploads asynchronously: a message posted with (multiple)
  * attachments can reach the app with an incomplete file set — or none at all —
@@ -181,12 +173,9 @@ function slackFileKeyList(value: unknown): string {
  * notifications silently drops the user's documents.
  *
  * Promote a user-authored `message_changed` back into the regular message
- * pipeline only when it actually delivers new content: the file set differs
- * from `previous_message`, or text appeared where there was none, or the text
- * changed alongside attached files. Plain edits keep flowing to the
- * system-event path so replies are not re-triggered (see #28834), and the
- * downstream seen-message dedupe still applies to the promoted event's
- * original `ts`.
+ * pipeline only when its nested `file_share` carries a new media version.
+ * Plain edits keep flowing to the system-event path so replies are not
+ * re-triggered (see #28834).
  */
 function resolveFileShareMessageChangedInbound(params: {
   event: SlackMessageEvent;
@@ -215,41 +204,37 @@ function resolveFileShareMessageChangedInbound(params: {
   if (!senderId || !isSlackUserId(senderId)) {
     return undefined;
   }
-  const nextText = asString(next.text)?.trim() ?? "";
-  const nextFiles = Array.isArray(next.files) ? next.files : [];
-  const nextAttachments = Array.isArray(next.attachments) ? next.attachments : [];
-  if (!nextText && nextFiles.length === 0 && nextAttachments.length === 0) {
+  if (!hasSlackInboundDeliverableMedia(next)) {
     return undefined;
   }
   const previous = asRecord(changed.previous_message) as SlackAssistantMessageRecord | undefined;
-  const prevText = asString(previous?.text)?.trim() ?? "";
-  const deliversNewContent =
-    slackFileKeyList(next.files) !== slackFileKeyList(previous?.files) ||
-    (!prevText && Boolean(nextText)) ||
-    (prevText !== nextText && nextFiles.length > 0);
-  if (!deliversNewContent) {
+  const contentVersion = buildSlackInboundContentVersion(next);
+  if (contentVersion === buildSlackInboundContentVersion(previous ?? {})) {
     return undefined;
   }
   const channelType = normalizeSlackChannelType(
     asString((changed as SlackMessageChangedEvent & { channel_type?: unknown }).channel_type),
     changed.channel,
   );
-  return {
-    type: "message",
-    ...(nextSubtype ? { subtype: nextSubtype } : {}),
-    channel: changed.channel ?? params.event.channel,
-    ...(channelType ? { channel_type: channelType } : {}),
-    user: senderId,
-    text: asString(next.text),
-    ts: asString(next.ts) ?? asString(changed.event_ts),
-    thread_ts: asString(next.thread_ts),
-    event_ts: changed.event_ts,
-    files: Array.isArray(next.files) ? (next.files as SlackMessageEvent["files"]) : undefined,
-    attachments: Array.isArray(next.attachments)
-      ? (next.attachments as SlackMessageEvent["attachments"])
-      : undefined,
-    blocks: Array.isArray(next.blocks) ? (next.blocks as SlackMessageEvent["blocks"]) : undefined,
-  };
+  return withSlackInboundContentVersion(
+    {
+      type: "message",
+      ...(nextSubtype ? { subtype: nextSubtype } : {}),
+      channel: changed.channel ?? params.event.channel,
+      ...(channelType ? { channel_type: channelType } : {}),
+      user: senderId,
+      text: asString(next.text),
+      ts: asString(next.ts) ?? asString(changed.event_ts),
+      thread_ts: asString(next.thread_ts),
+      event_ts: changed.event_ts,
+      files: Array.isArray(next.files) ? (next.files as SlackMessageEvent["files"]) : undefined,
+      attachments: Array.isArray(next.attachments)
+        ? (next.attachments as SlackMessageEvent["attachments"])
+        : undefined,
+      blocks: Array.isArray(next.blocks) ? (next.blocks as SlackMessageEvent["blocks"]) : undefined,
+    },
+    contentVersion,
+  );
 }
 
 export function registerSlackMessageEvents(params: {
@@ -305,10 +290,6 @@ export function registerSlackMessageEvents(params: {
         logVerbose("slack: drop enterprise bot-authored message");
         return;
       }
-      if (eventScope && message.subtype && message.subtype !== "file_share") {
-        logVerbose(`slack: drop enterprise message subtype=${message.subtype}`);
-        return;
-      }
       const assistantChangedInbound = resolveAssistantMessageChangedInbound({
         event: message,
         ctx,
@@ -346,6 +327,11 @@ export function registerSlackMessageEvents(params: {
           source: "message",
           ...(eventScope ? { eventScope, awaitDispatch: true } : {}),
         });
+        return;
+      }
+
+      if (eventScope && message.subtype && message.subtype !== "file_share") {
+        logVerbose(`slack: drop enterprise message subtype=${message.subtype}`);
         return;
       }
 

--- a/extensions/slack/src/monitor/events/system-event-test-harness.ts
+++ b/extensions/slack/src/monitor/events/system-event-test-harness.ts
@@ -18,6 +18,7 @@ export type SlackSystemEventTestOverrides = {
 
 export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTestOverrides) {
   const handlers: Record<string, SlackSystemEventHandler> = {};
+  const rememberedChannelTypes = new Map<string, "im" | "mpim" | "channel" | "group">();
   const channelType = overrides?.channelType ?? "im";
   const app = {
     event: (name: string, handler: SlackSystemEventHandler) => {
@@ -49,7 +50,16 @@ export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTe
     reactionAllowlist: overrides?.reactionAllowlist ?? [],
     shouldDropMismatchedSlackEvent: () => false,
     isChannelAllowed: () => true,
-    rememberSlackChannelType: () => {},
+    rememberSlackChannelType: (channelId: string | undefined, type: string | undefined) => {
+      if (
+        channelId &&
+        (type === "im" || type === "mpim" || type === "channel" || type === "group")
+      ) {
+        rememberedChannelTypes.set(channelId, type);
+      }
+    },
+    recallSlackChannelType: (channelId: string | undefined) =>
+      channelId ? rememberedChannelTypes.get(channelId) : undefined,
     resolveChannelName: async () => ({
       name: channelType === "im" ? "direct" : "general",
       type: channelType,

--- a/extensions/slack/src/monitor/inbound-delivery-identity.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-identity.ts
@@ -1,0 +1,136 @@
+// Slack plugin module owns stable inbound delivery identities.
+import { createHash } from "node:crypto";
+import type { SlackMessageEvent } from "../types.js";
+
+const SLACK_CONTENT_VERSION = Symbol("slackInboundContentVersion");
+
+type SlackContentVersionMessage = SlackMessageEvent & {
+  [SLACK_CONTENT_VERSION]?: string;
+};
+
+type SlackInboundContent = {
+  files?: unknown;
+  attachments?: unknown;
+};
+
+type SlackFileVersion = {
+  identity: string;
+  access: "direct" | "resolvable" | "missing";
+};
+
+type SlackAttachmentVersion = {
+  identity: string;
+  hasImage: boolean;
+  files: SlackFileVersion[];
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function compareJson(left: unknown, right: unknown): number {
+  const leftJson = JSON.stringify(left) ?? "";
+  const rightJson = JSON.stringify(right) ?? "";
+  return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+}
+
+function projectSlackFiles(value: unknown): SlackFileVersion[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item, index) => {
+      const file = asRecord(item);
+      if (!file) {
+        return null;
+      }
+      const id = stringField(file, "id");
+      const hasDirectUrl = Boolean(
+        stringField(file, "url_private_download") ?? stringField(file, "url_private"),
+      );
+      return {
+        identity: id ? `id:${id}` : `index:${index}`,
+        access: id ? "resolvable" : hasDirectUrl ? "direct" : "missing",
+      } satisfies SlackFileVersion;
+    })
+    .filter((file): file is SlackFileVersion => file !== null)
+    .toSorted(compareJson);
+}
+
+function projectSlackAttachments(value: unknown): SlackAttachmentVersion[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item, index) => {
+      const attachment = asRecord(item);
+      if (!attachment || attachment.is_share !== true) {
+        return null;
+      }
+      const ts = stringField(attachment, "ts");
+      const fallbackIdentity = [
+        stringField(attachment, "channel_id"),
+        stringField(attachment, "author_id"),
+      ]
+        .filter(Boolean)
+        .join(":");
+      return {
+        identity: ts ? `ts:${ts}` : fallbackIdentity || `index:${index}`,
+        hasImage: Boolean(stringField(attachment, "image_url")),
+        files: projectSlackFiles(attachment.files),
+      } satisfies SlackAttachmentVersion;
+    })
+    .filter((attachment): attachment is SlackAttachmentVersion => attachment !== null)
+    .filter(
+      (attachment) =>
+        attachment.hasImage || attachment.files.some((file) => file.access !== "missing"),
+    )
+    .toSorted(compareJson);
+}
+
+function projectSlackInboundContent(content: SlackInboundContent) {
+  return {
+    attachments: projectSlackAttachments(content.attachments),
+    files: projectSlackFiles(content.files),
+  };
+}
+
+export function hasSlackInboundDeliverableMedia(content: SlackInboundContent): boolean {
+  const projection = projectSlackInboundContent(content);
+  return (
+    projection.files.some((file) => file.access !== "missing") ||
+    projection.attachments.some(
+      (attachment) =>
+        attachment.hasImage || attachment.files.some((file) => file.access !== "missing"),
+    )
+  );
+}
+
+export function buildSlackInboundContentVersion(content: SlackInboundContent): string {
+  // Mutable previews and URL values are intentionally excluded. An ID remains
+  // one version while files.info hydrates Slack Connect access placeholders.
+  const material = JSON.stringify(projectSlackInboundContent(content));
+  return createHash("sha256").update(material).digest("base64url");
+}
+
+export function withSlackInboundContentVersion(
+  message: SlackMessageEvent,
+  version = buildSlackInboundContentVersion(message),
+): SlackMessageEvent {
+  return { ...message, [SLACK_CONTENT_VERSION]: version } as SlackContentVersionMessage;
+}
+
+export function resolveSlackInboundDeliveryId(message: SlackMessageEvent): string | undefined {
+  if (!message.ts) {
+    return undefined;
+  }
+  const version = (message as SlackContentVersionMessage)[SLACK_CONTENT_VERSION];
+  return version ? `${message.ts}:content-v1:${version}` : message.ts;
+}

--- a/extensions/slack/src/monitor/inbound-delivery-identity.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-identity.ts
@@ -102,15 +102,38 @@ function projectSlackInboundContent(content: SlackInboundContent) {
   };
 }
 
-export function hasSlackInboundDeliverableMedia(content: SlackInboundContent): boolean {
+function collectSlackInboundDeliverableMediaIdentities(content: SlackInboundContent): Set<string> {
   const projection = projectSlackInboundContent(content);
-  return (
-    projection.files.some((file) => file.access !== "missing") ||
-    projection.attachments.some(
-      (attachment) =>
-        attachment.hasImage || attachment.files.some((file) => file.access !== "missing"),
-    )
-  );
+  const identities = new Set<string>();
+  for (const file of projection.files) {
+    if (file.access !== "missing") {
+      identities.add(`file:${file.identity}`);
+    }
+  }
+  for (const attachment of projection.attachments) {
+    if (attachment.hasImage) {
+      identities.add(`attachment:${attachment.identity}:image`);
+    }
+    for (const file of attachment.files) {
+      if (file.access !== "missing") {
+        identities.add(`attachment:${attachment.identity}:file:${file.identity}`);
+      }
+    }
+  }
+  return identities;
+}
+
+export function hasNewSlackInboundDeliverableMedia(
+  next: SlackInboundContent,
+  previous: SlackInboundContent,
+): boolean {
+  const previousIdentities = collectSlackInboundDeliverableMediaIdentities(previous);
+  for (const identity of collectSlackInboundDeliverableMediaIdentities(next)) {
+    if (!previousIdentities.has(identity)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function buildSlackInboundContentVersion(content: SlackInboundContent): string {

--- a/extensions/slack/src/monitor/inbound-delivery-state.test.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-state.test.ts
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearSlackRuntime, setSlackRuntime } from "../runtime.js";
 import type { SlackMessageEvent } from "../types.js";
 import {
+  buildSlackInboundContentVersion,
+  withSlackInboundContentVersion,
+} from "./inbound-delivery-identity.js";
+import {
   clearSlackInboundDeliveryStateForTest,
   hasSlackInboundMessageDelivery,
   recordSlackInboundMessageDeliveries,
@@ -58,16 +62,79 @@ describe("slack inbound delivery state", () => {
     await expect(
       hasSlackInboundMessageDelivery({
         accountId: "A1",
-        channelId: "C1",
-        ts: "100.001",
+        message: message("C1", "100.001"),
       }),
     ).resolves.toBe(true);
     await expect(
       hasSlackInboundMessageDelivery({
         accountId: "A2",
-        channelId: "C1",
-        ts: "100.001",
+        message: message("C1", "100.001"),
       }),
     ).resolves.toBe(false);
+  });
+
+  it("keys a same-timestamp finalization by its stable content version", async () => {
+    const initial = { ...message("C1", "100.001"), files: [{ id: "F1" }] };
+    const finalized = withSlackInboundContentVersion({
+      ...initial,
+      files: [
+        { id: "F1", name: "one.pdf" },
+        { id: "F2", name: "two.pdf" },
+      ],
+    });
+    await recordSlackInboundMessageDeliveries({ accountId: "A1", messages: [initial] });
+
+    await expect(
+      hasSlackInboundMessageDelivery({ accountId: "A1", message: finalized }),
+    ).resolves.toBe(false);
+
+    await recordSlackInboundMessageDeliveries({ accountId: "A1", messages: [finalized] });
+    await expect(
+      hasSlackInboundMessageDelivery({
+        accountId: "A1",
+        message: withSlackInboundContentVersion({
+          ...initial,
+          files: [
+            { name: "renamed-one.pdf", id: "F1" },
+            { name: "renamed-two.pdf", id: "F2" },
+          ],
+        }),
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      hasSlackInboundMessageDelivery({
+        accountId: "A1",
+        message: withSlackInboundContentVersion({
+          ...initial,
+          files: [{ id: "F1" }, { id: "F2" }, { id: "F3" }],
+        }),
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("keeps Slack Connect placeholders stable across metadata hydration", () => {
+    const pending = {
+      files: [{ id: "F1", mode: "file_access", file_access: "check_file_info" }],
+    };
+    const available = {
+      files: [{ id: "F1", url_private: "https://files.slack.com/first" }],
+    };
+    const refreshed = {
+      files: [
+        {
+          id: "F1",
+          name: "renamed.pdf",
+          thumb_64: "https://files.slack.com/new-preview",
+          url_private_download: "https://files.slack.com/refreshed",
+        },
+      ],
+    };
+
+    expect(buildSlackInboundContentVersion(pending)).toBe(
+      buildSlackInboundContentVersion(available),
+    );
+    expect(buildSlackInboundContentVersion(available)).toBe(
+      buildSlackInboundContentVersion(refreshed),
+    );
   });
 });

--- a/extensions/slack/src/monitor/inbound-delivery-state.test.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-state.test.ts
@@ -4,6 +4,7 @@ import { clearSlackRuntime, setSlackRuntime } from "../runtime.js";
 import type { SlackMessageEvent } from "../types.js";
 import {
   buildSlackInboundContentVersion,
+  hasNewSlackInboundDeliverableMedia,
   withSlackInboundContentVersion,
 } from "./inbound-delivery-identity.js";
 import {
@@ -136,5 +137,38 @@ describe("slack inbound delivery state", () => {
     expect(buildSlackInboundContentVersion(available)).toBe(
       buildSlackInboundContentVersion(refreshed),
     );
+    expect(hasNewSlackInboundDeliverableMedia(available, pending)).toBe(false);
+    expect(hasNewSlackInboundDeliverableMedia(refreshed, available)).toBe(false);
+  });
+
+  it("distinguishes added deliverable media from removals", () => {
+    const files = [{ id: "F1" }, { id: "F2" }];
+    expect(hasNewSlackInboundDeliverableMedia({ files }, { files: files.slice(0, 1) })).toBe(true);
+    expect(hasNewSlackInboundDeliverableMedia({ files: files.slice(0, 1) }, { files })).toBe(false);
+  });
+
+  it("detects new shared-attachment media without re-delivering removals", () => {
+    const first = {
+      is_share: true,
+      ts: "100.001",
+      files: [{ id: "F1" }],
+    };
+    const second = {
+      is_share: true,
+      ts: "100.002",
+      image_url: "https://files.slack.com/preview",
+    };
+    expect(
+      hasNewSlackInboundDeliverableMedia(
+        { attachments: [first, second] },
+        { attachments: [first] },
+      ),
+    ).toBe(true);
+    expect(
+      hasNewSlackInboundDeliverableMedia(
+        { attachments: [first] },
+        { attachments: [first, second] },
+      ),
+    ).toBe(false);
   });
 });

--- a/extensions/slack/src/monitor/inbound-delivery-state.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-state.ts
@@ -2,6 +2,7 @@
 import { createPersistentDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { getOptionalSlackRuntime } from "../runtime.js";
 import type { SlackMessageEvent } from "../types.js";
+import { resolveSlackInboundDeliveryId } from "./inbound-delivery-identity.js";
 
 const TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_ENTRIES = 20_000;
@@ -33,21 +34,26 @@ const deliveredMessages = createPersistentDedupeCache<SlackInboundDeliveryRecord
   },
 });
 
-function makeKey(accountId: string, channelId: string, ts: string, teamId?: string): string {
-  return `${accountId}:${teamId ? `${teamId}:` : ""}${channelId}:${ts}`;
+function makeKey(
+  accountId: string,
+  channelId: string,
+  deliveryId: string,
+  teamId?: string,
+): string {
+  return `${accountId}:${teamId ? `${teamId}:` : ""}${channelId}:${deliveryId}`;
 }
 
 export async function hasSlackInboundMessageDelivery(params: {
   accountId: string;
-  channelId: string | undefined;
-  ts: string | undefined;
+  message: SlackMessageEvent;
   teamId?: string;
 }): Promise<boolean> {
-  if (!params.accountId || !params.channelId || !params.ts) {
+  const deliveryId = resolveSlackInboundDeliveryId(params.message);
+  if (!params.accountId || !params.message.channel || !deliveryId) {
     return false;
   }
   return await deliveredMessages.lookup(
-    makeKey(params.accountId, params.channelId, params.ts, params.teamId),
+    makeKey(params.accountId, params.message.channel, deliveryId, params.teamId),
   );
 }
 
@@ -62,10 +68,11 @@ export async function recordSlackInboundMessageDeliveries(params: {
   const deliveredAt = Date.now();
   const keys = new Set<string>();
   for (const message of params.messages) {
-    if (!message.channel || !message.ts) {
+    const deliveryId = resolveSlackInboundDeliveryId(message);
+    if (!message.channel || !deliveryId) {
       continue;
     }
-    keys.add(makeKey(params.accountId, message.channel, message.ts, params.teamId));
+    keys.add(makeKey(params.accountId, message.channel, deliveryId, params.teamId));
   }
   await Promise.all(
     Array.from(keys, (key) =>

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -15,6 +15,7 @@ import type { SlackMessageEvent } from "../types.js";
 import { stripSlackMentionsForCommandDetection } from "./commands.js";
 import type { SlackMonitorContext } from "./context.js";
 import type { SlackEventScope } from "./event-scope.js";
+import { resolveSlackInboundDeliveryId } from "./inbound-delivery-identity.js";
 import {
   hasSlackInboundMessageDelivery,
   recordSlackInboundMessageDeliveries,
@@ -99,13 +100,13 @@ function shouldDebounceSlackMessage(message: SlackMessageEvent, cfg: SlackMonito
 
 function buildSeenMessageKey(
   channelId: string | undefined,
-  ts: string | undefined,
+  deliveryId: string | undefined,
   teamId?: string,
 ): string | null {
-  if (!channelId || !ts) {
+  if (!channelId || !deliveryId) {
     return null;
   }
-  return `${teamId ? `${teamId}:` : ""}${channelId}:${ts}`;
+  return `${teamId ? `${teamId}:` : ""}${channelId}:${deliveryId}`;
 }
 
 export function createSlackMessageHandler(params: {
@@ -208,7 +209,7 @@ export function createSlackMessageHandler(params: {
           };
           const seenMessageKey = buildSeenMessageKey(
             last.message.channel,
-            last.message.ts,
+            resolveSlackInboundDeliveryId(last.message),
             last.opts.eventScope?.teamId,
           );
           try {
@@ -303,7 +304,7 @@ export function createSlackMessageHandler(params: {
               for (const entry of entries) {
                 const entrySeenKey = buildSeenMessageKey(
                   entry.message.channel,
-                  entry.message.ts,
+                  resolveSlackInboundDeliveryId(entry.message),
                   entry.opts.eventScope?.teamId,
                 );
                 if (entrySeenKey) {
@@ -311,7 +312,7 @@ export function createSlackMessageHandler(params: {
                 }
                 ctx.releaseSeenMessage(
                   entry.message.channel,
-                  entry.message.ts,
+                  resolveSlackInboundDeliveryId(entry.message),
                   entry.opts.eventScope,
                 );
               }
@@ -408,22 +409,25 @@ export function createSlackMessageHandler(params: {
     ctx.rememberSlackChannelType(message.channel, message.channel_type, opts.eventScope);
     const seenMessageKey = buildSeenMessageKey(
       message.channel,
-      message.ts,
+      resolveSlackInboundDeliveryId(message),
       opts.eventScope?.teamId,
     );
     if (
       seenMessageKey &&
       (await hasSlackInboundMessageDelivery({
         accountId: ctx.accountId,
-        channelId: message.channel,
-        ts: message.ts,
+        message,
         ...(opts.eventScope ? { teamId: opts.eventScope.teamId } : {}),
       }))
     ) {
       return undefined;
     }
     const wasSeen = seenMessageKey
-      ? ctx.markMessageSeen(message.channel, message.ts, opts.eventScope)
+      ? ctx.markMessageSeen(
+          message.channel,
+          resolveSlackInboundDeliveryId(message),
+          opts.eventScope,
+        )
       : false;
     if (seenMessageKey && opts.source === "message" && !wasSeen) {
       // Prime exactly one fallback app_mention allowance immediately so a near-simultaneous


### PR DESCRIPTION
Related: #28834

## What Problem This Solves

Slack can deliver a later `message_changed` envelope whose nested user message contains finalized file attachments. Routing that envelope only as a generic edit loses those attachments. Reusing the original message timestamp as the only delivery identity also makes both Slack dedupe layers discard a legitimate finalized version after the initial message was processed.

## Why This Change Was Made

The maintainer rewrite gives qualifying file finalizations a stable content-version delivery identity while preserving the original Slack timestamp for reply semantics. That identity is resolved once and shared by the persistent and in-memory dedupe gates, so a finalized version is delivered once and exact replays remain suppressed.

The resolver runs before Enterprise Grid subtype filtering. It promotes only user-authored nested messages that add or change deliverable file content; plain edits, self-attributed changes, unchanged file sets, and replays keep their existing paths.

## User Impact

When Slack provides attachments in a later nested file finalization, OpenClaw delivers the finalized files once instead of silently dropping them. Ordinary edits still do not trigger duplicate agent replies.

## Evidence

- Exact head: `e8cab0e77be45fa4a4d5109ba30e0a9aa97b18f2`.
- Blacksmith Testbox: 75 focused tests passed across the event router, inbound delivery state, real message handler, app-mention race, and debounce-key suites.
- Exact `check:changed` passed formatting, extension typechecks, lint, database-first guards, media helper guards, runtime sidecar checks, and import-cycle checks.
- Full-handler tests cover standard and Enterprise initial/final/replay delivery, both dedupe layers, bot attribution, routing metadata, subtype-less generic messages, Slack Connect placeholders, caption edits, missing snapshots, and file removal.
- [Hosted CI at the exact head](https://github.com/openclaw/openclaw/actions/runs/29212041740) passed 64 checks and skipped 30. Its two failures are outside this PR's surface: a stale generated docs map and raw-SQL guardrail violations in `src/snapshot/local-repository.ts`.
- Fresh exact-head autoreview found no actionable issues.
- Slack documents the [outer and nested `MessageChangedEvent` shape](https://docs.slack.dev/tools/node-slack-sdk/reference/types/interfaces/MessageChangedEvent/), but not the exact incomplete-to-final sequence claimed here.
- Two hosted Slack Web API probes, including a two-document 10 MiB upload, emitted one complete outer `file_share` event and did not reproduce the claimed follow-up `message_changed` finalization.

## Remaining Gate

Landing is blocked on a redacted real initial/final payload pair from the affected Slack client or workspace. The trace request is tracked in [this PR comment](https://github.com/openclaw/openclaw/pull/104703#issuecomment-4952706836).
