### PR TITLE
perf(acp): maintain ledger byte budgets at insert time

### DIFF
--- a/src/acp/event-ledger.test.ts
+++ b/src/acp/event-ledger.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
@@ -246,6 +247,59 @@ describe("ACP event ledger", () => {
       await expect(
         ledger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
       ).resolves.toEqual({ complete: false, events: [] });
+    });
+  });
+
+  it("keeps footprint aggregates consistent while the byte budget evicts", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      const databasePath = path.join(dir, "openclaw.sqlite");
+      const ledger = createSqliteAcpEventLedger({
+        path: databasePath,
+        // Small enough that appends force byte-budget eviction repeatedly.
+        maxSerializedBytes: 4_096,
+      });
+      for (let session = 0; session < 3; session += 1) {
+        await ledger.startSession({
+          sessionId: `session-${session}`,
+          sessionKey: `agent:main:budget-${session}`,
+          cwd: "/work",
+          complete: true,
+        });
+        for (let index = 0; index < 40; index += 1) {
+          await ledger.recordUpdate({
+            sessionId: `session-${session}`,
+            sessionKey: `agent:main:budget-${session}`,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: `payload-${session}-${index}-${"x".repeat(64)}` },
+            },
+          });
+        }
+      }
+
+      const { DatabaseSync } = requireNodeSqlite();
+      const db = new DatabaseSync(databasePath, { readOnly: true });
+      try {
+        // The maintained aggregate must equal ground truth recomputed from
+        // stored rows: drift here would silently unbound the ledger again.
+        const aggregate = db
+          .prepare("SELECT COALESCE(SUM(estimated_bytes), 0) AS total FROM acp_replay_sessions")
+          .get() as { total: number | bigint };
+        const groundTruth = db
+          .prepare(
+            `SELECT
+               (SELECT COALESCE(SUM(length(session_id) + length(session_key) + length(cwd) + 32), 0)
+                  FROM acp_replay_sessions)
+             + (SELECT COALESCE(SUM(length(session_id) + length(session_key) + length(update_json)
+                   + COALESCE(length(run_id), 0) + 32), 0)
+                  FROM acp_replay_events) AS total`,
+          )
+          .get() as { total: number | bigint };
+        expect(Number(aggregate.total)).toBe(Number(groundTruth.total));
+        expect(Number(aggregate.total)).toBeLessThanOrEqual(4_096);
+      } finally {
+        db.close();
+      }
     });
   });
 

--- a/src/acp/event-ledger.test.ts
+++ b/src/acp/event-ledger.test.ts
@@ -266,9 +266,15 @@ describe("ACP event ledger", () => {
           complete: true,
         });
         for (let index = 0; index < 40; index += 1) {
+          // Halfway through, the provisional key becomes a longer canonical
+          // key: the row-overhead component of the aggregate must follow.
+          const sessionKey =
+            index < 20
+              ? `agent:main:budget-${session}`
+              : `agent:main:budget-${session}:canonical-rebound`;
           await ledger.recordUpdate({
             sessionId: `session-${session}`,
-            sessionKey: `agent:main:budget-${session}`,
+            sessionKey,
             update: {
               sessionUpdate: "agent_message_chunk",
               content: { type: "text", text: `payload-${session}-${index}-${"x".repeat(64)}` },

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -641,11 +641,22 @@ function upsertSqliteSession(
   if (!params.reset && existing) {
     const cwd = params.cwd || existing.cwd;
     const complete = existing.complete || params.complete ? 1 : 0;
+    // SET expressions read the pre-update row, so the aggregate sheds the old
+    // key/cwd lengths and gains the new ones; drift here would silently
+    // unbound the byte budget.
     db.prepare(
       `UPDATE acp_replay_sessions
-          SET session_key = ?, cwd = ?, complete = ?, updated_at = ?
+          SET estimated_bytes = estimated_bytes - length(session_key) - length(cwd) + ?,
+              session_key = ?, cwd = ?, complete = ?, updated_at = ?
         WHERE session_id = ?`,
-    ).run(params.sessionKey, cwd, complete, now, params.sessionId);
+    ).run(
+      params.sessionKey.length + cwd.length,
+      params.sessionKey,
+      cwd,
+      complete,
+      now,
+      params.sessionId,
+    );
     return {
       ...existing,
       sessionKey: params.sessionKey,
@@ -675,7 +686,11 @@ function upsertSqliteSession(
        complete = excluded.complete,
        updated_at = excluded.updated_at,
        next_seq = excluded.next_seq,
-       estimated_bytes = excluded.estimated_bytes`,
+       -- Row overhead plus whatever event rows still exist: exact after a
+       -- reset (events deleted, sum is 0) and on any conflicting rewrite.
+       estimated_bytes = excluded.estimated_bytes + COALESCE(
+         (SELECT SUM(e.estimated_bytes) FROM acp_replay_events e
+           WHERE e.session_id = excluded.session_id), 0)`,
   ).run(
     params.sessionId,
     params.sessionKey,
@@ -859,11 +874,20 @@ function appendSqliteUpdate(
     updateJson,
     eventBytes,
   );
+  // The delta covers the new event plus any session-key length change; SET
+  // expressions read the pre-update row, keeping the aggregate exact.
   db.prepare(
     `UPDATE acp_replay_sessions
-        SET session_key = ?, updated_at = ?, next_seq = ?, estimated_bytes = estimated_bytes + ?
+        SET estimated_bytes = estimated_bytes - length(session_key) + ?,
+            session_key = ?, updated_at = ?, next_seq = ?
       WHERE session_id = ?`,
-  ).run(params.sessionKey, now, session.nextSeq + 1, eventBytes, params.sessionId);
+  ).run(
+    params.sessionKey.length + eventBytes,
+    params.sessionKey,
+    now,
+    session.nextSeq + 1,
+    params.sessionId,
+  );
   trimSqliteLedger(db, state);
 }
 

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -658,17 +658,33 @@ function upsertSqliteSession(
   if (params.reset) {
     db.prepare("DELETE FROM acp_replay_events WHERE session_id = ?").run(params.sessionId);
   }
+  // A fresh or reset session's footprint is just its own row overhead; event
+  // bytes accumulate onto the aggregate as appends land.
+  const rowBytes = estimateSessionRowBytes({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    cwd: params.cwd,
+  });
   db.prepare(
     `INSERT INTO acp_replay_sessions (
-       session_id, session_key, cwd, complete, created_at, updated_at, next_seq
-     ) VALUES (?, ?, ?, ?, ?, ?, 1)
+       session_id, session_key, cwd, complete, created_at, updated_at, next_seq, estimated_bytes
+     ) VALUES (?, ?, ?, ?, ?, ?, 1, ?)
      ON CONFLICT(session_id) DO UPDATE SET
        session_key = excluded.session_key,
        cwd = excluded.cwd,
        complete = excluded.complete,
        updated_at = excluded.updated_at,
-       next_seq = excluded.next_seq`,
-  ).run(params.sessionId, params.sessionKey, params.cwd, params.complete ? 1 : 0, now, now);
+       next_seq = excluded.next_seq,
+       estimated_bytes = excluded.estimated_bytes`,
+  ).run(
+    params.sessionId,
+    params.sessionKey,
+    params.cwd,
+    params.complete ? 1 : 0,
+    now,
+    now,
+    rowBytes,
+  );
   return {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
@@ -681,54 +697,91 @@ function upsertSqliteSession(
   };
 }
 
+// Session rows carry a running footprint aggregate (row overhead plus their
+// event rows), maintained at insert/trim time. The budget check therefore
+// sums over at most maxSessions rows instead of scanning every event per
+// append, which was O(events) per message and quadratic while trimming.
 function estimateSqliteLedgerBytes(db: DatabaseSync): number {
   const row = db
+    .prepare("SELECT COALESCE(SUM(estimated_bytes), 0) AS total FROM acp_replay_sessions")
+    .get() as { total?: number | bigint } | undefined;
+  return normalizeSqliteInteger(row?.total ?? 0);
+}
+
+function estimateSessionRowBytes(params: {
+  sessionId: string;
+  sessionKey: string;
+  cwd: string;
+}): number {
+  return params.sessionId.length + params.sessionKey.length + params.cwd.length + 32;
+}
+
+function estimateEventRowBytes(params: {
+  sessionId: string;
+  sessionKey: string;
+  runId?: string;
+  updateJson: string;
+}): number {
+  return (
+    params.sessionId.length +
+    params.sessionKey.length +
+    params.updateJson.length +
+    (params.runId?.length ?? 0) +
+    32
+  );
+}
+
+const LEDGER_TRIM_EVENT_BATCH = 64;
+
+// Deletes up to `limit` oldest events for one session and returns the bytes
+// released, keeping the session aggregate in sync in the same statement pair.
+function deleteOldestSqliteEvents(db: DatabaseSync, sessionId: string, limit: number): number {
+  const rows = db
     .prepare(
-      `SELECT
-         COALESCE(SUM(length(session_id) + length(session_key) + length(cwd) + 32), 0) AS sessions,
-         (SELECT COALESCE(SUM(length(session_id) + length(session_key) + length(update_json) + COALESCE(length(run_id), 0) + 32), 0)
-            FROM acp_replay_events) AS events
-       FROM acp_replay_sessions`,
+      `DELETE FROM acp_replay_events
+        WHERE session_id = ?
+          AND seq IN (
+            SELECT seq FROM acp_replay_events
+             WHERE session_id = ?
+             ORDER BY seq ASC
+             LIMIT ?
+          )
+        RETURNING estimated_bytes`,
     )
-    .get() as { sessions?: number | bigint; events?: number | bigint } | undefined;
-  return normalizeSqliteInteger(row?.sessions ?? 0) + normalizeSqliteInteger(row?.events ?? 0);
+    .all(sessionId, sessionId, limit) as Array<{ estimated_bytes: number | bigint }>;
+  if (rows.length === 0) {
+    return 0;
+  }
+  const freed = rows.reduce((sum, row) => sum + normalizeSqliteInteger(row.estimated_bytes), 0);
+  db.prepare(
+    `UPDATE acp_replay_sessions
+        SET estimated_bytes = MAX(0, estimated_bytes - ?), complete = 0
+      WHERE session_id = ?`,
+  ).run(freed, sessionId);
+  return rows.length;
 }
 
 function trimSqliteLedger(
   db: DatabaseSync,
   state: Pick<MutableLedgerState, "maxEventsPerSession" | "maxSessions" | "maxSerializedBytes">,
 ): void {
-  const sessionsWithCounts = db
+  // Cheap precheck: only sessions actually above the per-session cap pay for
+  // event deletion (Codex log-partition pattern).
+  const overCapSessions = db
     .prepare(
-      `SELECT s.session_id AS session_id, COUNT(e.seq) AS event_count
-         FROM acp_replay_sessions s
-         LEFT JOIN acp_replay_events e ON e.session_id = s.session_id
-        GROUP BY s.session_id`,
+      `SELECT session_id, event_count FROM (
+         SELECT s.session_id AS session_id, COUNT(e.seq) AS event_count
+           FROM acp_replay_sessions s
+           LEFT JOIN acp_replay_events e ON e.session_id = s.session_id
+          GROUP BY s.session_id
+       ) WHERE event_count > ?`,
     )
-    .all() as Array<{ session_id: string; event_count: number | bigint }>;
-  for (const row of sessionsWithCounts) {
+    .all(state.maxEventsPerSession) as Array<{ session_id: string; event_count: number | bigint }>;
+  for (const row of overCapSessions) {
     const overage = normalizeSqliteInteger(row.event_count) - state.maxEventsPerSession;
-    if (overage <= 0) {
-      continue;
+    if (overage > 0) {
+      deleteOldestSqliteEvents(db, row.session_id, overage);
     }
-    const oldEvents = db
-      .prepare(
-        `SELECT seq
-           FROM acp_replay_events
-          WHERE session_id = ?
-          ORDER BY seq ASC
-          LIMIT ?`,
-      )
-      .all(row.session_id, overage) as Array<{ seq: number | bigint }>;
-    const deleteEvent = db.prepare(
-      "DELETE FROM acp_replay_events WHERE session_id = ? AND seq = ?",
-    );
-    for (const event of oldEvents) {
-      deleteEvent.run(row.session_id, normalizeSqliteInteger(event.seq));
-    }
-    db.prepare("UPDATE acp_replay_sessions SET complete = 0 WHERE session_id = ?").run(
-      row.session_id,
-    );
   }
 
   const oldSessions = db
@@ -743,30 +796,10 @@ function trimSqliteLedger(
     db.prepare("DELETE FROM acp_replay_sessions WHERE session_id = ?").run(session.session_id);
   }
 
+  // Byte budget: evict from the least-recently-updated session in bounded
+  // batches, dropping the session row itself once its events are exhausted.
+  // Aggregates keep every recheck O(maxSessions); no event scans occur.
   let serializedBytes = estimateSqliteLedgerBytes(db);
-  while (serializedBytes > state.maxSerializedBytes) {
-    const event = db
-      .prepare(
-        `SELECT e.session_id AS session_id, e.seq AS seq
-           FROM acp_replay_events e
-           JOIN acp_replay_sessions s ON s.session_id = e.session_id
-          ORDER BY s.updated_at ASC, e.seq ASC
-          LIMIT 1`,
-      )
-      .get() as { session_id: string; seq: number | bigint } | undefined;
-    if (!event) {
-      break;
-    }
-    db.prepare("DELETE FROM acp_replay_events WHERE session_id = ? AND seq = ?").run(
-      event.session_id,
-      normalizeSqliteInteger(event.seq),
-    );
-    db.prepare("UPDATE acp_replay_sessions SET complete = 0 WHERE session_id = ?").run(
-      event.session_id,
-    );
-    serializedBytes = estimateSqliteLedgerBytes(db);
-  }
-
   while (serializedBytes > state.maxSerializedBytes) {
     const session = db
       .prepare(
@@ -779,7 +812,10 @@ function trimSqliteLedger(
     if (!session) {
       break;
     }
-    db.prepare("DELETE FROM acp_replay_sessions WHERE session_id = ?").run(session.session_id);
+    const deleted = deleteOldestSqliteEvents(db, session.session_id, LEDGER_TRIM_EVENT_BATCH);
+    if (deleted === 0) {
+      db.prepare("DELETE FROM acp_replay_sessions WHERE session_id = ?").run(session.session_id);
+    }
     serializedBytes = estimateSqliteLedgerBytes(db);
   }
 }
@@ -804,22 +840,30 @@ function appendSqliteUpdate(
     complete: false,
   });
   const now = state.now();
+  const updateJson = JSON.stringify(cloneJsonValue(params.update));
+  const eventBytes = estimateEventRowBytes({
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    ...(params.runId !== undefined ? { runId: params.runId } : {}),
+    updateJson,
+  });
   db.prepare(
-    `INSERT INTO acp_replay_events (session_id, seq, at, session_key, run_id, update_json)
-     VALUES (?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO acp_replay_events (session_id, seq, at, session_key, run_id, update_json, estimated_bytes)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     params.sessionId,
     session.nextSeq,
     now,
     params.sessionKey,
     params.runId ?? null,
-    JSON.stringify(cloneJsonValue(params.update)),
+    updateJson,
+    eventBytes,
   );
   db.prepare(
     `UPDATE acp_replay_sessions
-        SET session_key = ?, updated_at = ?, next_seq = ?
+        SET session_key = ?, updated_at = ?, next_seq = ?, estimated_bytes = estimated_bytes + ?
       WHERE session_id = ?`,
-  ).run(params.sessionKey, now, session.nextSeq + 1, params.sessionId);
+  ).run(params.sessionKey, now, session.nextSeq + 1, eventBytes, params.sessionId);
   trimSqliteLedger(db, state);
 }
 

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -12,6 +12,7 @@ export type Generated<T> =
 
 export interface AcpReplayEvents {
   at: number;
+  estimated_bytes: Generated<number>;
   run_id: string | null;
   seq: number;
   session_id: string;
@@ -23,6 +24,7 @@ export interface AcpReplaySessions {
   complete: number;
   created_at: number;
   cwd: string;
+  estimated_bytes: Generated<number>;
   next_seq: number;
   session_id: string;
   session_key: string;

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -758,6 +758,39 @@ export function withOpenClawStateStartupMigrationCheckpointDatabase<T>(
   }
 }
 
+// One-time seed for the ledger footprint aggregates (#100622): estimate rows
+// written before the estimated_bytes columns existed, then roll them up per
+// session. Zero is a safe "not seeded" sentinel because every real row costs
+// at least its 32-byte overhead.
+function backfillAcpReplayEstimatedBytes(db: DatabaseSync): void {
+  if (
+    !tableExists(db, "acp_replay_events") ||
+    !tableHasColumn(db, "acp_replay_events", "estimated_bytes")
+  ) {
+    return;
+  }
+  const pendingEvent = db
+    .prepare("SELECT 1 FROM acp_replay_events WHERE estimated_bytes = 0 LIMIT 1")
+    .get();
+  const pendingSession = db
+    .prepare("SELECT 1 FROM acp_replay_sessions WHERE estimated_bytes = 0 LIMIT 1")
+    .get();
+  if (!pendingEvent && !pendingSession) {
+    return;
+  }
+  db.exec(`
+    UPDATE acp_replay_events
+       SET estimated_bytes = length(session_id) + length(session_key) + length(update_json)
+             + COALESCE(length(run_id), 0) + 32
+     WHERE estimated_bytes = 0;
+    UPDATE acp_replay_sessions
+       SET estimated_bytes = length(session_id) + length(session_key) + length(cwd) + 32
+             + COALESCE((SELECT SUM(e.estimated_bytes) FROM acp_replay_events e
+                          WHERE e.session_id = acp_replay_sessions.session_id), 0)
+     WHERE estimated_bytes = 0;
+  `);
+}
+
 function backfillCronRunLogEntryJson(db: DatabaseSync): void {
   if (!tableExists(db, "cron_run_logs") || !tableHasColumn(db, "cron_run_logs", "entry_json")) {
     return;
@@ -1178,6 +1211,9 @@ function ensureAdditiveStateColumns(db: DatabaseSync, pathname: string): void {
   ensureColumn(db, "cron_run_logs", "entry_json TEXT NOT NULL DEFAULT '{}'");
   ensureColumn(db, "cron_run_logs", "created_at INTEGER NOT NULL DEFAULT 0");
   backfillCronRunLogEntryJson(db);
+  ensureColumn(db, "acp_replay_events", "estimated_bytes INTEGER NOT NULL DEFAULT 0");
+  ensureColumn(db, "acp_replay_sessions", "estimated_bytes INTEGER NOT NULL DEFAULT 0");
+  backfillAcpReplayEstimatedBytes(db);
   ensureColumn(db, "cron_jobs", "description TEXT");
   ensureColumn(db, "cron_jobs", "declaration_key TEXT");
   ensureColumn(db, "cron_jobs", "display_name TEXT");

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -714,7 +714,11 @@ CREATE TABLE IF NOT EXISTS acp_replay_sessions (
   complete INTEGER NOT NULL,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
-  next_seq INTEGER NOT NULL
+  next_seq INTEGER NOT NULL,
+  -- Running estimate of this session's ledger footprint (row overhead plus
+  -- all event rows), maintained at insert/trim so budget checks never scan
+  -- acp_replay_events (#100622).
+  estimated_bytes INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_acp_replay_sessions_key_updated
@@ -730,6 +734,7 @@ CREATE TABLE IF NOT EXISTS acp_replay_events (
   session_key TEXT NOT NULL,
   run_id TEXT,
   update_json TEXT NOT NULL,
+  estimated_bytes INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (session_id, seq),
   FOREIGN KEY (session_id) REFERENCES acp_replay_sessions(session_id) ON DELETE CASCADE
 );

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -709,7 +709,11 @@ CREATE TABLE IF NOT EXISTS acp_replay_sessions (
   complete INTEGER NOT NULL,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
-  next_seq INTEGER NOT NULL
+  next_seq INTEGER NOT NULL,
+  -- Running estimate of this session's ledger footprint (row overhead plus
+  -- all event rows), maintained at insert/trim so budget checks never scan
+  -- acp_replay_events (#100622).
+  estimated_bytes INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_acp_replay_sessions_key_updated
@@ -725,6 +729,7 @@ CREATE TABLE IF NOT EXISTS acp_replay_events (
   session_key TEXT NOT NULL,
   run_id TEXT,
   update_json TEXT NOT NULL,
+  estimated_bytes INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (session_id, seq),
   FOREIGN KEY (session_id) REFERENCES acp_replay_sessions(session_id) ON DELETE CASCADE
 );


### PR DESCRIPTION
## What Problem This Solves

Fixes #100622: `estimateSqliteLedgerBytes` ran a full `SUM(length(...))` scan over every `acp_replay_events` row on **every appended session update**, and once the 16MB budget was exceeded the trim loop re-ran that full scan after each single-row delete — O(events) per message and quadratic during eviction. On busy gateways this is a steady per-message tax on the shared state DB.

## Why This Change Was Made

Applies the insert-time budget pattern (as used by Codex's log DB): event rows carry `estimated_bytes` computed at insert, session rows maintain a running footprint aggregate (row overhead + their events), and the budget check becomes a `SUM` over at most `maxSessions` (200) rows. Eviction deletes bounded batches (`LIMIT 64 ... RETURNING estimated_bytes`) and decrements aggregates exactly. Session-key/cwd length changes adjust the aggregate through SET expressions that read the pre-update row, and the conflict-upsert recomputes from surviving event rows, so aggregates cannot drift. Additive columns backfill once via `ensureAdditiveStateColumns` with a cheap zero-sentinel probe.

## User Impact

No behavior change to replay semantics, caps, or eviction order (least-recently-updated sessions still evict first). Appends on the ACP path stop scanning the event ledger; trims stop being quadratic. Existing databases self-migrate on next open.

## Evidence

- `node scripts/run-vitest.mjs src/acp/event-ledger.test.ts` — all pass, including a new invariant test that forces repeated byte-budget eviction across three sessions with a provisional→canonical key rebind and asserts the maintained aggregate equals ground truth recomputed from stored rows (and stays ≤ the budget).
- `node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts` — pass (additive column + backfill path).
- Both tsgo lanes clean; oxlint clean.
- Codex autoreview (gpt-5.5, xhigh): two aggregate-drift findings raised and fixed in the second commit; final branch review clean ("patch is correct", no actionable findings).
