### PR TITLE
fix(macos): preflight supervised app restarts

### DIFF
--- a/scripts/restart-mac.sh
+++ b/scripts/restart-mac.sh
@@ -246,6 +246,77 @@ managed_openclaw_process_pids() {
   } | sort -u
 }
 
+launch_domain_jobs() {
+  local domain="$1"
+  local snapshot=""
+  if ! snapshot="$(/bin/launchctl print "${domain}" 2>/dev/null)"; then
+    return 1
+  fi
+  printf '%s\n' "${snapshot}" | /usr/bin/awk -v domain="${domain}" '
+    /^[[:space:]]*services = \{$/ { services = 1; next }
+    services && /^[[:space:]]*\}$/ { services = 0; next }
+    services && NF >= 3 { print domain "|" $NF }
+  '
+}
+
+loaded_launch_jobs() {
+  local uid=""
+  uid="$(/usr/bin/id -u)"
+  local domain=""
+  for domain in "gui/${uid}" "user/${uid}" system; do
+    launch_domain_jobs "${domain}" || return 1
+  done
+}
+
+launch_job_snapshot() {
+  local domain="$1"
+  local label="$2"
+  /bin/launchctl print "${domain}/${label}" 2>/dev/null
+}
+
+# A launchd-owned app will immediately respawn after target-only cleanup. Find
+# exact managed executables before the expensive Swift build so the operator
+# can stop the owning job instead of waiting for an inevitable switch failure.
+print_managed_openclaw_supervisor_label() {
+  local domain="$1"
+  local label="$2"
+  local job=""
+  if ! job="$(launch_job_snapshot "${domain}" "${label}")"; then
+    return 0
+  fi
+  local executable=""
+  executable="$(printf '%s\n' "${job}" | /usr/bin/awk -F ' = ' '/^[[:space:]]*program = / { print $2; exit }')"
+  local properties=""
+  properties="$(printf '%s\n' "${job}" | /usr/bin/awk -F ' = ' '/^[[:space:]]*properties = / { print $2; exit }')"
+  local is_managed_executable=0
+  if [[ "${executable}" == "${TARGET_EXECUTABLE}" || "${executable}" == "${INSTALLED_EXECUTABLE}" ]]; then
+    is_managed_executable=1
+  fi
+  if [[ "${is_managed_executable}" -eq 1 && " ${properties} " == *" keepalive "* ]]; then
+    printf '%s\n' "${label}"
+  fi
+}
+
+managed_openclaw_supervisor_labels() {
+  local jobs=""
+  if ! jobs="$(loaded_launch_jobs)"; then
+    return 1
+  fi
+  local batch_size=0
+  local domain=""
+  local label=""
+  while IFS='|' read -r domain label; do
+    [[ -n "${domain}" && -n "${label}" ]] || continue
+    print_managed_openclaw_supervisor_label "${domain}" "${label}" &
+    batch_size=$((batch_size + 1))
+    if [[ "${batch_size}" -ge 16 ]]; then
+      wait
+      batch_size=0
+    fi
+  done <<< "${jobs}"
+  wait
+}
+
 kill_managed_openclaw() {
   for _ in {1..10}; do
     local pids=""
@@ -277,6 +348,12 @@ stop_launch_agent() {
 # 1) Validate the process set selected by the requested mode. Target-only keeps
 # the current managed app alive while the replacement builds and signs.
 if [[ "$TARGET_ONLY" -eq 1 ]]; then
+  if ! managed_supervisors="$(managed_openclaw_supervisor_labels | sort -u | /usr/bin/paste -sd, -)"; then
+    fail "Unable to inspect loaded launchd jobs before target-only restart"
+  fi
+  if [[ -n "${managed_supervisors}" ]]; then
+    fail "Managed OpenClaw app is supervised by launchd job(s): ${managed_supervisors}; stop those jobs before a target-only restart"
+  fi
   if [[ -n "$(foreign_openclaw_process_pids)" ]]; then
     fail "Another OpenClaw app or test process is active; target-only restart deferred"
   fi
@@ -291,10 +368,6 @@ fi
 
 # Bundle Gateway-hosted plugin assets.
 run_step "bundle plugin assets" bash -lc "cd '${ROOT_DIR}' && pnpm plugins:assets:build"
-
-# 2) Rebuild into the same path the packager consumes (.build).
-run_step "clean build cache" bash -lc "cd '${ROOT_DIR}/apps/macos' && rm -rf .build .build-swift .swiftpm 2>/dev/null || true"
-run_step "swift build" bash -lc "cd '${ROOT_DIR}/apps/macos' && swift build -q --product OpenClaw"
 
 if [ "$AUTO_DETECT_SIGNING" -eq 1 ]; then
   if check_signing_keys; then

--- a/test/scripts/restart-mac.test.ts
+++ b/test/scripts/restart-mac.test.ts
@@ -99,6 +99,58 @@ function runCleanupFunction(fakePs: string) {
   return { killCalls, result };
 }
 
+function runManagedSupervisorClassifier(
+  records: Array<{ domain: string; label: string; program: string; properties?: string }>,
+  options: { failEnumeration?: boolean } = {},
+) {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-restart-mac-supervisor-test-"));
+  tempRoots.push(root);
+  const recordsPath = join(root, "loaded-jobs.txt");
+  writeFileSync(
+    recordsPath,
+    records
+      .map(
+        (record) => `${record.domain}|${record.label}|${record.program}|${record.properties ?? ""}`,
+      )
+      .join("\n"),
+  );
+
+  const script = readFileSync(restartScriptPath, "utf8");
+  const classifierFunctions = script.slice(
+    script.indexOf("print_managed_openclaw_supervisor_label()"),
+    script.indexOf("kill_managed_openclaw()"),
+  );
+  const harnessPath = join(root, "supervisor-harness.sh");
+  writeFileSync(
+    harnessPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      classifierFunctions,
+      "loaded_launch_jobs() {",
+      '  [[ "${OPENCLAW_TEST_FAIL_ENUMERATION:-0}" != "1" ]] || return 1',
+      "  cut -d'|' -f1,2 \"$OPENCLAW_TEST_LOADED_JOBS\"",
+      "}",
+      "launch_job_snapshot() {",
+      '  grep "^$1|$2|" "$OPENCLAW_TEST_LOADED_JOBS" |',
+      "    awk -F'|' '{ print \"program = \" $3; print \"properties = \" $4 }'",
+      "}",
+      'TARGET_EXECUTABLE="/worktree/dist/OpenClaw.app/Contents/MacOS/OpenClaw"',
+      'INSTALLED_EXECUTABLE="/Applications/OpenClaw.app/Contents/MacOS/OpenClaw"',
+      "managed_openclaw_supervisor_labels",
+    ].join("\n"),
+  );
+  chmodSync(harnessPath, 0o755);
+  return spawnSync("bash", [harnessPath], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      OPENCLAW_TEST_FAIL_ENUMERATION: options.failEnumeration ? "1" : "0",
+      OPENCLAW_TEST_LOADED_JOBS: recordsPath,
+    },
+  });
+}
+
 function runCanonicalizeAppBundle(appBundle: string) {
   const root = mkdtempSync(join(tmpdir(), "openclaw-restart-mac-test-"));
   tempRoots.push(root);
@@ -250,6 +302,12 @@ describe("scripts/restart-mac.sh", () => {
     expect(result.stderr).toBe("");
   });
 
+  it("fails closed when loaded launchd jobs cannot be enumerated", () => {
+    const result = runManagedSupervisorClassifier([], { failEnumeration: true });
+
+    expect(result.status).toBe(1);
+  });
+
   it("fails the gateway verification when lsof finds no listener", () => {
     const result = runGatewayPortCheck("#!/usr/bin/env bash\nexit 1\n");
 
@@ -390,6 +448,62 @@ describe("scripts/restart-mac.sh", () => {
     expect(script).toContain('[[ "${executable}" == "${TARGET_EXECUTABLE}" ]] && continue');
     expect(script).toContain('process_pids_for_executable "${TARGET_EXECUTABLE}"');
     expect(script).toContain("target-only restart deferred");
+  });
+
+  it("finds persistent launchd supervisors across explicit domains", () => {
+    const result = runManagedSupervisorClassifier([
+      {
+        domain: "gui/501",
+        label: "ai.openclaw.mac.custom",
+        program: "/Applications/OpenClaw.app/Contents/MacOS/OpenClaw",
+        properties: "keepalive | runatload",
+      },
+      {
+        domain: "user/501",
+        label: "ai.openclaw.mac.target",
+        program: "/worktree/dist/OpenClaw.app/Contents/MacOS/OpenClaw",
+        properties: "keepalive",
+      },
+      {
+        domain: "gui/501",
+        label: "application.ai.openclaw.mac.123",
+        program: "/Applications/OpenClaw.app/Contents/MacOS/OpenClaw",
+      },
+      {
+        domain: "system",
+        label: "com.example.other",
+        program: "/Applications/Other.app/Contents/MacOS/Other",
+        properties: "keepalive",
+      },
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim().split("\n").toSorted()).toEqual([
+      "ai.openclaw.mac.custom",
+      "ai.openclaw.mac.target",
+    ]);
+    expect(result.stderr).toBe("");
+  });
+
+  it("checks managed launchd supervisors before starting the Swift package build", () => {
+    const script = readFileSync(restartScriptPath, "utf8");
+    const supervisorIndex = script.indexOf(
+      'managed_supervisors="$(managed_openclaw_supervisor_labels',
+    );
+    const packageIndex = script.indexOf('run_step "package app"');
+
+    expect(supervisorIndex).toBeGreaterThan(-1);
+    expect(packageIndex).toBeGreaterThan(supervisorIndex);
+    expect(script).toContain("Unable to inspect loaded launchd jobs");
+    expect(script).toContain("stop those jobs before a target-only restart");
+  });
+
+  it("lets the packager own the single incremental Swift product build", () => {
+    const script = readFileSync(restartScriptPath, "utf8");
+
+    expect(script).not.toContain('run_step "clean build cache"');
+    expect(script).not.toContain('run_step "swift build"');
+    expect(script).toContain('run_step "package app"');
   });
 
   it("keeps the managed app alive until the signed replacement is ready", () => {


### PR DESCRIPTION
## What Problem This Solves

`scripts/restart-mac.sh --target-only` can spend minutes rebuilding before discovering that an external keepalive launchd job will immediately respawn the installed app and prevent the final switch. The script also performed a clean Swift product build immediately before the packager built the same product again.

## Why This Change Was Made

The restart preflight now enumerates the live GUI, user, and system launchd domains, resolves each loaded job, and rejects only keepalive jobs whose program exactly matches the managed target or installed executable. Ordinary LaunchServices application jobs are not treated as supervisors. Launchd enumeration failures remain fail-closed.

The redundant clean-cache and standalone Swift build were removed so `package-mac-app.sh` remains the single owner of the product build and can reuse SwiftPM and MLX artifacts.

## User Impact

Target-only Mac app updates fail early with the owning launchd label when a persistent external supervisor must be stopped. Normal app launches remain allowed, and successful updates avoid one duplicate clean build.

## Evidence

- Blacksmith Testbox `tbx_01kx9gsdg7n9snxjewb84jdp1q`: `corepack pnpm test test/scripts/restart-mac.test.ts test/scripts/package-mac-app.test.ts` — 50 passed, 2 skipped.
- `bash -n scripts/restart-mac.sh`
- `git diff --check`
- Live macOS target-only preflight detected a custom keepalive LaunchAgent in about nine seconds and exited before plugin assets, Swift build, packaging, or app mutation.
- Fresh autoreview: no accepted or actionable findings.
