### PR TITLE
feat(fleet): harden create, port allocation, drift visibility, and operator docs

### DIFF
--- a/docs/cli/fleet.md
+++ b/docs/cli/fleet.md
@@ -14,6 +14,8 @@ Fleet is **experimental**. Command names, flags, output shapes, and the containe
 
 Fleet supports Docker and Podman. The default image is `ghcr.io/openclaw/openclaw:latest`.
 
+Fleet is tested on Linux and macOS hosts. Windows hosts are currently untested.
+
 ## Quick start
 
 ```bash
@@ -85,6 +87,12 @@ Automatic allocation selects the first unused registry port at or above `19100`.
 Image references are passed as one container-runtime argument. Empty references and values beginning with `-` are rejected so an image cannot be interpreted as a Docker or Podman option.
 
 The selected Docker or Podman endpoint must be local. Fleet rejects remote Docker contexts, `DOCKER_HOST` endpoints, and remote Podman services before reserving a port or creating local state; remote cell hosts need a separate storage and endpoint contract and are deferred from this MVP.
+
+When Fleet starts a new cell, create waits up to about a minute for its Gateway to answer `/healthz`. If the cell does not become healthy, Fleet leaves its container and registry row intact for `fleet status`, `fleet logs`, or explicit removal. `--no-start` skips this health gate. The generated Gateway token of an unhealthy new cell is not lost - it remains in the container environment (`docker|podman inspect`), and because the cell has served no traffic yet, `fleet rm --force` followed by a fresh create is always a safe alternative.
+
+### Pinning by digest
+
+Create and upgrade accept digest-pinned image references such as `--image ghcr.io/openclaw/openclaw@sha256:<digest>`. Fleet passes the image reference through verbatim to Docker or Podman, which lets an operator keep a cell on immutable image bytes instead of a moving tag.
 
 The create result includes the tenant ID, container name, host port, Gateway token, and local URL. Even in JSON output, treat the result as secret-bearing because it contains the token.
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1507,6 +1507,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Tenant IDs
   - H2: fleet create
   - H3: Create options
+  - H3: Pinning by digest
   - H3: Disk limits
   - H3: Egress policy
   - H2: fleet list

--- a/docs/gateway/multi-tenant-hosting.md
+++ b/docs/gateway/multi-tenant-hosting.md
@@ -14,6 +14,8 @@ OpenClaw's default security model is one trusted operator boundary per Gateway, 
 
 Fleet is **experimental**: its commands, flags, and container profile can change between releases without a deprecation window while the surface settles.
 
+Fleet is tested on Linux and macOS hosts. Windows hosts are currently untested.
+
 ## Why each tenant needs a cell
 
 An authenticated operator inside one Gateway has a trusted control-plane role. Session IDs select routing; they do not authorize one tenant against another. Agent sandboxing can reduce the effect of untrusted content and tool execution, but it does not turn one shared Gateway into a tenant authorization boundary.

--- a/src/fleet/service-removal.runtime.test.ts
+++ b/src/fleet/service-removal.runtime.test.ts
@@ -6,10 +6,21 @@ import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { cellAuthSecretDir, cellOwnerId } from "./cell-profile.js";
 import type { FleetContainerInspectResult, FleetContainerRuntime } from "./containers.runtime.js";
 import { getFleetCell, reserveFleetCell } from "./registry.js";
-import { createFleetService } from "./service.runtime.js";
+import {
+  createFleetService as createFleetServiceRuntime,
+  type FleetServiceOptions,
+} from "./service.runtime.js";
 
 let root: string;
 const TEST_ATTEMPT_ID = "22222222222222222222222222222222";
+
+function createFleetService(options: FleetServiceOptions = {}) {
+  return createFleetServiceRuntime({
+    fetch: vi.fn<typeof fetch>(async () => new Response(null, { status: 200 })),
+    probePort: async () => true,
+    ...options,
+  });
+}
 
 function fleetLabels(tenant = "acme", attemptId = TEST_ATTEMPT_ID): Record<string, string> {
   return {
@@ -56,7 +67,13 @@ function createContainerMock(
   },
 ) {
   const assertLocal = vi.fn<FleetContainerRuntime["assertLocal"]>(async () => undefined);
-  const inspect = vi.fn<FleetContainerRuntime["inspect"]>(async () => initialInspection);
+  const inspections = new Map<string, FleetContainerInspectResult>();
+  const removedContainers = new Set<string>();
+  const inspect = vi.fn<FleetContainerRuntime["inspect"]>(async (_runtime, name) =>
+    removedContainers.has(name)
+      ? { kind: "missing", state: "missing" }
+      : (inspections.get(name) ?? initialInspection),
+  );
   const networks = new Map<
     string,
     Extract<Awaited<ReturnType<FleetContainerRuntime["inspectNetwork"]>>, { kind: "ok" }>
@@ -65,7 +82,22 @@ function createContainerMock(
     async (_runtime, name) => networks.get(name) ?? { kind: "missing" },
   );
   const isDockerRootless = vi.fn<FleetContainerRuntime["isDockerRootless"]>(async () => false);
-  const run = vi.fn<FleetContainerRuntime["run"]>(async () => undefined);
+  const run = vi.fn<FleetContainerRuntime["run"]>(async (profile, start) => {
+    removedContainers.delete(profile.containerName);
+    inspections.set(
+      profile.containerName,
+      runningInspection({
+        state: start ? "running" : "created",
+        running: start,
+        labels: fleetLabels(profile.tenantId, profile.attemptId),
+        environment: { ...profile.environment },
+        imageId: `sha256:${profile.attemptId}`,
+        memory: profile.memory,
+        cpus: profile.cpus,
+        pidsLimit: profile.pidsLimit,
+      }),
+    );
+  });
   const pull = vi.fn<FleetContainerRuntime["pull"]>(async () => undefined);
   const createNetwork = vi.fn<FleetContainerRuntime["createNetwork"]>(
     async (_runtime, name, labels, options) => {
@@ -80,11 +112,18 @@ function createContainerMock(
   const removeNetwork = vi.fn<FleetContainerRuntime["removeNetwork"]>(async (_runtime, name) => {
     networks.delete(name);
   });
-  const start = vi.fn<FleetContainerRuntime["start"]>(async () => undefined);
+  const start = vi.fn<FleetContainerRuntime["start"]>(async (_runtime, name) => {
+    const current = await inspect("docker", name);
+    if (current.kind === "ok") {
+      inspections.set(name, { ...current, state: "running", running: true });
+    }
+  });
   const stop = vi.fn<FleetContainerRuntime["stop"]>(async () => undefined);
   const restart = vi.fn<FleetContainerRuntime["restart"]>(async () => undefined);
   const logs = vi.fn<FleetContainerRuntime["logs"]>(async () => undefined);
-  const remove = vi.fn<FleetContainerRuntime["remove"]>(async () => {
+  const remove = vi.fn<FleetContainerRuntime["remove"]>(async (_runtime, name) => {
+    inspections.delete(name);
+    removedContainers.add(name);
     inspect.mockResolvedValue({ kind: "missing", state: "missing" });
   });
   return {
@@ -199,6 +238,7 @@ describe("fleet service filesystem and removal", () => {
     const betaDir = path.join(root, "fleet", "cells", "beta");
     await fs.rm(acmeDir, { recursive: true });
     await fs.symlink(betaDir, acmeDir, "dir");
+    containers.inspect.mockClear();
 
     await expect(service.remove({ tenant: "acme", purgeData: true, force: true })).rejects.toThrow(
       /symlinked fleet tenant directory/iu,
@@ -214,6 +254,7 @@ describe("fleet service filesystem and removal", () => {
     const service = createFleetService({ env, containers: containers.runtime, now: () => 1000 });
     await service.create({ tenant: "acme", gatewayToken: "token" });
     await service.create({ tenant: "beta", gatewayToken: "token" });
+    containers.inspect.mockResolvedValue(runningInspection({ state: "exited", running: false }));
     await service.remove({ tenant: "acme" });
     const acmeConfig = path.join(root, "fleet", "cells", "acme", "openclaw.json");
     const betaConfig = path.join(root, "fleet", "cells", "beta", "openclaw.json");
@@ -243,6 +284,7 @@ describe("fleet service filesystem and removal", () => {
     const containers = createContainerMock();
     const service = createFleetService({ env, containers: containers.runtime, now: () => 1000 });
     await service.create({ tenant: "acme", gatewayToken: "token" });
+    containers.inspect.mockResolvedValue(runningInspection({ state: "exited", running: false }));
     await service.remove({ tenant: "acme" });
     const configPath = path.join(root, "fleet", "cells", "acme", "openclaw.json");
     const configBefore = await fs.readFile(configPath, "utf8");

--- a/src/fleet/service-support.runtime.ts
+++ b/src/fleet/service-support.runtime.ts
@@ -457,7 +457,7 @@ export async function verifyReplacementHealthy(params: {
   checkpoint: () => void;
   timeoutMs: number;
   pollMs: number;
-  context: "upgrade" | "restore";
+  context: "upgrade" | "restore" | "create";
 }): Promise<void> {
   const deadline = params.now() + params.timeoutMs;
   for (;;) {

--- a/src/fleet/service.runtime.test.ts
+++ b/src/fleet/service.runtime.test.ts
@@ -5,12 +5,19 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { cellAuthSecretDir, cellOwnerId } from "./cell-profile.js";
 import type { FleetContainerInspectResult, FleetContainerRuntime } from "./containers.runtime.js";
-import { deleteFleetCell, getFleetCell } from "./registry.js";
-import { createFleetService } from "./service.runtime.js";
+import { deleteFleetCell, getFleetCell, listFleetCells } from "./registry.js";
+import {
+  createFleetService as createFleetServiceRuntime,
+  type FleetServiceOptions,
+} from "./service.runtime.js";
 
 let root: string;
 const TEST_ATTEMPT_ID = "22222222222222222222222222222222";
 const NEXT_ATTEMPT_ID = "44444444444444444444444444444444";
+
+function createFleetService(options: FleetServiceOptions = {}) {
+  return createFleetServiceRuntime({ probePort: async () => true, ...options });
+}
 
 function fleetLabels(tenant = "acme", attemptId = TEST_ATTEMPT_ID): Record<string, string> {
   return {
@@ -57,7 +64,13 @@ function createContainerMock(
   },
 ) {
   const assertLocal = vi.fn<FleetContainerRuntime["assertLocal"]>(async () => undefined);
-  const inspect = vi.fn<FleetContainerRuntime["inspect"]>(async () => initialInspection);
+  const inspections = new Map<string, FleetContainerInspectResult>();
+  const removedContainers = new Set<string>();
+  const inspect = vi.fn<FleetContainerRuntime["inspect"]>(async (_runtime, name) =>
+    removedContainers.has(name)
+      ? { kind: "missing", state: "missing" }
+      : (inspections.get(name) ?? initialInspection),
+  );
   const networks = new Map<
     string,
     Extract<Awaited<ReturnType<FleetContainerRuntime["inspectNetwork"]>>, { kind: "ok" }>
@@ -66,7 +79,22 @@ function createContainerMock(
     async (_runtime, name) => networks.get(name) ?? { kind: "missing" },
   );
   const isDockerRootless = vi.fn<FleetContainerRuntime["isDockerRootless"]>(async () => false);
-  const run = vi.fn<FleetContainerRuntime["run"]>(async () => undefined);
+  const run = vi.fn<FleetContainerRuntime["run"]>(async (profile, start) => {
+    removedContainers.delete(profile.containerName);
+    inspections.set(
+      profile.containerName,
+      runningInspection({
+        state: start ? "running" : "created",
+        running: start,
+        labels: fleetLabels(profile.tenantId, profile.attemptId),
+        environment: { ...profile.environment },
+        imageId: `sha256:${profile.attemptId}`,
+        memory: profile.memory,
+        cpus: profile.cpus,
+        pidsLimit: profile.pidsLimit,
+      }),
+    );
+  });
   const pull = vi.fn<FleetContainerRuntime["pull"]>(async () => undefined);
   const createNetwork = vi.fn<FleetContainerRuntime["createNetwork"]>(
     async (_runtime, name, labels, options) => {
@@ -81,11 +109,18 @@ function createContainerMock(
   const removeNetwork = vi.fn<FleetContainerRuntime["removeNetwork"]>(async (_runtime, name) => {
     networks.delete(name);
   });
-  const start = vi.fn<FleetContainerRuntime["start"]>(async () => undefined);
+  const start = vi.fn<FleetContainerRuntime["start"]>(async (_runtime, name) => {
+    const current = await inspect("docker", name);
+    if (current.kind === "ok") {
+      inspections.set(name, { ...current, state: "running", running: true });
+    }
+  });
   const stop = vi.fn<FleetContainerRuntime["stop"]>(async () => undefined);
   const restart = vi.fn<FleetContainerRuntime["restart"]>(async () => undefined);
   const logs = vi.fn<FleetContainerRuntime["logs"]>(async () => undefined);
-  const remove = vi.fn<FleetContainerRuntime["remove"]>(async () => {
+  const remove = vi.fn<FleetContainerRuntime["remove"]>(async (_runtime, name) => {
+    inspections.delete(name);
+    removedContainers.add(name);
     inspect.mockResolvedValue({ kind: "missing", state: "missing" });
   });
   return {
@@ -128,10 +163,15 @@ describe("fleet service", () => {
   beforeEach(async () => {
     root = await tempRoot.setup();
     env = { ...process.env, OPENCLAW_STATE_DIR: root };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response(null, { status: 200 })),
+    );
   });
 
   afterEach(async () => {
     closeOpenClawStateDatabaseForTest();
+    vi.unstubAllGlobals();
     await tempRoot.cleanup();
   });
 
@@ -221,9 +261,134 @@ describe("fleet service", () => {
     expect(result.token).toMatch(/^[a-f0-9]{32}$/u);
   });
 
+  it("health-gates started creates and skips the gate with --no-start", async () => {
+    const containers = createContainerMock();
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
+    const service = createFleetService({
+      env,
+      containers: containers.runtime,
+      fetch: fetchMock,
+      probePort: async () => true,
+    });
+
+    await expect(
+      service.create({ tenant: "healthy", gatewayToken: "token" }),
+    ).resolves.toMatchObject({ tenant: "healthy", started: true });
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    fetchMock.mockClear();
+    await expect(
+      service.create({ tenant: "stopped", gatewayToken: "token", start: false }),
+    ).resolves.toMatchObject({ tenant: "stopped", started: false });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps an unhealthy created cell and its runtime evidence", async () => {
+    const containers = createContainerMock();
+    let clock = 0;
+    const service = createFleetService({
+      env,
+      containers: containers.runtime,
+      fetch: vi.fn<typeof fetch>(async () => new Response(null, { status: 503 })),
+      now: () => (clock += 50_000),
+      sleep: async () => {},
+      probePort: async () => true,
+    });
+
+    await expect(service.create({ tenant: "sick", gatewayToken: "token" })).rejects.toThrow(
+      "Fleet cell sick was created but did not become healthy within 60s; inspect it with `openclaw fleet status sick` or `openclaw fleet logs sick`, or remove it with `openclaw fleet rm sick --force`.",
+    );
+
+    expect(getFleetCell(env, "sick")).toBeDefined();
+    expect(containers.remove).not.toHaveBeenCalled();
+    expect(containers.removeNetwork).not.toHaveBeenCalled();
+  });
+
+  it("rejects busy explicit ports before reservation and propagates probe errors", async () => {
+    const containers = createContainerMock();
+    const busy = createFleetService({
+      env,
+      containers: containers.runtime,
+      probePort: async () => false,
+    });
+    await expect(
+      busy.create({ tenant: "busy", port: 20_000, gatewayToken: "token" }),
+    ).rejects.toThrow("Host port 20000 is already in use on 127.0.0.1 by another process.");
+    expect(getFleetCell(env, "busy")).toBeUndefined();
+
+    const failure = new Error("bind permission denied");
+    const broken = createFleetService({
+      env,
+      containers: containers.runtime,
+      probePort: async () => {
+        throw failure;
+      },
+    });
+    await expect(broken.create({ tenant: "broken", gatewayToken: "token" })).rejects.toBe(failure);
+    expect(getFleetCell(env, "broken")).toBeUndefined();
+  });
+
+  it("skips probe-busy ports during automatic allocation", async () => {
+    const containers = createContainerMock();
+    const probePort = vi.fn(async (port: number) => port !== 19_100);
+    const service = createFleetService({ env, containers: containers.runtime, probePort });
+
+    const result = await service.create({ tenant: "acme", gatewayToken: "token" });
+
+    expect(probePort.mock.calls.map(([port]) => port)).toEqual([19_100, 19_101]);
+    expect(result.port).toBe(19_101);
+    expect(getFleetCell(env, "acme")?.hostPort).toBe(19_101);
+  });
+
+  it("keeps scanning past long busy runs instead of capping attempts", async () => {
+    const containers = createContainerMock();
+    const probePort = vi.fn(async (port: number) => port >= 19_130);
+    const service = createFleetService({ env, containers: containers.runtime, probePort });
+
+    const result = await service.create({ tenant: "acme", gatewayToken: "token" });
+
+    expect(result.port).toBe(19_130);
+    expect(probePort).toHaveBeenCalledTimes(31);
+  });
+
+  it("retries automatic allocation when another tenant reserves the probed port", async () => {
+    const containers = createContainerMock();
+    let releaseFirstProbes: (() => void) | undefined;
+    let firstProbeCount = 0;
+    const firstProbes = new Promise<void>((resolve) => {
+      releaseFirstProbes = resolve;
+    });
+    const probePort = vi.fn(async (port: number) => {
+      if (port === 19_100 && (firstProbeCount += 1) < 2) {
+        await firstProbes;
+      } else if (port === 19_100) {
+        releaseFirstProbes?.();
+      }
+      return true;
+    });
+    const service = createFleetService({ env, containers: containers.runtime, probePort });
+
+    const [alpha, beta] = await Promise.all([
+      service.create({ tenant: "alpha", gatewayToken: "alpha-token" }),
+      service.create({ tenant: "beta", gatewayToken: "beta-token" }),
+    ]);
+
+    expect(new Set([alpha.port, beta.port])).toEqual(new Set([19_100, 19_101]));
+    expect(
+      listFleetCells(env)
+        .map((cell) => cell.hostPort)
+        .toSorted((left, right) => left - right),
+    ).toEqual([19_100, 19_101]);
+  });
+
   it("threads disk and Podman internal networking into provisioning", async () => {
     const containers = createContainerMock();
-    const service = createFleetService({ env, containers: containers.runtime, now: () => 1000 });
+    const service = createFleetService({
+      env,
+      containers: containers.runtime,
+      fetch: vi.fn<typeof fetch>(async () => new Response(null, { status: 200 })),
+      now: () => 1000,
+    });
     await service.create({
       tenant: "acme",
       runtime: "podman",
@@ -313,7 +478,12 @@ describe("fleet service", () => {
 
     const status = await service.status("acme");
 
-    expect(status.container).toEqual({ state: "running", running: true, managed: true });
+    expect(status.container).toEqual({
+      state: "running",
+      running: true,
+      managed: true,
+      imageId: "sha256:old-image-id",
+    });
     expect(status.health).toEqual({
       status: "ok",
       url: "http://127.0.0.1:19100/healthz",
@@ -328,7 +498,10 @@ describe("fleet service", () => {
 
   it("reports failed and skipped health outcomes without probing a stopped cell", async () => {
     const containers = createContainerMock();
-    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 503 }));
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValue(new Response(null, { status: 503 }));
     const service = createFleetService({
       env,
       containers: containers.runtime,
@@ -336,6 +509,7 @@ describe("fleet service", () => {
       now: () => 1000,
     });
     await service.create({ tenant: "acme", gatewayToken: "token" });
+    fetchMock.mockClear();
     containers.inspect.mockResolvedValue(runningInspection({ state: "exited", running: false }));
 
     await expect(service.status("acme")).resolves.toMatchObject({
@@ -347,6 +521,17 @@ describe("fleet service", () => {
     await expect(service.status("acme")).resolves.toMatchObject({
       health: { status: "failed", httpStatus: 503, error: "HTTP 503" },
     });
+  });
+
+  it("omits imageId for missing and unmanaged status", async () => {
+    const containers = createContainerMock();
+    const service = createFleetService({ env, containers: containers.runtime, now: () => 1000 });
+    await service.create({ tenant: "acme", gatewayToken: "token" });
+
+    containers.inspect.mockResolvedValue(runningInspection({ labels: {} }));
+    expect((await service.status("acme")).container).not.toHaveProperty("imageId");
+    containers.inspect.mockResolvedValue({ kind: "missing", state: "missing" });
+    expect((await service.status("acme")).container).not.toHaveProperty("imageId");
   });
 
   it.each(["start", "stop", "restart"] as const)("runs the %s lifecycle action", async (action) => {
@@ -402,6 +587,7 @@ describe("fleet service", () => {
     const containers = createContainerMock();
     const service = createFleetService({ env, containers: containers.runtime, now: () => 1000 });
     await service.create({ tenant: "acme", gatewayToken: "token" });
+    containers.inspect.mockClear();
     containers.assertLocal.mockRejectedValue(new Error("daemon unavailable"));
 
     await expect(service.logs({ tenant: "acme" })).rejects.toThrow(/daemon unavailable/iu);
@@ -457,6 +643,28 @@ describe("fleet service", () => {
     });
     expect(profile?.environment).not.toHaveProperty("NODE_VERSION");
     expect(getFleetCell(env, "acme")?.image).toBe("ghcr.io/openclaw/openclaw:v2");
+  });
+
+  it("passes digest-pinned images verbatim to create and upgrade", async () => {
+    const containers = createContainerMock();
+    const digest = `ghcr.io/openclaw/openclaw@sha256:${"a".repeat(64)}`;
+    const service = createFleetService({
+      env,
+      containers: containers.runtime,
+      generateAttemptId: () => NEXT_ATTEMPT_ID,
+    });
+
+    await service.create({ tenant: "acme", image: digest, gatewayToken: "old-token" });
+    expect(containers.run.mock.calls[0]?.[0].image).toBe(digest);
+
+    containers.run.mockClear();
+    containers.inspect
+      .mockResolvedValueOnce(runningInspection())
+      .mockResolvedValueOnce(runningInspection({ labels: fleetLabels("acme", NEXT_ATTEMPT_ID) }));
+    await service.upgrade("acme");
+
+    expect(containers.pull).toHaveBeenCalledWith("docker", digest);
+    expect(containers.run.mock.calls[0]?.[0].image).toBe(digest);
   });
 
   it("restores the immutable old image when replacement fails", async () => {
@@ -552,12 +760,14 @@ describe("fleet service", () => {
 
   it("restores the previous cell when the replacement crashes after starting", async () => {
     const containers = createContainerMock();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockRejectedValue(new Error("connect ECONNREFUSED"));
     const service = createFleetService({
       env,
       containers: containers.runtime,
-      fetch: vi.fn<typeof fetch>(async () => {
-        throw new Error("connect ECONNREFUSED");
-      }),
+      fetch: fetchMock,
       sleep: async () => {},
       now: () => 1000,
       generateAttemptId: () => NEXT_ATTEMPT_ID,
@@ -585,10 +795,14 @@ describe("fleet service", () => {
   it("restores the previous cell when the replacement never becomes healthy", async () => {
     const containers = createContainerMock();
     let clock = 0;
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValue(new Response(null, { status: 503 }));
     const service = createFleetService({
       env,
       containers: containers.runtime,
-      fetch: vi.fn<typeof fetch>(async () => new Response(null, { status: 503 })),
+      fetch: fetchMock,
       sleep: async () => {},
       now: () => (clock += 50_000),
       generateAttemptId: () => NEXT_ATTEMPT_ID,

--- a/src/fleet/service.runtime.ts
+++ b/src/fleet/service.runtime.ts
@@ -1,9 +1,11 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import { createServer } from "node:net";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { backupFleetCell, restoreFleetCell } from "./backup.runtime.js";
 import {
+  allocateHostPort,
   buildCellEnvironment,
   cellAuthSecretDir,
   cellContainerName,
@@ -30,6 +32,7 @@ import {
 import { runFleetDoctor } from "./doctor.runtime.js";
 import {
   deleteFleetCell,
+  getFleetCell,
   listFleetCells,
   reserveFleetCell,
   updateFleetCellImage,
@@ -62,8 +65,23 @@ const OFFICIAL_IMAGE_GID = 1_000;
 // Mirrors the compose healthcheck contract: an upgrade commits only after /healthz
 // answers. The deadline bounds how long a broken image can hold the cell before
 // restore without rolling back slow-booting cells prematurely.
-const UPGRADE_VERIFY_TIMEOUT_MS = 60_000;
-const UPGRADE_VERIFY_POLL_MS = 1_000;
+const CELL_VERIFY_TIMEOUT_MS = 60_000;
+const CELL_VERIFY_POLL_MS = 1_000;
+
+async function probeLoopbackPort(port: number): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const server = createServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      // The probe exists only to catch the one legible failure early (address in
+      // use). Anything else - e.g. EACCES on a privileged port an unprivileged CLI
+      // cannot bind but a rootful daemon can - defers to the authoritative runtime bind.
+      resolve(error.code !== "EADDRINUSE");
+    });
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
 
 export type FleetCreateOptions = {
   tenant: string;
@@ -114,10 +132,11 @@ export type FleetStatusResult = {
   image: string;
   created: string;
   dataDir: string;
-  container:
+  container: { imageId?: string } & (
     | { state: string; running: boolean; managed: boolean }
     | { state: "missing"; running: false; managed: false }
-    | { state: "unknown"; running: false; managed: false; error: string };
+    | { state: "unknown"; running: false; managed: false; error: string }
+  );
   health: FleetHealthResult;
 };
 
@@ -147,6 +166,7 @@ export type FleetServiceOptions = {
   getuid?: () => number | undefined;
   getgid?: () => number | undefined;
   sleep?: (ms: number) => Promise<void>;
+  probePort?: (port: number) => Promise<boolean>;
   selinuxEnabled?: () => Promise<boolean>;
   updateImage?: typeof updateFleetCellImage;
 };
@@ -169,6 +189,7 @@ export function createFleetService(options: FleetServiceOptions = {}) {
       }));
   const selinuxEnabled = options.selinuxEnabled ?? detectHostSelinux;
   const updateImage = options.updateImage ?? updateFleetCellImage;
+  const probePort = options.probePort ?? probeLoopbackPort;
 
   return {
     async create(createOptions: FleetCreateOptions): Promise<FleetCreateResult> {
@@ -198,16 +219,57 @@ export function createFleetService(options: FleetServiceOptions = {}) {
         operation: async (checkpoint) => {
           checkpoint();
           const stateDir = resolveStateDir(env);
-          const record = reserveFleetCell(env, {
+          const usedPorts = new Set(listFleetCells(env).map((cell) => cell.hostPort));
+          const reservation = {
             tenantId,
             createdAtMs: now(),
             image,
             runtime,
-            requestedPort: createOptions.port,
             containerName: cellContainerName(tenantId),
             dataDir: cellDataDir(stateDir, tenantId),
-          });
+          };
+          let record: ReturnType<typeof reserveFleetCell> | undefined;
+          if (createOptions.port !== undefined) {
+            const candidatePort = allocateHostPort(usedPorts, createOptions.port);
+            if (!(await probePort(candidatePort))) {
+              throw new Error(
+                `Host port ${candidatePort} is already in use on 127.0.0.1 by another process.`,
+              );
+            }
+            // The probe is best-effort UX; the runtime bind remains authoritative across this TOCTOU gap.
+            record = reserveFleetCell(env, { ...reservation, requestedPort: candidatePort });
+          } else {
+            const unavailablePorts = new Set(usedPorts);
+            // The exclusion set only grows, so this terminates: allocateHostPort throws
+            // its range-exhaustion error once every port through 65535 is excluded.
+            while (!record) {
+              for (const cell of listFleetCells(env)) {
+                unavailablePorts.add(cell.hostPort);
+              }
+              const candidate = allocateHostPort(unavailablePorts);
+              if (!(await probePort(candidate))) {
+                unavailablePorts.add(candidate);
+                continue;
+              }
+              try {
+                // The probe is best-effort UX; the runtime bind remains authoritative across this TOCTOU gap.
+                record = reserveFleetCell(env, { ...reservation, requestedPort: candidate });
+              } catch (error) {
+                if (getFleetCell(env, tenantId)) {
+                  throw error;
+                }
+                const candidateWasReserved = listFleetCells(env).some(
+                  (cell) => cell.hostPort === candidate,
+                );
+                if (!candidateWasReserved) {
+                  throw error;
+                }
+                unavailablePorts.add(candidate);
+              }
+            }
+          }
 
+          let result: FleetCreateResult;
           let networkAttempted = false;
           let containerAttempted = false;
           try {
@@ -272,7 +334,7 @@ export function createFleetService(options: FleetServiceOptions = {}) {
               assertCurrentReservation(env, record);
             }
             const url = `http://127.0.0.1:${record.hostPort}`;
-            return {
+            result = {
               tenant: tenantId,
               containerName: record.containerName,
               port: record.hostPort,
@@ -326,6 +388,30 @@ export function createFleetService(options: FleetServiceOptions = {}) {
             }
             throw error;
           }
+          if (result.started) {
+            try {
+              await verifyReplacementHealthy({
+                containers,
+                record,
+                attemptId,
+                fetchImpl,
+                now,
+                sleep,
+                checkpoint,
+                timeoutMs: CELL_VERIFY_TIMEOUT_MS,
+                pollMs: CELL_VERIFY_POLL_MS,
+                context: "create",
+              });
+            } catch (error) {
+              // Unlike upgrade/restore, create has no previous container to bring back;
+              // keep the sick cell (container + registry row) as diagnosable evidence.
+              throw new Error(
+                `Fleet cell ${tenantId} was created but did not become healthy within 60s; inspect it with \`openclaw fleet status ${tenantId}\` or \`openclaw fleet logs ${tenantId}\`, or remove it with \`openclaw fleet rm ${tenantId} --force\`.`,
+                { cause: error },
+              );
+            }
+          }
+          return result;
         },
       });
     },
@@ -392,6 +478,7 @@ export function createFleetService(options: FleetServiceOptions = {}) {
           state: managed ? inspection.state : "unknown",
           running: inspection.running,
           managed,
+          ...(managed ? { imageId: inspection.imageId } : {}),
         };
         health =
           managed && inspection.running
@@ -536,8 +623,8 @@ export function createFleetService(options: FleetServiceOptions = {}) {
               now,
               sleep,
               checkpoint,
-              timeoutMs: UPGRADE_VERIFY_TIMEOUT_MS,
-              pollMs: UPGRADE_VERIFY_POLL_MS,
+              timeoutMs: CELL_VERIFY_TIMEOUT_MS,
+              pollMs: CELL_VERIFY_POLL_MS,
               context: "upgrade",
             });
             checkpoint();

--- a/src/security/audit-extra.summary.ts
+++ b/src/security/audit-extra.summary.ts
@@ -149,7 +149,7 @@ export function collectAttackSurfaceSummaryFindings(cfg: OpenClawConfig): Securi
     `\n` +
     `browser control: ${browserEnabled ? "enabled" : "disabled"}` +
     `\n` +
-    "trust model: personal assistant (one trusted operator boundary), not hostile multi-tenant on one shared gateway";
+    "trust model: personal assistant (one trusted operator boundary), not hostile multi-tenant on one shared gateway. For multiple users or organizations, run one isolated Gateway cell per tenant: https://docs.openclaw.ai/gateway/multi-tenant-hosting";
 
   return [
     {

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1252,7 +1252,7 @@ export function collectLikelyMultiUserSetupFindings(cfg: OpenClawConfig): Securi
       "Heuristic signals indicate this gateway may be reachable by multiple users:\n" +
       signals.map((signal) => `- ${signal}`).join("\n") +
       `\n${impactLine}\n${riskyContextsDetail}\n` +
-      "OpenClaw's default security model is personal-assistant (one trusted operator boundary), not hostile multi-tenant isolation on one shared gateway.",
+      "OpenClaw's default security model is personal-assistant (one trusted operator boundary), not hostile multi-tenant isolation on one shared gateway. For multiple users or organizations, run one isolated Gateway cell per tenant: https://docs.openclaw.ai/gateway/multi-tenant-hosting",
     remediation:
       'If users may be mutually untrusted, split trust boundaries (separate gateways + credentials, ideally separate OS users/hosts). If you intentionally run shared-user access, set agents.defaults.sandbox.mode="all", keep tools.fs.workspaceOnly=true, deny runtime/fs/web tools unless required, and keep personal/private identities + credentials off that runtime.',
   });

--- a/src/security/audit-summary.test.ts
+++ b/src/security/audit-summary.test.ts
@@ -34,7 +34,7 @@ describe("security audit attack surface summary", () => {
         "hooks.webhooks: enabled",
         "hooks.internal: disabled",
         "browser control: enabled",
-        "trust model: personal assistant (one trusted operator boundary), not hostile multi-tenant on one shared gateway",
+        "trust model: personal assistant (one trusted operator boundary), not hostile multi-tenant on one shared gateway. For multiple users or organizations, run one isolated Gateway cell per tenant: https://docs.openclaw.ai/gateway/multi-tenant-hosting",
       ].join("\n"),
     );
   });

--- a/src/security/audit-trust-model.test.ts
+++ b/src/security/audit-trust-model.test.ts
@@ -120,6 +120,7 @@ describe("security audit trust model findings", () => {
             'channels.discord.groupPolicy="allowlist" with configured group targets',
           );
           expect(finding.detail).toContain("personal-assistant");
+          expect(finding.detail).toContain("https://docs.openclaw.ai/gateway/multi-tenant-hosting");
           expect(finding.remediation).toContain('agents.defaults.sandbox.mode="all"');
         },
       },


### PR DESCRIPTION
## What Problem This Solves

Operational rough edges in the experimental fleet supervisor, collected from review and live testing of #104527/#104669: create reported success on broken images, image drift under mutable tags was invisible, host port collisions surfaced as opaque container errors, `openclaw security audit` guidance predated the multi-tenant docs, and digest-pinning/platform expectations were undocumented. Closes #104791.

Scope note: this PR was rebased over #104828 (disk limits, egress policy, backup/restore, diagnostics), which landed in parallel. The originally planned backup/restore documentation recipe was dropped as superseded by that PR's real `fleet backup`/`fleet restore` commands; the create health gate now reuses that PR's `verifyReplacementHealthy` helper (widened with a `create` context) instead of introducing a parallel one.

## Why This Change Was Made

- **Health-gated create.** `create` now applies the same bounded `/healthz` wait as upgrade/restore. Failure semantics deliberately differ and are commented: there is no previous container to bring back, so an unhealthy new cell is *kept* (container + registry row) as diagnosable evidence, and the error directs to `fleet status|logs|rm` with the verifier's outcome preserved as `cause`. `--no-start` skips the gate. Docs note the token of an unhealthy new cell stays recoverable from container env, and rm+recreate is always safe pre-traffic.
- **Port bind probing.** Before reserving, create probe-binds `127.0.0.1:<candidate>`: an explicit `--port` in host use fails with a clear error; auto-allocation skips host-busy ports and retries reservation races, scanning until the allocator's own range-exhaustion error (no arbitrary attempt cap). The probe fails open on anything but `EADDRINUSE` — e.g. EACCES on a privileged port an unprivileged CLI cannot bind but a rootful daemon can — so the runtime bind stays authoritative (commented, including the deliberate TOCTOU acceptance).
- **Image drift visibility.** `fleet status` surfaces the live image ID from inspection for managed cells (no schema change); digest pinning via `--image ...@sha256:...` is verified by test and documented.
- **Audit alignment.** The security audit's multi-user and attack-surface trust-model strings now point at the supported model: one isolated Gateway cell per tenant (docs link).
- **Docs.** Digest pinning, create health-gate behavior with token-recovery note, and an explicit platform statement (Linux/macOS tested, Windows untested).

No new config keys, no new dependencies, no schema changes.

## User Impact

Broken images fail loudly at create instead of leaving silently dead cells; port conflicts fail early with a clear message; drift is visible in `status`; audit guidance matches the product. Fleet remains experimental.

## Evidence

- Focused tests green on Blacksmith Testbox (195 fleet/CLI + 22 audit; new coverage: create gating healthy/never-healthy/`--no-start` with evidence retention asserted, port probing explicit-busy/auto-skip/race-retry/uncapped-scan, digest pass-through, status image ID, audit strings): https://github.com/openclaw/openclaw/actions/runs/29176329106 (3 shards green)
- `pnpm tsgo`, `pnpm check:test-types`, oxlint, `docs:map:check`: clean.
- Pre-existing unrelated failures ruled out earlier by stash A/B on clean `origin/main` (`audit-plugin-readonly-scope`, `secret-equal`).
- Structured autoreview (Codex) across the bundle's development: four accepted findings fixed (concurrent port reservation retry, restore-options documentation, EACCES fail-open, uncapped range scan) and one resolved via docs (token recovery). Final review on the rebased bundle: clean, "no accepted/actionable findings" (0.88).
