### PR TITLE
fix(agents): surface utility-model narration failures and show the utility model in models status

### DIFF
--- a/src/auto-reply/reply/progress-narrator.test.ts
+++ b/src/auto-reply/reply/progress-narrator.test.ts
@@ -2,6 +2,19 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
+
+const narratorWarnSpy = vi.hoisted(() => vi.fn());
+vi.mock("../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => ({
+      ...actual.createSubsystemLogger(subsystem),
+      warn: narratorWarnSpy,
+    }),
+  };
+});
+
 import {
   attachProgressNarratorToReplyOptions,
   createProgressNarrator,
@@ -129,7 +142,8 @@ describe("createProgressNarrator", () => {
     expect(onUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("disables after consecutive failed generations", async () => {
+  it("disables after consecutive failed generations and warns once", async () => {
+    narratorWarnSpy.mockClear();
     let nowMs = 0;
     const { narrator, generate, onUpdate } = createNarratorHarness({
       texts: [null],
@@ -144,6 +158,10 @@ describe("createProgressNarrator", () => {
 
     expect(generate).toHaveBeenCalledTimes(2);
     expect(onUpdate).not.toHaveBeenCalled();
+    expect(narratorWarnSpy).toHaveBeenCalledTimes(1);
+    expect(String(narratorWarnSpy.mock.calls[0]?.[0])).toContain(
+      "narration disabled after 2 consecutive failures",
+    );
   });
 
   it("clears rendered narration when it disables after failures", async () => {

--- a/src/auto-reply/reply/progress-narrator.ts
+++ b/src/auto-reply/reply/progress-narrator.ts
@@ -11,7 +11,10 @@ import { isChannelProgressDraftWorkToolName, isCommandToolName } from "../../cha
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import type { TextContent } from "../../llm/types.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
+
+const narratorLog = createSubsystemLogger("auto-reply/progress-narrator");
 
 const MIN_EVENTS_PER_NARRATION = 4;
 const MIN_INTERVAL_MS = 12_000;
@@ -109,7 +112,7 @@ async function generateNarrationWithUtilityModel(params: {
   prepared: NonNullable<Awaited<ReturnType<typeof prepareNarrationModel>>>;
   input: ProgressNarrationInput;
   abortSignal?: AbortSignal;
-}): Promise<string | null> {
+}): Promise<{ text: string | null; error?: string }> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), NARRATION_TIMEOUT_MS);
   const onOuterAbort = () => controller.abort();
@@ -136,20 +139,19 @@ async function generateNarrationWithUtilityModel(params: {
       },
     });
     if (result.stopReason === "error") {
-      logVerbose(
-        `progress-narrator: completion failed: ${result.errorMessage?.trim() || "unknown error"}`,
-      );
-      return null;
+      const error = result.errorMessage?.trim() || "unknown error";
+      logVerbose(`progress-narrator: completion failed: ${error}`);
+      return { text: null, error };
     }
     const text = result.content
       .filter(isTextContentBlock)
       .map((block) => block.text)
       .join("")
       .trim();
-    return text || null;
+    return { text: text || null };
   } catch (err) {
     logVerbose(`progress-narrator: completion failed: ${String(err)}`);
-    return null;
+    return { text: null, error: String(err) };
   } finally {
     clearTimeout(timeout);
     params.abortSignal?.removeEventListener("abort", onOuterAbort);
@@ -199,6 +201,8 @@ export function createProgressNarrator(params: {
   let consecutiveFailures = 0;
   let lastText = "";
   let preparedPromise: ReturnType<typeof prepareNarrationModel> | undefined;
+  let lastFailure: string | undefined;
+  let utilityModelLabel: string | undefined;
 
   const generate =
     params.generate ??
@@ -209,13 +213,17 @@ export function createProgressNarrator(params: {
         disabled = true;
         return null;
       }
-      return await generateNarrationWithUtilityModel({
+      const { provider, modelId, profileId } = prepared.selection;
+      utilityModelLabel = `${provider}/${modelId}${profileId ? ` via ${profileId}` : ""}`;
+      const outcome = await generateNarrationWithUtilityModel({
         cfg: params.cfg,
         agentId: params.agentId,
         prepared,
         input,
         abortSignal: params.abortSignal,
       });
+      lastFailure = outcome.error;
+      return outcome.text;
     });
 
   // Stopping mid-turn must clear any rendered narration so the channel draft
@@ -290,6 +298,14 @@ export function createProgressNarrator(params: {
         if (!text) {
           consecutiveFailures += 1;
           if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            // A dead utility-model credential otherwise degrades silently to raw
+            // tool lines; per-attempt detail is verbose-only, so emit one warn
+            // per turn naming the model/profile operators must repair.
+            narratorLog.warn(
+              `narration disabled after ${consecutiveFailures} consecutive failures` +
+                (utilityModelLabel ? ` (${utilityModelLabel})` : "") +
+                (lastFailure ? `: ${lastFailure}` : ""),
+            );
             disableNarration();
           }
           return;

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -479,11 +479,22 @@ export async function modelsStatusCommand(
     for (const raw of [defaultLabel, ...fallbacks]) {
       addProviderUse(raw, true);
     }
-    // Utility completions (narration/titles) ride the plain API path like image
-    // models, so missing utility-provider auth must fail --check instead of
-    // hiding behind the primary's codex-runtime fallback.
-    for (const raw of [imageModel, ...imageFallbacks, utilityModelRef ?? ""]) {
+    for (const raw of [imageModel, ...imageFallbacks]) {
       addProviderUse(raw, false);
+    }
+    // Utility completions (narration/titles) are a real runtime auth consumer.
+    // Register the utility ref only when no other configured model already
+    // covers its provider: shared providers are analyzed via those uses, while
+    // a utility-only provider would otherwise stay invisible to --check.
+    if (utilityModelRef) {
+      const utilityProvider = resolveStatusModelRef(utilityModelRef)?.provider;
+      const normalizedUtilityProvider = utilityProvider ? normalizeProviderId(utilityProvider) : "";
+      if (
+        normalizedUtilityProvider &&
+        !providerUseRefs.some((use) => use.provider === normalizedUtilityProvider)
+      ) {
+        addProviderUse(utilityModelRef, false);
+      }
     }
 
     const providersFromEnv = new Set<string>();

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -463,7 +463,14 @@ export async function modelsStatusCommand(
         });
       }
     };
-    for (const raw of [defaultLabel, ...fallbacks, imageModel, ...imageFallbacks, ...allowed]) {
+    for (const raw of [
+      defaultLabel,
+      ...fallbacks,
+      imageModel,
+      ...imageFallbacks,
+      utilityModelRef ?? "",
+      ...allowed,
+    ]) {
       const ref = resolveStatusModelRef(raw);
       if (ref?.provider) {
         providersFromModels.add(normalizeProviderId(ref.provider));
@@ -472,7 +479,10 @@ export async function modelsStatusCommand(
     for (const raw of [defaultLabel, ...fallbacks]) {
       addProviderUse(raw, true);
     }
-    for (const raw of [imageModel, ...imageFallbacks]) {
+    // Utility completions (narration/titles) ride the plain API path like image
+    // models, so missing utility-provider auth must fail --check instead of
+    // hiding behind the primary's codex-runtime fallback.
+    for (const raw of [imageModel, ...imageFallbacks, utilityModelRef ?? ""]) {
       addProviderUse(raw, false);
     }
 

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -46,6 +46,10 @@ import {
 } from "../../agents/model-selection.js";
 import { OPENAI_PROVIDER_ID } from "../../agents/openai-routing.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
+import {
+  readUtilityModelSetting,
+  resolveUtilityModelRefForAgent,
+} from "../../agents/utility-model.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { requestExitAfterOneShotOutput } from "../../cli/one-shot-exit.js";
 import { createConfigIO } from "../../config/config.js";
@@ -378,6 +382,19 @@ export async function modelsStatusCommand(
     const fallbacks = agentFallbacksOverride ?? defaultsFallbacks;
     const imageModel = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.imageModel) ?? "";
     const imageFallbacks = resolveAgentModelFallbackValues(cfg.agents?.defaults?.imageModel);
+    // Narration/titles ride the utility model on a plain API auth path that can
+    // differ from the primary's (e.g. OAuth primary, api_key utility); show the
+    // resolved ref so a broken utility credential is inspectable here.
+    const utilitySetting = readUtilityModelSetting(cfg, workspaceAgentId);
+    const utilityModelRef = resolveUtilityModelRefForAgent({ cfg, agentId: workspaceAgentId });
+    const utilityModelSource =
+      utilitySetting.kind === "explicit"
+        ? "config"
+        : utilitySetting.kind === "disabled"
+          ? "disabled"
+          : utilityModelRef
+            ? "provider-default"
+            : "none";
     const aliases = Object.entries(cfg.agents?.defaults?.models ?? {}).reduce<
       Record<string, string>
     >((acc, [key, entry]) => {
@@ -1131,6 +1148,7 @@ export async function modelsStatusCommand(
         fallbacks,
         imageModel: imageModel || null,
         imageFallbacks,
+        utilityModel: { ref: utilityModelRef ?? null, source: utilityModelSource },
         ...(agentId
           ? {
               modelConfig: {
@@ -1206,6 +1224,17 @@ export async function modelsStatusCommand(
         rich,
         fallbacks.length ? theme.warn : theme.muted,
         fallbacks.length ? fallbacks.join(", ") : "-",
+      )}`,
+    );
+    runtime.log(
+      `${label("Utility model")}${colorize(rich, theme.muted, ":")} ${colorize(
+        rich,
+        utilityModelRef ? theme.success : theme.muted,
+        utilityModelRef
+          ? `${utilityModelRef}${utilityModelSource === "provider-default" ? " (provider default)" : ""}`
+          : utilityModelSource === "disabled"
+            ? "off"
+            : "-",
       )}`,
     );
     runtime.log(

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -479,22 +479,12 @@ export async function modelsStatusCommand(
     for (const raw of [defaultLabel, ...fallbacks]) {
       addProviderUse(raw, true);
     }
-    for (const raw of [imageModel, ...imageFallbacks]) {
+    // Utility completions (narration/titles) are a real runtime auth consumer
+    // with their own per-model route requirements: an OAuth-healthy primary
+    // does not prove the utility's plain API path, so the utility ref is
+    // analyzed like image models instead of hiding behind the primary.
+    for (const raw of [imageModel, ...imageFallbacks, utilityModelRef ?? ""]) {
       addProviderUse(raw, false);
-    }
-    // Utility completions (narration/titles) are a real runtime auth consumer.
-    // Register the utility ref only when no other configured model already
-    // covers its provider: shared providers are analyzed via those uses, while
-    // a utility-only provider would otherwise stay invisible to --check.
-    if (utilityModelRef) {
-      const utilityProvider = resolveStatusModelRef(utilityModelRef)?.provider;
-      const normalizedUtilityProvider = utilityProvider ? normalizeProviderId(utilityProvider) : "";
-      if (
-        normalizedUtilityProvider &&
-        !providerUseRefs.some((use) => use.provider === normalizedUtilityProvider)
-      ) {
-        addProviderUse(utilityModelRef, false);
-      }
     }
 
     const providersFromEnv = new Set<string>();

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -498,6 +498,12 @@ export async function modelsStatusCommand(
     // plain API path, so the ref gets full route analysis without inheriting
     // the primary's codex-runtime fallback.
     addProviderUse(utilityModelRef, false, "text");
+    // Display the canonical provider/model: utilityModel accepts aliases, and
+    // route issues/probes always report the resolved ref.
+    const resolvedUtilityRef = utilityModelRef ? resolveStatusModelRef(utilityModelRef) : undefined;
+    const utilityModelDisplayRef = resolvedUtilityRef
+      ? modelKey(normalizeProviderId(resolvedUtilityRef.provider), resolvedUtilityRef.model)
+      : (utilityModelRef ?? null);
 
     const providersFromEnv = new Set<string>();
     // Use the shared provider-env registry so `models status` stays aligned with
@@ -975,6 +981,18 @@ export async function modelsStatusCommand(
         },
       ];
     });
+    // Utility (or duplicate fallback) refs can repeat a configured model;
+    // identical diagnostics collapse while genuinely different evaluations
+    // for the same model (e.g. codex-fallback vs plain route) stay separate.
+    const seenRouteIssues = new Set<string>();
+    const dedupedModelRouteIssues = modelRouteIssues.filter((issue) => {
+      const key = JSON.stringify(issue);
+      if (seenRouteIssues.has(key)) {
+        return false;
+      }
+      seenRouteIssues.add(key);
+      return true;
+    });
     const missingProvidersInUse = Array.from(
       new Set(
         providerUses
@@ -1149,7 +1167,7 @@ export async function modelsStatusCommand(
       };
       const routeAuthHealth = new Set(providerUses.map(resolveRouteAuthHealth));
       const hasExpiredOrMissing =
-        modelRouteIssues.some(
+        dedupedModelRouteIssues.some(
           (issue) => issue.kind === "incompatible" || issue.kind === "indeterminate",
         ) ||
         routeAuthHealth.has("missing") ||
@@ -1175,7 +1193,7 @@ export async function modelsStatusCommand(
         fallbacks,
         imageModel: imageModel || null,
         imageFallbacks,
-        utilityModel: { ref: utilityModelRef ?? null, source: utilityModelSource },
+        utilityModel: { ref: utilityModelDisplayRef, source: utilityModelSource },
         ...(agentId
           ? {
               modelConfig: {
@@ -1194,7 +1212,7 @@ export async function modelsStatusCommand(
           },
           providersWithOAuth: providersWithOauth,
           missingProvidersInUse,
-          modelRouteIssues,
+          modelRouteIssues: dedupedModelRouteIssues,
           runtimeAuthRoutes,
           providers: providerAuth,
           unusableProfiles,
@@ -1256,9 +1274,9 @@ export async function modelsStatusCommand(
     runtime.log(
       `${label("Utility model")}${colorize(rich, theme.muted, ":")} ${colorize(
         rich,
-        utilityModelRef ? theme.success : theme.muted,
-        utilityModelRef
-          ? `${utilityModelRef}${utilityModelSource === "provider-default" ? " (provider default)" : ""}`
+        utilityModelDisplayRef ? theme.success : theme.muted,
+        utilityModelDisplayRef
+          ? `${utilityModelDisplayRef}${utilityModelSource === "provider-default" ? " (provider default)" : ""}`
           : utilityModelSource === "disabled"
             ? "off"
             : "-",
@@ -1409,10 +1427,10 @@ export async function modelsStatusCommand(
       }
     }
 
-    if (modelRouteIssues.length > 0) {
+    if (dedupedModelRouteIssues.length > 0) {
       runtime.log("");
       runtime.log(colorize(rich, theme.heading, "Model route issues"));
-      for (const issue of modelRouteIssues) {
+      for (const issue of dedupedModelRouteIssues) {
         const modelRef = `${issue.provider}/${issue.model}`;
         if (issue.kind === "incompatible") {
           runtime.log(`- ${theme.heading(modelRef)} [${issue.code}] ${issue.message}`);
@@ -1434,7 +1452,7 @@ export async function modelsStatusCommand(
       runtime.log("");
       runtime.log(colorize(rich, theme.heading, "Missing auth"));
       for (const provider of missingProvidersInUse) {
-        const requiresSubscription = modelRouteIssues.some(
+        const requiresSubscription = dedupedModelRouteIssues.some(
           (issue) =>
             issue.kind === "missing-auth" &&
             issue.provider === provider &&

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -153,6 +153,8 @@ type StatusProviderUseRef = {
   provider: string;
   model: string;
   allowCodexRuntimeFallback: boolean;
+  /** Text uses get per-model route analysis; image auth stays provider-wide. */
+  routeScope: "text" | "image";
 };
 
 type StatusProviderUse = {
@@ -452,7 +454,11 @@ export async function modelsStatusCommand(
     );
     const providersFromModels = new Set<string>();
     const providerUseRefs: StatusProviderUseRef[] = [];
-    const addProviderUse = (raw: string | undefined, allowCodexRuntimeFallback: boolean) => {
+    const addProviderUse = (
+      raw: string | undefined,
+      allowCodexRuntimeFallback: boolean,
+      routeScope: StatusProviderUseRef["routeScope"],
+    ) => {
       const ref = resolveStatusModelRef(raw);
       if (ref?.provider) {
         const provider = normalizeProviderId(ref.provider);
@@ -460,6 +466,7 @@ export async function modelsStatusCommand(
           provider,
           model: ref.model,
           allowCodexRuntimeFallback,
+          routeScope,
         });
       }
     };
@@ -477,15 +484,16 @@ export async function modelsStatusCommand(
       }
     }
     for (const raw of [defaultLabel, ...fallbacks]) {
-      addProviderUse(raw, true);
+      addProviderUse(raw, true, "text");
     }
-    // Utility completions (narration/titles) are a real runtime auth consumer
-    // with their own per-model route requirements: an OAuth-healthy primary
-    // does not prove the utility's plain API path, so the utility ref is
-    // analyzed like image models instead of hiding behind the primary.
-    for (const raw of [imageModel, ...imageFallbacks, utilityModelRef ?? ""]) {
-      addProviderUse(raw, false);
+    for (const raw of [imageModel, ...imageFallbacks]) {
+      addProviderUse(raw, false, "image");
     }
+    // Utility completions (narration/titles) are a text-route auth consumer in
+    // their own right: an OAuth-healthy primary does not prove the utility's
+    // plain API path, so the ref gets full route analysis without inheriting
+    // the primary's codex-runtime fallback.
+    addProviderUse(utilityModelRef, false, "text");
 
     const providersFromEnv = new Set<string>();
     // Use the shared provider-env registry so `models status` stays aligned with
@@ -564,12 +572,13 @@ export async function modelsStatusCommand(
         };
         // Image tools own their provider auth behavior. The text-route artifact
         // must not reinterpret image auth as an OpenAI text transport.
-        const rawEvaluation: ModelAuthAvailabilityEvaluation = usage.allowCodexRuntimeFallback
-          ? resolver.evaluateModelAuth(usage.provider, ref)
-          : {
-              availability: resolver.resolveProviderAuthAvailability(usage.provider, ref),
-              routeResolution: null,
-            };
+        const rawEvaluation: ModelAuthAvailabilityEvaluation =
+          usage.routeScope === "text"
+            ? resolver.evaluateModelAuth(usage.provider, ref)
+            : {
+                availability: resolver.resolveProviderAuthAvailability(usage.provider, ref),
+                routeResolution: null,
+              };
         const routeAuth: StatusProviderRouteAuth = (() => {
           if (rawEvaluation.routeResolution?.kind === "incompatible") {
             return {

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -389,6 +389,10 @@ export async function modelsStatusCommand(
     // resolved ref so a broken utility credential is inspectable here.
     const utilitySetting = readUtilityModelSetting(cfg, workspaceAgentId);
     const utilityModelRef = resolveUtilityModelRefForAgent({ cfg, agentId: workspaceAgentId });
+    // resolveUtilityModelRefForAgent never falls back to the primary model: an
+    // unset setting yields the provider-declared default or undefined, so a
+    // non-null auto result really is a provider default (unlike the runtime's
+    // simple-completion selection, which does fall back to the primary).
     const utilityModelSource =
       utilitySetting.kind === "explicit"
         ? "config"
@@ -1016,6 +1020,9 @@ export async function modelsStatusCommand(
       ...fallbacks,
       imageModel,
       ...imageFallbacks,
+      // Probe the configured utility model itself; an arbitrary catalog model
+      // from the same provider can sit on a different auth route.
+      utilityModelRef ?? "",
       ...allowed,
     ].filter(Boolean);
     const resolvedCandidates = rawCandidates

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -620,7 +620,8 @@ describe("modelsStatusCommand auth overview", () => {
       });
 
       // The utility model is a real runtime auth consumer: a provider that only
-      // narration/titles use must surface in the missing-auth overview.
+      // narration/titles use must enter the route/auth analysis instead of
+      // staying invisible to `models status`.
       mocks.loadConfig.mockReturnValue({
         ...baseConfig,
         agents: {
@@ -634,7 +635,11 @@ describe("modelsStatusCommand auth overview", () => {
         ref: "mistral/mistral-small",
         source: "config",
       });
-      expect(missingPayload.auth.missingProvidersInUse).toContain("mistral");
+      expect(missingPayload.auth.modelRouteIssues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ provider: "mistral", model: "mistral-small" }),
+        ]),
+      );
     } finally {
       if (originalLoadConfig) {
         mocks.loadConfig.mockImplementation(originalLoadConfig);

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -644,6 +644,24 @@ describe("modelsStatusCommand auth overview", () => {
           expect.objectContaining({ provider: "mistral", model: "mistral-small" }),
         ]),
       );
+
+      // Aliases are valid utilityModel input; the report shows the canonical ref.
+      mocks.loadConfig.mockReturnValue({
+        ...baseConfig,
+        agents: {
+          defaults: {
+            ...baseConfig.agents.defaults,
+            models: { "anthropic/claude-opus-4-6": { alias: "Opus" } },
+            utilityModel: "Opus",
+          },
+        },
+      });
+      const aliasRuntime = createRuntime();
+      await modelsStatusCommand({ json: true }, aliasRuntime as never);
+      expect(parseFirstJsonLog(aliasRuntime).utilityModel).toEqual({
+        ref: "anthropic/claude-opus-4-6",
+        source: "config",
+      });
     } finally {
       if (originalLoadConfig) {
         mocks.loadConfig.mockImplementation(originalLoadConfig);

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -54,6 +54,7 @@ const mocks = vi.hoisted(() => {
     resolveAgentExplicitModelPrimary: vi.fn().mockReturnValue(undefined),
     resolveAgentEffectiveModelPrimary: vi.fn().mockReturnValue(undefined),
     resolveAgentModelFallbacksOverride: vi.fn().mockReturnValue(undefined),
+    resolveAgentConfig: vi.fn().mockReturnValue(undefined),
     listAgentIds: vi.fn().mockReturnValue(["main", "jeremiah"]),
     listAgentEntries: vi.fn().mockReturnValue([{ id: "main" }, { id: "jeremiah" }]),
     ensureAuthProfileStore: vi.fn().mockReturnValue(store),
@@ -167,6 +168,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentExplicitModelPrimary: mocks.resolveAgentExplicitModelPrimary,
   resolveAgentEffectiveModelPrimary: mocks.resolveAgentEffectiveModelPrimary,
   resolveAgentModelFallbacksOverride: mocks.resolveAgentModelFallbacksOverride,
+  resolveAgentConfig: mocks.resolveAgentConfig,
   listAgentIds: mocks.listAgentIds,
   listAgentEntries: mocks.listAgentEntries,
 }));
@@ -577,6 +579,50 @@ describe("modelsStatusCommand auth overview", () => {
     expect((payload.auth.providersWithOAuth as string[]).some((e) => e.startsWith("openai"))).toBe(
       true,
     );
+  });
+
+  it("reports the resolved utility model in JSON output", async () => {
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const baseConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6", fallbacks: [] },
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: true } },
+    };
+    try {
+      mocks.loadConfig.mockReturnValue({
+        ...baseConfig,
+        agents: {
+          defaults: { ...baseConfig.agents.defaults, utilityModel: "openai/gpt-5.6-luna" },
+        },
+      });
+      const explicitRuntime = createRuntime();
+      await modelsStatusCommand({ json: true }, explicitRuntime as never);
+      expect(parseFirstJsonLog(explicitRuntime).utilityModel).toEqual({
+        ref: "openai/gpt-5.6-luna",
+        source: "config",
+      });
+
+      mocks.loadConfig.mockReturnValue({
+        ...baseConfig,
+        agents: {
+          defaults: { ...baseConfig.agents.defaults, utilityModel: "" },
+        },
+      });
+      const disabledRuntime = createRuntime();
+      await modelsStatusCommand({ json: true }, disabledRuntime as never);
+      expect(parseFirstJsonLog(disabledRuntime).utilityModel).toEqual({
+        ref: null,
+        source: "disabled",
+      });
+    } finally {
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+    }
   });
 
   it("honors OPENCLAW_AGENT_DIR when no --agent override is provided", async () => {

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -423,6 +423,7 @@ async function withOpenAIStatusFixture<T>(
     agentRuntime?: string;
     catalog?: unknown[];
     routeVariants?: unknown[];
+    utilityModel?: string;
   },
   run: () => Promise<T>,
 ): Promise<T> {
@@ -443,6 +444,9 @@ async function withOpenAIStatusFixture<T>(
     agents: {
       defaults: {
         model: { primary: params.primary, fallbacks: params.fallbacks ?? [] },
+        // Route tests target the configured primary/fallback models; keep the
+        // derived utility model out unless a test opts in explicitly.
+        utilityModel: params.utilityModel ?? "",
         models: Object.fromEntries(
           Object.keys(configuredModels).map((model) => [
             model,
@@ -792,6 +796,39 @@ describe("modelsStatusCommand auth overview", () => {
       },
     ]);
     expect(localRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("flags a utility model whose route needs api-key auth despite an OAuth-healthy primary", async () => {
+    const localRuntime = createRuntime();
+    await withOpenAIStatusFixture(
+      {
+        primary: "openai/gpt-5.5",
+        utilityModel: "openai/gpt-5.6",
+        profiles: {
+          "openai:default": {
+            type: "oauth",
+            provider: "openai",
+            access: "oauth-access",
+            refresh: "oauth-refresh",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+      async () => {
+        await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      },
+    );
+    const payload = parseFirstJsonLog(localRuntime);
+    expect(payload.utilityModel).toEqual({ ref: "openai/gpt-5.6", source: "config" });
+    expect(payload.auth.modelRouteIssues).toEqual([
+      {
+        kind: "missing-auth",
+        provider: "openai",
+        model: "gpt-5.6",
+        authRequirement: "api-key",
+        message: "No usable api-key authentication is available for openai/gpt-5.6.",
+      },
+    ]);
   });
 
   it("reports incompatible model routes separately in JSON and text", async () => {

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -618,6 +618,23 @@ describe("modelsStatusCommand auth overview", () => {
         ref: null,
         source: "disabled",
       });
+
+      // The utility model is a real runtime auth consumer: a provider that only
+      // narration/titles use must surface in the missing-auth overview.
+      mocks.loadConfig.mockReturnValue({
+        ...baseConfig,
+        agents: {
+          defaults: { ...baseConfig.agents.defaults, utilityModel: "mistral/mistral-small" },
+        },
+      });
+      const missingAuthRuntime = createRuntime();
+      await modelsStatusCommand({ json: true }, missingAuthRuntime as never);
+      const missingPayload = parseFirstJsonLog(missingAuthRuntime);
+      expect(missingPayload.utilityModel).toEqual({
+        ref: "mistral/mistral-small",
+        source: "config",
+      });
+      expect(missingPayload.auth.missingProvidersInUse).toContain("mistral");
     } finally {
       if (originalLoadConfig) {
         mocks.loadConfig.mockImplementation(originalLoadConfig);


### PR DESCRIPTION
## What Problem This Solves

Utility-model narration (#103463, #103769) fails silently when its credential is dead. Observed live on the Molty gateway: the primary model rides Codex OAuth, but the derived utility model (`openai/gpt-5.6-luna`) resolves the `openai:api-key` auth profile, which held a revoked key. Every narration call 401ed, the narrator disabled itself after 2 consecutive failures, and Discord kept showing the old raw tool lines — with zero operator-visible signal:

- narrator failures were `logVerbose`-only, and the log line did not name the agent, model, or auth profile;
- `openclaw models status` never mentioned the utility model, so nothing showed that narration depends on a different auth path than the primary.

Fixes #104764.

## Why This Change Was Made

A dead utility credential silently degrades the product experience (narrated progress drafts fall back to raw tool lines). The failure needs to be visible at default log levels and the utility model needs to be inspectable in `models status`, which owns runtime auth visibility (`--probe`/`--check`).

## User Impact

- When narration disables after consecutive failures, the gateway now logs one warn per turn: `narration disabled after 2 consecutive failures (openai/gpt-5.6-luna via openai:api-key): OpenAI API error (401): …` — naming exactly what to repair.
- `openclaw models status` shows a `Utility model` line (explicit config / provider default / disabled) and a `utilityModel: { ref, source }` field in `--json`.

## Evidence

- Live root-cause log (Molty gateway, 2026-07-11 22:25Z): `progress-narrator: completion failed: OpenAI API error (401): 401 Incorrect API key provided: sk-proj-…` repeated per turn while Discord rendered old-style tool lines; details in #104764.
- Testbox (blacksmith, lease `tbx_01kx9pjsm0ct72rze4k3ks3zzh`, [run](https://github.com/openclaw/openclaw/actions/runs/29171446325)): `pnpm format:check` green; `pnpm test src/auto-reply/reply/progress-narrator.test.ts src/commands/models/list.status.test.ts` → 15 + 34 tests pass, including the new warn assertion and the new `utilityModel` JSON cases (explicit config and disabled).

Follow-up tracked separately in #104764: `models status --probe` routes `api_key`-profile probes through the codex app-server harness, which cannot validate an API key (needs the Codex-contract review gate).
