### PR TITLE
ci: pass frozen UI test options to Vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1052,7 +1052,7 @@ jobs:
           if [[ "$COMPATIBILITY_TARGET" == "true" ]]; then
             # Frozen targets can contain timing-sensitive tests fixed on current main.
             # Preserve one retry, but let their browser helpers use their 10-second waits.
-            pnpm --dir ui test -- --retry=1 --testTimeout=10000
+            pnpm --dir ui test --retry=1 --testTimeout=10000
           else
             pnpm --dir ui test
           fi

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1875,7 +1875,8 @@ describe("ci workflow guards", () => {
       "${{ needs.preflight.outputs.compatibility_target }}",
     );
     expect(uiTest.run).toContain('if [[ "$COMPATIBILITY_TARGET" == "true" ]]');
-    expect(uiTest.run).toContain("pnpm --dir ui test -- --retry=1 --testTimeout=10000");
+    expect(uiTest.run).toContain("pnpm --dir ui test --retry=1 --testTimeout=10000");
+    expect(uiTest.run).not.toContain("pnpm --dir ui test -- --retry");
     expect(uiTest.run).toContain("pnpm --dir ui test");
   });
 


### PR DESCRIPTION
## What Problem This Solves

The frozen-target compatibility command inserted a literal `--` before Vitest's `--retry` and `--testTimeout` options. The UI package script therefore invoked `vitest ... -- --retry=1 --testTimeout=10000`; Vitest did not parse those as runner options. Beta retained the 5-second timeout, while LTS also suffered 45 cascading test-process failures.

## Why This Change Was Made

Pass the options directly through pnpm: `pnpm --dir ui test --retry=1 --testTimeout=10000`. Add an explicit guard rejecting the invalid separator form. Current-main UI tests remain unchanged and strict.

## User Impact

No runtime behavior changes. Authenticated frozen beta, July, and LTS targets receive the intended compatibility-only retry and 10-second test budget.

## Evidence

- LTS failure showing the malformed invocation: https://github.com/openclaw/openclaw/actions/runs/29170838552/job/86591691875
- Blacksmith Testbox `tbx_01kx9nrrwzvszahb8kwemhe85d`: workflow guards 51/51 passed.
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Fresh autoreview: clean, correctness confidence 0.98.
