### PR TITLE
test(qa): follow canonical frontier defaults

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -111,6 +111,8 @@ import { runQaTelegramCommand } from "./live-transports/telegram/cli.runtime.js"
 import { defaultQaModelForMode as defaultQaProviderModelForMode } from "./model-selection.js";
 import type { QaProviderModeInput } from "./run-config.js";
 
+const DEFAULT_LIVE_FRONTIER_MODEL = defaultQaProviderModelForMode("live-frontier");
+
 function mockFirstObjectArg(mock: unknown): Record<string, unknown> {
   const calls = (mock as { mock?: { calls?: Array<Array<unknown>> } }).mock?.calls ?? [];
   const [arg] = calls[0] ?? [];
@@ -2426,8 +2428,8 @@ describe("qa cli runtime", () => {
       repoRoot: path.resolve("/tmp/openclaw-repo"),
       transportId: "qa-channel",
       providerMode: "live-frontier",
-      primaryModel: "openai/gpt-5.5",
-      alternateModel: "openai/gpt-5.5",
+      primaryModel: DEFAULT_LIVE_FRONTIER_MODEL,
+      alternateModel: DEFAULT_LIVE_FRONTIER_MODEL,
       fastMode: undefined,
       message: "read qa kickoff and reply short",
       timeoutMs: undefined,

--- a/extensions/qa-lab/src/run-config.test.ts
+++ b/extensions/qa-lab/src/run-config.test.ts
@@ -19,6 +19,8 @@ import {
   type QaProviderModeInput,
 } from "./run-config.js";
 
+const DEFAULT_LIVE_FRONTIER_MODEL = defaultQaProviderModelForMode("live-frontier");
+
 const scenarios = [
   {
     id: "dm-chat-baseline",
@@ -60,8 +62,8 @@ describe("qa run config", () => {
   it("creates a live-by-default selection that arms flow scenarios", () => {
     expect(createDefaultQaRunSelection(scenarios)).toEqual({
       providerMode: "live-frontier",
-      primaryModel: "openai/gpt-5.5",
-      alternateModel: "openai/gpt-5.5",
+      primaryModel: DEFAULT_LIVE_FRONTIER_MODEL,
+      alternateModel: DEFAULT_LIVE_FRONTIER_MODEL,
       fastMode: true,
       scenarioIds: ["dm-chat-baseline", "thread-lifecycle"],
     });
@@ -82,7 +84,7 @@ describe("qa run config", () => {
     ).toEqual({
       providerMode: "live-frontier",
       primaryModel: "openai/gpt-5.5",
-      alternateModel: "openai/gpt-5.5",
+      alternateModel: DEFAULT_LIVE_FRONTIER_MODEL,
       fastMode: true,
       scenarioIds: ["thread-lifecycle"],
     });
@@ -130,8 +132,8 @@ describe("qa run config", () => {
 
     const selection = createIdleQaRunnerSnapshot(scenarios).selection;
     expect(selection.providerMode).toBe("live-frontier");
-    expect(selection.primaryModel).toBe("openai/gpt-5.5");
-    expect(selection.alternateModel).toBe("openai/gpt-5.5");
+    expect(selection.primaryModel).toBe(DEFAULT_LIVE_FRONTIER_MODEL);
+    expect(selection.alternateModel).toBe(DEFAULT_LIVE_FRONTIER_MODEL);
     expect(defaultQaRuntimeModelForMode).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What Problem This Solves

The July release branch correctly defaults QA Lab's live-frontier lane to GPT-5.6, but four downstream tests still hard-code GPT-5.5. Plugin Prerelease therefore fails deterministically even though the runtime and canonical model-selection tests agree on GPT-5.6.

## Why This Change Was Made

Backport the canonical QA test fix from `main`: derive default and fallback expectations through `defaultQaProviderModelForMode("live-frontier")` while preserving explicit GPT-5.5 override coverage and the mocked idle-snapshot assertion.

## User Impact

No runtime behavior changes. July release validation now tests the canonical live-frontier default instead of a stale literal.

## Evidence

- Blacksmith Testbox: focused QA tests 100/100 green.
- Full QA Lab batch: 1,354/1,354 green across 102 files.
- Run: https://github.com/openclaw/openclaw/actions/runs/29169223837
- Fresh branch autoreview: clean, 0.98 confidence.
- Root cause: https://github.com/openclaw/openclaw/actions/runs/29169010294

