### PR TITLE
fix(ai): guard payload-less media blocks from erasing tool-result text

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -89,6 +89,7 @@ import {
   describeToolResultMediaPlaceholder,
   extractToolResultBlockText,
   extractToolResultText,
+  hasInlineMediaData,
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -201,7 +202,7 @@ function convertContentBlocks(
       blocks.push({ type: "text" as const, text: sanitizeSurrogates(blockText) });
       hasTextBlock = true;
     }
-    if (record.type !== "image") {
+    if (record.type !== "image" || !hasInlineMediaData(record)) {
       continue;
     }
     blocks.push({

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -32,7 +32,11 @@ import type {
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasInlineMediaData,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 type GoogleApiType = "google-generative-ai" | "google-vertex";
@@ -282,7 +286,7 @@ export function convertMessages<T extends GoogleApiType>(
       // Extract text and image content
       const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
-        ? msg.content.filter((c): c is ImageContent => c.type === "image")
+        ? msg.content.filter((c): c is ImageContent => c.type === "image" && hasInlineMediaData(c))
         : [];
 
       const hasText = textResult.length > 0;

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -33,7 +33,11 @@ import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import { buildBaseOptions } from "./simple-options.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasInlineMediaData,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 const MISTRAL_TOOL_CALL_ID_LENGTH = 9;
@@ -909,7 +913,7 @@ function toChatMessages(
       if (!supportsImages) {
         continue;
       }
-      if (part.type !== "image") {
+      if (part.type !== "image" || !hasInlineMediaData(part)) {
         continue;
       }
       toolContent.push({

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -61,7 +61,11 @@ import {
   type OpenAIToolProjection,
 } from "./openai-tool-projection.js";
 import { buildBaseOptions } from "./simple-options.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasInlineMediaData,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 /**
@@ -98,7 +102,7 @@ function isToolCallBlock(block: { type: string }): block is ToolCall {
 }
 
 function isImageContentBlock(block: { type: string }): block is ImageContent {
-  return block.type === "image";
+  return block.type === "image" && hasInlineMediaData(block);
 }
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -58,7 +58,11 @@ import {
   resolveResponsesMessageSnapshotCollapse,
 } from "./openai-responses-stream-compat.js";
 import { convertResponsesToolPayload, convertResponsesTools } from "./openai-responses-tools.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasInlineMediaData,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================
@@ -464,7 +468,7 @@ export function convertResponsesMessages<TApi extends Api>(
         }
 
         for (const block of msg.content) {
-          if (block.type === "image") {
+          if (block.type === "image" && hasInlineMediaData(block)) {
             contentParts.push({
               type: "input_image",
               detail: "auto",

--- a/packages/ai/src/providers/tool-result-text.test.ts
+++ b/packages/ai/src/providers/tool-result-text.test.ts
@@ -90,6 +90,31 @@ describe("extractToolResultText", () => {
     expect(text).toContain("…(truncated)…");
     expect(text).not.toContain(tail);
   });
+
+  it("returns a fixed placeholder for payload-less image blocks instead of swallowing text", () => {
+    const text = extractToolResultText([
+      { type: "image", mimeType: "image/png" },
+      { type: "image_url" },
+    ]);
+
+    expect(text).toBe("[image omitted: missing payload]\n[image omitted: missing payload]");
+    expect(text).not.toBe("(see attached image)");
+  });
+
+  it("preserves text content when payload-less image blocks are present", () => {
+    const text = extractToolResultText([
+      { type: "text", text: "real tool output" },
+      { type: "image", mimeType: "image/png" },
+    ]);
+
+    expect(text).toBe("real tool output");
+  });
+
+  it("returns a fixed placeholder for payload-less audio blocks", () => {
+    const text = extractToolResultText([{ type: "audio", mimeType: "audio/mpeg" }]);
+
+    expect(text).toBe("[audio omitted: missing payload]");
+  });
 });
 
 describe("describeToolResultMediaPlaceholder", () => {
@@ -114,5 +139,23 @@ describe("describeToolResultMediaPlaceholder", () => {
         { type: "audio", mimeType: "audio/mpeg", data: "audio" },
       ]),
     ).toBe("(see attached media)");
+  });
+
+  it("does not advertise phantom media for payload-less image blocks", () => {
+    expect(
+      describeToolResultMediaPlaceholder([{ type: "image", mimeType: "image/png" }]),
+    ).toBeUndefined();
+  });
+
+  it("does not advertise phantom media for payload-less audio blocks", () => {
+    expect(
+      describeToolResultMediaPlaceholder([{ type: "audio", mimeType: "audio/mpeg" }]),
+    ).toBeUndefined();
+  });
+
+  it("does not detect images from text blocks with image-like mime metadata", () => {
+    expect(
+      describeToolResultMediaPlaceholder([{ type: "text", text: "hello", mimeType: "image/png" }]),
+    ).toBeUndefined();
   });
 });

--- a/packages/ai/src/providers/tool-result-text.test.ts
+++ b/packages/ai/src/providers/tool-result-text.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasInlineMediaData,
+} from "./tool-result-text.js";
 
 describe("extractToolResultText", () => {
   it("keeps media-only blocks out of provider replay text", () => {
@@ -157,5 +161,19 @@ describe("describeToolResultMediaPlaceholder", () => {
     expect(
       describeToolResultMediaPlaceholder([{ type: "text", text: "hello", mimeType: "image/png" }]),
     ).toBeUndefined();
+  });
+});
+
+describe("hasInlineMediaData", () => {
+  it("returns true for blocks with non-empty data", () => {
+    expect(hasInlineMediaData({ type: "image", data: "img", mimeType: "image/png" })).toBe(true);
+  });
+
+  it("returns false for blocks without data", () => {
+    expect(hasInlineMediaData({ type: "image", mimeType: "image/png" })).toBe(false);
+  });
+
+  it("returns false for blocks with empty data", () => {
+    expect(hasInlineMediaData({ type: "image", data: "", mimeType: "image/png" })).toBe(false);
   });
 });

--- a/packages/ai/src/providers/tool-result-text.ts
+++ b/packages/ai/src/providers/tool-result-text.ts
@@ -23,6 +23,47 @@ const MIME_KEY_CANDIDATES = [
 const TEXTUAL_MIME_PATTERN =
   /^(?:text\/|application\/(?:json|ld\+json|x-ndjson|xml|javascript|x-www-form-urlencoded)|[^/]+\/[^+]+\+(?:json|xml)$)/i;
 const OPAQUE_OR_BINARY_FIELD_RE = /^(?:blob|buffer|bytes|encrypted_content|encrypted_stdout)$/i;
+const MISSING_IMAGE_PAYLOAD_TEXT = "[image omitted: missing payload]";
+const MISSING_AUDIO_PAYLOAD_TEXT = "[audio omitted: missing payload]";
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** True when a media-shaped content block carries recognizable payload data
+ *  in one of the canonical or provider wire shapes. Payload-less media blocks
+ *  are malformed husks that must not suppress tool-result text or be emitted
+ *  as native media parts (provider APIs reject empty payloads). */
+function hasMediaPayload(block: unknown): boolean {
+  if (!isRecord(block)) {
+    return false;
+  }
+  if (
+    isNonEmptyString(block.data) ||
+    isNonEmptyString(block.url) ||
+    isNonEmptyString(block.file_id) ||
+    isNonEmptyString(block.audio_url)
+  ) {
+    return true;
+  }
+  const imageUrl = block.image_url;
+  if (isNonEmptyString(imageUrl) || (isRecord(imageUrl) && isNonEmptyString(imageUrl.url))) {
+    return true;
+  }
+  const source = block.source;
+  if (isRecord(source) && (isNonEmptyString(source.data) || isNonEmptyString(source.url))) {
+    return true;
+  }
+  const inputAudio = block.input_audio;
+  if (isNonEmptyString(inputAudio) || (isRecord(inputAudio) && isNonEmptyString(inputAudio.data))) {
+    return true;
+  }
+  const audio = block.audio;
+  if (isNonEmptyString(audio) || (isRecord(audio) && isNonEmptyString(audio.data))) {
+    return true;
+  }
+  return false;
+}
 
 function readMimeType(value: unknown): string | undefined {
   if (!isRecord(value)) {
@@ -131,20 +172,23 @@ export function describeToolResultMediaPlaceholder(blocks: readonly unknown[]): 
     }
     const record = block as Record<string, unknown>;
     const type = typeof record.type === "string" ? record.type : undefined;
-    const mimeType = readMimeType(record);
-
-    if (
-      (type && IMAGE_TOOL_RESULT_TYPES.has(type)) ||
-      mimeType?.toLowerCase().startsWith("image/")
-    ) {
-      hasImage = true;
+    // A text block's own mime metadata describes its content (e.g. SVG source),
+    // not attached media; skip it to avoid false image detection.
+    const mimeType = type === "text" ? undefined : readMimeType(record)?.toLowerCase();
+    const looksImage =
+      (type ? IMAGE_TOOL_RESULT_TYPES.has(type) : false) || mimeType?.startsWith("image/") === true;
+    const looksAudio =
+      (type ? AUDIO_TOOL_RESULT_TYPES.has(type) : false) || mimeType?.startsWith("audio/") === true;
+    if (!looksImage && !looksAudio) {
+      continue;
     }
-    if (
-      (type && AUDIO_TOOL_RESULT_TYPES.has(type)) ||
-      mimeType?.toLowerCase().startsWith("audio/")
-    ) {
-      hasAudio = true;
+    // A media-shaped block with no payload is a malformed husk, not attached
+    // media; advertising it would point the model at media that was never sent.
+    if (!hasMediaPayload(record)) {
+      continue;
     }
+    hasImage ||= looksImage;
+    hasAudio ||= looksAudio;
   }
 
   if (hasImage && hasAudio) {
@@ -165,7 +209,17 @@ export function extractToolResultBlockText(block: unknown): string | undefined {
   }
   const record = block as Record<string, unknown>;
   if (typeof record.type === "string" && MEDIA_ONLY_TOOL_RESULT_TYPES.has(record.type)) {
-    return undefined;
+    if (hasMediaPayload(record)) {
+      // Genuine media replays through provider media paths, not as text.
+      return undefined;
+    }
+    // A media-labeled husk with no payload has nothing to render on the media
+    // path. Surface a fixed placeholder: dropping the block would make the tool
+    // output vanish for the model, and JSON-stringifying it can leak nested
+    // payload-shaped fields into provider text.
+    return AUDIO_TOOL_RESULT_TYPES.has(record.type)
+      ? MISSING_AUDIO_PAYLOAD_TEXT
+      : MISSING_IMAGE_PAYLOAD_TEXT;
   }
   if (record.type === "text") {
     const text = typeof record.text === "string" ? record.text : "";

--- a/packages/ai/src/providers/tool-result-text.ts
+++ b/packages/ai/src/providers/tool-result-text.ts
@@ -65,6 +65,16 @@ function hasMediaPayload(block: unknown): boolean {
   return false;
 }
 
+/**
+ * True when a canonical media block carries inline base64 `data` that provider
+ * converters can embed directly. Converters must not emit a native media part
+ * from a block that fails this check — an empty payload produces an invalid
+ * part the provider API rejects.
+ */
+export function hasInlineMediaData(block: unknown): boolean {
+  return isRecord(block) && isNonEmptyString(block.data);
+}
+
 function readMimeType(value: unknown): string | undefined {
   if (!isRecord(value)) {
     return undefined;

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -44,6 +44,7 @@ import {
   describeToolResultMediaPlaceholder,
   extractToolResultBlockText,
   extractToolResultText,
+  hasInlineMediaData,
 } from "@openclaw/ai/internal/shared";
 /**
  * Native Anthropic Messages streaming transport.
@@ -369,7 +370,7 @@ function convertContentBlocks(content: readonly unknown[]) {
       blocks.push({ type: "text", text: sanitizeTransportPayloadText(blockText) });
       hasTextBlock = true;
     }
-    if (record.type !== "image") {
+    if (record.type !== "image" || !hasInlineMediaData(record)) {
       continue;
     }
     blocks.push({

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -44,6 +44,7 @@ import {
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultText,
+  hasInlineMediaData,
   stripSystemPromptCacheBoundary,
 } from "@openclaw/ai/internal/shared";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -1324,7 +1325,7 @@ function convertResponsesMessages(
                     ? [{ type: "input_text", text: mediaPlaceholder }]
                     : []),
                 ...msg.content
-                  .filter((item) => item.type === "image")
+                  .filter((item) => item.type === "image" && hasInlineMediaData(item))
                   .map((item) => ({
                     type: "input_image",
                     detail: "auto",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1326,11 +1326,14 @@ function convertResponsesMessages(
                     : []),
                 ...msg.content
                   .filter((item) => item.type === "image" && hasInlineMediaData(item))
-                  .map((item) => ({
-                    type: "input_image",
-                    detail: "auto",
-                    image_url: `data:${item.mimeType};base64,${item.data}`,
-                  })),
+                  .map((item) => {
+                    const image = item as { mimeType: string; data: string };
+                    return {
+                      type: "input_image",
+                      detail: "auto",
+                      image_url: `data:${image.mimeType};base64,${image.data}`,
+                    };
+                  }),
               ] as ResponseFunctionCallOutputItemList)
             : sanitizeNonEmptyTransportPayloadText(textResult, mediaPlaceholder ?? "(no output)"),
       });


### PR DESCRIPTION
## What Problem This Solves

A tool-result content block labeled `image` or `audio` with no recognizable payload causes the entire tool output to be replaced by `"(see attached image)"` — the phantom media placeholder tells the model media was attached when nothing was sent.
- **Problem**: `extractToolResultBlockText` returns `undefined` for every media-typed block regardless of payload, and `describeToolResultMediaPlaceholder` advertises media from payload-less husks. When a tool result contains only payload-less media blocks (no text blocks), the output degrades to `"(see attached image)"`.
- **Solution**: Add `hasMediaPayload()` and `hasInlineMediaData()` predicates. Use them in `describeToolResultMediaPlaceholder` and `extractToolResultBlockText` to skip/flag payload-less blocks instead of producing phantom media placeholders. Guard all provider emitters against emitting empty image blocks.
- **What changed**:
  - `packages/ai/src/providers/tool-result-text.ts` — shared helpers (hasMediaPayload, hasInlineMediaData, fixed placeholder fallback)
  - `packages/ai/src/providers/tool-result-text.test.ts` — 18 tests
  - `packages/ai/src/providers/anthropic.ts` — emitter guard
  - `packages/ai/src/providers/google-shared.ts` — emitter guard
  - `packages/ai/src/providers/mistral.ts` — emitter guard
  - `packages/ai/src/providers/openai-completions.ts` — emitter guard
  - `packages/ai/src/providers/openai-responses-shared.ts` — emitter guard
  - `src/agents/anthropic-transport-stream.ts` — transport emitter guard
  - `src/agents/openai-transport-stream.ts` — transport emitter guard
- **What did NOT change**: Session persistence, database schema, config format, public API types

## Change Type

- [x] Bug fix

## Scope

- [x] API / contracts

## Linked Issue/PR

- Fixes #104721
- Related #100795 (broader approach — same root cause, this PR is a focused subset)
- [x] This PR fixes a bug or regression

## Motivation

Issue #104721 reports that all tool results return `"(see attached image)"` literal placeholder text instead of actual output across deepseek-v4-flash and gpt-5.5 models. The root cause is that `describeToolResultMediaPlaceholder` and `extractToolResultBlockText` in the shared `tool-result-text.ts` treat every media-typed content block as genuine media, even when it carries no payload. A payload-less media block (from session corruption, plugin bugs, or older sessions) causes the tool result text to vanish and be replaced with a media placeholder.

## Evidence

- Behavior addressed: Tool results with payload-less media blocks no longer degrade to phantom media placeholders
- Real environment tested: Linux, Node 22, branch `fix/media-payload-guard-104721`
- Exact steps or command run after this patch:

```
pnpm test packages/ai/src/providers/tool-result-text.test.ts
```

- Evidence after fix:

```console
$ pnpm test packages/ai/src/providers/tool-result-text.test.ts

 Test Files  1 passed (1)
      Tests  18 passed (18)

$ pnpm test packages/ai/src/providers/anthropic.test.ts

 Test Files  1 passed (1)
      Tests  68 passed (68)

$ pnpm test packages/ai/src/providers/openai-completions.test.ts

 Test Files  1 passed (1)
      Tests  43 passed (43)
```

**Matrix-style evidence (before vs after)**:

| Scenario | Input | Before (main) | After (this PR) |
|---|---|---|---|
| Phantom image replaces output | `[{type:"image"}]` (no data) | `extractToolResultText` → `""` → output becomes `"(see attached image)"` | `extractToolResultText` → `"[image omitted: missing payload]"` |
| Phantom audio replaces output | `[{type:"audio"}]` (no data) | Same, `"(see attached audio)"` | `"[audio omitted: missing payload]"` |
| Text + phantom image | `[{type:"text",text:"real output"},{type:"image"}]` | `"real output"` (text preserved) but emitter sends empty image block | `"real output"` + emitter skips empty image |
| Genuine image (unchanged) | `[{type:"image",data:"img"}]` | `undefined` (media path) / `"(see attached image)"` | Same ✅ |
| Text block with image mime | `[{type:"text",text:"hello",mimeType:"image/png"}]` | False image detection → `"(see attached image)"` | No false detection → `undefined` ✅ |
| hasInlineMediaData | `{type:"image",data:"img"}` | N/A (new function) | `true` ✅ |
| hasInlineMediaData | `{type:"image"}` (no data) | N/A (new function) | `false` ✅ |

- Observed result after fix:
  1. `extractToolResultText` returns `"[image omitted: missing payload]"` for payload-less image-only content instead of empty string
  2. `describeToolResultMediaPlaceholder` returns `undefined` for payload-less media blocks instead of `"(see attached image)"`
  3. Text blocks with image-like mime metadata no longer trigger false image detection
  4. Mixed text + payload-less-image content correctly returns the text
  5. Provider-native emitters skip payload-less image blocks instead of emitting empty image URLs / base64 data
- What was not tested: Live end-to-end provider API calls (guarded by the same pattern in converters + unit tests)

- **Fix completeness pre-check (4 questions)**
  - ✅ Auth guard: N/A — no permission/policy changes
  - ✅ Enum completeness: `hasMediaPayload` covers all canonical wire shapes (data, url, file_id, image_url string/object, source.data/url, input_audio, audio); `hasInlineMediaData` covers inline base64
  - ✅ Path coverage: Shared helpers (`describeToolResultMediaPlaceholder`, `extractToolResultBlockText`) + all 5 provider emitters + 2 transport streams use the same guards
  - ✅ Cleanup symmetry: Payload-less media blocks get a fixed placeholder text, not JSON stringification (which could leak nested payload-shaped fields)

## Root Cause

Payload-less media-typed content blocks (e.g. `{ type: "image", mimeType: "image/png" }` without `data`) suppress text extraction and advertise phantom media. The shared functions in `packages/ai/src/providers/tool-result-text.ts` trusted the type label alone — no payload verification existed.

## Regression Test Plan

All 18 existing + new tests pass. Broader provider tests (anthropic 68, openai-completions 43, google-shared 12) also pass unchanged.

## User-visible / Behavior Changes

- Tool results with payload-less media blocks show `"[image omitted: missing payload]"` instead of `"(see attached image)"`
- All other behavior unchanged

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Best-fix Verdict

- **Best fix**: Yes — the shared `tool-result-text.ts` is the correct boundary for text extraction; all provider emitters also need the inline-data guard to prevent invalid API payloads
- **Refactor needed**: No — targeted 9-file change with consistent pattern across all emitters
- **Alternative considered**: Shared-helper-only approach (commit 1) — fixed text extraction but didn't prevent emitters from sending empty image blocks. Expanded to cover emitters after ClawSweeper review (commit 2)

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

**Highest risk area**: A payload-less media block from a genuine source (e.g. plugin that intentionally sends empty media) now renders as `"[image omitted: missing payload]"` text instead of `"(see attached image)"`. This is strictly better — the model gets a readable explanation rather than a misleading "image was attached" message.

**Mitigation**: Backward compatible for genuine media (blocks with `data`/`url`/`file_id` payloads are unaffected). The change only affects payload-less blocks that were already broken (producing incorrect placeholder text).

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

---

Fixes #104721
