### PR TITLE
ci: allow frozen UI fixture headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1051,9 +1051,9 @@ jobs:
         run: |
           if [[ "$COMPATIBILITY_TARGET" == "true" ]]; then
             # Frozen targets can contain timing-sensitive tests fixed on current main.
-            # Let their browser helpers use their 10-second waits. Do not retry whole
-            # legacy files: several rely on one-shot mocked browser globals.
-            pnpm --dir ui test --testTimeout=10000
+            # Give legacy browser fixtures enough headroom on shared hosted runners.
+            # Do not retry whole files: several rely on one-shot mocked browser globals.
+            pnpm --dir ui test --testTimeout=30000
           else
             pnpm --dir ui test
           fi

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1875,7 +1875,7 @@ describe("ci workflow guards", () => {
       "${{ needs.preflight.outputs.compatibility_target }}",
     );
     expect(uiTest.run).toContain('if [[ "$COMPATIBILITY_TARGET" == "true" ]]');
-    expect(uiTest.run).toContain("pnpm --dir ui test --testTimeout=10000");
+    expect(uiTest.run).toContain("pnpm --dir ui test --testTimeout=30000");
     expect(uiTest.run).not.toContain("--retry");
     expect(uiTest.run).toContain("pnpm --dir ui test");
   });


### PR DESCRIPTION
## What Problem This Solves

After removing unsafe whole-file retries, six LTS browser-layout tests still exceeded the 10-second compatibility budget on shared hosted runners. Their aborted fixtures then contaminated browser globals used by later node tests, creating downstream failures.

## Why This Change Was Made

Raise only authenticated frozen-target UI validation to a 30-second test timeout. Keep retries disabled and keep all assertions enabled. Current-main UI validation remains strict and unchanged.

## User Impact

No runtime behavior changes. Frozen beta, July, and LTS browser fixtures receive enough hosted-runner headroom without skipping tests or masking deterministic assertion failures.

## Evidence

- LTS timeout failure: https://github.com/openclaw/openclaw/actions/runs/29172868096/job/86596816628
- Blacksmith Testbox `tbx_01kx9t8r3c60g7bfh3w3e0q6en`: workflow guards 51/51 passed.
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Fresh autoreview: clean, correctness confidence 0.98.
