### PR TITLE
fix: quiet expected live updater warnings

### DIFF
--- a/scripts/restart-mac.sh
+++ b/scripts/restart-mac.sh
@@ -285,9 +285,9 @@ print_managed_openclaw_supervisor_label() {
     return 0
   fi
   local executable=""
-  executable="$(printf '%s\n' "${job}" | /usr/bin/awk -F ' = ' '/^[[:space:]]*program = / { print $2; exit }')"
+  executable="$(/usr/bin/awk -F ' = ' '/^[[:space:]]*program = / { print $2; exit }' <<<"${job}")"
   local properties=""
-  properties="$(printf '%s\n' "${job}" | /usr/bin/awk -F ' = ' '/^[[:space:]]*properties = / { print $2; exit }')"
+  properties="$(/usr/bin/awk -F ' = ' '/^[[:space:]]*properties = / { print $2; exit }' <<<"${job}")"
   local is_managed_executable=0
   if [[ "${executable}" == "${TARGET_EXECUTABLE}" || "${executable}" == "${INSTALLED_EXECUTABLE}" ]]; then
     is_managed_executable=1
@@ -367,7 +367,7 @@ else
 fi
 
 # Bundle Gateway-hosted plugin assets.
-run_step "bundle plugin assets" bash -lc "cd '${ROOT_DIR}' && pnpm plugins:assets:build"
+run_step "bundle plugin assets" bash -c "cd '${ROOT_DIR}' && pnpm plugins:assets:build"
 
 if [ "$AUTO_DETECT_SIGNING" -eq 1 ]; then
   if check_signing_keys; then
@@ -445,8 +445,8 @@ fi
 # When unsigned, ensure the gateway LaunchAgent targets the repo CLI (before the app launches).
 # This reduces noisy "could not connect" errors during app startup.
 if [ "$NO_SIGN" -eq 1 ] && [ "$ATTACH_ONLY" -ne 1 ]; then
-  run_step "install gateway launch agent (unsigned)" bash -lc "cd '${ROOT_DIR}' && node openclaw.mjs daemon install --force --runtime node"
-  run_step "restart gateway daemon (unsigned)" bash -lc "cd '${ROOT_DIR}' && node openclaw.mjs daemon restart"
+  run_step "install gateway launch agent (unsigned)" bash -c "cd '${ROOT_DIR}' && node openclaw.mjs daemon install --force --runtime node"
+  run_step "restart gateway daemon (unsigned)" bash -c "cd '${ROOT_DIR}' && node openclaw.mjs daemon restart"
   if [[ "${GATEWAY_WAIT_SECONDS}" -gt 0 ]]; then
     run_step "wait for gateway (unsigned)" sleep "${GATEWAY_WAIT_SECONDS}"
   fi
@@ -506,5 +506,5 @@ else
 fi
 
 if [ "$NO_SIGN" -eq 1 ] && [ "$ATTACH_ONLY" -ne 1 ]; then
-  run_step "show gateway launch agent args (unsigned)" bash -lc "/usr/bin/plutil -p '${HOME}/Library/LaunchAgents/ai.openclaw.gateway.plist' | head -n 40 || true"
+  run_step "show gateway launch agent args (unsigned)" bash -c "/usr/bin/plutil -p '${HOME}/Library/LaunchAgents/ai.openclaw.gateway.plist' | head -n 40 || true"
 fi

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -636,7 +636,7 @@ async function prewarmConfiguredPrimaryModelWithTimeout(
   params: {
     cfg: OpenClawConfig;
     workspaceDir?: string;
-    log: { warn: (msg: string) => void };
+    log: { warn: (msg: string) => void; debug?: (msg: string) => void };
     timeoutMs?: number;
   },
   prewarm: typeof prewarmConfiguredPrimaryModel = prewarmConfiguredPrimaryModel,
@@ -653,7 +653,7 @@ async function prewarmConfiguredPrimaryModelWithTimeout(
     ref: false,
   }).then(() => {
     if (!settled) {
-      params.log.warn(
+      params.log.debug?.(
         `startup model warmup timed out after ${params.timeoutMs ?? PRIMARY_MODEL_PREWARM_TIMEOUT_MS}ms; continuing without waiting`,
       );
     }
@@ -665,7 +665,7 @@ function schedulePrimaryModelPrewarm(
   params: {
     cfg: OpenClawConfig;
     workspaceDir?: string;
-    log: { warn: (msg: string) => void };
+    log: { warn: (msg: string) => void; debug?: (msg: string) => void };
     startupTrace?: GatewayStartupTrace;
   },
   prewarm: typeof prewarmConfiguredPrimaryModel = prewarmConfiguredPrimaryModel,

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -36,6 +36,7 @@ vi.mock("../agents/model-selection.js", () => ({
 }));
 
 let prewarmConfiguredPrimaryModel: typeof import("./server-startup-post-attach.js").testing.prewarmConfiguredPrimaryModel;
+let prewarmConfiguredPrimaryModelWithTimeout: typeof import("./server-startup-post-attach.js").testing.prewarmConfiguredPrimaryModelWithTimeout;
 let shouldSkipStartupModelPrewarm: typeof import("./server-startup-post-attach.js").testing.shouldSkipStartupModelPrewarm;
 
 function expectModelsJsonPrewarmCall(cfg: OpenClawConfig) {
@@ -54,7 +55,11 @@ function expectModelsJsonPrewarmCall(cfg: OpenClawConfig) {
 describe("gateway startup primary model warmup", () => {
   beforeAll(async () => {
     ({
-      testing: { prewarmConfiguredPrimaryModel, shouldSkipStartupModelPrewarm },
+      testing: {
+        prewarmConfiguredPrimaryModel,
+        prewarmConfiguredPrimaryModelWithTimeout,
+        shouldSkipStartupModelPrewarm,
+      },
     } = await import("./server-startup-post-attach.js"));
   });
 
@@ -151,5 +156,24 @@ describe("gateway startup primary model warmup", () => {
     expect(warn).toHaveBeenCalledWith(
       "startup model warmup failed for codex/gpt-5.4: Error: models write failed",
     );
+  });
+
+  it("debug-logs an optional warmup timeout without warning", async () => {
+    const warn = vi.fn();
+    const debug = vi.fn();
+
+    await prewarmConfiguredPrimaryModelWithTimeout(
+      {
+        cfg: {} as OpenClawConfig,
+        log: { warn, debug },
+        timeoutMs: 1,
+      },
+      async () => await new Promise<void>(() => {}),
+    );
+
+    expect(debug).toHaveBeenCalledWith(
+      "startup model warmup timed out after 1ms; continuing without waiting",
+    );
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/test/scripts/restart-mac.test.ts
+++ b/test/scripts/restart-mac.test.ts
@@ -340,6 +340,14 @@ describe("scripts/restart-mac.sh", () => {
     expect(script).not.toContain("lsof -iTCP:${GATEWAY_PORT} -sTCP:LISTEN | head -n 5 || true");
   });
 
+  it("avoids login-shell noise and early-exit pipe warnings", () => {
+    const script = readFileSync(restartScriptPath, "utf8");
+
+    expect(script).not.toContain("bash -lc");
+    expect(script).not.toContain(`printf '%s\\n' "\${job}" | /usr/bin/awk`);
+    expect(script).toContain("/usr/bin/awk -F ' = '");
+  });
+
   it("keeps the default restart log scoped to the current worktree lock", () => {
     const script = readFileSync(restartScriptPath, "utf8");
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where routine live-update builds and healthy Gateway restarts emitted warning-level noise despite completing successfully.

## Why This Change Was Made

Mac restart helpers now avoid login-shell profile side effects and SIGPIPE-prone early-exit pipelines. The optional model prewarm timeout is logged at debug level while genuine warmup failures remain warnings.

## User Impact

Operators get cleaner maintenance logs: warning summaries stay focused on actionable failures rather than expected optional timeouts or shell mechanics.

## Evidence

- Blacksmith Testbox `blacksmith-testbox`, lease `tbx_01kx9tx2baytvgprp2q0z3jqm4`: 28 restart-script tests and 12 Gateway startup tests passed.
- `pnpm check:changed`: passed core, core tests, test root, tooling, typecheck, lint, and guard lanes.
- `bash -n scripts/restart-mac.sh`: passed.
- Fresh autoreview: clean, no accepted or actionable findings.

Third-party SwiftPM package-manifest warnings remain out of scope; this PR does not add dependency patches or overrides.
