### PR TITLE
fix(tui): keep the newer session when a stale switch history resolves last

### DIFF
--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -300,10 +300,34 @@ async function writeTuiPtyFixtureScript(dir: string) {
           return { ok: true, aborted: true };
         }
 
-        async loadHistory() {
-          record("loadHistory");
-          if (startupDelayMs > 0) {
-            await new Promise((resolve) => setTimeout(resolve, startupDelayMs));
+        async loadHistory(opts: Parameters<TuiBackend["loadHistory"]>[0]) {
+          const sessionKey = opts?.sessionKey ?? "main";
+          record("loadHistory", { sessionKey });
+          const rapidSwitchMarker = sessionKey.endsWith("switch-a")
+            ? "A"
+            : sessionKey.endsWith("switch-b")
+              ? "B"
+              : null;
+          const delayMs =
+            rapidSwitchMarker === "A" ? 500 : rapidSwitchMarker === "B" ? 40 : startupDelayMs;
+          if (delayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
+          if (rapidSwitchMarker) {
+            record("loadHistoryResolved", { sessionKey });
+            return {
+              sessionId: "session-" + rapidSwitchMarker,
+              sessionInfo: {
+                key: sessionKey,
+                sessionId: "session-" + rapidSwitchMarker,
+                model: currentModel,
+                modelProvider: "fixture-provider",
+                contextTokens: 128,
+                fastMode,
+                thinkingLevels: [],
+              },
+              messages: [{ role: "user", content: rapidSwitchMarker + "_HISTORY_MARKER" }],
+            };
           }
           return { messages: [], fastMode };
         }
@@ -780,6 +804,29 @@ describe.sequential("TUI PTY harness", () => {
         const key = (entry.payload as Record<string, unknown>).key;
         return typeof key === "string" && (key === "main" || key.startsWith("agent:main:"));
       });
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps the newer session when a rapid switch's history resolves last",
+    async () => {
+      await fixture.run.write("/session agent:main:switch-a\r", { delay: false });
+      await fixture.run.write("/session agent:main:switch-b\r", { delay: false });
+      await fixture.run.waitForOutput("B_HISTORY_MARKER");
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "loadHistoryResolved" &&
+          objectFieldEquals(entry, "sessionKey", "agent:main:switch-a"),
+      );
+
+      await fixture.run.write("after switch\r", { delay: false });
+      const sent = await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "sendChat" && objectFieldEquals(entry, "message", "after switch"),
+      );
+      expect(sent.payload).toMatchObject({ sessionKey: "agent:main:switch-b" });
+      expect(fixture.run.output()).not.toContain("A_HISTORY_MARKER");
     },
     TEST_TIMEOUT_MS,
   );

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -752,6 +752,67 @@ describe("tui session actions", () => {
     expect(renderedUsers).not.toContain("message from A");
   });
 
+  it("ignores a superseded switch whose history request rejects", async () => {
+    let rejectA: ((reason: unknown) => void) | undefined;
+    let resolveB: ((value: unknown) => void) | undefined;
+    const loadHistory = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectA = reject;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveB = resolve;
+          }),
+      );
+    const addSystem = vi.fn();
+    const addUser = vi.fn();
+    const chatLog = {
+      addSystem,
+      clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
+      addUser,
+      finalizeAssistant: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
+      restorePendingUsers: vi.fn(),
+      updateAssistant: vi.fn(),
+      startTool: vi.fn(),
+    } as unknown as import("./components/chat-log.js").ChatLog;
+    const state = createBaseState({ currentSessionKey: "agent:main:home" });
+    const setActivityStatus = vi.fn();
+
+    const { setSession } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog,
+      state,
+      setActivityStatus,
+    });
+
+    const firstSwitch = setSession("agent:main:A");
+    const secondSwitch = setSession("agent:main:B");
+
+    resolveB?.({
+      sessionId: "session-b",
+      sessionInfo: { key: "agent:main:B", sessionId: "session-b", updatedAt: 20 },
+      messages: [{ role: "user", content: "message from B" }],
+    });
+    rejectA?.(new Error("history rpc aborted"));
+
+    await Promise.all([firstSwitch, secondSwitch]);
+
+    expect(state.currentSessionKey).toBe("agent:main:B");
+    expect(state.currentSessionId).toBe("session-b");
+    expect(state.activeChatRunId).toBeNull();
+    const systemMessages = addSystem.mock.calls.map((call) => String(call[0]));
+    expect(systemMessages.some((message) => message.includes("history failed"))).toBe(false);
+    const renderedUsers = addUser.mock.calls.map((call) => call[0]);
+    expect(renderedUsers).toContain("message from B");
+  });
+
   it("applies default model info when the current session has no persisted entry yet", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -688,6 +688,70 @@ describe("tui session actions", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
   });
 
+  it("keeps the newer session when an earlier switch's history resolves last", async () => {
+    let resolveA: ((value: unknown) => void) | undefined;
+    let resolveB: ((value: unknown) => void) | undefined;
+    const loadHistory = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveA = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveB = resolve;
+          }),
+      );
+    const addUser = vi.fn();
+    const chatLog = {
+      addSystem: vi.fn(),
+      clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
+      addUser,
+      finalizeAssistant: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
+      restorePendingUsers: vi.fn(),
+      updateAssistant: vi.fn(),
+      startTool: vi.fn(),
+    } as unknown as import("./components/chat-log.js").ChatLog;
+    const state = createBaseState({ currentSessionKey: "agent:main:home" });
+    const setActivityStatus = vi.fn();
+
+    const { setSession } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog,
+      state,
+      setActivityStatus,
+    });
+
+    const firstSwitch = setSession("agent:main:A");
+    const secondSwitch = setSession("agent:main:B");
+
+    resolveB?.({
+      sessionId: "session-b",
+      sessionInfo: { key: "agent:main:B", sessionId: "session-b", updatedAt: 20 },
+      messages: [{ role: "user", content: "message from B" }],
+    });
+    resolveA?.({
+      sessionId: "session-a",
+      sessionInfo: { key: "agent:main:A", sessionId: "session-a", updatedAt: 10 },
+      messages: [{ role: "user", content: "message from A" }],
+      inFlightRun: { runId: "run-a", text: "stale A run" },
+    });
+
+    await Promise.all([firstSwitch, secondSwitch]);
+
+    expect(state.currentSessionKey).toBe("agent:main:B");
+    expect(state.currentSessionId).toBe("session-b");
+    expect(state.activeChatRunId).toBeNull();
+    const renderedUsers = addUser.mock.calls.map((call) => call[0]);
+    expect(renderedUsers).toContain("message from B");
+    expect(renderedUsers).not.toContain("message from A");
+  });
+
   it("applies default model info when the current session has no persisted entry yet", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1,5 +1,6 @@
 // Covers TUI session action routing and backend calls.
 import { describe, expect, it, vi } from "vitest";
+import type { ChatLog } from "./components/chat-log.js";
 import type { TuiBackend } from "./tui-backend.js";
 import { createSessionActions } from "./tui-session-actions.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
@@ -24,6 +25,31 @@ describe("tui session actions", () => {
     clear: vi.fn(),
     showResult: vi.fn(),
   });
+  const createDeferred = <T>() => {
+    let resolve: (value: T) => void = () => {};
+    let reject: (reason?: unknown) => void = () => {};
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  };
+  const createHistoryChatLog = () => {
+    const addSystem = vi.fn();
+    const addUser = vi.fn();
+    const chatLog = {
+      addSystem,
+      clearAll: vi.fn(),
+      clearPendingUsers: vi.fn(),
+      addUser,
+      finalizeAssistant: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
+      restorePendingUsers: vi.fn(),
+      updateAssistant: vi.fn(),
+      startTool: vi.fn(),
+    } as unknown as ChatLog;
+    return { chatLog, addSystem, addUser };
+  };
 
   const createBaseState = (overrides: Partial<TuiStateAccess> = {}): TuiStateAccess => ({
     agentDefaultId: "main",
@@ -689,34 +715,13 @@ describe("tui session actions", () => {
   });
 
   it("keeps the newer session when an earlier switch's history resolves last", async () => {
-    let resolveA: ((value: unknown) => void) | undefined;
-    let resolveB: ((value: unknown) => void) | undefined;
+    const historyA = createDeferred<unknown>();
+    const historyB = createDeferred<unknown>();
     const loadHistory = vi
       .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveA = resolve;
-          }),
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveB = resolve;
-          }),
-      );
-    const addUser = vi.fn();
-    const chatLog = {
-      addSystem: vi.fn(),
-      clearAll: vi.fn(),
-      clearPendingUsers: vi.fn(),
-      addUser,
-      finalizeAssistant: vi.fn(),
-      reconcilePendingUsers: vi.fn().mockReturnValue([]),
-      restorePendingUsers: vi.fn(),
-      updateAssistant: vi.fn(),
-      startTool: vi.fn(),
-    } as unknown as import("./components/chat-log.js").ChatLog;
+      .mockImplementationOnce(() => historyA.promise)
+      .mockImplementationOnce(() => historyB.promise);
+    const { chatLog, addUser } = createHistoryChatLog();
     const state = createBaseState({ currentSessionKey: "agent:main:home" });
     const setActivityStatus = vi.fn();
 
@@ -730,12 +735,12 @@ describe("tui session actions", () => {
     const firstSwitch = setSession("agent:main:A");
     const secondSwitch = setSession("agent:main:B");
 
-    resolveB?.({
+    historyB.resolve({
       sessionId: "session-b",
       sessionInfo: { key: "agent:main:B", sessionId: "session-b", updatedAt: 20 },
       messages: [{ role: "user", content: "message from B" }],
     });
-    resolveA?.({
+    historyA.resolve({
       sessionId: "session-a",
       sessionInfo: { key: "agent:main:A", sessionId: "session-a", updatedAt: 10 },
       messages: [{ role: "user", content: "message from A" }],
@@ -753,35 +758,13 @@ describe("tui session actions", () => {
   });
 
   it("ignores a superseded switch whose history request rejects", async () => {
-    let rejectA: ((reason: unknown) => void) | undefined;
-    let resolveB: ((value: unknown) => void) | undefined;
+    const historyA = createDeferred<unknown>();
+    const historyB = createDeferred<unknown>();
     const loadHistory = vi
       .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise((_resolve, reject) => {
-            rejectA = reject;
-          }),
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveB = resolve;
-          }),
-      );
-    const addSystem = vi.fn();
-    const addUser = vi.fn();
-    const chatLog = {
-      addSystem,
-      clearAll: vi.fn(),
-      clearPendingUsers: vi.fn(),
-      addUser,
-      finalizeAssistant: vi.fn(),
-      reconcilePendingUsers: vi.fn().mockReturnValue([]),
-      restorePendingUsers: vi.fn(),
-      updateAssistant: vi.fn(),
-      startTool: vi.fn(),
-    } as unknown as import("./components/chat-log.js").ChatLog;
+      .mockImplementationOnce(() => historyA.promise)
+      .mockImplementationOnce(() => historyB.promise);
+    const { chatLog, addSystem, addUser } = createHistoryChatLog();
     const state = createBaseState({ currentSessionKey: "agent:main:home" });
     const setActivityStatus = vi.fn();
 
@@ -795,12 +778,12 @@ describe("tui session actions", () => {
     const firstSwitch = setSession("agent:main:A");
     const secondSwitch = setSession("agent:main:B");
 
-    resolveB?.({
+    historyB.resolve({
       sessionId: "session-b",
       sessionInfo: { key: "agent:main:B", sessionId: "session-b", updatedAt: 20 },
       messages: [{ role: "user", content: "message from B" }],
     });
-    rejectA?.(new Error("history rpc aborted"));
+    historyA.reject(new Error("history rpc aborted"));
 
     await Promise.all([firstSwitch, secondSwitch]);
 
@@ -811,6 +794,60 @@ describe("tui session actions", () => {
     expect(systemMessages.some((message) => message.includes("history failed"))).toBe(false);
     const renderedUsers = addUser.mock.calls.map((call) => call[0]);
     expect(renderedUsers).toContain("message from B");
+  });
+
+  it("keeps the newer session when an earlier history load awaits session info", async () => {
+    const historyA = createDeferred<unknown>();
+    const historyB = createDeferred<unknown>();
+    const sessionInfoA = createDeferred<unknown>();
+    const sessionInfoB = createDeferred<unknown>();
+    const loadHistory = vi
+      .fn()
+      .mockImplementationOnce(() => historyA.promise)
+      .mockImplementationOnce(() => historyB.promise);
+    const listSessions = vi
+      .fn()
+      .mockImplementationOnce(() => sessionInfoA.promise)
+      .mockImplementationOnce(() => sessionInfoB.promise);
+    const { chatLog, addSystem, addUser } = createHistoryChatLog();
+    const state = createBaseState({ currentSessionKey: "agent:main:home" });
+
+    const { setSession } = createTestSessionActions({
+      client: { listSessions, loadHistory } as unknown as TuiBackend,
+      chatLog,
+      state,
+    });
+
+    const firstSwitch = setSession("agent:main:A");
+    historyA.resolve({
+      sessionId: "session-a",
+      messages: [{ role: "user", content: "message from A" }],
+    });
+    await vi.waitFor(() => expect(listSessions).toHaveBeenCalledTimes(1));
+
+    const secondSwitch = setSession("agent:main:B");
+    historyB.resolve({
+      sessionId: "session-b",
+      messages: [{ role: "user", content: "message from B" }],
+    });
+
+    sessionInfoA.resolve({
+      defaults: {},
+      sessions: [{ key: "agent:main:A", sessionId: "session-a", updatedAt: 10 }],
+    });
+    await vi.waitFor(() => expect(listSessions).toHaveBeenCalledTimes(2));
+    sessionInfoB.resolve({
+      defaults: {},
+      sessions: [{ key: "agent:main:B", sessionId: "session-b", updatedAt: 20 }],
+    });
+    await Promise.all([firstSwitch, secondSwitch]);
+
+    expect(state.currentSessionKey).toBe("agent:main:B");
+    expect(state.currentSessionId).toBe("session-b");
+    const renderedUsers = addUser.mock.calls.map((call) => call[0]);
+    expect(renderedUsers).toContain("message from B");
+    expect(renderedUsers).not.toContain("message from A");
+    expect(addSystem).not.toHaveBeenCalledWith(expect.stringContaining("sessions list failed"));
   });
 
   it("applies default model info when the current session has no persisted entry yet", async () => {

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -850,6 +850,65 @@ describe("tui session actions", () => {
     expect(addSystem).not.toHaveBeenCalledWith(expect.stringContaining("sessions list failed"));
   });
 
+  it("ignores stale session info after switching away and back to the same key", async () => {
+    const firstHistoryA = createDeferred<unknown>();
+    const historyB = createDeferred<unknown>();
+    const secondHistoryA = createDeferred<unknown>();
+    const firstSessionInfoA = createDeferred<unknown>();
+    const loadHistory = vi
+      .fn()
+      .mockImplementationOnce(() => firstHistoryA.promise)
+      .mockImplementationOnce(() => historyB.promise)
+      .mockImplementationOnce(() => secondHistoryA.promise);
+    const listSessions = vi.fn(() => firstSessionInfoA.promise);
+    const state = createBaseState({ currentSessionKey: "agent:main:home" });
+
+    const { setSession } = createTestSessionActions({
+      client: { listSessions, loadHistory } as unknown as TuiBackend,
+      state,
+    });
+
+    const firstSwitchA = setSession("agent:main:A");
+    firstHistoryA.resolve({ sessionId: "session-a-old", messages: [] });
+    await vi.waitFor(() => expect(listSessions).toHaveBeenCalledTimes(1));
+
+    const switchB = setSession("agent:main:B");
+    historyB.resolve({
+      sessionInfo: { key: "agent:main:B", sessionId: "session-b", updatedAt: 20 },
+      messages: [],
+    });
+    await switchB;
+
+    const secondSwitchA = setSession("agent:main:A");
+    secondHistoryA.resolve({
+      sessionInfo: {
+        key: "agent:main:A",
+        sessionId: "session-a-new",
+        model: "new-model",
+        updatedAt: 30,
+      },
+      messages: [],
+    });
+    await secondSwitchA;
+
+    firstSessionInfoA.resolve({
+      defaults: {},
+      sessions: [
+        {
+          key: "agent:main:A",
+          sessionId: "session-a-old",
+          model: "old-model",
+          updatedAt: 10,
+        },
+      ],
+    });
+    await firstSwitchA;
+
+    expect(state.currentSessionKey).toBe("agent:main:A");
+    expect(state.currentSessionId).toBe("session-a-new");
+    expect(state.sessionInfo.model).toBe("new-model");
+  });
+
   it("applies default model info when the current session has no persisted entry yet", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1410,7 +1410,7 @@ describe("tui session actions", () => {
       messages: [],
     });
     const rememberSessionKey = vi.fn();
-    const state = createBaseState();
+    const state = createBaseState({ currentSessionKey: "main" });
 
     const { loadHistory: runLoadHistory } = createTestSessionActions({
       client: {
@@ -1424,6 +1424,7 @@ describe("tui session actions", () => {
     await runLoadHistory();
 
     expect(state.currentSessionId).toBe("session-main");
+    expect(state.currentSessionKey).toBe("agent:main:main");
     expect(rememberSessionKey).toHaveBeenCalledWith("agent:main:main");
   });
 

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -132,6 +132,7 @@ export function createSessionActions(context: SessionActionContext) {
   } = context;
   let refreshSessionInfoInFlight: Promise<void> | null = null;
   let refreshSessionInfoQueued = false;
+  let sessionSwitchGeneration = 0;
   let lastSessionDefaults: SessionInfoDefaults | null = null;
 
   const applyAgentsResult = (result: TuiAgentsList) => {
@@ -435,12 +436,16 @@ export function createSessionActions(context: SessionActionContext) {
   };
 
   const loadHistory = async (): Promise<TuiHistoryLoadResult> => {
+    const generation = sessionSwitchGeneration;
     try {
       const history = await client.loadHistory({
         sessionKey: state.currentSessionKey,
         ...(state.currentSessionKey === "global" ? { agentId: state.currentAgentId } : {}),
         limit: opts.historyLimit ?? 200,
       });
+      if (generation !== sessionSwitchGeneration) {
+        return { loaded: false };
+      }
       const record = history as {
         messages?: unknown[];
         sessionId?: string;
@@ -578,6 +583,7 @@ export function createSessionActions(context: SessionActionContext) {
   };
 
   const setSession = async (rawKey: string) => {
+    sessionSwitchGeneration += 1;
     const nextKey = resolveSessionKey(rawKey);
     updateAgentFromSessionKey(nextKey);
     state.currentSessionKey = nextKey;

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -132,8 +132,17 @@ export function createSessionActions(context: SessionActionContext) {
   } = context;
   let refreshSessionInfoInFlight: Promise<void> | null = null;
   let refreshSessionInfoQueued = false;
-  let sessionSwitchGeneration = 0;
+  let historyLoadGeneration = 0;
   let lastSessionDefaults: SessionInfoDefaults | null = null;
+
+  const captureSessionSelection = () => ({
+    sessionKey: state.currentSessionKey,
+    agentId: state.currentAgentId,
+  });
+
+  const isCurrentSessionSelection = (selection: { sessionKey: string; agentId: string }): boolean =>
+    state.currentAgentId === selection.agentId &&
+    agentSessionKeysMatchByRequestKey(state.currentSessionKey, selection.sessionKey);
 
   const applyAgentsResult = (result: TuiAgentsList) => {
     state.agentDefaultId = normalizeAgentId(result.defaultId);
@@ -327,27 +336,31 @@ export function createSessionActions(context: SessionActionContext) {
   };
 
   const runRefreshSessionInfo = async () => {
+    const selection = captureSessionSelection();
     try {
       const resolveListAgentId = () => {
-        if (state.currentSessionKey === "global") {
-          return state.currentAgentId;
+        if (selection.sessionKey === "global") {
+          return selection.agentId;
         }
-        if (state.currentSessionKey === "unknown") {
+        if (selection.sessionKey === "unknown") {
           return undefined;
         }
-        const parsed = parseAgentSessionKey(state.currentSessionKey);
-        return parsed?.agentId ? normalizeAgentId(parsed.agentId) : state.currentAgentId;
+        const parsed = parseAgentSessionKey(selection.sessionKey);
+        return parsed?.agentId ? normalizeAgentId(parsed.agentId) : selection.agentId;
       };
       const listAgentId = resolveListAgentId();
       const result = await client.listSessions({
         limit: TUI_SESSION_LOOKUP_LIMIT,
-        search: state.currentSessionKey,
-        includeGlobal: state.currentSessionKey === "global",
-        includeUnknown: state.currentSessionKey === "unknown",
+        search: selection.sessionKey,
+        includeGlobal: selection.sessionKey === "global",
+        includeUnknown: selection.sessionKey === "unknown",
         agentId: listAgentId,
       });
+      if (!isCurrentSessionSelection(selection)) {
+        return;
+      }
       const entry = result.sessions.find((row) => {
-        return agentSessionKeysMatchByRequestKey(row.key, state.currentSessionKey);
+        return agentSessionKeysMatchByRequestKey(row.key, selection.sessionKey);
       });
       if (entry?.key && entry.key !== state.currentSessionKey) {
         updateAgentFromSessionKey(entry.key);
@@ -360,6 +373,9 @@ export function createSessionActions(context: SessionActionContext) {
         defaults: result.defaults,
       });
     } catch (err) {
+      if (!isCurrentSessionSelection(selection)) {
+        return;
+      }
       chatLog.addSystem(`sessions list failed: ${String(err)}`);
     }
   };
@@ -436,14 +452,19 @@ export function createSessionActions(context: SessionActionContext) {
   };
 
   const loadHistory = async (): Promise<TuiHistoryLoadResult> => {
-    const generation = sessionSwitchGeneration;
+    // History rebuilds mutate shared UI state after multiple awaits. Only the
+    // latest request may render, or a slow reload can replace a newer selection.
+    const generation = ++historyLoadGeneration;
+    const selection = captureSessionSelection();
+    const isCurrentLoad = () =>
+      generation === historyLoadGeneration && isCurrentSessionSelection(selection);
     try {
       const history = await client.loadHistory({
-        sessionKey: state.currentSessionKey,
-        ...(state.currentSessionKey === "global" ? { agentId: state.currentAgentId } : {}),
+        sessionKey: selection.sessionKey,
+        ...(selection.sessionKey === "global" ? { agentId: selection.agentId } : {}),
         limit: opts.historyLimit ?? 200,
       });
-      if (generation !== sessionSwitchGeneration) {
+      if (!isCurrentLoad()) {
         return { loaded: false };
       }
       const record = history as {
@@ -462,6 +483,8 @@ export function createSessionActions(context: SessionActionContext) {
       if (sessionInfo?.key && sessionInfo.key !== state.currentSessionKey) {
         updateAgentFromSessionKey(sessionInfo.key);
         state.currentSessionKey = sessionInfo.key;
+        selection.sessionKey = state.currentSessionKey;
+        selection.agentId = state.currentAgentId;
         updateHeader();
       }
       const historySessionInfo =
@@ -487,6 +510,9 @@ export function createSessionActions(context: SessionActionContext) {
       });
       if (!sessionInfo) {
         await refreshSessionInfo();
+        if (!isCurrentLoad()) {
+          return { loaded: false };
+        }
       }
       const showTools = (state.sessionInfo.verboseLevel ?? "off") !== "off";
       const historyUsers: Array<{ text: string; timestamp?: number | null }> = [];
@@ -576,7 +602,7 @@ export function createSessionActions(context: SessionActionContext) {
       tui.requestRender(true);
       return { loaded: true, inFlightRunId: inFlightRunId || null };
     } catch (err) {
-      if (generation !== sessionSwitchGeneration) {
+      if (!isCurrentLoad()) {
         return { loaded: false };
       }
       chatLog.addSystem(`history failed: ${String(err)}`);
@@ -586,7 +612,6 @@ export function createSessionActions(context: SessionActionContext) {
   };
 
   const setSession = async (rawKey: string) => {
-    sessionSwitchGeneration += 1;
     const nextKey = resolveSessionKey(rawKey);
     updateAgentFromSessionKey(nextKey);
     state.currentSessionKey = nextKey;

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -337,6 +337,9 @@ export function createSessionActions(context: SessionActionContext) {
 
   const runRefreshSessionInfo = async () => {
     const selection = captureSessionSelection();
+    const historyGeneration = historyLoadGeneration;
+    const isCurrentRefresh = () =>
+      historyGeneration === historyLoadGeneration && isCurrentSessionSelection(selection);
     try {
       const resolveListAgentId = () => {
         if (selection.sessionKey === "global") {
@@ -358,7 +361,7 @@ export function createSessionActions(context: SessionActionContext) {
       });
       // Agent-scoped list results may expand a legacy alias to its canonical key,
       // but cannot move the selection to another agent.
-      if (!isCurrentSessionSelection(selection)) {
+      if (!isCurrentRefresh()) {
         return;
       }
       const entry = result.sessions.find((row) => {
@@ -375,7 +378,7 @@ export function createSessionActions(context: SessionActionContext) {
         defaults: result.defaults,
       });
     } catch (err) {
-      if (!isCurrentSessionSelection(selection)) {
+      if (!isCurrentRefresh()) {
         return;
       }
       chatLog.addSystem(`sessions list failed: ${String(err)}`);

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -356,6 +356,8 @@ export function createSessionActions(context: SessionActionContext) {
         includeUnknown: selection.sessionKey === "unknown",
         agentId: listAgentId,
       });
+      // Agent-scoped list results may expand a legacy alias to its canonical key,
+      // but cannot move the selection to another agent.
       if (!isCurrentSessionSelection(selection)) {
         return;
       }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -576,6 +576,9 @@ export function createSessionActions(context: SessionActionContext) {
       tui.requestRender(true);
       return { loaded: true, inFlightRunId: inFlightRunId || null };
     } catch (err) {
+      if (generation !== sessionSwitchGeneration) {
+        return { loaded: false };
+      }
       chatLog.addSystem(`history failed: ${String(err)}`);
       tui.requestRender(true);
       return { loaded: false };


### PR DESCRIPTION
## What Problem This Solves

Two quick TUI session switches can complete out of order. If `/session A` starts a slow history load and `/session B` completes first, stale work from A could overwrite B's session id, transcript, active run, or failure banner. The same race remained possible when a history response lacked session metadata and awaited `sessions.list` before rebuilding the transcript.

## Why This Change Was Made

The TUI session-action owner now snapshots the selected session key and agent before asynchronous history and session-info requests. Every history reload gets a monotonic generation; stale success and failure completions are discarded, and ownership is checked again after the nested session-info refresh. Agent-scoped alias canonicalization remains valid, while an actually newer selection wins.

The maintainer pass also removed the unrelated type-hoisting workaround, kept private history types with their owner module, consolidated the race-test fixtures, and added coverage for:

- stale history success after a newer switch;
- stale history rejection after a newer switch;
- stale history waiting on a coalesced session-info refresh;
- stale A metadata after an A → B → A switch;
- legacy alias canonicalization within the selected agent;
- real PTY routing of the next message to session B after delayed A resolves.

## User Impact

After rapid session switches, the visible transcript and subsequent messages remain attached to the session the user most recently selected. An abandoned request can no longer silently route the next message to the prior session or leak its failure into the active transcript.

## Evidence

- Blacksmith Testbox `tbx_01kxhchk9t5dxms2cxd47drm5s`: `pnpm test src/tui/tui-session-actions.test.ts` — 44 passed.
- Fake-backend PTY configuration — 20 passed, including delayed A / active B and post-race send routing.
- `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1` PTY configuration — 29 passed across the fake harness plus nine embedded/real-Gateway scenarios.
- `pnpm check:changed` — passed core and core-test typechecks, lint, formatting, max-lines, dependency, SDK, import-cycle, persistence, and policy guards.
- Fresh structured autoreview of the maintainer patch — clean at 0.94 confidence; the alias-contract follow-up — clean at 0.99; the A → B → A generation fix — clean at 0.96.
- Final full-branch structured autoreview — clean at 0.92 confidence with no actionable findings.

The precise out-of-order transport sequence is deterministic through the injected TUI backend; the embedded and real-Gateway PTY lanes provide adjacent full-runtime smoke rather than forcing production transport reordering.
