### PR TITLE
fix(zai): honor max thinking through gateway

### DIFF
--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -36,6 +36,7 @@ import { detectZaiEndpoint, type ZaiEndpointId } from "./detect.js";
 import { zaiMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { buildZaiModelDefinition, resolveZaiBaseUrl } from "./model-definitions.js";
 import { applyZaiConfig, applyZaiProviderConfig, resolveZaiModelId } from "./onboard.js";
+import { isGlm52ModelId, resolveThinkingProfile } from "./provider-policy-api.js";
 
 const PROVIDER_ID = "zai";
 const GLM5_TEMPLATE_MODEL_ID = "glm-4.7";
@@ -126,10 +127,6 @@ function shouldPreserveZaiThinking(extraParams?: Record<string, unknown>): boole
 
 function isDisabledThinkingLevel(thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"]) {
   return thinkingLevel === "off";
-}
-
-function isGlm52ModelId(modelId?: string | null): boolean {
-  return normalizeLowercaseStringOrEmpty(modelId).startsWith("glm-5.2");
 }
 
 function mapThinkingLevelToZaiReasoningEffort(
@@ -394,24 +391,7 @@ export default definePluginEntry({
       }),
       prepareExtraParams: (ctx) => defaultToolStreamExtraParams(ctx.extraParams),
       wrapStreamFn: (ctx) => wrapZaiStreamFn(ctx),
-      resolveThinkingProfile: (ctx) =>
-        isGlm52ModelId(ctx.modelId)
-          ? {
-              levels: [
-                { id: "off", label: "off" },
-                { id: "low", label: "low" },
-                { id: "high", label: "high" },
-                { id: "max", label: "max" },
-              ],
-              defaultLevel: "off",
-            }
-          : {
-              levels: [
-                { id: "off", label: "off" },
-                { id: "low", label: "on" },
-              ],
-              defaultLevel: "off",
-            },
+      resolveThinkingProfile,
       isModernModelRef: ({ modelId }) => {
         const lower = normalizeLowercaseStringOrEmpty(modelId);
         return (

--- a/extensions/zai/provider-policy-api.test.ts
+++ b/extensions/zai/provider-policy-api.test.ts
@@ -1,0 +1,27 @@
+// Z.AI tests cover its cold provider thinking policy.
+import { describe, expect, it } from "vitest";
+import { resolveThinkingProfile } from "./provider-policy-api.js";
+
+describe("zai provider thinking policy", () => {
+  it.each(["glm-5.2", "glm-5.2-flash"])("exposes full GLM 5.2 levels for %s", (modelId) => {
+    expect(resolveThinkingProfile({ provider: "zai", modelId })).toEqual({
+      levels: [
+        { id: "off", label: "off" },
+        { id: "low", label: "low" },
+        { id: "high", label: "high" },
+        { id: "max", label: "max" },
+      ],
+      defaultLevel: "off",
+    });
+  });
+
+  it.each(["glm-5.1", "glm-4.7"])("keeps older GLM models binary for %s", (modelId) => {
+    expect(resolveThinkingProfile({ provider: "zai", modelId })).toEqual({
+      levels: [
+        { id: "off", label: "off" },
+        { id: "low", label: "on" },
+      ],
+      defaultLevel: "off",
+    });
+  });
+});

--- a/extensions/zai/provider-policy-api.ts
+++ b/extensions/zai/provider-policy-api.ts
@@ -1,0 +1,33 @@
+// Z.AI public policy surface shared by cold selection and the provider runtime.
+import type {
+  ProviderDefaultThinkingPolicyContext,
+  ProviderThinkingProfile,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export function isGlm52ModelId(modelId?: string | null): boolean {
+  return normalizeLowercaseStringOrEmpty(modelId).startsWith("glm-5.2");
+}
+
+export function resolveThinkingProfile(
+  ctx: ProviderDefaultThinkingPolicyContext,
+): ProviderThinkingProfile {
+  if (isGlm52ModelId(ctx.modelId)) {
+    return {
+      levels: [
+        { id: "off", label: "off" },
+        { id: "low", label: "low" },
+        { id: "high", label: "high" },
+        { id: "max", label: "max" },
+      ],
+      defaultLevel: "off",
+    };
+  }
+  return {
+    levels: [
+      { id: "off", label: "off" },
+      { id: "low", label: "on" },
+    ],
+    defaultLevel: "off",
+  };
+}

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -129,6 +129,7 @@ vi.mock("./provider-model-normalization.runtime.js", () => ({
 vi.mock("../plugins/provider-public-artifacts.js", () => ({
   resolveBundledProviderPolicySurface:
     providerPolicySurfaceMock.resolveBundledProviderPolicySurface,
+  resolveProviderPolicySurface: providerPolicySurfaceMock.resolveBundledProviderPolicySurface,
 }));
 
 vi.mock("./model-selection-cli.js", () => ({

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -694,6 +694,7 @@ describe("gateway session utils", () => {
     expect(row.thinkingLevels?.map((level) => level.id)).toContain("xhigh");
     expect(providerArtifactMocks.resolveBundledProviderPolicySurface).toHaveBeenCalledWith(
       "openai",
+      { manifestRegistry: undefined },
     );
   });
 

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -50,6 +50,7 @@ const providerArtifactMocks = vi.hoisted(() => ({
 
 vi.mock("../plugins/provider-public-artifacts.js", () => ({
   resolveBundledProviderPolicySurface: providerArtifactMocks.resolveBundledProviderPolicySurface,
+  resolveProviderPolicySurface: providerArtifactMocks.resolveBundledProviderPolicySurface,
 }));
 
 function closeSessionSqliteDatabasesForTest(): void {

--- a/src/plugins/provider-policy-surface.ts
+++ b/src/plugins/provider-policy-surface.ts
@@ -16,7 +16,10 @@ import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
 } from "./provider-thinking.types.js";
-import { loadBundledPluginPublicArtifactModuleSync } from "./public-surface-loader.js";
+import {
+  loadBundledPluginPublicArtifactModuleSync,
+  loadPluginPublicArtifactModuleSync,
+} from "./public-surface-loader.js";
 
 const PROVIDER_POLICY_ARTIFACT_CANDIDATES = ["provider-policy-api.js"] as const;
 const providerPolicySurfaceByPluginId = new Map<string, BundledProviderPolicySurface | null>();
@@ -52,35 +55,64 @@ function hasProviderPolicyHook(
   );
 }
 
-/** Loads policy hooks directly by canonical bundled plugin id. */
-export function resolveDirectBundledProviderPolicySurface(
-  pluginId: string,
-): BundledProviderPolicySurface | null {
-  const cacheKey = `${resolveBundledPluginsDir() ?? ""}\0${pluginId}`;
-  const cached = providerPolicySurfaceByPluginId.get(cacheKey);
+function resolveCachedProviderPolicySurface(params: {
+  cacheKey: string;
+  loadModule: (artifactBasename: string) => Record<string, unknown>;
+  missingSurfacePrefix: string;
+}): BundledProviderPolicySurface | null {
+  const cached = providerPolicySurfaceByPluginId.get(params.cacheKey);
   if (cached !== undefined) {
     return cached;
   }
   for (const artifactBasename of PROVIDER_POLICY_ARTIFACT_CANDIDATES) {
     try {
-      const mod = loadBundledPluginPublicArtifactModuleSync<Record<string, unknown>>({
-        dirName: pluginId,
-        artifactBasename,
-      });
+      const mod = params.loadModule(artifactBasename);
       if (hasProviderPolicyHook(mod)) {
-        providerPolicySurfaceByPluginId.set(cacheKey, mod);
+        providerPolicySurfaceByPluginId.set(params.cacheKey, mod);
         return mod;
       }
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.startsWith("Unable to resolve bundled plugin public surface ")
-      ) {
+      if (error instanceof Error && error.message.startsWith(params.missingSurfacePrefix)) {
         continue;
       }
       throw error;
     }
   }
-  providerPolicySurfaceByPluginId.set(cacheKey, null);
+  providerPolicySurfaceByPluginId.set(params.cacheKey, null);
   return null;
+}
+
+/** Loads policy hooks directly by canonical bundled plugin id. */
+export function resolveDirectBundledProviderPolicySurface(
+  pluginId: string,
+): BundledProviderPolicySurface | null {
+  return resolveCachedProviderPolicySurface({
+    cacheKey: `${resolveBundledPluginsDir() ?? ""}\0${pluginId}`,
+    loadModule: (artifactBasename) =>
+      loadBundledPluginPublicArtifactModuleSync<Record<string, unknown>>({
+        dirName: pluginId,
+        artifactBasename,
+      }),
+    missingSurfacePrefix: "Unable to resolve bundled plugin public surface ",
+  });
+}
+
+/** Loads policy hooks from a host-verified official external plugin install. */
+export function resolveTrustedExternalProviderPolicySurface(params: {
+  pluginId: string;
+  pluginRoot: string;
+  trustedOfficialInstall?: boolean;
+}): BundledProviderPolicySurface | null {
+  if (params.trustedOfficialInstall !== true) {
+    return null;
+  }
+  return resolveCachedProviderPolicySurface({
+    cacheKey: `${params.pluginRoot}\0${params.pluginId}`,
+    loadModule: (artifactBasename) =>
+      loadPluginPublicArtifactModuleSync<Record<string, unknown>>({
+        pluginRoot: params.pluginRoot,
+        artifactBasename,
+      }),
+    missingSurfacePrefix: "Unable to resolve plugin public surface ",
+  });
 }

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -5,13 +5,33 @@ import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig } from "../config/types.models.js";
-import { resolveBundledProviderPolicySurface } from "./provider-public-artifacts.js";
+import {
+  resolveBundledProviderPolicySurface,
+  resolveProviderPolicySurface,
+} from "./provider-public-artifacts.js";
+
+function writeExternalPolicyFixture(): string {
+  const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-provider-policy-external-"));
+  fs.writeFileSync(
+    path.join(pluginRoot, "provider-policy-api.js"),
+    [
+      "export function resolveThinkingProfile({ modelId }) {",
+      '  return modelId === "full"',
+      '    ? { levels: [{ id: "off" }, { id: "high" }, { id: "max" }], defaultLevel: "off" }',
+      '    : { levels: [{ id: "off" }, { id: "low", label: "on" }], defaultLevel: "off" };',
+      "}",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return pluginRoot;
+}
 
 describe("provider public artifacts", () => {
   const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
   const originalTrustBundledPluginsDir = process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
 
-  afterEach(() => {
+  function restoreBundledPluginEnv() {
     if (originalBundledPluginsDir === undefined) {
       delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
     } else {
@@ -22,6 +42,10 @@ describe("provider public artifacts", () => {
     } else {
       process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = originalTrustBundledPluginsDir;
     }
+  }
+
+  afterEach(() => {
+    restoreBundledPluginEnv();
     vi.doUnmock("./bundled-dir.js");
     vi.doUnmock("./manifest-registry.js");
     vi.doUnmock("./public-surface-loader.js");
@@ -96,6 +120,67 @@ describe("provider public artifacts", () => {
       defaultLevel: "low",
       preserveWhenCatalogReasoningFalse: true,
     });
+  });
+
+  it("loads trusted official external provider policy before runtime registration", () => {
+    const bundledPluginsDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-empty-bundled-plugins-"),
+    );
+    const pluginRoot = writeExternalPolicyFixture();
+
+    try {
+      process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledPluginsDir;
+      process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = "1";
+      const fixturePlugin = {
+        id: "fixture-provider",
+        origin: "external",
+        trustedOfficialInstall: true,
+        rootDir: pluginRoot,
+        providers: ["fixture-provider"],
+        cliBackends: [],
+      } as const;
+      const surface = resolveProviderPolicySurface("fixture-provider", {
+        manifestRegistry: { plugins: [fixturePlugin as never] },
+      });
+
+      expect(
+        surface
+          ?.resolveThinkingProfile?.({ provider: "fixture-provider", modelId: "full" })
+          ?.levels.map((level) => level.id),
+      ).toEqual(["off", "high", "max"]);
+      expect(
+        surface
+          ?.resolveThinkingProfile?.({ provider: "fixture-provider", modelId: "legacy" })
+          ?.levels.map((level) => level.label),
+      ).toEqual([undefined, "on"]);
+    } finally {
+      restoreBundledPluginEnv();
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+      fs.rmSync(bundledPluginsDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not load public policy code from untrusted external plugins", () => {
+    const pluginRoot = writeExternalPolicyFixture();
+    try {
+      expect(
+        resolveProviderPolicySurface("fixture-provider", {
+          manifestRegistry: {
+            plugins: [
+              {
+                id: "fixture-provider",
+                origin: "external",
+                rootDir: pluginRoot,
+                providers: ["fixture-provider"],
+                cliBackends: [],
+              } as never,
+            ],
+          },
+        }),
+      ).toBeNull();
+    } finally {
+      fs.rmSync(pluginRoot, { recursive: true, force: true });
+    }
   });
 
   it("resolves multi-provider policy artifacts by manifest-owned provider id", async () => {

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -4,6 +4,7 @@ import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manifest-registry.js";
 import {
   resolveDirectBundledProviderPolicySurface,
+  resolveTrustedExternalProviderPolicySurface,
   type BundledProviderPolicySurface,
 } from "./provider-policy-surface.js";
 
@@ -77,4 +78,37 @@ export function resolveBundledProviderPolicySurface(
     return null;
   }
   return resolveDirectBundledProviderPolicySurface(ownerPluginId);
+}
+
+/** Resolves provider policy hooks from bundled or trusted official plugin artifacts. */
+export function resolveProviderPolicySurface(
+  providerId: string,
+  options: { manifestRegistry?: Pick<PluginManifestRegistry, "plugins"> } = {},
+): BundledProviderPolicySurface | null {
+  const bundledSurface = resolveBundledProviderPolicySurface(providerId, options);
+  if (bundledSurface) {
+    return bundledSurface;
+  }
+  const normalizedProviderId = normalizeProviderId(providerId);
+  if (!normalizedProviderId || !options.manifestRegistry) {
+    return null;
+  }
+  for (const plugin of options.manifestRegistry.plugins.toSorted((left, right) =>
+    left.id.localeCompare(right.id),
+  )) {
+    if (
+      pluginOwnsProviderPolicyRef(plugin, normalizedProviderId) &&
+      plugin.trustedOfficialInstall === true
+    ) {
+      const surface = resolveTrustedExternalProviderPolicySurface({
+        pluginId: plugin.id,
+        pluginRoot: plugin.rootDir,
+        trustedOfficialInstall: plugin.trustedOfficialInstall,
+      });
+      if (surface) {
+        return surface;
+      }
+    }
+  }
+  return null;
 }

--- a/src/plugins/provider-thinking.external-policy.test.ts
+++ b/src/plugins/provider-thinking.external-policy.test.ts
@@ -1,0 +1,90 @@
+// Verifies cold thinking policy resolution for trusted external providers.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const fixtureState = vi.hoisted(() => ({ pluginRoot: "" }));
+const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+const originalTrustBundledPluginsDir = process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
+const emptyBundledPluginsDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-empty-plugins-"));
+const externalPluginRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), "openclaw-provider-policy-external-"),
+);
+fs.writeFileSync(
+  path.join(externalPluginRoot, "provider-policy-api.js"),
+  [
+    "export function resolveThinkingProfile({ modelId }) {",
+    '  return modelId === "full"',
+    '    ? { levels: [{ id: "off" }, { id: "high" }, { id: "max" }], defaultLevel: "off" }',
+    '    : { levels: [{ id: "off" }, { id: "low", label: "on" }], defaultLevel: "off" };',
+    "}",
+    "",
+  ].join("\n"),
+  "utf8",
+);
+fixtureState.pluginRoot = externalPluginRoot;
+process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = emptyBundledPluginsDir;
+process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = "1";
+
+vi.mock("./current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: () => ({
+    manifestRegistry: {
+      plugins: [
+        {
+          id: "fixture-provider",
+          origin: "external",
+          trustedOfficialInstall: true,
+          rootDir: fixtureState.pluginRoot,
+          providers: ["fixture-provider"],
+          cliBackends: [],
+        },
+      ],
+    },
+  }),
+}));
+
+const { isThinkingLevelSupported, listThinkingLevels, resolveThinkingDefaultForModel } =
+  await import("../auto-reply/thinking.js");
+
+afterAll(() => {
+  if (originalBundledPluginsDir === undefined) {
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  } else {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = originalBundledPluginsDir;
+  }
+  if (originalTrustBundledPluginsDir === undefined) {
+    delete process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
+  } else {
+    process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = originalTrustBundledPluginsDir;
+  }
+  fs.rmSync(emptyBundledPluginsDir, { recursive: true, force: true });
+  fs.rmSync(externalPluginRoot, { recursive: true, force: true });
+});
+
+describe("trusted external provider thinking policy", () => {
+  it("resolves a full profile without activating the provider runtime", () => {
+    expect(listThinkingLevels("fixture-provider", "full")).toEqual(["off", "high", "max"]);
+    expect(
+      isThinkingLevelSupported({
+        provider: "fixture-provider",
+        model: "full",
+        level: "max",
+      }),
+    ).toBe(true);
+    expect(resolveThinkingDefaultForModel({ provider: "fixture-provider", model: "full" })).toBe(
+      "off",
+    );
+  });
+
+  it("keeps the fixture legacy model on its binary profile", () => {
+    expect(listThinkingLevels("fixture-provider", "legacy")).toEqual(["off", "low"]);
+    expect(
+      isThinkingLevelSupported({
+        provider: "fixture-provider",
+        model: "legacy",
+        level: "high",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/plugins/provider-thinking.ts
+++ b/src/plugins/provider-thinking.ts
@@ -1,6 +1,7 @@
 // Resolves provider thinking-level policy from plugin metadata.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { resolveBundledProviderPolicySurface } from "./provider-public-artifacts.js";
+import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import { resolveProviderPolicySurface } from "./provider-public-artifacts.js";
 import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
@@ -57,6 +58,16 @@ function resolveActiveThinkingProvider(providerId: string): ThinkingProviderPlug
   return undefined;
 }
 
+function resolveProviderPublicPolicySurface(providerId: string) {
+  const metadataSnapshot = getCurrentPluginMetadataSnapshot({
+    allowScopedSnapshot: true,
+    allowWorkspaceScopedSnapshot: true,
+  });
+  return resolveProviderPolicySurface(providerId, {
+    manifestRegistry: metadataSnapshot?.manifestRegistry,
+  });
+}
+
 type ThinkingHookParams<TContext> = {
   provider: string;
   context: TContext;
@@ -86,7 +97,7 @@ export function resolveProviderThinkingProfile(
   if (activeProfile !== undefined) {
     return activeProfile;
   }
-  return resolveBundledProviderPolicySurface(params.provider)?.resolveThinkingProfile?.(
+  return resolveProviderPublicPolicySurface(params.provider)?.resolveThinkingProfile?.(
     params.context,
   );
 }

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -11,7 +11,10 @@ import {
   getCachedPluginModuleLoader,
   type PluginModuleLoaderCache,
 } from "./plugin-module-loader-cache.js";
-import { resolveBundledPluginPublicSurfacePath } from "./public-surface-runtime.js";
+import {
+  resolveBundledPluginPublicSurfacePath,
+  resolvePluginRootPublicSurfacePath,
+} from "./public-surface-runtime.js";
 import { resolvePluginLoaderTryNative, resolveLoaderPackageRoot } from "./sdk-alias.js";
 
 const OPENCLAW_PACKAGE_ROOT =
@@ -114,6 +117,49 @@ function loadPublicSurfaceModule(modulePath: string): unknown {
   return getModuleLoader(modulePath)(modulePath);
 }
 
+function loadValidatedPublicSurfaceModule(params: {
+  modulePath: string;
+  boundaryRoot: string;
+  boundaryLabel: string;
+  surfaceLabel: string;
+}): object {
+  const cached = publicSurfaceModuleCache.get(params.modulePath);
+  if (cached) {
+    return cached as object;
+  }
+
+  const opened = openRootFileSync({
+    absolutePath: params.modulePath,
+    rootPath: params.boundaryRoot,
+    boundaryLabel: params.boundaryLabel,
+    rejectHardlinks: false,
+  });
+  if (!opened.ok) {
+    throw new Error(`Unable to open ${params.surfaceLabel}`, { cause: opened.error });
+  }
+  const validatedPath = opened.path;
+  const validatedStat = opened.stat;
+  fs.closeSync(opened.fd);
+
+  const currentStat = fs.statSync(validatedPath);
+  if (!sameFileIdentity(validatedStat, currentStat)) {
+    throw new Error(`${params.surfaceLabel} changed after validation`);
+  }
+
+  const sentinel: Record<string, unknown> = {};
+  publicSurfaceModuleCache.set(params.modulePath, sentinel);
+  publicSurfaceModuleCache.set(validatedPath, sentinel);
+  try {
+    const loaded = loadPublicSurfaceModule(validatedPath) as object;
+    Object.assign(sentinel, loaded);
+    return sentinel;
+  } catch (error) {
+    publicSurfaceModuleCache.delete(params.modulePath);
+    publicSurfaceModuleCache.delete(validatedPath);
+    throw error;
+  }
+}
+
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Dynamic public artifact loaders use caller-supplied module surface types.
 export function loadBundledPluginPublicArtifactModuleSync<T extends object>(params: {
   dirName: string;
@@ -125,47 +171,32 @@ export function loadBundledPluginPublicArtifactModuleSync<T extends object>(para
       `Unable to resolve bundled plugin public surface ${params.dirName}/${params.artifactBasename}`,
     );
   }
-  const cached = publicSurfaceModuleCache.get(location.modulePath);
-  if (cached) {
-    return cached as T;
-  }
-
-  const opened = openRootFileSync({
-    absolutePath: location.modulePath,
-    rootPath: location.boundaryRoot,
+  return loadValidatedPublicSurfaceModule({
+    modulePath: location.modulePath,
+    boundaryRoot: location.boundaryRoot,
     boundaryLabel:
       location.boundaryRoot === OPENCLAW_PACKAGE_ROOT ? "OpenClaw package root" : "plugin root",
-    rejectHardlinks: false,
-  });
-  if (!opened.ok) {
+    surfaceLabel: `bundled plugin public surface ${params.dirName}/${params.artifactBasename}`,
+  }) as T;
+}
+
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Dynamic public artifact loaders use caller-supplied module surface types.
+export function loadPluginPublicArtifactModuleSync<T extends object>(params: {
+  pluginRoot: string;
+  artifactBasename: string;
+}): T {
+  const modulePath = resolvePluginRootPublicSurfacePath(params);
+  if (!modulePath) {
     throw new Error(
-      `Unable to open bundled plugin public surface ${params.dirName}/${params.artifactBasename}`,
-      { cause: opened.error },
+      `Unable to resolve plugin public surface ${params.pluginRoot}/${params.artifactBasename}`,
     );
   }
-  const validatedPath = opened.path;
-  const validatedStat = opened.stat;
-  fs.closeSync(opened.fd);
-
-  const currentStat = fs.statSync(validatedPath);
-  if (!sameFileIdentity(validatedStat, currentStat)) {
-    throw new Error(
-      `Bundled plugin public surface changed after validation: ${params.dirName}/${params.artifactBasename}`,
-    );
-  }
-
-  const sentinel = {} as T;
-  publicSurfaceModuleCache.set(location.modulePath, sentinel);
-  publicSurfaceModuleCache.set(validatedPath, sentinel);
-  try {
-    const loaded = loadPublicSurfaceModule(validatedPath) as T;
-    Object.assign(sentinel, loaded);
-    return sentinel;
-  } catch (error) {
-    publicSurfaceModuleCache.delete(location.modulePath);
-    publicSurfaceModuleCache.delete(validatedPath);
-    throw error;
-  }
+  return loadValidatedPublicSurfaceModule({
+    modulePath,
+    boundaryRoot: path.resolve(params.pluginRoot),
+    boundaryLabel: "plugin root",
+    surfaceLabel: `plugin public surface ${params.artifactBasename}`,
+  }) as T;
 }
 
 /** Loads the first resolvable bundled public artifact from an ordered candidate list. */

--- a/src/plugins/public-surface-runtime.ts
+++ b/src/plugins/public-surface-runtime.ts
@@ -75,6 +75,31 @@ export function resolveBundledPluginSourcePublicSurfacePath(params: {
   return null;
 }
 
+/** Resolves a public surface artifact within one installed plugin root. */
+export function resolvePluginRootPublicSurfacePath(params: {
+  pluginRoot: string;
+  artifactBasename: string;
+}): string | null {
+  const artifactBasename = normalizeBundledPluginArtifactSubpath(params.artifactBasename);
+  const pluginRoot = path.resolve(params.pluginRoot);
+  for (const candidate of [
+    path.join(pluginRoot, artifactBasename),
+    path.join(pluginRoot, "dist", artifactBasename),
+  ]) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  const sourceBaseName = artifactBasename.replace(/\.js$/u, "");
+  for (const ext of PUBLIC_SURFACE_SOURCE_EXTENSIONS) {
+    const candidate = path.join(pluginRoot, `${sourceBaseName}${ext}`);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 function resolvePackageFallbackForBundledDir(params: {
   rootDir: string;
   bundledPluginsDir: string;

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -1189,9 +1189,11 @@ describe("TUI PTY real backends", () => {
       await requireSharedGatewayFixture();
     }, LOCAL_TEST_TIMEOUT_MS);
 
-    registerValidationLoopTest("gateway");
     for (const register of gatewayTestRegistrations) {
       register();
     }
+    // Validation abort can terminalize the TUI before the embedded command lanes
+    // finish unwinding. Keep it last so shared-Gateway teardown owns that tail.
+    registerValidationLoopTest("gateway");
   });
 });

--- a/test/scripts/check-plugin-npm-runtime-builds.test.ts
+++ b/test/scripts/check-plugin-npm-runtime-builds.test.ts
@@ -102,4 +102,33 @@ describe("plugin npm runtime build checks", () => {
       },
     ]);
   });
+
+  it("builds top-level public policy surfaces as standalone package artifacts", async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "openclaw-plugin-runtime-check-"));
+    tempDirs.push(repoRoot);
+    writePackage(repoRoot, "provider-plugin", { publishToNpm: true }, ["./index.ts"]);
+    const packageDir = join(repoRoot, "extensions", "provider-plugin");
+    writeFileSync(join(packageDir, "index.ts"), "export default {};\n");
+    writeFileSync(
+      join(packageDir, "provider-policy-api.ts"),
+      "export function resolveThinkingProfile() { return { levels: [] }; }\n",
+    );
+
+    await expect(
+      checkPluginNpmRuntimeBuilds({
+        repoRoot,
+        packageDirs: ["extensions/provider-plugin"],
+      }),
+    ).resolves.toEqual([
+      {
+        pluginDir: "provider-plugin",
+        status: "built",
+        entryCount: 2,
+        copiedStaticAssets: [],
+      },
+    ]);
+    expect(await import(join(packageDir, "dist", "provider-policy-api.js"))).toHaveProperty(
+      "resolveThinkingProfile",
+    );
+  });
 });

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -224,7 +224,7 @@ describe("production lint suppressions", () => {
         "src/plugins/hooks.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/host-hooks.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/lazy-service-module.ts|typescript/no-unnecessary-type-parameters|1",
-        "src/plugins/public-surface-loader.ts|typescript/no-unnecessary-type-parameters|2",
+        "src/plugins/public-surface-loader.ts|typescript/no-unnecessary-type-parameters|3",
         "src/plugins/runtime/runtime-plugin-boundary.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/runtime/types-channel.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/trusted-tool-policy.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## What Problem This Solves

Fixes #104716.

Z.AI GLM-5.2 supports `--thinking max`, but cold gateway and agent validation rejected it before dispatch while local infer succeeded. The external Z.AI plugin owned the correct thinking policy, but the pre-dispatch path could only see the generic core fallback before provider runtime activation.

## Why This Change Was Made

This adds a narrow public policy artifact for trusted official external providers. Cold thinking validation can load that artifact without activating the full provider runtime.

The loader remains generic and trust-gated:

- only tracked `trustedOfficialInstall` plugins are eligible,
- the artifact must remain inside the resolved plugin root,
- file identity and manifest ownership are verified,
- the result is process-cached as stable plugin metadata,
- Z.AI policy stays owned by the Z.AI plugin rather than being hardcoded in core.

## User Impact

`zai/glm-5.2 --thinking max` now works consistently through local infer, gateway infer, and `openclaw agent`. Models that do not advertise `max`, including GLM-5.1, are still rejected before provider dispatch.

## Evidence

- Fresh autoreview: clean, confidence 0.87.
- AWS Crabbox `run_7aa28d57c76d`: 148 focused tests passed and the packed Z.AI package contained `dist/provider-policy-api.js`.
- AWS Crabbox `run_955a2379f4b8`: typechecks and core/extensions lint passed; the only failure was an unrelated pre-existing scripts boundary violation identical on base and current `main`.
- AWS Crabbox `run_168843f423c9`: real CN coding endpoint proof passed for local GLM-5.2 `max`, gateway GLM-5.2 `max`, gateway `high`, agent `max`, persisted session `max`, and GLM-5.1 pre-dispatch rejection.
- Candidate: `96e6571a5e1db570b38260b700c03969e77d9bcc`, tree `8493cc9a5272d0d084f41454754491a633df72fd`.
- Changed-path drift check against current `main`: no overlap.
