### PR TITLE
fix(release/2026.7.1): tier-1 backports — migration lease release, Discord resume recovery, completions refusal text

### DIFF
--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -70,14 +70,16 @@ class FakeSocket extends EventEmitter {
 class TestGatewayPlugin extends GatewayPlugin {
   sockets: FakeSocket[] = [];
   connectCalls: boolean[] = [];
+  urls: string[] = [];
 
   override connect(resume = false): void {
     this.connectCalls.push(resume);
     super.connect(resume);
   }
 
-  protected override createWebSocket(): never {
+  protected override createWebSocket(url: string): never {
     const socket = new FakeSocket();
+    this.urls.push(url);
     this.sockets.push(socket);
     return socket as never;
   }
@@ -211,7 +213,7 @@ describe("GatewayPlugin", () => {
     originalSocket?.emit("close", 1006);
 
     await vi.advanceTimersByTimeAsync(2_000);
-    expect(gateway.connectCalls).toEqual([false, true]);
+    expect(gateway.connectCalls).toEqual([false, false]);
     const replacementSocket = gateway.sockets[1];
     replacementSocket?.emit("open");
 
@@ -347,6 +349,7 @@ describe("GatewayPlugin", () => {
     };
     gateway.isConnected = false;
     (gateway as unknown as { reconnectAttempts: number }).reconnectAttempts = 7;
+    (gateway as unknown as { consecutiveResumeFailures: number }).consecutiveResumeFailures = 2;
 
     await (
       gateway as unknown as {
@@ -359,6 +362,9 @@ describe("GatewayPlugin", () => {
 
     expect(gateway.isConnected).toBe(true);
     expect((gateway as unknown as { reconnectAttempts: number }).reconnectAttempts).toBe(0);
+    expect(
+      (gateway as unknown as { consecutiveResumeFailures: number }).consecutiveResumeFailures,
+    ).toBe(0);
   });
 
   it("queues outbound gateway events when the connection window is exhausted", () => {
@@ -462,22 +468,133 @@ describe("GatewayPlugin", () => {
     clearInterval(heartbeat);
   });
 
-  it("reconnects after active remote normal closes", async () => {
+  it("logs and re-identifies after a resumable close without session state", async () => {
     vi.useFakeTimers();
     const gateway = new TestGatewayPlugin({
       autoInteractions: false,
       url: "wss://gateway.example.test",
     });
+    const debugSpy = vi.fn();
+    gateway.emitter.on("debug", debugSpy);
 
     gateway.connect(false);
     gateway.sockets[0]?.emit("open");
     gateway.sockets[0]?.emit("close", 1000);
 
     expect(gateway.sockets).toHaveLength(1);
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Gateway reconnect scheduled in 2000ms (close, resume=false)",
+    );
     await vi.advanceTimersByTimeAsync(2_000);
 
-    expect(gateway.connectCalls).toEqual([false, true]);
+    expect(gateway.connectCalls).toEqual([false, false]);
     expect(gateway.sockets).toHaveLength(2);
+    const reconnectSocket = gateway.sockets[1];
+    reconnectSocket?.emit("open");
+    reconnectSocket?.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOpcodes.Hello,
+        d: { heartbeat_interval: 45_000 },
+        s: null,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sentGatewayOpcodes(reconnectSocket?.send ?? vi.fn())).toContain(GatewayOpcodes.Identify);
+    expect(sentGatewayOpcodes(reconnectSocket?.send ?? vi.fn())).not.toContain(
+      GatewayOpcodes.Resume,
+    );
+  });
+
+  it("falls back to a fresh IDENTIFY after three failed resume attempts", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const gateway = new TestGatewayPlugin({
+      autoInteractions: false,
+      url: "wss://gateway.example.test",
+    });
+    const debugSpy = vi.fn();
+    gateway.emitter.on("debug", debugSpy);
+    (gateway as unknown as { client: unknown }).client = {
+      options: { token: "token" },
+      dispatchGatewayEvent: vi.fn(async () => {}),
+    };
+
+    gateway.connect(false);
+    const initialSocket = gateway.sockets[0];
+    initialSocket?.emit("open");
+    initialSocket?.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOpcodes.Hello,
+        d: { heartbeat_interval: 45_000 },
+        s: null,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sentGatewayOpcodes(initialSocket?.send ?? vi.fn())).toContain(GatewayOpcodes.Identify);
+    initialSocket?.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOpcodes.Dispatch,
+        t: GatewayDispatchEvents.Ready,
+        s: 42,
+        d: {
+          session_id: "session-1",
+          resume_gateway_url: "wss://resume.example.test",
+        },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    for (const delayMs of [2_000, 4_000, 8_000]) {
+      gateway.sockets.at(-1)?.emit("close", 1006);
+      await vi.advanceTimersByTimeAsync(delayMs);
+      const resumeSocket = gateway.sockets.at(-1);
+      expect(gateway.urls.at(-1)).toMatch(/^wss:\/\/resume\.example\.test\//);
+      resumeSocket?.emit("open");
+      resumeSocket?.emit(
+        "message",
+        JSON.stringify({
+          op: GatewayOpcodes.Hello,
+          d: { heartbeat_interval: 45_000 },
+          s: null,
+        }),
+      );
+      expect(sentGatewayOpcodes(resumeSocket?.send ?? vi.fn())).toContain(GatewayOpcodes.Resume);
+      expect(debugSpy).toHaveBeenCalledWith(
+        `Gateway reconnect scheduled in ${delayMs}ms (close, resume=true)`,
+      );
+    }
+
+    gateway.sockets.at(-1)?.emit("close", 1006);
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Gateway forcing fresh IDENTIFY after 3 failed resume attempts",
+    );
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Gateway reconnect scheduled in 16000ms (close, resume=false)",
+    );
+
+    await vi.advanceTimersByTimeAsync(16_000);
+    const freshSocket = gateway.sockets.at(-1);
+    expect(gateway.urls.at(-1)).toMatch(/^wss:\/\/gateway\.example\.test\//);
+    freshSocket?.emit("open");
+    freshSocket?.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOpcodes.Hello,
+        d: { heartbeat_interval: 45_000 },
+        s: null,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sentGatewayOpcodes(freshSocket?.send ?? vi.fn())).toContain(GatewayOpcodes.Identify);
+    expect(sentGatewayOpcodes(freshSocket?.send ?? vi.fn())).not.toContain(GatewayOpcodes.Resume);
+    const sessionState = gatewaySessionState(gateway);
+    expect(sessionState.sessionId).toBeNull();
+    expect(sessionState.resumeGatewayUrl).toBeNull();
+    expect(sessionState.sequence).toBeNull();
   });
 
   it.each([GatewayCloseCodes.InvalidSeq, GatewayCloseCodes.AlreadyAuthenticated])(
@@ -546,7 +663,7 @@ describe("GatewayPlugin", () => {
     expect(gateway.connectCalls).toEqual([false]);
 
     await vi.advanceTimersByTimeAsync(1);
-    expect(gateway.connectCalls).toEqual([false, true]);
+    expect(gateway.connectCalls).toEqual([false, false]);
   });
 
   it("includes close code details when reconnect attempts are exhausted", async () => {

--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -43,6 +43,18 @@ type GatewayPluginOptions = {
   shard?: [number, number];
   url?: string;
 };
+type GatewayReconnectReason =
+  | "close"
+  | "identify"
+  | "invalid-session"
+  | "reconnect-opcode"
+  | "zombie";
+type GatewayReconnectOptions = {
+  reason: GatewayReconnectReason;
+  preferResume: boolean;
+  closeCode?: number;
+  minDelayMs?: number;
+};
 
 const READY_STATE_OPEN = 1;
 const DEFAULT_GATEWAY_URL = "wss://gateway.discord.gg/";
@@ -54,6 +66,7 @@ export const DISCORD_GATEWAY_WS_CLIENT_OPTIONS = Object.freeze({
 }) satisfies ws.ClientOptions;
 const INVALID_SESSION_MIN_DELAY_MS = 1_000;
 const INVALID_SESSION_JITTER_MS = 4_000;
+const RESUME_FAILURE_THRESHOLD = 3;
 
 function ensureGatewayParams(url: string): string {
   const parsed = new URL(url);
@@ -92,6 +105,7 @@ export class GatewayPlugin extends Plugin {
   private sessionId: string | null = null;
   private resumeGatewayUrl: string | null = null;
   private reconnectAttempts = 0;
+  private consecutiveResumeFailures = 0;
   private shouldReconnect = false;
   private isConnecting = false;
   private readonly heartbeatTimers = new GatewayHeartbeatTimers();
@@ -173,6 +187,7 @@ export class GatewayPlugin extends Plugin {
     this.isConnecting = false;
     this.isConnected = false;
     this.reconnectAttempts = 0;
+    this.consecutiveResumeFailures = 0;
   }
 
   protected createWebSocket(url: string): ws.WebSocket {
@@ -224,7 +239,11 @@ export class GatewayPlugin extends Plugin {
       if (!canResume) {
         this.resetSessionState();
       }
-      this.scheduleReconnect(canResume, closeCode);
+      this.scheduleReconnect({
+        reason: "close",
+        preferResume: canResume,
+        closeCode,
+      });
     });
     socket.on("error", (error) => {
       if (socket !== this.ws) {
@@ -243,18 +262,19 @@ export class GatewayPlugin extends Plugin {
       this.sequence = payload.s;
     }
     switch (payload.op) {
-      case GatewayOpcodes.Hello:
+      case GatewayOpcodes.Hello: {
         this.startHeartbeat(
           (payload.d as { heartbeat_interval?: number }).heartbeat_interval ?? 45_000,
         );
-        if (resume && this.sessionId) {
+        const resumeState = resume ? this.getResumeState() : null;
+        if (resumeState) {
           this.send(
             {
               op: GatewayOpcodes.Resume,
               d: {
                 token: this.client?.options.token ?? "",
-                session_id: this.sessionId,
-                seq: this.sequence ?? 0,
+                session_id: resumeState.sessionId,
+                seq: resumeState.sequence,
               },
             } as GatewaySendPayload,
             true,
@@ -268,6 +288,7 @@ export class GatewayPlugin extends Plugin {
           });
         }
         break;
+      }
       case GatewayOpcodes.HeartbeatAck:
         this.lastHeartbeatAck = true;
         break;
@@ -286,14 +307,15 @@ export class GatewayPlugin extends Plugin {
         if (!payload.d) {
           this.resetSessionState();
         }
-        this.scheduleReconnect(
-          payload.d,
-          undefined,
-          INVALID_SESSION_MIN_DELAY_MS + Math.floor(Math.random() * INVALID_SESSION_JITTER_MS),
-        );
+        this.scheduleReconnect({
+          reason: "invalid-session",
+          preferResume: payload.d,
+          minDelayMs:
+            INVALID_SESSION_MIN_DELAY_MS + Math.floor(Math.random() * INVALID_SESSION_JITTER_MS),
+        });
         break;
       case GatewayOpcodes.Reconnect:
-        this.scheduleReconnect(true);
+        this.scheduleReconnect({ reason: "reconnect-opcode", preferResume: true });
         break;
     }
   }
@@ -305,7 +327,7 @@ export class GatewayPlugin extends Plugin {
       onHeartbeat: () => this.sendHeartbeat(),
       onAckTimeout: () => {
         this.emitter.emit("error", new Error("Gateway heartbeat ACK timeout"));
-        this.scheduleReconnect(true);
+        this.scheduleReconnect({ reason: "zombie", preferResume: true });
       },
     });
   }
@@ -351,7 +373,7 @@ export class GatewayPlugin extends Plugin {
       return;
     }
     if (socket.readyState !== READY_STATE_OPEN) {
-      this.scheduleReconnect(false);
+      this.scheduleReconnect({ reason: "identify", preferResume: false });
       return;
     }
     this.identify();
@@ -390,10 +412,12 @@ export class GatewayPlugin extends Plugin {
       this.sessionId = ready.session_id ?? null;
       this.resumeGatewayUrl = ready.resume_gateway_url ?? null;
       this.reconnectAttempts = 0;
+      this.consecutiveResumeFailures = 0;
       this.isConnected = true;
     }
     if (payload.t === GatewayDispatchEvents.Resumed) {
       this.reconnectAttempts = 0;
+      this.consecutiveResumeFailures = 0;
       this.isConnected = true;
     }
     dispatchVoiceGatewayEvent(this.client, payload.t, payload.d);
@@ -408,9 +432,16 @@ export class GatewayPlugin extends Plugin {
     this.sessionId = null;
     this.resumeGatewayUrl = null;
     this.sequence = null;
+    this.consecutiveResumeFailures = 0;
   }
 
-  private scheduleReconnect(resume: boolean, closeCode?: number, minDelayMs = 0): void {
+  private getResumeState(): { sessionId: string; sequence: number } | null {
+    return this.sessionId && this.sequence !== null
+      ? { sessionId: this.sessionId, sequence: this.sequence }
+      : null;
+  }
+
+  private scheduleReconnect(options: GatewayReconnectOptions): void {
     if (!this.shouldReconnect) {
       return;
     }
@@ -427,17 +458,37 @@ export class GatewayPlugin extends Plugin {
       this.emitter.emit(
         "error",
         new Error(
-          `Max reconnect attempts (${maxAttempts}) reached${closeCode !== undefined ? ` after close code ${closeCode}` : ""}`,
+          `Max reconnect attempts (${maxAttempts}) reached${options.closeCode !== undefined ? ` after close code ${options.closeCode}` : ""}`,
         ),
       );
       return;
     }
+    let shouldResume = options.preferResume && this.getResumeState() !== null;
+    // Abnormal closes can leave a cached session permanently rejected. READY or RESUMED
+    // resets this streak; after the threshold, discard the poisoned session and IDENTIFY.
+    if (shouldResume && this.consecutiveResumeFailures >= RESUME_FAILURE_THRESHOLD) {
+      this.resetSessionState();
+      shouldResume = false;
+      this.emitter.emit(
+        "debug",
+        `Gateway forcing fresh IDENTIFY after ${RESUME_FAILURE_THRESHOLD} failed resume attempts`,
+      );
+    }
+    if (shouldResume) {
+      this.consecutiveResumeFailures += 1;
+    } else {
+      this.consecutiveResumeFailures = 0;
+    }
     const delay = Math.max(
-      minDelayMs,
+      options.minDelayMs ?? 0,
       Math.min(30_000, 1_000 * 2 ** Math.min(this.reconnectAttempts, 5)),
     );
+    this.emitter.emit(
+      "debug",
+      `Gateway reconnect scheduled in ${delay}ms (${options.reason}, resume=${String(shouldResume)})`,
+    );
     this.reconnectTimer.schedule(delay, () => {
-      this.connect(resume);
+      this.connect(shouldResume);
     });
   }
 

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -9,8 +9,13 @@ type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 type OpenAICompatibleDelta = DeepPartial<ChatCompletionChunk["choices"][number]["delta"]> & {
   reasoning_content?: string;
 };
-type OpenAICompatibleChoice = Omit<DeepPartial<ChatCompletionChunk["choices"][number]>, "delta"> & {
+type OpenAICompatibleChoice = Omit<
+  DeepPartial<ChatCompletionChunk["choices"][number]>,
+  "delta" | "message"
+> & {
   delta?: OpenAICompatibleDelta;
+  // Some OpenAI-compatible endpoints deliver a full message instead of delta.
+  message?: OpenAICompatibleDelta;
 };
 type OpenAICompatibleChatCompletionChunk = Omit<
   DeepPartial<ChatCompletionChunk>,
@@ -124,6 +129,32 @@ function makeTextChunk(text: string): OpenAICompatibleChatCompletionChunk {
   };
 }
 
+function makeRefusalChunk(refusal: string): OpenAICompatibleChatCompletionChunk {
+  return {
+    id: "chatcmpl-test",
+    choices: [
+      {
+        index: 0,
+        delta: { role: "assistant", content: null, refusal },
+        finish_reason: "stop",
+      },
+    ],
+  };
+}
+
+function makeRefusalMessageChunk(refusal: string): OpenAICompatibleChatCompletionChunk {
+  return {
+    id: "chatcmpl-test",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: null, refusal },
+        finish_reason: "stop",
+      },
+    ],
+  };
+}
+
 function makeToolCallChunk(
   id: string,
   name: string,
@@ -219,6 +250,30 @@ describe("OpenAI-compatible completions params", () => {
     } finally {
       configureAiTransportHost({});
     }
+  });
+
+  it("surfaces chat-completions refusal deltas as visible assistant text", async () => {
+    mockChunksRef.chunks = [makeRefusalChunk("I can't help with that.")];
+
+    const result = await streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    }).result();
+
+    expect(result.content).toStrictEqual([{ type: "text", text: "I can't help with that." }]);
+    expect(result.stopReason).toBe("stop");
+  });
+
+  it("surfaces aggregated chat-completions message.refusal as visible assistant text", async () => {
+    mockChunksRef.chunks = [makeRefusalMessageChunk("Requests like this are not allowed.")];
+
+    const result = await streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    }).result();
+
+    expect(result.content).toStrictEqual([
+      { type: "text", text: "Requests like this are not allowed." },
+    ]);
+    expect(result.stopReason).toBe("stop");
   });
 
   it("preserves a valid provider-reported usage cost", async () => {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -424,13 +424,19 @@ export const streamOpenAICompletions: StreamFunction<
           hasFinishReason = true;
         }
 
-        if (choice.delta) {
+        // Some OpenAI-compatible endpoints deliver a full `message` instead of
+        // `delta` (including refusal-only turns with content: null). Normalize
+        // the same way the managed agent transport does.
+        const choiceDelta =
+          choice.delta ??
+          (choice as { message?: ChatCompletionChunk["choices"][number]["delta"] }).message;
+        if (choiceDelta) {
           // Some endpoints return reasoning in reasoning_content (llama.cpp),
           // or reasoning (other openai compatible endpoints)
           // Use the first non-empty reasoning field to avoid duplication
           // (e.g., chutes.ai returns both reasoning_content and reasoning with same content)
           const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
-          const deltaFields = choice.delta as Record<string, unknown>;
+          const deltaFields = choiceDelta as Record<string, unknown>;
           const shouldEmitReasoning = Boolean(model.reasoning && options?.reasoningEffort);
           let foundReasoningField: string | null = null;
           for (const field of reasoningFields) {
@@ -454,19 +460,27 @@ export const streamOpenAICompletions: StreamFunction<
             }
           }
           if (
-            choice.delta.content !== null &&
-            choice.delta.content !== undefined &&
-            choice.delta.content.length > 0
+            choiceDelta.content !== null &&
+            choiceDelta.content !== undefined &&
+            choiceDelta.content.length > 0
           ) {
-            appendPartitionedContent(choice.delta.content, Boolean(foundReasoningField));
+            appendPartitionedContent(choiceDelta.content, Boolean(foundReasoningField));
           }
 
-          if (choice?.delta?.tool_calls) {
+          // Chat Completions can put safety/structured-output refusals in a
+          // top-level `refusal` field with content null. Surface that as
+          // visible text so the assistant turn is not empty.
+          const refusalText = typeof choiceDelta.refusal === "string" ? choiceDelta.refusal : "";
+          if (refusalText.length > 0) {
+            appendPartitionedContent(refusalText, Boolean(foundReasoningField));
+          }
+
+          if (choiceDelta.tool_calls) {
             flushPartitionedContent();
             // The tool-call lane is also a reasoning boundary; seal the thought
             // before toolcall_start so thinking_end never trails the action.
             sealNativeReasoningBeforeText();
-            for (const toolCall of choice.delta.tool_calls) {
+            for (const toolCall of choiceDelta.tool_calls) {
               const block = ensureToolCallBlock(toolCall);
               if (!block.id && toolCall.id) {
                 block.id = toolCall.id;
@@ -492,7 +506,7 @@ export const streamOpenAICompletions: StreamFunction<
             }
           }
 
-          const reasoningDetails = (choice.delta as { reasoning_details?: unknown })
+          const reasoningDetails = (choiceDelta as { reasoning_details?: unknown })
             .reasoning_details;
           if (reasoningDetails && Array.isArray(reasoningDetails)) {
             for (const detail of reasoningDetails) {

--- a/scripts/check-cli-startup-memory.mjs
+++ b/scripts/check-cli-startup-memory.mjs
@@ -95,6 +95,9 @@ function resolveDefaultLimitsMb(platform = process.platform) {
     // higher RSS for the same launcher path, so keep it supported without hiding
     // Linux help-path regressions.
     help: platform === "darwin" ? 300 : 100,
+    // Plugin discovery is heavier than help, but must stay below the doctor/channel
+    // runtime graph that an empty metadata-only invocation must not import.
+    pluginsList: platform === "darwin" ? 500 : 350,
     statusJson: 400,
     gatewayStatus: 500,
   };
@@ -108,6 +111,15 @@ const cases = [
     label: "--help",
     args: ["openclaw.mjs", "--help"],
     limitMb: readPositiveNumberEnv("OPENCLAW_STARTUP_MEMORY_HELP_MB", DEFAULT_LIMITS_MB.help),
+  },
+  {
+    id: "pluginsList",
+    label: "plugins list --json",
+    args: ["openclaw.mjs", "plugins", "list", "--json"],
+    limitMb: readPositiveNumberEnv(
+      "OPENCLAW_STARTUP_MEMORY_PLUGINS_LIST_MB",
+      DEFAULT_LIMITS_MB.pluginsList,
+    ),
   },
   {
     id: "statusJson",

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2785,6 +2785,101 @@ describe("openai transport stream", () => {
     expect(output.stopReason).toBe("stop");
   });
 
+  it("surfaces chat-completions refusal deltas as visible assistant text", async () => {
+    const model = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-completions" as const,
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: false,
+      input: ["text"] as const,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 4096,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-refusal-delta",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant", content: null, refusal: "I can't help with that." },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    expect(output.content).toStrictEqual([{ type: "text", text: "I can't help with that." }]);
+    expect(output.stopReason).toBe("stop");
+    expect(
+      events.some(
+        (event) => event.type === "text_delta" && event.delta === "I can't help with that.",
+      ),
+    ).toBe(true);
+  });
+
+  it("surfaces aggregated chat-completions message.refusal as visible assistant text", async () => {
+    const model = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-completions" as const,
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: false,
+      input: ["text"] as const,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 4096,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-refusal-message",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              // Some OpenAI-compatible endpoints deliver a full message instead of delta.
+              message: {
+                role: "assistant",
+                content: null,
+                refusal: "Requests like this are not allowed.",
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            } as unknown as ChatCompletionChunk["choices"][number],
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toStrictEqual([
+      { type: "text", text: "Requests like this are not allowed." },
+    ]);
+    expect(output.stopReason).toBe("stop");
+  });
+
   it("filters DeepSeek DSML content without disturbing native tool calls", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3167,6 +3167,18 @@ async function processOpenAICompletionsStream(
         }
       }
     }
+    // Chat Completions can put safety/structured-output refusals in a top-level
+    // `refusal` field with content null. Surface that as visible text so the
+    // assistant turn is not empty (Responses path already routes refusal deltas).
+    const refusalText = typeof choiceDelta.refusal === "string" ? choiceDelta.refusal : "";
+    if (refusalText) {
+      const routedDeltas = hasMirroredReasoning
+        ? reasoningTagTextPartitioner.push(refusalText)
+        : reasoningTagTextPartitioner.pushVisible(refusalText);
+      for (const routedDelta of routedDeltas) {
+        appendPartitionedVisibleDelta(routedDelta);
+      }
+    }
     for (const reasoningDelta of reasoningDeltas) {
       if (reasoningDelta.kind === "thinking" && !emitReasoning) {
         continue;

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -1,7 +1,7 @@
 // Gateway startup checks that must run before shared CLI bootstrap can migrate state.
 import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "../../config/future-version-guard.js";
 import type { ConfigFileSnapshot } from "../../config/types.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import { ExitError, type RuntimeEnv } from "../../runtime.js";
 import type { GatewayRunPreBootstrapOptions } from "./future-config-guard.js";
 import { enforceGatewayRunFutureConfigGuard } from "./future-config-guard.js";
 import { getGatewayRunRuntimeHooks } from "./runtime-hooks.js";
@@ -655,23 +655,30 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
 export async function recheckGatewayRunBootstrap(
   params: GatewayRunGuardParams & { snapshot?: ConfigFileSnapshot },
 ): Promise<boolean> {
+  // This callback can run while startup preflight owns the shared migration lease.
+  // Throw a typed exit so its finally releases the lease before the CLI exits.
+  const deferredExitRuntime: RuntimeEnv = {
+    ...params.runtime,
+    exit: (code) => {
+      throw new ExitError(code);
+    },
+  };
   const expected = preparedGatewayRunBootstrapSnapshot;
   if (!expected) {
     params.runtime.error(
       "Refusing to run automatic gateway startup migrations without a prepared config snapshot. Retry startup.",
     );
-    params.runtime.exit(1);
-    return false;
+    throw new ExitError(1);
   }
   const current = params.snapshot
     ? enforceGatewayRunFutureConfigGuard({
         opts: params.opts,
-        runtime: params.runtime,
+        runtime: deferredExitRuntime,
         snapshot: params.snapshot,
       })
       ? params.snapshot
       : null
-    : await readGuardedGatewayRunConfig(params);
+    : await readGuardedGatewayRunConfig({ ...params, runtime: deferredExitRuntime });
   if (!current) {
     return false;
   }
@@ -685,6 +692,5 @@ export async function recheckGatewayRunBootstrap(
   params.runtime.error(
     "Refusing to run automatic gateway startup migrations because the selected config changed during startup. Retry startup so the new config can be validated.",
   );
-  params.runtime.exit(1);
-  return false;
+  throw new ExitError(1);
 }

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -164,6 +164,11 @@ describe("ensureConfigReady", () => {
       expectedDoctorCalls: 0,
     },
     {
+      name: "skips doctor flow for plugin listing without legacy state",
+      commandPath: ["plugins", "list"],
+      expectedDoctorCalls: 0,
+    },
+    {
       name: "runs doctor flow for commands that may mutate state without legacy state",
       commandPath: ["message"],
       expectedDoctorCalls: 1,
@@ -250,6 +255,43 @@ describe("ensureConfigReady", () => {
     });
   });
 
+  it("preserves plugin listing migrations when the legacy plugin install index exists", async () => {
+    const root = useTempOpenClawHome();
+    writeStateMarker(root, "plugins/installs.json");
+    const migratedSnapshot = {
+      ...makeSnapshot(),
+      config: { plugins: { entries: { legacy: { enabled: true } } } },
+      runtimeConfig: { plugins: { entries: { legacy: { enabled: true } } } },
+      sourceConfig: { plugins: { entries: { legacy: { enabled: true } } } },
+    };
+    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({
+      snapshot: migratedSnapshot,
+      baseConfig: {},
+    });
+
+    await runEnsureConfigReady(["plugins", "list"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledOnce();
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+      migrateState: true,
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+    });
+    expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(
+      migratedSnapshot.runtimeConfig,
+      migratedSnapshot.sourceConfig,
+    );
+  });
+
+  it("preserves plugin listing migrations when the shared state database exists", async () => {
+    const root = useTempOpenClawHome();
+    writeStateMarker(root, "state/openclaw.sqlite");
+
+    await runEnsureConfigReady(["plugins", "list"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledOnce();
+  });
+
   it("runs doctor flow before agent commands when default exec approvals must move to a custom state dir", async () => {
     const root = useTempOpenClawHome();
     const stateDir = path.join(root, "custom-state");
@@ -301,7 +343,10 @@ describe("ensureConfigReady", () => {
     expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledOnce();
   });
 
-  it("runs doctor flow for read-only commands with configured custom session stores", async () => {
+  it.each([
+    { name: "status", commandPath: ["status"] },
+    { name: "plugin listing", commandPath: ["plugins", "list"] },
+  ])("runs doctor flow for $name with configured custom session stores", async ({ commandPath }) => {
     const root = useTempOpenClawHome();
     const customStore = path.join(root, "sessions", "sessions.json");
     const snapshot = {
@@ -315,7 +360,7 @@ describe("ensureConfigReady", () => {
       baseConfig: {},
     });
 
-    await runEnsureConfigReady(["status"]);
+    await runEnsureConfigReady(commandPath);
 
     expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledOnce();
   });
@@ -331,6 +376,24 @@ describe("ensureConfigReady", () => {
 
     await runEnsureConfigReady(["health"]);
 
+    expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(
+      snapshot.runtimeConfig,
+      snapshot.sourceConfig,
+    );
+  });
+
+  it("pins plugin listing config without loading state migration runtime", async () => {
+    const snapshot = {
+      ...makeSnapshot(),
+      config: { plugins: { entries: { alpha: { enabled: true } } } },
+      runtimeConfig: { plugins: { entries: { alpha: { enabled: true } } } },
+      sourceConfig: { plugins: { entries: { alpha: { enabled: true } } } },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+
+    await runEnsureConfigReady(["plugins", "list"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
     expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(
       snapshot.runtimeConfig,
       snapshot.sourceConfig,

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { note } from "../../../packages/terminal-core/src/note.js";
+import { ExitError } from "../../runtime.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { formatCliCommand } from "../command-format.js";
 import { ensureConfigReady, testApi } from "./config-guard.js";
@@ -222,6 +223,27 @@ describe("ensureConfigReady", () => {
     });
   });
 
+  it("honors a deferred migration exit after preflight resources unwind", async () => {
+    let preflightUnwound = false;
+    loadAndMaybeMigrateDoctorConfigMock.mockImplementation(async () => {
+      try {
+        throw new ExitError(78);
+      } finally {
+        preflightUnwound = true;
+      }
+    });
+    const runtime = makeRuntime();
+    runtime.exit.mockImplementation(() => {
+      expect(preflightUnwound).toBe(true);
+    });
+
+    await expect(
+      ensureConfigReady({ runtime: runtime as never, commandPath: ["gateway"] }),
+    ).rejects.toMatchObject({ name: "ExitError", code: 78 });
+
+    expect(runtime.exit).toHaveBeenCalledWith(78);
+  });
+
   it("does not require a startup migration checkpoint for gateway probes", async () => {
     await runEnsureConfigReady(["gateway", "health"]);
 
@@ -346,24 +368,27 @@ describe("ensureConfigReady", () => {
   it.each([
     { name: "status", commandPath: ["status"] },
     { name: "plugin listing", commandPath: ["plugins", "list"] },
-  ])("runs doctor flow for $name with configured custom session stores", async ({ commandPath }) => {
-    const root = useTempOpenClawHome();
-    const customStore = path.join(root, "sessions", "sessions.json");
-    const snapshot = {
-      ...makeSnapshot(),
-      config: { session: { store: customStore } },
-      runtimeConfig: { session: { store: customStore } },
-    };
-    readConfigFileSnapshotMock.mockResolvedValue(snapshot);
-    loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({
-      snapshot,
-      baseConfig: {},
-    });
+  ])(
+    "runs doctor flow for $name with configured custom session stores",
+    async ({ commandPath }) => {
+      const root = useTempOpenClawHome();
+      const customStore = path.join(root, "sessions", "sessions.json");
+      const snapshot = {
+        ...makeSnapshot(),
+        config: { session: { store: customStore } },
+        runtimeConfig: { session: { store: customStore } },
+      };
+      readConfigFileSnapshotMock.mockResolvedValue(snapshot);
+      loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({
+        snapshot,
+        baseConfig: {},
+      });
 
-    await runEnsureConfigReady(commandPath);
+      await runEnsureConfigReady(commandPath);
 
-    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledOnce();
-  });
+      expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledOnce();
+    },
+  );
 
   it("pins a valid preflight snapshot for command code reuse", async () => {
     const snapshot = {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -7,7 +7,7 @@ import { readConfigFileSnapshot, setRuntimeConfigSnapshot } from "../../config/c
 import { resolveLegacyStateDirs, resolveOAuthDir, resolveStateDir } from "../../config/paths.js";
 import type { ConfigFileSnapshot } from "../../config/types.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import { ExitError, type RuntimeEnv } from "../../runtime.js";
 import { shouldMigrateStateFromPath } from "../argv.js";
 
 const ALLOWED_INVALID_COMMANDS = new Set(["audit", "doctor", "logs", "health", "help", "status"]);
@@ -225,9 +225,17 @@ export async function ensureConfigReady(params: {
           ? { beforeStateMigrations: params.beforeStateMigrations }
           : {}),
       });
-    return !params.suppressDoctorStdout
-      ? (await runDoctorConfigPreflight()).snapshot
-      : (await withSuppressedNotes(runDoctorConfigPreflight)).snapshot;
+    try {
+      return !params.suppressDoctorStdout
+        ? (await runDoctorConfigPreflight()).snapshot
+        : (await withSuppressedNotes(runDoctorConfigPreflight)).snapshot;
+    } catch (error) {
+      if (error instanceof ExitError) {
+        // The migration owner has unwound its lease and heartbeat before this handoff.
+        params.runtime.exit(error.code);
+      }
+      throw error;
+    }
   };
   if (
     !didRunDoctorConfigFlow &&

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -142,6 +142,7 @@ function hasLegacyStateMigrationInputs(): boolean {
       path.join(stateDir, "agents"),
       path.join(stateDir, "plugins", "installs.json"),
       path.join(stateDir, "sessions"),
+      path.join(stateDir, "state", "openclaw.sqlite"),
     ].some(fileOrDirExists) ||
     sqliteSidecarPaths.some(
       (sourcePath) => fileOrDirExists(sourcePath) || hasPendingSqliteSidecarArchive(sourcePath),
@@ -154,9 +155,12 @@ function hasLegacyStateMigrationInputs(): boolean {
 function shouldRunStateMigrationOnlyWithLegacyInputs(commandPath: string[]): boolean {
   const commandName = commandPath[0];
   const subcommandName = commandPath[1];
+  // Metadata-only plugin listing still migrates known legacy inputs, but an empty
+  // state must not cold-load doctor and bundled channel runtime graphs.
   return (
     commandName === "agent" ||
     commandName === "status" ||
+    (commandName === "plugins" && subcommandName === "list") ||
     (commandName === "tasks" &&
       (subcommandName === undefined || ALLOWED_INVALID_TASK_SUBCOMMANDS.has(subcommandName)))
   );

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -95,7 +95,7 @@ type GatewayRunCommandHooks = {
   beforeRun?: (opts: { reset?: boolean }) => Promise<void>;
 };
 type CliExecutionBootstrapOptions = {
-  beforeStateMigrations?: () => Promise<boolean>;
+  beforeStateMigrations?: (snapshot?: ConfigSnapshotStub) => Promise<boolean>;
 };
 const addGatewayRunCommandMock = vi.hoisted(() =>
   vi.fn<(command: unknown, hooks?: GatewayRunCommandHooks) => unknown>((command) => command),
@@ -610,7 +610,7 @@ describe("runCli exit behavior", () => {
     expect(bootstrapOrder).toBeGreaterThan(recoveryOrder);
   });
 
-  it("rechecks the effective guarded config before automatic startup migrations", async () => {
+  it("defers config-drift exit to the migration owner before startup migrations", async () => {
     readConfigFileSnapshotMock.mockResolvedValue({
       exists: true,
       hash: "guarded",
@@ -629,7 +629,7 @@ describe("runCli exit behavior", () => {
     await hooks?.beforeRun?.({});
     const beforeStateMigrations = (
       ensureCliExecutionBootstrapMock.mock.calls[0]?.[0] as
-        | { beforeStateMigrations?: () => Promise<boolean> }
+        | { beforeStateMigrations?: (snapshot?: ConfigSnapshotStub) => Promise<boolean> }
         | undefined
     )?.beforeStateMigrations;
     readConfigFileSnapshotMock.mockResolvedValue({
@@ -648,8 +648,65 @@ describe("runCli exit behavior", () => {
       throw new Error(`exit:${String(code)}`);
     }) as typeof process.exit);
     try {
-      await expect(beforeStateMigrations?.()).rejects.toThrow("exit:1");
+      await expect(beforeStateMigrations?.()).rejects.toMatchObject({
+        name: "ExitError",
+        code: 1,
+      });
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("changed during startup"));
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("defers a service-mode future-config exit to the migration owner", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      hash: "guarded",
+      path: "/tmp/openclaw.json",
+      raw: "{}",
+      valid: true,
+      sourceConfig: { gateway: { mode: "local" } },
+    });
+    await runCli(["node", "openclaw", "gateway"]);
+    const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+      | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
+      | undefined;
+    await hooks?.beforeRun?.({});
+    const beforeStateMigrations =
+      ensureCliExecutionBootstrapMock.mock.calls[0]?.[0]?.beforeStateMigrations;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${String(code)}`);
+    }) as typeof process.exit);
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
+          OPENCLAW_SERVICE_MARKER: undefined,
+        },
+        async () => {
+          await expect(
+            beforeStateMigrations?.({
+              exists: true,
+              hash: "future",
+              path: "/tmp/openclaw.json",
+              raw: "{}",
+              valid: true,
+              sourceConfig: {
+                env: { vars: { OPENCLAW_SERVICE_MARKER: "gateway" } },
+                meta: { lastTouchedVersion: "9999.1.1" },
+              },
+            }),
+          ).rejects.toMatchObject({ name: "ExitError", code: 78 });
+          expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining("start the gateway service"),
+          );
+          expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
+          expect(exitSpy).not.toHaveBeenCalled();
+        },
+      );
     } finally {
       exitSpy.mockRestore();
       errorSpy.mockRestore();

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -1,5 +1,6 @@
 // Doctor config preflight tests cover state migration preflight behavior before config repair.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExitError } from "../runtime.js";
 
 type StateMigrationResult = {
   migrated: boolean;
@@ -74,7 +75,9 @@ const startupMigrationLease = vi.hoisted(() => ({
   owner: "startup-test-owner",
   release: startupMigrationLeaseRelease,
 }));
-const acquireStartupMigrationLease = vi.hoisted(() => vi.fn(() => startupMigrationLease));
+const acquireStartupMigrationLease = vi.hoisted(() =>
+  vi.fn((_params: { env: NodeJS.ProcessEnv }) => startupMigrationLease),
+);
 const recordSuccessfulStartupMigrations = vi.hoisted(() => vi.fn());
 const runPostCorePluginConvergence = vi.hoisted(() =>
   vi.fn(
@@ -235,6 +238,73 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(readConfigFileSnapshot).not.toHaveBeenCalled();
   });
 
+  it("releases the startup lease when the fresh config guard rejects", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = "/tmp/openclaw-original-state";
+    let leaseEnv: NodeJS.ProcessEnv | undefined;
+    acquireStartupMigrationLease.mockImplementationOnce(({ env }) => {
+      leaseEnv = env;
+      return {
+        ...startupMigrationLease,
+        release: vi.fn(() => {
+          expect(env.OPENCLAW_STATE_DIR).toBe("/tmp/openclaw-original-state");
+          startupMigrationLeaseRelease();
+        }),
+      };
+    });
+    const beforeStateMigrations = vi
+      .fn<(_snapshot?: Record<string, unknown>) => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockImplementationOnce(async () => {
+        process.env.OPENCLAW_STATE_DIR = "/tmp/openclaw-drifted-state";
+        return false;
+      });
+
+    try {
+      await expect(
+        runDoctorConfigPreflight({
+          migrateLegacyConfig: false,
+          invalidConfigNote: false,
+          beforeStateMigrations,
+          requireStartupMigrationCheckpoint: true,
+        }),
+      ).rejects.toThrow("selected config changed during startup");
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+
+    expect(leaseEnv).not.toBe(process.env);
+    expect(beforeStateMigrations).toHaveBeenCalledTimes(2);
+    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+  });
+
+  it("releases the startup lease before propagating a deferred service exit", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    const deferredExit = new ExitError(78);
+    const beforeStateMigrations = vi
+      .fn<(_snapshot?: Record<string, unknown>) => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(deferredExit);
+
+    await expect(
+      runDoctorConfigPreflight({
+        migrateLegacyConfig: false,
+        invalidConfigNote: false,
+        beforeStateMigrations,
+        requireStartupMigrationCheckpoint: true,
+      }),
+    ).rejects.toBe(deferredExit);
+
+    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+  });
+
   it("skips config-dependent migrations when the fresh snapshot guard rejects", async () => {
     const beforeStateMigrations = vi
       .fn<(snapshot?: Record<string, unknown>) => Promise<boolean>>()
@@ -283,13 +353,16 @@ describe("runDoctorConfigPreflight state migration", () => {
       requireStartupMigrationCheckpoint: true,
     });
 
-    expect(acquireStartupMigrationLease).toHaveBeenCalledWith({ env: process.env });
+    const pinnedEnv = acquireStartupMigrationLease.mock.calls[0]?.[0]?.env;
+    expect(pinnedEnv).toBeDefined();
+    expect(pinnedEnv).not.toBe(process.env);
+    expect(needsStartupMigrationCheckpoint).toHaveBeenCalledWith({ env: pinnedEnv });
     expect(runPostCorePluginConvergence).toHaveBeenCalledWith({
       cfg: { gateway: { mode: "local", port: 19091 } },
       env: process.env,
     });
     expect(recordSuccessfulStartupMigrations).toHaveBeenCalledWith({
-      env: process.env,
+      env: pinnedEnv,
       lease: startupMigrationLease,
     });
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
@@ -311,8 +384,9 @@ describe("runDoctorConfigPreflight state migration", () => {
       requireStartupMigrationCheckpoint: true,
     });
 
+    const pinnedEnv = acquireStartupMigrationLease.mock.calls[0]?.[0]?.env;
     expect(recordSuccessfulStartupMigrations).toHaveBeenCalledWith({
-      env: process.env,
+      env: pinnedEnv,
       lease: startupMigrationLease,
     });
     expect(note).toHaveBeenCalledWith("- Left reviewed residue in place.", "Doctor notices");

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
+import { cloneEnvWithPlatformSemantics } from "../config/env-vars.js";
 import {
   readConfigFileSnapshot,
   recoverConfigFromJsonRootSuffix,
@@ -158,6 +159,12 @@ function formatStartupMigrationFailure(params: { warnings: string[]; blockers: s
   ].join("\n");
 }
 
+function throwStartupMigrationGuardRejected(): never {
+  throw new Error(
+    "OpenClaw startup migrations were skipped because the selected config changed during startup; refusing to report the gateway ready. Retry startup so the new config can be validated.",
+  );
+}
+
 /**
  * Runs early doctor config checks before the main config repair flow.
  *
@@ -171,6 +178,7 @@ export async function runDoctorConfigPreflight(
     repairPrefixedConfig?: boolean;
     recoverCorruptTargetStore?: boolean;
     invalidConfigNote?: string | false;
+    /** Return false or reject on config drift; the preflight always unwinds owned resources. */
     beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
     requireStartupMigrationCheckpoint?: boolean;
   } = {},
@@ -181,6 +189,7 @@ export async function runDoctorConfigPreflight(
     options.requireStartupMigrationCheckpoint === true
       ? await import("../infra/startup-migration-checkpoint.js")
       : undefined;
+  let startupMigrationEnv = process.env;
   let shouldRecordStartupCheckpoint = false;
   let startupMigrationLease: StartupMigrationLease | undefined;
   let startupMigrationHeartbeat: ReturnType<typeof setInterval> | undefined;
@@ -202,16 +211,16 @@ export async function runDoctorConfigPreflight(
       options.beforeStateMigrations === undefined ||
       (await options.beforeStateMigrations());
     if (startupCheckpoint && !stateMigrationsAllowed) {
-      throw new Error(
-        "OpenClaw startup migrations were skipped because the selected config changed during startup; refusing to report the gateway ready. Retry startup so the new config can be validated.",
-      );
+      throwStartupMigrationGuardRejected();
     }
     if (startupCheckpoint) {
+      // Later config reads can apply state selectors. Pin the accepted lease target for its lifetime.
+      startupMigrationEnv = cloneEnvWithPlatformSemantics(process.env);
       shouldRecordStartupCheckpoint = startupCheckpoint.needsStartupMigrationCheckpoint({
-        env: process.env,
+        env: startupMigrationEnv,
       });
       startupMigrationLease = shouldRecordStartupCheckpoint
-        ? startupCheckpoint.acquireStartupMigrationLease({ env: process.env })
+        ? startupCheckpoint.acquireStartupMigrationLease({ env: startupMigrationEnv })
         : undefined;
       if (startupMigrationLease) {
         startupMigrationHeartbeat = setInterval(() => {
@@ -277,12 +286,15 @@ export async function runDoctorConfigPreflight(
 
     const baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
     const stateMigrationInput = resolveStateMigrationConfigInput({ snapshot, baseConfig });
-    const configStateMigrationsAllowed =
-      stateMigrations !== undefined &&
-      stateMigrationsAllowed &&
-      (options.beforeStateMigrations === undefined ||
-        (await options.beforeStateMigrations(snapshot)));
-    if (stateMigrations && configStateMigrationsAllowed) {
+    const freshConfigGuardAllowed =
+      stateMigrations === undefined ||
+      !stateMigrationsAllowed ||
+      options.beforeStateMigrations === undefined ||
+      (await options.beforeStateMigrations(snapshot));
+    if (startupCheckpoint && !freshConfigGuardAllowed) {
+      throwStartupMigrationGuardRejected();
+    }
+    if (stateMigrations && stateMigrationsAllowed && freshConfigGuardAllowed) {
       const {
         autoMigrateLegacyState,
         autoMigrateLegacyPluginDoctorState,
@@ -344,7 +356,7 @@ export async function runDoctorConfigPreflight(
         );
       }
       startupCheckpoint?.recordSuccessfulStartupMigrations({
-        env: process.env,
+        env: startupMigrationEnv,
         lease: startupMigrationLease,
       });
     }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -95,7 +95,7 @@ export const defaultRuntime: OutputRuntimeEnv = {
   },
 };
 
-/** Error thrown by createNonExitingRuntime.exit() to signal simulated process exit. */
+/** Signals a deferred or non-exiting runtime exit so callers can unwind owned resources. */
 export class ExitError extends Error {
   constructor(
     public readonly code: number,

--- a/test/scripts/check-cli-startup-memory.test.ts
+++ b/test/scripts/check-cli-startup-memory.test.ts
@@ -52,6 +52,17 @@ describe("check-cli-startup-memory", () => {
     expect(testing.resolveDefaultLimitsMb("darwin").help).toBeGreaterThan(100);
   });
 
+  it("guards packaged plugin listing startup memory", () => {
+    expect(testing.resolveDefaultLimitsMb("linux").pluginsList).toBe(350);
+    expect(testing.resolveDefaultLimitsMb("darwin").pluginsList).toBeGreaterThan(350);
+    expect(testing.cases).toContainEqual(
+      expect.objectContaining({
+        id: "pluginsList",
+        args: ["openclaw.mjs", "plugins", "list", "--json"],
+      }),
+    );
+  });
+
   it("keeps invalid startup memory env values from bypassing budgets", () => {
     expect(() =>
       testing.readPositiveNumberEnv("OPENCLAW_STARTUP_MEMORY_HELP_MB", 100, {
@@ -188,8 +199,8 @@ describe("check-cli-startup-memory", () => {
         },
       ),
     ).toThrow("--help timed out after 1234ms");
-    expect(seenTimeouts).toEqual([1234, 1234, 1234]);
-    expect(seenKillSignals).toEqual(["SIGKILL", "SIGKILL", "SIGKILL"]);
+    expect(seenTimeouts).toEqual(testing.cases.map(() => 1234));
+    expect(seenKillSignals).toEqual(testing.cases.map(() => "SIGKILL"));
   });
 
   it("rejects zero RSS markers instead of passing empty resource evidence", () => {


### PR DESCRIPTION
# What Problem This Solves

Final tier-1 backports for the 2026.7.1 stable cut, targeting the release's own headline surfaces:

- The startup-migration failure domain (the beta.5 release blocker family): a migration process exiting without releasing its lease blocks subsequent startups — the same restart-loop shape sallyom reported. #103157 completes the migration-hang cluster already on this branch.
- Discord sessions silently wedging after a failed gateway resume ("tool wedges and gateway quirks" in today's guild field report).
- With GPT-5.6 now the fresh-setup default and its completions-transport fix on this branch, OpenAI chat-completions refusals surfaced as raw errors instead of readable assistant text.

# Why This Change Was Made

Exact `-x` cherry-picks in dependency order (all patch-id-identical to their reviewed `main` originals except the two noted CHANGELOG skips):

- `3fd52514e35f` fix: surface OpenAI chat-completions refusal as assistant text (#102344)
- `a1ce77d2a9d2` fix(cli): reduce plugin listing startup memory (#103132) — prerequisite: owns the plugin-listing config-guard behavior #103157 refines; without it the branch's config-guard tests contradict the new prod behavior (verified by a failing Testbox run before including it)
- `53378459cd11` fix: release startup migration lease before exit (#103157) — CHANGELOG hunk skipped (release generation owns it)
- `abbd5ae3ea73` fix(discord): recover from failed gateway resumes (#103596)

# User Impact

Startup migrations can no longer strand a lease and block the next start; Discord channels recover instead of going quiet after failed resumes; `plugins list` starts leaner; OpenAI completions refusals render as assistant text.

# Evidence

- All four commits merged on `main` with green CI; picks verified patch-id-identical (modulo skipped CHANGELOG hunks).
- Targeted Blacksmith Testbox runs on this exact head over every touched suite (`extensions/discord/src/internal/gateway.test.ts`, `packages/ai/src/providers/openai-completions.test.ts`, `src/agents/openai-transport-stream.test.ts`, `src/cli/program/config-guard.test.ts`, `src/cli/run-main.exit.test.ts`, `src/commands/doctor-config-preflight.state-migration.test.ts`, `src/cli/plugins-cli.list.test.ts`, `test/scripts/check-cli-startup-memory.test.ts`): 560 tests passed, `exit=0` (lease `tbx_01kx9rtk04cx8p67pj8rrjc9at`).
