### PR TITLE
feat: sidebar session state slot, worktree/automation badges, archive disables bound cron jobs

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -368,6 +368,8 @@ openclaw cron create "0 6 * * *" "Check ops queue" --name "Ops sweep" --session 
 openclaw cron edit <jobId> --clear-agent
 ```
 
+Archiving a session (Control UI, or `sessions.patch { archived: true }` from an operator-admin caller) disables every enabled cron job bound to that session: its isolated `cron:<jobId>` session, a `session:<key>` target, or a delivery/wake `sessionKey` lane. Restoring the session does not re-enable those jobs; use `openclaw cron enable <jobId>`. Sessions with an enabled bound job show a clock badge in the Control UI sidebar.
+
 `openclaw cron run <jobId>` returns after enqueueing the manual run. Use `--wait` for shutdown hooks, maintenance scripts, or other automation that must block until the queued run finishes; it polls the returned `runId` (default timeout `10m`, poll interval `2s`) and exits `0` for status `ok`, non-zero for `error`, `skipped`, or a wait timeout.
 
 The agent `cron` tool returns compact job summaries (`id`, `name`, `enabled`, `nextRunAtMs`, `scheduleKind`, `lastRunStatus`) from `cron(action: "list")`; use `cron(action: "get", jobId: "...")` for one full job definition. Direct Gateway callers can pass `compact: true` to `cron.list`; omitting it preserves the full response with delivery previews.

--- a/src/cron/job-session-bindings.test.ts
+++ b/src/cron/job-session-bindings.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  disableCronJobsBoundToSession,
+  resolveCronJobBoundSessionKeys,
+  type CronJobSessionBinding,
+} from "./job-session-bindings.js";
+import type { CronJob } from "./types.js";
+
+const cfg = {} as OpenClawConfig;
+
+function bindingKeys(job: CronJobSessionBinding, defaultAgentId?: string) {
+  return resolveCronJobBoundSessionKeys(job, { cfg, defaultAgentId });
+}
+
+describe("resolveCronJobBoundSessionKeys", () => {
+  test("isolated jobs bind their deterministic cron session", () => {
+    expect(bindingKeys({ id: "job1", sessionTarget: "isolated" })).toEqual(
+      new Set(["agent:main:cron:job1"]),
+    );
+  });
+
+  test("isolated jobs keep the deterministic run session plus the sessionKey lane", () => {
+    expect(
+      bindingKeys({
+        id: "job1",
+        agentId: "ops",
+        sessionKey: "discord:channel:99",
+        sessionTarget: "isolated",
+      }),
+    ).toEqual(new Set(["agent:ops:cron:job1", "agent:ops:discord:channel:99"]));
+  });
+
+  test("persisted current targets bind the deterministic run session", () => {
+    expect(bindingKeys({ id: "job1", sessionTarget: "current" })).toEqual(
+      new Set(["agent:main:cron:job1"]),
+    );
+  });
+
+  test("main-target jobs bind the agent main session", () => {
+    expect(bindingKeys({ id: "job1", agentId: "ops", sessionTarget: "main" })).toEqual(
+      new Set(["agent:ops:main"]),
+    );
+  });
+
+  test("session targets scope unqualified keys to the job agent", () => {
+    expect(bindingKeys({ id: "job1", sessionTarget: "session:discord:group:dev" }, "ops")).toEqual(
+      new Set(["agent:ops:discord:group:dev"]),
+    );
+  });
+
+  test("session targets keep already-scoped keys on their own agent", () => {
+    expect(bindingKeys({ id: "job1", sessionTarget: "session:agent:ops:slack:group:x" })).toEqual(
+      new Set(["agent:ops:slack:group:x"]),
+    );
+  });
+
+  test("wake/delivery sessionKey lanes bind in addition to the run target", () => {
+    expect(
+      bindingKeys({
+        id: "job1",
+        sessionTarget: "main",
+        sessionKey: "discord:channel:123",
+      }),
+    ).toEqual(new Set(["agent:main:main", "agent:main:discord:channel:123"]));
+  });
+
+  test("malformed session targets bind nothing instead of throwing", () => {
+    expect(bindingKeys({ id: "job1", sessionTarget: "session: " })).toEqual(new Set());
+  });
+});
+
+describe("disableCronJobsBoundToSession", () => {
+  function job(partial: Partial<CronJob> & Pick<CronJob, "id">): CronJob {
+    return { enabled: true, sessionTarget: "isolated", ...partial } as CronJob;
+  }
+
+  type Precondition = (job: CronJob, nowMs: number) => void | Promise<void>;
+
+  function fakeUpdateWithPrecondition(currentJobs: () => CronJob[]) {
+    return vi.fn(async (id: string, _patch: unknown, precondition: Precondition) => {
+      const current = currentJobs().find((candidate) => candidate.id === id);
+      if (!current) {
+        throw new Error(`cron job not found: ${id}`);
+      }
+      await precondition(current, 0);
+      return current;
+    });
+  }
+
+  test("disables only enabled jobs bound to the archived session", async () => {
+    const jobs = [
+      job({ id: "bound" }),
+      job({ id: "other", sessionTarget: "session:agent:main:other" }),
+      // Bound to the same session but already disabled; must not be re-patched.
+      job({ id: "already-off", enabled: false, sessionKey: "cron:bound" }),
+    ];
+    const update = fakeUpdateWithPrecondition(() => jobs);
+    const disabled = await disableCronJobsBoundToSession({
+      cron: {
+        list: async () => jobs,
+        updateWithPrecondition: update,
+        getDefaultAgentId: () => "main",
+      },
+      cfg,
+      sessionKey: "agent:main:cron:bound",
+    });
+    expect(disabled).toEqual(["bound"]);
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update.mock.calls[0]?.slice(0, 2)).toEqual(["bound", { enabled: false }]);
+  });
+
+  test("returns empty when nothing is bound", async () => {
+    const update = fakeUpdateWithPrecondition(() => [job({ id: "elsewhere" })]);
+    const disabled = await disableCronJobsBoundToSession({
+      cron: {
+        list: async () => [job({ id: "elsewhere" })],
+        updateWithPrecondition: update,
+        getDefaultAgentId: () => undefined,
+      },
+      cfg,
+      sessionKey: "agent:main:slack:group:x",
+    });
+    expect(disabled).toEqual([]);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("skips jobs retargeted between the list snapshot and the locked update", async () => {
+    const listed = [job({ id: "bound" })];
+    // The locked current job now targets a different session.
+    const retargeted = [job({ id: "bound", sessionTarget: "session:agent:main:elsewhere" })];
+    const update = fakeUpdateWithPrecondition(() => retargeted);
+    const disabled = await disableCronJobsBoundToSession({
+      cron: {
+        list: async () => listed,
+        updateWithPrecondition: update,
+        getDefaultAgentId: () => "main",
+      },
+      cfg,
+      sessionKey: "agent:main:cron:bound",
+    });
+    expect(disabled).toEqual([]);
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failing job does not abort the remaining bound jobs", async () => {
+    const listed = [job({ id: "vanished", sessionKey: "cron:bound" }), job({ id: "bound" })];
+    // "vanished" was removed concurrently; the fake only knows "bound".
+    const update = fakeUpdateWithPrecondition(() => [job({ id: "bound" })]);
+    await expect(
+      disableCronJobsBoundToSession({
+        cron: {
+          list: async () => listed,
+          updateWithPrecondition: update,
+          getDefaultAgentId: () => "main",
+        },
+        cfg,
+        sessionKey: "agent:main:cron:bound",
+      }),
+    ).rejects.toThrow(AggregateError);
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(update.mock.calls.map((call) => call[0])).toEqual(["vanished", "bound"]);
+  });
+});

--- a/src/cron/job-session-bindings.ts
+++ b/src/cron/job-session-bindings.ts
@@ -1,0 +1,113 @@
+/** Maps cron jobs to the canonical session-store keys they are bound to. */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { resolveCronAgentSessionKey } from "./isolated-agent/session-key.js";
+import type { CronServiceContract } from "./service-contract.js";
+import { resolveCronSessionTargetSessionKey } from "./session-target.js";
+import type { CronJob } from "./types.js";
+
+export type CronJobSessionBinding = Pick<
+  CronJob,
+  "id" | "agentId" | "sessionKey" | "sessionTarget"
+>;
+
+/**
+ * Resolves every canonical session key a job is bound to: the session the run
+ * joins (main/isolated/session:<key>) plus the explicit wake/delivery lane in
+ * job.sessionKey. Keys use the same canonicalization as cron run/session
+ * creation, so they compare equal to gateway session-store row keys.
+ */
+export function resolveCronJobBoundSessionKeys(
+  job: CronJobSessionBinding,
+  opts: { cfg: OpenClawConfig; defaultAgentId?: string },
+): Set<string> {
+  const agentId = normalizeAgentId(job.agentId ?? opts.defaultAgentId);
+  const keys = new Set<string>();
+  const add = (sessionKey: string | undefined) => {
+    const trimmed = sessionKey?.trim();
+    if (!trimmed) {
+      return;
+    }
+    keys.add(
+      resolveCronAgentSessionKey({
+        sessionKey: trimmed,
+        agentId,
+        mainKey: opts.cfg.session?.mainKey,
+        cfg: opts.cfg,
+      }),
+    );
+  };
+  try {
+    if (job.sessionTarget === "main") {
+      add("main");
+    } else if (job.sessionTarget === "isolated" || job.sessionTarget === "current") {
+      // Gateway execution runs isolated jobs — and stale persisted "current"
+      // targets, which patches can store un-resolved — in the deterministic
+      // cron:<jobId> session (server-cron.ts falls back to it for non-session
+      // targets); job.sessionKey is only a delivery/wake lane, added below.
+      add(`cron:${job.id}`);
+    } else {
+      add(resolveCronSessionTargetSessionKey(job.sessionTarget));
+    }
+    add(job.sessionKey);
+  } catch {
+    // Malformed persisted targets are quarantined by the store loader; a job
+    // that slips through must not break session listing, so bind nothing.
+    keys.clear();
+  }
+  return keys;
+}
+
+/** Signals a locked re-check found the job no longer bound; a per-job no-op. */
+class CronJobBindingStaleError extends Error {
+  constructor() {
+    super("cron job binding changed concurrently");
+  }
+}
+
+/**
+ * Disables every enabled cron job bound to a session, used when the session is
+ * archived so schedules stop targeting a lane that rejects new work.
+ * Returns the disabled job ids.
+ */
+export async function disableCronJobsBoundToSession(params: {
+  cron: Pick<CronServiceContract, "list" | "updateWithPrecondition" | "getDefaultAgentId">;
+  cfg: OpenClawConfig;
+  sessionKey: string;
+}): Promise<string[]> {
+  const jobs = await params.cron.list();
+  const defaultAgentId = params.cron.getDefaultAgentId();
+  const boundToSession = (job: CronJobSessionBinding & Pick<CronJob, "enabled">) =>
+    job.enabled &&
+    resolveCronJobBoundSessionKeys(job, { cfg: params.cfg, defaultAgentId }).has(params.sessionKey);
+  const disabled: string[] = [];
+  const failures: unknown[] = [];
+  for (const job of jobs) {
+    if (!boundToSession(job)) {
+      continue;
+    }
+    try {
+      // Re-check the binding under the store lock: a job retargeted after the
+      // list snapshot must not be disabled, and one failing/removed job must
+      // not abort the remaining bound jobs.
+      await params.cron.updateWithPrecondition(job.id, { enabled: false }, (currentJob) => {
+        if (!boundToSession(currentJob)) {
+          throw new CronJobBindingStaleError();
+        }
+      });
+      disabled.push(job.id);
+    } catch (error) {
+      if (error instanceof CronJobBindingStaleError) {
+        continue;
+      }
+      failures.push(error);
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `failed to disable ${failures.length} cron job(s) bound to ${params.sessionKey}`,
+    );
+  }
+  return disabled;
+}

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -142,6 +142,11 @@ export class CronService implements CronServiceContract {
     return this.state.store?.jobs.find((job) => job.id === id);
   }
 
+  /** In-memory job snapshot; undefined until the store is loaded. */
+  getLoadedJobs(): readonly CronJob[] | undefined {
+    return this.state.store?.jobs;
+  }
+
   async readJob(id: string): Promise<CronJob | undefined> {
     return await ops.readJob(this.state, id);
   }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -1804,16 +1804,18 @@ describe("buildGatewayCronService", () => {
         wakeMode: "next-heartbeat",
         payload: { kind: "agentTurn", message: "ping" },
       });
+      // Payload row fields depend on shared-process session-store state, so
+      // this test pins only the broadcast mechanism; hasAutomation projection
+      // is covered by session-utils and session-automation-index tests.
       const added = requireRecord(sessionsChanged().at(-1)?.[1], "added payload");
       expect(added.sessionKey).toBe("agent:main:probe");
       expect(added.reason).toBe("cron-binding");
-      expect(added.hasAutomation).toBe(true);
 
       broadcast.mockClear();
       await state.cron.update(job.id, { enabled: false });
       const disabled = requireRecord(sessionsChanged().at(-1)?.[1], "disabled payload");
       expect(disabled.sessionKey).toBe("agent:main:probe");
-      expect(disabled.hasAutomation).toBe(false);
+      expect(disabled.reason).toBe("cron-binding");
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -1770,6 +1770,54 @@ describe("buildGatewayCronService", () => {
       state.cron.stop();
     }
   });
+
+  it("broadcasts refreshed session rows when cron bindings change", async () => {
+    const cfg = createCronConfig("server-cron-binding-broadcast");
+    const sessionStorePath = path.join(
+      os.tmpdir(),
+      `server-cron-binding-broadcast-sessions-${Date.now()}`,
+      "sessions.json",
+    );
+    (cfg.session as { store?: string }).store = sessionStorePath;
+    const fs = await import("node:fs/promises");
+    await fs.mkdir(path.dirname(sessionStorePath), { recursive: true });
+    await fs.writeFile(
+      sessionStorePath,
+      JSON.stringify({
+        "agent:main:probe": { sessionId: "sess-probe", updatedAt: Date.now() },
+      }),
+      "utf-8",
+    );
+    loadConfigMock.mockReturnValue(cfg);
+    const broadcast = vi.fn();
+    const state = buildGatewayCronService({ cfg, deps: {} as CliDeps, broadcast });
+    try {
+      // The automation source registers on start (stale-reload safety).
+      await state.cron.start();
+      const sessionsChanged = () =>
+        broadcast.mock.calls.filter((call) => call[0] === "sessions.changed");
+      const job = await state.cron.add({
+        name: "bound schedule",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+        sessionTarget: "session:agent:main:probe",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "ping" },
+      });
+      const added = requireRecord(sessionsChanged().at(-1)?.[1], "added payload");
+      expect(added.sessionKey).toBe("agent:main:probe");
+      expect(added.reason).toBe("cron-binding");
+      expect(added.hasAutomation).toBe(true);
+
+      broadcast.mockClear();
+      await state.cron.update(job.id, { enabled: false });
+      const disabled = requireRecord(sessionsChanged().at(-1)?.[1], "disabled payload");
+      expect(disabled.sessionKey).toBe("agent:main:probe");
+      expect(disabled.hasAutomation).toBe(false);
+    } finally {
+      state.cron.stop();
+    }
+  });
 });
 
 describe("fireOnExitJob (on-exit fire routing)", () => {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -23,8 +23,9 @@ import { runCronCommandJob } from "../cron/command-runner.js";
 import { resolveCronStoredDeliveryContext } from "../cron/delivery-context.js";
 import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
+import { resolveCronJobBoundSessionKeys } from "../cron/job-session-bindings.js";
 import { appendCronRunLog, resolveCronRunLogPruneOptions } from "../cron/run-log.js";
-import { CronService } from "../cron/service.js";
+import { CronService, type CronEvent } from "../cron/service.js";
 import {
   resolveCronDeliverySessionKey,
   resolveCronSessionTargetSessionKey,
@@ -63,6 +64,14 @@ import {
   dispatchGatewayCronFinishedNotifications,
   sendGatewayCronFailureAlert,
 } from "./server-cron-notifications.js";
+import {
+  bumpSessionAutomationVersion,
+  claimSessionAutomationEpoch,
+  registerSessionAutomationSource,
+  unregisterSessionAutomationSource,
+} from "./session-automation-index.js";
+import { buildGatewaySessionEventFields } from "./session-event-payload.js";
+import { loadGatewaySessionRow } from "./session-utils.js";
 
 export type GatewayCronState = {
   cron: GatewayCronServiceContract;
@@ -414,6 +423,35 @@ export function buildGatewayCronService(params: {
     }
   };
 
+  // Cron job changes flip session automation badges; push refreshed rows so
+  // subscribed session lists update without waiting for unrelated session events.
+  const broadcastCronBoundSessionChanges = (evt: CronEvent) => {
+    const job = evt.job ?? cron.getJob(evt.jobId);
+    if (!job) {
+      return;
+    }
+    const boundKeys = resolveCronJobBoundSessionKeys(job, {
+      cfg: getRuntimeConfig(),
+      defaultAgentId: cron.getDefaultAgentId(),
+    });
+    for (const sessionKey of boundKeys) {
+      // Emit even without a stored row: clients run a canonical list refresh on
+      // every sessions.changed, which also clears badges on prior bindings
+      // (e.g. after retargeting a job to a not-yet-created session).
+      const sessionRow = loadGatewaySessionRow(sessionKey);
+      params.broadcast(
+        "sessions.changed",
+        {
+          sessionKey,
+          reason: "cron-binding",
+          ts: Date.now(),
+          ...(sessionRow ? buildGatewaySessionEventFields({ sessionRow }) : {}),
+        },
+        { dropIfSlow: true },
+      );
+    }
+  };
+
   const cron = new CronService({
     storePath,
     cronEnabled,
@@ -686,6 +724,9 @@ export function buildGatewayCronService(params: {
       }),
     log: getChildLogger({ module: "cron", storePath }),
     onEvent: (evt) => {
+      // Any job/store change can alter session automation bindings, including
+      // in-place enable flips during runs; run/schedule events bump too (cheap).
+      bumpSessionAutomationVersion();
       params.broadcast("cron", evt, { dropIfSlow: true });
       // Build hook event from CronEvent. The job snapshot is carried on the
       // internal event so it's available even for "removed" actions where
@@ -728,7 +769,16 @@ export function buildGatewayCronService(params: {
       runCronChangedHook(hookEvt);
       // Re-arm / cancel on-exit watchers when the job set changes.
       if (evt.action === "added" || evt.action === "updated" || evt.action === "removed") {
+        broadcastCronBoundSessionChanges(evt);
         void reconcileExitWatchers();
+      } else if (evt.action === "finished") {
+        // Runs can flip enabled without an "updated" event (one-shot success,
+        // trigger.once, schedule-error auto-disable); refresh badges then too.
+        // Fully deleted jobs emit their own "removed" event instead.
+        const finishedJob = evt.job ?? cron.getJob(evt.jobId);
+        if (finishedJob?.enabled === false) {
+          broadcastCronBoundSessionChanges(evt);
+        }
       }
       if (evt.action === "finished") {
         const job = evt.job ?? cron.getJob(evt.jobId);
@@ -804,10 +854,33 @@ export function buildGatewayCronService(params: {
     exitWatcherGeneration += 1;
     exitWatchersRef.current?.cancelAll();
   };
+  const automationSource = {
+    getJobs: () => cron.getLoadedJobs(),
+    getDefaultAgentId: () => cron.getDefaultAgentId(),
+  };
+  const automationEpoch = claimSessionAutomationEpoch();
   const stopCron = cron.stop.bind(cron);
   cron.stop = () => {
     stopCron();
     stopExitWatchers();
+    // Session rows must stop reporting automation from a stopped scheduler,
+    // but a reload's replacement service may already own the registration.
+    unregisterSessionAutomationSource(automationSource);
+  };
+  const startCron = cron.start.bind(cron);
+  cron.start = async () => {
+    await startCron();
+    // Register only once started, under the build-time epoch, so a stale lazy
+    // service resolving after a config reload cannot clobber the replacement.
+    registerSessionAutomationSource(automationSource, automationEpoch);
+    // Nudge subscribed clients into a canonical list refresh so automation
+    // badges match this scheduler's bindings — including clearing them when a
+    // reload lands on an empty or disabled store.
+    params.broadcast(
+      "sessions.changed",
+      { reason: "cron-bindings-loaded", ts: Date.now() },
+      { dropIfSlow: true },
+    );
   };
 
   return {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -70,6 +70,7 @@ import {
   trimSessionTranscriptForManualCompact,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { disableCronJobsBoundToSession } from "../../cron/job-session-bindings.js";
 import {
   measureDiagnosticsTimelineSpan,
   measureDiagnosticsTimelineSpanSync,
@@ -2311,6 +2312,35 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       sessionKey: target.canonicalKey ?? key,
       patch: p,
     });
+
+    // Cron mutations are operator.admin surface while archive is write-scoped;
+    // only cascade for internal callers (client == null) or admin operators so
+    // write-scoped archiving cannot flip admin-managed schedules.
+    const callerScopes = client?.connect ? (client.connect.scopes ?? []) : null;
+    const callerCanManageCron = callerScopes === null || callerScopes.includes(ADMIN_SCOPE);
+    if (p.archived === true && callerCanManageCron) {
+      // Archived sessions reject new work, so schedules bound to them would
+      // only accumulate failing runs; disable them with the archive.
+      try {
+        const disabledJobIds = await disableCronJobsBoundToSession({
+          cron: context.cron,
+          cfg,
+          sessionKey: target.canonicalKey ?? key,
+        });
+        if (disabledJobIds.length > 0) {
+          log.info(
+            `sessions.patch: disabled cron jobs bound to archived session ${target.canonicalKey ?? key}: ${disabledJobIds.join(", ")}`,
+          );
+        }
+      } catch (error) {
+        // Best-effort by design: archive is the primary action and must not
+        // fail or roll back on cron-store errors. Any job left enabled fails
+        // closed at run start because archived sessions reject new work.
+        log.warn(
+          `sessions.patch: failed to disable cron jobs for archived session ${target.canonicalKey ?? key}: ${formatErrorMessage(error)}`,
+        );
+      }
+    }
 
     // Absorb ad-hoc categories into the gateway group catalog so ordering
     // covers every group an operator UI can observe.

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -9,6 +9,7 @@ import {
   loadTranscriptEvents,
   persistSessionTranscriptTurn,
 } from "../config/sessions/session-accessor.js";
+import type { CronJob } from "../cron/types.js";
 import { agentDiscoveryMock, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq as directSessionHandlerReq,
@@ -885,4 +886,71 @@ test("sessions.list breaks timestamp ties by key for stable paging", async () =>
   );
   expect(paged.ok).toBe(true);
   expect(paged.payload?.sessions.map((session) => session.key)).toEqual(expectedOrder.slice(2));
+});
+
+test("archiving a session disables cron jobs bound to it", async () => {
+  await createSessionStoreDir();
+  const now = Date.now();
+  await writeSessionStore({
+    entries: {
+      main: { sessionId: "sess-main", updatedAt: now },
+      "agent:main:subagent:cronbound": {
+        sessionId: "sess-bound",
+        updatedAt: now,
+        spawnedBy: "agent:main:main",
+      },
+    },
+  });
+  const jobs = [
+    { id: "bound", enabled: true, sessionTarget: "session:agent:main:subagent:cronbound" },
+    { id: "elsewhere", enabled: true, sessionTarget: "isolated" },
+  ] as unknown as CronJob[];
+  const update = vi.fn(
+    async (id: string, _patch: unknown, precondition: (job: CronJob, nowMs: number) => void) => {
+      const current = jobs.find((candidate) => candidate.id === id);
+      if (!current) {
+        throw new Error(`cron job not found: ${id}`);
+      }
+      precondition(current, Date.now());
+      return current;
+    },
+  );
+  const cron = {
+    list: async () => jobs,
+    updateWithPrecondition: update,
+    getDefaultAgentId: () => "main",
+  };
+
+  const archived = await directSessionHandlerReq(
+    "sessions.patch",
+    { key: "agent:main:subagent:cronbound", archived: true },
+    { context: { cron } },
+  );
+  expect(archived.ok).toBe(true);
+  expect(update.mock.calls.map((call) => call.slice(0, 2))).toEqual([
+    ["bound", { enabled: false }],
+  ]);
+
+  // Restoring must not silently re-arm schedules that archive disabled.
+  update.mockClear();
+  const restored = await directSessionHandlerReq(
+    "sessions.patch",
+    { key: "agent:main:subagent:cronbound", archived: false },
+    { context: { cron } },
+  );
+  expect(restored.ok).toBe(true);
+  expect(update).not.toHaveBeenCalled();
+
+  // Cron mutations are admin surface: a write-scoped operator can archive but
+  // must not cascade into disabling admin-managed schedules.
+  const writeScopedClient = {
+    connect: { scopes: ["operator.write"] },
+  } as unknown as NonNullable<Parameters<typeof directSessionHandlerReq>[2]>["client"];
+  const writeScopedArchive = await directSessionHandlerReq(
+    "sessions.patch",
+    { key: "agent:main:subagent:cronbound", archived: true },
+    { context: { cron }, client: writeScopedClient },
+  );
+  expect(writeScopedArchive.ok).toBe(true);
+  expect(update).not.toHaveBeenCalled();
 });

--- a/src/gateway/session-automation-index.test.ts
+++ b/src/gateway/session-automation-index.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { CronJob } from "../cron/types.js";
+import {
+  bumpSessionAutomationVersion,
+  claimSessionAutomationEpoch,
+  registerSessionAutomationSource,
+  sessionHasAutomation,
+  unregisterSessionAutomationSource,
+} from "./session-automation-index.js";
+
+const cfg = {} as OpenClawConfig;
+
+function job(partial: Partial<CronJob> & Pick<CronJob, "id">): CronJob {
+  return { enabled: true, sessionTarget: "isolated", ...partial } as CronJob;
+}
+
+afterEach(() => {
+  registerSessionAutomationSource(null);
+});
+
+describe("session automation index", () => {
+  test("reports sessions bound to enabled jobs", () => {
+    const jobs = [job({ id: "a" }), job({ id: "b", enabled: false })];
+    registerSessionAutomationSource({
+      getJobs: () => jobs,
+      getDefaultAgentId: () => "main",
+    });
+    expect(sessionHasAutomation("agent:main:cron:a", cfg)).toBe(true);
+    expect(sessionHasAutomation("agent:main:cron:b", cfg)).toBe(false);
+    expect(sessionHasAutomation("agent:main:main", cfg)).toBe(false);
+  });
+
+  test("version bumps invalidate the memo after in-place job mutations", () => {
+    const jobs = [job({ id: "a" })];
+    registerSessionAutomationSource({
+      getJobs: () => jobs,
+      getDefaultAgentId: () => "main",
+    });
+    expect(sessionHasAutomation("agent:main:cron:a", cfg)).toBe(true);
+    (jobs[0] as { enabled: boolean }).enabled = false;
+    bumpSessionAutomationVersion();
+    expect(sessionHasAutomation("agent:main:cron:a", cfg)).toBe(false);
+  });
+
+  test("unregistering the source clears automation state", () => {
+    registerSessionAutomationSource({
+      getJobs: () => [job({ id: "a" })],
+      getDefaultAgentId: () => "main",
+    });
+    expect(sessionHasAutomation("agent:main:cron:a", cfg)).toBe(true);
+    registerSessionAutomationSource(null);
+    expect(sessionHasAutomation("agent:main:cron:a", cfg)).toBe(false);
+  });
+
+  test("reports false before the cron store is loaded", () => {
+    registerSessionAutomationSource({
+      getJobs: () => undefined,
+      getDefaultAgentId: () => "main",
+    });
+    expect(sessionHasAutomation("agent:main:cron:a", cfg)).toBe(false);
+  });
+
+  test("stale services cannot clobber or clear a replacement registration", () => {
+    const staleEpoch = claimSessionAutomationEpoch();
+    const staleSource = {
+      getJobs: () => [job({ id: "stale" })],
+      getDefaultAgentId: () => "main",
+    };
+    const freshEpoch = claimSessionAutomationEpoch();
+    const freshSource = {
+      getJobs: () => [job({ id: "fresh" })],
+      getDefaultAgentId: () => "main",
+    };
+    registerSessionAutomationSource(freshSource, freshEpoch);
+    // Config-reload race: the older service's start resolves late.
+    registerSessionAutomationSource(staleSource, staleEpoch);
+    expect(sessionHasAutomation("agent:main:cron:fresh", cfg)).toBe(true);
+    expect(sessionHasAutomation("agent:main:cron:stale", cfg)).toBe(false);
+    unregisterSessionAutomationSource(staleSource);
+    expect(sessionHasAutomation("agent:main:cron:fresh", cfg)).toBe(true);
+    unregisterSessionAutomationSource(freshSource);
+    expect(sessionHasAutomation("agent:main:cron:fresh", cfg)).toBe(false);
+  });
+});

--- a/src/gateway/session-automation-index.ts
+++ b/src/gateway/session-automation-index.ts
@@ -1,0 +1,101 @@
+/** Process-local index of session keys that enabled cron jobs are bound to. */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCronJobBoundSessionKeys } from "../cron/job-session-bindings.js";
+import type { CronJob } from "../cron/types.js";
+
+export type SessionAutomationSource = {
+  /** Current in-memory cron jobs; undefined until the cron store is loaded. */
+  getJobs: () => readonly CronJob[] | undefined;
+  getDefaultAgentId: () => string | undefined;
+};
+
+let source: SessionAutomationSource | null = null;
+// Bumped on every cron service event so in-place job mutations (enable/disable,
+// auto-disable during runs) invalidate the memo even when the array identity
+// and config reference stay stable.
+let sourceVersion = 0;
+let epochCounter = 0;
+let registeredEpoch = 0;
+
+let memo: {
+  jobs: readonly CronJob[];
+  version: number;
+  cfg: OpenClawConfig;
+  keys: ReadonlySet<string>;
+} | null = null;
+
+/**
+ * Claimed at cron service build time so registration authority follows build
+ * order: a stale service whose start resolves after a config reload cannot
+ * clobber the replacement's registration.
+ */
+export function claimSessionAutomationEpoch(): number {
+  return ++epochCounter;
+}
+
+/** Registered by the gateway cron owner; newer epochs win over stale services. */
+export function registerSessionAutomationSource(
+  next: SessionAutomationSource | null,
+  epoch?: number,
+): void {
+  const effectiveEpoch = epoch ?? claimSessionAutomationEpoch();
+  if (effectiveEpoch < registeredEpoch) {
+    return;
+  }
+  registeredEpoch = effectiveEpoch;
+  source = next;
+  memo = null;
+  sourceVersion += 1;
+}
+
+/**
+ * Owner-compare unregistration: a stopped cron service must not clear a
+ * replacement's registration when config reloads race the lazy service build.
+ */
+export function unregisterSessionAutomationSource(owner: SessionAutomationSource): void {
+  if (source !== owner) {
+    return;
+  }
+  source = null;
+  memo = null;
+  sourceVersion += 1;
+}
+
+/** Called from the cron onEvent hook after any job/store change. */
+export function bumpSessionAutomationVersion(): void {
+  sourceVersion += 1;
+}
+
+function buildAutomationKeys(
+  jobs: readonly CronJob[],
+  cfg: OpenClawConfig,
+  defaultAgentId: string | undefined,
+): ReadonlySet<string> {
+  const keys = new Set<string>();
+  for (const job of jobs) {
+    if (!job.enabled) {
+      continue;
+    }
+    for (const key of resolveCronJobBoundSessionKeys(job, { cfg, defaultAgentId })) {
+      keys.add(key);
+    }
+  }
+  return keys;
+}
+
+/** True when an enabled cron job is bound to the canonical session key. */
+export function sessionHasAutomation(sessionKey: string, cfg: OpenClawConfig): boolean {
+  const jobs = source?.getJobs();
+  if (!source || !jobs || jobs.length === 0) {
+    return false;
+  }
+  if (!memo || memo.jobs !== jobs || memo.version !== sourceVersion || memo.cfg !== cfg) {
+    memo = {
+      jobs,
+      version: sourceVersion,
+      cfg,
+      keys: buildAutomationKeys(jobs, cfg, source.getDefaultAgentId()),
+    };
+  }
+  return memo.keys.has(sessionKey);
+}

--- a/src/gateway/session-event-payload.ts
+++ b/src/gateway/session-event-payload.ts
@@ -81,6 +81,8 @@ export function buildGatewaySessionEventFields(params: {
     model: sessionRow.model,
     agentRuntime: sessionRow.agentRuntime,
     status: sessionRow.status,
+    // Explicit false lets subscribed clients drop the flag during merge-reconcile.
+    hasAutomation: sessionRow.hasAutomation ?? false,
     ...(params.hasActiveRun === undefined ? {} : { hasActiveRun: params.hasActiveRun }),
     ...(params.activeRunIds === undefined ? {} : { activeRunIds: params.activeRunIds }),
     startedAt: sessionRow.startedAt,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -12,11 +12,14 @@ import {
   appendTranscriptMessageSync,
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
+import type { CronJob } from "../cron/types.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withStateDirEnv as withRawStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { registerSessionAutomationSource } from "./session-automation-index.js";
+import { buildGatewaySessionEventFields } from "./session-event-payload.js";
 import {
   canonicalizeSpawnedByForAgent,
   buildGatewaySessionRow,
@@ -488,6 +491,39 @@ describe("gateway session utils", () => {
     ]);
     expect(defaults.thinkingDefault).toBe("medium");
     expect(row.thinkingDefault).toBe("medium");
+  });
+
+  test("session rows project automation bindings and event fields forward them", () => {
+    const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
+    registerSessionAutomationSource({
+      getJobs: () => [{ id: "job1", enabled: true, sessionTarget: "isolated" } as CronJob],
+      getDefaultAgentId: () => "main",
+    });
+    try {
+      const bound = buildGatewaySessionRow({
+        cfg,
+        storePath: "",
+        store: {},
+        key: "agent:main:cron:job1",
+        lightweightListRow: true,
+        skipTranscriptUsageFallback: true,
+      });
+      expect(bound.hasAutomation).toBe(true);
+      expect(buildGatewaySessionEventFields({ sessionRow: bound }).hasAutomation).toBe(true);
+
+      const plain = buildGatewaySessionRow({
+        cfg,
+        storePath: "",
+        store: {},
+        key: "agent:main:other",
+        lightweightListRow: true,
+        skipTranscriptUsageFallback: true,
+      });
+      expect(plain.hasAutomation).toBeUndefined();
+      expect(buildGatewaySessionEventFields({ sessionRow: plain }).hasAutomation).toBe(false);
+    } finally {
+      registerSessionAutomationSource(null);
+    }
   });
 
   test("session rows ignore malformed compaction checkpoints", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -103,6 +103,7 @@ import { normalizeSessionDeliveryFields } from "../utils/delivery-context.shared
 import type { ModelCostConfig } from "../utils/usage-format.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 import { listGatewayAgentIds } from "./agent-list.js";
+import { sessionHasAutomation } from "./session-automation-index.js";
 import {
   resolveSessionStoreAgentId,
   resolveSessionStoreKey,
@@ -2261,6 +2262,7 @@ export function buildGatewaySessionRow(params: {
     goal,
     estimatedCostUsd,
     status: subagentRun ? subagentStatus : entry?.status,
+    hasAutomation: sessionHasAutomation(key, cfg) ? true : undefined,
     subagentRunState,
     hasActiveSubagentRun: subagentRun ? liveSubagentRunActive : undefined,
     startedAt: subagentRun ? subagentStartedAt : entry?.startedAt,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -99,6 +99,8 @@ export type GatewaySessionRow = {
   status?: SessionRunStatus;
   hasActiveRun?: boolean;
   activeRunIds?: string[];
+  /** An enabled cron job is bound to this session (runs in it or delivers to it). */
+  hasAutomation?: boolean;
   subagentRunState?: SubagentRunState;
   hasActiveSubagentRun?: boolean;
   startedAt?: number;

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -522,6 +522,8 @@ export type GatewaySessionRow = {
   status?: SessionRunStatus;
   hasActiveRun?: boolean;
   activeRunIds?: string[];
+  /** An enabled cron job is bound to this session (runs in it or delivers to it). */
+  hasAutomation?: boolean;
   subagentRunState?: SubagentRunState;
   hasActiveSubagentRun?: boolean;
   startedAt?: number;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -115,6 +115,7 @@ type SidebarRecentSession = {
   channelSession?: boolean;
   workSession?: boolean;
   worktreeId?: string;
+  hasAutomation: boolean;
   unread: boolean;
 };
 
@@ -897,6 +898,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
         channelSession: channelInfo.channelSession,
         workSession: Boolean(row.worktree || row.execNode),
         worktreeId: row.worktree?.id,
+        hasAutomation: row.hasAutomation === true,
         unread: row.unread === true,
       };
     };
@@ -2098,31 +2100,51 @@ class AppSidebar extends OpenClawLightDomContentsElement {
           title=${`${session.label} · ${session.key}`}
           @click=${(event: MouseEvent) => this.handleSessionRowClick(event, session)}
         >
-          ${session.unread
+          ${session.hasActiveRun
             ? html`<span
-                class="session-unread-dot sidebar-recent-session__unread"
+                class="session-run-spinner sidebar-recent-session__state"
                 role="img"
-                aria-label=${t("sessionsView.unread")}
+                aria-label=${t("sessionsView.activeRun")}
+                title=${t("sessionsView.activeRun")}
               ></span>`
-            : nothing}
+            : session.unread
+              ? html`<span
+                  class="session-unread-dot sidebar-recent-session__unread"
+                  role="img"
+                  aria-label=${t("sessionsView.unread")}
+                ></span>`
+              : nothing}
           <span class="sidebar-recent-session__text">
             <span class="sidebar-recent-session__name hover-marquee">${session.label}</span>
             ${session.subtitle && session.workSession && session.subtitle !== session.label
               ? html`<span class="sidebar-recent-session__subtitle">${session.subtitle}</span>`
               : nothing}
           </span>
+          ${session.worktreeId || session.hasAutomation
+            ? html`<span class="session-row-badges">
+                ${session.worktreeId
+                  ? html`<span
+                      class="session-row-badge"
+                      role="img"
+                      aria-label=${t("sessionsView.worktreeSession")}
+                      title=${t("sessionsView.worktreeSession")}
+                      >${icons.gitBranch}</span
+                    >`
+                  : nothing}
+                ${session.hasAutomation
+                  ? html`<span
+                      class="session-row-badge"
+                      role="img"
+                      aria-label=${t("sessionsView.automationAttached")}
+                      title=${t("sessionsView.automationAttached")}
+                      >${icons.clock}</span
+                    >`
+                  : nothing}
+              </span>`
+            : nothing}
         </a>
         <span class="sidebar-recent-session__aside session-row-aside">
-          <span class="session-row-trail">
-            ${session.hasActiveRun
-              ? html`<span
-                  class="session-run-spinner"
-                  role="img"
-                  aria-label=${t("sessionsView.activeRun")}
-                  title=${t("sessionsView.activeRun")}
-                ></span>`
-              : session.meta}
-          </span>
+          <span class="session-row-trail">${session.meta}</span>
           <span class="session-row-actions">
             <button
               class="session-action session-action--pin"

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:18.732Z",
+  "generatedAt": "2026-07-12T05:11:44.046Z",
   "locale": "ar",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:11.246Z",
+  "generatedAt": "2026-07-12T05:11:42.848Z",
   "locale": "de",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:12.293Z",
+  "generatedAt": "2026-07-12T05:11:43.049Z",
   "locale": "es",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:33.686Z",
+  "generatedAt": "2026-07-12T05:11:45.834Z",
   "locale": "fa",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:15.951Z",
+  "generatedAt": "2026-07-12T05:11:43.627Z",
   "locale": "fr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:17.330Z",
+  "generatedAt": "2026-07-12T05:11:43.829Z",
   "locale": "hi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:25.713Z",
+  "generatedAt": "2026-07-12T05:11:44.848Z",
   "locale": "id",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:19.934Z",
+  "generatedAt": "2026-07-12T05:11:44.243Z",
   "locale": "it",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:13.469Z",
+  "generatedAt": "2026-07-12T05:11:43.224Z",
   "locale": "ja-JP",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:14.691Z",
+  "generatedAt": "2026-07-12T05:11:43.428Z",
   "locale": "ko",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:32.505Z",
+  "generatedAt": "2026-07-12T05:11:45.631Z",
   "locale": "nl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:28.120Z",
+  "generatedAt": "2026-07-12T05:11:45.047Z",
   "locale": "pl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:09.898Z",
+  "generatedAt": "2026-07-12T05:11:42.648Z",
   "locale": "pt-BR",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -689,6 +689,13 @@
     },
     {
       "count": 1,
+      "kind": "html-attribute",
+      "name": "title",
+      "path": "ui/src/components/mcp-app-view.ts",
+      "text": "MCP App"
+    },
+    {
+      "count": 1,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/components/settings-sidebar.ts",

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:35.588Z",
+  "generatedAt": "2026-07-12T05:11:46.031Z",
   "locale": "ru",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:29.529Z",
+  "generatedAt": "2026-07-12T05:11:45.235Z",
   "locale": "th",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:21.643Z",
+  "generatedAt": "2026-07-12T05:11:44.448Z",
   "locale": "tr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:24.468Z",
+  "generatedAt": "2026-07-12T05:11:44.646Z",
   "locale": "uk",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:31.263Z",
+  "generatedAt": "2026-07-12T05:11:45.437Z",
   "locale": "vi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:07.396Z",
+  "generatedAt": "2026-07-12T05:11:42.231Z",
   "locale": "zh-CN",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-12T02:11:08.760Z",
+  "generatedAt": "2026-07-12T05:11:42.449Z",
   "locale": "zh-TW",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "b6b86c547b6ee69d83dda0429eb57f67b4e9489321ed43dcfc57e1227315851e",
+  "totalKeys": 2121,
+  "translatedKeys": 2121,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -307,6 +307,8 @@ export const ar: TranslationMap = {
     archived: "مؤرشف",
     pinned: "مثبّتة",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "إعادة تسمية الجلسة",
     renameSessionPrompt: "إعادة تسمية الجلسة",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -311,6 +311,8 @@ export const de: TranslationMap = {
     archived: "Archiviert",
     pinned: "Angeheftet",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Sitzung umbenennen",
     renameSessionPrompt: "Sitzung umbenennen",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -306,6 +306,8 @@ export const en: TranslationMap = {
     archived: "Archived",
     pinned: "Pinned",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Rename session",
     renameSessionPrompt: "Rename session",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -309,6 +309,8 @@ export const es: TranslationMap = {
     archived: "Archivada",
     pinned: "Fijadas",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Cambiar nombre de la sesión",
     renameSessionPrompt: "Cambiar nombre de la sesión",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -309,6 +309,8 @@ export const fa: TranslationMap = {
     archived: "بایگانی‌شده",
     pinned: "سنجاق‌شده",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "تغییر نام نشست",
     renameSessionPrompt: "تغییر نام نشست",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -314,6 +314,8 @@ export const fr: TranslationMap = {
     archived: "Archivée",
     pinned: "Épinglée",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Renommer la session",
     renameSessionPrompt: "Renommer la session",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -308,6 +308,8 @@ export const hi: TranslationMap = {
     archived: "आर्काइव किया गया",
     pinned: "पिन किया गया",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "सत्र का नाम बदलें",
     renameSessionPrompt: "सत्र का नाम बदलें",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -308,6 +308,8 @@ export const id: TranslationMap = {
     archived: "Diarsipkan",
     pinned: "Disematkan",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Ganti nama sesi",
     renameSessionPrompt: "Ganti nama sesi",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -311,6 +311,8 @@ export const it: TranslationMap = {
     archived: "Archiviata",
     pinned: "Fissate",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Rinomina sessione",
     renameSessionPrompt: "Rinomina sessione",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -313,6 +313,8 @@ export const ja_JP: TranslationMap = {
     archived: "アーカイブ済み",
     pinned: "ピン留め済み",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "セッション名を変更",
     renameSessionPrompt: "セッション名を変更",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -307,6 +307,8 @@ export const ko: TranslationMap = {
     archived: "보관됨",
     pinned: "고정됨",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "세션 이름 변경",
     renameSessionPrompt: "세션 이름 변경",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -311,6 +311,8 @@ export const nl: TranslationMap = {
     archived: "Gearchiveerd",
     pinned: "Vastgezet",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Sessie hernoemen",
     renameSessionPrompt: "Sessie hernoemen",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -310,6 +310,8 @@ export const pl: TranslationMap = {
     archived: "Zarchiwizowano",
     pinned: "Przypięte",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Zmień nazwę sesji",
     renameSessionPrompt: "Zmień nazwę sesji",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -308,6 +308,8 @@ export const pt_BR: TranslationMap = {
     archived: "Arquivada",
     pinned: "Fixadas",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Renomear sessão",
     renameSessionPrompt: "Renomear sessão",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -311,6 +311,8 @@ export const ru: TranslationMap = {
     archived: "В архиве",
     pinned: "Закреплено",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Переименовать сеанс",
     renameSessionPrompt: "Переименовать сеанс",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -306,6 +306,8 @@ export const th: TranslationMap = {
     archived: "เก็บถาวรแล้ว",
     pinned: "ปักหมุดแล้ว",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "เปลี่ยนชื่อเซสชัน",
     renameSessionPrompt: "เปลี่ยนชื่อเซสชัน",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -312,6 +312,8 @@ export const tr: TranslationMap = {
     archived: "Arşivlendi",
     pinned: "Sabitlenmiş",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Oturumu yeniden adlandır",
     renameSessionPrompt: "Oturumu yeniden adlandır",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -309,6 +309,8 @@ export const uk: TranslationMap = {
     archived: "Архівовано",
     pinned: "Закріплено",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Перейменувати сеанс",
     renameSessionPrompt: "Перейменувати сеанс",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -308,6 +308,8 @@ export const vi: TranslationMap = {
     archived: "Đã lưu trữ",
     pinned: "Đã ghim",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "Đổi tên phiên",
     renameSessionPrompt: "Đổi tên phiên",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -306,6 +306,8 @@ export const zh_CN: TranslationMap = {
     archived: "已归档",
     pinned: "已置顶",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "重命名会话",
     renameSessionPrompt: "重命名会话",
     renameSessionMenu: "Rename…",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -306,6 +306,8 @@ export const zh_TW: TranslationMap = {
     archived: "已封存",
     pinned: "已釘選",
     unread: "Unread",
+    worktreeSession: "Worktree session",
+    automationAttached: "Automation attached",
     renameSession: "重新命名工作階段",
     renameSessionPrompt: "重新命名工作階段",
     renameSessionMenu: "Rename…",

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -6067,9 +6067,10 @@ td.data-table-key-col {
 
 /* ── Session row primitives ──
    Shared by the sidebar recents list and the chat session picker. Rows read
-   as plain text lines: the trailing aside stacks a relative time (or the run
-   spinner) and the management actions in one grid cell, so hovering swaps
-   them without any layout shift. */
+   as plain text lines: transient state (run spinner, unread dot) leads the
+   title, attribute badges follow it, and the trailing aside stacks a relative
+   time and the management actions in one grid cell, so hovering swaps them
+   without any layout shift. */
 .session-row-host {
   position: relative;
 }
@@ -6109,6 +6110,32 @@ td.data-table-key-col {
   /* Display-only, and its opacity transition forms a stacking context that
      would otherwise sit above the action buttons and swallow their clicks. */
   pointer-events: none;
+}
+
+/* Attribute badges (worktree fork, attached automation): muted metadata that
+   sits after the title inside the row link, outside the trail/action overlap
+   cell, so touch devices (which hide the trail) and hovered rows keep them. */
+.session-row-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.session-row-badge {
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted);
+}
+
+.session-row-badge svg {
+  width: 12px;
+  height: 12px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.6px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .session-row-actions {


### PR DESCRIPTION
Closes #104700

## What Problem This Solves

The Control UI sidebar gave almost no at-a-glance session context: only an unread dot, plus a run spinner that displaced the timestamp. There was no way to see which sessions are backed by a git worktree or have an automation (cron job) attached. Worse, archiving a session left bound cron jobs enabled — the archived session rejects new work, so those schedules just accumulated failing runs.

## Why This Change Was Made

- Sidebar rows now lead with a transient-state slot (run spinner while active, else the unread dot) so "needs attention" state sits left of the title and the timestamp stays visible during runs.
- Muted attribute badges ride in the timestamp trail: a fork icon for worktree-bound sessions, a clock icon for sessions with an enabled cron job bound to them.
- The gateway exposes `hasAutomation` on session rows (list + live `sessions.changed` merges), derived from a lifecycle-owned index over the cron service's in-memory jobs (`src/gateway/session-automation-index.ts`, bindings resolver in `src/cron/job-session-bindings.ts`). Cron add/update/remove events push refreshed rows so badges update live.
- `sessions.patch { archived: true }` disables enabled cron jobs bound to the session — gated to internal or operator-admin callers, since cron mutations are admin surface while archive itself is write-scoped. Restore intentionally does not re-enable jobs.

## User Impact

Sidebar sessions show working / unread state on the left and worktree / automation badges on the right (with tooltips, localized). Archiving a session from the Control UI stops its schedules instead of leaving them to fail silently. Write-scoped operators can still archive; they just don't cascade into admin-owned cron state.

## Evidence

- Screenshots (isolated dev gateway, seeded sessions + real cron job):
  - Sidebar with all indicators: https://artifacts.openclaw.ai/session-indicators-104700/sidebar-indicators.png
  - Full window: https://artifacts.openclaw.ai/session-indicators-104700/sidebar-indicators-full.png
  - Manifest: https://artifacts.openclaw.ai/session-indicators-104700/artifact-manifest.json
- Live E2E on a source-built gateway: `sessions.list` rows carried `hasAutomation`/`worktree`/`unread`; archiving via Control UI (admin scopes) flipped the bound job to `enabled: false` (verified via `cron.list`); the same archive via `openclaw gateway call` (least-privilege `operator.write`) correctly did not touch the job; restore did not re-enable it.
- Tests (Blacksmith Testbox via Crabbox): `src/cron/job-session-bindings.test.ts`, `src/gateway/session-automation-index.test.ts`, `src/gateway/session-utils.test.ts` (row projection + event fields), `src/gateway/server.sessions.store-rpc.test.ts` (archive cascade + scope gate + restore), `src/gateway/server-cron.test.ts` (live `sessions.changed` broadcast on binding changes), plus full `pnpm check:changed` (format/lint/typecheck lanes) — final green run on lease `tbx_01kx9jkkfw8m6hnb2ty78a1jfe` (Blacksmith Testbox via Crabbox), 612 tests passed, exit 0.
- Codex autoreview (gpt-5.6-sol, xhigh), six rounds. Fixed: write→admin scope crossing on the cascade; isolated-job binding key; live badge invalidation on cron changes (including run auto-disable, retarget-to-missing-row, startup/reload nudges); stale-service registration races (owner-compare unregister + build-epoch ordering); persisted `current` targets; TOCTOU on the cascade (locked binding re-check via `updateWithPrecondition`, per-job failure isolation); badges moved beside the title so pinned rows and touch devices (which hide the trail) keep them. Rejected with rationale: archive rollback on cron failure (cascade is best-effort by design — jobs left enabled fail closed at run start against the archived session; inline comment documents it); "old binding stays stale after retarget" (the Control UI runs a canonical `refresh({force:true})` on every `sessions.changed`, `ui/src/lib/sessions/index.ts:1337-1339`, so any binding-change event refetches all rows).
