### PR TITLE
test(live): align July GPT-5.6 defaults

### DIFF
--- a/src/agents/openai-tool-projection.live.test.ts
+++ b/src/agents/openai-tool-projection.live.test.ts
@@ -51,7 +51,7 @@ const context = {
 } satisfies Context;
 
 describeLive("OpenAI tool projection live", () => {
-  const modelId = process.env.OPENCLAW_LIVE_OPENAI_TOOL_MODEL || "gpt-5.5";
+  const modelId = process.env.OPENCLAW_LIVE_OPENAI_TOOL_MODEL || "gpt-5.6-luna";
   const client = new OpenAI({ apiKey: OPENAI_KEY });
 
   it("calls a healthy Responses function after quarantining an unreadable sibling", async () => {

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts
@@ -12,7 +12,7 @@ const describeLive = LIVE ? describe : describe.skip;
 
 describeLive("OpenAI-compatible Anthropic tool payload wrapper live", () => {
   it("projects and sends a custom pinned tool after quarantining an unreadable sibling", async () => {
-    const liveModelId = process.env.OPENCLAW_LIVE_OPENAI_CHAT_TOOL_MODEL || "gpt-5.5";
+    const liveModelId = process.env.OPENCLAW_LIVE_OPENAI_CHAT_TOOL_MODEL || "gpt-5.6-luna";
     let projectedPayload: Record<string, unknown> | undefined;
     const baseStreamFn: StreamFn = (model, context, options) => {
       const payload: Record<string, unknown> = {


### PR DESCRIPTION
## What Problem This Solves

July release validation backported GPT-5.6 reasoning assertions into two live-provider tests but retained their GPT-5.5 fallback models. The tests therefore failed locally during payload projection before making the provider request: one expected `reasoning_effort=none` but received no GPT-5.6 projection, while the Anthropic-family wrapper correctly preserved GPT-5.5's `low` setting.

## Why This Change Was Made

Backport the exact two fixture-default updates from main commit `fa77fe10d526b5c78910193a5ed73315aa600b5c`. Both live tests now default to `gpt-5.6-luna`, matching their existing GPT-5.6-specific assertions while preserving explicit environment overrides. No runtime behavior changes.

## User Impact

The July release train's live-provider gate validates the intended GPT-5.6 contract instead of combining GPT-5.6 assertions with GPT-5.5 fixtures.

## Evidence

- Failing release-check job: https://github.com/openclaw/openclaw/actions/runs/29170113701/job/86590065715
- Blacksmith Testbox `tbx_01kx9mw02fkp7kjjz9f7rw6vaj`: 50/50 adjacent stream-wrapper unit tests passed.
- Patch is an exact two-line backport from main commit `fa77fe10d526b5c78910193a5ed73315aa600b5c`.
- `git diff --check`
- Fresh autoreview: clean, correctness confidence 0.98.
- Direct live proof in the disposable Testbox was blocked because that box has no `OPENAI_API_KEY`; the credentialed hosted release-check rerun is the authoritative post-merge proof.
