### PR TITLE
fix(microsoft-foundry): reject malformed endpoints

### DIFF
--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -18,6 +18,7 @@ import {
   COGNITIVE_SERVICES_RESOURCE,
   FOUNDRY_ANTHROPIC_SCOPE,
   buildFoundryAuthResult,
+  extractFoundryEndpoint,
   formatFoundryApiLabel,
   isAnthropicFoundryDeployment,
   isFoundryMaiImageModel,
@@ -468,6 +469,28 @@ describe("microsoft-foundry plugin", () => {
     expect(execFileMock.mock.calls[0]?.[1]).toEqual(
       expect.arrayContaining(["--resource", COGNITIVE_SERVICES_RESOURCE]),
     );
+  });
+
+  it("falls back to Entra metadata when a configured Foundry endpoint is malformed", async () => {
+    const provider = registerProvider();
+    const prepareRuntimeAuth = requirePrepareRuntimeAuth(provider);
+    mockAzureCliToken({ accessToken: "test-token", expiresInMs: 60_000 });
+    ensureAuthProfileStoreMock.mockReturnValueOnce(buildEntraProfileStore());
+
+    const prepared = requireRuntimeAuthResult(
+      await prepareRuntimeAuth(
+        buildFoundryRuntimeAuthContext({
+          model: buildFoundryModel({ baseUrl: "not a url" }),
+        }),
+      ),
+    );
+
+    expect(extractFoundryEndpoint("not a url")).toBeUndefined();
+    expect(prepared.baseUrl).toBe("https://example.services.ai.azure.com/openai/v1");
+    expect(prepared.request?.auth).toEqual({
+      mode: "authorization-bearer",
+      token: "test-token",
+    });
   });
 
   it.each([

--- a/extensions/microsoft-foundry/shared.ts
+++ b/extensions/microsoft-foundry/shared.ts
@@ -397,11 +397,16 @@ export function buildFoundryProviderBaseUrl(
 }
 
 export function extractFoundryEndpoint(baseUrl: string | null | undefined): string | undefined {
-  if (!baseUrl) {
+  const trimmed = normalizeOptionalString(baseUrl);
+  if (!trimmed) {
     return undefined;
   }
   try {
-    return normalizeFoundryEndpoint(baseUrl);
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return undefined;
+    }
+    return normalizeFoundryEndpoint(trimmed) || undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Malformed Microsoft Foundry base URLs could be treated as usable endpoints. `extractFoundryEndpoint()` called `normalizeFoundryEndpoint()` directly, and the fallback normalization path returned a trimmed string even when `new URL(...)` could not parse the value.

## Why This Change Was Made

Runtime endpoint extraction should only accept real HTTP(S) URLs. When a configured model endpoint is malformed, the provider should ignore that unusable value and continue to the existing metadata or environment fallback path instead of building provider URLs from invalid text.

## User Impact

Users with stale or malformed Foundry model base URLs can still recover through valid Entra profile metadata or endpoint fallback sources. Invalid configured endpoint strings no longer block a working Foundry configuration from being used.

## Evidence

The regression test covers a model with `baseUrl: "not a url"` and valid Entra profile metadata. Before this change, endpoint extraction treated the malformed string as present; after this change it returns `undefined` and runtime auth builds the base URL from the metadata endpoint.

## Proof

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-foundry-endpoint node scripts/run-vitest.mjs extensions/microsoft-foundry/index.test.ts`
- `node_modules/.bin/oxfmt --check extensions/microsoft-foundry/shared.ts extensions/microsoft-foundry/index.test.ts`
- `node_modules/.bin/oxlint extensions/microsoft-foundry/shared.ts extensions/microsoft-foundry/index.test.ts`
- `git diff --check upstream/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine claude`
