### PR TITLE
fix(gateway): refresh model availability after OAuth renewal

### DIFF
--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -8,7 +8,7 @@ import {
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
 import {
-  ensureAuthProfileStoreWithoutExternalProfiles,
+  loadAuthProfileStoreWithoutExternalProfiles,
   resolveAuthProfileOrder,
   type AuthProfileCredential,
   type AuthProfileStore,
@@ -170,10 +170,10 @@ function createModelsListProviderAuthChecker(params: {
   workspaceDir: string;
 }): ModelsListProviderAuthChecker {
   const agentDir = resolveAgentDir(params.cfg, params.agentId);
-  const store = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+  // Auth refreshes can be persisted by another CLI process while the gateway
+  // keeps an older execution snapshot, so browse availability reads SQLite.
+  const store = loadAuthProfileStoreWithoutExternalProfiles(agentDir, {
     allowKeychainPrompt: false,
-    readOnly: true,
-    syncExternalCli: false,
   });
   return createInFlightProviderAuthChecker(
     (provider, modelApi) =>

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -2,6 +2,10 @@
 // validation errors, and protocol response shapes.
 import { describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  replaceRuntimeAuthProfileStoreSnapshots,
+} from "../../agents/auth-profiles.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createDeferred } from "../../test-utils/deferred.js";
 import { withEnvAsync } from "../../test-utils/env.js";
@@ -20,6 +24,21 @@ const withoutOpenAIEnvAuth = async <T>(run: () => Promise<T>): Promise<T> =>
     },
     run,
   );
+
+function createDemoOAuthStore(params: { access: string; expires: number }) {
+  return {
+    version: 1 as const,
+    profiles: {
+      "demo-provider:oauth": {
+        type: "oauth" as const,
+        provider: "demo-provider",
+        access: params.access,
+        refresh: "refresh-token",
+        expires: params.expires,
+      },
+    },
+  };
+}
 
 function requestModelsList(params: {
   view: "configured" | "all";
@@ -488,18 +507,12 @@ describe("models.list", () => {
         agentEnv: "main",
       },
       async (state) => {
-        await state.writeAuthProfiles({
-          version: 1,
-          profiles: {
-            "demo-provider:expired": {
-              type: "oauth",
-              provider: "demo-provider",
-              access: "expired-access",
-              refresh: "refresh-token",
-              expires: Date.now() - 60_000,
-            },
-          },
-        });
+        await state.writeAuthProfiles(
+          createDemoOAuthStore({
+            access: "expired-access",
+            expires: Date.now() - 60_000,
+          }),
+        );
 
         const { request, respond } = requestModelsList({
           view: "all",
@@ -524,6 +537,64 @@ describe("models.list", () => {
           },
           undefined,
         );
+      },
+    );
+  });
+
+  it("uses refreshed persisted OAuth when the runtime auth snapshot is stale", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-models-list-stale-runtime-profile-",
+        agentEnv: "main",
+      },
+      async (state) => {
+        const agentDir = state.agentDir();
+        await state.writeAuthProfiles(
+          createDemoOAuthStore({
+            access: "refreshed-access",
+            expires: Date.now() + 60 * 60_000,
+          }),
+        );
+        replaceRuntimeAuthProfileStoreSnapshots([
+          {
+            agentDir,
+            store: createDemoOAuthStore({
+              access: "expired-access",
+              expires: Date.now() - 60_000,
+            }),
+          },
+        ]);
+
+        try {
+          const { request, respond } = requestModelsList({
+            view: "all",
+            loadGatewayModelCatalog: vi.fn(() =>
+              Promise.resolve([
+                { id: "demo-model", name: "Demo Model", provider: "demo-provider" },
+              ]),
+            ),
+            reqId: "req-models-list-stale-runtime-profile",
+          });
+          await request;
+
+          expect(respond).toHaveBeenCalledWith(
+            true,
+            {
+              models: [
+                {
+                  id: "demo-model",
+                  name: "Demo Model",
+                  provider: "demo-provider",
+                  available: true,
+                },
+              ],
+            },
+            undefined,
+          );
+        } finally {
+          clearRuntimeAuthProfileStoreSnapshots();
+        }
       },
     );
   });


### PR DESCRIPTION
Backport of #102289 to `release/2026.7.1`.

## What Problem This Solves

Fixes an issue where users who renewed provider OAuth from another CLI process could continue seeing models reported as unavailable while the Gateway retained an older runtime auth snapshot.

## Why This Change Was Made

Model browsing now reads the persisted auth-profile store for availability checks without mutating the Gateway's execution snapshot. This is the exact source patch from #102289, including its regression test.

## User Impact

Freshly renewed OAuth credentials become visible to model listing without requiring a Gateway restart.

## Evidence

- Stable patch ID matches merged PR #102289 exactly.
- `pnpm test src/gateway/server-methods/models.test.ts -- --reporter=verbose`: 30/30 tests passed on AWS Crabbox `cbx_f3a7847dadfa` (`run_f139cd26d7b7`) against the final release-branch base.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
- `git diff --check upstream/release/2026.7.1...HEAD`: clean.

Known proof gap: no live provider call was run; the focused regression exercises the persisted OAuth refresh boundary directly.
