### PR TITLE
ci: avoid retries in frozen UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1051,8 +1051,9 @@ jobs:
         run: |
           if [[ "$COMPATIBILITY_TARGET" == "true" ]]; then
             # Frozen targets can contain timing-sensitive tests fixed on current main.
-            # Preserve one retry, but let their browser helpers use their 10-second waits.
-            pnpm --dir ui test --retry=1 --testTimeout=10000
+            # Let their browser helpers use their 10-second waits. Do not retry whole
+            # legacy files: several rely on one-shot mocked browser globals.
+            pnpm --dir ui test --testTimeout=10000
           else
             pnpm --dir ui test
           fi

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1875,8 +1875,8 @@ describe("ci workflow guards", () => {
       "${{ needs.preflight.outputs.compatibility_target }}",
     );
     expect(uiTest.run).toContain('if [[ "$COMPATIBILITY_TARGET" == "true" ]]');
-    expect(uiTest.run).toContain("pnpm --dir ui test --retry=1 --testTimeout=10000");
-    expect(uiTest.run).not.toContain("pnpm --dir ui test -- --retry");
+    expect(uiTest.run).toContain("pnpm --dir ui test --testTimeout=10000");
+    expect(uiTest.run).not.toContain("--retry");
     expect(uiTest.run).toContain("pnpm --dir ui test");
   });
 


### PR DESCRIPTION
## What Problem This Solves

Compatibility-only `--retry=1` reruns whole legacy UI test files. Several LTS files use one-shot mocked browser globals, so the retry path deterministically corrupts their second attempt and creates 21 failures even though the original test contract is sound.

## Why This Change Was Made

Keep only `--testTimeout=10000` for authenticated frozen targets. That covers beta's browser helper, which already waits up to 10 seconds, without re-executing stateful legacy files. Add a workflow guard forbidding `--retry` in the compatibility command. Current-main UI tests remain strict and unchanged.

## User Impact

No runtime behavior changes. Frozen beta, July, and LTS UI validation gets the intended timeout budget without retry-induced mock-state failures.

## Evidence

- LTS retry failure: https://github.com/openclaw/openclaw/actions/runs/29172255552/job/86595270834
- Blacksmith Testbox `tbx_01kx9rke9bzdnp8ckjt738a30k`: workflow guards 51/51 passed.
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Fresh autoreview: clean, correctness confidence 0.99.
