### PR TITLE
fix(state): guide forward-schema recovery

### DIFF
--- a/src/infra/sqlite-user-version.ts
+++ b/src/infra/sqlite-user-version.ts
@@ -4,3 +4,14 @@ export function readSqliteUserVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version?: unknown } | undefined;
   return Number(row?.user_version ?? 0);
 }
+
+export function createNewerSqliteSchemaVersionError(
+  databaseLabel: string,
+  pathname: string,
+  schemaVersion: number,
+  supportedVersion: number,
+): Error {
+  return new Error(
+    `${databaseLabel} ${pathname} uses newer schema version ${schemaVersion}; this OpenClaw build supports ${supportedVersion}. Upgrade OpenClaw before opening this database. Do not downgrade OpenClaw or modify the database. To run this older build, use a separate state directory or restore a compatible backup.`,
+  );
+}

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -1201,7 +1201,9 @@ describe("openclaw agent database", () => {
         agentId: "worker-1",
         env: { OPENCLAW_STATE_DIR: stateDir },
       }),
-    ).toThrow(`newer schema version ${OPENCLAW_AGENT_SCHEMA_VERSION + 1}`);
+    ).toThrow(
+      `OpenClaw agent database ${databasePath} uses newer schema version ${OPENCLAW_AGENT_SCHEMA_VERSION + 1}; this OpenClaw build supports ${OPENCLAW_AGENT_SCHEMA_VERSION}. Upgrade OpenClaw before opening this database. Do not downgrade OpenClaw or modify the database. To run this older build, use a separate state directory or restore a compatible backup.`,
+    );
   });
 
   it("closes cached handles on normal process exit so no stale WAL remains", () => {

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -14,7 +14,10 @@ import {
   runSqliteImmediateTransactionSync,
   type SqliteTransactionOptions,
 } from "../infra/sqlite-transaction.js";
-import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import {
+  createNewerSqliteSchemaVersionError,
+  readSqliteUserVersion,
+} from "../infra/sqlite-user-version.js";
 import {
   configureSqliteConnectionPragmas,
   registerSqliteCacheExitClose,
@@ -106,8 +109,11 @@ function logSlowAgentDatabaseOpen(params: {
 function assertSupportedAgentSchemaVersion(db: DatabaseSync, pathname: string): void {
   const userVersion = readSqliteUserVersion(db);
   if (userVersion > OPENCLAW_AGENT_SCHEMA_VERSION) {
-    throw new Error(
-      `OpenClaw agent database ${pathname} uses newer schema version ${userVersion}; this OpenClaw build supports ${OPENCLAW_AGENT_SCHEMA_VERSION}.`,
+    throw createNewerSqliteSchemaVersionError(
+      "OpenClaw agent database",
+      pathname,
+      userVersion,
+      OPENCLAW_AGENT_SCHEMA_VERSION,
     );
   }
 }

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1518,7 +1518,9 @@ describe("openclaw state database", () => {
       openOpenClawStateDatabase({
         env: { OPENCLAW_STATE_DIR: stateDir },
       }),
-    ).toThrow(new RegExp(`newer schema version ${OPENCLAW_STATE_SCHEMA_VERSION + 1}`));
+    ).toThrow(
+      `OpenClaw state database ${databasePath} uses newer schema version ${OPENCLAW_STATE_SCHEMA_VERSION + 1}; this OpenClaw build supports ${OPENCLAW_STATE_SCHEMA_VERSION}. Upgrade OpenClaw before opening this database. Do not downgrade OpenClaw or modify the database. To run this older build, use a separate state directory or restore a compatible backup.`,
+    );
   });
 
   it("does not chmod shared parent directories for explicit database paths", () => {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -11,7 +11,10 @@ import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
-import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import {
+  createNewerSqliteSchemaVersionError,
+  readSqliteUserVersion,
+} from "../infra/sqlite-user-version.js";
 import {
   configureSqliteConnectionPragmas,
   type SqliteWalMaintenance,
@@ -67,8 +70,11 @@ type OpenClawStateMetadataDatabase = Pick<OpenClawStateKyselyDatabase, "schema_m
 function assertSupportedSchemaVersion(db: DatabaseSync, pathname: string): void {
   const userVersion = readSqliteUserVersion(db);
   if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
-    throw new Error(
-      `OpenClaw state database ${pathname} uses newer schema version ${userVersion}; this OpenClaw build supports ${OPENCLAW_STATE_SCHEMA_VERSION}.`,
+    throw createNewerSqliteSchemaVersionError(
+      "OpenClaw state database",
+      pathname,
+      userVersion,
+      OPENCLAW_STATE_SCHEMA_VERSION,
     );
   }
 }


### PR DESCRIPTION
## What Problem This Solves

When an older OpenClaw build encounters a state database created by a newer schema, it correctly refuses to open the database but only reports the version mismatch. Operators are left without safe recovery guidance and may try to edit or downgrade the database.

## Why This Change Was Made

The existing fail-closed schema guard remains unchanged. Its shared error now explains the safe paths: upgrade OpenClaw before opening the database, do not downgrade or modify the database, and use a separate state directory or restore a compatible backup when intentionally running the older build.

The formatter is owned by the existing SQLite user-version module and reused by both shared-state and per-agent database guards, removing their duplicated message construction.

## User Impact

Forward-schema failures remain fail-closed but now tell operators exactly how to recover without risking state corruption or accidental downgrade access.

## Evidence

- Blacksmith Testbox-through-Crabbox `tbx_01kx9mvsz3sjtfxp04ep69c3kt`: 150 focused tests passed across shared state, per-agent state, startup checkpoint, and doctor migration paths.
- `pnpm tsgo:prod` passed.
- `pnpm check:test-types` passed.
- Targeted oxlint and oxfmt checks passed for all five changed files.
- `git diff --check` passed.
- Fresh autoreview: no accepted or actionable findings.

Release-note context: forward-schema errors now include explicit upgrade, separate-state-directory, and compatible-backup guidance while preserving fail-closed behavior.
