### PR TITLE
fix(ci): finish AWS Crabbox hydration after pnpm exit hang

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -146,7 +146,56 @@ jobs:
             ln -sfn . "$PNPM_CONFIG_MODULES_DIR/node_modules"
             export NODE_PATH="$PNPM_CONFIG_MODULES_DIR${NODE_PATH:+:$NODE_PATH}"
           fi
-          pnpm "${install_args[@]}" || pnpm "${install_args[@]}"
+          pnpm_install_artifacts_ready() {
+            test -s "$PNPM_CONFIG_MODULES_DIR/.modules.yaml" &&
+              test -x "$PNPM_CONFIG_MODULES_DIR/.bin/oxfmt" &&
+              test -f "$PNPM_CONFIG_MODULES_DIR/typescript/package.json"
+          }
+          run_pnpm_install() {
+            local log_file="$RUNNER_TEMP/openclaw-pnpm-install.log"
+            local pnpm_pid
+            local done_seen=0
+            rm -f "$log_file"
+            setsid pnpm "${install_args[@]}" > >(tee "$log_file") 2>&1 &
+            pnpm_pid=$!
+            while kill -0 "$pnpm_pid" 2>/dev/null; do
+              if grep -qE '^Done in .+ using pnpm v' "$log_file"; then
+                done_seen=1
+                break
+              fi
+              sleep 1
+            done
+            if [ "$done_seen" = 1 ]; then
+              for _ in {1..10}; do
+                if ! kill -0 "$pnpm_pid" 2>/dev/null; then
+                  break
+                fi
+                sleep 1
+              done
+              if kill -0 "$pnpm_pid" 2>/dev/null; then
+                # pnpm 11 may finish successfully but retain its event loop on Linux CI.
+                # https://github.com/pnpm/pnpm/issues/12297
+                echo "::warning::pnpm printed its completion marker but did not exit; terminating it after the grace period"
+                kill -TERM -- "-$pnpm_pid" 2>/dev/null || true
+                for _ in {1..10}; do
+                  if ! kill -0 "$pnpm_pid" 2>/dev/null; then
+                    break
+                  fi
+                  sleep 1
+                done
+                kill -KILL -- "-$pnpm_pid" 2>/dev/null || true
+                wait "$pnpm_pid" 2>/dev/null || true
+                if pnpm_install_artifacts_ready; then
+                  echo "pnpm install artifacts verified after exit-hang termination"
+                  return 0
+                fi
+                echo "::error::pnpm exit-hang termination left incomplete install artifacts"
+                return 1
+              fi
+            fi
+            wait "$pnpm_pid"
+          }
+          run_pnpm_install || run_pnpm_install
           if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ]; then
             rm -rf node_modules
             ln -sfn "$PNPM_CONFIG_MODULES_DIR" node_modules

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -582,6 +582,16 @@ describe("package acceptance workflow", () => {
     expect(hydratePnpm.run).toContain(
       '[ "$(readlink node_modules)" = "${PNPM_CONFIG_MODULES_DIR:-}" ]',
     );
+    expect(hydratePnpm.run).toContain("pnpm_install_artifacts_ready");
+    expect(hydratePnpm.run).toContain("run_pnpm_install || run_pnpm_install");
+    expect(hydratePnpm.run).toContain('setsid pnpm "${install_args[@]}"');
+    expect(hydratePnpm.run).toContain("grep -qE '^Done in .+ using pnpm v'");
+    expect(hydratePnpm.run).toContain("https://github.com/pnpm/pnpm/issues/12297");
+    expect(hydratePnpm.run).toContain('kill -TERM -- "-$pnpm_pid"');
+    expect(hydratePnpm.run).toContain('kill -KILL -- "-$pnpm_pid"');
+    expect(hydratePnpm.run).toContain('test -s "$PNPM_CONFIG_MODULES_DIR/.modules.yaml"');
+    expect(hydratePnpm.run).toContain('test -x "$PNPM_CONFIG_MODULES_DIR/.bin/oxfmt"');
+    expect(hydratePnpm.run).toContain('test -f "$PNPM_CONFIG_MODULES_DIR/typescript/package.json"');
     expect(workflowStep(hydrate, "Fetch main ref").run).toContain(
       "timeout --signal=TERM --kill-after=10s 30s git",
     );


### PR DESCRIPTION
Closes #104709

## What Problem This Solves

Fixes an issue where direct AWS Crabbox hydration could complete every pnpm install lifecycle step, print pnpm's final success marker, and then hang indefinitely instead of reaching ready state.

## Why This Change Was Made

The Linux hydration step now supervises pnpm in its own process group. Normal exits and the existing retry stay unchanged; if pnpm remains alive for ten seconds after its final success marker, hydration terminates the process group and accepts the result only when the external modules metadata plus representative executable and package artifacts are present. This is a bounded workaround for upstream pnpm issue https://github.com/pnpm/pnpm/issues/12297.

## User Impact

Direct AWS Crabbox leases can finish hydration after a successful pnpm install instead of timing out minutes or hours later. Real install failures and incomplete artifact states still retry or fail.

## Evidence

- Before: live AWS process and `/proc` inspection after `Done in 34.1s using pnpm v11.2.2` showed no lifecycle child; pnpm itself remained in `ep_poll` with the shared store's `v11/index.db`, WAL/SHM descriptors, and a socket open.
- After: local Actions hydration of the patched workflow completed with exit 0 in 54.75s; `.modules.yaml`, the `oxfmt` executable, and the TypeScript package gate passed, with no pnpm install process left behind.
- Direct AWS Crabbox `run_fd2eb7ad214b`: targeted formatting passed; `test/scripts/package-acceptance-workflow.test.ts` and `test/scripts/ci-workflow-guards.test.ts` passed (118 tests).
- Direct AWS Crabbox `run_e604a99094af`: `corepack pnpm check:workflows` passed actionlint, zizmor, and composite-action interpolation checks.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`: clean, no accepted/actionable findings (0.93 confidence).

AI-assisted: yes, with Codex; the implementation and live proof were manually inspected.
