### PR TITLE
ci(perf): pin optimized Kova evaluator

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -50,7 +50,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 5425ee9e6c59cc18c1fd52a65df09fbc758381a7
+        default: 2b02b7d33418db0c6952c4cf8fe8a608e7964859
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -153,7 +153,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '5425ee9e6c59cc18c1fd52a65df09fbc758381a7' }}
+      KOVA_REF: ${{ inputs.kova_ref || '2b02b7d33418db0c6952c4cf8fe8a608e7964859' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -82,7 +82,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "5425ee9e6c59cc18c1fd52a65df09fbc758381a7";
+    const kovaRef = "2b02b7d33418db0c6952c4cf8fe8a608e7964859";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
 


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's performance workflow still defaults to a Kova revision that predates the sampler and report-size optimizations landed in openclaw/Kova#32. Scheduled and manual runs without an explicit override would therefore keep using the slower, much larger report format.

## Why This Change Was Made

Pin both the workflow-dispatch default and runtime fallback to landed Kova commit `2b02b7d33418db0c6952c4cf8fe8a608e7964859`, and update the mapped workflow contract test to require the same immutable revision.

## User Impact

Default OpenClaw performance runs now reuse live gateway PID lookups and emit compact cumulative timeline evidence. The release workflow remains reproducible because it continues to pin an exact Kova commit.

## Evidence

- Kova change: https://github.com/openclaw/Kova/pull/32
- Exact release proof: https://github.com/openclaw/openclaw/actions/runs/29171181864
  - OpenClaw `release/2026.7.1` at `058484a52e560e7a2fe43a11572f63f07cd14f29`
  - Tested Kova head `775bfd01a8d1bf9ca0657c84f3c9903ef4400fd9`; rebase-merged equivalent `2b02b7d33418db0c6952c4cf8fe8a608e7964859`
  - 18/18 records passed and 241/241 required proofs were present
  - Full JSON report was 64.63% smaller
- `node scripts/check-workflows.mjs`
- Testbox `tbx_01kx9q5wwyp4gjfd4hb8hveqgk`: 28/28 workflow tests passed
- Fresh branch autoreview: no actionable findings, correctness confidence 0.84
