### PR TITLE
fix(macos): make onboarding advance with Return

### DIFF
--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -317,7 +317,7 @@ enum CommandResolver {
         switch runtimeResult {
         case .success:
             let missingEntry = """
-            openclaw entrypoint missing (looked for dist/index.js or openclaw.mjs); run pnpm build.
+            openclaw CLI not found. Install the CLI, or run pnpm build in an OpenClaw source checkout.
             """
             return self.errorCommand(with: missingEntry)
         case let .failure(error):

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -404,7 +404,8 @@ extension OnboardingView {
                 Text(self.buttonTitle)
                     .frame(minWidth: 88)
             }
-            .keyboardShortcut(.return)
+            // KeyEquivalent.return defaults to Command-Return; defaultAction is plain Return.
+            .keyboardShortcut(.defaultAction)
             .buttonStyle(.borderedProminent)
             .disabled(!self.canAdvance)
         }

--- a/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
@@ -137,6 +137,28 @@ import Testing
         #expect(cmd.suffix(2).elementsEqual(["--timeout", "5"]))
     }
 
+    @Test func `missing CLI explains install and source checkout paths`() throws {
+        let defaults = self.makeLocalDefaults()
+        let tmp = try makeTempDirForTests()
+        let binDir = tmp.appendingPathComponent("bin")
+        let nodePath = binDir.appendingPathComponent("node")
+        try makeExecutableForTests(at: nodePath)
+        try "#!/bin/sh\necho v22.19.0\n".write(to: nodePath, atomically: true, encoding: .utf8)
+        try FileManager().setAttributes([.posixPermissions: 0o755], ofItemAtPath: nodePath.path)
+
+        let cmd = CommandResolver.openclawCommand(
+            subcommand: "status",
+            defaults: defaults,
+            configRoot: [:],
+            searchPaths: [binDir.path],
+            projectRoot: tmp)
+
+        #expect(cmd.first == "/bin/sh")
+        #expect(cmd.last?.contains("openclaw CLI not found") == true)
+        #expect(cmd.last?.contains("Install the CLI") == true)
+        #expect(cmd.last?.contains("run pnpm build in an OpenClaw source checkout") == true)
+    }
+
     @Test func `preferred paths start with project node bins`() throws {
         let tmp = try makeTempDirForTests()
 


### PR DESCRIPTION
Related: #104424

## What Problem This Solves

Fixes an issue where users starting macOS onboarding could see a highlighted Next button that ignored plain Return, and where a fresh packaged app reported source-checkout build instructions when the CLI was not installed yet.

## Why This Change Was Made

The onboarding action now uses SwiftUI's default-action shortcut, which maps plain Return rather than the KeyEquivalent overload's default Command modifier. Missing-CLI failures now explain both valid recovery paths: install the CLI, or build an actual source checkout.

## User Impact

Keyboard users can advance onboarding with Return. Fresh packaged-app failures give an accurate, copyable remediation instead of implying the app bundle itself needs `pnpm build`.

## Evidence

- Reproduced both symptoms from the signed exact-landed macOS app on a pristine Parallels snapshot.
- `swift test --package-path apps/macos --filter CommandResolverTests` — 25 tests passed.
- `swiftlint lint --strict --config config/swiftlint.yml ...` — 0 violations across the three touched files.
- `pnpm check:changed` on Testbox-through-Crabbox `tbx_01kx9fgbsq12kbr8xhqe04xhkn` — passed; macOS app packaging/runtime shards passed.
- Fresh Codex autoreview — clean, 0.96 correctness.
