### PR TITLE
ci: honor frozen target tool versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1051,8 +1051,8 @@ jobs:
         run: |
           if [[ "$COMPATIBILITY_TARGET" == "true" ]]; then
             # Frozen targets can contain timing-sensitive tests fixed on current main.
-            # Retry only failures once; deterministic regressions still fail twice.
-            pnpm --dir ui test -- --retry=1
+            # Preserve one retry, but let their browser helpers use their 10-second waits.
+            pnpm --dir ui test -- --retry=1 --testTimeout=10000
           else
             pnpm --dir ui test
           fi
@@ -2091,11 +2091,24 @@ jobs:
             "$swift_tools_dir/swiftformat" --version
             "$swift_tools_dir/swiftlint" version
           elif [[ "$HISTORICAL_TARGET" == "true" ]]; then
-            # Frozen release targets before the pinned installer used SwiftFormat 0.61.1.
-            # Keep their lint contract stable instead of inheriting new Homebrew rules.
+            # Frozen release targets before the pinned installer used one of these
+            # reviewed formatter contracts. Fail closed for any unknown minimum.
             brew install xcodegen swiftlint
-            swiftformat_version="0.61.1"
-            swiftformat_checksum="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"
+            swiftformat_min_version="$(awk '$1 == "--min-version" { print $2; exit }' config/swiftformat)"
+            case "$swiftformat_min_version" in
+              ""|0.61.1)
+                swiftformat_version="0.61.1"
+                swiftformat_checksum="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"
+                ;;
+              0.62.1)
+                swiftformat_version="0.62.1"
+                swiftformat_checksum="7cb1cb1fae04932047c7015441c543848e8e60e1572d808d080e0a1f1661114a"
+                ;;
+              *)
+                echo "Unsupported frozen-target SwiftFormat minimum: $swiftformat_min_version" >&2
+                exit 1
+                ;;
+            esac
             swiftformat_archive="$RUNNER_TEMP/swiftformat-$swiftformat_version.zip"
             swift_tools_dir="$RUNNER_TEMP/openclaw-legacy-swift-tools"
             curl --fail --location --silent --show-error --retry 3 \

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1838,6 +1838,15 @@ describe("ci workflow guards", () => {
     expect(swiftInstall.run).toContain(
       'swiftformat_checksum="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"',
     );
+    expect(swiftInstall.run).toContain(
+      'swiftformat_checksum="7cb1cb1fae04932047c7015441c543848e8e60e1572d808d080e0a1f1661114a"',
+    );
+    expect(swiftInstall.run).toContain(
+      'swiftformat_min_version="$(awk \'$1 == "--min-version" { print $2; exit }\' config/swiftformat)"',
+    );
+    expect(swiftInstall.run).toContain(
+      'echo "Unsupported frozen-target SwiftFormat minimum: $swiftformat_min_version" >&2',
+    );
     expect(swiftInstall.run).toContain('echo "$swift_tools_dir" >> "$GITHUB_PATH"');
     expect(swiftInstall.run).toContain(
       '[[ "$("$swift_tools_dir/swiftformat" --version)" == "$swiftformat_version" ]]',
@@ -1866,7 +1875,7 @@ describe("ci workflow guards", () => {
       "${{ needs.preflight.outputs.compatibility_target }}",
     );
     expect(uiTest.run).toContain('if [[ "$COMPATIBILITY_TARGET" == "true" ]]');
-    expect(uiTest.run).toContain("pnpm --dir ui test -- --retry=1");
+    expect(uiTest.run).toContain("pnpm --dir ui test -- --retry=1 --testTimeout=10000");
     expect(uiTest.run).toContain("pnpm --dir ui test");
   });
 


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation uses the trusted workflow from `main` against frozen beta and extended-stable targets. The compatibility fallback pinned every older target to SwiftFormat 0.61.1 even when the target explicitly required 0.62.1, and frozen browser tests were capped below their own declared 10-second waits.

## Why This Change Was Made

Select SwiftFormat only from a closed, checksum-pinned allowlist based on the frozen target's `config/swiftformat` minimum. Preserve 0.61.1 for targets without a minimum, use 0.62.1 only when explicitly required, and fail closed for any unknown version. Compatibility-only UI validation retains one retry and raises Vitest's timeout to the tests' existing 10-second wait budget; current-main CI remains strict.

## User Impact

No runtime behavior changes. Beta, July, and LTS candidates can be validated by the current trusted workflow without inheriting incompatible formatter or browser-test timing defaults.

## Evidence

- Blacksmith Testbox `tbx_01kx9m6qfjshykfkcge2943qxq`: `corepack pnpm test test/scripts/ci-workflow-guards.test.ts` — 51/51 passed.
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Official SwiftFormat 0.62.1 archive SHA-256 verified as `7cb1cb1fae04932047c7015441c543848e8e60e1572d808d080e0a1f1661114a`.
- Fresh autoreview: clean, correctness confidence 0.87.
