### PR TITLE
fix(ui): unify sidebar sessions into one scrollable list

### DIFF
--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -338,6 +338,38 @@ describe("AppSidebar session catalog pagination", () => {
     ],
   });
 
+  it("renders catalog groups inside the shared sessions scroller", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi
+        .fn()
+        .mockResolvedValue(catalogPage([{ threadId: "thread-1", name: "Newest" }]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      // One scroll region: catalog groups live inside the sessions scroller.
+      // Sibling scroll-less sections flex-squeeze and paint over each other.
+      expect(
+        sidebar.querySelector('.sidebar-recent-sessions [data-session-section="catalog:codex"]'),
+      ).not.toBeNull();
+      expect(sidebar.querySelectorAll(".sidebar-sessions")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("appends host pages and keeps them through the next poll refresh", async () => {
     vi.useFakeTimers();
     try {

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -2482,12 +2482,16 @@ class AppSidebar extends OpenClawLightDomContentsElement {
                 showDraft: Boolean(this.draftSessionAgentId),
                 showFallback: true,
               })}
+          ${this.renderSessionCatalogs()}
         </div>
       </section>
-      ${this.renderSessionCatalogs()}
     `;
   }
 
+  // Catalog groups render inside the shared sessions scroller. Sibling
+  // .sidebar-sessions sections would form a second scroll-less region that
+  // flex-squeezes under the shell body's overflow clip and paints rows over
+  // the following section.
   private renderSessionCatalogs() {
     return this.sessionCatalogs.map((catalog) => {
       const sectionId = `catalog:${catalog.id}`;
@@ -2497,44 +2501,42 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       const loadingMore = this.loadingMoreSessionCatalogIds.has(catalog.id);
       const hasMore = hosts.some((host) => Boolean(host.nextCursor));
       return html`
-        <section class="sidebar-sessions">
-          <div class="sidebar-recent-sessions__group" data-session-section=${sectionId}>
-            <div class="sidebar-recent-sessions__head">
-              <button
-                type="button"
-                class="sidebar-session-group-toggle"
-                aria-expanded=${String(!collapsed)}
-                aria-label=${catalog.label}
-                @click=${() => this.toggleSessionSection(sectionId)}
+        <div class="sidebar-recent-sessions__group" data-session-section=${sectionId}>
+          <div class="sidebar-recent-sessions__head">
+            <button
+              type="button"
+              class="sidebar-session-group-toggle"
+              aria-expanded=${String(!collapsed)}
+              aria-label=${catalog.label}
+              @click=${() => this.toggleSessionSection(sectionId)}
+            >
+              <span class="sidebar-session-group-toggle__icon" aria-hidden="true"
+                >${collapsed ? icons.chevronRight : icons.chevronDown}</span
               >
-                <span class="sidebar-session-group-toggle__icon" aria-hidden="true"
-                  >${collapsed ? icons.chevronRight : icons.chevronDown}</span
-                >
-                <span class="sidebar-recent-sessions__label-text">${catalog.label}</span>
-                <span class="sidebar-session-group-count">${rows.length}</span>
-              </button>
-            </div>
-            ${collapsed
-              ? nothing
-              : html`<div class="sidebar-recent-sessions__list">
-                    ${rows.map(({ host, session }) =>
-                      this.renderCatalogSession(catalog, host, session),
-                    )}
-                  </div>
-                  ${hasMore
-                    ? html`<button
-                        type="button"
-                        class="sidebar-session-catalog-load-more"
-                        data-session-catalog-load-more=${catalog.id}
-                        ?disabled=${loadingMore}
-                        aria-busy=${String(loadingMore)}
-                        @click=${() => void this.loadMoreSessionCatalog(catalog.id)}
-                      >
-                        ${t("chat.selectors.loadMoreSessions")}
-                      </button>`
-                    : nothing}`}
+              <span class="sidebar-recent-sessions__label-text">${catalog.label}</span>
+              <span class="sidebar-session-group-count">${rows.length}</span>
+            </button>
           </div>
-        </section>
+          ${collapsed
+            ? nothing
+            : html`<div class="sidebar-recent-sessions__list">
+                  ${rows.map(({ host, session }) =>
+                    this.renderCatalogSession(catalog, host, session),
+                  )}
+                </div>
+                ${hasMore
+                  ? html`<button
+                      type="button"
+                      class="sidebar-session-catalog-load-more"
+                      data-session-catalog-load-more=${catalog.id}
+                      ?disabled=${loadingMore}
+                      aria-busy=${String(loadingMore)}
+                      @click=${() => void this.loadMoreSessionCatalog(catalog.id)}
+                    >
+                      ${t("chat.selectors.loadMoreSessions")}
+                    </button>`
+                  : nothing}`}
+        </div>
       `;
     });
   }


### PR DESCRIPTION
## What Problem This Solves

The sidebar stacked the main SESSIONS list and the external session catalogs (Claude/Codex) as separate scroll regions: the main list scrolled inside its own box while each catalog rendered below it as a sibling `sidebar-sessions` section. With both populated, the main list got squeezed to a few rows, the catalog sections had no scroll of their own, and under the shell body's overflow clip the flex-squeezed sections painted over each other (the "Load more sessions" button and the CODEX SESSIONS header rendering on top of other rows — see the before screenshot). The catalog content also sat 8px right of the main list because the sibling sections keep `sidebar-sessions` padding without the scroller's negative-margin cancellation, producing a staircase left edge.

## Why This Change Was Made

One list should scroll as one list. The catalog groups now render inside the shared `.sidebar-recent-sessions` scroller, after the native session groups. That makes them ordinary group children of the scroller: they inherit the `flex: 0 0 auto` no-squeeze contract, the 10px group rhythm, and the same head/row insets as the main list, and they scroll together under the pinned SESSIONS header. Since `sessionCatalogs` is component state, catalog hydration re-renders the sidebar and the existing scroll-state handling keeps the edge fade correct — no extra observer needed.

History: an earlier revision of this PR fixed the same two-split/misalignment in the previous `openclaw-codex-sidebar` plugin surface; #104717 replaced that surface with native session catalogs (and deleted those files) while this was in flight, so the fix was rewritten against the new catalog rendering — which had inherited the same layout flaw.

## User Impact

- The sidebar is a single scrollable sessions list: native sessions and Claude/Codex catalog groups scroll together under the pinned SESSIONS header.
- Catalog section headers and rows share the main list's left edge instead of sitting 8px right of it.
- Long catalogs no longer overlap the following section (rows painting over the CODEX SESSIONS header and vice versa).

| Before | After | After (scrolled) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-unified-sessions/sidebar-before-v2.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-unified-sessions/sidebar-after-v2.png) | ![after scrolled](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-unified-sessions/sidebar-after-v2-scrolled.png) |

## Evidence

- New regression test: `AppSidebar session catalog pagination > renders catalog groups inside the shared sessions scroller` (`ui/src/components/app-sidebar.test.ts`) — asserts catalog groups are inside `.sidebar-recent-sessions` and only one `sidebar-sessions` section exists.
- Existing catalog pagination tests use placement-independent selectors (`data-session-section`, `data-session-catalog-load-more`) and are unaffected.
- Before/after screenshots captured with the mocked-gateway Playwright harness (`installMockGateway` with `sessions.catalog.list` fixtures: Claude catalog with 3 hosts + pagination cursor, Codex catalog, 12 native sessions). The scrolled capture shows Megaclaw / Mac Studio host rows and the Codex catalog scrolling in the same region with the pinned header and top fade.
- Structured autoreview (codex `gpt-5.6-sol`, thinking xhigh): clean, no accepted findings (0.94).
- Unit-test proof runs on hosted CI for this head; Blacksmith Testbox leases were dying immediately at capture time (broker-side), so the jsdom lane could not be run remotely pre-push.
