### PR TITLE
fix(ui): prevent scroll-to-bottom button from shrinking transcript

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -1831,6 +1831,65 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("overlays the scroll-to-bottom affordance without shrinking the transcript", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const baseTs = Date.now() - 100_000;
+    const historyMessages = Array.from({ length: 50 }, (_, index) => ({
+      content: [
+        {
+          text: `Scrollable history ${index}\n${"extra transcript line\n".repeat(4)}`,
+          type: "text",
+        },
+      ],
+      role: index % 2 === 0 ? "assistant" : "user",
+      timestamp: baseTs + index,
+    }));
+    await installMockGateway(page, { historyMessages });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByText("Scrollable history 49").waitFor({ timeout: 10_000 });
+      await waitForChatScrollIdle(page);
+
+      const readLayout = () =>
+        page.locator(".chat-main").evaluate((container) => {
+          const thread = container.querySelector<HTMLElement>(".chat-thread");
+          const composer = container.querySelector<HTMLElement>(".agent-chat__composer-shell");
+          const button = container.querySelector<HTMLElement>(".chat-scroll-to-bottom");
+          if (!thread || !composer) {
+            throw new Error("expected chat thread and composer");
+          }
+          const threadRect = thread.getBoundingClientRect();
+          const composerRect = composer.getBoundingClientRect();
+          const buttonRect = button?.getBoundingClientRect();
+          return {
+            buttonBottom: buttonRect ? Math.round(buttonRect.bottom) : null,
+            composerTop: Math.round(composerRect.top),
+            threadBottom: Math.round(threadRect.bottom),
+          };
+        });
+
+      const before = await readLayout();
+      expect(before.buttonBottom).toBeNull();
+
+      await scrollChatThreadToTop(page);
+      await page.getByRole("button", { name: "Scroll to latest" }).waitFor({ timeout: 10_000 });
+      const after = await readLayout();
+
+      expect(after.threadBottom).toBe(before.threadBottom);
+      expect(after.composerTop).toBe(before.composerTop);
+      expect(after.buttonBottom).not.toBeNull();
+      expect(after.buttonBottom!).toBeLessThan(after.composerTop);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("shows persisted user messages after opening History and scrolling mixed history", async () => {
     const context = await newBrowserContext({
       locale: "en-US",

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -120,20 +120,25 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   margin-inline: auto;
 }
 
-/* Scroll-to-bottom affordance centered above the composer. */
+/* The zero-height anchor keeps the affordance out of the flex flow so showing
+   it never shrinks the transcript or moves the composer. */
 .chat-scroll-to-bottom-wrap {
-  align-self: center;
-  display: flex;
-  margin: 8px auto 0;
+  position: relative;
+  align-self: stretch;
+  height: 0;
+  flex: 0 0 0;
   z-index: 10;
 }
 
 .chat-scroll-to-bottom {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: 36px;
+  height: 36px;
   padding: 0;
   line-height: 1;
   color: var(--text);
@@ -143,6 +148,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   box-shadow: var(--shadow-sm);
   cursor: pointer;
   pointer-events: auto;
+  transform: translateX(-50%);
 }
 
 .chat-scroll-to-bottom:focus-visible {
@@ -151,8 +157,8 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 }
 
 .chat-scroll-to-bottom svg {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.5px;


### PR DESCRIPTION
Related: #104724

## What Problem This Solves

Fixes an issue where the chat transcript would lose vertical space when the scroll-to-latest button appeared after a user scrolled away from the newest message. The button rendered in its own flex row above the composer, creating a visible empty block and shortening the transcript viewport.

## Why This Change Was Made

The scroll-to-latest button now uses a zero-height anchor and absolute positioning at the existing transcript/composer boundary. It remains centered above the composer without participating in flex layout, measuring footer height, or changing scroll behavior. The button and icon are also slightly smaller to keep the overlay visually lightweight.

## User Impact

Users can scroll back through chat history and use the scroll-to-latest control without the transcript jumping or losing usable space when the control appears.

## Evidence

### Before

The control occupies a separate row and shrinks the transcript viewport.

![Before: scroll-to-latest button creates a block above the composer](https://hollow-willow-8yyc.here.now/before.png)

### After

The control overlays the transcript while the transcript/composer boundary remains unchanged.

![After: scroll-to-latest button overlays the transcript without changing composer layout](https://hollow-willow-8yyc.here.now/after.png)

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.e2e.test.ts -t "overlays the scroll-to-bottom affordance without shrinking the transcript"` — 1 passed
- Red/green proof: the regression test measured the transcript bottom moving from 779px to 731px with the previous layout, then remaining unchanged with the overlay layout.
- `node_modules/.bin/oxfmt --check ui/src/e2e/chat-flow.e2e.test.ts ui/src/styles/chat/layout.css`
- `git diff --check origin/main...HEAD`
