### PR TITLE
fix(security): keep secret mask from splitting UTF-16 surrogate pairs

### DIFF
--- a/src/security/secret-mask.test.ts
+++ b/src/security/secret-mask.test.ts
@@ -21,8 +21,21 @@ describe("maskApiKey", () => {
     expect(maskApiKey("\u0000\n")).toBe("missing");
   });
 
-  it("preserves the existing UTF-16 code-unit slicing contract", () => {
-    expect(maskApiKey("😀")).toBe("\ud83d...\ude00");
+  it("does not split UTF-16 surrogate pairs at mask boundaries", () => {
+    // Short values: when the only characters are astral, both edges are dropped
+    // rather than emitting isolated surrogate halves.
+    expect(maskApiKey("😀")).toBe("...");
+    expect(maskApiKey("😀ab")).toBe("...b");
+    expect(maskApiKey("ab😀")).toBe("a...");
+    expect(maskApiKey("a😀b")).toBe("a...b");
+
+    // Long values keep their prefix/suffix when the 8-code-unit boundary lands
+    // in the middle of a surrogate pair.
+    const long = "😀".repeat(3) + "a😀" + "b".repeat(10);
+    const masked = maskApiKey(long);
+    expect(() => encodeURIComponent(masked)).not.toThrow();
+    expect(masked).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(masked).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
     expect(maskApiKey("😀abcdefghijklmno😀")).toBe("😀abcdef...jklmno😀");
   });
 });

--- a/src/security/secret-mask.ts
+++ b/src/security/secret-mask.ts
@@ -1,16 +1,18 @@
-/** Masks credential-like values while preserving the existing UTF-16 prefix/suffix policy. */
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
+/** Masks credential-like values without splitting UTF-16 surrogate pairs at the edges. */
 export function maskApiKey(value: string): string {
   const trimmed = stripControlCharacters(value).trim();
   if (!trimmed) {
     return "missing";
   }
   if (trimmed.length <= 6) {
-    return `${trimmed.slice(0, 1)}...${trimmed.slice(-1)}`;
+    return `${sliceUtf16Safe(trimmed, 0, 1)}...${sliceUtf16Safe(trimmed, -1)}`;
   }
   if (trimmed.length <= 16) {
-    return `${trimmed.slice(0, 2)}...${trimmed.slice(-2)}`;
+    return `${sliceUtf16Safe(trimmed, 0, 2)}...${sliceUtf16Safe(trimmed, -2)}`;
   }
-  return `${trimmed.slice(0, 8)}...${trimmed.slice(-8)}`;
+  return `${sliceUtf16Safe(trimmed, 0, 8)}...${sliceUtf16Safe(trimmed, -8)}`;
 }
 
 function stripControlCharacters(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where masking a credential-like value that contains astral characters (e.g., emoji) could produce isolated UTF-16 surrogate halves at the head or tail of the masked preview.

## Why This Change Was Made

`maskApiKey` sliced its prefix/suffix with raw `String.prototype.slice`, which can bisect surrogate pairs. It now uses the repository's existing `sliceUtf16Safe` helper so the visible prefix and suffix always fall on safe UTF-16 boundaries. The change is scoped to the secret mask function and its existing test.

## User Impact

Credential previews shown in setup prompts and status output remain readable and well-formed when the underlying value contains non-BMP characters.

## Evidence

- Added regression tests in `src/security/secret-mask.test.ts` that assert no lone surrogates are emitted for short and long astral inputs.
- Existing ASCII masking cases remain unchanged.

## Real behavior proof

- **Behavior addressed:** Before the patch, `maskApiKey("😀")` returned `"\ud83d...\ude00"` (two isolated surrogate halves). After the patch it returns `"..."`, and `maskApiKey("😀abcdefghijklmno😀")` still returns `"😀abcdef...jklmno😀"`.
- **Real environment tested:** Local checkout of `fix/secret-mask-utf16-boundaries` at `a6df5a1bd419cc9da7ddeca214de3e7c2ae3223a`.
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx -e 'import { maskApiKey } from "./src/security/secret-mask.ts"; for (const v of ["😀", "😀abcdefghijklmno😀", "1234567890abcdefghijklmnop"]) console.log(JSON.stringify(maskApiKey(v)));'
  ```
  And to verify the masked astral value survives a real disk round-trip without corrupting:
  ```bash
  node --import tsx -e 'import { maskApiKey } from "./src/security/secret-mask.ts"; import { writeFileSync, readFileSync, mkdtempSync } from "node:fs"; import { tmpdir } from "node:os"; import { join } from "node:path"; const f = join(mkdtempSync(join(tmpdir(), "sm-")), "m.txt"); const m = maskApiKey("😀abcdefghijklmno😀"); writeFileSync(f, m, "utf8"); const r = readFileSync(f, "utf8"); console.log(JSON.stringify(r)); console.log("round-trip ok:", r === m);'
  ```
- **Evidence after fix:**
  ```
  "..."
  "😀abcdef...jklmno😀"
  "12345678...ijklmnop"

  "😀abcdef...jklmno😀"
  round-trip ok: true
  ```
- **Observed result after fix:** The regression test `does not split UTF-16 surrogate pairs at mask boundaries` passes, `encodeURIComponent(masked)` does not throw, and the masked value survives a disk write/read round-trip without corrupting astral characters.
- **What was not tested:** No runtime provider/channel integration; change is a pure string-formatting helper.

_AI-assisted PR: changes and tests were generated with AI assistance and manually reviewed._
