### PR TITLE
fix(test): restore Docker E2E boundary lint

### DIFF
--- a/test/helpers/sqlite-sessions-transcripts-flip-proof.ts
+++ b/test/helpers/sqlite-sessions-transcripts-flip-proof.ts
@@ -35,7 +35,7 @@ import {
   resolveSessionTranscriptIdentity,
 } from "../../src/plugin-sdk/session-transcript-runtime.js";
 import { sleep } from "../../src/utils.js";
-import { createOpenClawTestInstance } from "../../test/helpers/openclaw-test-instance.js";
+import { createOpenClawTestInstance } from "./openclaw-test-instance.js";
 
 type DoctorMode = "import" | "inspect" | "validate" | "restore";
 type ProofChildProcess = ChildProcessByStdio<null, Readable, Readable>;

--- a/test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts
+++ b/test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts
@@ -1,6 +1,6 @@
 // Built-CLI SQLite flip proof requires dist entrypoints before running the gateway lifecycle.
 import { describe, expect, it } from "vitest";
-import { runSqliteSessionsTranscriptsFlipProof } from "../../scripts/e2e/sqlite-sessions-transcripts-flip-proof.ts";
+import { runSqliteSessionsTranscriptsFlipProof } from "../helpers/sqlite-sessions-transcripts-flip-proof.ts";
 
 describe("SQLite sessions/transcripts flip built CLI proof", () => {
   it("proves the lifecycle through the built gateway CLI entrypoint", async () => {

--- a/test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts
+++ b/test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts
@@ -1,6 +1,6 @@
 // SQLite sessions/transcripts flip proof test runs the script-style gateway lifecycle probe.
 import { describe, expect, it } from "vitest";
-import { runSqliteSessionsTranscriptsFlipProof } from "../../scripts/e2e/sqlite-sessions-transcripts-flip-proof.ts";
+import { runSqliteSessionsTranscriptsFlipProof } from "../helpers/sqlite-sessions-transcripts-flip-proof.ts";
 
 describe("SQLite sessions/transcripts flip proof harness", () => {
   it("proves isolated gateway lifecycle state stays SQLite-first", async () => {


### PR DESCRIPTION
Related: #98236

## What Problem This Solves

Fixes an issue where `pnpm lint:docker-e2e` failed for every `scripts/` change after the SQLite session/transcript flip proof landed under `scripts/e2e` with source-only imports.

## Why This Change Was Made

Moves the non-Docker Vitest lifecycle harness to the shared test-helper tree and updates its two test consumers. Actual Docker E2E harnesses remain subject to the package-only `dist` import boundary.

## User Impact

No runtime behavior changes. Contributors can run the scripts lint lane without an unrelated Docker E2E boundary failure.

## Evidence

- Before: `pnpm lint:docker-e2e` failed on Testbox `tbx_01kx9qyz6et4swwadr9w5z2zen` with `Docker E2E harness must import built dist, not ../../src` ([run](https://github.com/openclaw/openclaw/actions/runs/29172086905)).
- After: `pnpm lint:docker-e2e` passed on fresh Testbox `tbx_01kx9r9pa2ea8xtwvsw2qjndae` ([run](https://github.com/openclaw/openclaw/actions/runs/29172239648)).
- `pnpm check:changed` passed on Testbox, including format, script and test-root typechecks, Docker E2E boundary checks, and script lint.
- `git diff --check` passed.
- AI-assisted. The structured autoreview bundle scanner failed closed on secret-shaped fixture content in the unchanged moved harness; manual review confirmed a 99% rename with exactly three import-path changes.
