### PR TITLE
fix(signal): align supported message actions

### DIFF
--- a/extensions/signal/src/message-actions.test.ts
+++ b/extensions/signal/src/message-actions.test.ts
@@ -61,7 +61,7 @@ describe("signalMessageActions", () => {
     );
   });
 
-  it("skips send for plugin dispatch", () => {
+  it("supports only reactions for plugin dispatch", () => {
     expect(signalMessageActions.supportsAction?.({ action: "send" })).toBe(false);
     expect(signalMessageActions.supportsAction?.({ action: "react" })).toBe(true);
     expect(signalMessageActions.supportsAction?.({ action: "delete" })).toBe(false);

--- a/extensions/signal/src/message-actions.test.ts
+++ b/extensions/signal/src/message-actions.test.ts
@@ -64,6 +64,8 @@ describe("signalMessageActions", () => {
   it("skips send for plugin dispatch", () => {
     expect(signalMessageActions.supportsAction?.({ action: "send" })).toBe(false);
     expect(signalMessageActions.supportsAction?.({ action: "react" })).toBe(true);
+    expect(signalMessageActions.supportsAction?.({ action: "delete" })).toBe(false);
+    expect(signalMessageActions.supportsAction?.({ action: "pin" })).toBe(false);
   });
 
   it("blocks reactions when the action gate is disabled", async () => {

--- a/extensions/signal/src/message-actions.ts
+++ b/extensions/signal/src/message-actions.ts
@@ -96,7 +96,7 @@ export const signalMessageActions: ChannelMessageActionAdapter = {
 
     return { actions: Array.from(actions) };
   },
-  supportsAction: ({ action }) => action !== "send",
+  supportsAction: ({ action }) => action === "react",
 
   handleAction: async ({ action, params, cfg, accountId, toolContext }) => {
     if (action === "send") {


### PR DESCRIPTION
## What Problem This Solves

Signal's message-action adapter advertised support for every non-`send` action, but its handler only implements `react`. That meant unsupported actions like `delete` or `pin` could pass the ownership-boundary support check and then fail later inside the handler.

## Why This Change Was Made

The Signal adapter should advertise only the actions it can actually handle. `send` still stays on the normal outbound path, and reaction add/remove behavior remains represented by the existing `react` action parameters.

## User Impact

Unsupported Signal message actions are rejected earlier and consistently by the plugin action support contract. Existing Signal reactions continue to work, and send behavior is unchanged.

## Evidence

- `extensions/signal/src/message-actions.ts` now returns `true` only for `react` in `supportsAction`.
- `extensions/signal/src/message-actions.test.ts` keeps the existing `send=false` / `react=true` assertions and adds `delete=false` / `pin=false` coverage.
- Current head also registers the real Signal plugin in the shared message-action dispatcher test registry and proves `delete` is declined at the dispatcher boundary while `react` still reaches the Signal reaction handler.

## Proof

- Dispatcher-boundary proof: `dispatchChannelMessageAction({ channel: "signal", action: "delete", ... })` returns `null` for an exact-current Signal conversation and does not call `sendReactionSignal` or `removeReactionSignal`.
- Reaction continuity proof: `dispatchChannelMessageAction({ channel: "signal", action: "react", ... })` returns `{ ok: true, added: "👍" }` and calls `sendReactionSignal("+15550001111", 123, "👍", { accountId: "work", ... })`.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/signal/src/message-actions.test.ts -- --reporter=verbose` passed, 1 file / 8 tests, after rebasing onto remote head `16649e2951`.
- `node_modules/.bin/oxfmt --check extensions/signal/src/message-actions.ts extensions/signal/src/message-actions.test.ts` passed.
- `node_modules/.bin/oxlint extensions/signal/src/message-actions.ts extensions/signal/src/message-actions.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --engine claude` passed on exact head `ed055e03e7`, no accepted/actionable findings.
