### PR TITLE
fix(providers): complete repaired tool call streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **LM Studio and xAI repaired tool calls:** emit the terminal tool-call event before completion when promoting serialized plain-text tool calls, preserving the complete streaming lifecycle for consumers.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Telegram token redaction:** redact bot tokens even when log transports split them across chunks, preventing fragmented credentials from escaping structured and streamed logs. (#103861) Thanks @vincentkoc.

--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -374,8 +374,17 @@ describe("createOllamaStreamFn thinking events", () => {
       "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
+    const toolCallEnd = events.find((event) => event.type === "toolcall_end") as {
+      toolCall?: Record<string, unknown>;
+    };
+    expect(toolCallEnd.toolCall).toMatchObject({
+      type: "toolCall",
+      name: "mempalace_mempalace_search",
+      arguments: { query: "codename", wing: "personal", room: "identities" },
+    });
     const done = events.find((event) => event.type === "done") as {
       message?: { content?: Array<Record<string, unknown>>; stopReason?: string };
       reason?: string;
@@ -422,6 +431,7 @@ describe("createOllamaStreamFn thinking events", () => {
       "start",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
     const done = events.find((event) => event.type === "done") as {

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -372,8 +372,15 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     expect(events.map((event) => (event as { type?: string }).type)).toEqual([
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
+    const toolCallEnd = requireRecord(events.at(-2), "tool call end");
+    expect(requireRecord(toolCallEnd.toolCall, "completed tool call")).toMatchObject({
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/tmp/file.txt" },
+    });
     const done = events.at(-1) as { message?: { content?: unknown; stopReason?: unknown } };
     expect(done.message?.stopReason).toBe("toolUse");
     expect(done.message?.content).toEqual([
@@ -621,6 +628,7 @@ describe("createPlainTextToolCallCompatWrapper", () => {
       "thinking_delta",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
     const thinkingEvent = requireRecord(events[0], "thinking event");
@@ -679,6 +687,7 @@ describe("createPlainTextToolCallCompatWrapper", () => {
       "thinking_delta",
       "toolcall_start",
       "toolcall_delta",
+      "toolcall_end",
       "done",
     ]);
     const thinkingEvent = requireRecord(events[0], "thinking event");

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -112,6 +112,7 @@ function emitPromotedToolCallEvents(
       delta: typeof record.partialArgs === "string" ? record.partialArgs : "{}",
       partial: message,
     });
+    stream.push({ type: "toolcall_end", contentIndex, toolCall: record, partial: message });
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

The July release branch promotes serialized plain-text tool calls for LM Studio, xAI, and Ollama, but its shared compatibility wrapper emits only `toolcall_start` and `toolcall_delta` before `done`. Plugin Prerelease exposed this as deterministic LM Studio failures, and the incomplete lifecycle can leave streaming consumers without the finalized tool-call event.

## Why This Change Was Made

Emit the provider-neutral `toolcall_end` event from the existing shared promotion helper, matching the `AssistantMessageEvent` contract and current `main` behavior. The shared and Ollama tests now assert both lifecycle ordering and the finalized payload. This avoids backporting the much larger stream-normalization refactor while fixing the exact release-owned contract gap.

## User Impact

LM Studio, xAI, and Ollama serialized tool-call repair now completes the streaming lifecycle before the final message, so consumers can finalize repaired calls consistently.

## Evidence

- Blacksmith Testbox: 121 focused tests passed across the shared wrapper and LM Studio, xAI, and Ollama provider streams.
- Run: https://github.com/openclaw/openclaw/actions/runs/29168389236
- Fresh autoreview: clean, 0.98 confidence.
- `oxfmt` and `git diff --check`: green.
- Root cause run: https://github.com/openclaw/openclaw/actions/runs/29166714037

