### PR TITLE
fix: prevent session exports from writing outside workspace

### DIFF
--- a/docs/cli/pairing.md
+++ b/docs/cli/pairing.md
@@ -52,7 +52,7 @@ Options: `--channel <channel>`, `--account <accountId>`, `--notify` (send a conf
 
 If `commands.ownerAllowFrom` is empty when you approve a pairing code, OpenClaw also records the approved sender as the command owner, using a channel-scoped entry such as `telegram:123456789`. This only bootstraps the first owner - later pairing approvals never replace or expand `commands.ownerAllowFrom`.
 
-The command owner is the human operator account allowed to run owner-only commands and approve dangerous actions such as `/diagnostics`, `/export-trajectory`, `/config`, and exec approvals. Pairing only lets a sender talk to the agent; it does not by itself grant owner privileges beyond this one-time bootstrap.
+The command owner is the human operator account allowed to run owner-only commands and approve dangerous actions such as `/diagnostics`, `/export-session`, `/export-trajectory`, `/config`, and exec approvals. Pairing only lets a sender talk to the agent; it does not by itself grant owner privileges beyond this one-time bootstrap.
 
 If you approved a sender before this bootstrap existed, run `openclaw doctor`; it warns when no command owner is configured and shows the exact `openclaw config set commands.ownerAllowFrom ...` command to fix it.
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -178,8 +178,11 @@ plugins.
     | `/stop` | Abort the current run |
     | `/session idle <duration\|off>` | Manage thread-binding idle expiry |
     | `/session max-age <duration\|off>` | Manage thread-binding max-age expiry |
-    | `/export-session [path]` | Export the current session to HTML. Alias: `/export` |
+    | `/export-session [path]` | Owner-only. Export the current session to HTML inside the workspace. Alias: `/export` |
     | `/export-trajectory [path]` | Export a JSONL trajectory bundle for the current session. Alias: `/trajectory` |
+
+    Explicit `/export-session` paths replace existing files inside the
+    workspace. Omit the path to generate a collision-safe filename.
 
     <Note>
       Control UI intercepts typed `/new` to create and switch to a fresh

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -373,7 +373,7 @@ export function buildBuiltinChatCommands(
     defineChatCommand({
       key: "export-session",
       nativeName: "export-session",
-      description: "Export current session to HTML file with full system prompt.",
+      description: "Export current session to an owner-only HTML file in the workspace.",
       textAliases: ["/export-session", "/export"],
       acceptsArgs: true,
       category: "status",
@@ -381,7 +381,7 @@ export function buildBuiltinChatCommands(
       args: [
         {
           name: "path",
-          description: "Output path (default: workspace)",
+          description: "Output path inside workspace (default: workspace)",
           type: "string",
           required: false,
         },

--- a/src/auto-reply/reply/commands-export-session-file.test.ts
+++ b/src/auto-reply/reply/commands-export-session-file.test.ts
@@ -1,0 +1,102 @@
+// Tests the real fs-safe boundary used by session-export artifacts.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { writeSessionExportFile } from "./commands-export-session-file.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function makeWorkspace(): string {
+  return tempDirs.make("openclaw-session-export-");
+}
+
+async function writeExport(params: {
+  workspaceDir: string;
+  requestedPath?: string;
+  defaultFileName?: string;
+  contents?: string;
+}) {
+  return await writeSessionExportFile({
+    workspaceDir: params.workspaceDir,
+    requestedPath: params.requestedPath,
+    defaultFileName: params.defaultFileName ?? "session.html",
+    contents: params.contents ?? "new export",
+  });
+}
+
+describe("writeSessionExportFile", () => {
+  it.each([
+    ["relative", "exports/session.html"],
+    ["absolute", null],
+  ])("writes an explicit %s path inside the workspace", async (_label, requestedPath) => {
+    const workspaceDir = makeWorkspace();
+    const targetPath = requestedPath ?? path.join(workspaceDir, "exports", "session.html");
+
+    const result = await writeExport({ workspaceDir, requestedPath: targetPath });
+
+    expect(result).toEqual({
+      absolutePath: path.join(workspaceDir, "exports", "session.html"),
+      displayPath: path.join("exports", "session.html"),
+    });
+    expect(await fs.readFile(result.absolutePath, "utf-8")).toBe("new export");
+    if (process.platform !== "win32") {
+      expect((await fs.stat(result.absolutePath)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("preserves explicit overwrite behavior for an in-workspace regular file", async () => {
+    const workspaceDir = makeWorkspace();
+    const targetPath = path.join(workspaceDir, "session.html");
+    await fs.writeFile(targetPath, "old export", "utf-8");
+    if (process.platform !== "win32") {
+      await fs.chmod(targetPath, 0o644);
+    }
+
+    await writeExport({ workspaceDir, requestedPath: targetPath });
+
+    expect(await fs.readFile(targetPath, "utf-8")).toBe("new export");
+    if (process.platform !== "win32") {
+      expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it.each([
+    ["absolute", (workspaceDir: string) => path.join(path.dirname(workspaceDir), "outside.html")],
+    ["traversal", () => "../outside.html"],
+  ])("rejects an %s path outside the workspace", async (_label, requestedPath) => {
+    const workspaceDir = makeWorkspace();
+
+    await expect(
+      writeExport({ workspaceDir, requestedPath: requestedPath(workspaceDir) }),
+    ).rejects.toMatchObject({ code: "outside-workspace", category: "policy" });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlink target without changing the linked file",
+    async () => {
+      const workspaceDir = makeWorkspace();
+      const outsideDir = tempDirs.make("openclaw-session-export-outside-");
+      const outsidePath = path.join(outsideDir, "outside.html");
+      const linkedPath = path.join(workspaceDir, "session.html");
+      await fs.writeFile(outsidePath, "outside", "utf-8");
+      await fs.symlink(outsidePath, linkedPath);
+
+      await expect(writeExport({ workspaceDir, requestedPath: linkedPath })).rejects.toMatchObject({
+        category: "policy",
+      });
+      expect(await fs.readFile(outsidePath, "utf-8")).toBe("outside");
+    },
+  );
+
+  it("suffixes a colliding generated filename instead of overwriting", async () => {
+    const workspaceDir = makeWorkspace();
+    await fs.writeFile(path.join(workspaceDir, "session.html"), "existing", "utf-8");
+
+    const result = await writeExport({ workspaceDir });
+
+    expect(result.displayPath).toBe("session-2.html");
+    expect(await fs.readFile(path.join(workspaceDir, "session.html"), "utf-8")).toBe("existing");
+    expect(await fs.readFile(result.absolutePath, "utf-8")).toBe("new export");
+  });
+});

--- a/src/auto-reply/reply/commands-export-session-file.test.ts
+++ b/src/auto-reply/reply/commands-export-session-file.test.ts
@@ -73,6 +73,25 @@ describe("writeSessionExportFile", () => {
   });
 
   it.runIf(process.platform !== "win32")(
+    "accepts an absolute path written through a symlinked workspace root",
+    async () => {
+      const workspaceDir = makeWorkspace();
+      const aliasParent = tempDirs.make("openclaw-session-export-alias-");
+      const workspaceAlias = path.join(aliasParent, "workspace");
+      await fs.symlink(workspaceDir, workspaceAlias, "dir");
+      const requestedPath = path.join(workspaceAlias, "exports", "session.html");
+
+      const result = await writeExport({ workspaceDir: workspaceAlias, requestedPath });
+
+      expect(result).toEqual({
+        absolutePath: path.join(workspaceDir, "exports", "session.html"),
+        displayPath: path.join("exports", "session.html"),
+      });
+      expect(await fs.readFile(result.absolutePath, "utf-8")).toBe("new export");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "rejects a symlink target without changing the linked file",
     async () => {
       const workspaceDir = makeWorkspace();

--- a/src/auto-reply/reply/commands-export-session-file.ts
+++ b/src/auto-reply/reply/commands-export-session-file.ts
@@ -1,6 +1,6 @@
 // Owns the filesystem boundary for session-export artifacts.
 import path from "node:path";
-import { FsSafeError, root, type Root } from "../../infra/fs-safe.js";
+import { FsSafeError, isPathInside, root, type Root } from "../../infra/fs-safe.js";
 
 const MAX_DEFAULT_FILENAME_ATTEMPTS = 100;
 
@@ -30,6 +30,18 @@ async function createUnusedFile(
   throw new Error(`Could not find an unused export filename near ${filePath}`);
 }
 
+function normalizeWorkspaceAliasPath(workspaceRoot: Root, requestedPath: string): string {
+  if (!path.isAbsolute(requestedPath)) {
+    return requestedPath;
+  }
+  const normalizedRequest = path.resolve(requestedPath);
+  if (!isPathInside(workspaceRoot.rootDir, normalizedRequest)) {
+    return requestedPath;
+  }
+  const relativePath = path.relative(workspaceRoot.rootDir, normalizedRequest);
+  return relativePath || requestedPath;
+}
+
 export async function writeSessionExportFile(params: {
   workspaceDir: string;
   requestedPath?: string;
@@ -40,10 +52,11 @@ export async function writeSessionExportFile(params: {
 
   let writtenPath: string;
   if (params.requestedPath) {
-    // An explicit regular file keeps the shipped overwrite behavior; Root still
-    // blocks path aliases, symlinks, and paths outside the workspace.
-    await workspaceRoot.write(params.requestedPath, params.contents, { encoding: "utf-8" });
-    writtenPath = params.requestedPath;
+    // Explicit regular files retain overwrite behavior. Rebase only lexical workspace
+    // aliases onto the canonical Root; nested aliases, symlinks, and outside paths
+    // still reach fs-safe unchanged and are blocked.
+    writtenPath = normalizeWorkspaceAliasPath(workspaceRoot, params.requestedPath);
+    await workspaceRoot.write(writtenPath, params.contents, { encoding: "utf-8" });
   } else {
     writtenPath = await createUnusedFile(workspaceRoot, params.defaultFileName, params.contents);
   }

--- a/src/auto-reply/reply/commands-export-session-file.ts
+++ b/src/auto-reply/reply/commands-export-session-file.ts
@@ -1,0 +1,57 @@
+// Owns the filesystem boundary for session-export artifacts.
+import path from "node:path";
+import { FsSafeError, root, type Root } from "../../infra/fs-safe.js";
+
+const MAX_DEFAULT_FILENAME_ATTEMPTS = 100;
+
+function addCollisionSuffix(filePath: string, suffix: number): string {
+  const ext = path.extname(filePath);
+  const baseName = path.basename(filePath, ext);
+  return path.join(path.dirname(filePath), `${baseName}-${suffix}${ext}`);
+}
+
+async function createUnusedFile(
+  workspaceRoot: Root,
+  filePath: string,
+  contents: string,
+): Promise<string> {
+  for (let suffix = 1; suffix <= MAX_DEFAULT_FILENAME_ATTEMPTS; suffix++) {
+    const candidate = suffix === 1 ? filePath : addCollisionSuffix(filePath, suffix);
+    try {
+      await workspaceRoot.create(candidate, contents, { encoding: "utf-8" });
+      return candidate;
+    } catch (error) {
+      if (error instanceof FsSafeError && error.code === "already-exists") {
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error(`Could not find an unused export filename near ${filePath}`);
+}
+
+export async function writeSessionExportFile(params: {
+  workspaceDir: string;
+  requestedPath?: string;
+  defaultFileName: string;
+  contents: string;
+}): Promise<{ absolutePath: string; displayPath: string }> {
+  const workspaceRoot = await root(params.workspaceDir, { mkdir: true, mode: 0o600 });
+
+  let writtenPath: string;
+  if (params.requestedPath) {
+    // An explicit regular file keeps the shipped overwrite behavior; Root still
+    // blocks path aliases, symlinks, and paths outside the workspace.
+    await workspaceRoot.write(params.requestedPath, params.contents, { encoding: "utf-8" });
+    writtenPath = params.requestedPath;
+  } else {
+    writtenPath = await createUnusedFile(workspaceRoot, params.defaultFileName, params.contents);
+  }
+
+  const absolutePath = await workspaceRoot.resolve(writtenPath);
+  const relativePath = path.relative(workspaceRoot.rootReal, absolutePath);
+  return {
+    absolutePath,
+    displayPath: relativePath.startsWith("..") ? absolutePath : relativePath,
+  };
+}

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -1,7 +1,6 @@
 // Tests session export command packaging, filesystem writes, and prompt bundle capture.
-import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HandleCommandsParams } from "./commands-types.js";
 
 const hoisted = await vi.hoisted(async () => {
@@ -16,11 +15,17 @@ const hoisted = await vi.hoisted(async () => {
       injectedFiles: [],
       sandboxRuntime: { sandboxed: false, mode: "off" },
     })),
-    writeFileMock: vi.fn(
-      async (_filePath: string, _dataValue: string, _encoding?: BufferEncoding) => undefined,
+    writeSessionExportFileMock: vi.fn(
+      async (_params: {
+        workspaceDir: string;
+        requestedPath?: string;
+        defaultFileName: string;
+        contents: string;
+      }) => ({
+        absolutePath: "/tmp/workspace/openclaw-session.html",
+        displayPath: "openclaw-session.html",
+      }),
     ),
-    mkdirMock: vi.fn(async (_filePath: string, _options?: { recursive?: boolean }) => undefined),
-    accessMock: vi.fn(async (_filePath: string) => undefined),
     migrateSessionEntriesMock: vi.fn((_entries: unknown[]) => undefined),
     readAcpSessionMetaForEntryMock: vi.fn<
       (params: { sessionKey: string; entry?: { sessionId?: string } }) => unknown
@@ -54,6 +59,10 @@ vi.mock("../../config/sessions/session-accessor.js", () => ({
 vi.mock("./commands-system-prompt.js", () => ({
   resolveCommandsSystemPromptBundle: hoisted.resolveCommandsSystemPromptBundleMock,
 }));
+
+vi.mock("./commands-export-session-file.js", () => {
+  return { writeSessionExportFile: hoisted.writeSessionExportFileMock };
+});
 
 vi.mock("../../agents/sessions/session-manager.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../agents/sessions/session-manager.js")>();
@@ -89,9 +98,6 @@ vi.mock("node:fs/promises", async () => {
   const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
   const mockedFsPromises = {
     ...actual,
-    access: hoisted.accessMock,
-    mkdir: hoisted.mkdirMock,
-    writeFile: hoisted.writeFileMock,
     readFile: vi.fn(async (filePath: string, encoding?: BufferEncoding) => {
       for (const [suffix, contents] of hoisted.exportHtmlTemplateContents) {
         if (filePath.endsWith(suffix)) {
@@ -107,6 +113,7 @@ vi.mock("node:fs/promises", async () => {
   };
 });
 
+import { FsSafeError } from "../../infra/fs-safe.js";
 import { buildExportSessionReply } from "./commands-export-session.js";
 
 function makeParams(): HandleCommandsParams {
@@ -144,27 +151,16 @@ function makeParams(): HandleCommandsParams {
   } as unknown as HandleCommandsParams;
 }
 
-function writeFileArg(callIndex: number, argIndex: number): unknown {
-  const call = hoisted.writeFileMock.mock.calls.at(callIndex);
+function exportWriteParams(callIndex = 0): { contents: string } {
+  const call = hoisted.writeSessionExportFileMock.mock.calls.at(callIndex);
   if (!call) {
-    throw new Error(`Expected writeFile call ${callIndex}`);
+    throw new Error(`Expected export write call ${callIndex}`);
   }
-  if (!(argIndex in call)) {
-    throw new Error(`Expected writeFile call ${callIndex} argument ${argIndex}`);
-  }
-  return call[argIndex];
-}
-
-function writeFilePath(callIndex: number): string {
-  const value = writeFileArg(callIndex, 0);
-  if (typeof value !== "string") {
-    throw new Error(`Expected writeFile call ${callIndex} path`);
-  }
-  return value;
+  return call[0];
 }
 
 function writtenHtml(): string {
-  const value = writeFileArg(0, 1);
+  const value = exportWriteParams().contents;
   if (typeof value !== "string") {
     throw new Error("Expected exported HTML");
   }
@@ -184,10 +180,6 @@ function sessionDataFromHtml(html: string): Record<string, unknown> {
 }
 
 describe("buildExportSessionReply", () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
     hoisted.resolveDefaultSessionStorePathMock.mockReturnValue("/tmp/target-store/sessions.json");
@@ -209,7 +201,10 @@ describe("buildExportSessionReply", () => {
       injectedFiles: [],
       sandboxRuntime: { sandboxed: false, mode: "off" },
     });
-    hoisted.accessMock.mockResolvedValue(undefined);
+    hoisted.writeSessionExportFileMock.mockResolvedValue({
+      absolutePath: "/tmp/workspace/openclaw-session.html",
+      displayPath: "openclaw-session.html",
+    });
     hoisted.readAcpSessionMetaForEntryMock.mockReturnValue(undefined);
     hoisted.loadTranscriptEventsMock.mockImplementation(
       async () => hoisted.sessionTranscriptEvents,
@@ -488,29 +483,35 @@ describe("buildExportSessionReply", () => {
     );
   });
 
-  it("suffixes colliding default export filenames instead of overwriting", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-05T10:11:12.345Z"));
-    const collision = Object.assign(new Error("exists"), { code: "EEXIST" });
-    hoisted.writeFileMock.mockRejectedValueOnce(collision).mockResolvedValueOnce(undefined);
-
-    const reply = await buildExportSessionReply(makeParams());
-
-    const expectedBase = path.join(
-      "/tmp/workspace",
-      "openclaw-session-session--2026-05-05T10-11-12.html",
-    );
-    const expectedSuffix = path.join(
-      "/tmp/workspace",
-      "openclaw-session-session--2026-05-05T10-11-12-2.html",
-    );
-    expect(writeFilePath(0)).toBe(expectedBase);
-    expect(writeFileArg(0, 2)).toEqual({
-      encoding: "utf-8",
-      flag: "wx",
+  it("passes the generated HTML and explicit path to the export boundary", async () => {
+    const params = makeParams();
+    params.command.commandBodyNormalized = "/export-session exports/session.html";
+    hoisted.writeSessionExportFileMock.mockResolvedValueOnce({
+      absolutePath: "/tmp/workspace/exports/session.html",
+      displayPath: "exports/session.html",
     });
-    expect(writeFilePath(1)).toBe(expectedSuffix);
-    expect(reply.text).toContain("📄 File: openclaw-session-session--2026-05-05T10-11-12-2.html");
+
+    const reply = await buildExportSessionReply(params);
+
+    expect(hoisted.writeSessionExportFileMock).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace",
+      requestedPath: "exports/session.html",
+      defaultFileName: expect.stringMatching(/^openclaw-session-session--.+\.html$/),
+      contents: expect.stringContaining('id="session-data"'),
+    });
+    expect(reply.text).toContain("📄 File: exports/session.html");
+  });
+
+  it("turns an unsafe output path into a bounded user-facing error", async () => {
+    const params = makeParams();
+    params.command.commandBodyNormalized = "/export-session ../outside.html";
+    hoisted.writeSessionExportFileMock.mockRejectedValueOnce(
+      new FsSafeError("outside-workspace", "file is outside workspace root"),
+    );
+
+    await expect(buildExportSessionReply(params)).resolves.toEqual({
+      text: "❌ Output path must be a regular file inside the workspace.",
+    });
   });
 
   it("preserves replacement text with dollar sequences", async () => {

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -15,12 +15,14 @@ import {
 import { loadTranscriptEvents } from "../../config/sessions/session-accessor.js";
 import { scanSessionTranscriptTree } from "../../config/sessions/transcript-tree.js";
 import type { SessionEntry as StoredSessionEntry } from "../../config/sessions/types.js";
+import { FsSafeError } from "../../infra/fs-safe.js";
 import type { ReplyPayload } from "../types.js";
 import {
   isReplyPayload,
   parseExportCommandOutputPath,
   resolveExportCommandSessionTarget,
 } from "./commands-export-common.js";
+import { writeSessionExportFile } from "./commands-export-session-file.js";
 import { resolveCommandsSystemPromptBundle } from "./commands-system-prompt.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
@@ -203,28 +205,6 @@ async function generateHtml(sessionData: SessionData): Promise<string> {
   );
 }
 
-function addCollisionSuffix(filePath: string, suffix: number): string {
-  const ext = path.extname(filePath);
-  const baseName = path.basename(filePath, ext);
-  return path.join(path.dirname(filePath), `${baseName}-${suffix}${ext}`);
-}
-
-async function writeNewDefaultExportFile(filePath: string, html: string): Promise<string> {
-  for (let suffix = 1; suffix <= 100; suffix++) {
-    const candidate = suffix === 1 ? filePath : addCollisionSuffix(filePath, suffix);
-    try {
-      await fsp.writeFile(candidate, html, { encoding: "utf-8", flag: "wx" });
-      return candidate;
-    } catch (error) {
-      if (typeof error === "object" && error && "code" in error && error.code === "EEXIST") {
-        continue;
-      }
-      throw error;
-    }
-  }
-  throw new Error(`Could not find an unused export filename near ${filePath}`);
-}
-
 function isSessionFileEntry(value: unknown): value is SessionFileEntry {
   if (!isRecord(value) || typeof value.type !== "string") {
     return false;
@@ -402,27 +382,21 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   // 6. Determine output path
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
   const defaultFileName = `openclaw-session-${entry.sessionId.slice(0, 8)}-${timestamp}.html`;
-  let outputPath = args.outputPath
-    ? path.resolve(
-        args.outputPath.startsWith("~")
-          ? args.outputPath.replace("~", process.env.HOME ?? "")
-          : args.outputPath,
-      )
-    : path.join(params.workspaceDir, defaultFileName);
-
-  // Ensure directory exists
-  const outputDir = path.dirname(outputPath);
-  await fsp.mkdir(outputDir, { recursive: true });
-
-  // 7. Write file
-  if (args.outputPath) {
-    await fsp.writeFile(outputPath, html, "utf-8");
-  } else {
-    outputPath = await writeNewDefaultExportFile(outputPath, html);
+  let displayPath: string;
+  try {
+    const written = await writeSessionExportFile({
+      workspaceDir: params.workspaceDir,
+      requestedPath: args.outputPath,
+      defaultFileName,
+      contents: html,
+    });
+    displayPath = written.displayPath;
+  } catch (error) {
+    if (error instanceof FsSafeError && error.category === "policy") {
+      return { text: "❌ Output path must be a regular file inside the workspace." };
+    }
+    throw error;
   }
-
-  const relativePath = path.relative(params.workspaceDir, outputPath);
-  const displayPath = relativePath.startsWith("..") ? outputPath : relativePath;
 
   return {
     text: [

--- a/src/auto-reply/reply/commands-info.test.ts
+++ b/src/auto-reply/reply/commands-info.test.ts
@@ -1,10 +1,11 @@
-// Tests info-style commands that report context, status, skills, and trajectory exports.
+// Tests info-style commands that report context, status, skills, and session exports.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { MsgContext } from "../templating.js";
 import { handleContextCommand } from "./commands-context-command.js";
 import {
+  handleExportSessionCommand,
   handleExportTrajectoryCommand,
   handleSkillCommandUsage,
   handleStatusCommand,
@@ -17,6 +18,9 @@ const buildContextReplyMock = vi.hoisted(() => vi.fn());
 const buildExportTrajectoryCommandReplyMock = vi.hoisted(() =>
   vi.fn(async () => ({ text: "exported" })),
 );
+const buildExportSessionReplyMock = vi.hoisted(() =>
+  vi.fn(async () => ({ text: "session exported" })),
+);
 const listSkillCommandsForAgentsMock = vi.hoisted(() => vi.fn(() => []));
 const buildCommandsMessagePaginatedMock = vi.hoisted(() =>
   vi.fn(() => ({ text: "/commands", currentPage: 1, totalPages: 1 })),
@@ -28,6 +32,10 @@ vi.mock("./commands-context-report.js", () => ({
 
 vi.mock("./commands-export-trajectory.js", () => ({
   buildExportTrajectoryCommandReply: buildExportTrajectoryCommandReplyMock,
+}));
+
+vi.mock("./commands-export-session.js", () => ({
+  buildExportSessionReply: buildExportSessionReplyMock,
 }));
 
 vi.mock("./commands-status.js", () => ({
@@ -115,6 +123,7 @@ function buildInfoParams(
 describe("info command handlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    buildExportSessionReplyMock.mockResolvedValue({ text: "session exported" });
     buildExportTrajectoryCommandReplyMock.mockResolvedValue({ text: "exported" });
     buildContextReplyMock.mockImplementation(async (params: HandleCommandsParams) => {
       const normalized = params.command.commandBodyNormalized;
@@ -131,6 +140,36 @@ describe("info command handlers", () => {
       currentPage: 1,
       totalPages: 1,
     });
+  });
+
+  it.each([
+    ["unauthorized sender", false, true],
+    ["authorized non-owner", true, false],
+  ])("blocks %s from exporting a session", async (_label, isAuthorizedSender, senderIsOwner) => {
+    const params = buildInfoParams("/export-session", {
+      commands: { text: true },
+    } as OpenClawConfig);
+    params.command.isAuthorizedSender = isAuthorizedSender;
+    params.command.senderIsOwner = senderIsOwner;
+
+    const result = await handleExportSessionCommand(params, true);
+
+    expect(result).toEqual({ shouldContinue: false });
+    expect(buildExportSessionReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("allows the owner to export a session", async () => {
+    const params = buildInfoParams("/export-session", {
+      commands: { text: true },
+    } as OpenClawConfig);
+
+    const result = await handleExportSessionCommand(params, true);
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "session exported" },
+    });
+    expect(buildExportSessionReplyMock).toHaveBeenCalledWith(params);
   });
 
   it("ignores trajectory export requests from unauthorized senders", async () => {

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -321,11 +321,13 @@ export const handleExportSessionCommand: CommandHandler = async (params, allowTe
   ) {
     return null;
   }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /export-session from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
+  const unauthorized = rejectUnauthorizedCommand(params, "/export-session");
+  if (unauthorized) {
+    return unauthorized;
+  }
+  const nonOwner = rejectNonOwnerCommand(params, "/export-session");
+  if (nonOwner) {
+    return nonOwner;
   }
   return { shouldContinue: false, reply: await buildExportSessionReply(params) };
 };

--- a/src/commands/doctor-command-owner.test.ts
+++ b/src/commands/doctor-command-owner.test.ts
@@ -44,7 +44,7 @@ describe("command owner health", () => {
     expect(note).toHaveBeenCalledWith(
       [
         "No command owner is configured.",
-        "A command owner is the human operator account allowed to run owner-only commands and approve dangerous actions, including /diagnostics, /export-trajectory, /config, and exec approvals.",
+        "A command owner is the human operator account allowed to run owner-only commands and approve dangerous actions, including /diagnostics, /export-session, /export-trajectory, /config, and exec approvals.",
         "DM pairing only lets someone talk to the bot; it does not make that sender the owner for privileged commands.",
         "Fix: set commands.ownerAllowFrom to your channel user id, for example openclaw config set commands.ownerAllowFrom '[\"telegram:123456789\"]'",
         "Restart the gateway after changing this if it is already running.",

--- a/src/commands/doctor-command-owner.ts
+++ b/src/commands/doctor-command-owner.ts
@@ -48,7 +48,7 @@ export function noteCommandOwnerHealth(cfg: OpenClawConfig): void {
   note(
     [
       "No command owner is configured.",
-      "A command owner is the human operator account allowed to run owner-only commands and approve dangerous actions, including /diagnostics, /export-trajectory, /config, and exec approvals.",
+      "A command owner is the human operator account allowed to run owner-only commands and approve dangerous actions, including /diagnostics, /export-session, /export-trajectory, /config, and exec approvals.",
       "DM pairing only lets someone talk to the bot; it does not make that sender the owner for privileged commands.",
       `Fix: set commands.ownerAllowFrom to your channel user id, for example ${formatCliCommand("openclaw config set commands.ownerAllowFrom '[\"telegram:123456789\"]'")}`,
       "Restart the gateway after changing this if it is already running.",


### PR DESCRIPTION
Closes #102391.

## What Problem This Solves

`/export-session` includes the transcript, full system prompt, and tool schemas. In the shipped `v2026.7.1` release, any authorized sender could invoke it and pass an absolute or traversal path that OpenClaw wrote directly, including outside the workspace.

This PR now targets `main` and fixes both boundaries:

- only the configured command owner may invoke `/export-session` or `/export`;
- every output path is confined to a regular file inside the configured workspace.

## Why This Change Was Made

The sibling `/export-trajectory` command already treats complete conversation exports as owner-only. The same owner gate is the right authorization boundary here, while independent filesystem confinement protects future callers too.

The port also moves the write policy into one focused module instead of leaving security-sensitive path behavior inside HTML generation. It uses the pinned `@openclaw/fs-safe` `Root` contract for canonical containment, symlink/path-alias rejection, private `0600` files, and atomic writes.

## User Impact

- Authorized non-owners can no longer export complete sessions.
- Owners can use relative or absolute paths only when they resolve inside the workspace.
- Explicit in-workspace regular files retain the existing overwrite behavior.
- Generated names never overwrite an existing export; collisions receive a numeric suffix.
- Invalid paths return a bounded error without exposing filesystem details.

## Evidence

Current shipped reproduction:

- GitHub release `v2026.7.1` was published on 2026-07-13.
- `openclaw@2026.7.1` is the current npm version.
- The tag checks only `isAuthorizedSender`, then passes a caller-controlled resolved path to `mkdir` and `writeFile` without a workspace boundary.

Current-main port:

- Final port head: `f703c7109e8ab1b6f3a75015cf7220458837bbaa`.
- The final head passed 51 focused assertions plus the complete `check:changed` gate in a fresh, public-network, no-hydrate AWS Crabbox lease (`run_dbe022a270cf`). The bootstrap verified the exact SHA and rejected IMDS credentials before installing pinned Node and pnpm.
- The exact-head hosted CI cohort passed: [run 29348270773](https://github.com/openclaw/openclaw/actions/runs/29348270773).
- A fresh Codex autoreview against `origin/main` reported no accepted/actionable findings (`patch is correct`, confidence `0.90`).
- `git diff --check` and targeted `oxfmt` passed.

The real fs-safe boundary now has filesystem-backed regression coverage for:

- relative and absolute in-workspace writes;
- absolute paths expressed through a symlinked workspace root;
- absolute and traversal escape rejection;
- symlink escape rejection without changing the linked target;
- explicit overwrite with private `0600` permissions;
- collision-safe generated filenames.

The contributor's original exact-head Proxmox Crabbox proof exercised synthetic owner/helper identities plus absolute, traversal, in-workspace, overwrite, collision, and symlink-parent cases on the release-targeted implementation. The final main-targeted head additionally has both the exact-head isolated AWS proof and hosted CI cohort above.

## Proof Scope

The shared command handler and real filesystem implementation are covered. No production session data or credentials were used. Individual chat transports are not re-tested because they all enter the same shared command handler.
