### PR TITLE
fix(telegram): restore projection fixture identities

### DIFF
--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -240,6 +240,7 @@ async function writeDirectTelegramTranscriptMessages(params: {
         content: message.text,
         timestamp: message.timestamp,
       },
+      eventId: message.id,
     });
   }
 }


### PR DESCRIPTION
Related: #98236
Related: #102469

## What Problem This Solves

Fixes nine deterministic failures in `extensions/telegram/src/bot.test.ts` on current `main`. The SQLite session/transcript migration preserved fixture content and timestamps but replaced fixture-owned transcript event IDs with generated UUIDs, breaking projection correlation assertions.

## Why This Change Was Made

Pass each fixture message's declared ID through the transcript SDK's supported `eventId` option. This restores the identity contract used by the projection fixtures without changing production Telegram behavior or reintroducing JSON transcript seeding.

## User Impact

No runtime behavior change. Maintainers regain reliable coverage for Telegram prompt-context projection provenance, multipart completion, and transcript deduplication.

## Evidence

- Before, Blacksmith Testbox `tbx_01kx9qchb2makrwx2erc9z1hv0`: `env CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 corepack pnpm test extensions/telegram/src/bot.test.ts` -> 9 failed, 102 passed.
- After, same Testbox and command -> 111 passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed -- extensions/telegram/src/bot.test.ts` -> extension test typecheck, format, lint, and guards passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings; correctness confidence 0.98.

AI-assisted; implementation and proof reviewed against the SQLite transcript SDK contract.
