### PR TITLE
fix: prevent large session migrations from stalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Session SQLite migration scale:** batch recovery-manifest checkpoints for unreferenced JSONL archive moves and replace manifests atomically, preventing large pre-flip stores from incurring quadratic startup I/O while preserving crash recovery. Fixes #104731.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Session SQLite migration scale:** batch recovery-manifest checkpoints for unreferenced JSONL archive moves and replace manifests atomically, preventing large pre-flip stores from incurring quadratic startup I/O while preserving crash recovery. Fixes #104731.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveStateDir } from "../config/paths.js";
+import * as replaceFile from "../infra/replace-file.js";
 import { VERSION } from "../version.js";
 import type {
   DoctorSessionSqliteIssue,
@@ -100,8 +101,12 @@ export function writeSessionSqliteMigrationManifest(
   activeRun: ActiveSessionSqliteMigrationRun,
 ): void {
   fs.mkdirSync(path.dirname(activeRun.manifestPath), { recursive: true, mode: 0o700 });
-  fs.writeFileSync(activeRun.manifestPath, `${JSON.stringify(activeRun.manifest, null, 2)}\n`, {
+  replaceFile.replaceFileAtomicSync({
+    filePath: activeRun.manifestPath,
+    content: `${JSON.stringify(activeRun.manifest, null, 2)}\n`,
+    dirMode: 0o700,
     mode: 0o600,
+    tempPrefix: path.basename(activeRun.manifestPath),
   });
 }
 
@@ -129,14 +134,15 @@ export function recordPlannedMigrationMove(
   target: SessionSqliteMigrationTargetInput,
   move: SessionSqliteMigrationMove,
 ): void {
-  const manifestTarget = findMigrationManifestTarget(activeRun, target);
-  if (!activeRun || !manifestTarget) {
-    return;
-  }
-  if (!manifestTarget.plannedMoves.some((item) => movesMatch(item, move))) {
-    manifestTarget.plannedMoves.push(move);
-  }
-  writeSessionSqliteMigrationManifest(activeRun);
+  recordPlannedMigrationMoves(activeRun, target, [move]);
+}
+
+export function recordPlannedMigrationMoves(
+  activeRun: ActiveSessionSqliteMigrationRun | undefined,
+  target: SessionSqliteMigrationTargetInput,
+  moves: readonly SessionSqliteMigrationMove[],
+): void {
+  recordMigrationMoves(activeRun, target, "plannedMoves", moves);
 }
 
 export function recordCompletedMigrationMove(
@@ -144,14 +150,46 @@ export function recordCompletedMigrationMove(
   target: SessionSqliteMigrationTargetInput,
   move: SessionSqliteMigrationMove,
 ): void {
+  recordCompletedMigrationMoves(activeRun, target, [move]);
+}
+
+export function recordCompletedMigrationMoves(
+  activeRun: ActiveSessionSqliteMigrationRun | undefined,
+  target: SessionSqliteMigrationTargetInput,
+  moves: readonly SessionSqliteMigrationMove[],
+): void {
+  recordMigrationMoves(activeRun, target, "completedMoves", moves);
+}
+
+function recordMigrationMoves(
+  activeRun: ActiveSessionSqliteMigrationRun | undefined,
+  target: SessionSqliteMigrationTargetInput,
+  listKey: "completedMoves" | "plannedMoves",
+  moves: readonly SessionSqliteMigrationMove[],
+): void {
   const manifestTarget = findMigrationManifestTarget(activeRun, target);
-  if (!activeRun || !manifestTarget) {
+  if (!activeRun || !manifestTarget || moves.length === 0) {
     return;
   }
-  if (!manifestTarget.completedMoves.some((item) => movesMatch(item, move))) {
-    manifestTarget.completedMoves.push(move);
+  const targetMoves = manifestTarget[listKey];
+  const knownMoves = new Set(targetMoves.map(migrationMoveKey));
+  let changed = false;
+  for (const move of moves) {
+    const key = migrationMoveKey(move);
+    if (knownMoves.has(key)) {
+      continue;
+    }
+    knownMoves.add(key);
+    targetMoves.push(move);
+    changed = true;
   }
-  writeSessionSqliteMigrationManifest(activeRun);
+  if (changed) {
+    writeSessionSqliteMigrationManifest(activeRun);
+  }
+}
+
+function migrationMoveKey(move: SessionSqliteMigrationMove): string {
+  return `${move.sourcePath}\u0000${move.archivePath}`;
 }
 
 export function restoreSessionSqliteMigrationRuns(params: {
@@ -331,10 +369,6 @@ function findMigrationManifestTarget(
   return activeRun.manifest.targets.find(
     (item) => sessionSqliteMigrationTargetKey(item) === sessionSqliteMigrationTargetKey(target),
   );
-}
-
-function movesMatch(left: SessionSqliteMigrationMove, right: SessionSqliteMigrationMove): boolean {
-  return left.sourcePath === right.sourcePath && left.archivePath === right.archivePath;
 }
 
 function emptyRestoreReport(): DoctorSessionSqliteRestoreReport {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -2,13 +2,14 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   loadExactSqliteSessionEntry,
   loadSqliteTranscriptEventsSync,
   upsertSqliteSessionEntry,
 } from "../config/sessions/session-accessor.sqlite.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import * as replaceFile from "../infra/replace-file.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { SessionSqliteMigrationManifest } from "./doctor-session-sqlite-migration-run.js";
@@ -389,6 +390,53 @@ describe("runDoctorSessionSqlite", () => {
       "session-1.trajectory.jsonl",
       "sessions.json",
     ]);
+  });
+
+  it("checkpoints bulk unreferenced archive moves without per-file manifest rewrites", async () => {
+    const store = createLegacyStore();
+    for (let index = 0; index < 64; index += 1) {
+      fs.writeFileSync(path.join(store.sessionDir, `orphan-${index}.jsonl`), "{}\n", {
+        mode: 0o600,
+      });
+    }
+    fs.writeFileSync(path.join(store.sessionDir, "orphan collision.jsonl"), "{}\n", {
+      mode: 0o600,
+    });
+    fs.writeFileSync(path.join(store.sessionDir, "orphan_collision.jsonl"), "{}\n", {
+      mode: 0o600,
+    });
+    const replaceFileAtomicSync = vi.spyOn(replaceFile, "replaceFileAtomicSync");
+
+    try {
+      const report = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+      const manifest = readMigrationManifest(report.migrationRun?.manifestPath);
+      const manifestWrites = replaceFileAtomicSync.mock.calls.filter(([options]) =>
+        options.filePath.includes("session-sqlite-migration-runs"),
+      ).length;
+      const plannedUnreferencedMoves =
+        manifest.targets[0]?.plannedMoves.filter((move) => move.kind === "unreferenced-jsonl") ??
+        [];
+
+      expect(plannedUnreferencedMoves).toHaveLength(67);
+      expect(new Set(plannedUnreferencedMoves.map((move) => move.archivePath)).size).toBe(67);
+      expect(
+        manifest.targets[0]?.completedMoves.filter((move) => move.kind === "unreferenced-jsonl"),
+      ).toHaveLength(67);
+      expect(manifestWrites).toBeLessThan(20);
+      expect(replaceFileAtomicSync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filePath: report.migrationRun?.manifestPath,
+          mode: 0o600,
+          tempPrefix: path.basename(report.migrationRun?.manifestPath ?? ""),
+        }),
+      );
+    } finally {
+      replaceFileAtomicSync.mockRestore();
+    }
   });
 
   it("archives legacy trajectory pointer files with imported transcripts", async () => {

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -25,11 +25,14 @@ import { compactDoctorSessionSqliteTarget } from "./doctor-session-sqlite-compac
 import {
   createSessionSqliteMigrationRun,
   recordCompletedMigrationMove,
+  recordCompletedMigrationMoves,
   recordPlannedMigrationMove,
+  recordPlannedMigrationMoves,
   updateMigrationManifestTarget,
   writeSessionSqliteMigrationFailureReports,
   writeSessionSqliteMigrationManifest,
   type ActiveSessionSqliteMigrationRun,
+  type SessionSqliteMigrationMove,
   type SessionSqliteMigrationMoveKind,
   type SessionSqliteMigrationTargetInput,
 } from "./doctor-session-sqlite-migration-run.js";
@@ -627,25 +630,46 @@ function archiveUnreferencedJsonlFiles(
   referencedPaths: readonly string[],
   activeRun: ActiveSessionSqliteMigrationRun | undefined,
 ): void {
-  for (const sourcePath of listUnreferencedJsonlFiles(target.storePath, referencedPaths)) {
-    try {
-      report.archivedUnreferencedJsonlFiles.push(
-        moveSessionJsonlToArchive({
-          activeRun,
+  const reservedArchivePaths = new Set<string>();
+  const plannedMoves = listUnreferencedJsonlFiles(target.storePath, referencedPaths).flatMap(
+    (sourcePath) => {
+      try {
+        const move = planSessionJsonlArchiveMove({
           archiveKey: "archive-tier",
           baseNameRaw: path.basename(sourcePath),
           kind: "unreferenced-jsonl",
+          reservedArchivePaths,
           sourcePathRaw: sourcePath,
           target,
-        }),
-      );
+        });
+        reservedArchivePaths.add(move.archivePath);
+        return [move];
+      } catch (err) {
+        report.issues.push({
+          code: "unreferenced_jsonl_archive_failed",
+          message: `${sourcePath}: ${String(err)}`,
+        });
+        return [];
+      }
+    },
+  );
+  // Persist every source/destination before the first rename. A crash can then
+  // restore moved files even when the completion checkpoint was never written.
+  recordPlannedMigrationMoves(activeRun, createMigrationTargetInput(target), plannedMoves);
+  const completedMoves: SessionSqliteMigrationMove[] = [];
+  for (const move of plannedMoves) {
+    try {
+      fs.renameSync(move.sourcePath, move.archivePath);
+      report.archivedUnreferencedJsonlFiles.push(move.archivePath);
+      completedMoves.push(move);
     } catch (err) {
       report.issues.push({
         code: "unreferenced_jsonl_archive_failed",
-        message: `${sourcePath}: ${String(err)}`,
+        message: `${move.sourcePath}: ${String(err)}`,
       });
     }
   }
+  recordCompletedMigrationMoves(activeRun, createMigrationTargetInput(target), completedMoves);
 }
 
 function archiveImportedLegacySessionStores(
@@ -1035,48 +1059,48 @@ function moveSessionJsonlToArchive(params: {
   sourcePathRaw: string;
   target: SessionStoreTarget;
 }): string {
-  const { archiveKey, baseNameRaw, sourcePathRaw } = params;
-  const sourcePath = path.resolve(sourcePathRaw);
+  const move = planSessionJsonlArchiveMove(params);
+  recordPlannedMigrationMove(params.activeRun, createMigrationTargetInput(params.target), move);
+  fs.renameSync(move.sourcePath, move.archivePath);
+  recordCompletedMigrationMove(params.activeRun, createMigrationTargetInput(params.target), move);
+  return move.archivePath;
+}
+
+function planSessionJsonlArchiveMove(params: {
+  archiveKey: string;
+  baseNameRaw: string;
+  kind: SessionSqliteMigrationMoveKind;
+  reservedArchivePaths?: ReadonlySet<string>;
+  sessionKey?: string;
+  sourcePathRaw: string;
+  target: SessionStoreTarget;
+}): SessionSqliteMigrationMove {
+  const sourcePath = path.resolve(params.sourcePathRaw);
   const stat = fs.statSync(sourcePath);
   if (!stat.isFile()) {
     throw new Error("source is not a regular file");
   }
   const archiveDir = resolveImportedTranscriptArchiveDir(params.target.storePath);
   fs.mkdirSync(archiveDir, { recursive: true });
-  const baseName = baseNameRaw.replace(/[^A-Za-z0-9_.-]+/g, "_").slice(0, 160) || "artifact";
-  const keySlug = archiveKey.replace(/[^A-Za-z0-9_.-]+/g, "_").slice(0, 120) || "session";
+  const baseName = params.baseNameRaw.replace(/[^A-Za-z0-9_.-]+/g, "_").slice(0, 160) || "artifact";
+  const keySlug = params.archiveKey.replace(/[^A-Za-z0-9_.-]+/g, "_").slice(0, 120) || "session";
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const suffix = attempt === 0 ? "" : `.${attempt}`;
     const archivePath = path.join(
       archiveDir,
       `${keySlug}.${baseName}.imported-${Date.now()}${suffix}`,
     );
-    if (fs.existsSync(archivePath)) {
+    if (fs.existsSync(archivePath) || params.reservedArchivePaths?.has(archivePath)) {
       continue;
     }
-    try {
-      const move = {
-        archivePath,
-        kind: params.kind,
-        ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-        sourcePath,
-      };
-      recordPlannedMigrationMove(params.activeRun, createMigrationTargetInput(params.target), move);
-      fs.renameSync(sourcePath, archivePath);
-      recordCompletedMigrationMove(
-        params.activeRun,
-        createMigrationTargetInput(params.target),
-        move,
-      );
-      return archivePath;
-    } catch (err) {
-      if ((err as { code?: unknown })?.code === "EEXIST") {
-        continue;
-      }
-      throw err;
-    }
+    return {
+      archivePath,
+      kind: params.kind,
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+      sourcePath,
+    };
   }
-  throw new Error(`Could not archive ${baseName} for ${archiveKey}`);
+  throw new Error(`Could not archive ${baseName} for ${params.archiveKey}`);
 }
 
 function resolveImportedTranscriptArchiveDir(storePath: string): string {


### PR DESCRIPTION
Closes #104731
Related: #98236

AI-assisted: Codex

## What Problem This Solves

Fixes an issue where operators upgrading a long-lived OpenClaw state directory could experience a prolonged Gateway startup stall when the SQLite session migration encountered many unreferenced legacy JSONL artifacts. The archive operation itself is a same-filesystem rename, but the recovery manifest was fully serialized twice per file and grew after every move.

## Why This Change Was Made

The migration now persists the complete bulk move plan once before the first rename, reserves unique archive destinations across the batch, and checkpoints all successful moves once afterward. Recovery manifests are replaced atomically, preserving the existing crash-recovery contract without per-file quadratic write amplification.

## User Impact

Large pre-flip session stores migrate with bounded manifest persistence instead of quadratic serialization and disk I/O. Interrupted migrations still retain every source/destination mapping needed by `openclaw doctor --session-sqlite restore`.

## Evidence

- `corepack pnpm test src/commands/doctor-session-sqlite.test.ts` — 33/33 passed on Blacksmith Testbox `tbx_01kx9kn6jtsb2cwxn7fhj0rmdh` ([run](https://github.com/openclaw/openclaw/actions/runs/29170032342)).
- Regression creates 67 unreferenced artifacts, including two filenames that normalize to the same archive basename; it proves unique planned destinations, complete planned/completed recovery mappings, atomic replacement, and fewer than 20 manifest checkpoints.
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed format, core and core-test tsgo, core lint, and all selected architecture guards on Testbox `tbx_01kx9kndwx88v80ae3ht7200mk` ([run](https://github.com/openclaw/openclaw/actions/runs/29170035996)).
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking high --codex-speed fast` — clean after accepting and fixing the archive-path collision finding.
