### PR TITLE
fix(moonshot): resolve Kimi search secret refs

### DIFF
--- a/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
@@ -11,14 +11,13 @@ import {
   MAX_SEARCH_COUNT,
   mergeScopedSearchConfig,
   readCachedSearchPayload,
-  readConfiguredSecretString,
   readPositiveIntegerParam,
-  readProviderEnvValue,
   readStringParam,
   resolveProviderWebSearchPluginConfig,
   resolveSearchCacheTtlMs,
   resolveSearchCount,
   resolveSearchTimeoutSeconds,
+  resolveWebSearchProviderCredential,
   setProviderWebSearchPluginConfigValue,
   type SearchConfigRecord,
   type WebSearchProviderSetupContext,
@@ -48,7 +47,7 @@ const KIMI_WEB_SEARCH_TOOL = {
 } as const;
 
 type KimiConfig = {
-  apiKey?: string;
+  apiKey?: unknown;
   baseUrl?: string;
   model?: string;
 };
@@ -97,10 +96,11 @@ function resolveKimiConfig(searchConfig?: SearchConfigRecord): KimiConfig {
 }
 
 function resolveKimiApiKey(kimi?: KimiConfig): string | undefined {
-  return (
-    readConfiguredSecretString(kimi?.apiKey, "plugins.entries.moonshot.config.webSearch.apiKey") ??
-    readProviderEnvValue(["KIMI_API_KEY", "MOONSHOT_API_KEY"])
-  );
+  return resolveWebSearchProviderCredential({
+    credentialValue: kimi?.apiKey,
+    path: "plugins.entries.moonshot.config.webSearch.apiKey",
+    envVars: ["KIMI_API_KEY", "MOONSHOT_API_KEY"],
+  });
 }
 
 function resolveKimiModel(kimi?: KimiConfig): string {

--- a/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
@@ -361,7 +361,7 @@ export async function executeKimiWebSearchProviderTool(
     return {
       error: "missing_kimi_api_key",
       message:
-        "web_search (kimi) needs a Moonshot API key. Set KIMI_API_KEY or MOONSHOT_API_KEY in the Gateway environment, or configure plugins.entries.moonshot.config.webSearch.apiKey. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
+        "web_search (kimi) needs a Moonshot API key. Configure plugins.entries.moonshot.config.webSearch.apiKey, or set KIMI_API_KEY or MOONSHOT_API_KEY in the Gateway environment. If plugins.entries.moonshot.config.webSearch.apiKey contains an unavailable SecretRef, repair or remove that SecretRef; KIMI_API_KEY and MOONSHOT_API_KEY are ignored until then. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -1,6 +1,5 @@
 // Moonshot tests cover kimi web search provider plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
-import type { SearchConfigRecord } from "openclaw/plugin-sdk/provider-web-search";
 import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { testing } from "../test-api.js";
@@ -19,10 +18,10 @@ function jsonResponse(body: unknown): Response {
 
 async function executeKimiSearch(
   query: string,
-  searchConfig: SearchConfigRecord = {},
+  config: OpenClawConfig = {},
 ): Promise<Record<string, unknown>> {
   const provider = createKimiWebSearchProvider();
-  const tool = provider.createTool({ config: {}, searchConfig });
+  const tool = provider.createTool({ config, searchConfig: {} });
   if (!tool) {
     throw new Error("Expected tool definition");
   }
@@ -97,7 +96,7 @@ describe("kimi web search provider", () => {
     );
   });
 
-  it("resolves configured env SecretRef apiKey through provider searchConfig", async () => {
+  it("resolves configured env SecretRef apiKey through plugin config", async () => {
     const configuredApiKey = {
       source: "env",
       provider: "default",
@@ -124,7 +123,13 @@ describe("kimi web search provider", () => {
       },
       async () => {
         const result = await executeKimiSearch("kimi configured SecretRef search", {
-          kimi: { apiKey: configuredApiKey },
+          plugins: {
+            entries: {
+              moonshot: {
+                config: { webSearch: { apiKey: configuredApiKey } },
+              },
+            },
+          },
         });
 
         const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -1,11 +1,14 @@
 // Moonshot tests cover kimi web search provider plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
+import type { SearchConfigRecord } from "openclaw/plugin-sdk/provider-web-search";
 import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { testing } from "../test-api.js";
 import { createKimiWebSearchProvider } from "./kimi-web-search-provider.js";
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
+const moonshotApiKeyEnv = ["MOONSHOT_API", "KEY"].join("_");
+const kimiSecretRefApiKeyEnv = ["KIMI_WEB_SEARCH_REF", "KEY"].join("_");
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -14,9 +17,12 @@ function jsonResponse(body: unknown): Response {
   });
 }
 
-async function executeKimiSearch(query: string): Promise<Record<string, unknown>> {
+async function executeKimiSearch(
+  query: string,
+  searchConfig: SearchConfigRecord = {},
+): Promise<Record<string, unknown>> {
   const provider = createKimiWebSearchProvider();
-  const tool = provider.createTool({ config: {}, searchConfig: {} });
+  const tool = provider.createTool({ config: {}, searchConfig });
   if (!tool) {
     throw new Error("Expected tool definition");
   }
@@ -51,6 +57,81 @@ describe("kimi web search provider", () => {
         "use web_fetch for a specific URL or the browser tool",
       );
     });
+  });
+
+  it("resolves configured env SecretRef apiKey", () => {
+    const configuredApiKey = {
+      source: "env",
+      provider: "default",
+      id: kimiSecretRefApiKeyEnv,
+    };
+
+    withEnv(
+      {
+        [kimiSecretRefApiKeyEnv]: "sample",
+        [kimiApiKeyEnv]: undefined,
+        [moonshotApiKeyEnv]: undefined,
+      },
+      () => {
+        expect(testing.resolveKimiApiKey({ apiKey: configuredApiKey })).toBe("sample");
+      },
+    );
+  });
+
+  it("does not use ambient env fallback when configured env SecretRef is missing", () => {
+    const configuredApiKey = {
+      source: "env",
+      provider: "default",
+      id: kimiSecretRefApiKeyEnv,
+    };
+
+    withEnv(
+      {
+        [kimiSecretRefApiKeyEnv]: undefined,
+        [kimiApiKeyEnv]: "dummy",
+        [moonshotApiKeyEnv]: "example",
+      },
+      () => {
+        expect(testing.resolveKimiApiKey({ apiKey: configuredApiKey })).toBeUndefined();
+      },
+    );
+  });
+
+  it("resolves configured env SecretRef apiKey through provider searchConfig", async () => {
+    const configuredApiKey = {
+      source: "env",
+      provider: "default",
+      id: kimiSecretRefApiKeyEnv,
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        search_results: [{ url: "https://example.test/kimi" }],
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { content: "Kimi configured ref answer." },
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await withEnvAsync(
+      {
+        [kimiSecretRefApiKeyEnv]: "sample",
+        [kimiApiKeyEnv]: undefined,
+        [moonshotApiKeyEnv]: undefined,
+      },
+      async () => {
+        const result = await executeKimiSearch("kimi configured SecretRef search", {
+          kimi: { apiKey: configuredApiKey },
+        });
+
+        const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+        expect(result).not.toHaveProperty("error");
+        expect(requestInit?.headers).toMatchObject({ Authorization: "Bearer sample" });
+      },
+    );
   });
 
   it("uses configured model and base url overrides with sane defaults", () => {

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -77,21 +77,40 @@ describe("kimi web search provider", () => {
     );
   });
 
-  it("does not use ambient env fallback when configured env SecretRef is missing", () => {
+  it("explains recovery when a configured env SecretRef is missing", async () => {
     const configuredApiKey = {
       source: "env",
       provider: "default",
       id: kimiSecretRefApiKeyEnv,
     };
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
 
-    withEnv(
+    await withEnvAsync(
       {
         [kimiSecretRefApiKeyEnv]: undefined,
         [kimiApiKeyEnv]: "dummy",
         [moonshotApiKeyEnv]: "example",
       },
-      () => {
-        expect(testing.resolveKimiApiKey({ apiKey: configuredApiKey })).toBeUndefined();
+      async () => {
+        const result = await executeKimiSearch("kimi missing configured SecretRef", {
+          plugins: {
+            entries: {
+              moonshot: {
+                config: { webSearch: { apiKey: configuredApiKey } },
+              },
+            },
+          },
+        });
+
+        expect(result.error).toBe("missing_kimi_api_key");
+        expectStringFieldContains(result, "message", "repair or remove that SecretRef");
+        expectStringFieldContains(
+          result,
+          "message",
+          "KIMI_API_KEY and MOONSHOT_API_KEY are ignored until then",
+        );
+        expect(fetchMock).not.toHaveBeenCalled();
       },
     );
   });


### PR DESCRIPTION
## What Problem This Solves

Kimi web search accepted `tools.web.search.kimi.apiKey` as a configured credential, but runtime lookup only handled string values before falling back to ambient `KIMI_API_KEY` / `MOONSHOT_API_KEY`.

That meant an env SecretRef configured at `tools.web.search.kimi.apiKey` was not resolved at runtime, and a missing configured ref could silently fall through to ambient env credentials.

## Why This Change Was Made

The Kimi web search provider now uses the shared web-search credential resolver for the configured apiKey path and preserves the existing env fallback list only when no configured credential is present.

The config type is widened so SecretRef objects can flow through the existing Kimi config plumbing instead of being treated as strings only.

## User Impact

Users can configure Kimi web search with an env SecretRef and have it resolve at runtime.

If the configured SecretRef is missing, Kimi search now fails closed instead of unexpectedly using ambient `KIMI_API_KEY` or `MOONSHOT_API_KEY`.

## Evidence

- Live open PR collision check: no open PR touched `extensions/moonshot/`.
- `pnpm exec oxfmt --write --threads=1 extensions/moonshot/src/kimi-web-search-provider.runtime.ts extensions/moonshot/src/kimi-web-search-provider.test.ts`
- `node scripts/run-vitest.mjs extensions/moonshot/src/kimi-web-search-provider.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/moonshot/src/kimi-web-search-provider.runtime.ts extensions/moonshot/src/kimi-web-search-provider.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/moonshot/src/kimi-web-search-provider.runtime.ts extensions/moonshot/src/kimi-web-search-provider.test.ts`
- `git diff --check`
- `git diff --check upstream/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --engine claude` clean

## Proof

- Added a direct SecretRef regression test for `tools.web.search.kimi.apiKey`.
- Added a fail-closed regression test proving a missing configured SecretRef does not use ambient Kimi/Moonshot env fallback.
- Kept the existing normal env fallback test for the no-configured-SecretRef path.
- Added a provider-entry regression test that passes the SecretRef through `searchConfig` and verifies the outgoing Kimi request uses the resolved Authorization header.
- Exact-head secretless runtime proof on 2026-07-20 UTC:
  - [Actions run 29726144503](https://github.com/Leon-SK668/openclaw/actions/runs/29726144503) / [job 88299576266](https://github.com/Leon-SK668/openclaw/actions/runs/29726144503/job/88299576266) succeeded on exact PR head `9a9f0eabb9a9d601388f5df0213ee8cfcec62e69` with Node `v24.15.0`, a frozen lockfile install, and a full build.
  - The proof harness revision is `bb8355dd119e0563f646b459c6624a7c507dafd6`; its sole parent is the exact PR head above, and its diff only adds the disposable workflow and harness.
  - The formal `createKimiWebSearchProvider()` -> `createTool()` -> lazy runtime `execute` path used public-shaped `plugins.entries.moonshot.config.webSearch.baseUrl` and reached a real loopback HTTP CONNECT socket through `EnvHttpProxyAgent`; `fetch` was not mocked.
  - Success case: the configured env SecretRef and two distinct ambient Kimi/Moonshot sentinels were all present. The captured Bearer value was redacted; matching booleans showed the configured SecretRef won and both ambient values did not. A grounded Kimi-shaped response completed without an error.
  - Missing case: the referenced env value was removed while both ambient values remained present. Runtime returned `missing_kimi_api_key`, and proxy CONNECT plus tunneled POST counts both stayed `1 -> 1`, proving fail-closed behavior before network access.
  - [Artifact 8454417762](https://github.com/Leon-SK668/openclaw/actions/runs/29726144503/artifacts/8454417762): GitHub archive digest `sha256:822bcdf41bfe8015c01f59a75051d320a5140be5ae9685bac9a9f7c69227df33`; contained JSON SHA-256 `edd19bbc01135ba048ff0f9078e6fb27e6925a70c67f4552c700fc7c79ac2d09`.
  - Scope: this proves local runtime credential precedence, guarded proxy transport, and fail-closed behavior with synthetic values. It makes no vendor endpoint or vendor-auth claim.

### Exact-Head Recovery Guidance Repair (2026-08-07)

Exact head: `b9279fdaeecc510ef986fe39af1a093cada7ccf8`. Frozen rebase base: `f87d8bb72daaf9853b1f6c2e0dda7a1201d365b5`.

- The missing-key response now states that an unavailable configured SecretRef must be repaired or removed and that `KIMI_API_KEY` / `MOONSHOT_API_KEY` remain ignored until then.
- The provider-tool regression configures a missing env SecretRef while both ambient variables are populated, executes the real Kimi tool path, asserts the actionable `missing_kimi_api_key` response, and proves that `fetch` is never called.
- [Exact-head CI run 31148704782](https://github.com/openclaw/openclaw/actions/runs/31148704782) completed successfully with no pending or failed jobs; the final [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/31148704782/job/92776321777) passed.
- The exact-head [Node changed-test job](https://github.com/openclaw/openclaw/actions/runs/31148704782/job/92773737316) passed `kimi-web-search-provider.test.ts` (19/19), and both [production types](https://github.com/openclaw/openclaw/actions/runs/31148704782/job/92773737349) and [lint](https://github.com/openclaw/openclaw/actions/runs/31148704782/job/92773737367) passed.

Scope remains provider-local and atomic. Brave (#103726) and Google/Gemini (#104672) already have separate provider-local SecretRef repairs. Broadening this Moonshot repair across Exa, MiniMax, Parallel, and Perplexity would cross plugin owner boundaries and should be handled as separately reviewable work. This does not claim owner approval: maintainers still decide whether a canonical sibling follow-up is required before accepting the Kimi-only repair.
