### PR TITLE
fix(restart): keep deferring when pending inspection fails

### DIFF
--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -142,6 +142,8 @@ const hoisted = vi.hoisted(() => ({
     title?: string;
   }>,
   activeEmbeddedRunCount: { value: 0 },
+  activeEmbeddedRunCountCalls: { value: 0 },
+  activeEmbeddedRunCountThrowOnCalls: new Set<number>(),
   activeEmbeddedRunSessionIds: [] as string[],
   activeEmbeddedRunSessionKeys: [] as string[],
   markRestartAbortedMainSessions: vi.fn(async (_params: unknown) => ({ marked: 1, skipped: 0 })),
@@ -202,7 +204,13 @@ vi.mock("../tasks/task-registry.maintenance.js", async () => {
 });
 
 vi.mock("../agents/embedded-agent-runner/run-state.js", () => ({
-  getActiveEmbeddedRunCount: () => hoisted.activeEmbeddedRunCount.value,
+  getActiveEmbeddedRunCount: () => {
+    hoisted.activeEmbeddedRunCountCalls.value += 1;
+    if (hoisted.activeEmbeddedRunCountThrowOnCalls.has(hoisted.activeEmbeddedRunCountCalls.value)) {
+      throw new Error("embedded run state unavailable");
+    }
+    return hoisted.activeEmbeddedRunCount.value;
+  },
   listActiveEmbeddedRunSessionIds: () => hoisted.activeEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys: () => hoisted.activeEmbeddedRunSessionKeys,
 }));
@@ -696,6 +704,8 @@ afterEach(() => {
   hoisted.activeTaskCount.value = 0;
   hoisted.activeTaskBlockers.length = 0;
   hoisted.activeEmbeddedRunCount.value = 0;
+  hoisted.activeEmbeddedRunCountCalls.value = 0;
+  hoisted.activeEmbeddedRunCountThrowOnCalls.clear();
   hoisted.activeEmbeddedRunSessionIds.length = 0;
   hoisted.activeEmbeddedRunSessionKeys.length = 0;
   hoisted.markRestartAbortedMainSessions.mockClear();
@@ -2361,6 +2371,64 @@ describe("gateway restart deferral preflight", () => {
       );
     } finally {
       process.removeListener("SIGUSR1", signalSpy);
+      restartTesting.resetSigusr1State();
+      resetGatewayWorkAdmission();
+    }
+  });
+
+  it("keeps one config restart deferral after a pending inspection error", async () => {
+    restartTesting.resetSigusr1State();
+    resetGatewayWorkAdmission();
+    const logReload = { info: vi.fn(), warn: vi.fn() };
+    const requestRecoveryRestart = vi
+      .fn<NonNullable<ReloadHandlerParams["requestRecoveryRestart"]>>()
+      .mockReturnValue({ status: "emitted" });
+    const { requestGatewayRestart, stopRestartRetries } = createReloadHandlersForTest(
+      logReload,
+      undefined,
+      undefined,
+      undefined,
+      requestRecoveryRestart,
+    );
+    const plan = {
+      changedPaths: ["gateway.port"],
+      restartGateway: true,
+      restartReasons: ["gateway.port"],
+      hotReasons: [],
+      reloadHooks: false,
+      restartGmailWatcher: false,
+      restartCron: false,
+      restartHeartbeat: false,
+      restartHealthMonitor: false,
+      reloadPlugins: false,
+      restartChannels: new Set<ChannelKind>(),
+      disposeMcpRuntimes: false,
+      noopPaths: [],
+    };
+    const config = { gateway: { reload: { deferralTimeoutMs: 60_000 } } };
+    hoisted.activeEmbeddedRunCount.value = 1;
+    hoisted.activeEmbeddedRunCountThrowOnCalls.add(2);
+    vi.useFakeTimers();
+
+    try {
+      expect(requestGatewayRestart(plan, config).status).toBe("accepted");
+      expect(logReload.warn).toHaveBeenCalledWith(
+        "restart deferral check failed (Error: embedded run state unavailable); waiting and retrying",
+      );
+
+      expect(requestGatewayRestart(plan, config).status).toBe("accepted");
+
+      hoisted.activeEmbeddedRunCount.value = 0;
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(requestRecoveryRestart).toHaveBeenCalledTimes(1);
+      expect(logReload.info).toHaveBeenCalledWith(
+        "all operations and replies completed; restarting gateway now",
+      );
+    } finally {
+      stopRestartRetries();
+      hoisted.activeEmbeddedRunCount.value = 0;
+      vi.useRealTimers();
       restartTesting.resetSigusr1State();
       resetGatewayWorkAdmission();
     }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1446,10 +1446,8 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
             );
           },
           onCheckError: (err) => {
-            restartPending = false;
-            restartDeferral = null;
             params.logReload.warn(
-              `restart deferral check failed (${String(err)}); restarting gateway now`,
+              `restart deferral check failed (${String(err)}); waiting and retrying`,
             );
           },
         },

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -1326,17 +1326,27 @@ describe("infra runtime", () => {
       }
     });
 
-    it("emits SIGUSR1 if deferral check throws", async () => {
+    it("keeps SIGUSR1 deferred if the deferral check throws", async () => {
       const emitSpy = vi.spyOn(process, "emit");
       const handler = () => {};
       process.on("SIGUSR1", handler);
       try {
+        let checks = 0;
         setPreRestartDeferralCheck(() => {
-          throw new Error("boom");
+          checks += 1;
+          if (checks === 1) {
+            throw new Error("boom");
+          }
+          return 0;
         });
         scheduleGatewaySigusr1Restart({ delayMs: 0 });
+
         await vi.advanceTimersByTimeAsync(0);
+        expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
+
+        await vi.advanceTimersByTimeAsync(500);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+        expect(checks).toBeGreaterThan(1);
       } finally {
         process.removeListener("SIGUSR1", handler);
       }

--- a/src/infra/restart.deferral-timeout.test.ts
+++ b/src/infra/restart.deferral-timeout.test.ts
@@ -214,20 +214,107 @@ describe("deferGatewayRestartUntilIdle timeout", () => {
     expect(hooks.onTimeout).not.toHaveBeenCalled();
   });
 
-  it("handles getPendingCount error by restarting immediately", () => {
+  it("keeps deferring when the initial pending inspection throws", async () => {
+    const events: string[] = [];
     const hooks: RestartDeferralHooks = {
-      onCheckError: vi.fn(),
+      onCheckError: vi.fn(() => events.push("check-error")),
       onReady: vi.fn(),
+      onDeferring: vi.fn(() => events.push("deferring")),
     };
+    const pending = 0;
+    let calls = 0;
 
     deferGatewayRestartUntilIdle({
       getPendingCount: () => {
-        throw new Error("store corrupted");
+        calls += 1;
+        if (calls === 1) {
+          throw new Error("store corrupted");
+        }
+        return pending;
       },
+      pollMs: 100,
       hooks,
     });
 
     expect(hooks.onCheckError).toHaveBeenCalledOnce();
+    expect(hooks.onDeferring).toHaveBeenCalledWith(1);
+    expect(events).toEqual(["deferring", "check-error"]);
     expect(hooks.onReady).not.toHaveBeenCalled();
+    expect(consumeGatewaySigusr1RestartIntent()).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(hooks.onReady).toHaveBeenCalledOnce();
+  });
+
+  it("times out through persistent pending inspection failures", async () => {
+    const hooks: RestartDeferralHooks = {
+      onCheckError: vi.fn(),
+      onReady: vi.fn(),
+      onTimeout: vi.fn(),
+    };
+    const emitRestart = vi.fn(() => ({ status: "emitted" as const }));
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => {
+        throw new Error("queue unavailable");
+      },
+      pollMs: 100,
+      maxWaitMs: 300,
+      timeoutIntent: { force: true, reason: "gateway.restart.deferral-timeout" },
+      hooks,
+      emitHooks: { emitRestart },
+    });
+
+    expect(hooks.onCheckError).toHaveBeenCalledOnce();
+    expect(hooks.onReady).not.toHaveBeenCalled();
+    expect(hooks.onTimeout).not.toHaveBeenCalled();
+    expect(emitRestart).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(hooks.onCheckError).toHaveBeenCalledTimes(4);
+    expect(hooks.onReady).not.toHaveBeenCalled();
+    expect(hooks.onTimeout).toHaveBeenCalledWith(1, 300);
+    expect(emitRestart).toHaveBeenCalledWith(undefined, {
+      force: true,
+      reason: "gateway.restart.deferral-timeout",
+    });
+  });
+
+  it("keeps polling when a later pending inspection throws", async () => {
+    const hooks: RestartDeferralHooks = {
+      onCheckError: vi.fn(),
+      onReady: vi.fn(),
+      onTimeout: vi.fn(),
+    };
+    const counts = [2, 2, "throw", 0] as const;
+    let index = 0;
+
+    deferGatewayRestartUntilIdle({
+      getPendingCount: () => {
+        const value = counts[Math.min(index, counts.length - 1)] ?? 0;
+        index += 1;
+        if (value === "throw") {
+          throw new Error("queue unavailable");
+        }
+        return value;
+      },
+      pollMs: 100,
+      maxWaitMs: 1_000,
+      hooks,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(hooks.onReady).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(hooks.onCheckError).toHaveBeenCalledOnce();
+    expect(hooks.onReady).not.toHaveBeenCalled();
+    expect(consumeGatewaySigusr1RestartIntent()).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(hooks.onReady).toHaveBeenCalledOnce();
+    expect(hooks.onTimeout).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -778,10 +778,8 @@ export function deferGatewayRestartUntilIdle(opts: {
     try {
       current = opts.getPendingCount();
     } catch (err) {
-      stopPoll();
+      current = 1;
       opts.hooks?.onCheckError?.(err);
-      void emitPreparedGatewayRestart(opts.emitHooks, opts.reason);
-      return;
     }
     if (current <= 0) {
       attemptEmission({ notifyReady: true });
@@ -803,18 +801,23 @@ export function deferGatewayRestartUntilIdle(opts: {
     }
   };
   let pending: number;
+  let initialCheckError: unknown;
+  let hasInitialCheckError = false;
   try {
     pending = opts.getPendingCount();
   } catch (err) {
-    opts.hooks?.onCheckError?.(err);
-    void emitPreparedGatewayRestart(opts.emitHooks, opts.reason);
-    return handle;
+    pending = 1;
+    initialCheckError = err;
+    hasInitialCheckError = true;
   }
   if (pending > 0) {
     opts.hooks?.onDeferring?.(pending);
   }
   poll = setInterval(inspectPending, pollMs);
   activeDeferralPolls.add(poll);
+  if (hasInitialCheckError) {
+    opts.hooks?.onCheckError?.(initialCheckError);
+  }
   if (pending <= 0) {
     attemptEmission({ notifyReady: true });
   }


### PR DESCRIPTION
Fixes #104064.

## What Problem This Solves

Gateway restart deferral treated pending-work inspection exceptions as proof that the gateway was idle. That fail-open path could restart while active work still existed but could not be inspected. The config-reload caller also needed to keep its restartPending guard active while the helper kept retrying.

The latest follow-up also fixes the review finding where `onCheckError` could run before the helper committed synthetic unknown-pending state for the initial inspection failure. Initial inspection failures now publish the pending deferral state and register polling before notifying the error hook.

## Summary

- Treat pending-count inspection exceptions as unknown pending work instead of safe-to-restart.
- Keep the existing deferral lifecycle active after both initial and later getPendingCount failures.
- Preserve the config-reload restartPending guard when retrying inspection failures.
- Commit initial synthetic pending=1 state before calling onCheckError, preventing status-hook re-entry from observing a non-deferring state.
- Add persistent-failure timeout coverage proving always-throwing inspection reaches the forced timeout emission path.

## Evidence

Exact-head validation on `02bacf97a74fa7adde4ca8e304c628f378c55b15`:

- `node scripts/run-vitest.mjs src/infra/restart.deferral-timeout.test.ts src/infra/infra-runtime.test.ts src/gateway/server-reload-handlers.test.ts` -> passed; 2 shards, 152 tests.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.non-agents.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-non-agents.tsbuildinfo` -> passed.
- `./node_modules/.bin/oxfmt --check --threads=1 src/infra/restart.ts src/infra/restart.deferral-timeout.test.ts src/infra/infra-runtime.test.ts src/gateway/server-reload-handlers.ts src/gateway/server-reload-handlers.test.ts` -> passed.
- `./node_modules/.bin/oxlint src/infra/restart.ts src/infra/restart.deferral-timeout.test.ts src/infra/infra-runtime.test.ts src/gateway/server-reload-handlers.ts src/gateway/server-reload-handlers.test.ts` -> passed.
- `pnpm check:loc --base upstream/main --head HEAD` -> passed.
- `git diff --check` -> passed.

Live terminal proof with real timers, not fake timers:

```text
[transient] starting live deferral probe
[transient] deferring pending=1
[transient] check-error=Error: transient pending store unavailable
[transient] emit reason=undefined intent=null
[transient] ready after calls=3
[persistent] starting live deferral probe
[persistent] deferring pending=1
[persistent] check-error=Error: persistent pending store unavailable
[persistent] check-error=Error: persistent pending store unavailable
[persistent] check-error=Error: persistent pending store unavailable
[persistent] timeout pending=1 elapsed=82 calls=3
[persistent] emit reason=undefined intent={"force":true,"reason":"gateway.restart.deferral-timeout"}
```

Focused behavior covered:

- Initial pending inspection throw now records deferring pending=1 before onCheckError notification.
- Transient initial failure keeps deferring, retries, and emits only after a later successful idle check.
- Later polling failure keeps polling and emits only after a later successful idle check.
- Persistent inspection failure keeps retrying and reaches the configured forced timeout path.
- Config-reload caller keeps restartPending active after an inspection error; a later config restart request does not create duplicate restart emission work.

## Root Cause

The helper and its production caller disagreed about onCheckError semantics. The helper now treats inspection failure as non-terminal, and the caller keeps its deferral guard active until ready, timeout, cancel, or emission settlement.

## Behavior After This Patch

- Initial inspection throw: commits synthetic pending=1, starts the deferral poll, then calls onCheckError.
- Later polling throw: treats the result as pending=1, keeps the interval registered, and retries on the next poll.
- Config reload inspection throw: keeps restartPending true and logs waiting/retrying.
- Confirmed pending=0 still emits restart through the normal ready path.
- Persistent failure reaches maxWaitMs and emits using the existing forced-timeout intent.