### PR TITLE
fix(models): redact synthetic auth credentials from models status --json

### DIFF
--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -99,6 +99,31 @@ describe("resolveProviderAuthOverview", () => {
     vi.mocked(resolveEnvApiKey).mockClear();
   });
 
+  it("projects synthetic auth to value/source and drops runtime credential fields", () => {
+    // #104713: status callers pass their richer runtime object (credential,
+    // mode, expiresAt); the overview must not let those reach JSON output.
+    const runtimeSyntheticAuth = {
+      value: "plugin-owned",
+      source: "xAI plugin config",
+      credential: "xai-raw-credential-material",
+      mode: "api-key",
+      expiresAt: Date.now() + 60_000,
+    };
+    const overview = resolveProviderAuthOverview({
+      provider: "xai",
+      cfg: {},
+      store: { version: 1, profiles: {} } as never,
+      modelsPath: "/tmp/models.json",
+      syntheticAuth: runtimeSyntheticAuth,
+    });
+
+    expect(overview.syntheticAuth).toStrictEqual({
+      value: "plugin-owned",
+      source: "xAI plugin config",
+    });
+    expect(JSON.stringify(overview)).not.toContain("xai-raw-credential-material");
+  });
+
   it("labels token profiles that only have tokenRef", () => {
     const overview = resolveProviderAuthOverview({
       provider: "github-copilot",

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -218,6 +218,16 @@ export function resolveProviderAuthOverview(params: {
           },
         }
       : {}),
-    ...(params.syntheticAuth ? { syntheticAuth: params.syntheticAuth } : {}),
+    // Re-project instead of passing the caller's object through: status callers
+    // hand richer runtime shapes that also carry the raw synthetic credential,
+    // and structural typing would let it leak into `--json` output verbatim.
+    ...(params.syntheticAuth
+      ? {
+          syntheticAuth: {
+            value: params.syntheticAuth.value,
+            source: params.syntheticAuth.source,
+          },
+        }
+      : {}),
   };
 }

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -1922,6 +1922,13 @@ describe("modelsStatusCommand auth overview", () => {
         value: "plugin-owned",
         source: "codex-app-server",
       });
+      // #104713: the summary must ship only the projected fields; the runtime
+      // synthetic-auth object also carries the raw credential and must never
+      // reach the JSON payload.
+      expect(
+        Object.keys(requireRecord(codexProvider.syntheticAuth, "codex synthetic auth")),
+      ).toStrictEqual(["value", "source"]);
+      expect(JSON.stringify(payload)).not.toContain("codex-runtime-token");
       expectRecordFields(requireRecord(codexProvider.effective, "codex effective auth"), {
         kind: "synthetic",
         detail: "codex-app-server",


### PR DESCRIPTION
## What Problem This Solves

`openclaw models status --json` can include **raw credential material** in its JSON payload (#104713). Any provider whose plugin resolves synthetic auth to a real secret (for example xAI, which returns the configured API key or `XAI_API_KEY` env value; LM Studio/Ollama variants; Codex app-server tokens on affected setups) ships that secret verbatim under `auth.providers[].syntheticAuth.credential` — in a diagnostic surface that users routinely paste into bug reports and logs.

## Why This Change Was Made

Root cause is a structural-typing leak at the overview boundary. `resolveProviderAuthOverview` declares `syntheticAuth?: { value: string; source: string }` (`src/commands/models/list.auth-overview.ts`), but the status command passes its richer runtime object (`StatusSyntheticAuth`, which also carries `credential`, `mode`, `expiresAt` — `src/commands/models/list.status-command.ts`). TypeScript accepts the wider object, and the overview returned it **by reference**, so the raw credential rode along into `writeRuntimeJson`.

Every other field in the overview already masks secrets (`maskApiKey`, `formatMarkerOrSecret`, profile label masking); `syntheticAuth` was the one passthrough. The fix re-projects at the boundary so the returned entry contains exactly the declared `value`/`source` fields, with an inline comment stating the contract. No caller changes and no output-shape changes for the documented fields — `--json` consumers keep `value`/`source`; only the undeclared leaked fields disappear.

## User Impact

- `models status --json` no longer emits raw API keys / tokens under `auth.providers[].syntheticAuth`.
- Status/diagnostic output keeps the useful metadata (`value: "plugin-owned"`, `source`, effective-auth kind, expiry health) — nothing an operator relies on is removed.

## Evidence

**Live CLI before/after** (temp `OPENCLAW_STATE_DIR`, default model `xai/grok-4`, fake key seeded at `plugins.entries.xai.config.webSearch.apiKey` — the xAI plugin's `resolveSyntheticAuth` returns it as real credential material):

- **Before (main, `dbdc61e897`)**: `node openclaw.mjs models status --json` emits `"syntheticAuth": {"value": "plugin-owned", "source": "...", "credential": "xai-FAKE-...", "mode": "api-key"}` — raw key present in the payload.
- **After (this PR)**: same command emits `"syntheticAuth": {"value": "plugin-owned", "source": "..."}`; grepping the full JSON for the fake key finds nothing.

(Exact transcripts in the first PR comment.)

**Regression tests (fail on main, pass here):**

- `src/commands/models/list.auth-overview.test.ts` — passes a runtime-shaped synthetic-auth object carrying `credential`; asserts the returned overview is exactly `{value, source}` and the serialized overview does not contain the credential.
- `src/commands/models/list.status.test.ts` — the existing end-to-end status test now asserts the codex `syntheticAuth` JSON has exactly `["value", "source"]` keys and that the mocked runtime token does not appear anywhere in the full `--json` payload.

Both files: 43/43 locally (`node scripts/run-vitest.mjs run src/commands/models/list.auth-overview.test.ts src/commands/models/list.status.test.ts`). Reverting only the prod file makes the new assertions fail, confirming they gate the leak.

Fixes #104713
