### PR TITLE
docs(discord): document shared tool warning suppression

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1706,6 +1706,7 @@ Primary reference: [Configuration reference - Discord](/gateway/config-channels#
 
 - Treat bot tokens as secrets (`DISCORD_BOT_TOKEN` preferred in supervised environments).
 - Grant least-privilege Discord permissions.
+- To hide synthesized `⚠️` tool-error warnings in Discord replies, use the shared message policy `messages.suppressToolErrors: true`. The agent still sees tool failures in context, and diagnostics remain available in logs and transcripts.
 - If command deploy/state is stale, restart the gateway and re-check with `openclaw channels status --probe`.
 
 ## Related

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -166,6 +166,7 @@ type DispatchInboundParams = {
       status?: string;
       exitCode?: number | null;
     }) => Promise<false | void> | false | void;
+    suppressToolErrorWarnings?: boolean;
     onPatchSummary?: (payload: {
       phase?: string;
       summary?: string;
@@ -2330,6 +2331,18 @@ describe("processDiscordMessage draft streaming", () => {
 
     expect(callbackResult).toBe(false);
     expect(draftStream.update).not.toHaveBeenCalled();
+  });
+
+  it("leaves shared tool-error warning policy to message config", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async () => createNoQueuedDispatchResult());
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(getLastDispatchReplyOptions()?.suppressToolErrorWarnings).toBeUndefined();
   });
 
   it("counts window thinking bursts closed by a tool call when no end event fires", async () => {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #92517.

We originally proposed a Discord-specific `channels.discord.suppressToolErrorWarnings` setting because our fleet has been running a stricter Discord hot patch to avoid visible `⚠️ 🛠️ ... failed` messages after otherwise useful replies.

Review correctly pointed out that current OpenClaw already has a shared native policy for this exact fallback warning path:

```json5
{
  messages: {
    suppressToolErrors: true,
  },
}
```

So this PR now documents that supported path instead of adding a second Discord-specific setting.

## What Changed

- Documents in the Discord channel guide that `messages.suppressToolErrors: true` hides synthesized `⚠️` tool-error warnings in Discord replies while preserving logs/transcripts/context.
- Adds a Discord handler regression confirming Discord does not set a channel-specific suppression override and leaves the shared policy to message config.

## Why This Direction

This follows the ClawSweeper feedback on the earlier draft:

- avoids a duplicate public config key
- avoids new precedence/account inheritance questions
- keeps `messages.suppressToolErrors` as the canonical policy
- gives Discord-heavy deployments a documented native way to stop using installed-bundle hot patches

## Validation

- `pnpm test extensions/discord/src/monitor/message-handler.process.test.ts` — 124/124 passed
- `pnpm test src/config/schema.test.ts src/config/schema.shared.test.ts src/config/schema.base.generated.test.ts src/config/schema.hints.test.ts` — 78/78 passed across 2 shards
- `pnpm exec oxfmt --check --threads=1 extensions/discord/src/config-ui-hints.ts extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.process.test.ts src/config/zod-schema.providers-core.ts docs/channels/discord.md`
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/discord/src/config-ui-hints.ts extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.process.test.ts`
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/config/zod-schema.providers-core.ts`
- `git diff --check`
