### PR TITLE
feat: lobster pet rarely fills in for the sidebar brand logo

### DIFF
--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -15,6 +15,11 @@ import {
 import type { SessionCapability, SessionState } from "../lib/sessions/index.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import "./app-sidebar.ts";
+import {
+  LOBSTER_LOGO_VISIT_EVENT,
+  createLobsterPetLook,
+  type LobsterLogoVisitDetail,
+} from "./lobster-pet.ts";
 
 const PROVIDER_ELEMENT_NAME = "test-app-sidebar-context-provider";
 
@@ -319,6 +324,45 @@ describe("AppSidebar lobster outcome wiring", () => {
       expect(pet?.runOutcome).toBe(expectedOutcome);
     },
   );
+});
+
+describe("AppSidebar logo stand-in wiring", () => {
+  it("swaps the brand mark while the pet's logo visit is in, leaving, then out", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    const pet = sidebar.querySelector("openclaw-lobster-pet");
+    if (!pet) {
+      throw new Error("Expected sidebar lobster pet");
+    }
+    const dispatch = (detail: LobsterLogoVisitDetail) =>
+      pet.dispatchEvent(
+        new CustomEvent(LOBSTER_LOGO_VISIT_EVENT, { detail, bubbles: true, composed: true }),
+      );
+    const logo = () => sidebar.querySelector(".sidebar-brand__logo");
+    const standIn = () => sidebar.querySelector(".sidebar-brand__pet");
+
+    expect(logo()?.classList.contains("sidebar-brand__logo--vacated")).toBe(false);
+    expect(standIn()).toBeNull();
+
+    const look = createLobsterPetLook(70);
+    dispatch({ phase: "in", look, name: "Pinchy" });
+    await sidebar.updateComplete;
+    expect(logo()?.classList.contains("sidebar-brand__logo--vacated")).toBe(true);
+    const sprite = standIn();
+    expect(sprite).not.toBeNull();
+    expect(sprite?.classList.contains(`lobster-pet--palette-${look.palette.id}`)).toBe(true);
+    expect(sprite?.getAttribute("title")).toContain("Pinchy");
+    expect(sprite?.querySelector(".lobster-pet__svg")).not.toBeNull();
+
+    dispatch({ phase: "leaving", look, name: "Pinchy" });
+    await sidebar.updateComplete;
+    expect(standIn()?.classList.contains("sidebar-brand__pet--leaving")).toBe(true);
+
+    dispatch({ phase: "out", look: null, name: null });
+    await sidebar.updateComplete;
+    expect(standIn()).toBeNull();
+    expect(logo()?.classList.contains("sidebar-brand__logo--vacated")).toBe(false);
+  });
 });
 
 describe("AppSidebar session source lifecycle", () => {

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -75,7 +75,16 @@ import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import { pluginTabKey, pluginTabSearch } from "../pages/plugin/route.ts";
 import { icons, type IconName } from "./icons.ts";
-import { lobsterPetSeed, resolveLobsterPetMode, resolveLobsterRunOutcome } from "./lobster-pet.ts";
+import {
+  LOBSTER_LOGO_VISIT_EVENT,
+  LOBSTER_PET_BUILD_MULS,
+  LOBSTER_PET_CLAW_MULS,
+  lobsterPetSeed,
+  renderLobsterSvg,
+  resolveLobsterPetMode,
+  resolveLobsterRunOutcome,
+  type LobsterLogoVisitDetail,
+} from "./lobster-pet.ts";
 import { fetchSessionMenuWork } from "./session-menu-work.ts";
 import type { SessionMenuAction, SessionMenuWork } from "./session-menu.ts";
 
@@ -231,6 +240,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   @state() private sessionsLoading = false;
   @state() private nativeSessionSidebarReady = false;
   @state() private sessionsScrollState: SidebarSessionsScrollState = "none";
+  @state() private logoVisit: LobsterLogoVisitDetail | null = null;
 
   private readonly subscriptions = new SubscriptionsController(this);
   private customizeMenuTrigger: HTMLElement | null = null;
@@ -256,6 +266,9 @@ class AppSidebar extends OpenClawLightDomContentsElement {
 
   constructor() {
     super();
+    // Host listener: the footer pet announces logo stand-in phases (bubbling
+    // custom event) and the brand slot here renders the swap.
+    this.addEventListener(LOBSTER_LOGO_VISIT_EVENT, this.handleLogoVisit as EventListener);
     this.subscriptions
       .watch(
         () => this.context?.gateway,
@@ -425,17 +438,55 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     this.sessionCreatedOrder.clear();
   }
 
+  private readonly handleLogoVisit = (event: Event) => {
+    const detail = (event as CustomEvent<LobsterLogoVisitDetail>).detail;
+    this.logoVisit = detail.phase === "out" || !detail.look ? null : detail;
+  };
+
+  // Rare treat: on planned loads the footer pet's first visit perches here
+  // instead, filling in for the brand mark (see lobster-pet.ts logo visits).
+  private renderLogoStandIn() {
+    const visit = this.logoVisit;
+    if (!visit?.look) {
+      return nothing;
+    }
+    const look = visit.look;
+    const classes = [
+      "sidebar-brand__pet",
+      `lobster-pet--palette-${look.palette.id}`,
+      visit.phase === "leaving" ? "sidebar-brand__pet--leaving" : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    const style = [
+      `--lob-shell:${look.palette.shell}`,
+      `--lob-claw:${look.palette.claw}`,
+      `--lob-blink-delay:${look.blinkDelayS}s`,
+      `--lob-w:${LOBSTER_PET_BUILD_MULS[look.build].w}`,
+      `--lob-h:${LOBSTER_PET_BUILD_MULS[look.build].h}`,
+      `--lob-claw-scale:${LOBSTER_PET_CLAW_MULS[look.clawSize]}`,
+    ].join(";");
+    // Native title tooltip like the ledge sprite's names: no i18n surface.
+    const title = `${visit.name} · filling in for the logo`;
+    return html`
+      <span class=${classes} style=${style} title=${title}>${renderLobsterSvg(look)}</span>
+    `;
+  }
+
   private renderBrand() {
     const collapseLabel = t("nav.collapse");
     return html`
       <div class="sidebar-brand">
         <div class="sidebar-brand__identity">
-          <img
-            class="sidebar-brand__logo"
-            src=${controlUiPublicAssetPath("apple-touch-icon.png", this.basePath)}
-            alt=""
-            aria-hidden="true"
-          />
+          <span class="sidebar-brand__logo-slot">
+            <img
+              class="sidebar-brand__logo ${this.logoVisit ? "sidebar-brand__logo--vacated" : ""}"
+              src=${controlUiPublicAssetPath("apple-touch-icon.png", this.basePath)}
+              alt=""
+              aria-hidden="true"
+            />
+            ${this.renderLogoStandIn()}
+          </span>
           <span class="sidebar-brand__title">OpenClaw</span>
         </div>
         <div class="sidebar-brand__actions">

--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -4,9 +4,11 @@ import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getLobsterdex, getLobsterdexEntries } from "./lobster-dex.ts";
 import {
+  LOBSTER_LOGO_VISIT_EVENT,
   LOBSTER_PET_ACT_DURATION_MS,
   LOBSTER_PET_MODE_ACTS,
   createLobsterPetLook,
+  isLobsterLogoLoad,
   isLobsterMoltLoad,
   isLobsterNightTime,
   isLobsterTwinLoad,
@@ -17,6 +19,7 @@ import {
   strangerLookFor,
   resolveLobsterPetMode,
   resolveLobsterRunOutcome,
+  type LobsterLogoVisitDetail,
   type LobsterPet,
   type LobsterPetMode,
   type LobsterPetPaletteId,
@@ -1060,5 +1063,107 @@ describe("lobster pet element", () => {
     await element.updateComplete;
     const act = await advanceUntilAct(element, 30_000);
     expect(act).toBeNull();
+  });
+});
+
+describe("lobster pet logo stand-in", () => {
+  function trackLogoPhases(element: LobsterPetElement): LobsterLogoVisitDetail[] {
+    const phases: LobsterLogoVisitDetail[] = [];
+    element.addEventListener(LOBSTER_LOGO_VISIT_EVENT, (event) => {
+      phases.push((event as CustomEvent<LobsterLogoVisitDetail>).detail);
+    });
+    return phases;
+  }
+
+  // Seed 70 is a planned logo load, not shy, first arrival ~25s.
+  const LOGO_SEED = 70;
+
+  it("plans logo loads deterministically at a rare rate", () => {
+    expect(isLobsterLogoLoad(LOGO_SEED)).toBe(true);
+    expect(isLobsterLogoLoad(LOGO_SEED)).toBe(isLobsterLogoLoad(LOGO_SEED));
+    let planned = 0;
+    for (let seed = 0; seed < 4000; seed++) {
+      if (isLobsterLogoLoad(seed)) {
+        planned++;
+      }
+    }
+    expect(planned / 4000).toBeGreaterThan(0.08);
+    expect(planned / 4000).toBeLessThan(0.16);
+  });
+
+  it("spends the first visit in the brand slot, then returns to the ledge", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(LOGO_SEED);
+    const phases = trackLogoPhases(element);
+    await element.updateComplete;
+
+    const arrived = await advanceUntil(element, () => phases.length > 0, 200_000);
+    expect(arrived).toBe(true);
+    expect(phases[0].phase).toBe("in");
+    expect(phases[0].look).not.toBeNull();
+    expect(phases[0].name).toBeTruthy();
+    // One crab, two homes: the ledge stays empty while it plays logo.
+    expect(spritePresent(element)).toBe(false);
+
+    const left = await advanceUntil(element, () => phases.some((p) => p.phase === "out"), 400_000);
+    expect(left).toBe(true);
+    expect(phases.map((p) => p.phase)).toEqual(["in", "leaving", "out"]);
+    expect(phases[2].look).toBeNull();
+
+    // Logo visits are once per load: the next arrival is a normal ledge perch.
+    const returned = await advanceUntil(element, () => spritePresent(element), 1_300_000);
+    expect(returned).toBe(true);
+    expect(phases.length).toBe(3);
+  });
+
+  it("recalls the stand-in to ledge duty when the gateway drops", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(LOGO_SEED);
+    const phases = trackLogoPhases(element);
+    await advanceUntil(element, () => phases.length > 0, 200_000);
+    expect(phases.at(-1)?.phase).toBe("in");
+    expect(spritePresent(element)).toBe(false);
+
+    element.mode = "offline";
+    await element.updateComplete;
+    expect(phases.at(-1)?.phase).toBe("out");
+    expect(spritePresent(element)).toBe(true);
+  });
+
+  it("sends offline summons to the ledge even on planned logo loads", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(LOGO_SEED, "offline");
+    const phases = trackLogoPhases(element);
+    await element.updateComplete;
+    expect(spritePresent(element)).toBe(true);
+    expect(phases).toEqual([]);
+  });
+
+  it("disabling visits mid-stand-in clears the brand slot immediately", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(LOGO_SEED);
+    const phases = trackLogoPhases(element);
+    await advanceUntil(element, () => phases.length > 0, 200_000);
+    expect(phases.at(-1)?.phase).toBe("in");
+
+    element.visitsEnabled = false;
+    await element.updateComplete;
+    expect(phases.at(-1)?.phase).toBe("out");
+    expect(spritePresent(element)).toBe(false);
+  });
+
+  it("keeps unplanned loads on the ledge with no logo events", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    expect(isLobsterLogoLoad(42)).toBe(false);
+    const element = createPet(42);
+    const phases = trackLogoPhases(element);
+    await arrive(element);
+    expect(spritePresent(element)).toBe(true);
+    expect(phases).toEqual([]);
   });
 });

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -376,6 +376,25 @@ export function isLobsterTwinLoad(seed: number): boolean {
   return mulberry32((seed ^ 0x7715) >>> 0)() < 0.04;
 }
 
+// On a logo load the pet's first scheduled visit skips the ledge entirely:
+// it climbs up top and fills in for the brand logo until the stay ends.
+// Offline summons still report to the ledge - status duty outranks cosplay.
+export function isLobsterLogoLoad(seed: number): boolean {
+  return mulberry32((seed ^ 0x1063) >>> 0)() < 0.12;
+}
+
+export type LobsterLogoVisitPhase = "in" | "leaving" | "out";
+
+export type LobsterLogoVisitDetail = {
+  phase: LobsterLogoVisitPhase;
+  look: LobsterPetLook | null;
+  name: string | null;
+};
+
+// Fired on the pet host whenever the logo stand-in phase changes; the
+// sidebar owns the brand slot, so the swap renders there, not here.
+export const LOBSTER_LOGO_VISIT_EVENT = "openclaw-lobster-logo-visit";
+
 export type LobsterPasserKind = "stranger" | "crab";
 
 export type LobsterPasserPlan = {
@@ -901,6 +920,10 @@ export class LobsterPet extends LitElement {
   @state() private presence: "out" | "in" | "leaving" = "out";
   @state() private anchor: LobsterPetAnchor = "ledge";
   @state() private scheduledVisiting = false;
+  @state() private logoPerched = false;
+  private logoPlanned = false;
+  private logoDone = false;
+  private lastLogoPhase: LobsterLogoVisitPhase = "out";
   @state() private dismissed = false;
   @state() private grumpy = false;
   @state() private vigil = false;
@@ -1016,6 +1039,9 @@ export class LobsterPet extends LitElement {
       }
       this.moltPlanned = isLobsterMoltLoad(this.seed);
       this.twinPlanned = isLobsterTwinLoad(this.seed);
+      this.logoPlanned = isLobsterLogoLoad(this.seed);
+      this.logoDone = false;
+      this.logoPerched = false;
       this.familiarity = getLobsterFamiliarity();
       this.sailorDay = isLobsterDay(new Date());
       this.greetedThisLoad = false;
@@ -1027,6 +1053,12 @@ export class LobsterPet extends LitElement {
       this.outcomePresenceOwner = null;
       this.trackVigil();
     } else if (changed.has("mode")) {
+      // Status duty outranks the impersonation: any non-idle mode sends the
+      // logo stand-in scurrying back to the ledge, where the status acts
+      // below play out as usual.
+      if (this.logoPerched && this.mode !== "idle") {
+        this.logoPerched = false;
+      }
       const previousMode = changed.get("mode") as LobsterPetMode | undefined;
       const finished = previousMode === "busy" && this.mode === "idle";
       const presenceOwner = finished && this.vigil ? "vigil" : null;
@@ -1068,6 +1100,13 @@ export class LobsterPet extends LitElement {
       }
       if (this.presence === "out") {
         this.rollPerch();
+        // A planned logo load spends its first scheduled visit up top as the
+        // brand mark (once per load); offline summons always take the ledge.
+        this.logoPerched =
+          this.logoPlanned && !this.logoDone && this.scheduledVisiting && this.mode === "idle";
+        if (this.logoPerched) {
+          this.logoDone = true;
+        }
         if (this.look) {
           // Anniversary check reads the dex before this arrival records into
           // it: a first-ever visit today must not celebrate itself.
@@ -1097,11 +1136,13 @@ export class LobsterPet extends LitElement {
       this.leaveTimer = window.setTimeout(() => {
         this.leaveTimer = null;
         this.presence = "out";
+        this.logoPerched = false;
       }, LEAVE_MS);
     }
   }
 
   override updated() {
+    this.dispatchLogoPhase();
     if (!this.restartPending) {
       return;
     }
@@ -1110,10 +1151,12 @@ export class LobsterPet extends LitElement {
       this.enterTimer = null;
       this.entering = false;
       // Old friends get a hello: the first arrival of the load waves at you.
+      // A logo stand-in skips the greeting (and keeps it for a ledge visit).
       if (
         !this.greetedThisLoad &&
         this.familiarity.tier === "friend" &&
         this.presence === "in" &&
+        !this.logoPerched &&
         !prefersReducedMotion()
       ) {
         this.greetedThisLoad = true;
@@ -1121,6 +1164,41 @@ export class LobsterPet extends LitElement {
       }
     }, ENTER_MS);
     this.scheduleNextAct();
+  }
+
+  private logoVisitPhase(): LobsterLogoVisitPhase {
+    if (!this.logoPerched || !this.visitsEnabled || this.dismissed) {
+      return "out";
+    }
+    return this.presence === "in" ? "in" : this.presence === "leaving" ? "leaving" : "out";
+  }
+
+  // The brand slot lives in the sidebar's DOM; phase edges cross over as
+  // events so exactly one home renders the crab at any moment.
+  private dispatchLogoPhase() {
+    const phase = this.logoVisitPhase();
+    if (phase === this.lastLogoPhase) {
+      return;
+    }
+    this.lastLogoPhase = phase;
+    const look = phase === "out" || !this.look ? null : this.look;
+    // The ledge sprite dresses up for palette anniversaries; the stand-in
+    // celebrates the same way.
+    const dressed =
+      look && this.anniversary && look.accessory !== "party"
+        ? { ...look, accessory: "party" as const }
+        : look;
+    this.dispatchEvent(
+      new CustomEvent<LobsterLogoVisitDetail>(LOBSTER_LOGO_VISIT_EVENT, {
+        detail: {
+          phase,
+          look: dressed,
+          name: dressed ? lobsterPetName(dressed, this.seed) : null,
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   private readonly handleVisibilityChange = () => {
@@ -1440,6 +1518,7 @@ export class LobsterPet extends LitElement {
     if (
       !this.look ||
       this.presence !== "in" ||
+      this.logoPerched ||
       this.vigil ||
       this.passer !== null ||
       this.idleTimer !== null ||
@@ -1655,7 +1734,9 @@ export class LobsterPet extends LitElement {
     if (!look) {
       return nothing;
     }
-    const showSprites = this.presence !== "out";
+    // While the pet is upstairs playing logo, the ledge stays empty - one
+    // crab, two homes, never both at once.
+    const showSprites = this.presence !== "out" && !this.logoPerched;
     // The shell may outlive the visit while it fades, but dismissal and the
     // visits setting silence it like everything else.
     const showShell = this.shellVisible && this.visitsEnabled && !this.dismissed;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -743,11 +743,29 @@ html.openclaw-native-nav .topbar .topbar-nav-toggle {
   flex: 1 1 auto;
 }
 
+/* Positioning box for the brand mark; the lobster pet's logo stand-in
+   (lobster-pet.css) overlays the img here during a logo visit. */
+.sidebar-brand__logo-slot {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+}
+
 .sidebar-brand__logo {
+  display: block;
   width: 24px;
   height: 24px;
   border-radius: var(--radius-md);
-  flex: 0 0 auto;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
+}
+
+/* The crab took over: the static mark steps aside until the visit ends. */
+.sidebar-brand__logo--vacated {
+  opacity: 0;
+  transform: scale(0.55);
 }
 
 .sidebar-brand__title {

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -799,3 +799,73 @@ openclaw-lobster-pet[data-spot="bar"] .lobster-pet {
 .lobsterdex__mini--unseen {
   filter: grayscale(1) brightness(0.45) opacity(0.55);
 }
+
+/* ---- Logo stand-in ----
+   On planned loads (isLobsterLogoLoad) the pet's first scheduled visit
+   perches in the sidebar brand slot instead of the ledge. The sidebar
+   renders this sprite into .sidebar-brand__logo-slot (layout.css); the
+   ledge stays empty meanwhile - one crab, two homes. */
+
+.sidebar-brand__pet {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  cursor: default;
+  animation: lobster-pet-logo-settle 0.45s ease-out;
+}
+
+.sidebar-brand__pet .lobster-pet__svg {
+  width: calc(22px * var(--lob-w, 1));
+  height: calc(19px * var(--lob-h, 1));
+  overflow: visible;
+  animation: lobster-pet-breathe 3.4s ease-in-out infinite;
+}
+
+/* Blink like the ledge sprite. The closed-lid curves need an explicit
+   resting opacity here: the base rule is scoped to .lobster-pet, which the
+   brand slot intentionally does not use (it would drag perch layout along). */
+.sidebar-brand__pet .lob-eye-closed {
+  opacity: 0;
+  animation: lobster-pet-blink-closed 5.2s linear infinite;
+  animation-delay: var(--lob-blink-delay, 0s);
+}
+
+.sidebar-brand__pet .lob-eye-open {
+  animation: lobster-pet-blink-open 5.2s linear infinite;
+  animation-delay: var(--lob-blink-delay, 0s);
+}
+
+/* Departure mirrors LEAVE_MS in lobster-pet.ts: the stand-in sinks toward
+   the ledge while the real logo scales back in underneath. */
+.sidebar-brand__pet--leaving {
+  opacity: 0;
+  transform: translateY(7px);
+  transition:
+    transform 0.3s ease-in,
+    opacity 0.25s ease 0.05s;
+}
+
+@keyframes lobster-pet-logo-settle {
+  0% {
+    opacity: 0;
+    transform: translateY(-7px);
+  }
+  55% {
+    opacity: 1;
+    transform: translateY(1.5px) scaleY(0.92);
+  }
+  100% {
+    transform: translateY(0) scaleY(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-brand__pet,
+  .sidebar-brand__pet *,
+  .sidebar-brand__logo {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
Closes #104738

## What Problem This Solves

The sidebar shows the OpenClaw crab twice: a static brand mark at the top and the animated lobster pet on the footer ledge. The duplication reads as redundancy, but animating the brand mark independently would either compete with the pet or look like a rendering bug. This PR makes them one character: on rare page loads the pet's first scheduled visit perches in the brand-logo slot instead of the ledge — the crab is briefly, literally, the logo.

## Why This Change Was Made

Follows the pet's existing per-load event planner pattern (`isLobsterMoltLoad` / `isLobsterTwinLoad`): a seeded `isLobsterLogoLoad` (~12% of loads, at most once per load) routes the first scheduled visit to the brand slot. The pet stays the single owner of scheduling/presence and announces phase edges (`in` / `leaving` / `out`) via a bubbling custom event; the sidebar renders the swap in its own brand slot, so exactly one home shows the crab at any moment. Status duty outranks cosplay: gateway offline/busy instantly recalls the stand-in to the ledge, and offline summons always report to the ledge. No new config — it rides the existing visit scheduler, the `lobsterPetVisits` setting, shoo/dismissal, and reduced-motion handling (static swap, no settle/leave animation).

## User Impact

Roughly one in eight Control UI loads, the brand logo's spot is taken over by *your* session's seeded lobster — palette, build, accessory, blink and all — while the footer ledge stays empty; a few minutes later it hops down and the logo fades back. The brand mark remains the stable anchor the rest of the time, and users who disabled pet visits never see it.

## Evidence

Captured on the mock-gateway dev harness by dispatching the real logo-visit event on the real pet element (production listener + CSS path).

### Before / after

| Normal (logo + ledge pet) | Logo visit (crab up top, ledge empty) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-logo-standin/01-normal-light.png" width="257" alt="Normal sidebar, light theme: static logo on top, lobster pet on the footer ledge" /> | <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-logo-standin/02-logo-visit-light.png" width="257" alt="Logo visit, light theme: crimson lobster sprite in the brand slot, empty ledge" /> |
| <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-logo-standin/09-normal-dark.png" width="257" alt="Normal sidebar, dark theme" /> | <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-logo-standin/10-logo-visit-dark.png" width="257" alt="Logo visit, dark theme: teal lobster in the brand slot" /> |

### The stand-in inherits the session's seeded look

| Crimson | Teal (dark) | Gold + crown |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-logo-standin/03-brand-crimson-light.png" width="199" alt="Crimson lobster as the logo" /> | <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-logo-standin/11-brand-teal-dark.png" width="199" alt="Teal lobster as the logo, dark theme" /> | <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-logo-standin/05-brand-gold-crown-light.png" width="199" alt="Gold lobster wearing a crown as the logo" /> |

| Ghost (1-in-100M rarity) | Retro grail (classic-logo homage) | Violet + party hat |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-logo-standin/06-brand-ghost-light.png" width="199" alt="Translucent ghost lobster as the logo" /> | <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-logo-standin/07-brand-retro-light.png" width="199" alt="Retro palette lobster as the logo, mimicking the classic OpenClaw logo" /> | <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/lobster-logo-standin/08-brand-violet-party-light.png" width="199" alt="Violet lobster with party hat as the logo" /> |

(The retro grail impersonating the logo is the intended easter-egg-inside-an-easter-egg: that palette *is* the classic logo homage.)

More angles in [steipete/openclaw-pr-assets/lobster-logo-standin](https://github.com/steipete/openclaw-pr-assets/tree/main/lobster-logo-standin) (teal light, retro dark).

### Tests / review

- Unit (jsdom, Testbox): `pnpm test ui/src/components/lobster-pet.test.ts ui/src/components/app-sidebar.test.ts` — new coverage: planner determinism + rate bounds, seeded logo arrival empties the ledge and fires `in → leaving → out` exactly once per load, offline recall to ledge duty, offline summons never take the slot, `visitsEnabled` mid-visit kill, unplanned loads unaffected, and sidebar brand-slot swap wiring (vacated class, palette class, title, restore). Result: 79/79 passed (60 pet + 19 sidebar) on Blacksmith Testbox.
- Existing pet suite unaffected: the planner uses a dedicated RNG stream (no visit-schedule draws consumed) and a XOR constant chosen so all seeds used by existing tests stay unplanned.
- Structured review (Codex `gpt-5.6-sol`, xhigh, tools+web): clean — "no accepted/actionable findings", overall "patch is correct (0.84)".
- `oxfmt` clean; `scripts/run-oxlint.mjs` clean on touched files.
