### PR TITLE
fix(ci): block source imports in Docker E2E harnesses

### DIFF
--- a/scripts/run-additional-boundary-checks.mjs
+++ b/scripts/run-additional-boundary-checks.mjs
@@ -16,6 +16,7 @@ const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
 export const BOUNDARY_CHECKS = [
   ["prompt:snapshots:check", "pnpm", ["prompt:snapshots:check"]],
   ["plugin-extension-boundary", "pnpm", ["run", "lint:plugins:no-extension-imports"]],
+  ["lint:docker-e2e", "pnpm", ["run", "lint:docker-e2e"]],
   ["lint:tmp:no-random-messaging", "pnpm", ["run", "lint:tmp:no-random-messaging"]],
   ["lint:tmp:channel-agnostic-boundaries", "pnpm", ["run", "lint:tmp:channel-agnostic-boundaries"]],
   ["lint:tmp:tsgo-core-boundary", "pnpm", ["run", "lint:tmp:tsgo-core-boundary"]],

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -213,6 +213,14 @@ describe("run-additional-boundary-checks", () => {
     });
   });
 
+  it("keeps the Docker E2E package guard in CI boundary checks", () => {
+    expect(BOUNDARY_CHECKS).toContainEqual({
+      label: "lint:docker-e2e",
+      command: "pnpm",
+      args: ["run", "lint:docker-e2e"],
+    });
+  });
+
   it("keeps the Telegram grammY type import guard in source boundary checks", () => {
     expect(BOUNDARY_CHECKS).toContainEqual({
       label: "lint:extensions:telegram-grammy-types",


### PR DESCRIPTION
Related: #98236
Related: #104784

## What Problem This Solves

Fixes an operational CI gap where a Docker E2E harness could import the source checkout even though `lint:docker-e2e` forbids that package-boundary violation. The SQLite flip proof introduced in #98236 demonstrated the gap: its dedicated proof and the existing additional-boundary shards passed while the standalone guard failed.

## Why This Change Was Made

Registers the existing `lint:docker-e2e` command with the additional boundary-check runner used by CI, and adds a focused assertion that keeps the exact command in that aggregate. #104784 already reclassified the source-only SQLite probe under `test/helpers`; this change prevents a future `scripts/e2e` violation from bypassing CI.

## User Impact

No user-visible runtime change. Maintainers now get a blocking CI failure when a Docker E2E package harness reaches into `src` instead of testing the packaged surface.

## Evidence

- `node scripts/check-docker-e2e-boundaries.mjs` — passed
- `pnpm test test/scripts/run-additional-boundary-checks.test.ts` — 16/16 passed
- `pnpm check:changed` — passed, including formatting, test-root typecheck, Docker E2E guard, raw HTTP/2 guard, and targeted script lint
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts` — passed in 49.47s after #104784's reclassification
- Blacksmith Testbox: `tbx_01kx9s1v6je5fttt3r176zkvkf`
- Fresh autoreview: clean, no accepted/actionable findings
