### PR TITLE
fix(sessions): read zstd transcript archives through a materialized cache

### DIFF
--- a/src/config/sessions/archive-compression.test.ts
+++ b/src/config/sessions/archive-compression.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   encodeSessionArchiveContent,
+  materializeSessionArchiveForRead,
   readSessionArchiveContentSync,
   SESSION_ARCHIVE_ZSTD_SUFFIX,
   stripSessionArchiveCompressionSuffix,
@@ -52,6 +53,29 @@ describe("archive compression", () => {
     fs.writeFileSync(archivePath, "plain\n", "utf8");
 
     expect(readSessionArchiveContentSync(archivePath)).toBe("plain\n");
+  });
+
+  it("materializes compressed archives to a stable plain JSONL cache path", () => {
+    const content = `${JSON.stringify({ type: "message", body: "cold" })}\n`;
+    const encoded = encodeSessionArchiveContent(content);
+    const dir = makeTempDir();
+    const archivePath = path.join(
+      dir,
+      `sess.jsonl.deleted.2026-07-11T00-00-00.000Z${encoded.suffix}`,
+    );
+    fs.writeFileSync(archivePath, encoded.bytes);
+
+    const first = materializeSessionArchiveForRead(archivePath);
+    const second = materializeSessionArchiveForRead(archivePath);
+
+    expect(second).toBe(first);
+    expect(fs.readFileSync(first, "utf8")).toBe(content);
+    if (encoded.suffix === "") {
+      // Plain archives pass through untouched.
+      expect(first).toBe(archivePath);
+    } else {
+      expect(first.endsWith(".jsonl")).toBe(true);
+    }
   });
 
   it("strips the zstd suffix so archive name parsers see one shape", () => {

--- a/src/config/sessions/archive-compression.ts
+++ b/src/config/sessions/archive-compression.ts
@@ -1,8 +1,11 @@
 // Zstd compression for archived transcript artifacts (Codex-style cold tier).
 // Archives are kept long-term by default, so compressing them is what keeps
 // "never delete conversations" cheap: JSONL transcripts compress ~10:1.
+import { createHash } from "node:crypto";
 import fs from "node:fs";
+import path from "node:path";
 import zlib from "node:zlib";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 
 export const SESSION_ARCHIVE_ZSTD_SUFFIX = ".zst";
 
@@ -65,4 +68,29 @@ export function readSessionArchiveContentSync(filePath: string): string {
     );
   }
   return zstdCodec.decompress(fs.readFileSync(filePath)).toString("utf8");
+}
+
+/**
+ * Materializes a compressed archive as a plain JSONL cache file and returns
+ * the readable path; plain archives pass through untouched. Archives are
+ * write-once (timestamped names), so a cache hit never needs revalidation —
+ * this lets every downstream transcript reader (index, tail chunks, header
+ * probes) work on archives without learning about compression.
+ */
+export function materializeSessionArchiveForRead(filePath: string): string {
+  if (!filePath.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX)) {
+    return filePath;
+  }
+  const cacheDir = path.join(resolvePreferredOpenClawTmpDir(), "session-archive-read-cache");
+  const cacheName = `${createHash("sha256").update(filePath).digest("hex").slice(0, 32)}.jsonl`;
+  const cachePath = path.join(cacheDir, cacheName);
+  if (fs.existsSync(cachePath)) {
+    return cachePath;
+  }
+  const content = readSessionArchiveContentSync(filePath);
+  fs.mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
+  const tempPath = `${cachePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempPath, content, { encoding: "utf8", mode: 0o600 });
+  fs.renameSync(tempPath, cachePath);
+  return cachePath;
 }

--- a/src/config/sessions/archive-compression.ts
+++ b/src/config/sessions/archive-compression.ts
@@ -1,7 +1,7 @@
 // Zstd compression for archived transcript artifacts (Codex-style cold tier).
 // Archives are kept long-term by default, so compressing them is what keeps
 // "never delete conversations" cheap: JSONL transcripts compress ~10:1.
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import zlib from "node:zlib";
@@ -96,19 +96,33 @@ export function materializeSessionArchiveForRead(filePath: string): string {
     cacheDir,
     `${pathKey}-${sourceStat.size}-${Math.trunc(sourceStat.mtimeMs)}.jsonl`,
   );
+  sweepMaterializedArchiveCache(cacheDir);
   if (fs.existsSync(cachePath)) {
     return cachePath;
   }
   const content = readSessionArchiveContentSync(filePath);
-  removeMaterializedArchiveCacheEntries(cacheDir, pathKey);
+  removeMaterializedArchiveCacheEntries(cacheDir, pathKey, path.basename(cachePath));
   fs.mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
-  const tempPath = `${cachePath}.${process.pid}.tmp`;
+  const tempPath = `${cachePath}.${process.pid}.${randomUUID()}.tmp`;
   fs.writeFileSync(tempPath, content, { encoding: "utf8", mode: 0o600 });
+  // Concurrent readers may race to the same identity; last rename wins with
+  // identical content, so neither can observe a torn or missing cache file.
   fs.renameSync(tempPath, cachePath);
   return cachePath;
 }
 
-function removeMaterializedArchiveCacheEntries(cacheDir: string, pathKey: string): void {
+// Bounded plaintext exposure: cache entries expire on age so archives deleted
+// by budget eviction cannot leave decompressed copies behind indefinitely,
+// and the cache itself cannot outgrow the archives it mirrors for long.
+const MATERIALIZED_ARCHIVE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+let lastMaterializedArchiveCacheSweepMs = 0;
+
+function sweepMaterializedArchiveCache(cacheDir: string): void {
+  const now = Date.now();
+  if (now - lastMaterializedArchiveCacheSweepMs < MATERIALIZED_ARCHIVE_CACHE_TTL_MS / 24) {
+    return;
+  }
+  lastMaterializedArchiveCacheSweepMs = now;
   let entries: string[];
   try {
     entries = fs.readdirSync(cacheDir);
@@ -116,8 +130,35 @@ function removeMaterializedArchiveCacheEntries(cacheDir: string, pathKey: string
     return;
   }
   for (const entry of entries) {
-    if (entry.startsWith(`${pathKey}-`)) {
-      fs.rmSync(path.join(cacheDir, entry), { force: true });
+    const entryPath = path.join(cacheDir, entry);
+    try {
+      if (now - fs.statSync(entryPath).mtimeMs > MATERIALIZED_ARCHIVE_CACHE_TTL_MS) {
+        fs.rmSync(entryPath, { force: true });
+      }
+    } catch {
+      // Another sweep may have removed it first; nothing to do.
     }
+  }
+}
+
+// Scrubs stale identities for one archive path while leaving the current
+// identity and any in-flight temp files (unique per writer) untouched, so
+// concurrent readers can never delete each other's live materialization.
+function removeMaterializedArchiveCacheEntries(
+  cacheDir: string,
+  pathKey: string,
+  keepName?: string,
+): void {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(cacheDir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.startsWith(`${pathKey}-`) || entry === keepName || entry.endsWith(".tmp")) {
+      continue;
+    }
+    fs.rmSync(path.join(cacheDir, entry), { force: true });
   }
 }

--- a/src/config/sessions/archive-compression.ts
+++ b/src/config/sessions/archive-compression.ts
@@ -82,15 +82,39 @@ export function materializeSessionArchiveForRead(filePath: string): string {
     return filePath;
   }
   const cacheDir = path.join(resolvePreferredOpenClawTmpDir(), "session-archive-read-cache");
-  const cacheName = `${createHash("sha256").update(filePath).digest("hex").slice(0, 32)}.jsonl`;
-  const cachePath = path.join(cacheDir, cacheName);
+  const pathKey = createHash("sha256").update(filePath).digest("hex").slice(0, 32);
+  // Source identity gates every hit: a deleted or replaced archive must never
+  // keep serving plaintext from the cache (budget eviction deletes archives).
+  let sourceStat: fs.Stats;
+  try {
+    sourceStat = fs.statSync(filePath);
+  } catch (error) {
+    removeMaterializedArchiveCacheEntries(cacheDir, pathKey);
+    throw error;
+  }
+  const cachePath = path.join(cacheDir, `${pathKey}-${sourceStat.size}.jsonl`);
   if (fs.existsSync(cachePath)) {
     return cachePath;
   }
   const content = readSessionArchiveContentSync(filePath);
+  removeMaterializedArchiveCacheEntries(cacheDir, pathKey);
   fs.mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
   const tempPath = `${cachePath}.${process.pid}.tmp`;
   fs.writeFileSync(tempPath, content, { encoding: "utf8", mode: 0o600 });
   fs.renameSync(tempPath, cachePath);
   return cachePath;
+}
+
+function removeMaterializedArchiveCacheEntries(cacheDir: string, pathKey: string): void {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(cacheDir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.startsWith(`${pathKey}-`)) {
+      fs.rmSync(path.join(cacheDir, entry), { force: true });
+    }
+  }
 }

--- a/src/config/sessions/archive-compression.ts
+++ b/src/config/sessions/archive-compression.ts
@@ -92,7 +92,10 @@ export function materializeSessionArchiveForRead(filePath: string): string {
     removeMaterializedArchiveCacheEntries(cacheDir, pathKey);
     throw error;
   }
-  const cachePath = path.join(cacheDir, `${pathKey}-${sourceStat.size}.jsonl`);
+  const cachePath = path.join(
+    cacheDir,
+    `${pathKey}-${sourceStat.size}-${Math.trunc(sourceStat.mtimeMs)}.jsonl`,
+  );
   if (fs.existsSync(cachePath)) {
     return cachePath;
   }

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -184,7 +184,7 @@ async function resetArchiveHeaderMatchesSessionId(
   // Compressed archives must be probed through the materialized JSONL cache:
   // a raw prefix read of zstd bytes never matches a session header, which
   // would silently drop every compressed archive from fallback history.
-  let probePath = archivePath;
+  let probePath: string;
   try {
     probePath = materializeSessionArchiveForRead(archivePath);
   } catch {

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { materializeSessionArchiveForRead } from "../config/sessions/archive-compression.js";
 import {
   formatSessionArchiveTimestamp,
   parseSessionArchiveTimestamp,
@@ -180,7 +181,16 @@ async function resetArchiveHeaderMatchesSessionId(
   sessionId: string,
   archivePath: string,
 ): Promise<boolean> {
-  const stat = await fs.promises.stat(archivePath).catch(() => null);
+  // Compressed archives must be probed through the materialized JSONL cache:
+  // a raw prefix read of zstd bytes never matches a session header, which
+  // would silently drop every compressed archive from fallback history.
+  let probePath = archivePath;
+  try {
+    probePath = materializeSessionArchiveForRead(archivePath);
+  } catch {
+    return false;
+  }
+  const stat = await fs.promises.stat(probePath).catch(() => null);
   if (!stat?.isFile()) {
     return false;
   }
@@ -193,7 +203,7 @@ async function resetArchiveHeaderMatchesSessionId(
   }
 
   let matches = false;
-  const handle = await fs.promises.open(archivePath, "r").catch(() => null);
+  const handle = await fs.promises.open(probePath, "r").catch(() => null);
   if (!handle) {
     return false;
   }

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -13,6 +13,7 @@ import {
   normalizeUsage,
   type ContextUsage,
 } from "../agents/usage.js";
+import { materializeSessionArchiveForRead } from "../config/sessions/archive-compression.js";
 import {
   scanSessionTranscriptTree,
   selectSessionTranscriptTreePathNodes,
@@ -1236,7 +1237,14 @@ async function findExistingTranscriptHistoryPathAsync(
           return refreshedActivePath;
         }
       }
-      return archivePath;
+      // Compressed archives materialize to a plain JSONL cache once (archives
+      // are write-once) so every downstream reader — index, tail chunks,
+      // header probes — keeps working without knowing about zstd.
+      try {
+        return materializeSessionArchiveForRead(archivePath);
+      } catch {
+        continue;
+      }
     }
   }
   return null;

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -9,7 +9,7 @@ import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import {
-  readSessionArchiveContentSync,
+  materializeSessionArchiveForRead,
   SESSION_ARCHIVE_ZSTD_SUFFIX,
 } from "../config/sessions/archive-compression.js";
 import {
@@ -1388,35 +1388,15 @@ async function* readTranscriptRecords(
     }
     return;
   }
-  // Compressed archives cannot be byte-range streamed; decompress and parse
-  // whole (archives are cold, budget-bounded artifacts). Without this branch
-  // zstd archives parse as malformed lines and silently count zero usage.
+  // Compressed archives read through the materialized plain-JSONL cache so
+  // startOffset/endOffset keep their byte semantics against decompressed
+  // content — incremental scans persist offsets per path, and mixing raw
+  // zstd bytes with plain offsets would overcount archived usage.
   if (filePath.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX)) {
-    for (const record of parseJsonlObjects(readSessionArchiveContentSync(filePath))) {
-      yield record;
-    }
+    yield* readJsonlRecords(materializeSessionArchiveForRead(filePath), startOffset, endOffset);
     return;
   }
   yield* readJsonlRecords(filePath, startOffset, endOffset);
-}
-
-function parseJsonlObjects(content: string): Record<string, unknown>[] {
-  const records: Record<string, unknown>[] = [];
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) {
-      continue;
-    }
-    try {
-      const parsed = JSON.parse(trimmed) as unknown;
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        records.push(parsed as Record<string, unknown>);
-      }
-    } catch {
-      // Ignore malformed lines, matching the streaming reader's tolerance.
-    }
-  }
-  return records;
 }
 
 async function* readTranscriptRecordsBestEffort(

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -419,6 +419,23 @@ async function listUsageCountedTranscriptFileStats(
       if (params?.minMtimeMs !== undefined && stats.mtimeMs < params.minMtimeMs) {
         return undefined;
       }
+      // Compressed archives normalize to their materialized plain-JSONL cache
+      // at discovery, so every downstream size, incremental offset, and cache
+      // signature measures decompressed bytes; mixing offset spaces would
+      // truncate or overcount archived usage.
+      if (filePath.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX)) {
+        try {
+          const materialized = materializeSessionArchiveForRead(filePath);
+          const materializedStats = await fs.promises.stat(materialized);
+          return {
+            filePath: materialized,
+            size: materializedStats.size,
+            mtimeMs: stats.mtimeMs,
+          };
+        } catch {
+          return undefined;
+        }
+      }
       return { filePath, size: stats.size, mtimeMs: stats.mtimeMs };
     });
   const { results } = await runTasksWithConcurrency({
@@ -503,6 +520,19 @@ async function resolveUsageCostTranscriptFile(
       sessionId: marker.sessionId,
       size: stats.sizeBytes,
     };
+  }
+  if (sessionFile.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX)) {
+    try {
+      const materialized = materializeSessionArchiveForRead(sessionFile);
+      const materializedStats = await fs.promises.stat(materialized);
+      return {
+        filePath: materialized,
+        size: materializedStats.size,
+        mtimeMs: materializedStats.mtimeMs,
+      };
+    } catch {
+      return undefined;
+    }
   }
   const stats = await fs.promises.stat(sessionFile).catch(() => null);
   return stats ? { filePath: sessionFile, size: stats.size, mtimeMs: stats.mtimeMs } : undefined;
@@ -1388,10 +1418,9 @@ async function* readTranscriptRecords(
     }
     return;
   }
-  // Compressed archives read through the materialized plain-JSONL cache so
-  // startOffset/endOffset keep their byte semantics against decompressed
-  // content — incremental scans persist offsets per path, and mixing raw
-  // zstd bytes with plain offsets would overcount archived usage.
+  // Discovery normalizes compressed archives to their materialized cache, so
+  // this branch only serves direct callers that pass a raw .zst path; those
+  // callers never carry persisted offsets, keeping the range space coherent.
   if (filePath.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX)) {
     yield* readJsonlRecords(materializeSessionArchiveForRead(filePath), startOffset, endOffset);
     return;

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -9,6 +9,10 @@ import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import {
+  readSessionArchiveContentSync,
+  SESSION_ARCHIVE_ZSTD_SUFFIX,
+} from "../config/sessions/archive-compression.js";
+import {
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
@@ -1384,7 +1388,35 @@ async function* readTranscriptRecords(
     }
     return;
   }
+  // Compressed archives cannot be byte-range streamed; decompress and parse
+  // whole (archives are cold, budget-bounded artifacts). Without this branch
+  // zstd archives parse as malformed lines and silently count zero usage.
+  if (filePath.endsWith(SESSION_ARCHIVE_ZSTD_SUFFIX)) {
+    for (const record of parseJsonlObjects(readSessionArchiveContentSync(filePath))) {
+      yield record;
+    }
+    return;
+  }
   yield* readJsonlRecords(filePath, startOffset, endOffset);
+}
+
+function parseJsonlObjects(content: string): Record<string, unknown>[] {
+  const records: Record<string, unknown>[] = [];
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        records.push(parsed as Record<string, unknown>);
+      }
+    } catch {
+      // Ignore malformed lines, matching the streaming reader's tolerance.
+    }
+  }
+  return records;
 }
 
 async function* readTranscriptRecordsBestEffort(


### PR DESCRIPTION
## What Problem This Solves

Post-flip audit (during the #98236 close-out sweeps) found that zstd-compressed transcript archives were discovered but unreadable: the reset-archive header probe read raw zstd bytes and every JSONL reader parsed compressed content as malformed lines, so compressed archives silently contributed zero fallback history and zero usage/cost.

## Why This Change Was Made

Applies the materialize-for-read pattern (as Codex uses for compressed rollouts): a compressed archive materializes once into a plain-JSONL cache under the OpenClaw tmp dir (archives are write-once), and every downstream reader — transcript index, tail chunks, header probes, usage scans — works unchanged on the materialized path. Usage discovery normalizes `.zst` entries to the materialized path and decompressed size so incremental offsets, sizes, and cache signatures all measure one offset space. The cache is identity-gated (source path hash + size + mtime), TTL-swept (24h) so budget-evicted archives cannot leave plaintext copies behind, and concurrency-safe (unique temp names, last-rename-wins, scrub never touches the live identity or in-flight temps).

## User Impact

Archived conversations (reset/deleted sessions) are readable again in history fallback and counted again in usage/cost on installs with zstd-capable runtimes. No config changes.

## Evidence

- `node scripts/run-vitest.mjs src/config/sessions/archive-compression.test.ts src/infra/session-cost-usage.test.ts src/gateway/session-transcript-files.fs.archive-cleanup.test.ts src/gateway/session-transcript-files.fs.archive-events.test.ts` — all pass, including a new materialize round-trip/idempotency test.
- Production typecheck clean.
- Codex autoreview (gpt-5.5, xhigh): five findings across four review rounds (range semantics, offset-space mismatch, deletion lifecycle, replacement aliasing, concurrent scrub races) — each fixed in its own commit; final branch review clean.
