### PR TITLE
fix(audit): correlate prefixed outbound conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Message audit correlation:** normalize routed outbound targets before deriving fallback conversation references so provider and kind prefixes do not split inbound/outbound audit histories.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Message audit correlation:** normalize routed outbound targets before deriving fallback conversation references so provider and kind prefixes do not split inbound/outbound audit histories.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/src/infra/outbound/outbound-audit.test.ts
+++ b/src/infra/outbound/outbound-audit.test.ts
@@ -219,6 +219,33 @@ describe("outbound audit projection", () => {
     });
   });
 
+  it("normalizes a routed target used as the fallback conversation identifier", () => {
+    const events: TrustedMessageAuditEvent[] = [];
+    const unsubscribe = onTrustedMessageAuditEvent((event) => events.push(event));
+    try {
+      emitOutboundAuditTerminals({
+        context: {
+          channel: "discord",
+          to: "discord:channel:123456789",
+          payloads: [{ text: "sent" }],
+        },
+        terminals: uniformOutboundAuditTerminals(1, {
+          outcome: "sent",
+          results: [{ channel: "discord", messageId: "message-1" }],
+        }),
+        startedAt: Date.now(),
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      conversationId: "123456789",
+      targetId: "discord:channel:123456789",
+    });
+  });
+
   function conversationKindFor(
     context: Omit<Parameters<typeof emitOutboundAuditTerminals>[0]["context"], "payloads">,
   ): string | undefined {

--- a/src/infra/outbound/outbound-audit.ts
+++ b/src/infra/outbound/outbound-audit.ts
@@ -234,6 +234,28 @@ const TARGET_KIND_TO_ROUTE_KINDS: Record<
 };
 const TARGET_PREFIX_RE = /^\s*([a-z][a-z0-9_-]*):/i;
 
+function resolveOutboundTargetFacts(context: OutboundAuditDeliveryContext): {
+  conversationId: string;
+  withoutProvider: string;
+  allowedRouteKinds: readonly ("channel" | "direct" | "dm" | "group")[] | undefined;
+} {
+  const channel = context.channel.toLowerCase();
+  const aliasChannel = resolveTargetPrefixedChannel(context.to);
+  const targetPrefix = TARGET_PREFIX_RE.exec(context.to)?.[1];
+  const providerPrefixes =
+    aliasChannel === channel
+      ? [context.channel, targetPrefix ?? context.channel]
+      : [context.channel];
+  const withoutProvider = stripTargetProviderPrefix(context.to, ...providerPrefixes);
+  const kindPrefix = TARGET_PREFIX_RE.exec(withoutProvider)?.[1]?.toLowerCase();
+  const allowedRouteKinds = kindPrefix ? TARGET_KIND_TO_ROUTE_KINDS[kindPrefix] : undefined;
+  const conversationId = stripTargetKindPrefix(
+    withoutProvider,
+    Object.keys(TARGET_KIND_TO_ROUTE_KINDS),
+  );
+  return { conversationId, withoutProvider, allowedRouteKinds };
+}
+
 /** True when a parsed session route provably names this delivery's destination. */
 function routeNamesDestination(
   route: ReturnType<typeof parseSessionDeliveryRoute>,
@@ -242,26 +264,14 @@ function routeNamesDestination(
   if (!route || route.channel !== context.channel.toLowerCase()) {
     return false;
   }
-  // Targets can nest a provider prefix around a kind prefix ("discord:dm:123",
-  // alias "tg:123"), so strip the provider layer first — including registered
-  // plugin aliases proven to belong to this channel — and evaluate the kind on
-  // what remains.
-  const aliasChannel = resolveTargetPrefixedChannel(context.to);
-  const providerPrefixes =
-    aliasChannel === context.channel.toLowerCase()
-      ? [context.channel, TARGET_PREFIX_RE.exec(context.to)?.[1] ?? context.channel]
-      : [context.channel];
-  const withoutProvider = stripTargetProviderPrefix(context.to, ...providerPrefixes);
-  const prefix = TARGET_PREFIX_RE.exec(withoutProvider)?.[1]?.toLowerCase();
-  const allowedRouteKinds = prefix ? TARGET_KIND_TO_ROUTE_KINDS[prefix] : undefined;
+  // Provider aliases and kind prefixes are routing syntax, not platform ids.
+  // Keep this shared with audit correlation so both decisions peel the same layers.
+  const { conversationId, withoutProvider, allowedRouteKinds } =
+    resolveOutboundTargetFacts(context);
   if (allowedRouteKinds && !allowedRouteKinds.includes(route.peerKind)) {
     return false;
   }
-  const candidates = [
-    context.to,
-    withoutProvider,
-    stripTargetKindPrefix(withoutProvider, Object.keys(TARGET_KIND_TO_ROUTE_KINDS)),
-  ];
+  const candidates = [context.to, withoutProvider, conversationId];
   return candidates.some((candidate) => {
     const normalized = normalizeSessionPeerId({
       channel: route.channel,
@@ -313,25 +323,26 @@ function firstIdentifier(...values: Array<string | undefined>): string | undefin
   return undefined;
 }
 
-function resolveResultIdentifiers(results: readonly OutboundDeliveryResult[]): {
+function resolveResultIdentifiers(
+  context: OutboundAuditDeliveryContext,
+  results: readonly OutboundDeliveryResult[],
+): {
   conversationId?: string;
   messageId?: string;
 } {
   const last = results.at(-1);
-  if (!last) {
-    return {};
-  }
-  const conversationId = firstIdentifier(
-    last.conversationId,
-    last.chatId,
-    last.channelId,
-    last.roomId,
-    last.toJid,
-  );
+  const conversationId =
+    firstIdentifier(
+      last?.conversationId,
+      last?.chatId,
+      last?.channelId,
+      last?.roomId,
+      last?.toJid,
+    ) ?? resolveOutboundTargetFacts(context).conversationId;
   const messageId = firstIdentifier(
-    last.messageId,
-    last.receipt?.primaryPlatformMessageId,
-    last.receipt?.platformMessageIds.at(-1),
+    last?.messageId,
+    last?.receipt?.primaryPlatformMessageId,
+    last?.receipt?.platformMessageIds.at(-1),
   );
   return {
     ...(conversationId ? { conversationId } : {}),
@@ -354,7 +365,7 @@ function emitOutboundAuditTerminal(params: {
     const { context, terminal } = params;
     const results = terminal.results ?? [];
     const agentId = context.session?.agentId ?? context.mirror?.agentId;
-    const identifiers = resolveResultIdentifiers(results);
+    const identifiers = resolveResultIdentifiers(context, results);
     const sentBeforeError =
       (terminal.outcome === "failed" || terminal.outcome === "unknown") &&
       terminal.sentBeforeError === true;


### PR DESCRIPTION
Related: #103903

## What Problem This Solves

Fixes an issue where operators correlating inbound and outbound message audit records could get different conversation references when an outbound adapter returned only a message ID and the routed target contained provider or target-kind prefixes.

## Why This Change Was Made

The outbound audit projection now removes routing-only provider aliases and recognized kind prefixes before using the target as a fallback conversation identifier. Adapter-returned conversation IDs remain authoritative, and the raw routed target remains available through its separate target reference.

This PR is AI-assisted. I reviewed the implementation and its surrounding audit, routing, and adapter contracts.

## User Impact

Audit queries can correlate both directions of a conversation even when outbound targets use forms such as `discord:channel:123` and the channel adapter does not return a conversation ID.

## Evidence

- Before fix: brokered AWS Crabbox `cbx_5a41547fe9f3`, run `run_c1c01b771847` — focused regression failed because `conversationId` was absent (9 passed, 1 failed).
- After fix: same lease, run `run_84ce348d1653` — focused outbound audit suite passed (10/10).
- Final changed surface: same lease, run `run_60c4bdc86f29` — outbound audit and audit-store suites passed (20/20), followed by `pnpm check:changed` passing formatting, type checks, lint, and boundary guards.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean; no accepted or actionable findings (0.93 confidence).
