### PR TITLE
fix(memory): isolate local embedding services across runtimes

### DIFF
--- a/extensions/memory-core/cli-metadata.ts
+++ b/extensions/memory-core/cli-metadata.ts
@@ -9,7 +9,9 @@ export default definePluginEntry({
     api.registerCli(
       async ({ program }) => {
         const { registerMemoryCli } = await import("./cli.js");
-        registerMemoryCli(program);
+        registerMemoryCli(program, {
+          acquireLocalService: api.runtime.llm?.acquireLocalService,
+        });
       },
       {
         descriptors: [

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -13,12 +13,21 @@ import {
 import { buildPromptSection } from "./src/prompt-section.js";
 
 const closeMemorySearchManagerMock = vi.hoisted(() => vi.fn(async () => {}));
+const getMemorySearchManagerMock = vi.hoisted(() => vi.fn(async () => null));
+const createMemoryRuntimeMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    closeAllMemorySearchManagers: vi.fn(async () => {}),
+    closeMemorySearchManager: closeMemorySearchManagerMock,
+    getMemorySearchManager: getMemorySearchManagerMock,
+  })),
+);
 
 vi.mock("./src/runtime-provider.js", () => ({
+  createMemoryRuntime: createMemoryRuntimeMock,
   memoryRuntime: {
     closeAllMemorySearchManagers: vi.fn(async () => {}),
     closeMemorySearchManager: closeMemorySearchManagerMock,
-    getMemorySearchManager: vi.fn(async () => null),
+    getMemorySearchManager: getMemorySearchManagerMock,
   },
 }));
 
@@ -120,6 +129,15 @@ describe("memory-core plugin runtime registration", () => {
     await runtime.closeMemorySearchManager?.({ cfg, agentId: "main" });
 
     expect(closeMemorySearchManagerMock).toHaveBeenCalledWith({ cfg, agentId: "main" });
+  });
+
+  it("binds the host local-service hook to the registered memory runtime", async () => {
+    const runtime = registerMemoryCoreRuntime();
+    const cfg = {} as OpenClawConfig;
+
+    await runtime.getMemorySearchManager({ cfg, agentId: "main" });
+
+    expect(createMemoryRuntimeMock).toHaveBeenCalledWith(hostRuntime.llm.acquireLocalService);
   });
 });
 

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -18,7 +18,7 @@ import type { TSchema } from "typebox";
 import { configureMemoryCoreDreamingState } from "./src/dreaming-state.js";
 import { registerShortTermPromotionDreaming } from "./src/dreaming.js";
 import { buildMemoryFlushPlan } from "./src/flush-plan.js";
-import { configureMemoryCoreEmbeddingLocalService } from "./src/memory/embedding-local-service.js";
+import type { MemoryCoreAcquireLocalService } from "./src/memory/embedding-local-service.js";
 import { buildPromptSection } from "./src/prompt-section.js";
 
 type MemoryToolsModule = typeof import("./src/tools.js");
@@ -30,6 +30,7 @@ type MemoryToolOptions = {
   agentSessionKey?: string;
   sandboxed?: boolean;
   oneShotCliRun?: boolean;
+  acquireLocalService?: MemoryCoreAcquireLocalService;
 };
 
 const loadMemoryToolsModule = createLazyRuntimeModule(() => import("./src/tools.js"));
@@ -140,7 +141,10 @@ function createLazyMemoryGetTool(options: MemoryToolOptions): AnyAgentTool | nul
   });
 }
 
-function resolveMemoryToolOptions(ctx: OpenClawPluginToolContext): MemoryToolOptions {
+function resolveMemoryToolOptions(
+  ctx: OpenClawPluginToolContext,
+  acquireLocalService?: MemoryCoreAcquireLocalService,
+): MemoryToolOptions {
   const getConfig = () => ctx.getRuntimeConfig?.() ?? ctx.runtimeConfig ?? ctx.config;
   return {
     config: getConfig(),
@@ -149,33 +153,39 @@ function resolveMemoryToolOptions(ctx: OpenClawPluginToolContext): MemoryToolOpt
     agentSessionKey: ctx.sessionKey,
     sandboxed: ctx.sandboxed,
     oneShotCliRun: ctx.oneShotCliRun,
+    ...(acquireLocalService ? { acquireLocalService } : {}),
   };
 }
 
-const memoryRuntime: MemoryPluginRuntime = {
-  async getMemorySearchManager(params) {
-    const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
-    return await runtime.getMemorySearchManager(params);
-  },
-  resolveMemoryBackendConfig(params) {
-    return resolveMemoryBackendConfig(params);
-  },
-  async closeAllMemorySearchManagers() {
-    const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
-    await runtime.closeAllMemorySearchManagers?.();
-  },
-  async closeMemorySearchManager(params) {
-    const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
-    await runtime.closeMemorySearchManager?.(params);
-  },
-};
+function createLazyMemoryRuntime(
+  acquireLocalService?: MemoryCoreAcquireLocalService,
+): MemoryPluginRuntime {
+  return {
+    async getMemorySearchManager(params) {
+      const { createMemoryRuntime } = await loadRuntimeProviderModule();
+      return await createMemoryRuntime(acquireLocalService).getMemorySearchManager(params);
+    },
+    resolveMemoryBackendConfig(params) {
+      return resolveMemoryBackendConfig(params);
+    },
+    async closeAllMemorySearchManagers() {
+      const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
+      await runtime.closeAllMemorySearchManagers?.();
+    },
+    async closeMemorySearchManager(params) {
+      const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
+      await runtime.closeMemorySearchManager?.(params);
+    },
+  };
+}
+
 export default definePluginEntry({
   id: "memory-core",
   name: "Memory (Core)",
   description: "File-backed memory search tools and CLI",
   kind: "memory",
   register(api) {
-    configureMemoryCoreEmbeddingLocalService(api.runtime.llm?.acquireLocalService);
+    const acquireLocalService = api.runtime.llm?.acquireLocalService;
     configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
       api.runtime.state.openKeyedStore<T>(options),
     );
@@ -183,7 +193,7 @@ export default definePluginEntry({
     api.registerMemoryCapability({
       promptBuilder: buildPromptSection,
       flushPlanResolver: buildMemoryFlushPlan,
-      runtime: memoryRuntime,
+      runtime: createLazyMemoryRuntime(acquireLocalService),
       publicArtifacts: {
         async listArtifacts(params) {
           const { listMemoryCorePublicArtifacts } = await import("./src/public-artifacts.js");
@@ -192,13 +202,19 @@ export default definePluginEntry({
       },
     });
 
-    api.registerTool((ctx) => createLazyMemorySearchTool(resolveMemoryToolOptions(ctx)), {
-      names: ["memory_search"],
-    });
+    api.registerTool(
+      (ctx) => createLazyMemorySearchTool(resolveMemoryToolOptions(ctx, acquireLocalService)),
+      {
+        names: ["memory_search"],
+      },
+    );
 
-    api.registerTool((ctx) => createLazyMemoryGetTool(resolveMemoryToolOptions(ctx)), {
-      names: ["memory_get"],
-    });
+    api.registerTool(
+      (ctx) => createLazyMemoryGetTool(resolveMemoryToolOptions(ctx, acquireLocalService)),
+      {
+        names: ["memory_get"],
+      },
+    );
 
     api.registerCommand({
       name: "dreaming",
@@ -214,7 +230,7 @@ export default definePluginEntry({
     api.registerCli(
       async ({ program }) => {
         const { registerMemoryCli } = await import("./cli.js");
-        registerMemoryCli(program);
+        registerMemoryCli(program, { acquireLocalService });
       },
       {
         descriptors: [

--- a/extensions/memory-core/runtime-api.ts
+++ b/extensions/memory-core/runtime-api.ts
@@ -17,7 +17,6 @@ export { checkQmdBinaryAvailability } from "openclaw/plugin-sdk/memory-core-host
 export { hasConfiguredMemorySecretInput } from "openclaw/plugin-sdk/memory-core-host-secret";
 export { auditDreamingArtifacts, repairDreamingArtifacts } from "./src/dreaming-repair.js";
 export { configureMemoryCoreDreamingState } from "./src/dreaming-state.js";
-export { configureMemoryCoreEmbeddingLocalService } from "./src/memory/embedding-local-service.js";
 export {
   auditShortTermPromotionArtifacts,
   loadShortTermPromotionDreamingStats,

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -52,6 +52,10 @@ import {
 } from "./dreaming-repair.js";
 import { asRecord } from "./dreaming-shared.js";
 import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
+import type {
+  MemoryCoreAcquireLocalService,
+  MemoryCoreLocalServiceHost,
+} from "./memory/embedding-local-service.js";
 import { formatMemoryVectorDegradedWriteReason } from "./memory/manager-vector-warning.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
 import { previewRemHarness } from "./rem-harness.js";
@@ -540,6 +544,7 @@ async function withMemoryManagerForAgent(params: {
   cfg: OpenClawConfig;
   agentId: string;
   purpose?: MemoryManagerPurpose;
+  acquireLocalService?: MemoryCoreAcquireLocalService;
   run: (manager: MemoryManager) => Promise<void>;
 }): Promise<void> {
   const managerParams: Parameters<typeof getMemorySearchManager>[0] = {
@@ -548,6 +553,9 @@ async function withMemoryManagerForAgent(params: {
   };
   if (params.purpose) {
     managerParams.purpose = params.purpose;
+  }
+  if (params.acquireLocalService) {
+    managerParams.acquireLocalService = params.acquireLocalService;
   }
   await withManager<MemoryManager>({
     getManager: () => getMemorySearchManager(managerParams),
@@ -740,7 +748,10 @@ async function scanMemorySources(params: {
   return { sources: scans, totalFiles, issues };
 }
 
-export async function runMemoryStatus(opts: MemoryCommandOptions) {
+export async function runMemoryStatus(
+  opts: MemoryCommandOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   setVerbose(Boolean(opts.verbose));
   const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory status");
   emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
@@ -763,6 +774,7 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
       cfg,
       agentId,
       purpose: managerPurpose,
+      acquireLocalService: hostOptions?.acquireLocalService,
       run: async (manager) => {
         const deep = Boolean(opts.deep || opts.index);
         let embeddingProbe: MemoryEmbeddingProbeResult | undefined;
@@ -1166,7 +1178,10 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
   }
 }
 
-export async function runMemoryIndex(opts: MemoryCommandOptions) {
+export async function runMemoryIndex(
+  opts: MemoryCommandOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   setVerbose(Boolean(opts.verbose));
   const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory index");
   emitMemorySecretResolveDiagnostics(diagnostics);
@@ -1176,6 +1191,7 @@ export async function runMemoryIndex(opts: MemoryCommandOptions) {
       cfg,
       agentId,
       purpose: "cli",
+      acquireLocalService: hostOptions?.acquireLocalService,
       run: async (manager) => {
         try {
           const syncFn = manager.sync ? manager.sync.bind(manager) : undefined;
@@ -1329,6 +1345,7 @@ export async function runMemoryIndex(opts: MemoryCommandOptions) {
 export async function runMemorySearch(
   queryArg: string | undefined,
   opts: MemorySearchCommandOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
 ) {
   const query = opts.query ?? queryArg;
   if (!query) {
@@ -1352,6 +1369,7 @@ export async function runMemorySearch(
     cfg,
     agentId,
     purpose: "cli",
+    acquireLocalService: hostOptions?.acquireLocalService,
     run: async (manager) => {
       const sessionKey = buildCliMemorySearchSessionKey(agentId);
       let results: Awaited<ReturnType<typeof manager.search>>;
@@ -1416,7 +1434,10 @@ export async function runMemorySearch(
   });
 }
 
-export async function runMemoryPromote(opts: MemoryPromoteCommandOptions) {
+export async function runMemoryPromote(
+  opts: MemoryPromoteCommandOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory promote");
   emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
   const agentId = resolveAgent(cfg, opts.agent);
@@ -1425,6 +1446,7 @@ export async function runMemoryPromote(opts: MemoryPromoteCommandOptions) {
     cfg,
     agentId,
     purpose: "status",
+    acquireLocalService: hostOptions?.acquireLocalService,
     run: async (manager) => {
       const status = manager.status();
       const workspaceDir = status.workspaceDir?.trim();
@@ -1594,6 +1616,7 @@ export async function runMemoryPromote(opts: MemoryPromoteCommandOptions) {
 export async function runMemoryPromoteExplain(
   selectorArg: string | undefined,
   opts: MemoryPromoteExplainOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
 ) {
   const selector = selectorArg?.trim();
   if (!selector) {
@@ -1610,6 +1633,7 @@ export async function runMemoryPromoteExplain(
     cfg,
     agentId,
     purpose: "status",
+    acquireLocalService: hostOptions?.acquireLocalService,
     run: async (manager) => {
       const status = manager.status();
       const workspaceDir = status.workspaceDir?.trim();
@@ -1709,7 +1733,10 @@ export async function runMemoryPromoteExplain(
   });
 }
 
-export async function runMemoryRemHarness(opts: MemoryRemHarnessOptions) {
+export async function runMemoryRemHarness(
+  opts: MemoryRemHarnessOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory rem-harness");
   emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
   const agentId = resolveAgent(cfg, opts.agent);
@@ -1718,6 +1745,7 @@ export async function runMemoryRemHarness(opts: MemoryRemHarnessOptions) {
     cfg,
     agentId,
     purpose: "status",
+    acquireLocalService: hostOptions?.acquireLocalService,
     run: async (manager) => {
       const status = manager.status();
       const managerWorkspaceDir = status.workspaceDir?.trim();
@@ -1889,7 +1917,10 @@ export async function runMemoryRemHarness(opts: MemoryRemHarnessOptions) {
   });
 }
 
-export async function runMemoryRemBackfill(opts: MemoryRemBackfillOptions) {
+export async function runMemoryRemBackfill(
+  opts: MemoryRemBackfillOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory rem-backfill");
   emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
   const agentId = resolveAgent(cfg, opts.agent);
@@ -1898,6 +1929,7 @@ export async function runMemoryRemBackfill(opts: MemoryRemBackfillOptions) {
     cfg,
     agentId,
     purpose: "status",
+    acquireLocalService: hostOptions?.acquireLocalService,
     run: async (manager) => {
       const status = manager.status();
       const workspaceDir = status.workspaceDir?.trim();

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -216,10 +216,13 @@ describe("memory cli", () => {
     expect(loggedOutput(spy)).not.toContain(expected);
   }
 
-  async function runMemoryCli(args: string[]) {
+  async function runMemoryCli(
+    args: string[],
+    hostOptions?: Parameters<typeof registerMemoryCli>[1],
+  ) {
     const program = new Command();
     program.name("test");
-    registerMemoryCli(program);
+    registerMemoryCli(program, hostOptions);
     await program.parseAsync(["memory", ...args], { from: "user" });
   }
 
@@ -1442,6 +1445,21 @@ describe("memory cli", () => {
     });
     expect(log).toHaveBeenCalledWith("No matches.");
     expect(close).toHaveBeenCalled();
+  });
+
+  it("passes the host local-service hook to CLI memory managers", async () => {
+    const close = vi.fn(async () => {});
+    mockManager({ search: vi.fn(async () => []), close });
+    const acquireLocalService = vi.fn(async () => undefined);
+
+    await runMemoryCli(["search", "hello"], { acquireLocalService });
+
+    expect(getMemorySearchManager).toHaveBeenCalledWith({
+      cfg: {},
+      agentId: "main",
+      purpose: "cli",
+      acquireLocalService,
+    });
   });
 
   it("accepts --query for memory search", async () => {

--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -18,6 +18,7 @@ import type {
   MemoryRemHarnessOptions,
   MemorySearchCommandOptions,
 } from "./cli.types.js";
+import type { MemoryCoreLocalServiceHost } from "./memory/embedding-local-service.js";
 import {
   DEFAULT_PROMOTION_MIN_RECALL_COUNT,
   DEFAULT_PROMOTION_MIN_SCORE,
@@ -28,42 +29,62 @@ const loadMemoryCliRuntime = createLazyRuntimeModule(() => import("./cli.runtime
 
 const DECIMAL_NUMBER_RE = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
 
-export async function runMemoryStatus(opts: MemoryCommandOptions) {
+export async function runMemoryStatus(
+  opts: MemoryCommandOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryStatus(opts);
+  await runtime.runMemoryStatus(opts, hostOptions);
 }
 
-async function runMemoryIndex(opts: MemoryCommandOptions) {
+async function runMemoryIndex(
+  opts: MemoryCommandOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryIndex(opts);
+  await runtime.runMemoryIndex(opts, hostOptions);
 }
 
-async function runMemorySearch(queryArg: string | undefined, opts: MemorySearchCommandOptions) {
+async function runMemorySearch(
+  queryArg: string | undefined,
+  opts: MemorySearchCommandOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemorySearch(queryArg, opts);
+  await runtime.runMemorySearch(queryArg, opts, hostOptions);
 }
 
-async function runMemoryPromote(opts: MemoryPromoteCommandOptions) {
+async function runMemoryPromote(
+  opts: MemoryPromoteCommandOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryPromote(opts);
+  await runtime.runMemoryPromote(opts, hostOptions);
 }
 
 async function runMemoryPromoteExplain(
   selectorArg: string | undefined,
   opts: MemoryPromoteExplainOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
 ) {
   const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryPromoteExplain(selectorArg, opts);
+  await runtime.runMemoryPromoteExplain(selectorArg, opts, hostOptions);
 }
 
-async function runMemoryRemHarness(opts: MemoryRemHarnessOptions) {
+async function runMemoryRemHarness(
+  opts: MemoryRemHarnessOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryRemHarness(opts);
+  await runtime.runMemoryRemHarness(opts, hostOptions);
 }
 
-async function runMemoryRemBackfill(opts: MemoryRemBackfillOptions) {
+async function runMemoryRemBackfill(
+  opts: MemoryRemBackfillOptions,
+  hostOptions?: MemoryCoreLocalServiceHost,
+) {
   const runtime = await loadMemoryCliRuntime();
-  await runtime.runMemoryRemBackfill(opts);
+  await runtime.runMemoryRemBackfill(opts, hostOptions);
 }
 
 function invalidCliArgument(message: string): Error & { code: string; exitCode: number } {
@@ -100,7 +121,7 @@ function parseMemoryCliNonNegativeIntegerOption(value: string, flag: string): nu
   return parsed;
 }
 
-export function registerMemoryCli(program: Command) {
+export function registerMemoryCli(program: Command, hostOptions?: MemoryCoreLocalServiceHost) {
   const memory = program
     .command("memory")
     .description("Search, inspect, and reindex memory files")
@@ -158,7 +179,7 @@ export function registerMemoryCli(program: Command) {
     .option("--fix", "Repair stale recall locks and normalize promotion metadata")
     .option("--verbose", "Verbose logging", false)
     .action(async (opts: MemoryCommandOptions & { force?: boolean }) => {
-      await runMemoryStatus(opts);
+      await runMemoryStatus(opts, hostOptions);
     });
 
   memory
@@ -168,7 +189,7 @@ export function registerMemoryCli(program: Command) {
     .option("--force", "Force full reindex", false)
     .option("--verbose", "Verbose logging", false)
     .action(async (opts: MemoryCommandOptions) => {
-      await runMemoryIndex(opts);
+      await runMemoryIndex(opts, hostOptions);
     });
 
   memory
@@ -185,7 +206,7 @@ export function registerMemoryCli(program: Command) {
     )
     .option("--json", "Print JSON")
     .action(async (queryArg: string | undefined, opts: MemorySearchCommandOptions) => {
-      await runMemorySearch(queryArg, opts);
+      await runMemorySearch(queryArg, opts, hostOptions);
     });
 
   memory
@@ -214,7 +235,7 @@ export function registerMemoryCli(program: Command) {
     .option("--include-promoted", "Include already promoted candidates", false)
     .option("--json", "Print JSON")
     .action(async (opts: MemoryPromoteCommandOptions) => {
-      await runMemoryPromote(opts);
+      await runMemoryPromote(opts, hostOptions);
     });
 
   memory
@@ -225,7 +246,7 @@ export function registerMemoryCli(program: Command) {
     .option("--include-promoted", "Include already promoted candidates", false)
     .option("--json", "Print JSON")
     .action(async (selectorArg: string | undefined, opts: MemoryPromoteExplainOptions) => {
-      await runMemoryPromoteExplain(selectorArg, opts);
+      await runMemoryPromoteExplain(selectorArg, opts, hostOptions);
     });
 
   memory
@@ -237,7 +258,7 @@ export function registerMemoryCli(program: Command) {
     .option("--include-promoted", "Include already promoted deep candidates", false)
     .option("--json", "Print JSON")
     .action(async (opts: MemoryRemHarnessOptions) => {
-      await runMemoryRemHarness(opts);
+      await runMemoryRemHarness(opts, hostOptions);
     });
 
   memory
@@ -258,7 +279,7 @@ export function registerMemoryCli(program: Command) {
     )
     .option("--json", "Print JSON")
     .action(async (opts: MemoryRemBackfillOptions) => {
-      await runMemoryRemBackfill(opts);
+      await runMemoryRemBackfill(opts, hostOptions);
     });
 
   memory.action(() => {

--- a/extensions/memory-core/src/memory/embedding-local-service.ts
+++ b/extensions/memory-core/src/memory/embedding-local-service.ts
@@ -7,15 +7,3 @@ export type MemoryCoreAcquireLocalService = (
   },
   signal?: AbortSignal | null,
 ) => Promise<{ release: () => void } | undefined>;
-
-let acquireLocalService: MemoryCoreAcquireLocalService | undefined;
-
-export function configureMemoryCoreEmbeddingLocalService(
-  acquire: MemoryCoreAcquireLocalService | undefined,
-): void {
-  acquireLocalService = acquire;
-}
-
-export function getMemoryCoreEmbeddingLocalService(): MemoryCoreAcquireLocalService | undefined {
-  return acquireLocalService;
-}

--- a/extensions/memory-core/src/memory/embedding-local-service.ts
+++ b/extensions/memory-core/src/memory/embedding-local-service.ts
@@ -7,3 +7,7 @@ export type MemoryCoreAcquireLocalService = (
   },
   signal?: AbortSignal | null,
 ) => Promise<{ release: () => void } | undefined>;
+
+export type MemoryCoreLocalServiceHost = {
+  acquireLocalService?: MemoryCoreAcquireLocalService;
+};

--- a/extensions/memory-core/src/memory/embedding-local-service.ts
+++ b/extensions/memory-core/src/memory/embedding-local-service.ts
@@ -1,3 +1,5 @@
+import { resolveGlobalSingleton } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+
 // Memory Core receives local-service acquisition from the host before provider creation.
 export type MemoryCoreAcquireLocalService = (
   target: {
@@ -11,3 +13,32 @@ export type MemoryCoreAcquireLocalService = (
 export type MemoryCoreLocalServiceHost = {
   acquireLocalService?: MemoryCoreAcquireLocalService;
 };
+
+const MEMORY_LOCAL_SERVICE_HOST_IDENTITIES_KEY = Symbol.for(
+  "openclaw.memoryLocalServiceHostIdentities",
+);
+
+// Manager caches survive module reloads, so hook identities must survive too.
+// Otherwise a new runtime can collide with a cached manager owned by another host.
+const LOCAL_SERVICE_HOST_IDENTITIES = resolveGlobalSingleton<{
+  ids: WeakMap<MemoryCoreAcquireLocalService, number>;
+  nextId: number;
+}>(MEMORY_LOCAL_SERVICE_HOST_IDENTITIES_KEY, () => ({
+  ids: new WeakMap(),
+  nextId: 1,
+}));
+
+export function resolveMemoryCoreLocalServiceHostIdentity(
+  acquireLocalService: MemoryCoreAcquireLocalService | undefined,
+): string {
+  if (!acquireLocalService) {
+    return "none";
+  }
+  let id = LOCAL_SERVICE_HOST_IDENTITIES.ids.get(acquireLocalService);
+  if (id === undefined) {
+    id = LOCAL_SERVICE_HOST_IDENTITIES.nextId;
+    LOCAL_SERVICE_HOST_IDENTITIES.nextId += 1;
+    LOCAL_SERVICE_HOST_IDENTITIES.ids.set(acquireLocalService, id);
+  }
+  return String(id);
+}

--- a/extensions/memory-core/src/memory/embeddings.test.ts
+++ b/extensions/memory-core/src/memory/embeddings.test.ts
@@ -3,7 +3,6 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { EmbeddingProviderAdapter } from "openclaw/plugin-sdk/embedding-providers";
 import type { MemoryEmbeddingProviderAdapter } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { configureMemoryCoreEmbeddingLocalService } from "./embedding-local-service.js";
 import { createEmbeddingProvider, resolveEmbeddingProviderFallbackModel } from "./embeddings.js";
 
 const mockEmbeddingRegistry = vi.hoisted(() => ({
@@ -38,7 +37,10 @@ const missingBedrockCredentialsError = new Error(
   'No API key found for provider "bedrock". AWS credentials are not available.',
 );
 
-function createOptions(provider: string) {
+function createOptions(
+  provider: string,
+  acquireLocalService = mockEmbeddingRegistry.acquireLocalService,
+) {
   return {
     config: {
       plugins: {
@@ -59,6 +61,7 @@ function createOptions(provider: string) {
     provider,
     fallback: "none",
     model: "",
+    acquireLocalService,
   };
 }
 
@@ -102,11 +105,10 @@ function registerMemoryEmbeddingProvider(adapter: MemoryEmbeddingProviderAdapter
 describe("createEmbeddingProvider", () => {
   beforeEach(() => {
     clearMemoryEmbeddingProviders();
-    configureMemoryCoreEmbeddingLocalService(mockEmbeddingRegistry.acquireLocalService);
+    mockEmbeddingRegistry.acquireLocalService.mockReset();
   });
 
   afterEach(() => {
-    configureMemoryCoreEmbeddingLocalService(undefined);
     clearMemoryEmbeddingProviders();
   });
 
@@ -192,6 +194,36 @@ describe("createEmbeddingProvider", () => {
     expect(mockEmbeddingRegistry.genericLookupConfigs).toEqual([options.config]);
     await expect(result.provider?.embedQuery("hello")).resolves.toEqual([1]);
     await expect(result.provider?.embedBatch(["doc"])).resolves.toEqual([[3]]);
+  });
+
+  it("keeps concurrent provider creation bound to each caller's local-service hook", async () => {
+    const observedHooks: unknown[] = [];
+    registerGenericEmbeddingProvider({
+      id: "openai-compatible",
+      create: async (options) => {
+        observedHooks.push(
+          (options as typeof options & { acquireLocalService?: unknown }).acquireLocalService,
+        );
+        await Promise.resolve();
+        return {
+          provider: {
+            id: "generic",
+            model: "generic-model",
+            embed: async () => [1],
+            embedBatch: async (inputs) => inputs.map(() => [1]),
+          },
+        };
+      },
+    });
+    const firstAcquire = vi.fn(async () => undefined);
+    const secondAcquire = vi.fn(async () => undefined);
+
+    await Promise.all([
+      createEmbeddingProvider(createOptions("openai-compatible", firstAcquire)),
+      createEmbeddingProvider(createOptions("openai-compatible", secondAcquire)),
+    ]);
+
+    expect(observedHooks).toEqual([firstAcquire, secondAcquire]);
   });
 
   it("keeps memory-specific providers authoritative during dual registration", async () => {

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -13,7 +13,7 @@ import {
   type MemoryEmbeddingProviderRuntime,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { formatErrorMessage } from "../dreaming-shared.js";
-import { getMemoryCoreEmbeddingLocalService } from "./embedding-local-service.js";
+import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
 
 export type EmbeddingProvider = MemoryEmbeddingProvider;
 export type EmbeddingProviderId = string;
@@ -33,6 +33,7 @@ export type EmbeddingProviderResult = {
 type CreateEmbeddingProviderOptions = MemoryEmbeddingProviderCreateOptions & {
   provider: EmbeddingProviderRequest;
   fallback: EmbeddingProviderFallback;
+  acquireLocalService?: MemoryCoreAcquireLocalService;
 };
 
 const DEFAULT_MEMORY_EMBEDDING_PROVIDER = "openai";
@@ -239,7 +240,6 @@ async function createWithAdapter(
   const createOptions = {
     ...options,
     model: resolveProviderModel(adapter, options.model),
-    acquireLocalService: getMemoryCoreEmbeddingLocalService(),
   };
   const result = await adapter.create(createOptions);
   return {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1584,6 +1584,39 @@ describe("memory index", () => {
     expect(third).toBe(second);
   });
 
+  it("does not reuse memory index managers across local-service hosts", async () => {
+    const cfg = createCfg({});
+    const firstAcquire = vi.fn(async () => undefined);
+    const secondAcquire = vi.fn(async () => undefined);
+    const first = requireManager(
+      await getMemorySearchManager({
+        cfg,
+        agentId: "main",
+        acquireLocalService: firstAcquire,
+      }),
+    );
+    managersForCleanup.add(first);
+
+    const second = requireManager(
+      await getMemorySearchManager({
+        cfg,
+        agentId: "main",
+        acquireLocalService: secondAcquire,
+      }),
+    );
+    managersForCleanup.add(second);
+    const secondAgain = requireManager(
+      await getMemorySearchManager({
+        cfg,
+        agentId: "main",
+        acquireLocalService: secondAcquire,
+      }),
+    );
+
+    expect(Object.is(second, first)).toBe(false);
+    expect(Object.is(secondAgain, second)).toBe(true);
+  });
+
   it("retries embedding provider close before releasing the manager", async () => {
     providerCloseFailuresRemaining = 1;
     const cfg = createCfg({

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -296,7 +296,7 @@ function createSessionSyncYield(total: number): () => Promise<void> {
 }
 
 export abstract class MemoryManagerSyncOps {
-  protected abstract readonly acquireLocalService?: MemoryCoreAcquireLocalService;
+  protected readonly acquireLocalService?: MemoryCoreAcquireLocalService;
   protected abstract readonly cfg: OpenClawConfig;
   protected abstract readonly agentId: string;
   protected abstract readonly workspaceDir: string;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -50,6 +50,7 @@ import {
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
 import {
   createEmbeddingProvider,
   resolveEmbeddingProviderAdapterId,
@@ -295,6 +296,7 @@ function createSessionSyncYield(total: number): () => Promise<void> {
 }
 
 export abstract class MemoryManagerSyncOps {
+  protected abstract readonly acquireLocalService?: MemoryCoreAcquireLocalService;
   protected abstract readonly cfg: OpenClawConfig;
   protected abstract readonly agentId: string;
   protected abstract readonly workspaceDir: string;
@@ -2724,6 +2726,7 @@ export abstract class MemoryManagerSyncOps {
     const fallbackResult = await createEmbeddingProvider({
       config: this.cfg,
       agentDir: resolveAgentDir(this.cfg, this.agentId),
+      ...(this.acquireLocalService ? { acquireLocalService: this.acquireLocalService } : {}),
       ...fallbackRequest,
     });
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -29,6 +29,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { uniqueValues } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
 import {
   createEmbeddingProvider,
   resolveEmbeddingProviderAdapterTransport,
@@ -294,6 +295,7 @@ async function closeMemoryIndexManagersForScope(params: {
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {
   private readonly cacheKey: string;
   private readonly purpose: MemoryIndexManagerPurpose;
+  protected override readonly acquireLocalService?: MemoryCoreAcquireLocalService;
   protected readonly cfg: OpenClawConfig;
   protected readonly agentId: string;
   protected readonly workspaceDir: string;
@@ -372,10 +374,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     cfg: OpenClawConfig;
     agentId: string;
     settings: ResolvedMemorySearchConfig;
+    acquireLocalService?: MemoryCoreAcquireLocalService;
   }): Promise<EmbeddingProviderResult> {
     return await createEmbeddingProvider({
       config: params.cfg,
       agentDir: resolveAgentDir(params.cfg, params.agentId),
+      ...(params.acquireLocalService ? { acquireLocalService: params.acquireLocalService } : {}),
       ...resolveMemoryPrimaryProviderRequest({ settings: params.settings }),
     });
   }
@@ -384,6 +388,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     cfg: OpenClawConfig;
     agentId: string;
     purpose?: MemoryIndexManagerPurpose;
+    acquireLocalService?: MemoryCoreAcquireLocalService;
   }): Promise<MemoryIndexManager | null> {
     const { cfg, agentId } = params;
     const settings = resolveMemorySearchConfig(cfg, agentId);
@@ -428,6 +433,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           settings,
           providerRequirement,
           purpose: params.purpose,
+          acquireLocalService: params.acquireLocalService,
         });
         // Lightweight dirty-file detection for status mode: check for unindexed
         // session files on disk without triggering a full sync. This runs before
@@ -454,10 +460,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     providerRequirement: MemoryEmbeddingProviderRequirement;
     providerResult?: EmbeddingProviderResult;
     purpose?: MemoryIndexManagerPurpose;
+    acquireLocalService?: MemoryCoreAcquireLocalService;
   }) {
     super();
     const effectiveSettings = resolveEffectiveMemorySearchSettings(params.settings);
     this.cacheKey = params.cacheKey;
+    this.acquireLocalService = params.acquireLocalService;
     this.purpose =
       params.purpose === "status" || params.purpose === "cli" ? params.purpose : "default";
     this.cfg = params.cfg;
@@ -550,6 +558,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           cfg: this.cfg,
           agentId: this.agentId,
           settings: this.settings,
+          acquireLocalService: this.acquireLocalService,
         });
         this.applyProviderResult(providerResult);
         this.providerKey = this.computeProviderKey();

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -7,6 +7,7 @@ import {
   createSubsystemLogger,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
+  resolveGlobalSingleton,
   resolveMemorySearchConfig,
   type OpenClawConfig,
   type ResolvedMemorySearchConfig,
@@ -99,6 +100,9 @@ const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const PATH_FTS_TABLE = MEMORY_INDEX_PATHS_FTS_TABLE;
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
+const MEMORY_LOCAL_SERVICE_HOST_IDENTITIES_KEY = Symbol.for(
+  "openclaw.memoryLocalServiceHostIdentities",
+);
 export const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const KEYWORD_FALLBACK_SEARCH_TERM_LIMIT = 6;
 const EXACT_PATH_CANDIDATE_LIMIT = 200;
@@ -112,6 +116,15 @@ type MemoryEmbeddingProviderRequirement = {
 
 const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
   resolveSingletonManagedCache<MemoryIndexManager>(MEMORY_INDEX_MANAGER_CACHE_KEY);
+// The manager cache survives module reloads, so hook identities must survive too.
+// Otherwise a new runtime can collide with a cached manager owned by another host.
+const LOCAL_SERVICE_HOST_IDENTITIES = resolveGlobalSingleton<{
+  ids: WeakMap<MemoryCoreAcquireLocalService, number>;
+  nextId: number;
+}>(MEMORY_LOCAL_SERVICE_HOST_IDENTITIES_KEY, () => ({
+  ids: new WeakMap(),
+  nextId: 1,
+}));
 
 type EmbeddingProbeCacheEntry = {
   result: MemoryEmbeddingProbeResult;
@@ -243,12 +256,24 @@ function resolveMemoryIndexManagerCacheKey(params: {
   settings: ResolvedMemorySearchConfig;
   providerRequirement: MemoryEmbeddingProviderRequirement;
   purpose: MemoryIndexManagerPurpose;
+  acquireLocalService?: MemoryCoreAcquireLocalService;
 }): string {
+  let localServiceHostId = "none";
+  if (params.acquireLocalService) {
+    let id = LOCAL_SERVICE_HOST_IDENTITIES.ids.get(params.acquireLocalService);
+    if (id === undefined) {
+      id = LOCAL_SERVICE_HOST_IDENTITIES.nextId;
+      LOCAL_SERVICE_HOST_IDENTITIES.nextId += 1;
+      LOCAL_SERVICE_HOST_IDENTITIES.ids.set(params.acquireLocalService, id);
+    }
+    localServiceHostId = String(id);
+  }
   return [
     params.agentId,
     params.workspaceDir,
     JSON.stringify(params.settings),
     JSON.stringify(params.providerRequirement),
+    localServiceHostId,
     params.purpose,
   ].join(":");
 }
@@ -409,6 +434,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       settings,
       providerRequirement,
       purpose,
+      acquireLocalService: params.acquireLocalService,
     });
     const transient = purpose === "status" || purpose === "cli";
     if (!transient) {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -7,7 +7,6 @@ import {
   createSubsystemLogger,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
-  resolveGlobalSingleton,
   resolveMemorySearchConfig,
   type OpenClawConfig,
   type ResolvedMemorySearchConfig,
@@ -30,7 +29,10 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { uniqueValues } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
+import {
+  resolveMemoryCoreLocalServiceHostIdentity,
+  type MemoryCoreAcquireLocalService,
+} from "./embedding-local-service.js";
 import {
   createEmbeddingProvider,
   resolveEmbeddingProviderAdapterTransport,
@@ -100,9 +102,6 @@ const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const PATH_FTS_TABLE = MEMORY_INDEX_PATHS_FTS_TABLE;
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const MEMORY_INDEX_MANAGER_CACHE_KEY = Symbol.for("openclaw.memoryIndexManagerCache");
-const MEMORY_LOCAL_SERVICE_HOST_IDENTITIES_KEY = Symbol.for(
-  "openclaw.memoryLocalServiceHostIdentities",
-);
 export const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
 const KEYWORD_FALLBACK_SEARCH_TERM_LIMIT = 6;
 const EXACT_PATH_CANDIDATE_LIMIT = 200;
@@ -116,15 +115,6 @@ type MemoryEmbeddingProviderRequirement = {
 
 const { cache: INDEX_CACHE, pending: INDEX_CACHE_PENDING } =
   resolveSingletonManagedCache<MemoryIndexManager>(MEMORY_INDEX_MANAGER_CACHE_KEY);
-// The manager cache survives module reloads, so hook identities must survive too.
-// Otherwise a new runtime can collide with a cached manager owned by another host.
-const LOCAL_SERVICE_HOST_IDENTITIES = resolveGlobalSingleton<{
-  ids: WeakMap<MemoryCoreAcquireLocalService, number>;
-  nextId: number;
-}>(MEMORY_LOCAL_SERVICE_HOST_IDENTITIES_KEY, () => ({
-  ids: new WeakMap(),
-  nextId: 1,
-}));
 
 type EmbeddingProbeCacheEntry = {
   result: MemoryEmbeddingProbeResult;
@@ -258,22 +248,12 @@ function resolveMemoryIndexManagerCacheKey(params: {
   purpose: MemoryIndexManagerPurpose;
   acquireLocalService?: MemoryCoreAcquireLocalService;
 }): string {
-  let localServiceHostId = "none";
-  if (params.acquireLocalService) {
-    let id = LOCAL_SERVICE_HOST_IDENTITIES.ids.get(params.acquireLocalService);
-    if (id === undefined) {
-      id = LOCAL_SERVICE_HOST_IDENTITIES.nextId;
-      LOCAL_SERVICE_HOST_IDENTITIES.nextId += 1;
-      LOCAL_SERVICE_HOST_IDENTITIES.ids.set(params.acquireLocalService, id);
-    }
-    localServiceHostId = String(id);
-  }
   return [
     params.agentId,
     params.workspaceDir,
     JSON.stringify(params.settings),
     JSON.stringify(params.providerRequirement),
-    localServiceHostId,
+    resolveMemoryCoreLocalServiceHostIdentity(params.acquireLocalService),
     params.purpose,
   ].join(":");
 }

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -332,6 +332,38 @@ describe("getMemorySearchManager caching", () => {
     expect(second.debug?.qmdIdentityHash).toBe(first.debug?.qmdIdentityHash);
   });
 
+  it("does not reuse QMD fallback managers across local-service hosts", async () => {
+    const agentId = "local-service-hosts";
+    const cfg = createQmdCfg(agentId);
+    const firstAcquire = vi.fn(async () => undefined);
+    const secondAcquire = vi.fn(async () => undefined);
+    const firstPrimary = createQmdManagerInstanceMock();
+    const secondPrimary = createQmdManagerInstanceMock();
+    secondPrimary.search.mockRejectedValueOnce(new Error("qmd query failed"));
+    createQmdManagerMock
+      .mockImplementationOnce(async () => firstPrimary as unknown as QmdManagerInstance)
+      .mockImplementationOnce(async () => secondPrimary as unknown as QmdManagerInstance);
+
+    const first = await getMemorySearchManager({
+      cfg,
+      agentId,
+      acquireLocalService: firstAcquire,
+    });
+    const second = await getMemorySearchManager({
+      cfg,
+      agentId,
+      acquireLocalService: secondAcquire,
+    });
+    const secondManager = requireManager(second);
+    await secondManager.search("hello");
+
+    expect(Object.is(first.manager, second.manager)).toBe(false);
+    expect(firstPrimary.close).toHaveBeenCalledTimes(1);
+    expect(mockMemoryIndexGet).toHaveBeenCalledWith(
+      expect.objectContaining({ acquireLocalService: secondAcquire }),
+    );
+  });
+
   it("keeps the cached QMD manager active when the caller cancels a search", async () => {
     const agentId = "cancelled-search";
     const cfg = createQmdCfg(agentId);

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -25,6 +25,7 @@ import {
   type ResolvedQmdConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
 
 const MEMORY_SEARCH_MANAGER_CACHE_KEY = Symbol.for("openclaw.memorySearchManagerCache");
 type Maybe<T> = T | null;
@@ -125,6 +126,12 @@ export type MemorySearchManagerResult = {
 };
 
 export type MemorySearchManagerPurpose = "default" | "status" | "cli";
+type MemorySearchManagerParams = {
+  cfg: OpenClawConfig;
+  agentId: string;
+  purpose?: MemorySearchManagerPurpose;
+  acquireLocalService?: MemoryCoreAcquireLocalService;
+};
 
 function getActiveQmdManagerOpenFailure(
   scopeKey: string,
@@ -182,11 +189,9 @@ function applyManagerDebug(
   };
 }
 
-export async function getMemorySearchManager(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-  purpose?: MemorySearchManagerPurpose;
-}): Promise<MemorySearchManagerResult> {
+export async function getMemorySearchManager(
+  params: MemorySearchManagerParams,
+): Promise<MemorySearchManagerResult> {
   const acquireStartedAt = Date.now();
   const purpose = params.purpose ?? "default";
   const finish = (
@@ -414,11 +419,7 @@ export async function getMemorySearchManager(params: {
 }
 
 async function getBuiltinMemorySearchManagerAfterQmdFailure(
-  params: {
-    cfg: OpenClawConfig;
-    agentId: string;
-    purpose?: MemorySearchManagerPurpose;
-  },
+  params: MemorySearchManagerParams,
   qmdFailureReason: string | undefined,
 ): Promise<MemorySearchManagerResult> {
   const fallback = await getBuiltinMemorySearchManager(params);
@@ -434,11 +435,9 @@ async function getBuiltinMemorySearchManagerAfterQmdFailure(
   };
 }
 
-async function getBuiltinMemorySearchManager(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-  purpose?: MemorySearchManagerPurpose;
-}): Promise<MemorySearchManagerResult> {
+async function getBuiltinMemorySearchManager(
+  params: MemorySearchManagerParams,
+): Promise<MemorySearchManagerResult> {
   try {
     const { MemoryIndexManager } = await loadManagerRuntime();
     const manager = await MemoryIndexManager.get(params);

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -25,7 +25,10 @@ import {
   type ResolvedQmdConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
-import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
+import {
+  resolveMemoryCoreLocalServiceHostIdentity,
+  type MemoryCoreAcquireLocalService,
+} from "./embedding-local-service.js";
 
 const MEMORY_SEARCH_MANAGER_CACHE_KEY = Symbol.for("openclaw.memorySearchManagerCache");
 type Maybe<T> = T | null;
@@ -211,7 +214,12 @@ export async function getMemorySearchManager(
     const { workspaceDir } = runtimeConfig;
     const transient = params.purpose === "status" || params.purpose === "cli";
     const scopeKey = buildQmdManagerScopeKey(normalizedAgentId);
-    const identityKey = buildQmdManagerIdentityKey(normalizedAgentId, qmdResolved, runtimeConfig);
+    const identityKey = buildQmdManagerIdentityKey(
+      normalizedAgentId,
+      qmdResolved,
+      runtimeConfig,
+      params.acquireLocalService,
+    );
     const debugIdentityHash = hashQmdManagerIdentity(identityKey);
 
     const createPrimaryQmdManager = async (
@@ -759,10 +767,12 @@ function buildQmdManagerIdentityKey(
   agentId: string,
   config: ResolvedQmdConfig,
   runtimeConfig: QmdManagerRuntimeConfig,
+  acquireLocalService: MemoryCoreAcquireLocalService | undefined,
 ): string {
   // ResolvedQmdConfig is assembled in a stable field order in resolveMemoryBackendConfig.
   // Fast stringify avoids deep key-sorting overhead on this hot path.
-  return `${agentId}:${JSON.stringify(config)}:${JSON.stringify(runtimeConfig.syncSettings ?? null)}:${JSON.stringify(runtimeConfig.contextLimits ?? null)}:${runtimeConfig.workspaceDir}`;
+  const localServiceHostId = resolveMemoryCoreLocalServiceHostIdentity(acquireLocalService);
+  return `${agentId}:${JSON.stringify(config)}:${JSON.stringify(runtimeConfig.syncSettings ?? null)}:${JSON.stringify(runtimeConfig.contextLimits ?? null)}:${runtimeConfig.workspaceDir}:${localServiceHostId}`;
 }
 
 function resolveQmdManagerRuntimeConfig(

--- a/extensions/memory-core/src/runtime-provider.test.ts
+++ b/extensions/memory-core/src/runtime-provider.test.ts
@@ -24,7 +24,7 @@ vi.mock("./memory/index.js", () => ({
   getMemorySearchManager: getMemorySearchManagerMock,
 }));
 
-import { memoryRuntime } from "./runtime-provider.js";
+import { createMemoryRuntime, memoryRuntime } from "./runtime-provider.js";
 
 describe("memoryRuntime", () => {
   it("preserves manager debug metadata", async () => {
@@ -39,6 +39,28 @@ describe("memoryRuntime", () => {
     expect(getMemorySearchManagerMock).toHaveBeenCalledWith({
       cfg,
       agentId: "main",
+    });
+  });
+
+  it("keeps local-service acquisition scoped to each runtime instance", async () => {
+    const cfg = {} as OpenClawConfig;
+    const firstAcquire = vi.fn(async () => undefined);
+    const secondAcquire = vi.fn(async () => undefined);
+
+    await Promise.all([
+      createMemoryRuntime(firstAcquire).getMemorySearchManager({ cfg, agentId: "first" }),
+      createMemoryRuntime(secondAcquire).getMemorySearchManager({ cfg, agentId: "second" }),
+    ]);
+
+    expect(getMemorySearchManagerMock).toHaveBeenCalledWith({
+      cfg,
+      agentId: "first",
+      acquireLocalService: firstAcquire,
+    });
+    expect(getMemorySearchManagerMock).toHaveBeenCalledWith({
+      cfg,
+      agentId: "second",
+      acquireLocalService: secondAcquire,
     });
   });
 });

--- a/extensions/memory-core/src/runtime-provider.ts
+++ b/extensions/memory-core/src/runtime-provider.ts
@@ -1,28 +1,38 @@
 // Memory Core provider module implements model/runtime integration.
 import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { resolveMemoryBackendConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+import type { MemoryCoreAcquireLocalService } from "./memory/embedding-local-service.js";
 import {
   closeAllMemorySearchManagers,
   closeMemorySearchManager,
   getMemorySearchManager,
 } from "./memory/index.js";
 
-export const memoryRuntime: MemoryPluginRuntime = {
-  async getMemorySearchManager(params) {
-    const { manager, debug, error } = await getMemorySearchManager(params);
-    return {
-      manager,
-      debug,
-      error,
-    };
-  },
-  resolveMemoryBackendConfig(params) {
-    return resolveMemoryBackendConfig(params);
-  },
-  async closeAllMemorySearchManagers() {
-    await closeAllMemorySearchManagers();
-  },
-  async closeMemorySearchManager(params) {
-    await closeMemorySearchManager(params);
-  },
-};
+export function createMemoryRuntime(
+  acquireLocalService?: MemoryCoreAcquireLocalService,
+): MemoryPluginRuntime {
+  return {
+    async getMemorySearchManager(params) {
+      const { manager, debug, error } = await getMemorySearchManager({
+        ...params,
+        ...(acquireLocalService ? { acquireLocalService } : {}),
+      });
+      return {
+        manager,
+        debug,
+        error,
+      };
+    },
+    resolveMemoryBackendConfig(params) {
+      return resolveMemoryBackendConfig(params);
+    },
+    async closeAllMemorySearchManagers() {
+      await closeAllMemorySearchManagers();
+    },
+    async closeMemorySearchManager(params) {
+      await closeMemorySearchManager(params);
+    },
+  };
+}
+
+export const memoryRuntime = createMemoryRuntime();

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { Type } from "typebox";
+import type { MemoryCoreAcquireLocalService } from "./memory/embedding-local-service.js";
 type MemorySearchManagerResult = Awaited<
   ReturnType<(typeof import("./memory/index.js"))["getMemorySearchManager"]>
 >;
@@ -21,6 +22,7 @@ type MemoryToolOptions = {
   agentSessionKey?: string;
   sandboxed?: boolean;
   oneShotCliRun?: boolean;
+  acquireLocalService?: MemoryCoreAcquireLocalService;
 };
 
 export const loadMemoryToolRuntime = createLazyRuntimeModule(() => import("./tools.runtime.js"));
@@ -59,6 +61,7 @@ export async function getMemoryManagerContextWithPurpose(params: {
   cfg: OpenClawConfig;
   agentId: string;
   purpose?: "default" | "status" | "cli";
+  acquireLocalService?: MemoryCoreAcquireLocalService;
 }): Promise<
   | {
       manager: NonNullable<MemorySearchManagerResult["manager"]>;
@@ -74,6 +77,7 @@ export async function getMemoryManagerContextWithPurpose(params: {
     cfg: params.cfg,
     agentId: params.agentId,
     purpose: params.purpose,
+    ...(params.acquireLocalService ? { acquireLocalService: params.acquireLocalService } : {}),
   });
   return manager
     ? {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -169,6 +169,25 @@ describe("memory_search unavailable payloads", () => {
     expect(details.results.map((entry) => entry.score)).toEqual([1, 1, 1, 2]);
   });
 
+  it("passes the host local-service hook to tool memory managers", async () => {
+    const acquireLocalService = vi.fn(async () => undefined);
+    const tool = createMemorySearchTool({
+      config: asOpenClawConfig({
+        agents: { list: [{ id: "main", default: true }] },
+      }),
+      acquireLocalService,
+    });
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+
+    await tool.execute("local-service-hook", { query: "hello" });
+
+    expect(getMemorySearchManagerMockParams()).toEqual([
+      expect.objectContaining({ acquireLocalService }),
+    ]);
+  });
+
   it("returns explicit unavailable metadata for quota failures", async () => {
     setMemorySearchImpl(async () => {
       throw new Error("openai embeddings failed: 429 insufficient_quota");

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -23,6 +23,7 @@ import {
   resolveMemoryDeepDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { asRecord } from "./dreaming-shared.js";
+import type { MemoryCoreAcquireLocalService } from "./memory/embedding-local-service.js";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
 import { recordShortTermRecalls } from "./short-term-promotion.js";
 import {
@@ -453,6 +454,7 @@ export function createMemorySearchTool(options: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   oneShotCliRun?: boolean;
+  acquireLocalService?: MemoryCoreAcquireLocalService;
 }) {
   return createMemoryTool({
     options,
@@ -525,6 +527,7 @@ export function createMemorySearchTool(options: {
                         cfg,
                         agentId,
                         purpose: memoryManagerPurpose,
+                        acquireLocalService: options.acquireLocalService,
                       }),
                     ),
                   )
@@ -614,6 +617,7 @@ export function createMemorySearchTool(options: {
                         cfg,
                         agentId,
                         purpose: memoryManagerPurpose,
+                        acquireLocalService: options.acquireLocalService,
                       }),
                     );
                     if ("error" in refreshed) {
@@ -775,6 +779,7 @@ export function createMemoryGetTool(options: {
   agentId?: string;
   agentSessionKey?: string;
   sandboxed?: boolean;
+  acquireLocalService?: MemoryCoreAcquireLocalService;
 }) {
   return createMemoryTool({
     options,
@@ -839,6 +844,7 @@ export function createMemoryGetTool(options: {
           cfg,
           agentId,
           purpose: "status",
+          acquireLocalService: options.acquireLocalService,
         });
         if ("error" in memory) {
           return jsonResult({ path: relPath, text: "", disabled: true, error: memory.error });

--- a/src/plugin-sdk/memory-core-bundled-runtime.test.ts
+++ b/src/plugin-sdk/memory-core-bundled-runtime.test.ts
@@ -4,7 +4,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const loadBundledPluginPublicSurfaceModuleSync = vi.hoisted(() => vi.fn());
-const configureMemoryCoreEmbeddingLocalServiceImpl = vi.hoisted(() => vi.fn());
 const configureMemoryCoreDreamingStateImpl = vi.hoisted(() => vi.fn());
 const createEmbeddingProviderImpl = vi.hoisted(() => vi.fn());
 const removeGroundedShortTermCandidatesImpl = vi.hoisted(() => vi.fn());
@@ -25,7 +24,6 @@ vi.mock("./facade-loader.js", async () => {
 
 describe("plugin-sdk memory-core bundled runtime", () => {
   beforeEach(() => {
-    configureMemoryCoreEmbeddingLocalServiceImpl.mockReset();
     configureMemoryCoreDreamingStateImpl.mockReset();
     createEmbeddingProviderImpl.mockReset().mockResolvedValue({ provider: { id: "openai" } });
     removeGroundedShortTermCandidatesImpl.mockReset().mockResolvedValue({ removed: 1 });
@@ -40,7 +38,6 @@ describe("plugin-sdk memory-core bundled runtime", () => {
       .mockImplementation(({ artifactBasename }) => {
         if (artifactBasename === "runtime-api.js") {
           return {
-            configureMemoryCoreEmbeddingLocalService: configureMemoryCoreEmbeddingLocalServiceImpl,
             configureMemoryCoreDreamingState: configureMemoryCoreDreamingStateImpl,
             createEmbeddingProvider: createEmbeddingProviderImpl,
             removeGroundedShortTermCandidates: removeGroundedShortTermCandidatesImpl,
@@ -71,7 +68,9 @@ describe("plugin-sdk memory-core bundled runtime", () => {
       artifactBasename: "runtime-api.js",
     });
     expect(configureMemoryCoreDreamingStateImpl).toHaveBeenCalledWith(expect.any(Function));
-    expect(configureMemoryCoreEmbeddingLocalServiceImpl).toHaveBeenCalledWith(expect.any(Function));
+    expect(createEmbeddingProviderImpl).toHaveBeenCalledWith({
+      acquireLocalService: expect.any(Function),
+    });
   });
 
   it("delegates doctor and embedding helpers through the bundled public surfaces", async () => {

--- a/src/plugin-sdk/memory-core-bundled-runtime.ts
+++ b/src/plugin-sdk/memory-core-bundled-runtime.ts
@@ -21,9 +21,6 @@ type EmbeddingProviderResult = {
 };
 
 type RuntimeFacadeModule = {
-  configureMemoryCoreEmbeddingLocalService: (
-    acquireLocalService: ReturnType<typeof createConfiguredProviderLocalServiceAcquirer>,
-  ) => void;
   configureMemoryCoreDreamingState: (
     openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
   ) => void;
@@ -237,17 +234,21 @@ function loadRuntimeFacadeModule(): RuntimeFacadeModule {
   module.configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
     createPluginStateKeyedStore<T>("memory-core", options),
   );
-  module.configureMemoryCoreEmbeddingLocalService(
-    createConfiguredProviderLocalServiceAcquirer(getRuntimeConfig),
-  );
   return module;
 }
 
+const acquireLocalService = createConfiguredProviderLocalServiceAcquirer(getRuntimeConfig);
+
 /** Create a memory embedding provider with built-in fallback metadata. */
-export const createEmbeddingProvider: RuntimeFacadeModule["createEmbeddingProvider"] = ((...args) =>
-  loadRuntimeFacadeModule().createEmbeddingProvider(
-    ...args,
-  )) as RuntimeFacadeModule["createEmbeddingProvider"];
+export const createEmbeddingProvider: RuntimeFacadeModule["createEmbeddingProvider"] = ((
+  options,
+) => {
+  const createOptions = {
+    ...options,
+    acquireLocalService,
+  };
+  return loadRuntimeFacadeModule().createEmbeddingProvider(createOptions);
+}) as RuntimeFacadeModule["createEmbeddingProvider"];
 
 /** Remove short-term recall candidates already grounded into durable memory. */
 export const removeGroundedShortTermCandidates: RuntimeFacadeModule["removeGroundedShortTermCandidates"] =

--- a/src/plugin-sdk/memory-core-engine-runtime.test.ts
+++ b/src/plugin-sdk/memory-core-engine-runtime.test.ts
@@ -1,10 +1,34 @@
 /**
  * Tests memory core engine runtime facade behavior.
  */
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ShortTermAuditIssue } from "./memory-core-engine-runtime.js";
 
+const loadActivatedBundledPluginPublicSurfaceModuleSync = vi.hoisted(() => vi.fn());
+const getMemorySearchManagerImpl = vi.hoisted(() => vi.fn(async () => ({ manager: null })));
+const getMemoryIndexManagerImpl = vi.hoisted(() => vi.fn(async () => null));
+
+vi.mock("./facade-runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("./facade-runtime.js")>("./facade-runtime.js");
+  return {
+    ...actual,
+    loadActivatedBundledPluginPublicSurfaceModuleSync,
+  };
+});
+
 describe("memory-core engine runtime SDK facade", () => {
+  beforeEach(() => {
+    getMemorySearchManagerImpl.mockClear();
+    getMemoryIndexManagerImpl.mockClear();
+    loadActivatedBundledPluginPublicSurfaceModuleSync.mockReset().mockReturnValue({
+      configureMemoryCoreDreamingState: vi.fn(),
+      getMemorySearchManager: getMemorySearchManagerImpl,
+      MemoryIndexManager: {
+        get: getMemoryIndexManagerImpl,
+      },
+    });
+  });
+
   it("exposes the short-term recall overflow audit code", () => {
     const issue = {
       severity: "warn",
@@ -14,5 +38,24 @@ describe("memory-core engine runtime SDK facade", () => {
     } satisfies ShortTermAuditIssue;
 
     expect(issue.code).toBe("recall-store-over-limit");
+  });
+
+  it("injects local-service acquisition into manager facade calls", async () => {
+    const runtime = await import("./memory-core-engine-runtime.js");
+    const params = { cfg: {}, agentId: "main" } as never;
+
+    await runtime.getMemorySearchManager(params);
+    await runtime.MemoryIndexManager.get(params);
+
+    expect(getMemorySearchManagerImpl).toHaveBeenCalledWith({
+      cfg: {},
+      agentId: "main",
+      acquireLocalService: expect.any(Function),
+    });
+    expect(getMemoryIndexManagerImpl).toHaveBeenCalledWith({
+      cfg: {},
+      agentId: "main",
+      acquireLocalService: expect.any(Function),
+    });
   });
 });

--- a/src/plugin-sdk/memory-core-engine-runtime.ts
+++ b/src/plugin-sdk/memory-core-engine-runtime.ts
@@ -6,10 +6,7 @@ import { createConfiguredProviderLocalServiceAcquirer } from "../agents/provider
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { createPluginStateKeyedStore } from "../plugin-state/plugin-state-store.js";
-import {
-  createLazyFacadeObjectValue,
-  loadActivatedBundledPluginPublicSurfaceModuleSync,
-} from "./facade-runtime.js";
+import { loadActivatedBundledPluginPublicSurfaceModuleSync } from "./facade-runtime.js";
 import type { MemorySearchManager } from "./memory-core-host-engine-storage.js";
 import type { OpenKeyedStoreOptions, PluginStateKeyedStore } from "./plugin-state-runtime.js";
 
@@ -114,9 +111,6 @@ type MemoryIndexManagerFacade = {
 };
 
 type FacadeModule = {
-  configureMemoryCoreEmbeddingLocalService: (
-    acquireLocalService: ReturnType<typeof createConfiguredProviderLocalServiceAcquirer>,
-  ) => void;
   configureMemoryCoreDreamingState: (
     openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
   ) => void;
@@ -161,11 +155,10 @@ function loadFacadeModule(): FacadeModule {
   module.configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
     createPluginStateKeyedStore<T>("memory-core", options),
   );
-  module.configureMemoryCoreEmbeddingLocalService(
-    createConfiguredProviderLocalServiceAcquirer(getRuntimeConfig),
-  );
   return module;
 }
+
+const acquireLocalService = createConfiguredProviderLocalServiceAcquirer(getRuntimeConfig);
 /** Audit short-term promotion artifacts in an agent workspace. */
 export const auditShortTermPromotionArtifacts: FacadeModule["auditShortTermPromotionArtifacts"] = ((
   ...args
@@ -183,8 +176,13 @@ export const getBuiltinMemoryEmbeddingProviderDoctorMetadata: FacadeModule["getB
       ...args,
     )) as FacadeModule["getBuiltinMemoryEmbeddingProviderDoctorMetadata"];
 /** Resolve the active memory search manager and any runtime availability error. */
-export const getMemorySearchManager: FacadeModule["getMemorySearchManager"] = ((...args) =>
-  loadFacadeModule()["getMemorySearchManager"](...args)) as FacadeModule["getMemorySearchManager"];
+export const getMemorySearchManager: FacadeModule["getMemorySearchManager"] = ((params) => {
+  const managerParams = {
+    ...params,
+    acquireLocalService,
+  };
+  return loadFacadeModule()["getMemorySearchManager"](managerParams);
+}) as FacadeModule["getMemorySearchManager"];
 /** List built-in memory embedding providers eligible for automatic selection. */
 export const listBuiltinAutoSelectMemoryEmbeddingProviderDoctorMetadata: FacadeModule["listBuiltinAutoSelectMemoryEmbeddingProviderDoctorMetadata"] =
   ((...args) =>
@@ -192,9 +190,15 @@ export const listBuiltinAutoSelectMemoryEmbeddingProviderDoctorMetadata: FacadeM
       ...args,
     )) as FacadeModule["listBuiltinAutoSelectMemoryEmbeddingProviderDoctorMetadata"];
 /** Lazy memory index manager facade used by status and runtime callers. */
-export const MemoryIndexManager: FacadeModule["MemoryIndexManager"] = createLazyFacadeObjectValue(
-  () => loadFacadeModule()["MemoryIndexManager"] as object,
-) as FacadeModule["MemoryIndexManager"];
+export const MemoryIndexManager: FacadeModule["MemoryIndexManager"] = {
+  async get(params) {
+    const managerParams = {
+      ...params,
+      acquireLocalService,
+    };
+    return await loadFacadeModule()["MemoryIndexManager"].get(managerParams);
+  },
+};
 /** Repair invalid recall-store entries and stale short-term promotion locks. */
 export const repairShortTermPromotionArtifacts: FacadeModule["repairShortTermPromotionArtifacts"] =
   ((...args) =>


### PR DESCRIPTION
Related: #104306

## What Problem This Solves

Fixes an issue where embedding requests could reuse another plugin runtime's provider-local-service lifecycle after the on-demand local embedding service support landed.

## Why This Change Was Made

Memory Core now receives local-service acquisition as a narrow host-injected hook and passes it through provider creation, tools, CLI, and SDK facade calls. Builtin and QMD manager caches include the host-hook identity, preventing fallback managers from retaining another runtime's lifecycle owner.

The change stays within Memory Core and its dedicated SDK facades. It does not add a shared acceleration type or expose the core lifecycle owner to plugins.

## User Impact

Local OpenAI-compatible, Ollama, and LM Studio embedding requests use the same serialized startup, health, lease, abort, in-flight, and idle-stop lifecycle as model requests without leaking service ownership across plugin runtimes.

Configured provider aliases and base URLs remain intact.

## Evidence

- Blacksmith Testbox `tbx_01kx9jc2bd046s32j0k2d9e7tw`
- Focused changed-surface Memory Core and SDK suite: 163 tests passed
- `OPENCLAW_TESTBOX=1 pnpm check:changed` on all 24 changed files
- Fresh autoreview completed with no accepted/actionable findings
- Preserved the existing local embedding runtime-facts propagation and current-main ranking coverage during rebase
- The full `memory/index.test.ts` currently has five session-index failures on both this branch and clean current `main`; the new local-service cache-isolation test passes independently
