### PR TITLE
feat(sessions): let sessions_send register explicit state-change watchers

### DIFF
--- a/docs/concepts/session-state.md
+++ b/docs/concepts/session-state.md
@@ -1,0 +1,106 @@
+---
+summary: "Durable session state signal log: state versions, watchers, stale-state notices, and reconciliation"
+read_when:
+  - You want agents to notice when humans or other agents change a session behind their back
+  - You are debugging state-change notices, watch cursors, or session_status changesSince
+  - You want to understand how parent agents stay synchronized with child sessions
+title: "Session state awareness"
+sidebarTitle: "Session state awareness"
+---
+
+When several sessions work on the same problem — a manager delegating to children, a human jumping directly into a worker session, two agents coordinating over [`sessions_send`](/concepts/session-tool) — each session builds assumptions about the others. Those assumptions go stale the moment another actor intervenes. Session state awareness is the machinery that detects the intervention, tells the affected session once, and gives it a cheap way to catch up before acting.
+
+Three pieces work together:
+
+1. A **durable signal log** records selected state changes per session.
+2. **Watchers** hold per-target cursors and receive one coalesced stale-state notice.
+3. **Reconciliation** pulls the exact delta via `session_status` with `changesSince`.
+
+## The signal log
+
+OpenClaw appends a typed event to the shared state database (`session_state_events`) when a watched session materially changes. Events carry metadata and a one-line summary — never message content.
+
+| Kind                   | Recorded when                                            | Notifies watchers |
+| ---------------------- | -------------------------------------------------------- | ----------------- |
+| `human_direct_message` | A human sends a turn directly to a watched session       | Yes               |
+| `goal_changed`         | The session's goal state is created, updated, or cleared | Yes               |
+| `child_spawned`        | A sub-agent or ACP child session is created              | No (seeds cursor) |
+| `run_completed`        | A child run ends successfully                            | No (log only)     |
+| `run_failed`           | A child run fails, times out, or is cancelled            | No (log only)     |
+| `compacted`            | The session's history is compacted                       | No (log only)     |
+
+Each event names its actor (`human`, `agent`, or `system`). Cancelled and timed-out child runs are recorded as failures with the precise outcome (`cancelled`, `timeout`, or `error`) preserved in the event payload.
+
+A session's **state version** is simply the highest sequence number in its log, tracked in a durable per-session head that survives pruning. `sessions_list` rows include `stateVersion` when a session has logged changes; `session_status` always reports it.
+
+Log-only kinds exist for reconciliation history, not notification: ordinary child-run completion delivery stays owned by [sub-agent announcements](/tools/subagents), and the signal log never duplicates it.
+
+## Watchers
+
+A watcher is a session that holds a cursor (`session_watch_cursors`) on a target. Cursors come from two places:
+
+- **Implicit (spawn edges).** When a session spawns a sub-agent or ACP child, the parent's cursor is seeded automatically at the child's spawn version. Parents never subscribe manually.
+- **Explicit (`sessions_send watch: true`).** Any coordinator can watch a non-spawned target: pass `watch: true` on `sessions_send`, and after the send dispatches successfully the sender is registered as a watcher of the session that actually received the message. Registration starts at the target's current state version — prior history never produces notices. The tool result reports `watched: true|false` when the parameter was set.
+
+Watcher identity must be an agent-qualified session key. Under `session.scope="global"` the shared `global` key is ambiguous across agents, so such sessions get the durable log and `changesSince` but no proactive notices.
+
+Watches clean themselves up: cursor rows expire with signal-log retention, are removed when the watcher session resets, and are deleted with either session. There is no unwatch verb in v1.
+
+## Notices: one, not many
+
+When a notify-eligible event lands and a watcher's cursor is behind, the watcher receives one system notice on its next turn:
+
+```
+Session "agent:main:subagent:child" changed (other actor). Reconcile before acting: session_status sessionKey "agent:main:subagent:child" changesSince 12.
+```
+
+Main-session watchers are also woken immediately via a heartbeat wake; nested sub-agent watchers get the notice on their next turn.
+
+The protocol is deliberately anti-spam:
+
+- **One pending notice per watcher/target pair.** The notice text is byte-stable while pending and the system-event queue dedupes on it, so twenty rapid changes to the same target still produce a single line in the watcher's prompt.
+- **Frozen watermark.** The cursor freezes its notified position when a notice is queued. Further material events advance only the material watermark; they do not re-notify.
+- **Acknowledge on drain, reopen only for interleaved work.** When the watcher's turn consumes the notice, the cursor advances. If more material events arrived between queueing and draining, exactly one fresh notice is opened for the remainder.
+- **Self-suppression.** A watcher never gets notified about events it caused itself.
+- **Restart recovery.** Pending notices live in an in-memory queue; a startup sweep re-materializes them from durable cursors after a gateway restart.
+
+## Reconciling
+
+The notice tells the watcher exactly what to do. `session_status` with `changesSince: <version>` returns the typed events after that version (up to 200), without advancing any cursors:
+
+```json
+{
+  "stateVersion": 19,
+  "stateChanges": {
+    "events": [
+      {
+        "sequence": 14,
+        "kind": "human_direct_message",
+        "actorType": "human",
+        "summary": "human message via telegram"
+      },
+      { "sequence": 19, "kind": "goal_changed", "actorType": "human", "summary": "goal updated" }
+    ],
+    "historyGap": false
+  }
+}
+```
+
+`historyGap: true` means the requested version predates retained history — refresh the whole session state (`sessions_history`, `session_status`) instead of treating the response as an exact delta. The gap signal is exact: it comes from a per-session pruned watermark, not inferred from sequence arithmetic.
+
+## Storage and limits
+
+History lives in the shared state database, bounded to 30 days and 50,000 rows; per-session heads stay monotonic after pruning. Recording is best-effort — a failed append is logged and never fails the originating turn — so `stateVersion` is a signal-log head, not a transactional change-data-capture version.
+
+Current limits:
+
+- Notice delivery assumes one gateway process owns the shared state database. Multiple gateways share the durable log and `changesSince`, but v1 does not push notices across processes.
+- Compaction events cover the embedded runtime's compaction owners; native-harness-only compaction is not fully logged.
+- Cancelled-outcome payload detail is currently produced by ACP child runs; native sub-agent cancellations surface as generic failures.
+
+## Related
+
+- [Session tools](/concepts/session-tool) — `sessions_send`, `session_status`, `sessions_list`
+- [Sub-agents](/tools/subagents) — spawn edges and completion announcements
+- [Heartbeat](/gateway/heartbeat) — how queued notices wake main sessions
+- [Session management](/concepts/session) — session keys, scopes, lifecycle

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -71,6 +71,8 @@ Messages and A2A follow-up replies are marked as inter-session data in the recei
 
 After the target responds, OpenClaw can run a **reply-back loop** where the agents alternate messages (up to `session.agentToAgent.maxPingPongTurns`, range 0-20, default 5). The target agent can reply `REPLY_SKIP` to stop early.
 
+Pass `watch: true` to also register the sender as a state-change watcher of the target: when another actor later sends the target a direct human message or changes its goal, the sender receives a system notice pointing at `session_status` `changesSince` (see [Session state changes](/concepts/session-tool#session-state-changes)). Registration starts at the target's current state version, so only changes after the send produce notices. The result reports `watched: true` when registration succeeded; watches expire with normal signal-log retention and are cleared when the watcher session resets.
+
 ## Status and orchestration helpers
 
 `session_status` is the lightweight `/status`-equivalent tool for the current or another visible session. It reports usage, time, model/runtime state, and linked background-task context when present. Like `/status`, it can backfill sparse token/cache counters from the latest transcript usage entry, and `model=default` clears a per-session override. Use `sessionKey="current"` for the caller's current session; visible client labels such as `openclaw-tui` are not session keys.

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -71,7 +71,7 @@ Messages and A2A follow-up replies are marked as inter-session data in the recei
 
 After the target responds, OpenClaw can run a **reply-back loop** where the agents alternate messages (up to `session.agentToAgent.maxPingPongTurns`, range 0-20, default 5). The target agent can reply `REPLY_SKIP` to stop early.
 
-Pass `watch: true` to also register the sender as a state-change watcher of the target: when another actor later sends the target a direct human message or changes its goal, the sender receives a system notice pointing at `session_status` `changesSince` (see [Session state changes](/concepts/session-tool#session-state-changes)). Registration starts at the target's current state version, so only changes after the send produce notices. The result reports `watched: true` when registration succeeded; watches expire with normal signal-log retention and are cleared when the watcher session resets.
+Pass `watch: true` to also register the sender as a state-change watcher of the target: when another actor later sends the target a direct human message or changes its goal, the sender receives a system notice pointing at `session_status` `changesSince`. Registration happens after successful dispatch, targets the session that actually received the message, and starts at its current state version, so only later changes produce notices. The result reports `watched: true` when registration succeeded. See [Session state awareness](/concepts/session-state).
 
 ## Status and orchestration helpers
 
@@ -85,13 +85,9 @@ When route metadata is available, `session_status` also includes a visible `Rout
 
 ## Session state changes
 
-OpenClaw keeps a best-effort signal log for selected session state changes: direct human messages to child sessions, child-run completion or failure, child creation, goal changes, and compaction. Cancelled and timed-out child runs are recorded as failures, with the specific outcome (`cancelled`, `timeout`, or `error`) preserved in the event payload. The log contains metadata and one-line summaries, never message content. Its `stateVersion` is the session's signal-log head, not a transactional change-data-capture version; the session-store mutation and signal append use separate storage, so a failed append is logged without failing the originating turn.
+OpenClaw keeps a durable signal log of material session state changes (direct human messages to watched sessions, child-run outcomes, goal changes, compaction). `sessions_list` rows and `session_status` expose the session's `stateVersion`, and `session_status` accepts `changesSince: <version>` to return the typed events after that version, with exact `historyGap` signaling when the requested version predates retained history. Watchers — spawn parents automatically, `sessions_send watch: true` explicitly — receive one coalesced stale-state notice when another actor changes a watched session.
 
-`sessions_list` includes `stateVersion` on rows with logged changes. `session_status` always returns `stateVersion` in structured details. Pass `changesSince: <previousStateVersion>` to retrieve up to 200 retained events after that version; this read does not acknowledge or advance parent notification cursors. A `historyGap: true` result means the requested version predates retained history, so refresh the whole session state instead of treating the response as an exact delta.
-
-When another actor sends a direct human turn to a watched child or changes its goal, the parent receives a system notice telling it to call `session_status` with its last-seen version. Main-session parents are proactively woken. Nested sub-agent parents receive the notice on their next turn because heartbeat routing cannot target their queue directly. Completion announcements remain the owner for ordinary child-run completion delivery.
-
-History is bounded to 30 days and 50,000 rows, while per-session heads remain monotonic after pruning. Notice delivery uses the gateway's in-memory system-event queue and assumes one gateway process owns delivery for the shared state database. Multiple gateways still share the durable log and `changesSince` reconciliation surface, but v1 does not push notices across processes. Parent notices require an agent-qualified parent session key; under `session.scope="global"` the shared `global` key is ambiguous across agents, so those parents get the durable log and `changesSince` but no proactive notices in v1.
+See [Session state awareness](/concepts/session-state) for the full model: event kinds, watcher registration, the anti-spam notice protocol, reconciliation flow, and current limits.
 
 `sessions_yield` intentionally ends the current turn so the next message can be the follow-up event you are waiting for. Use it after spawning sub-agents when you want completion results to arrive as the next message instead of building poll loops.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1219,6 +1219,7 @@
                   "concepts/session-search",
                   "concepts/channel-docking",
                   "concepts/session-pruning",
+                  "concepts/session-state",
                   "concepts/session-tool",
                   {
                     "group": "Memory",

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2868,6 +2868,17 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Index lifecycle
   - H2: Session search vs. memory search
 
+## concepts/session-state.md
+
+- Route: /concepts/session-state
+- Headings:
+  - H2: The signal log
+  - H2: Watchers
+  - H2: Notices: one, not many
+  - H2: Reconciling
+  - H2: Storage and limits
+  - H2: Related
+
 ## concepts/session-tool.md
 
 - Route: /concepts/session-tool

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -43,7 +43,7 @@ export function describeSessionsSendTool(): string {
   return [
     "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label.",
     "Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available.",
-    "watch:true registers you for state-change notices when other actors later interact with the target session.",
+    "watch:true: notice arrives when others later change target session.",
   ].join(" ");
 }
 

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -43,6 +43,7 @@ export function describeSessionsSendTool(): string {
   return [
     "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label.",
     "Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available.",
+    "watch:true registers you for state-change notices when other actors later interact with the target session.",
   ].join(" ");
 }
 

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -23,6 +23,7 @@ import {
 import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
 import { isCronRunSessionKey, parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
+import { registerSessionStateWatch } from "../../sessions/session-state-events.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
 import {
   type GatewayMessageChannel,
@@ -66,6 +67,7 @@ const SessionsSendToolSchema = Type.Object({
   agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
   message: Type.String(),
   timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
+  watch: Type.Optional(Type.Boolean()),
 });
 
 type GatewayCaller = typeof callGateway;
@@ -559,6 +561,20 @@ export function createSessionsSendTool(opts?: {
       const requesterChannel = opts?.agentChannel;
       const sameSessionA2A = requesterSessionKey === resolvedKey;
       const isIsolatedCronRequester = isCronRunSessionKey(requesterSessionKey);
+      // Watch registration follows successful dispatch: a failed send must not leave
+      // a hidden watch, and cron run-scoped sends can fall back to the durable parent
+      // session, which is the key that receives future state changes.
+      const watchRequested = params.watch === true;
+      const registerWatchIfRequested = (targetSessionKey: string) => {
+        const watched =
+          watchRequested && requesterSessionKey && requesterSessionKey !== targetSessionKey
+            ? registerSessionStateWatch({
+                watcherSessionKey: requesterSessionKey,
+                targetSessionKey,
+              })
+            : false;
+        return watchRequested ? { watched } : {};
+      };
       const fallbackA2ASessionKey =
         timeoutSeconds === 0 && isIsolatedCronRequester
           ? resolveCronRunScopedFallbackSessionKey(displayKey)
@@ -705,6 +721,7 @@ export function createSessionsSendTool(opts?: {
           return start.result;
         }
         runId = start.runId;
+        const watchField = registerWatchIfRequested(start.a2aSessionKey ?? resolvedKey);
         if (!start.activeRunQueue) {
           startA2AFlow(undefined, runId, start.a2aSessionKey, start.a2aDisplayKey, true);
         }
@@ -713,6 +730,7 @@ export function createSessionsSendTool(opts?: {
           status: "accepted",
           sessionKey: displayKey,
           delivery,
+          ...watchField,
         });
       }
 
@@ -727,6 +745,7 @@ export function createSessionsSendTool(opts?: {
         return start.result;
       }
       runId = start.runId;
+      const watchField = registerWatchIfRequested(resolvedKey);
       const result = await waitForAgentRunAndReadUpdatedAssistantReply({
         runId,
         sessionKey: resolvedKey,
@@ -746,6 +765,7 @@ export function createSessionsSendTool(opts?: {
             sentBeforeError: true,
             sessionKey: displayKey,
             delivery,
+            ...watchField,
           });
         }
         if (!isTerminalAgentWaitTimeout(result)) {
@@ -755,6 +775,7 @@ export function createSessionsSendTool(opts?: {
             status: "accepted",
             sessionKey: displayKey,
             delivery,
+            ...watchField,
           });
         }
         return jsonResult({
@@ -763,6 +784,7 @@ export function createSessionsSendTool(opts?: {
           error: result.error,
           sentBeforeError: true,
           sessionKey: displayKey,
+          ...watchField,
         });
       }
       if (result.status === "error") {
@@ -772,6 +794,7 @@ export function createSessionsSendTool(opts?: {
           error: result.error ?? "agent error",
           sentBeforeError: true,
           sessionKey: displayKey,
+          ...watchField,
         });
       }
       const reply = result.replyText;
@@ -783,6 +806,7 @@ export function createSessionsSendTool(opts?: {
         reply,
         sessionKey: displayKey,
         delivery,
+        ...watchField,
       });
     },
   };

--- a/src/sessions/session-state-events.test.ts
+++ b/src/sessions/session-state-events.test.ts
@@ -26,9 +26,11 @@ import {
   pruneSessionStateEvents,
   recordSessionCompacted,
   recordSessionGoalChanged,
+  recordSessionHumanDirectMessage,
   recordSessionStateEvent,
   recordSubagentSpawned,
   recordSubagentTerminalState,
+  registerSessionStateWatch,
   sessionStateEventStoreLimits,
   sweepSessionStateWatchNotices,
 } from "./session-state-events.js";
@@ -461,6 +463,73 @@ describe("session state events", () => {
     expect(classifySessionStateActor({ internalEvents: [{}] })).toEqual({
       actorType: "system",
     });
+  });
+
+  it("registers explicit watchers who get notices only for later changes", () => {
+    const database = createDatabaseOptions();
+    const preRegistration = recordSessionStateEvent(
+      eventInput({ watcherSessionKeys: [] }),
+      database,
+    )!;
+
+    expect(registerSessionStateWatch({ watcherSessionKey: child, targetSessionKey: child })).toBe(
+      false,
+    );
+    expect(
+      registerSessionStateWatch({ watcherSessionKey: "global", targetSessionKey: child }),
+    ).toBe(false);
+    expect(
+      registerSessionStateWatch({ watcherSessionKey: watcher, targetSessionKey: child }, database),
+    ).toBe(true);
+
+    expect(peekSystemEventEntries(watcher)).toHaveLength(0);
+    expect(readCursor(database)).toMatchObject({ last_seen_sequence: preRegistration.sequence });
+
+    const afterRegistration = recordSessionStateEvent(
+      eventInput({ watcherSessionKeys: [] }),
+      database,
+    )!;
+    expect(peekSystemEventEntries(watcher)).toHaveLength(1);
+    expect(peekSystemEventEntries(watcher)[0]?.text).toContain(
+      `changesSince ${preRegistration.sequence}`,
+    );
+
+    // Re-registering must keep the pending-notice cursor intact.
+    expect(
+      registerSessionStateWatch({ watcherSessionKey: watcher, targetSessionKey: child }, database),
+    ).toBe(true);
+    expect(readCursor(database)).toEqual({
+      last_seen_sequence: preRegistration.sequence,
+      notified_sequence: afterRegistration.sequence,
+      material_sequence: afterRegistration.sequence,
+    });
+  });
+
+  it("gates unparented human turns on registered watchers", () => {
+    const database = createDatabaseOptions();
+    const entry = { sessionId: "session-child", updatedAt: Date.now() };
+    recordSessionHumanDirectMessage({
+      sessionKey: child,
+      entry,
+      agentId: "main",
+      actor: { actorType: "human" },
+      channel: "webchat",
+    });
+    expect(listSessionStateEventsSince(child, "main", 0, 200, database).events).toHaveLength(0);
+
+    registerSessionStateWatch({ watcherSessionKey: watcher, targetSessionKey: child }, database);
+    recordSessionHumanDirectMessage({
+      sessionKey: child,
+      entry,
+      agentId: "main",
+      actor: { actorType: "human" },
+      channel: "webchat",
+    });
+
+    const events = listSessionStateEventsSince(child, "main", 0, 200, database).events;
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: "human_direct_message" });
+    expect(peekSystemEventEntries(watcher)).toHaveLength(1);
   });
 
   it("projects spawn, terminal, goal, and compaction producer helpers", () => {

--- a/src/sessions/session-state-events.test.ts
+++ b/src/sessions/session-state-events.test.ts
@@ -207,7 +207,13 @@ describe("session state events", () => {
     recordSessionStateEvent(eventInput(), database);
     await vi.advanceTimersByTimeAsync(300);
     expect(wakes).toHaveBeenCalledWith(
-      expect.objectContaining({ source: "session-state", sessionKey: watcher }),
+      // intent "immediate" is load-bearing: event-intent wakes defer on heartbeat
+      // dueness and would sit on the notice until the next scheduled tick.
+      expect.objectContaining({
+        source: "session-state",
+        sessionKey: watcher,
+        intent: "immediate",
+      }),
     );
   });
 

--- a/src/sessions/session-state-events.ts
+++ b/src/sessions/session-state-events.ts
@@ -360,9 +360,21 @@ export function recordSessionStateEvent(
           ),
       );
 
-      const watcherSessionKeys = [...new Set(input.watcherSessionKeys ?? [])].filter(
-        (key) => Boolean(key) && isNotifiableWatcherKey(key),
-      );
+      // Explicit watch registrations (registerSessionStateWatch) live as cursor rows;
+      // union them with producer-passed watchers so sessions_send coordinators get
+      // notices without every producer knowing about registration.
+      const registeredWatcherKeys = NOTIFY_BY_KIND[input.kind]
+        ? executeSqliteQuerySync(
+            db,
+            getSessionStateKysely(db)
+              .selectFrom("session_watch_cursors")
+              .select("watcher_session_key")
+              .where("target_session_key", "=", input.sessionKey),
+          ).rows.map((row) => row.watcher_session_key)
+        : [];
+      const watcherSessionKeys = [
+        ...new Set([...(input.watcherSessionKeys ?? []), ...registeredWatcherKeys]),
+      ].filter((key) => Boolean(key) && isNotifiableWatcherKey(key));
       for (const watcherSessionKey of watcherSessionKeys) {
         if (input.kind === "child_spawned") {
           upsertSeedCursor({
@@ -813,7 +825,76 @@ export function recordSessionGoalChanged(params: {
   });
 }
 
-/** Record a direct human turn only when the target has an implicit parent watcher. */
+/** True when any seeded or explicitly registered watcher cursor targets this session. */
+function hasSessionStateWatchers(
+  targetSessionKey: string,
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  try {
+    const { db } = openOpenClawStateDatabase(options);
+    const row = executeSqliteQueryTakeFirstSync(
+      db,
+      getSessionStateKysely(db)
+        .selectFrom("session_watch_cursors")
+        .select("watcher_session_key")
+        .where("target_session_key", "=", targetSessionKey)
+        .limit(1),
+    );
+    return row !== undefined;
+  } catch (error) {
+    // Best-effort log: enrichment reads must never fail core session tools.
+    log.warn(`failed to probe session state watchers: ${String(error)}`);
+    return false;
+  }
+}
+
+/** Register an explicit watcher (e.g. a sessions_send coordinator) for a target session. */
+export function registerSessionStateWatch(
+  params: { watcherSessionKey: string; targetSessionKey: string; targetAgentId?: string },
+  options: OpenClawStateDatabaseOptions & { now?: number } = {},
+): boolean {
+  if (
+    params.watcherSessionKey === params.targetSessionKey ||
+    !isNotifiableWatcherKey(params.watcherSessionKey)
+  ) {
+    return false;
+  }
+  const now = options.now ?? Date.now();
+  try {
+    let registered = false;
+    runOpenClawStateWriteTransaction(({ db }) => {
+      // Re-watching must not clobber pending-notice cursor state.
+      if (readCursor(db, params.watcherSessionKey, params.targetSessionKey)) {
+        registered = true;
+        return;
+      }
+      const agentId = params.targetAgentId ?? resolveAgentIdFromSessionKey(params.targetSessionKey);
+      const head = executeSqliteQueryTakeFirstSync(
+        db,
+        getSessionStateKysely(db)
+          .selectFrom("session_state_heads")
+          .select("last_sequence")
+          .where("session_key", "=", params.targetSessionKey)
+          .where("agent_id", "=", agentId),
+      );
+      // Seed at the current head: the watcher is synced now; only future changes notify.
+      upsertSeedCursor({
+        db,
+        watcherSessionKey: params.watcherSessionKey,
+        targetSessionKey: params.targetSessionKey,
+        sequence: normalizeOptionalSqliteNumber(head?.last_sequence) ?? 0,
+        now,
+      });
+      registered = true;
+    }, options);
+    return registered;
+  } catch (error) {
+    log.warn(`failed to register session state watch: ${String(error)}`);
+    return false;
+  }
+}
+
+/** Record a direct human turn when the target has a parent or registered watcher. */
 export function recordSessionHumanDirectMessage(params: {
   sessionKey: string;
   entry?: SessionEntry;
@@ -823,7 +904,12 @@ export function recordSessionHumanDirectMessage(params: {
   runId?: string;
 }): void {
   const watcherSessionKey = params.entry?.spawnedBy ?? params.entry?.parentSessionKey;
-  if (params.actor.actorType !== "human" || !watcherSessionKey) {
+  if (params.actor.actorType !== "human") {
+    return;
+  }
+  // Unparented sessions record only when someone explicitly watches them: one
+  // indexed existence probe keeps ordinary un-watched human turns write-free.
+  if (!watcherSessionKey && !hasSessionStateWatchers(params.sessionKey)) {
     return;
   }
   recordSessionStateEvent({
@@ -835,7 +921,7 @@ export function recordSessionHumanDirectMessage(params: {
     ...(params.actor.actorId ? { actorId: params.actor.actorId } : {}),
     runId: params.runId,
     summary: `human message via ${params.channel?.trim() || "unknown"}`,
-    watcherSessionKeys: [watcherSessionKey],
+    ...(watcherSessionKey ? { watcherSessionKeys: [watcherSessionKey] } : {}),
   });
 }
 

--- a/src/sessions/session-state-events.ts
+++ b/src/sessions/session-state-events.ts
@@ -162,8 +162,11 @@ export function decodeSessionStateNoticeContextKey(contextKey: string): string |
   return Buffer.from(encoded, "hex").toString("utf8");
 }
 
+// Terse on purpose: this line lands in model prompts, possibly repeatedly across
+// turns. Text must stay byte-stable per frozen watermark so queue dedupe holds,
+// and the reconciliation call must be self-contained (explicit target sessionKey).
 function sessionStateNoticeText(targetSessionKey: string, lastSeenSequence: number): string {
-  return `Another actor has interacted with child session "${targetSessionKey}" since you last synced. Your assumptions about that session may be stale. Call session_status with sessionKey "${targetSessionKey}" and changesSince ${lastSeenSequence} before acting on it.`;
+  return `Session "${targetSessionKey}" changed (other actor). Reconcile before acting: session_status sessionKey "${targetSessionKey}" changesSince ${lastSeenSequence}.`;
 }
 
 function shouldWakeWatcher(watcherSessionKey: string): boolean {
@@ -192,9 +195,12 @@ function enqueueSessionStateNotice(params: {
   if (!shouldWakeWatcher(params.watcherSessionKey)) {
     return;
   }
+  // intent "immediate": event-intent wakes defer on heartbeat dueness, which would
+  // delay stale-state notices by up to the whole heartbeat interval. Task/cron
+  // wake-now paths use the same class; the flood guard remains the backstop.
   requestHeartbeat({
     source: "session-state",
-    intent: "event",
+    intent: "immediate",
     reason: `session-state:${params.targetSessionKey}`,
     sessionKey: params.watcherSessionKey,
   });

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Send/delete/manage channel messages. Supports actions: send.",
+    "description": "Send/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -18,7 +18,7 @@
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each entry uses media.",
+          "description": "Attachments; each uses media.",
           "items": {
             "properties": {
               "media": {
@@ -40,7 +40,7 @@
           "type": "array"
         },
         "buffer": {
-          "description": "Base64 attachment payload; data URL ok.",
+          "description": "Base64/data-URL attachment.",
           "type": "string"
         },
         "caption": {
@@ -60,14 +60,14 @@
           "type": "string"
         },
         "effectId": {
-          "description": "Effect id/name for sendWithEffect.",
+          "description": "sendWithEffect id/name.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document; avoids compression.",
+          "description": "Send media as document; no compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -125,7 +125,7 @@
     "type": "function"
   },
   {
-    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
+    "description": "List ids allowed for `sessions_spawn(runtime:\"subagent\")`.",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -134,7 +134,7 @@
     "type": "function"
   },
   {
-    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot; `mode=\"session\"` persistent/thread-bound, only when requester channel supports thread bindings. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work; run-mode results return, session-mode output stays in thread.",
+    "description": "Spawn clean child; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot; `mode=\"session\"` persistent/thread-bound only on supporting requester channel. Inherits parent workspace. Native task arrives as first `[Subagent Task]`. Native transcript needed: `context=\"fork\"`; else omit/isolated. Use fresh child for sidecar/parallel batch reads, multi-step search, data collection; avoid quick lookup/single read unless policy prefers. After spawn, do non-overlap work. Run result returns; session output stays thread.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -176,7 +176,7 @@
           "type": "string"
         },
         "context": {
-          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
+          "description": "Native: omit/isolated clean; fork only needing requester transcript.",
           "enum": ["isolated", "fork"],
           "type": "string"
         },
@@ -187,7 +187,7 @@
           "type": "string"
         },
         "lightContext": {
-          "description": "Light bootstrap context; runtime=\"subagent\" only.",
+          "description": "Light bootstrap; subagent only.",
           "type": "boolean"
         },
         "mode": {
@@ -209,14 +209,14 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
+          "description": "Stable later-target alias; starts lowercase letter; then lowercase/digit/_/-.",
           "type": "string"
         },
         "thinking": {
           "type": "string"
         },
         "thread": {
-          "description": "Bind spawn to new chat thread when supported. `thread=true` defaults mode=\"session\".",
+          "description": "Bind new chat thread when supported; true defaults mode=\"session\".",
           "type": "boolean"
         }
       },
@@ -227,7 +227,7 @@
     "type": "function"
   },
   {
-    "description": "End current turn. Use after spawning subagents; results arrive as next message.",
+    "description": "End turn after subagent spawn; results arrive next message.",
     "inputSchema": {
       "properties": {
         "message": {
@@ -245,7 +245,7 @@
     "tools": [
       {
         "deferLoading": true,
-        "description": "List paired nodes with status; describe/control a specific node by passing node. Supports pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
+        "description": "Paired nodes: status/list with active-computer presence; pass node to describe/control. Pairing, notify, camera/photos/screen/location/notifications, executable lookup (which + bins), generic invoke. Files: file_fetch.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -269,9 +269,20 @@
                 "device_info",
                 "device_permissions",
                 "device_health",
+                "which",
                 "invoke"
               ],
               "type": "string"
+            },
+            "bins": {
+              "description": "which: executable names to resolve on the selected node.",
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "minItems": 1,
+              "type": "array"
             },
             "body": {
               "type": "string"
@@ -396,7 +407,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: run only if due by default; needs jobId; pass runMode=\"force\" to trigger now\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane owned by the calling agent.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"trigger\": { \"script\": \"...\", \"once\": false }, // optional condition gate for every/cron\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nOptional trigger scripts poll headlessly on every/cron schedules and run the payload only when they return { fire: true }.\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
+        "description": "Gateway schedules/wakes: reminders, later checks/follow-ups, recurring work. Never exec sleep/process-poll as timer. Main job => heartbeat system event; isolated => background task in `openclaw tasks`.\n\nACTIONS:\n- status scheduler; list compact summaries (includeDisabled, session agentId auto-filter; get for full); get jobId\n- add job; update jobId+patch; remove jobId\n- run jobId (due only; runMode=\"force\" now); runs jobId history\n- wake text (+ optional mode). Default caller lane; top-level sessionKey/agentId selects another caller-owned lane.\n\nADD JOB:\n{ \"name\":\"...\", \"schedule\":{...}, \"trigger\":{ \"script\":\"...\", \"once\":false }, \"payload\":{...}, \"delivery\":{...}, \"sessionTarget\":\"main|isolated|current|session:<id>\", \"enabled\":true }\nRequired: schedule,payload. enabled default true. trigger only every/cron.\n\nTARGET/PAYLOAD:\n- main => systemEvent {kind:\"systemEvent\",text:\"...\"}; systemEvent defaults main.\n- isolated/current/session:<id> => agentTurn {kind:\"agentTurn\",message:\"...\",model?,thinking?,timeoutSeconds?}; agentTurn defaults isolated. timeoutSeconds=0 means none.\n- current binds caller session at creation. session:<id> is persistent. Prefer isolated unless user explicitly wants current binding.\n\nSCHEDULE:\n- at: {kind:\"at\",at:\"ISO-8601\"}; timezone-less = UTC.\n- every: {kind:\"every\",everyMs:<ms>,anchorMs?}.\n- cron: {kind:\"cron\",expr:\"...\",tz?:\"IANA\"}. Expr is requested local wall time; never pre-convert to UTC. Missing tz = Gateway host local, not UTC. Shanghai 18:00: {kind:\"cron\",expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n\nTRIGGER SCRIPT:\n- Requires cron.triggers.enabled; if off, explain and never model-poll fallback.\n- Headless owner allowlist; quiet check has no model. Prior trigger.state is frozen JSON. Return/json({fire:boolean,message?:string,state?:JSONValue}); create new state, never mutate prior.\n- fire:false saves state only; no payload/history. fire:true runs payload and appends message; fired state saves only after payload success. Check reads; payload acts.\n- Silent watcher: top-level delivery.mode=\"none\". Omitted delivery on isolated agentTurn announces and missing route may fail.\n- once:true disables after first successful fire. Per check: 30s, 5 tool calls, 16KB state.\n- Hidden Code Mode tools: await tools.call(\"exec\", {command:\"...\"}); unknown id => search/describe.\n\nDELIVERY top-level: {mode:\"none|announce|webhook\",channel?,to?,threadId?,bestEffort?}\n- Isolated agentTurn omitted delivery => announce. announce only isolated/current/session; channel/to optional; threadId chat topic. Specific chat: set channel/to; no messaging tool inside run.\n- webhook posts finished-run event to URL in to.\n\nRestricted isolated runs may only self status/list, current get/runs, and remove current job. wake mode: next-heartbeat default | now. jobId canonical; id compat. contextMessages 0-10 adds prior messages.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -440,7 +451,7 @@
                   "description": "Agent id, or null to keep it unset"
                 },
                 "declarationKey": {
-                  "description": "Idempotent declaration identity key",
+                  "description": "Idempotent declaration key.",
                   "maxLength": 200,
                   "minLength": 1,
                   "pattern": "\\S",
@@ -531,7 +542,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert object; false disables alerts",
+                  "description": "Failure alert; false disables.",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -551,7 +562,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Skipped runs count toward alert",
+                      "description": "Count skipped runs.",
                       "type": "boolean"
                     },
                     "mode": {
@@ -650,7 +661,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -664,7 +675,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
                       "type": "string"
                     }
                   },
@@ -820,7 +831,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Failure destination, or null to clear"
+                      "description": "Failure destination; null clears."
                     },
                     "mode": {
                       "description": "Delivery mode",
@@ -875,7 +886,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert object; false disables alerts",
+                  "description": "Failure alert; false disables.",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -895,7 +906,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Skipped runs count toward alert",
+                      "description": "Count skipped runs.",
                       "type": "boolean"
                     },
                     "mode": {
@@ -1003,7 +1014,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -1017,7 +1028,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
                       "type": "string"
                     }
                   },
@@ -1092,7 +1103,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
+        "description": "Only explicit voice/speech/TTS intent or active TTS config; never ordinary text reply. Audio auto-delivered. After success follow reply instructions; no duplicate text/audio.",
         "inputSchema": {
           "properties": {
             "channel": {
@@ -1117,7 +1128,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
+        "description": "Gateway restart/config/update. Before config edit: config.schema.lookup exact dot path. Partial merge: config.patch; full replace only: config.apply. Removing array entries via patch needs exact array replacePaths. Writes hot-reload/restart as needed. Always human note for post-restart delivery. Internal continuation: one-shot continuationMessage; its visible follow-up uses message tool. Never write restart sentinel directly.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1186,7 +1197,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List visible sessions; filter by kind, label, agentId, search, activity, archive state. Use before sessions_history or sessions_send target selection.",
+        "description": "List visible sessions; filter kind/label/agentId/search/activity/archive. Use before history/send target selection.",
         "inputSchema": {
           "properties": {
             "activeMinutes": {
@@ -1237,7 +1248,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limit, offset pagination, and tool-message inclusion.",
+        "description": "Read sanitized visible-session history. Before reply/debug/resume. Supports limit/offset/tool messages.",
         "inputSchema": {
           "properties": {
             "includeTools": {
@@ -1263,7 +1274,31 @@
       },
       {
         "deferLoading": true,
-        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true: notice arrives when others later change target session.",
+        "description": "Search your own past sessions for matching user and assistant text. Follow up with sessions_history using a returned sessionKey for full context.",
+        "inputSchema": {
+          "properties": {
+            "limit": {
+              "maximum": 25,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "query": {
+              "maxLength": 4096,
+              "type": "string"
+            },
+            "sessionKey": {
+              "type": "string"
+            }
+          },
+          "required": ["query"],
+          "type": "object"
+        },
+        "name": "sessions_search",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available. watch:true: notice arrives when others later change target session.",
         "inputSchema": {
           "properties": {
             "agentId": {
@@ -1298,7 +1333,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
+        "description": "List requester-session active/recent subagents. If available, wait via sessions_yield; never poll-loop.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1317,7 +1352,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
+        "description": "Show visible-session model/usage/time/cost/tasks. `sessionKey=\"current\"` for current; UI labels are not keys. `model` overrides; `model=default` resets. Use for active model/session questions.",
         "inputSchema": {
           "properties": {
             "changesSince": {
@@ -1338,7 +1373,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search web for current info; returns normalized provider results.",
+        "description": "Search current web; normalized provider results.",
         "inputSchema": {
           "properties": {
             "count": {
@@ -1406,7 +1441,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
+        "description": "Fetch URL; extract readable markdown/text. Lightweight; no browser automation.",
         "inputSchema": {
           "properties": {
             "extractMode": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Send/manage channel messages. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -18,7 +18,7 @@
           "type": "boolean"
         },
         "attachments": {
-          "description": "Attachments; each uses media.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
               "media": {
@@ -40,7 +40,7 @@
           "type": "array"
         },
         "buffer": {
-          "description": "Base64/data-URL attachment.",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -60,14 +60,14 @@
           "type": "string"
         },
         "effectId": {
-          "description": "sendWithEffect id/name.",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send media as document; no compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -125,7 +125,7 @@
     "type": "function"
   },
   {
-    "description": "List ids allowed for `sessions_spawn(runtime:\"subagent\")`.",
+    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -134,7 +134,7 @@
     "type": "function"
   },
   {
-    "description": "Spawn clean child; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot; `mode=\"session\"` persistent/thread-bound only on supporting requester channel. Inherits parent workspace. Native task arrives as first `[Subagent Task]`. Native transcript needed: `context=\"fork\"`; else omit/isolated. Use fresh child for sidecar/parallel batch reads, multi-step search, data collection; avoid quick lookup/single read unless policy prefers. After spawn, do non-overlap work. Run result returns; session output stays thread.",
+    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot; `mode=\"session\"` persistent/thread-bound, only when requester channel supports thread bindings. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work; run-mode results return, session-mode output stays in thread.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -176,7 +176,7 @@
           "type": "string"
         },
         "context": {
-          "description": "Native: omit/isolated clean; fork only needing requester transcript.",
+          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
           "enum": ["isolated", "fork"],
           "type": "string"
         },
@@ -187,7 +187,7 @@
           "type": "string"
         },
         "lightContext": {
-          "description": "Light bootstrap; subagent only.",
+          "description": "Light bootstrap context; runtime=\"subagent\" only.",
           "type": "boolean"
         },
         "mode": {
@@ -209,14 +209,14 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable later-target alias; starts lowercase letter; then lowercase/digit/_/-.",
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
           "type": "string"
         },
         "thinking": {
           "type": "string"
         },
         "thread": {
-          "description": "Bind new chat thread when supported; true defaults mode=\"session\".",
+          "description": "Bind spawn to new chat thread when supported. `thread=true` defaults mode=\"session\".",
           "type": "boolean"
         }
       },
@@ -227,7 +227,7 @@
     "type": "function"
   },
   {
-    "description": "End turn after subagent spawn; results arrive next message.",
+    "description": "End current turn. Use after spawning subagents; results arrive as next message.",
     "inputSchema": {
       "properties": {
         "message": {
@@ -245,7 +245,7 @@
     "tools": [
       {
         "deferLoading": true,
-        "description": "Paired nodes: status/list with active-computer presence; pass node to describe/control. Pairing, notify, camera/photos/screen/location/notifications, executable lookup (which + bins), generic invoke. Files: file_fetch.",
+        "description": "List paired nodes with status; describe/control a specific node by passing node. Supports pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -269,20 +269,9 @@
                 "device_info",
                 "device_permissions",
                 "device_health",
-                "which",
                 "invoke"
               ],
               "type": "string"
-            },
-            "bins": {
-              "description": "which: executable names to resolve on the selected node.",
-              "items": {
-                "minLength": 1,
-                "type": "string"
-              },
-              "maxItems": 64,
-              "minItems": 1,
-              "type": "array"
             },
             "body": {
               "type": "string"
@@ -407,7 +396,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway schedules/wakes: reminders, later checks/follow-ups, recurring work. Never exec sleep/process-poll as timer. Main job => heartbeat system event; isolated => background task in `openclaw tasks`.\n\nACTIONS:\n- status scheduler; list compact summaries (includeDisabled, session agentId auto-filter; get for full); get jobId\n- add job; update jobId+patch; remove jobId\n- run jobId (due only; runMode=\"force\" now); runs jobId history\n- wake text (+ optional mode). Default caller lane; top-level sessionKey/agentId selects another caller-owned lane.\n\nADD JOB:\n{ \"name\":\"...\", \"schedule\":{...}, \"trigger\":{ \"script\":\"...\", \"once\":false }, \"payload\":{...}, \"delivery\":{...}, \"sessionTarget\":\"main|isolated|current|session:<id>\", \"enabled\":true }\nRequired: schedule,payload. enabled default true. trigger only every/cron.\n\nTARGET/PAYLOAD:\n- main => systemEvent {kind:\"systemEvent\",text:\"...\"}; systemEvent defaults main.\n- isolated/current/session:<id> => agentTurn {kind:\"agentTurn\",message:\"...\",model?,thinking?,timeoutSeconds?}; agentTurn defaults isolated. timeoutSeconds=0 means none.\n- current binds caller session at creation. session:<id> is persistent. Prefer isolated unless user explicitly wants current binding.\n\nSCHEDULE:\n- at: {kind:\"at\",at:\"ISO-8601\"}; timezone-less = UTC.\n- every: {kind:\"every\",everyMs:<ms>,anchorMs?}.\n- cron: {kind:\"cron\",expr:\"...\",tz?:\"IANA\"}. Expr is requested local wall time; never pre-convert to UTC. Missing tz = Gateway host local, not UTC. Shanghai 18:00: {kind:\"cron\",expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n\nTRIGGER SCRIPT:\n- Requires cron.triggers.enabled; if off, explain and never model-poll fallback.\n- Headless owner allowlist; quiet check has no model. Prior trigger.state is frozen JSON. Return/json({fire:boolean,message?:string,state?:JSONValue}); create new state, never mutate prior.\n- fire:false saves state only; no payload/history. fire:true runs payload and appends message; fired state saves only after payload success. Check reads; payload acts.\n- Silent watcher: top-level delivery.mode=\"none\". Omitted delivery on isolated agentTurn announces and missing route may fail.\n- once:true disables after first successful fire. Per check: 30s, 5 tool calls, 16KB state.\n- Hidden Code Mode tools: await tools.call(\"exec\", {command:\"...\"}); unknown id => search/describe.\n\nDELIVERY top-level: {mode:\"none|announce|webhook\",channel?,to?,threadId?,bestEffort?}\n- Isolated agentTurn omitted delivery => announce. announce only isolated/current/session; channel/to optional; threadId chat topic. Specific chat: set channel/to; no messaging tool inside run.\n- webhook posts finished-run event to URL in to.\n\nRestricted isolated runs may only self status/list, current get/runs, and remove current job. wake mode: next-heartbeat default | now. jobId canonical; id compat. contextMessages 0-10 adds prior messages.",
+        "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: run only if due by default; needs jobId; pass runMode=\"force\" to trigger now\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane owned by the calling agent.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"trigger\": { \"script\": \"...\", \"once\": false }, // optional condition gate for every/cron\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nOptional trigger scripts poll headlessly on every/cron schedules and run the payload only when they return { fire: true }.\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -451,7 +440,7 @@
                   "description": "Agent id, or null to keep it unset"
                 },
                 "declarationKey": {
-                  "description": "Idempotent declaration key.",
+                  "description": "Idempotent declaration identity key",
                   "maxLength": 200,
                   "minLength": 1,
                   "pattern": "\\S",
@@ -542,7 +531,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert; false disables.",
+                  "description": "Failure alert object; false disables alerts",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -562,7 +551,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Count skipped runs.",
+                      "description": "Skipped runs count toward alert",
                       "type": "boolean"
                     },
                     "mode": {
@@ -661,7 +650,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -675,7 +664,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                       "type": "string"
                     }
                   },
@@ -831,7 +820,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Failure destination; null clears."
+                      "description": "Failure destination, or null to clear"
                     },
                     "mode": {
                       "description": "Delivery mode",
@@ -886,7 +875,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert; false disables.",
+                  "description": "Failure alert object; false disables alerts",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -906,7 +895,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Count skipped runs.",
+                      "description": "Skipped runs count toward alert",
                       "type": "boolean"
                     },
                     "mode": {
@@ -1014,7 +1003,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -1028,7 +1017,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                       "type": "string"
                     }
                   },
@@ -1103,7 +1092,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Only explicit voice/speech/TTS intent or active TTS config; never ordinary text reply. Audio auto-delivered. After success follow reply instructions; no duplicate text/audio.",
+        "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
         "inputSchema": {
           "properties": {
             "channel": {
@@ -1128,7 +1117,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway restart/config/update. Before config edit: config.schema.lookup exact dot path. Partial merge: config.patch; full replace only: config.apply. Removing array entries via patch needs exact array replacePaths. Writes hot-reload/restart as needed. Always human note for post-restart delivery. Internal continuation: one-shot continuationMessage; its visible follow-up uses message tool. Never write restart sentinel directly.",
+        "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1197,7 +1186,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List visible sessions; filter kind/label/agentId/search/activity/archive. Use before history/send target selection.",
+        "description": "List visible sessions; filter by kind, label, agentId, search, activity, archive state. Use before sessions_history or sessions_send target selection.",
         "inputSchema": {
           "properties": {
             "activeMinutes": {
@@ -1248,7 +1237,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Read sanitized visible-session history. Before reply/debug/resume. Supports limit/offset/tool messages.",
+        "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limit, offset pagination, and tool-message inclusion.",
         "inputSchema": {
           "properties": {
             "includeTools": {
@@ -1274,31 +1263,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search your own past sessions for matching user and assistant text. Follow up with sessions_history using a returned sessionKey for full context.",
-        "inputSchema": {
-          "properties": {
-            "limit": {
-              "maximum": 25,
-              "minimum": 1,
-              "type": "integer"
-            },
-            "query": {
-              "maxLength": 4096,
-              "type": "string"
-            },
-            "sessionKey": {
-              "type": "string"
-            }
-          },
-          "required": ["query"],
-          "type": "object"
-        },
-        "name": "sessions_search",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
-        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available.",
+        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true registers you for state-change notices when other actors later interact with the target session.",
         "inputSchema": {
           "properties": {
             "agentId": {
@@ -1320,6 +1285,9 @@
             "timeoutSeconds": {
               "minimum": 0,
               "type": "integer"
+            },
+            "watch": {
+              "type": "boolean"
             }
           },
           "required": ["message"],
@@ -1330,7 +1298,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List requester-session active/recent subagents. If available, wait via sessions_yield; never poll-loop.",
+        "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1349,7 +1317,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Show visible-session model/usage/time/cost/tasks. `sessionKey=\"current\"` for current; UI labels are not keys. `model` overrides; `model=default` resets. Use for active model/session questions.",
+        "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
         "inputSchema": {
           "properties": {
             "changesSince": {
@@ -1370,7 +1338,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search current web; normalized provider results.",
+        "description": "Search web for current info; returns normalized provider results.",
         "inputSchema": {
           "properties": {
             "count": {
@@ -1438,7 +1406,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Fetch URL; extract readable markdown/text. Lightweight; no browser automation.",
+        "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
         "inputSchema": {
           "properties": {
             "extractMode": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1263,7 +1263,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true registers you for state-change notices when other actors later interact with the target session.",
+        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true: notice arrives when others later change target session.",
         "inputSchema": {
           "properties": {
             "agentId": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1295,7 +1295,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true registers you for state-change notices when other actors later interact with the target session.",
+        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true: notice arrives when others later change target session.",
         "inputSchema": {
           "properties": {
             "agentId": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Send/delete/manage channel messages. Supports actions: send.",
+    "description": "Send/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -18,7 +18,7 @@
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each entry uses media.",
+          "description": "Attachments; each uses media.",
           "items": {
             "properties": {
               "media": {
@@ -40,7 +40,7 @@
           "type": "array"
         },
         "buffer": {
-          "description": "Base64 attachment payload; data URL ok.",
+          "description": "Base64/data-URL attachment.",
           "type": "string"
         },
         "caption": {
@@ -60,14 +60,14 @@
           "type": "string"
         },
         "effectId": {
-          "description": "Effect id/name for sendWithEffect.",
+          "description": "sendWithEffect id/name.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document; avoids compression.",
+          "description": "Send media as document; no compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -125,7 +125,7 @@
     "type": "function"
   },
   {
-    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
+    "description": "List ids allowed for `sessions_spawn(runtime:\"subagent\")`.",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -134,7 +134,7 @@
     "type": "function"
   },
   {
-    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
+    "description": "Spawn clean child; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background. Inherits parent workspace. Native task arrives as first `[Subagent Task]`. Native transcript needed: `context=\"fork\"`; else omit/isolated. Use fresh child for sidecar/parallel batch reads, multi-step search, data collection; avoid quick lookup/single read unless policy prefers. After spawn, do non-overlap work while run result returns.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -176,7 +176,7 @@
           "type": "string"
         },
         "context": {
-          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
+          "description": "Native: omit/isolated clean; fork only needing requester transcript.",
           "enum": ["isolated", "fork"],
           "type": "string"
         },
@@ -187,7 +187,7 @@
           "type": "string"
         },
         "lightContext": {
-          "description": "Light bootstrap context; runtime=\"subagent\" only.",
+          "description": "Light bootstrap; subagent only.",
           "type": "boolean"
         },
         "mode": {
@@ -209,7 +209,7 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
+          "description": "Stable later-target alias; starts lowercase letter; then lowercase/digit/_/-.",
           "type": "string"
         },
         "thinking": {
@@ -223,7 +223,7 @@
     "type": "function"
   },
   {
-    "description": "End current turn. Use after spawning subagents; results arrive as next message.",
+    "description": "End turn after subagent spawn; results arrive next message.",
     "inputSchema": {
       "properties": {
         "message": {
@@ -241,7 +241,7 @@
     "tools": [
       {
         "deferLoading": true,
-        "description": "List paired nodes with status; describe/control a specific node by passing node. Supports pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
+        "description": "Paired nodes: status/list with active-computer presence; pass node to describe/control. Pairing, notify, camera/photos/screen/location/notifications, executable lookup (which + bins), generic invoke. Files: file_fetch.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -265,9 +265,20 @@
                 "device_info",
                 "device_permissions",
                 "device_health",
+                "which",
                 "invoke"
               ],
               "type": "string"
+            },
+            "bins": {
+              "description": "which: executable names to resolve on the selected node.",
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "minItems": 1,
+              "type": "array"
             },
             "body": {
               "type": "string"
@@ -392,7 +403,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: run only if due by default; needs jobId; pass runMode=\"force\" to trigger now\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane owned by the calling agent.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"trigger\": { \"script\": \"...\", \"once\": false }, // optional condition gate for every/cron\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nOptional trigger scripts poll headlessly on every/cron schedules and run the payload only when they return { fire: true }.\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
+        "description": "Gateway schedules/wakes: reminders, later checks/follow-ups, recurring work. Never exec sleep/process-poll as timer. Main job => heartbeat system event; isolated => background task in `openclaw tasks`.\n\nACTIONS:\n- status scheduler; list compact summaries (includeDisabled, session agentId auto-filter; get for full); get jobId\n- add job; update jobId+patch; remove jobId\n- run jobId (due only; runMode=\"force\" now); runs jobId history\n- wake text (+ optional mode). Default caller lane; top-level sessionKey/agentId selects another caller-owned lane.\n\nADD JOB:\n{ \"name\":\"...\", \"schedule\":{...}, \"trigger\":{ \"script\":\"...\", \"once\":false }, \"payload\":{...}, \"delivery\":{...}, \"sessionTarget\":\"main|isolated|current|session:<id>\", \"enabled\":true }\nRequired: schedule,payload. enabled default true. trigger only every/cron.\n\nTARGET/PAYLOAD:\n- main => systemEvent {kind:\"systemEvent\",text:\"...\"}; systemEvent defaults main.\n- isolated/current/session:<id> => agentTurn {kind:\"agentTurn\",message:\"...\",model?,thinking?,timeoutSeconds?}; agentTurn defaults isolated. timeoutSeconds=0 means none.\n- current binds caller session at creation. session:<id> is persistent. Prefer isolated unless user explicitly wants current binding.\n\nSCHEDULE:\n- at: {kind:\"at\",at:\"ISO-8601\"}; timezone-less = UTC.\n- every: {kind:\"every\",everyMs:<ms>,anchorMs?}.\n- cron: {kind:\"cron\",expr:\"...\",tz?:\"IANA\"}. Expr is requested local wall time; never pre-convert to UTC. Missing tz = Gateway host local, not UTC. Shanghai 18:00: {kind:\"cron\",expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n\nTRIGGER SCRIPT:\n- Requires cron.triggers.enabled; if off, explain and never model-poll fallback.\n- Headless owner allowlist; quiet check has no model. Prior trigger.state is frozen JSON. Return/json({fire:boolean,message?:string,state?:JSONValue}); create new state, never mutate prior.\n- fire:false saves state only; no payload/history. fire:true runs payload and appends message; fired state saves only after payload success. Check reads; payload acts.\n- Silent watcher: top-level delivery.mode=\"none\". Omitted delivery on isolated agentTurn announces and missing route may fail.\n- once:true disables after first successful fire. Per check: 30s, 5 tool calls, 16KB state.\n- Hidden Code Mode tools: await tools.call(\"exec\", {command:\"...\"}); unknown id => search/describe.\n\nDELIVERY top-level: {mode:\"none|announce|webhook\",channel?,to?,threadId?,bestEffort?}\n- Isolated agentTurn omitted delivery => announce. announce only isolated/current/session; channel/to optional; threadId chat topic. Specific chat: set channel/to; no messaging tool inside run.\n- webhook posts finished-run event to URL in to.\n\nRestricted isolated runs may only self status/list, current get/runs, and remove current job. wake mode: next-heartbeat default | now. jobId canonical; id compat. contextMessages 0-10 adds prior messages.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -436,7 +447,7 @@
                   "description": "Agent id, or null to keep it unset"
                 },
                 "declarationKey": {
-                  "description": "Idempotent declaration identity key",
+                  "description": "Idempotent declaration key.",
                   "maxLength": 200,
                   "minLength": 1,
                   "pattern": "\\S",
@@ -527,7 +538,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert object; false disables alerts",
+                  "description": "Failure alert; false disables.",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -547,7 +558,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Skipped runs count toward alert",
+                      "description": "Count skipped runs.",
                       "type": "boolean"
                     },
                     "mode": {
@@ -646,7 +657,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -660,7 +671,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
                       "type": "string"
                     }
                   },
@@ -816,7 +827,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Failure destination, or null to clear"
+                      "description": "Failure destination; null clears."
                     },
                     "mode": {
                       "description": "Delivery mode",
@@ -871,7 +882,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert object; false disables alerts",
+                  "description": "Failure alert; false disables.",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -891,7 +902,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Skipped runs count toward alert",
+                      "description": "Count skipped runs.",
                       "type": "boolean"
                     },
                     "mode": {
@@ -999,7 +1010,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -1013,7 +1024,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
                       "type": "string"
                     }
                   },
@@ -1124,7 +1135,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
+        "description": "Only explicit voice/speech/TTS intent or active TTS config; never ordinary text reply. Audio auto-delivered. After success follow reply instructions; no duplicate text/audio.",
         "inputSchema": {
           "properties": {
             "channel": {
@@ -1149,7 +1160,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
+        "description": "Gateway restart/config/update. Before config edit: config.schema.lookup exact dot path. Partial merge: config.patch; full replace only: config.apply. Removing array entries via patch needs exact array replacePaths. Writes hot-reload/restart as needed. Always human note for post-restart delivery. Internal continuation: one-shot continuationMessage; its visible follow-up uses message tool. Never write restart sentinel directly.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1218,7 +1229,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List visible sessions; filter by kind, label, agentId, search, activity, archive state. Use before sessions_history or sessions_send target selection.",
+        "description": "List visible sessions; filter kind/label/agentId/search/activity/archive. Use before history/send target selection.",
         "inputSchema": {
           "properties": {
             "activeMinutes": {
@@ -1269,7 +1280,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limit, offset pagination, and tool-message inclusion.",
+        "description": "Read sanitized visible-session history. Before reply/debug/resume. Supports limit/offset/tool messages.",
         "inputSchema": {
           "properties": {
             "includeTools": {
@@ -1295,7 +1306,31 @@
       },
       {
         "deferLoading": true,
-        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true: notice arrives when others later change target session.",
+        "description": "Search your own past sessions for matching user and assistant text. Follow up with sessions_history using a returned sessionKey for full context.",
+        "inputSchema": {
+          "properties": {
+            "limit": {
+              "maximum": 25,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "query": {
+              "maxLength": 4096,
+              "type": "string"
+            },
+            "sessionKey": {
+              "type": "string"
+            }
+          },
+          "required": ["query"],
+          "type": "object"
+        },
+        "name": "sessions_search",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available. watch:true: notice arrives when others later change target session.",
         "inputSchema": {
           "properties": {
             "agentId": {
@@ -1330,7 +1365,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
+        "description": "List requester-session active/recent subagents. If available, wait via sessions_yield; never poll-loop.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1349,7 +1384,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
+        "description": "Show visible-session model/usage/time/cost/tasks. `sessionKey=\"current\"` for current; UI labels are not keys. `model` overrides; `model=default` resets. Use for active model/session questions.",
         "inputSchema": {
           "properties": {
             "changesSince": {
@@ -1370,7 +1405,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search web for current info; returns normalized provider results.",
+        "description": "Search current web; normalized provider results.",
         "inputSchema": {
           "properties": {
             "count": {
@@ -1438,7 +1473,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
+        "description": "Fetch URL; extract readable markdown/text. Lightweight; no browser automation.",
         "inputSchema": {
           "properties": {
             "extractMode": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Send/manage channel messages. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -18,7 +18,7 @@
           "type": "boolean"
         },
         "attachments": {
-          "description": "Attachments; each uses media.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
               "media": {
@@ -40,7 +40,7 @@
           "type": "array"
         },
         "buffer": {
-          "description": "Base64/data-URL attachment.",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -60,14 +60,14 @@
           "type": "string"
         },
         "effectId": {
-          "description": "sendWithEffect id/name.",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send media as document; no compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -125,7 +125,7 @@
     "type": "function"
   },
   {
-    "description": "List ids allowed for `sessions_spawn(runtime:\"subagent\")`.",
+    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -134,7 +134,7 @@
     "type": "function"
   },
   {
-    "description": "Spawn clean child; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background. Inherits parent workspace. Native task arrives as first `[Subagent Task]`. Native transcript needed: `context=\"fork\"`; else omit/isolated. Use fresh child for sidecar/parallel batch reads, multi-step search, data collection; avoid quick lookup/single read unless policy prefers. After spawn, do non-overlap work while run result returns.",
+    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -176,7 +176,7 @@
           "type": "string"
         },
         "context": {
-          "description": "Native: omit/isolated clean; fork only needing requester transcript.",
+          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
           "enum": ["isolated", "fork"],
           "type": "string"
         },
@@ -187,7 +187,7 @@
           "type": "string"
         },
         "lightContext": {
-          "description": "Light bootstrap; subagent only.",
+          "description": "Light bootstrap context; runtime=\"subagent\" only.",
           "type": "boolean"
         },
         "mode": {
@@ -209,7 +209,7 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable later-target alias; starts lowercase letter; then lowercase/digit/_/-.",
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
           "type": "string"
         },
         "thinking": {
@@ -223,7 +223,7 @@
     "type": "function"
   },
   {
-    "description": "End turn after subagent spawn; results arrive next message.",
+    "description": "End current turn. Use after spawning subagents; results arrive as next message.",
     "inputSchema": {
       "properties": {
         "message": {
@@ -241,7 +241,7 @@
     "tools": [
       {
         "deferLoading": true,
-        "description": "Paired nodes: status/list with active-computer presence; pass node to describe/control. Pairing, notify, camera/photos/screen/location/notifications, executable lookup (which + bins), generic invoke. Files: file_fetch.",
+        "description": "List paired nodes with status; describe/control a specific node by passing node. Supports pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -265,20 +265,9 @@
                 "device_info",
                 "device_permissions",
                 "device_health",
-                "which",
                 "invoke"
               ],
               "type": "string"
-            },
-            "bins": {
-              "description": "which: executable names to resolve on the selected node.",
-              "items": {
-                "minLength": 1,
-                "type": "string"
-              },
-              "maxItems": 64,
-              "minItems": 1,
-              "type": "array"
             },
             "body": {
               "type": "string"
@@ -403,7 +392,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway schedules/wakes: reminders, later checks/follow-ups, recurring work. Never exec sleep/process-poll as timer. Main job => heartbeat system event; isolated => background task in `openclaw tasks`.\n\nACTIONS:\n- status scheduler; list compact summaries (includeDisabled, session agentId auto-filter; get for full); get jobId\n- add job; update jobId+patch; remove jobId\n- run jobId (due only; runMode=\"force\" now); runs jobId history\n- wake text (+ optional mode). Default caller lane; top-level sessionKey/agentId selects another caller-owned lane.\n\nADD JOB:\n{ \"name\":\"...\", \"schedule\":{...}, \"trigger\":{ \"script\":\"...\", \"once\":false }, \"payload\":{...}, \"delivery\":{...}, \"sessionTarget\":\"main|isolated|current|session:<id>\", \"enabled\":true }\nRequired: schedule,payload. enabled default true. trigger only every/cron.\n\nTARGET/PAYLOAD:\n- main => systemEvent {kind:\"systemEvent\",text:\"...\"}; systemEvent defaults main.\n- isolated/current/session:<id> => agentTurn {kind:\"agentTurn\",message:\"...\",model?,thinking?,timeoutSeconds?}; agentTurn defaults isolated. timeoutSeconds=0 means none.\n- current binds caller session at creation. session:<id> is persistent. Prefer isolated unless user explicitly wants current binding.\n\nSCHEDULE:\n- at: {kind:\"at\",at:\"ISO-8601\"}; timezone-less = UTC.\n- every: {kind:\"every\",everyMs:<ms>,anchorMs?}.\n- cron: {kind:\"cron\",expr:\"...\",tz?:\"IANA\"}. Expr is requested local wall time; never pre-convert to UTC. Missing tz = Gateway host local, not UTC. Shanghai 18:00: {kind:\"cron\",expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n\nTRIGGER SCRIPT:\n- Requires cron.triggers.enabled; if off, explain and never model-poll fallback.\n- Headless owner allowlist; quiet check has no model. Prior trigger.state is frozen JSON. Return/json({fire:boolean,message?:string,state?:JSONValue}); create new state, never mutate prior.\n- fire:false saves state only; no payload/history. fire:true runs payload and appends message; fired state saves only after payload success. Check reads; payload acts.\n- Silent watcher: top-level delivery.mode=\"none\". Omitted delivery on isolated agentTurn announces and missing route may fail.\n- once:true disables after first successful fire. Per check: 30s, 5 tool calls, 16KB state.\n- Hidden Code Mode tools: await tools.call(\"exec\", {command:\"...\"}); unknown id => search/describe.\n\nDELIVERY top-level: {mode:\"none|announce|webhook\",channel?,to?,threadId?,bestEffort?}\n- Isolated agentTurn omitted delivery => announce. announce only isolated/current/session; channel/to optional; threadId chat topic. Specific chat: set channel/to; no messaging tool inside run.\n- webhook posts finished-run event to URL in to.\n\nRestricted isolated runs may only self status/list, current get/runs, and remove current job. wake mode: next-heartbeat default | now. jobId canonical; id compat. contextMessages 0-10 adds prior messages.",
+        "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: run only if due by default; needs jobId; pass runMode=\"force\" to trigger now\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane owned by the calling agent.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"trigger\": { \"script\": \"...\", \"once\": false }, // optional condition gate for every/cron\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nOptional trigger scripts poll headlessly on every/cron schedules and run the payload only when they return { fire: true }.\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -447,7 +436,7 @@
                   "description": "Agent id, or null to keep it unset"
                 },
                 "declarationKey": {
-                  "description": "Idempotent declaration key.",
+                  "description": "Idempotent declaration identity key",
                   "maxLength": 200,
                   "minLength": 1,
                   "pattern": "\\S",
@@ -538,7 +527,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert; false disables.",
+                  "description": "Failure alert object; false disables alerts",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -558,7 +547,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Count skipped runs.",
+                      "description": "Skipped runs count toward alert",
                       "type": "boolean"
                     },
                     "mode": {
@@ -657,7 +646,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -671,7 +660,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                       "type": "string"
                     }
                   },
@@ -827,7 +816,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Failure destination; null clears."
+                      "description": "Failure destination, or null to clear"
                     },
                     "mode": {
                       "description": "Delivery mode",
@@ -882,7 +871,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert; false disables.",
+                  "description": "Failure alert object; false disables alerts",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -902,7 +891,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Count skipped runs.",
+                      "description": "Skipped runs count toward alert",
                       "type": "boolean"
                     },
                     "mode": {
@@ -1010,7 +999,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -1024,7 +1013,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                       "type": "string"
                     }
                   },
@@ -1135,7 +1124,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Only explicit voice/speech/TTS intent or active TTS config; never ordinary text reply. Audio auto-delivered. After success follow reply instructions; no duplicate text/audio.",
+        "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
         "inputSchema": {
           "properties": {
             "channel": {
@@ -1160,7 +1149,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway restart/config/update. Before config edit: config.schema.lookup exact dot path. Partial merge: config.patch; full replace only: config.apply. Removing array entries via patch needs exact array replacePaths. Writes hot-reload/restart as needed. Always human note for post-restart delivery. Internal continuation: one-shot continuationMessage; its visible follow-up uses message tool. Never write restart sentinel directly.",
+        "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1229,7 +1218,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List visible sessions; filter kind/label/agentId/search/activity/archive. Use before history/send target selection.",
+        "description": "List visible sessions; filter by kind, label, agentId, search, activity, archive state. Use before sessions_history or sessions_send target selection.",
         "inputSchema": {
           "properties": {
             "activeMinutes": {
@@ -1280,7 +1269,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Read sanitized visible-session history. Before reply/debug/resume. Supports limit/offset/tool messages.",
+        "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limit, offset pagination, and tool-message inclusion.",
         "inputSchema": {
           "properties": {
             "includeTools": {
@@ -1306,31 +1295,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search your own past sessions for matching user and assistant text. Follow up with sessions_history using a returned sessionKey for full context.",
-        "inputSchema": {
-          "properties": {
-            "limit": {
-              "maximum": 25,
-              "minimum": 1,
-              "type": "integer"
-            },
-            "query": {
-              "maxLength": 4096,
-              "type": "string"
-            },
-            "sessionKey": {
-              "type": "string"
-            }
-          },
-          "required": ["query"],
-          "type": "object"
-        },
-        "name": "sessions_search",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
-        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available.",
+        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true registers you for state-change notices when other actors later interact with the target session.",
         "inputSchema": {
           "properties": {
             "agentId": {
@@ -1352,6 +1317,9 @@
             "timeoutSeconds": {
               "minimum": 0,
               "type": "integer"
+            },
+            "watch": {
+              "type": "boolean"
             }
           },
           "required": ["message"],
@@ -1362,7 +1330,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List requester-session active/recent subagents. If available, wait via sessions_yield; never poll-loop.",
+        "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1381,7 +1349,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Show visible-session model/usage/time/cost/tasks. `sessionKey=\"current\"` for current; UI labels are not keys. `model` overrides; `model=default` resets. Use for active model/session questions.",
+        "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
         "inputSchema": {
           "properties": {
             "changesSince": {
@@ -1402,7 +1370,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search current web; normalized provider results.",
+        "description": "Search web for current info; returns normalized provider results.",
         "inputSchema": {
           "properties": {
             "count": {
@@ -1470,7 +1438,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Fetch URL; extract readable markdown/text. Lightweight; no browser automation.",
+        "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
         "inputSchema": {
           "properties": {
             "extractMode": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Send/manage channel messages. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -18,7 +18,7 @@
           "type": "boolean"
         },
         "attachments": {
-          "description": "Attachments; each uses media.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
               "media": {
@@ -40,7 +40,7 @@
           "type": "array"
         },
         "buffer": {
-          "description": "Base64/data-URL attachment.",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -60,14 +60,14 @@
           "type": "string"
         },
         "effectId": {
-          "description": "sendWithEffect id/name.",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send media as document; no compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -125,7 +125,7 @@
     "type": "function"
   },
   {
-    "description": "List ids allowed for `sessions_spawn(runtime:\"subagent\")`.",
+    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -134,7 +134,7 @@
     "type": "function"
   },
   {
-    "description": "Spawn clean child; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background. Inherits parent workspace. Native task arrives as first `[Subagent Task]`. Native transcript needed: `context=\"fork\"`; else omit/isolated. Use fresh child for sidecar/parallel batch reads, multi-step search, data collection; avoid quick lookup/single read unless policy prefers. After spawn, do non-overlap work while run result returns.",
+    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -176,7 +176,7 @@
           "type": "string"
         },
         "context": {
-          "description": "Native: omit/isolated clean; fork only needing requester transcript.",
+          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
           "enum": ["isolated", "fork"],
           "type": "string"
         },
@@ -187,7 +187,7 @@
           "type": "string"
         },
         "lightContext": {
-          "description": "Light bootstrap; subagent only.",
+          "description": "Light bootstrap context; runtime=\"subagent\" only.",
           "type": "boolean"
         },
         "mode": {
@@ -209,7 +209,7 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable later-target alias; starts lowercase letter; then lowercase/digit/_/-.",
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
           "type": "string"
         },
         "thinking": {
@@ -223,7 +223,7 @@
     "type": "function"
   },
   {
-    "description": "End turn after subagent spawn; results arrive next message.",
+    "description": "End current turn. Use after spawning subagents; results arrive as next message.",
     "inputSchema": {
       "properties": {
         "message": {
@@ -241,7 +241,7 @@
     "tools": [
       {
         "deferLoading": true,
-        "description": "Paired nodes: status/list with active-computer presence; pass node to describe/control. Pairing, notify, camera/photos/screen/location/notifications, executable lookup (which + bins), generic invoke. Files: file_fetch.",
+        "description": "List paired nodes with status; describe/control a specific node by passing node. Supports pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -265,20 +265,9 @@
                 "device_info",
                 "device_permissions",
                 "device_health",
-                "which",
                 "invoke"
               ],
               "type": "string"
-            },
-            "bins": {
-              "description": "which: executable names to resolve on the selected node.",
-              "items": {
-                "minLength": 1,
-                "type": "string"
-              },
-              "maxItems": 64,
-              "minItems": 1,
-              "type": "array"
             },
             "body": {
               "type": "string"
@@ -403,7 +392,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway schedules/wakes: reminders, later checks/follow-ups, recurring work. Never exec sleep/process-poll as timer. Main job => heartbeat system event; isolated => background task in `openclaw tasks`.\n\nACTIONS:\n- status scheduler; list compact summaries (includeDisabled, session agentId auto-filter; get for full); get jobId\n- add job; update jobId+patch; remove jobId\n- run jobId (due only; runMode=\"force\" now); runs jobId history\n- wake text (+ optional mode). Default caller lane; top-level sessionKey/agentId selects another caller-owned lane.\n\nADD JOB:\n{ \"name\":\"...\", \"schedule\":{...}, \"trigger\":{ \"script\":\"...\", \"once\":false }, \"payload\":{...}, \"delivery\":{...}, \"sessionTarget\":\"main|isolated|current|session:<id>\", \"enabled\":true }\nRequired: schedule,payload. enabled default true. trigger only every/cron.\n\nTARGET/PAYLOAD:\n- main => systemEvent {kind:\"systemEvent\",text:\"...\"}; systemEvent defaults main.\n- isolated/current/session:<id> => agentTurn {kind:\"agentTurn\",message:\"...\",model?,thinking?,timeoutSeconds?}; agentTurn defaults isolated. timeoutSeconds=0 means none.\n- current binds caller session at creation. session:<id> is persistent. Prefer isolated unless user explicitly wants current binding.\n\nSCHEDULE:\n- at: {kind:\"at\",at:\"ISO-8601\"}; timezone-less = UTC.\n- every: {kind:\"every\",everyMs:<ms>,anchorMs?}.\n- cron: {kind:\"cron\",expr:\"...\",tz?:\"IANA\"}. Expr is requested local wall time; never pre-convert to UTC. Missing tz = Gateway host local, not UTC. Shanghai 18:00: {kind:\"cron\",expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n\nTRIGGER SCRIPT:\n- Requires cron.triggers.enabled; if off, explain and never model-poll fallback.\n- Headless owner allowlist; quiet check has no model. Prior trigger.state is frozen JSON. Return/json({fire:boolean,message?:string,state?:JSONValue}); create new state, never mutate prior.\n- fire:false saves state only; no payload/history. fire:true runs payload and appends message; fired state saves only after payload success. Check reads; payload acts.\n- Silent watcher: top-level delivery.mode=\"none\". Omitted delivery on isolated agentTurn announces and missing route may fail.\n- once:true disables after first successful fire. Per check: 30s, 5 tool calls, 16KB state.\n- Hidden Code Mode tools: await tools.call(\"exec\", {command:\"...\"}); unknown id => search/describe.\n\nDELIVERY top-level: {mode:\"none|announce|webhook\",channel?,to?,threadId?,bestEffort?}\n- Isolated agentTurn omitted delivery => announce. announce only isolated/current/session; channel/to optional; threadId chat topic. Specific chat: set channel/to; no messaging tool inside run.\n- webhook posts finished-run event to URL in to.\n\nRestricted isolated runs may only self status/list, current get/runs, and remove current job. wake mode: next-heartbeat default | now. jobId canonical; id compat. contextMessages 0-10 adds prior messages.",
+        "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: run only if due by default; needs jobId; pass runMode=\"force\" to trigger now\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane owned by the calling agent.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"trigger\": { \"script\": \"...\", \"once\": false }, // optional condition gate for every/cron\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nOptional trigger scripts poll headlessly on every/cron schedules and run the payload only when they return { fire: true }.\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -447,7 +436,7 @@
                   "description": "Agent id, or null to keep it unset"
                 },
                 "declarationKey": {
-                  "description": "Idempotent declaration key.",
+                  "description": "Idempotent declaration identity key",
                   "maxLength": 200,
                   "minLength": 1,
                   "pattern": "\\S",
@@ -538,7 +527,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert; false disables.",
+                  "description": "Failure alert object; false disables alerts",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -558,7 +547,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Count skipped runs.",
+                      "description": "Skipped runs count toward alert",
                       "type": "boolean"
                     },
                     "mode": {
@@ -657,7 +646,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -671,7 +660,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                       "type": "string"
                     }
                   },
@@ -827,7 +816,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Failure destination; null clears."
+                      "description": "Failure destination, or null to clear"
                     },
                     "mode": {
                       "description": "Delivery mode",
@@ -882,7 +871,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert; false disables.",
+                  "description": "Failure alert object; false disables alerts",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -902,7 +891,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Count skipped runs.",
+                      "description": "Skipped runs count toward alert",
                       "type": "boolean"
                     },
                     "mode": {
@@ -1010,7 +999,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -1024,7 +1013,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                       "type": "string"
                     }
                   },
@@ -1099,7 +1088,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Only explicit voice/speech/TTS intent or active TTS config; never ordinary text reply. Audio auto-delivered. After success follow reply instructions; no duplicate text/audio.",
+        "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
         "inputSchema": {
           "properties": {
             "channel": {
@@ -1124,7 +1113,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway restart/config/update. Before config edit: config.schema.lookup exact dot path. Partial merge: config.patch; full replace only: config.apply. Removing array entries via patch needs exact array replacePaths. Writes hot-reload/restart as needed. Always human note for post-restart delivery. Internal continuation: one-shot continuationMessage; its visible follow-up uses message tool. Never write restart sentinel directly.",
+        "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1193,7 +1182,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List visible sessions; filter kind/label/agentId/search/activity/archive. Use before history/send target selection.",
+        "description": "List visible sessions; filter by kind, label, agentId, search, activity, archive state. Use before sessions_history or sessions_send target selection.",
         "inputSchema": {
           "properties": {
             "activeMinutes": {
@@ -1244,7 +1233,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Read sanitized visible-session history. Before reply/debug/resume. Supports limit/offset/tool messages.",
+        "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limit, offset pagination, and tool-message inclusion.",
         "inputSchema": {
           "properties": {
             "includeTools": {
@@ -1270,31 +1259,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search your own past sessions for matching user and assistant text. Follow up with sessions_history using a returned sessionKey for full context.",
-        "inputSchema": {
-          "properties": {
-            "limit": {
-              "maximum": 25,
-              "minimum": 1,
-              "type": "integer"
-            },
-            "query": {
-              "maxLength": 4096,
-              "type": "string"
-            },
-            "sessionKey": {
-              "type": "string"
-            }
-          },
-          "required": ["query"],
-          "type": "object"
-        },
-        "name": "sessions_search",
-        "type": "function"
-      },
-      {
-        "deferLoading": true,
-        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available.",
+        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true registers you for state-change notices when other actors later interact with the target session.",
         "inputSchema": {
           "properties": {
             "agentId": {
@@ -1316,6 +1281,9 @@
             "timeoutSeconds": {
               "minimum": 0,
               "type": "integer"
+            },
+            "watch": {
+              "type": "boolean"
             }
           },
           "required": ["message"],
@@ -1326,7 +1294,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List requester-session active/recent subagents. If available, wait via sessions_yield; never poll-loop.",
+        "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1345,7 +1313,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Show visible-session model/usage/time/cost/tasks. `sessionKey=\"current\"` for current; UI labels are not keys. `model` overrides; `model=default` resets. Use for active model/session questions.",
+        "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
         "inputSchema": {
           "properties": {
             "changesSince": {
@@ -1366,7 +1334,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search current web; normalized provider results.",
+        "description": "Search web for current info; returns normalized provider results.",
         "inputSchema": {
           "properties": {
             "count": {
@@ -1434,7 +1402,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Fetch URL; extract readable markdown/text. Lightweight; no browser automation.",
+        "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
         "inputSchema": {
           "properties": {
             "extractMode": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1,6 +1,6 @@
 [
   {
-    "description": "Send/delete/manage channel messages. Supports actions: send.",
+    "description": "Send/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -18,7 +18,7 @@
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each entry uses media.",
+          "description": "Attachments; each uses media.",
           "items": {
             "properties": {
               "media": {
@@ -40,7 +40,7 @@
           "type": "array"
         },
         "buffer": {
-          "description": "Base64 attachment payload; data URL ok.",
+          "description": "Base64/data-URL attachment.",
           "type": "string"
         },
         "caption": {
@@ -60,14 +60,14 @@
           "type": "string"
         },
         "effectId": {
-          "description": "Effect id/name for sendWithEffect.",
+          "description": "sendWithEffect id/name.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document; avoids compression.",
+          "description": "Send media as document; no compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -125,7 +125,7 @@
     "type": "function"
   },
   {
-    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
+    "description": "List ids allowed for `sessions_spawn(runtime:\"subagent\")`.",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -134,7 +134,7 @@
     "type": "function"
   },
   {
-    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
+    "description": "Spawn clean child; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background. Inherits parent workspace. Native task arrives as first `[Subagent Task]`. Native transcript needed: `context=\"fork\"`; else omit/isolated. Use fresh child for sidecar/parallel batch reads, multi-step search, data collection; avoid quick lookup/single read unless policy prefers. After spawn, do non-overlap work while run result returns.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -176,7 +176,7 @@
           "type": "string"
         },
         "context": {
-          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
+          "description": "Native: omit/isolated clean; fork only needing requester transcript.",
           "enum": ["isolated", "fork"],
           "type": "string"
         },
@@ -187,7 +187,7 @@
           "type": "string"
         },
         "lightContext": {
-          "description": "Light bootstrap context; runtime=\"subagent\" only.",
+          "description": "Light bootstrap; subagent only.",
           "type": "boolean"
         },
         "mode": {
@@ -209,7 +209,7 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
+          "description": "Stable later-target alias; starts lowercase letter; then lowercase/digit/_/-.",
           "type": "string"
         },
         "thinking": {
@@ -223,7 +223,7 @@
     "type": "function"
   },
   {
-    "description": "End current turn. Use after spawning subagents; results arrive as next message.",
+    "description": "End turn after subagent spawn; results arrive next message.",
     "inputSchema": {
       "properties": {
         "message": {
@@ -241,7 +241,7 @@
     "tools": [
       {
         "deferLoading": true,
-        "description": "List paired nodes with status; describe/control a specific node by passing node. Supports pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
+        "description": "Paired nodes: status/list with active-computer presence; pass node to describe/control. Pairing, notify, camera/photos/screen/location/notifications, executable lookup (which + bins), generic invoke. Files: file_fetch.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -265,9 +265,20 @@
                 "device_info",
                 "device_permissions",
                 "device_health",
+                "which",
                 "invoke"
               ],
               "type": "string"
+            },
+            "bins": {
+              "description": "which: executable names to resolve on the selected node.",
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "minItems": 1,
+              "type": "array"
             },
             "body": {
               "type": "string"
@@ -392,7 +403,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: run only if due by default; needs jobId; pass runMode=\"force\" to trigger now\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane owned by the calling agent.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"trigger\": { \"script\": \"...\", \"once\": false }, // optional condition gate for every/cron\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nOptional trigger scripts poll headlessly on every/cron schedules and run the payload only when they return { fire: true }.\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
+        "description": "Gateway schedules/wakes: reminders, later checks/follow-ups, recurring work. Never exec sleep/process-poll as timer. Main job => heartbeat system event; isolated => background task in `openclaw tasks`.\n\nACTIONS:\n- status scheduler; list compact summaries (includeDisabled, session agentId auto-filter; get for full); get jobId\n- add job; update jobId+patch; remove jobId\n- run jobId (due only; runMode=\"force\" now); runs jobId history\n- wake text (+ optional mode). Default caller lane; top-level sessionKey/agentId selects another caller-owned lane.\n\nADD JOB:\n{ \"name\":\"...\", \"schedule\":{...}, \"trigger\":{ \"script\":\"...\", \"once\":false }, \"payload\":{...}, \"delivery\":{...}, \"sessionTarget\":\"main|isolated|current|session:<id>\", \"enabled\":true }\nRequired: schedule,payload. enabled default true. trigger only every/cron.\n\nTARGET/PAYLOAD:\n- main => systemEvent {kind:\"systemEvent\",text:\"...\"}; systemEvent defaults main.\n- isolated/current/session:<id> => agentTurn {kind:\"agentTurn\",message:\"...\",model?,thinking?,timeoutSeconds?}; agentTurn defaults isolated. timeoutSeconds=0 means none.\n- current binds caller session at creation. session:<id> is persistent. Prefer isolated unless user explicitly wants current binding.\n\nSCHEDULE:\n- at: {kind:\"at\",at:\"ISO-8601\"}; timezone-less = UTC.\n- every: {kind:\"every\",everyMs:<ms>,anchorMs?}.\n- cron: {kind:\"cron\",expr:\"...\",tz?:\"IANA\"}. Expr is requested local wall time; never pre-convert to UTC. Missing tz = Gateway host local, not UTC. Shanghai 18:00: {kind:\"cron\",expr:\"0 18 * * *\",tz:\"Asia/Shanghai\"}.\n\nTRIGGER SCRIPT:\n- Requires cron.triggers.enabled; if off, explain and never model-poll fallback.\n- Headless owner allowlist; quiet check has no model. Prior trigger.state is frozen JSON. Return/json({fire:boolean,message?:string,state?:JSONValue}); create new state, never mutate prior.\n- fire:false saves state only; no payload/history. fire:true runs payload and appends message; fired state saves only after payload success. Check reads; payload acts.\n- Silent watcher: top-level delivery.mode=\"none\". Omitted delivery on isolated agentTurn announces and missing route may fail.\n- once:true disables after first successful fire. Per check: 30s, 5 tool calls, 16KB state.\n- Hidden Code Mode tools: await tools.call(\"exec\", {command:\"...\"}); unknown id => search/describe.\n\nDELIVERY top-level: {mode:\"none|announce|webhook\",channel?,to?,threadId?,bestEffort?}\n- Isolated agentTurn omitted delivery => announce. announce only isolated/current/session; channel/to optional; threadId chat topic. Specific chat: set channel/to; no messaging tool inside run.\n- webhook posts finished-run event to URL in to.\n\nRestricted isolated runs may only self status/list, current get/runs, and remove current job. wake mode: next-heartbeat default | now. jobId canonical; id compat. contextMessages 0-10 adds prior messages.",
         "inputSchema": {
           "additionalProperties": true,
           "properties": {
@@ -436,7 +447,7 @@
                   "description": "Agent id, or null to keep it unset"
                 },
                 "declarationKey": {
-                  "description": "Idempotent declaration identity key",
+                  "description": "Idempotent declaration key.",
                   "maxLength": 200,
                   "minLength": 1,
                   "pattern": "\\S",
@@ -527,7 +538,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert object; false disables alerts",
+                  "description": "Failure alert; false disables.",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -547,7 +558,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Skipped runs count toward alert",
+                      "description": "Count skipped runs.",
                       "type": "boolean"
                     },
                     "mode": {
@@ -646,7 +657,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -660,7 +671,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
                       "type": "string"
                     }
                   },
@@ -816,7 +827,7 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Failure destination, or null to clear"
+                      "description": "Failure destination; null clears."
                     },
                     "mode": {
                       "description": "Delivery mode",
@@ -871,7 +882,7 @@
                 },
                 "failureAlert": {
                   "additionalProperties": true,
-                  "description": "Failure alert object; false disables alerts",
+                  "description": "Failure alert; false disables.",
                   "properties": {
                     "accountId": {
                       "type": "string"
@@ -891,7 +902,7 @@
                       "type": "integer"
                     },
                     "includeSkipped": {
-                      "description": "Skipped runs count toward alert",
+                      "description": "Count skipped runs.",
                       "type": "boolean"
                     },
                     "mode": {
@@ -999,7 +1010,7 @@
                       "type": "integer"
                     },
                     "expr": {
-                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "description": "Cron wall-time expr; never UTC-convert. Missing tz=Gateway local. Example \"0 18 * * *\", \"Asia/Shanghai\".",
                       "type": "string"
                     },
                     "kind": {
@@ -1013,7 +1024,7 @@
                       "type": "integer"
                     },
                     "tz": {
-                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "description": "IANA timezone for wall-clock fields; missing=Gateway host local timezone. Example \"Asia/Shanghai\".",
                       "type": "string"
                     }
                   },
@@ -1088,7 +1099,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
+        "description": "Only explicit voice/speech/TTS intent or active TTS config; never ordinary text reply. Audio auto-delivered. After success follow reply instructions; no duplicate text/audio.",
         "inputSchema": {
           "properties": {
             "channel": {
@@ -1113,7 +1124,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
+        "description": "Gateway restart/config/update. Before config edit: config.schema.lookup exact dot path. Partial merge: config.patch; full replace only: config.apply. Removing array entries via patch needs exact array replacePaths. Writes hot-reload/restart as needed. Always human note for post-restart delivery. Internal continuation: one-shot continuationMessage; its visible follow-up uses message tool. Never write restart sentinel directly.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1182,7 +1193,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List visible sessions; filter by kind, label, agentId, search, activity, archive state. Use before sessions_history or sessions_send target selection.",
+        "description": "List visible sessions; filter kind/label/agentId/search/activity/archive. Use before history/send target selection.",
         "inputSchema": {
           "properties": {
             "activeMinutes": {
@@ -1233,7 +1244,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limit, offset pagination, and tool-message inclusion.",
+        "description": "Read sanitized visible-session history. Before reply/debug/resume. Supports limit/offset/tool messages.",
         "inputSchema": {
           "properties": {
             "includeTools": {
@@ -1259,7 +1270,31 @@
       },
       {
         "deferLoading": true,
-        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true: notice arrives when others later change target session.",
+        "description": "Search your own past sessions for matching user and assistant text. Follow up with sessions_history using a returned sessionKey for full context.",
+        "inputSchema": {
+          "properties": {
+            "limit": {
+              "maximum": 25,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "query": {
+              "maxLength": 4096,
+              "type": "string"
+            },
+            "sessionKey": {
+              "type": "string"
+            }
+          },
+          "required": ["query"],
+          "type": "object"
+        },
+        "name": "sessions_search",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available. watch:true: notice arrives when others later change target session.",
         "inputSchema": {
           "properties": {
             "agentId": {
@@ -1294,7 +1329,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
+        "description": "List requester-session active/recent subagents. If available, wait via sessions_yield; never poll-loop.",
         "inputSchema": {
           "properties": {
             "action": {
@@ -1313,7 +1348,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
+        "description": "Show visible-session model/usage/time/cost/tasks. `sessionKey=\"current\"` for current; UI labels are not keys. `model` overrides; `model=default` resets. Use for active model/session questions.",
         "inputSchema": {
           "properties": {
             "changesSince": {
@@ -1334,7 +1369,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search web for current info; returns normalized provider results.",
+        "description": "Search current web; normalized provider results.",
         "inputSchema": {
           "properties": {
             "count": {
@@ -1402,7 +1437,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
+        "description": "Fetch URL; extract readable markdown/text. Lightweight; no browser automation.",
         "inputSchema": {
           "properties": {
             "extractMode": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1259,7 +1259,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true registers you for state-change notices when other actors later interact with the target session.",
+        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available. watch:true: notice arrives when others later change target session.",
         "inputSchema": {
           "properties": {
             "agentId": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -79,6 +79,7 @@
     "gateway",
     "sessions_list",
     "sessions_history",
+    "sessions_search",
     "sessions_send",
     "subagents",
     "session_status",
@@ -207,20 +208,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53888,
-    "roughTokens": 13472
+    "chars": 52644,
+    "roughTokens": 13161
   },
   "openClawDeveloperInstructions": {
-    "chars": 3245,
-    "roughTokens": 812
+    "chars": 3262,
+    "roughTokens": 816
   },
   "totalTextOnly": {
-    "chars": 27770,
-    "roughTokens": 6943
+    "chars": 27787,
+    "roughTokens": 6947
   },
   "totalWithDynamicToolsJson": {
-    "chars": 81660,
-    "roughTokens": 20415
+    "chars": 80433,
+    "roughTokens": 20109
   },
   "userInputText": {
     "chars": 1442,
@@ -407,7 +408,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
 
@@ -539,6 +540,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
   "gateway",
   "sessions_list",
   "sessions_history",
+  "sessions_search",
   "sessions_send",
   "subagents",
   "session_status",
@@ -552,7 +554,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
 ```json
 [
   {
-    "description": "Send/delete/manage channel messages. Supports actions: send.",
+    "description": "Send/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -570,7 +572,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each entry uses media.",
+          "description": "Attachments; each uses media.",
           "items": {
             "properties": {
               "media": {
@@ -592,7 +594,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "array"
         },
         "buffer": {
-          "description": "Base64 attachment payload; data URL ok.",
+          "description": "Base64/data-URL attachment.",
           "type": "string"
         },
         "caption": {
@@ -612,14 +614,14 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "string"
         },
         "effectId": {
-          "description": "Effect id/name for sendWithEffect.",
+          "description": "sendWithEffect id/name.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document; avoids compression.",
+          "description": "Send media as document; no compression.",
           "type": "boolean"
         },
         "gatewayToken": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -79,7 +79,6 @@
     "gateway",
     "sessions_list",
     "sessions_history",
-    "sessions_search",
     "sessions_send",
     "subagents",
     "session_status",
@@ -208,20 +207,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 52506,
-    "roughTokens": 13127
+    "chars": 53928,
+    "roughTokens": 13482
   },
   "openClawDeveloperInstructions": {
-    "chars": 3262,
-    "roughTokens": 816
+    "chars": 3245,
+    "roughTokens": 812
   },
   "totalTextOnly": {
-    "chars": 27787,
-    "roughTokens": 6947
+    "chars": 27770,
+    "roughTokens": 6943
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80295,
-    "roughTokens": 20074
+    "chars": 81700,
+    "roughTokens": 20425
   },
   "userInputText": {
     "chars": 1442,
@@ -408,7 +407,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
 
@@ -540,7 +539,6 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
   "gateway",
   "sessions_list",
   "sessions_history",
-  "sessions_search",
   "sessions_send",
   "subagents",
   "session_status",
@@ -554,7 +552,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
 ```json
 [
   {
-    "description": "Send/manage channel messages. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -572,7 +570,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "boolean"
         },
         "attachments": {
-          "description": "Attachments; each uses media.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
               "media": {
@@ -594,7 +592,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "array"
         },
         "buffer": {
-          "description": "Base64/data-URL attachment.",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -614,14 +612,14 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "string"
         },
         "effectId": {
-          "description": "sendWithEffect id/name.",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send media as document; no compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -207,8 +207,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53928,
-    "roughTokens": 13482
+    "chars": 53888,
+    "roughTokens": 13472
   },
   "openClawDeveloperInstructions": {
     "chars": 3245,
@@ -219,8 +219,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6943
   },
   "totalWithDynamicToolsJson": {
-    "chars": 81700,
-    "roughTokens": 20425
+    "chars": 81660,
+    "roughTokens": 20415
   },
   "userInputText": {
     "chars": 1442,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -79,6 +79,7 @@
     "gateway",
     "sessions_list",
     "sessions_history",
+    "sessions_search",
     "sessions_send",
     "subagents",
     "session_status",
@@ -207,20 +208,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53577,
-    "roughTokens": 13395
+    "chars": 52371,
+    "roughTokens": 13093
   },
   "openClawDeveloperInstructions": {
-    "chars": 2136,
-    "roughTokens": 534
+    "chars": 2153,
+    "roughTokens": 539
   },
   "totalTextOnly": {
-    "chars": 26252,
-    "roughTokens": 6563
+    "chars": 26269,
+    "roughTokens": 6568
   },
   "totalWithDynamicToolsJson": {
-    "chars": 79831,
-    "roughTokens": 19958
+    "chars": 78642,
+    "roughTokens": 19661
   },
   "userInputText": {
     "chars": 1033,
@@ -407,7 +408,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
 
@@ -526,6 +527,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
   "gateway",
   "sessions_list",
   "sessions_history",
+  "sessions_search",
   "sessions_send",
   "subagents",
   "session_status",
@@ -539,7 +541,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
 ```json
 [
   {
-    "description": "Send/delete/manage channel messages. Supports actions: send.",
+    "description": "Send/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -557,7 +559,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each entry uses media.",
+          "description": "Attachments; each uses media.",
           "items": {
             "properties": {
               "media": {
@@ -579,7 +581,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "array"
         },
         "buffer": {
-          "description": "Base64 attachment payload; data URL ok.",
+          "description": "Base64/data-URL attachment.",
           "type": "string"
         },
         "caption": {
@@ -599,14 +601,14 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "string"
         },
         "effectId": {
-          "description": "Effect id/name for sendWithEffect.",
+          "description": "sendWithEffect id/name.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document; avoids compression.",
+          "description": "Send media as document; no compression.",
           "type": "boolean"
         },
         "gatewayToken": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -207,8 +207,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53617,
-    "roughTokens": 13405
+    "chars": 53577,
+    "roughTokens": 13395
   },
   "openClawDeveloperInstructions": {
     "chars": 2136,
@@ -219,8 +219,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6563
   },
   "totalWithDynamicToolsJson": {
-    "chars": 79871,
-    "roughTokens": 19968
+    "chars": 79831,
+    "roughTokens": 19958
   },
   "userInputText": {
     "chars": 1033,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -79,7 +79,6 @@
     "gateway",
     "sessions_list",
     "sessions_history",
-    "sessions_search",
     "sessions_send",
     "subagents",
     "session_status",
@@ -208,20 +207,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 52233,
-    "roughTokens": 13059
+    "chars": 53617,
+    "roughTokens": 13405
   },
   "openClawDeveloperInstructions": {
-    "chars": 2153,
-    "roughTokens": 539
+    "chars": 2136,
+    "roughTokens": 534
   },
   "totalTextOnly": {
-    "chars": 26269,
-    "roughTokens": 6568
+    "chars": 26252,
+    "roughTokens": 6563
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78504,
-    "roughTokens": 19626
+    "chars": 79871,
+    "roughTokens": 19968
   },
   "userInputText": {
     "chars": 1033,
@@ -408,7 +407,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
 
@@ -527,7 +526,6 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
   "gateway",
   "sessions_list",
   "sessions_history",
-  "sessions_search",
   "sessions_send",
   "subagents",
   "session_status",
@@ -541,7 +539,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
 ```json
 [
   {
-    "description": "Send/manage channel messages. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -559,7 +557,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "attachments": {
-          "description": "Attachments; each uses media.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
               "media": {
@@ -581,7 +579,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "array"
         },
         "buffer": {
-          "description": "Base64/data-URL attachment.",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -601,14 +599,14 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "string"
         },
         "effectId": {
-          "description": "sendWithEffect id/name.",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send media as document; no compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -208,8 +208,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 54907,
-    "roughTokens": 13727
+    "chars": 54867,
+    "roughTokens": 13717
   },
   "openClawDeveloperInstructions": {
     "chars": 2155,
@@ -220,8 +220,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6799
   },
   "totalWithDynamicToolsJson": {
-    "chars": 82104,
-    "roughTokens": 20526
+    "chars": 82064,
+    "roughTokens": 20516
   },
   "userInputText": {
     "chars": 1271,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -80,6 +80,7 @@
     "gateway",
     "sessions_list",
     "sessions_history",
+    "sessions_search",
     "sessions_send",
     "subagents",
     "session_status",
@@ -124,7 +125,7 @@
   "collaborationMode": {
     "mode": "default",
     "settings": {
-      "developer_instructions": "This is an OpenClaw heartbeat turn. Apply these instructions only to this heartbeat wake; ordinary chat turns should stay in Codex Default mode.\n\nWhen you are ready to end the heartbeat, prefer the structured `heartbeat_respond` tool so OpenClaw can record the wake outcome and notification decision. If `heartbeat_respond` is not already available and `tool_search` is available, search for `heartbeat_respond`, load it, then call it. Use `notify=false` when nothing should visibly interrupt the user.\n\n### Heartbeats\n\nUse heartbeats to create useful proactive progress, not chatter.\nTreat a heartbeat as a wake-up: orient, read HEARTBEAT.md when present, then do what is actually useful now.\nIf HEARTBEAT.md assigns concrete or ongoing work, execute its spirit with judgment. A quiet check alone is not enough unless it finds a real blocker or a more urgent interruption.\nAvoid rote loops. Do not confuse orientation with accomplishment.\nPrefer meaningful action over commentary. A good heartbeat often looks like silent progress.\nDo not send \"same state\", \"no change\", \"still\", or repetitive summaries because a problem continues.\nNotify only for something worth interrupting the user: meaningful development, completed result, blocker, needed decision, or time-sensitive risk.\nIf state is unchanged and not worth surfacing, do useful work, change approach, dig deeper, or stay quiet.\n\n## OpenClaw Agent Soul\n\nOpenClaw loaded these workspace instruction files from the active agent workspace. They are the canonical definitions of who you are, how you think and work, and the human you work alongside. Internalize and follow them accordingly.\n\n### /tmp/openclaw-happy-path/workspace/IDENTITY.md\n\n<IDENTITY.md contents will be here>\n\n### /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n### /tmp/openclaw-happy-path/workspace/USER.md\n\n<USER.md contents will be here>\n\n## OpenClaw Heartbeat Workspace\n\nHEARTBEAT.md exists in the active agent workspace. Read it before proceeding with this heartbeat, then decide what action is appropriate.\n\n- /tmp/openclaw-happy-path/workspace/HEARTBEAT.md",
+      "developer_instructions": "This is an OpenClaw heartbeat turn. Apply these instructions only to this heartbeat wake; ordinary chat turns should stay in Codex Default mode.\n\nWhen you are ready to end the heartbeat, prefer the structured `heartbeat_respond` tool so OpenClaw can record the wake outcome and notification decision. If `heartbeat_respond` is not already available and `tool_search` is available, search for `heartbeat_respond`, load it, then call it. Use `notify=false` when nothing should visibly interrupt the user.\n\n### Heartbeats\n\nHeartbeat = useful proactive progress, not chatter. Wake, orient, read HEARTBEAT.md, act.\nAssigned/ongoing work: pursue spirit with judgment. Quiet check counts only if real blocker/urgent interruption.\nNo rote loops; orientation != accomplishment. Prefer action/silent progress.\nNever repetitive \"same/no change/still\" updates.\nInterrupt only for meaningful development/result/blocker/decision/time risk. Unchanged: work, change approach, dig deeper, or silence.\n\n## OpenClaw Agent Soul\n\nOpenClaw loaded these workspace instruction files from the active agent workspace. They are the canonical definitions of who you are, how you think and work, and the human you work alongside. Internalize and follow them accordingly.\n\n### /tmp/openclaw-happy-path/workspace/IDENTITY.md\n\n<IDENTITY.md contents will be here>\n\n### /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n### /tmp/openclaw-happy-path/workspace/USER.md\n\n<USER.md contents will be here>\n\n## OpenClaw Heartbeat Workspace\n\nHEARTBEAT.md exists in the active agent workspace. Read it before proceeding with this heartbeat, then decide what action is appropriate.\n\n- /tmp/openclaw-happy-path/workspace/HEARTBEAT.md",
       "model": "gpt-5.5",
       "reasoning_effort": "medium"
     }
@@ -192,8 +193,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
 ```json
 {
   "codexCollaborationModeDeveloperInstructions": {
-    "chars": 2119,
-    "roughTokens": 530
+    "chars": 1715,
+    "roughTokens": 429
   },
   "codexModelInstructions": {
     "chars": 21335,
@@ -208,20 +209,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 54867,
-    "roughTokens": 13717
+    "chars": 53661,
+    "roughTokens": 13416
   },
   "openClawDeveloperInstructions": {
-    "chars": 2155,
-    "roughTokens": 539
+    "chars": 2172,
+    "roughTokens": 543
   },
   "totalTextOnly": {
-    "chars": 27195,
-    "roughTokens": 6799
+    "chars": 26808,
+    "roughTokens": 6702
   },
   "totalWithDynamicToolsJson": {
-    "chars": 82064,
-    "roughTokens": 20516
+    "chars": 80471,
+    "roughTokens": 20118
   },
   "userInputText": {
     "chars": 1271,
@@ -408,7 +409,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: cron, gateway, heartbeat_respond, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, heartbeat_respond, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
 
@@ -451,14 +452,11 @@ When you are ready to end the heartbeat, prefer the structured `heartbeat_respon
 
 ### Heartbeats
 
-Use heartbeats to create useful proactive progress, not chatter.
-Treat a heartbeat as a wake-up: orient, read HEARTBEAT.md when present, then do what is actually useful now.
-If HEARTBEAT.md assigns concrete or ongoing work, execute its spirit with judgment. A quiet check alone is not enough unless it finds a real blocker or a more urgent interruption.
-Avoid rote loops. Do not confuse orientation with accomplishment.
-Prefer meaningful action over commentary. A good heartbeat often looks like silent progress.
-Do not send "same state", "no change", "still", or repetitive summaries because a problem continues.
-Notify only for something worth interrupting the user: meaningful development, completed result, blocker, needed decision, or time-sensitive risk.
-If state is unchanged and not worth surfacing, do useful work, change approach, dig deeper, or stay quiet.
+Heartbeat = useful proactive progress, not chatter. Wake, orient, read HEARTBEAT.md, act.
+Assigned/ongoing work: pursue spirit with judgment. Quiet check counts only if real blocker/urgent interruption.
+No rote loops; orientation != accomplishment. Prefer action/silent progress.
+Never repetitive "same/no change/still" updates.
+Interrupt only for meaningful development/result/blocker/decision/time risk. Unchanged: work, change approach, dig deeper, or silence.
 
 ## OpenClaw Agent Soul
 
@@ -537,6 +535,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
   "gateway",
   "sessions_list",
   "sessions_history",
+  "sessions_search",
   "sessions_send",
   "subagents",
   "session_status",
@@ -550,7 +549,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
 ```json
 [
   {
-    "description": "Send/delete/manage channel messages. Supports actions: send.",
+    "description": "Send/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -568,7 +567,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured attachments; each entry uses media.",
+          "description": "Attachments; each uses media.",
           "items": {
             "properties": {
               "media": {
@@ -590,7 +589,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "array"
         },
         "buffer": {
-          "description": "Base64 attachment payload; data URL ok.",
+          "description": "Base64/data-URL attachment.",
           "type": "string"
         },
         "caption": {
@@ -610,14 +609,14 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "string"
         },
         "effectId": {
-          "description": "Effect id/name for sendWithEffect.",
+          "description": "sendWithEffect id/name.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document; avoids compression.",
+          "description": "Send media as document; no compression.",
           "type": "boolean"
         },
         "gatewayToken": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -80,7 +80,6 @@
     "gateway",
     "sessions_list",
     "sessions_history",
-    "sessions_search",
     "sessions_send",
     "subagents",
     "session_status",
@@ -125,7 +124,7 @@
   "collaborationMode": {
     "mode": "default",
     "settings": {
-      "developer_instructions": "This is an OpenClaw heartbeat turn. Apply these instructions only to this heartbeat wake; ordinary chat turns should stay in Codex Default mode.\n\nWhen you are ready to end the heartbeat, prefer the structured `heartbeat_respond` tool so OpenClaw can record the wake outcome and notification decision. If `heartbeat_respond` is not already available and `tool_search` is available, search for `heartbeat_respond`, load it, then call it. Use `notify=false` when nothing should visibly interrupt the user.\n\n### Heartbeats\n\nHeartbeat = useful proactive progress, not chatter. Wake, orient, read HEARTBEAT.md, act.\nAssigned/ongoing work: pursue spirit with judgment. Quiet check counts only if real blocker/urgent interruption.\nNo rote loops; orientation != accomplishment. Prefer action/silent progress.\nNever repetitive \"same/no change/still\" updates.\nInterrupt only for meaningful development/result/blocker/decision/time risk. Unchanged: work, change approach, dig deeper, or silence.\n\n## OpenClaw Agent Soul\n\nOpenClaw loaded these workspace instruction files from the active agent workspace. They are the canonical definitions of who you are, how you think and work, and the human you work alongside. Internalize and follow them accordingly.\n\n### /tmp/openclaw-happy-path/workspace/IDENTITY.md\n\n<IDENTITY.md contents will be here>\n\n### /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n### /tmp/openclaw-happy-path/workspace/USER.md\n\n<USER.md contents will be here>\n\n## OpenClaw Heartbeat Workspace\n\nHEARTBEAT.md exists in the active agent workspace. Read it before proceeding with this heartbeat, then decide what action is appropriate.\n\n- /tmp/openclaw-happy-path/workspace/HEARTBEAT.md",
+      "developer_instructions": "This is an OpenClaw heartbeat turn. Apply these instructions only to this heartbeat wake; ordinary chat turns should stay in Codex Default mode.\n\nWhen you are ready to end the heartbeat, prefer the structured `heartbeat_respond` tool so OpenClaw can record the wake outcome and notification decision. If `heartbeat_respond` is not already available and `tool_search` is available, search for `heartbeat_respond`, load it, then call it. Use `notify=false` when nothing should visibly interrupt the user.\n\n### Heartbeats\n\nUse heartbeats to create useful proactive progress, not chatter.\nTreat a heartbeat as a wake-up: orient, read HEARTBEAT.md when present, then do what is actually useful now.\nIf HEARTBEAT.md assigns concrete or ongoing work, execute its spirit with judgment. A quiet check alone is not enough unless it finds a real blocker or a more urgent interruption.\nAvoid rote loops. Do not confuse orientation with accomplishment.\nPrefer meaningful action over commentary. A good heartbeat often looks like silent progress.\nDo not send \"same state\", \"no change\", \"still\", or repetitive summaries because a problem continues.\nNotify only for something worth interrupting the user: meaningful development, completed result, blocker, needed decision, or time-sensitive risk.\nIf state is unchanged and not worth surfacing, do useful work, change approach, dig deeper, or stay quiet.\n\n## OpenClaw Agent Soul\n\nOpenClaw loaded these workspace instruction files from the active agent workspace. They are the canonical definitions of who you are, how you think and work, and the human you work alongside. Internalize and follow them accordingly.\n\n### /tmp/openclaw-happy-path/workspace/IDENTITY.md\n\n<IDENTITY.md contents will be here>\n\n### /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n### /tmp/openclaw-happy-path/workspace/USER.md\n\n<USER.md contents will be here>\n\n## OpenClaw Heartbeat Workspace\n\nHEARTBEAT.md exists in the active agent workspace. Read it before proceeding with this heartbeat, then decide what action is appropriate.\n\n- /tmp/openclaw-happy-path/workspace/HEARTBEAT.md",
       "model": "gpt-5.5",
       "reasoning_effort": "medium"
     }
@@ -193,8 +192,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
 ```json
 {
   "codexCollaborationModeDeveloperInstructions": {
-    "chars": 1715,
-    "roughTokens": 429
+    "chars": 2119,
+    "roughTokens": 530
   },
   "codexModelInstructions": {
     "chars": 21335,
@@ -209,20 +208,20 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53523,
-    "roughTokens": 13381
+    "chars": 54907,
+    "roughTokens": 13727
   },
   "openClawDeveloperInstructions": {
-    "chars": 2172,
-    "roughTokens": 543
+    "chars": 2155,
+    "roughTokens": 539
   },
   "totalTextOnly": {
-    "chars": 26808,
-    "roughTokens": 6702
+    "chars": 27195,
+    "roughTokens": 6799
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80333,
-    "roughTokens": 20084
+    "chars": 82104,
+    "roughTokens": 20526
   },
   "userInputText": {
     "chars": 1271,
@@ -409,7 +408,7 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 ````text
 You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.
 
-Deferred searchable OpenClaw dynamic tools available: cron, gateway, heartbeat_respond, nodes, session_status, sessions_history, sessions_list, sessions_search, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
+Deferred searchable OpenClaw dynamic tools available: cron, gateway, heartbeat_respond, nodes, session_status, sessions_history, sessions_list, sessions_send, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. `spawn_agent` and the other native collaboration tools may be deferred: when `spawn_agent` is not directly listed, load it with `tool_search` before spawning. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation, never as a substitute for `spawn_agent`.
 
@@ -452,11 +451,14 @@ When you are ready to end the heartbeat, prefer the structured `heartbeat_respon
 
 ### Heartbeats
 
-Heartbeat = useful proactive progress, not chatter. Wake, orient, read HEARTBEAT.md, act.
-Assigned/ongoing work: pursue spirit with judgment. Quiet check counts only if real blocker/urgent interruption.
-No rote loops; orientation != accomplishment. Prefer action/silent progress.
-Never repetitive "same/no change/still" updates.
-Interrupt only for meaningful development/result/blocker/decision/time risk. Unchanged: work, change approach, dig deeper, or silence.
+Use heartbeats to create useful proactive progress, not chatter.
+Treat a heartbeat as a wake-up: orient, read HEARTBEAT.md when present, then do what is actually useful now.
+If HEARTBEAT.md assigns concrete or ongoing work, execute its spirit with judgment. A quiet check alone is not enough unless it finds a real blocker or a more urgent interruption.
+Avoid rote loops. Do not confuse orientation with accomplishment.
+Prefer meaningful action over commentary. A good heartbeat often looks like silent progress.
+Do not send "same state", "no change", "still", or repetitive summaries because a problem continues.
+Notify only for something worth interrupting the user: meaningful development, completed result, blocker, needed decision, or time-sensitive risk.
+If state is unchanged and not worth surfacing, do useful work, change approach, dig deeper, or stay quiet.
 
 ## OpenClaw Agent Soul
 
@@ -535,7 +537,6 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
   "gateway",
   "sessions_list",
   "sessions_history",
-  "sessions_search",
   "sessions_send",
   "subagents",
   "session_status",
@@ -549,7 +550,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
 ```json
 [
   {
-    "description": "Send/manage channel messages. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -567,7 +568,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "boolean"
         },
         "attachments": {
-          "description": "Attachments; each uses media.",
+          "description": "Structured attachments; each entry uses media.",
           "items": {
             "properties": {
               "media": {
@@ -589,7 +590,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "array"
         },
         "buffer": {
-          "description": "Base64/data-URL attachment.",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -609,14 +610,14 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "string"
         },
         "effectId": {
-          "description": "sendWithEffect id/name.",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send media as document; no compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {


### PR DESCRIPTION
## What Problem This Solves

Closes #104803.

The session state signal log (#104565, landed in #104636) only notifies watchers along spawn edges (`spawnedBy`/`parentSessionKey`). A session that coordinates a peer via `sessions_send` — a manager agent steering another agent's main session — never learns when a human later talks to that peer directly or its goal changes. The coordinator keeps acting on stale assumptions, which is the exact failure mode the signal log exists to prevent, one hierarchy edge over.

## Why This Change Was Made

Explicit watch registration built entirely on the existing cursor table — no schema change, no new config:

- `registerSessionStateWatch` seeds a `session_watch_cursors` row at the target's current signal-log head, so only changes after registration produce notices. Re-registering never clobbers pending-notice cursor state. Agent-qualified watcher keys only, per the existing `session.scope="global"` ambiguity guard.
- `recordSessionStateEvent` unions producer-passed watchers with registered cursor holders for notify-eligible kinds, so producers stay registration-agnostic.
- `recordSessionHumanDirectMessage` now gates unparented sessions on a single indexed watcher-existence probe instead of returning early, so watched peer sessions record human turns while unwatched sessions stay write-free on the human-turn hot path.
- `sessions_send` gains an opt-in `watch: true` parameter. Registration happens **after** successful dispatch and targets the actually-delivered session key (cron run-scoped sends that fall back to the durable parent watch the parent, and failed sends leave no hidden watch — both were autoreview findings, fixed and re-reviewed clean). Results report `watched: true|false` when the param was set.

Watches expire with normal signal-log retention and are cleared when the watcher session resets. Auto-watch on every send was deliberately rejected as noise; opt-in first.

## User Impact

A coordinator can now say `sessions_send({ ..., watch: true })` and later receive the standard state-invalidation notice (pointing at `session_status` `changesSince`) when another actor materially changes the target session. No behavior change for existing calls.

## Evidence

- New tests in `src/sessions/session-state-events.test.ts`: registration guards (self/bare keys rejected), seed-at-head (no notices for prior history), notice on post-registration change, re-registration preserving pending cursors, and the unparented human-turn gate flipping on registration.
- Autoreview (codex `gpt-5.6-sol`, xhigh): first pass surfaced two real P2 findings on the tool glue (hidden watch on dispatch failure; watch pinned to the ephemeral run key on cron fallback); both fixed, rerun clean — "patch is correct (0.82)".
- Prompt snapshots regenerated; drift is exactly the `watch` schema property + description sentence.
- Docs: `docs/concepts/session-tool.md` documents the param and registration semantics.
- Remote focused tests + `pnpm check:changed` (Blacksmith Testbox) + hosted CI on this PR.

## Follow-up commit: live verification, token-efficiency, docs page

Second commit (`2f116abe607`) after review + live testing:

- **Live end-to-end proof on a real gateway with an OpenAI key** (scratch state dir, two agents on `openai/gpt-5.6-terra`/`-luna`, embedded runtime): `sessions_send watch:true` returned `watched:true` and seeded a durable cursor; a direct human turn to the worker recorded `human_direct_message` and queued exactly one coalesced notice; the watcher's next reply-pipeline turn received the notice verbatim, called `session_status` with the given `changesSince`, got the typed delta, and correctly reported the change; cursor advanced 0 -> 3 across three interventions. Restart recovery verified live: pending notice re-materialized by the startup sweep after a gateway restart.
- **Bug found by the live test, fixed here:** session-state wakes used `intent: "event"`, which defers on heartbeat dueness — a notice could sit until the next scheduled tick (up to the whole heartbeat interval). Now `intent: "immediate"`, the same class as background-task completions and cron wake-now; the flood guard remains the backstop. Regression-asserted in the wake test.
- **Token-efficient model-facing strings:** the notice line is ~40% shorter and self-contained (explicit target `sessionKey` in the suggested `session_status` call — autoreview finding, fixed and re-reviewed clean), and the `sessions_send` tool description gained a terse `watch` sentence. Prompt snapshots regenerated.
- **Dedicated docs page:** `docs/concepts/session-state.md` ("Session state awareness") now explains the whole system — signal log and event kinds, state versions, implicit/explicit watchers, the anti-spam notice protocol (one pending notice per watcher/target, frozen watermark, ack-on-drain, self-suppression, restart sweep), `changesSince` reconciliation with `historyGap`, and v1 limits. `session-tool.md` sections trimmed to summaries linking there; nav + docs map updated.
- Duplication audit: keyed system events dedupe on byte-identical text + context key across the queue, so repeated changes to one target produce a single prompt line; heartbeat wakes coalesce separately. No duplicate or stacked notices possible while one is pending.
