### PR TITLE
docs(windows): link latest Hub installers

### DIFF
--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -16,19 +16,21 @@ Linux-compatible Gateway runtime.
 ## Recommended: Windows Hub
 
 Windows Hub is the native WinUI companion app for Windows 10 20H2+ and
-Windows 11. It installs without administrator privileges and ships as signed
-x64 and ARM64 installers on OpenClaw releases.
+Windows 11. It installs without administrator privileges and ships signed x64
+and ARM64 installers from its own release page.
 
-Download the latest stable installer from the
-[OpenClaw releases page](https://github.com/openclaw/openclaw/releases) or
-directly via `releases/latest/download`:
+Windows Hub publishes independently from the OpenClaw CLI and Gateway. Download
+the latest stable Hub installer from the
+[Windows Hub releases page](https://github.com/openclaw/openclaw-windows-node/releases/latest)
+or directly via `releases/latest/download`:
 
-- [OpenClawCompanion-Setup-x64.exe](https://github.com/openclaw/openclaw/releases/latest/download/OpenClawCompanion-Setup-x64.exe)
-- [OpenClawCompanion-Setup-arm64.exe](https://github.com/openclaw/openclaw/releases/latest/download/OpenClawCompanion-Setup-arm64.exe)
-- [Checksums](https://github.com/openclaw/openclaw/releases/latest/download/OpenClawCompanion-SHA256SUMS.txt)
+- [OpenClawCompanion-Setup-x64.exe](https://github.com/openclaw/openclaw-windows-node/releases/latest/download/OpenClawCompanion-Setup-x64.exe)
+- [OpenClawCompanion-Setup-arm64.exe](https://github.com/openclaw/openclaw-windows-node/releases/latest/download/OpenClawCompanion-Setup-arm64.exe)
 
-If a link above 404s, visit the [releases page](https://github.com/openclaw/openclaw/releases)
-and look for `OpenClawCompanion-Setup-*` assets on the latest release.
+If a link above 404s, visit the [Windows Hub releases page](https://github.com/openclaw/openclaw-windows-node/releases)
+and open the newest stable Windows Hub release. Regular OpenClaw stable releases
+also mirror a pinned, release-validated Windows Hub build; that mirror can lag a
+newer standalone Hub release.
 
 After install, launch **OpenClaw Companion** from the Start menu or system
 tray. The installer also adds shortcuts for Gateway Setup, Chat, Settings,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows users following the platform guide could install an older Windows Hub build when a newer standalone Hub release existed.

## Why This Change Was Made

Windows Hub publishes independently and self-updates from `openclaw/openclaw-windows-node`, so the guide now points its latest-release page and direct installer links at that canonical repository. It also explains that regular OpenClaw releases mirror a pinned, validated Hub build and may trail a newer standalone Hub release.

## User Impact

Windows users downloading from the platform guide now receive the latest stable signed x64 or ARM64 Hub installer instead of the older build mirrored on the most recent OpenClaw release.

## Evidence

- Both new `releases/latest/download` links currently redirect to Windows Hub v0.6.12.
- Live ARM64 install verified SHA-256 `0a971f691e72885e00663f6c200a5847f1561c59a91ad265f7dd31ddf470ab7e` and a valid OpenClaw Foundation Authenticode signature.
- `node scripts/check-docs-mdx.mjs docs/platforms/windows.md`
- `node scripts/docs-link-audit.mjs` (`broken_links=0`)
- `git diff --check`
