### PR TITLE
fix(exec): preserve Unicode in retained process output tails

### DIFF
--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -345,21 +345,25 @@ describe("process supervisor", () => {
     expect(exit.stdout).toBe("");
   });
 
-  it("bounds retained stdout and stderr while streaming full chunks", async () => {
+  it("bounds retained output on UTF-16 boundaries while streaming full chunks", async () => {
     const adapter = createStubChildAdapter();
     createChildAdapterMock.mockResolvedValue(adapter);
 
     const supervisor = createProcessSupervisor();
     let streamedStdout = "";
     let streamedStderr = "";
-    const stdoutChunk = `${"a".repeat(300)}stdout-tail`;
-    const stderrChunk = `${"b".repeat(300)}stderr-tail`;
+    const maxCapturedOutputChars = 256;
+    const stdoutMarker = `[openclaw: captured stdout truncated to last ${maxCapturedOutputChars} chars]\n`;
+    const stderrMarker = `[openclaw: captured stderr truncated to last ${maxCapturedOutputChars} chars]\n`;
+    const retainedChars = maxCapturedOutputChars - stdoutMarker.length - 1;
+    const stdoutChunk = `${"a".repeat(stdoutMarker.length)}😀${"s".repeat(retainedChars)}`;
+    const stderrChunk = `${"b".repeat(stderrMarker.length)}😀${"e".repeat(retainedChars)}`;
     const run = await spawnChild(supervisor, {
       sessionId: "s-capture-cap",
       argv: createWriteStdoutArgv(stdoutChunk),
       timeoutMs: 1_000,
       stdinMode: "pipe-closed",
-      maxCapturedOutputChars: 256,
+      maxCapturedOutputChars,
       onStdout: (chunk) => {
         streamedStdout += chunk;
       },
@@ -375,11 +379,7 @@ describe("process supervisor", () => {
     const exit = await run.wait();
     expect(streamedStdout).toBe(stdoutChunk);
     expect(streamedStderr).toBe(stderrChunk);
-    expect(exit.stdout.length).toBeLessThanOrEqual(256);
-    expect(exit.stderr.length).toBeLessThanOrEqual(256);
-    expect(exit.stdout).toContain("captured stdout truncated");
-    expect(exit.stderr).toContain("captured stderr truncated");
-    expect(exit.stdout.endsWith("stdout-tail")).toBe(true);
-    expect(exit.stderr.endsWith("stderr-tail")).toBe(true);
+    expect(exit.stdout).toBe(`${stdoutMarker}${"s".repeat(retainedChars)}`);
+    expect(exit.stderr).toBe(`${stderrMarker}${"e".repeat(retainedChars)}`);
   });
 });

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import { performance } from "node:perf_hooks";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getShellConfig } from "../../agents/shell-utils.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { createChildAdapter } from "./adapters/child.js";
@@ -54,7 +55,7 @@ function appendCapturedOutput(
   }
   const marker = `[openclaw: captured ${stream} truncated to last ${maxChars} chars]\n`;
   const tailChars = Math.max(0, maxChars - marker.length);
-  return `${marker}${next.slice(-tailChars)}`;
+  return `${marker}${sliceUtf16Safe(next, -tailChars)}`;
 }
 
 function isTimeoutReason(reason: TerminationReason) {


### PR DESCRIPTION
## What Problem This Solves

Long retained process output could be truncated through the middle of a UTF-16 surrogate pair. The streamed output remained correct, but the bounded stdout or stderr tail could end with a corrupted replacement character.

Supersedes #104531 because its fork does not allow maintainer writes.

## Why This Change Was Made

The process supervisor now uses the normalization package's canonical UTF-16-safe slicing helper when retaining the bounded tail. The consolidated regression drives both stdout and stderr through the real supervisor path and proves the exact retained result at the boundary.

The final patch is one focused commit on current `main`; the original contributor remains the commit author.

## User Impact

**Before:** a long child-process output tail could corrupt a boundary emoji in the retained result.

**After:** the incomplete surrogate pair is dropped while the truncation marker, size bound, and full streamed chunks remain unchanged.

## Evidence

- Changed: `src/process/supervisor/supervisor.ts`
- Regression: `src/process/supervisor/supervisor.test.ts`
- Prior sanitized AWS Crabbox on the identical patch: `run_56c83697a6cb`
- Fresh autoreview on the reviewed patch: no findings, confidence 0.98
- Targeted formatting and `git diff --check`: passed
- Native exact-head prepare remains the merge gate

## Real behavior proof

- **Behavior addressed:** retained stdout and stderr tails no longer split UTF-16 surrogate pairs.
- **Reachability:** child adapter output -> supervisor capture bound -> `RunExit.stdout` / `RunExit.stderr`.
- **Sibling coverage:** the same helper path handles both streams; the regression proves both.
- **Fix classification:** root-cause fix.

- [x] AI-assisted (Codex)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
