### PR TITLE
test(telegram): guard send-funnel chunk-boundary parity for streamed finals

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -1282,33 +1282,76 @@ describe("createTelegramDraftStream", () => {
     });
   });
 
-  it("shares durable Markdown chunk boundaries with final draft pagination", async () => {
-    const api = createMockDraftApi();
-    const text = Array.from(
-      { length: 12 },
-      (_, index) =>
-        `**${String(index).padStart(2, "0")}** overflow pagination line with filler text`,
-    ).join("\n");
-    const maxChars = 80;
-    const expectedChunks = markdownToTelegramChunks(text, maxChars);
-    const stream = createDraftStream(api, {
-      maxChars,
-      renderText: (value) => ({
-        text: renderTelegramHtmlText(value),
-        parseMode: "HTML",
-        markdownSource: { text: value },
-      }),
-    });
+  // Send funnel parity (extensions/telegram/CLAUDE.md): streamed FINAL pages must
+  // land on the exact chunk boundaries the durable reply funnel produces
+  // (delivery.replies.ts buildChunkTextResolver -> markdownToTelegramChunks), so
+  // pagination never splits mid-word, inside an HTML entity, or inside a tag.
+  it.each([
+    {
+      boundary: "mid-word",
+      maxChars: 96,
+      text: Array.from(
+        { length: 18 },
+        (_, index) => `sesquipedalian${index} incontrovertible counterrevolutionaries`,
+      ).join(" "),
+    },
+    {
+      boundary: "mid-entity",
+      maxChars: 96,
+      text: Array.from({ length: 24 }, (_, index) => `alpha & beta < gamma > delta ${index}`).join(
+        "\n",
+      ),
+    },
+    {
+      boundary: "mid-tag",
+      maxChars: 112,
+      text: Array.from(
+        { length: 16 },
+        (_, index) =>
+          `**bold span ${index}** plus [link ${index}](https://example.com/p${index}) and \`code${index}\``,
+      ).join("\n"),
+    },
+    {
+      boundary: "code-block",
+      maxChars: 128,
+      text: [
+        "Intro paragraph before the fence.",
+        "```ts",
+        ...Array.from({ length: 20 }, (_, index) => `const value${index} = compute(${index});`),
+        "```",
+        "Closing paragraph after the fence.",
+      ].join("\n"),
+    },
+  ])(
+    "shares durable chunk boundaries with final draft pagination ($boundary)",
+    async ({ maxChars, text }) => {
+      const api = createMockDraftApi();
+      const expectedChunks = markdownToTelegramChunks(text, maxChars);
+      // Guard the table: a case that fits in one page proves nothing about boundaries.
+      expect(expectedChunks.length).toBeGreaterThan(1);
+      const retainedPageTexts: string[] = [];
+      const stream = createDraftStream(api, {
+        maxChars,
+        onRetainedPage: (page) => retainedPageTexts.push(page.textSnapshot),
+        renderText: (value) => ({
+          text: renderTelegramHtmlText(value),
+          parseMode: "HTML",
+          markdownSource: { text: value },
+        }),
+      });
 
-    stream.update(text);
-    await stream.stop();
+      stream.update(text);
+      await stream.stop();
 
-    const pages = api.sendMessage.mock.calls.map((call) => call[1]);
-    expect(pages).toEqual(expectedChunks.map((chunk) => chunk.html));
-    expect(pages.map(telegramHtmlToPlainTextFallback)).toEqual(
-      expectedChunks.map((chunk) => chunk.text),
-    );
-  });
+      const pages = api.sendMessage.mock.calls.map((call) => call[1]);
+      expect(pages).toEqual(expectedChunks.map((chunk) => chunk.html));
+      // Plain-fallback parity: each page must carry the durable funnel's plainText
+      // projection so an HTML-parse 400 degrades both funnels to identical text.
+      expect([...retainedPageTexts, stream.currentMessageSnapshot?.()?.text]).toEqual(
+        expectedChunks.map((chunk) => chunk.text),
+      );
+    },
+  );
 
   it("paginates one rendered rich-code plan without reparsing Markdown tails", async () => {
     const api = createMockDraftApi();


### PR DESCRIPTION
Related: #104318

## What Problem This Solves

Telegram's guide mandates send-funnel parity (streaming and durable funnels must degrade identically), and #104608 just fixed the streamed-final pagination to use the shared chunker — but nothing guarded the invariant, which is exactly how the divergence crept in originally.

## Why This Change Was Made

Adds the missing table-driven parity regression test: for mid-word, mid-entity, mid-tag, and fenced code-block content, streamed final pages must equal the durable chunker's HTML chunks exactly, and retained/current page snapshots must carry the durable plainText projection (so parse-400 degradation behaves identically in both funnels). Test-only; the behavior fix shipped upstream in #104608 and its re-recorded overflow golden is untouched here.

## User Impact

None directly — prevents regression of the just-fixed mid-word HTML pagination class.

## Evidence

- Testbox `tbx_01kx9n9q7rksfxgr5baj0esw57`: draft-stream suite 84/84 (incl. the 4 new parity cases), delivery-trace goldens 5/5 verify-mode, full `pnpm check:changed` exit 0; repo-wide format green up front.
- Autoreview (codex gpt-5.6-sol, xhigh): clean (0.94).
- Known residual divergence (documented, out of scope): rich-messages draft finals and `chunkMode: "newline"` configs still diverge from the durable path for non-default config — tracked in #104318.
