### PR TITLE
fix(cli): prevent usage-cost stalls on unresponsive gateway calls

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -332,8 +332,13 @@ describe("gateway-cli coverage", () => {
         expect(observedStatuses[0]).toBe("refreshing");
         expect(observedStatuses.at(-1)).toBe("fresh");
         expect(callGateway.mock.calls.length).toBeGreaterThanOrEqual(2);
-        const firstCostCall = firstMockArg(callGateway) as { timeoutMs?: number };
-        expect(firstCostCall.timeoutMs).toBeGreaterThan(290_000);
+        const costCalls = callGateway.mock.calls.map(
+          ([raw]) => raw as { method?: string; timeoutMs?: number },
+        );
+        expect(costCalls.every((call) => call.method === "usage.cost")).toBe(true);
+        expect(costCalls.every((call) => (call.timeoutMs ?? 0) > 0)).toBe(true);
+        expect(costCalls.every((call) => (call.timeoutMs ?? 0) <= 10_000)).toBe(true);
+        expect(costCalls[0]?.timeoutMs).toBe(10_000);
         expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
           expect.objectContaining({
             totals: expect.objectContaining({ totalTokens: 100, totalCost: 0.1 }),

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -127,7 +127,10 @@ async function loadSettledCostUsageSummary(
     if (remainingBeforeCallMs <= 0) {
       throw createUsageCostSettleTimeoutError(lastSummary);
     }
-    const callOpts = { ...rpcOpts, timeout: String(remainingBeforeCallMs) };
+    const callOpts = {
+      ...rpcOpts,
+      timeout: String(Math.min(DEFAULT_GATEWAY_RPC_TIMEOUT_MS, remainingBeforeCallMs)),
+    };
     const summary = (await callGatewayCli("usage.cost", callOpts, params)) as CostUsageSummary;
     lastSummary = summary;
     const status = summary.cacheStatus?.status;
@@ -139,8 +142,8 @@ async function loadSettledCostUsageSummary(
     if (remainingMs <= 0) {
       throw createUsageCostSettleTimeoutError(summary);
     }
-    // The existing RPC timeout is the whole command budget. Giving each retry a
-    // fresh timeout would let a short bounded audit keep running for minutes.
+    // The usage-cost timeout is the whole command budget. Each transport call
+    // remains capped separately so one unresponsive RPC cannot consume it all.
     await sleep(Math.min(pollMs, remainingMs));
     pollMs = Math.min(pollMs * 2, USAGE_COST_SETTLE_MAX_POLL_MS);
   }


### PR DESCRIPTION
Related: #103998
Related: #103882

AI-assisted: Codex.

## What Problem This Solves

Fixes an issue where users running `openclaw gateway usage-cost --all-agents` could wait nearly the full five-minute cache-settlement budget when a single Gateway RPC stopped responding.

## Why This Change Was Made

The command keeps its five-minute overall settlement deadline, but caps each individual Gateway transport call at the established 10-second RPC timeout or the smaller remaining command budget. This preserves cold-cache polling without letting one call consume the whole audit window.

## User Impact

Usage-cost audits now fail promptly on an unresponsive Gateway call while still allowing healthy cache refreshes to settle for up to the configured command timeout.

## Evidence

- Focused CLI suite: 31/31 passed locally after rebasing onto current `main`.
- Blacksmith Testbox `tbx_01kx9vm5wqp6rp4a9cs5nzt52f`: 31/31 passed on Linux.
- `pnpm check:changed`: passed locally for the two changed files; sparse-only core-test typecheck skipped missing UI inputs per repository policy.
- Autoreview: clean, no actionable findings, 0.95 confidence.
- `git diff --check`: passed.