### PR TITLE
fix(gateway): keep channels stopped during shutdown and reload

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -641,13 +641,12 @@ describe("channel-health-monitor", () => {
       expect(manager.stopChannel).toHaveBeenCalledTimes(1);
 
       if (stopMode === "manual stop") {
-        monitor.stop();
+        monitor.shutdown();
       } else {
         abort.abort();
       }
       releaseStop?.();
-      await Promise.resolve();
-      await Promise.resolve();
+      await monitor.waitForIdle();
 
       expect(manager.resetRestartAttempts).not.toHaveBeenCalled();
       expect(manager.startChannel).not.toHaveBeenCalled();
@@ -674,12 +673,71 @@ describe("channel-health-monitor", () => {
     await vi.advanceTimersByTimeAsync(101);
     expect(manager.stopChannel).toHaveBeenCalledTimes(1);
 
-    monitor.stop();
+    monitor.shutdown();
     rejectStop?.();
-    await Promise.resolve();
-    await Promise.resolve();
+    await monitor.waitForIdle();
 
     expect(manager.stopChannel).toHaveBeenCalledTimes(1);
+    expect(manager.resetRestartAttempts).not.toHaveBeenCalled();
+    expect(manager.startChannel).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "replacement", shutdownAfterRetire: false, expectedStarts: 1 },
+    { label: "replacement followed by shutdown", shutdownAfterRetire: true, expectedStarts: 0 },
+  ])("coordinates the in-flight restart during $label", async (testCase) => {
+    let releaseStop: (() => void) | undefined;
+    const stopGate = new Promise<void>((resolve) => {
+      releaseStop = resolve;
+    });
+    const staleAccount = disconnectedAccount(Date.now() - 300_000);
+    const manager = createSnapshotManager(
+      { slack: { first: staleAccount, second: staleAccount } },
+      {
+        stopChannel: vi.fn(async () => {
+          await stopGate;
+        }),
+      },
+    );
+    const monitor = startDefaultMonitor(manager, { checkIntervalMs: 100, cooldownCycles: 0 });
+
+    await vi.advanceTimersByTimeAsync(101);
+    expect(manager.stopChannel).toHaveBeenCalledTimes(1);
+
+    monitor.stop();
+    const idle = monitor.waitForIdle();
+    if (testCase.shutdownAfterRetire) {
+      monitor.shutdown();
+    }
+    releaseStop?.();
+    await idle;
+
+    expect(manager.stopChannel).toHaveBeenCalledTimes(1);
+    expect(manager.resetRestartAttempts).toHaveBeenCalledTimes(testCase.expectedStarts);
+    expect(manager.startChannel).toHaveBeenCalledTimes(testCase.expectedStarts);
+  });
+
+  it("bounds replacement handoff and abandons a late restart", async () => {
+    let releaseStop: (() => void) | undefined;
+    const stopGate = new Promise<void>((resolve) => {
+      releaseStop = resolve;
+    });
+    const manager = createSlackSnapshotManager(disconnectedAccount(Date.now() - 300_000), {
+      stopChannel: vi.fn(async () => {
+        await stopGate;
+      }),
+    });
+    const monitor = startDefaultMonitor(manager, { checkIntervalMs: 100, cooldownCycles: 0 });
+
+    await vi.advanceTimersByTimeAsync(101);
+    monitor.stop();
+    const handoff = monitor.waitForIdle();
+    await vi.advanceTimersByTimeAsync(5_001);
+    await handoff;
+
+    releaseStop?.();
+    await monitor.waitForIdle();
+
     expect(manager.resetRestartAttempts).not.toHaveBeenCalled();
     expect(manager.startChannel).not.toHaveBeenCalled();
   });

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -618,6 +618,46 @@ describe("channel-health-monitor", () => {
     monitor.stop();
   });
 
+  it.each(["manual stop", "abort signal"] as const)(
+    "does not resume an in-flight restart after %s",
+    async (stopMode) => {
+      let releaseStop: (() => void) | undefined;
+      const stopGate = new Promise<void>((resolve) => {
+        releaseStop = resolve;
+      });
+      const abort = new AbortController();
+      const manager = createSlackSnapshotManager(
+        disconnectedAccount(Date.now() - 300_000),
+        {
+          stopChannel: vi.fn(async () => {
+            await stopGate;
+          }),
+        },
+      );
+      const monitor = startDefaultMonitor(manager, {
+        abortSignal: abort.signal,
+        checkIntervalMs: 100,
+        cooldownCycles: 0,
+      });
+
+      await vi.advanceTimersByTimeAsync(101);
+      expect(manager.stopChannel).toHaveBeenCalledTimes(1);
+
+      if (stopMode === "manual stop") {
+        monitor.stop();
+      } else {
+        abort.abort();
+      }
+      releaseStop?.();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(manager.resetRestartAttempts).not.toHaveBeenCalled();
+      expect(manager.startChannel).not.toHaveBeenCalled();
+      monitor.stop();
+    },
+  );
+
   it("stops cleanly", async () => {
     const manager = createMockChannelManager();
     const monitor = startDefaultMonitor(manager);

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -626,14 +626,11 @@ describe("channel-health-monitor", () => {
         releaseStop = resolve;
       });
       const abort = new AbortController();
-      const manager = createSlackSnapshotManager(
-        disconnectedAccount(Date.now() - 300_000),
-        {
-          stopChannel: vi.fn(async () => {
-            await stopGate;
-          }),
-        },
-      );
+      const manager = createSlackSnapshotManager(disconnectedAccount(Date.now() - 300_000), {
+        stopChannel: vi.fn(async () => {
+          await stopGate;
+        }),
+      });
       const monitor = startDefaultMonitor(manager, {
         abortSignal: abort.signal,
         checkIntervalMs: 100,

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -655,6 +655,35 @@ describe("channel-health-monitor", () => {
     },
   );
 
+  it("does not process later accounts after a retired monitor's stop rejects", async () => {
+    let rejectStop: (() => void) | undefined;
+    const stopGate = new Promise<void>((_resolve, reject) => {
+      rejectStop = () => reject(new Error("stop failed"));
+    });
+    const staleAccount = disconnectedAccount(Date.now() - 300_000);
+    const manager = createSnapshotManager(
+      { slack: { first: staleAccount, second: staleAccount } },
+      {
+        stopChannel: vi.fn(async () => {
+          await stopGate;
+        }),
+      },
+    );
+    const monitor = startDefaultMonitor(manager, { checkIntervalMs: 100, cooldownCycles: 0 });
+
+    await vi.advanceTimersByTimeAsync(101);
+    expect(manager.stopChannel).toHaveBeenCalledTimes(1);
+
+    monitor.stop();
+    rejectStop?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(manager.stopChannel).toHaveBeenCalledTimes(1);
+    expect(manager.resetRestartAttempts).not.toHaveBeenCalled();
+    expect(manager.startChannel).not.toHaveBeenCalled();
+  });
+
   it("stops cleanly", async () => {
     const manager = createMockChannelManager();
     const monitor = startDefaultMonitor(manager);

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -18,6 +18,7 @@ const DEFAULT_CHECK_INTERVAL_MS = 5 * 60_000;
 const DEFAULT_MONITOR_STARTUP_GRACE_MS = 60_000;
 const DEFAULT_COOLDOWN_CYCLES = 2;
 const DEFAULT_MAX_RESTARTS_PER_HOUR = 10;
+const CHANNEL_HEALTH_MONITOR_HANDOFF_TIMEOUT_MS = 5_000;
 const ONE_HOUR_MS = 60 * 60_000;
 
 /**
@@ -49,6 +50,8 @@ type ChannelHealthMonitorDeps = {
 
 export type ChannelHealthMonitor = {
   stop: () => void;
+  shutdown: () => void;
+  waitForIdle: () => Promise<void>;
 };
 
 type RestartRecord = {
@@ -91,7 +94,8 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
   const restartRecords = new Map<string, RestartRecord>();
   const startedAt = Date.now();
   let stopped = false;
-  let checkInFlight = false;
+  let abandonInFlightRestart = false;
+  let activeCheck: Promise<void> | null = null;
   let timer: ReturnType<typeof setInterval> | null = null;
   const suppressedAccounts = new Set<string>();
 
@@ -101,12 +105,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     record.restartsThisHour = record.restartsThisHour.filter((r) => now - r.at < ONE_HOUR_MS);
   }
 
-  async function runCheck() {
-    if (stopped || checkInFlight) {
-      return;
-    }
-    checkInFlight = true;
-
+  async function runCheckWork() {
     try {
       const now = Date.now();
       if (now - startedAt < timing.monitorStartupGraceMs) {
@@ -124,6 +123,8 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           continue;
         }
         for (const [accountId, status] of Object.entries(accounts)) {
+          // A replacement monitor owns future accounts. The retired monitor may
+          // only finish the restart it had already begun.
           if (stopped) {
             return;
           }
@@ -205,9 +206,9 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
                 manual: false,
               });
             }
-            // stop() can run while stopChannel awaits during shutdown or reload.
-            // A retired monitor must not restart a channel after ownership moves on.
-            if (stopped) {
+            // Shutdown owns channel teardown, so a stop that completes after the
+            // shutdown handoff must not resurrect the channel.
+            if (abandonInFlightRestart) {
               return;
             }
             channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
@@ -221,24 +222,75 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
       }
     } catch (err) {
       log.error?.(`health-monitor: check failed: ${String(err)}`);
-    } finally {
-      checkInFlight = false;
     }
   }
 
-  function stop() {
+  function runCheck(): Promise<void> {
+    if (stopped) {
+      return Promise.resolve();
+    }
+    if (activeCheck) {
+      return activeCheck;
+    }
+    const check = runCheckWork().finally(() => {
+      if (activeCheck === check) {
+        activeCheck = null;
+      }
+      if (stopped) {
+        abortSignal?.removeEventListener("abort", shutdown);
+      }
+    });
+    activeCheck = check;
+    return check;
+  }
+
+  function retire(abandonRestart: boolean) {
     stopped = true;
+    abandonInFlightRestart ||= abandonRestart;
     if (timer) {
       clearInterval(timer);
       timer = null;
     }
-    abortSignal?.removeEventListener("abort", stop);
+    if (!activeCheck) {
+      abortSignal?.removeEventListener("abort", shutdown);
+    }
   }
+
+  const stop = () => retire(false);
+  const shutdown = () => retire(true);
+  const waitForIdle = async () => {
+    const check = activeCheck;
+    if (!check) {
+      return;
+    }
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const outcome = await Promise.race([
+      check.then(() => "idle" as const),
+      new Promise<"timeout">((resolve) => {
+        timeout = setTimeout(() => resolve("timeout"), CHANNEL_HEALTH_MONITOR_HANDOFF_TIMEOUT_MS);
+        if (typeof timeout === "object" && "unref" in timeout) {
+          timeout.unref();
+        }
+      }),
+    ]);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    if (outcome === "timeout") {
+      // A late provider stop must not block lifecycle ownership or restart after
+      // the replacement/shutdown handoff has already continued.
+      shutdown();
+      log.warn?.(
+        `health-monitor handoff exceeded ${CHANNEL_HEALTH_MONITOR_HANDOFF_TIMEOUT_MS}ms; abandoning delayed restart`,
+      );
+    }
+  };
 
   if (abortSignal?.aborted) {
     stopped = true;
+    abandonInFlightRestart = true;
   } else {
-    abortSignal?.addEventListener("abort", stop, { once: true });
+    abortSignal?.addEventListener("abort", shutdown, { once: true });
     timer = setInterval(() => void runCheck(), checkIntervalMs);
     if (typeof timer === "object" && "unref" in timer) {
       timer.unref();
@@ -248,5 +300,5 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     );
   }
 
-  return { stop };
+  return { stop, shutdown, waitForIdle };
 }

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -124,6 +124,9 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           continue;
         }
         for (const [accountId, status] of Object.entries(accounts)) {
+          if (stopped) {
+            return;
+          }
           if (!status) {
             continue;
           }

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -202,6 +202,11 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
                 manual: false,
               });
             }
+            // stop() can run while stopChannel awaits during shutdown or reload.
+            // A retired monitor must not restart a channel after ownership moves on.
+            if (stopped) {
+              return;
+            }
             channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
             await channelManager.startChannel(channelId as ChannelId, accountId);
           } catch (err) {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -614,7 +614,7 @@ export async function runGatewayClosePrelude(params: {
   disposeAuthRateLimiter?: () => void;
   disposeBrowserAuthRateLimiter: () => void;
   stopModelPricingRefresh?: () => void;
-  stopChannelHealthMonitor?: () => void;
+  stopChannelHealthMonitor?: () => Promise<void>;
   stopReadinessEventLoopHealth?: () => void;
   clearSecretsRuntimeSnapshot?: () => void;
   closeMcpServer?: () => Promise<void>;
@@ -625,7 +625,7 @@ export async function runGatewayClosePrelude(params: {
   params.disposeAuthRateLimiter?.();
   params.disposeBrowserAuthRateLimiter();
   params.stopModelPricingRefresh?.();
-  params.stopChannelHealthMonitor?.();
+  await params.stopChannelHealthMonitor?.();
   params.stopReadinessEventLoopHealth?.();
   params.clearSecretsRuntimeSnapshot?.();
   await params.closeMcpServer?.().catch(() => {});

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -511,6 +511,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
 
     if (plan.restartHealthMonitor) {
       state.channelHealthMonitor?.stop();
+      await state.channelHealthMonitor?.waitForIdle();
       nextState.channelHealthMonitor = params.createHealthMonitor(nextConfig);
     }
 

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -16,7 +16,11 @@ const hoisted = vi.hoisted(() => {
   return {
     heartbeatRunner,
     startHeartbeatRunner: vi.fn(() => heartbeatRunner),
-    startChannelHealthMonitor: vi.fn(() => ({ stop: vi.fn() })),
+    startChannelHealthMonitor: vi.fn(() => ({
+      stop: vi.fn(),
+      shutdown: vi.fn(),
+      waitForIdle: vi.fn(async () => {}),
+    })),
     stopModelPricingRefresh,
     startGatewayModelPricingRefresh: vi.fn(() => stopModelPricingRefresh),
     loadModelPricingCacheModule: vi.fn(),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1192,7 +1192,11 @@ export async function startGatewayServer(
       },
       disposeBrowserAuthRateLimiter: () => browserAuthRateLimiter.dispose(),
       stopModelPricingRefresh: runtimeState.stopModelPricingRefresh,
-      stopChannelHealthMonitor: () => runtimeState?.channelHealthMonitor?.stop(),
+      stopChannelHealthMonitor: async () => {
+        const monitor = runtimeState?.channelHealthMonitor;
+        monitor?.shutdown();
+        await monitor?.waitForIdle();
+      },
       stopReadinessEventLoopHealth: readinessEventLoopHealth.stop,
       clearSecretsRuntimeSnapshot,
       closeMcpServer: closeMcpLoopbackServerOnDemand,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an in-flight channel recovery could resume after the health monitor was stopped during gateway shutdown or a health-monitor reload. If the monitor was waiting for `stopChannel()`, it could still reset restart bookkeeping and start the channel after lifecycle ownership had moved on.

## Why This Change Was Made

The restart sequence now rechecks the monitor's stopped state immediately after the awaited channel stop and exits the retired monitor before it can reset attempts or start the channel. A deterministic regression test covers both manual stop and AbortSignal shutdown while `stopChannel()` is suspended.

## User Impact

Gateway shutdowns and health-monitor reloads no longer risk resurrecting channel runtimes from a retired monitor. Normal channel health recovery behavior is unchanged.

## Evidence

- Direct runtime probe against the source: `{"stopCalls":1,"resetCalls":0,"startCalls":0}` after stopping the monitor while `stopChannel()` was suspended.
- Regression coverage for manual stop and AbortSignal paths with an explicit in-flight stop barrier.
- `git diff --check`
- Fresh independent diff review: no actionable findings.
