### PR TITLE
fix: Slack starts despite stale plugin build artifacts

### DIFF
--- a/src/crestodian/verified-inference.ts
+++ b/src/crestodian/verified-inference.ts
@@ -26,6 +26,7 @@ import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { passesManifestOwnerBasePolicy } from "../plugins/manifest-owner-policy.js";
+import type { OpenClawPackageBuild } from "../plugins/manifest.js";
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
 import { loadPluginRegistrySnapshot } from "../plugins/plugin-registry.js";
 import {
@@ -95,6 +96,7 @@ type CrestodianOwnerPluginRegistryRecord = {
   packageVersion?: string;
   installRecordHash?: string;
   packageJson?: { path: string; hash: string };
+  packageBuild?: OpenClawPackageBuild;
 };
 
 type CrestodianOwnerPluginRegistryLoader = (params: {
@@ -391,6 +393,7 @@ function projectOwnerPluginArtifacts(params: {
         origin: record.origin,
         rootDir: record.rootDir,
         ...(record.source ? { source: record.source } : {}),
+        ...(record.packageBuild ? { packageBuild: record.packageBuild } : {}),
       }),
     };
   });

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -1210,6 +1210,22 @@ function readChildDirectoryNames(dir: string | undefined): Set<string> {
   }
 }
 
+function readBundledDistOptOutDirectoryNames(sourceExtensionsDir: string | undefined): Set<string> {
+  const names = new Set<string>();
+  if (!sourceExtensionsDir) {
+    return names;
+  }
+  for (const name of readChildDirectoryNames(sourceExtensionsDir)) {
+    const packageManifest = getPackageManifestMetadata(
+      readTrustedPackageManifest(path.join(sourceExtensionsDir, name)) ?? undefined,
+    );
+    if (packageManifest?.build?.bundledDist === false) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
 function discoverFromPath(params: {
   rawPath: string;
   origin: PluginOrigin;
@@ -1595,6 +1611,26 @@ export function discoverOpenClawPlugins(params: {
           message: sourceCheckoutDependencyDiagnostic.message,
         });
       }
+      const sourceCheckoutExtensionsDir = resolveBundledSourceCheckoutExtensionsDir(roots.stock);
+      const bundledDistOptOutDirectories = readBundledDistOptOutDirectoryNames(
+        sourceCheckoutExtensionsDir,
+      );
+      if (sourceCheckoutExtensionsDir) {
+        for (const dirName of bundledDistOptOutDirectories) {
+          discoverFromPath({
+            rawPath: path.join(sourceCheckoutExtensionsDir, dirName),
+            origin: "bundled",
+            ownershipUid: params.ownershipUid,
+            workspaceDir,
+            env,
+            candidates: result.candidates,
+            diagnostics: result.diagnostics,
+            seen,
+            realpathCache,
+            packageManifestCache,
+          });
+        }
+      }
       if (roots.stock) {
         discoverInDirectory({
           dir: roots.stock,
@@ -1606,9 +1642,9 @@ export function discoverOpenClawPlugins(params: {
           seen,
           realpathCache,
           packageManifestCache,
+          skipDirectories: bundledDistOptOutDirectories,
         });
       }
-      const sourceCheckoutExtensionsDir = resolveBundledSourceCheckoutExtensionsDir(roots.stock);
       const sourceCheckoutMatchesBundledRoot = resolvesToSameDirectory(
         sourceCheckoutExtensionsDir,
         roots.stock,

--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -323,6 +323,9 @@ export function buildInstalledPluginIndexRecords(params: {
     if (packageChannel) {
       indexRecord.packageChannel = packageChannel;
     }
+    if (candidate?.packageManifest?.build) {
+      indexRecord.packageBuild = structuredClone(candidate.packageManifest.build);
+    }
     if (packageJson) {
       indexRecord.packageJson = packageJson;
     }

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -44,6 +44,7 @@ function createIndex(overrides: Partial<InstalledPluginIndex> = {}): InstalledPl
         manifestHash: "manifest-hash",
         rootDir: "/plugins/demo",
         origin: "global",
+        packageBuild: { bundledDist: false },
         enabled: true,
         syntheticAuthRefs: ["demo"],
         startup: {
@@ -224,6 +225,7 @@ describe("installed plugin index persistence", () => {
     expect(persisted.warning).toContain("DO NOT EDIT.");
     expect(persisted.policyHash).toBe(index.policyHash);
     expectPluginIds(persisted, ["demo"]);
+    expectPluginFields(persisted, "demo", { packageBuild: { bundledDist: false } });
   });
 
   it("preserves startup config paths across persisted index roundtrips", async () => {

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -88,6 +88,11 @@ const InstalledPluginIndexRecordSchema = z.object({
   installRecordHash: z.string().optional(),
   packageInstall: z.unknown().optional(),
   packageChannel: z.unknown().optional(),
+  packageBuild: z
+    .object({
+      bundledDist: z.boolean().optional(),
+    })
+    .optional(),
   manifestPath: z.string(),
   manifestHash: z.string(),
   manifestFile: InstalledPluginFileSignatureSchema.optional(),

--- a/src/plugins/installed-plugin-index-types.ts
+++ b/src/plugins/installed-plugin-index-types.ts
@@ -7,7 +7,7 @@ import type { PluginInstallSourceInfo } from "./install-source-info.js";
 import type { InstalledPluginFileSignature } from "./installed-plugin-index-hash.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
-import type { PluginPackageChannel } from "./manifest.js";
+import type { OpenClawPackageBuild, PluginPackageChannel } from "./manifest.js";
 
 /** Schema version for installed plugin index files. */
 export const INSTALLED_PLUGIN_INDEX_VERSION = 1;
@@ -113,6 +113,7 @@ export type InstalledPluginIndexRecord = {
    */
   packageInstall?: PluginInstallSourceInfo;
   packageChannel?: InstalledPluginPackageChannelInfo;
+  packageBuild?: OpenClawPackageBuild;
   manifestPath: string;
   manifestHash: string;
   manifestFile?: InstalledPluginFileSignature;

--- a/src/plugins/installed-plugin-index.test.ts
+++ b/src/plugins/installed-plugin-index.test.ts
@@ -180,6 +180,7 @@ function createRichPluginFixture(params: { id?: string; packageVersion?: string 
       packageName: "@vendor/demo-plugin",
       packageVersion: params.packageVersion ?? "1.2.3",
       packageManifest: {
+        build: { bundledDist: false },
         channel: {
           id: "demo",
           label: "Demo",
@@ -272,6 +273,9 @@ describe("installed plugin index", () => {
         nativeCommandsAutoEnabled: true,
         nativeSkillsAutoEnabled: false,
       },
+    });
+    expectRecordFields(readRecordField(plugin, "packageBuild", "package build"), {
+      bundledDist: false,
     });
     expectSha256(plugin.manifestHash);
     const packageJson = requireRecord(index.plugins[0]?.packageJson, "package json");

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -7478,6 +7478,102 @@ module.exports = {
     ).toBe("loaded");
   });
 
+  it("ignores built artifacts when the bundled source plugin opts out of core dist", () => {
+    const repoRoot = makeTempDir();
+    const sourceDir = path.join(repoRoot, "extensions", "source-only-artifact-test");
+    const runtimeDir = path.join(sourceDir, "dist");
+    const builtPluginDir = path.join(repoRoot, "dist", "extensions", "source-only-artifact-test");
+    mkdirSafe(path.join(repoRoot, ".git"));
+    mkdirSafe(path.join(repoRoot, "src"));
+    mkdirSafe(sourceDir);
+    mkdirSafe(runtimeDir);
+    mkdirSafe(builtPluginDir);
+    fs.writeFileSync(path.join(repoRoot, "pnpm-workspace.yaml"), "packages: []\n", "utf-8");
+    fs.writeFileSync(
+      path.join(sourceDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        { id: "source-only-artifact-test", configSchema: EMPTY_PLUGIN_SCHEMA },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(sourceDir, "package.json"),
+      JSON.stringify({
+        openclaw: {
+          extensions: ["./index.ts"],
+          build: { bundledDist: false },
+        },
+      }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(sourceDir, "index.ts"),
+      'export default { id: "source-only-artifact-test", register() {} };\n',
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(runtimeDir, "index.js"),
+      'throw new Error("stale package-local dist should not load");\n',
+      "utf-8",
+    );
+    fs.copyFileSync(
+      path.join(sourceDir, "openclaw.plugin.json"),
+      path.join(builtPluginDir, "openclaw.plugin.json"),
+    );
+    fs.writeFileSync(
+      path.join(builtPluginDir, "package.json"),
+      JSON.stringify({ openclaw: { extensions: ["./index.js"] } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(builtPluginDir, "index.js"),
+      'throw new Error("stale discovered core dist should not load");\n',
+      "utf-8",
+    );
+    const bundledRuntimeDir = path.join(
+      repoRoot,
+      "dist-runtime",
+      "extensions",
+      "source-only-artifact-test",
+    );
+    mkdirSafe(bundledRuntimeDir);
+    fs.writeFileSync(
+      path.join(bundledRuntimeDir, "index.js"),
+      'throw new Error("stale core dist should not load");\n',
+      "utf-8",
+    );
+
+    const config = {
+      plugins: {
+        allow: ["source-only-artifact-test"],
+        entries: { "source-only-artifact-test": { enabled: true } },
+      },
+    };
+    const registry = withEnv(
+      {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(repoRoot, "dist", "extensions"),
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+      },
+      () => {
+        const manifestRegistry = loadPluginManifestRegistry({ config });
+        return loadOpenClawPlugins({
+          cache: false,
+          preferBuiltPluginArtifacts: true,
+          onlyPluginIds: ["source-only-artifact-test"],
+          config,
+          manifestRegistry,
+        });
+      },
+    );
+
+    expect(registry.plugins.find((entry) => entry.id === "source-only-artifact-test")?.status).toBe(
+      "loaded",
+    );
+  });
+
   it("prefers package-local dist artifacts over workspace source TS when requested", () => {
     useNoBundledPlugins();
     const pluginDir = makeTempDir();

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -422,6 +422,7 @@ function createPluginCandidatesFromManifestRegistry(
     ...(record.workspaceDir !== undefined ? { workspaceDir: record.workspaceDir } : {}),
     ...(record.format !== undefined ? { format: record.format } : {}),
     ...(record.bundleFormat !== undefined ? { bundleFormat: record.bundleFormat } : {}),
+    ...(record.packageManifest !== undefined ? { packageManifest: record.packageManifest } : {}),
   }));
 }
 
@@ -2124,6 +2125,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         rootDir: pluginRoot,
         origin: candidate.origin,
         preferBuiltPluginArtifacts,
+        packageManifest: candidate.packageManifest,
       });
       const runtimeSetupEntry = manifestRecord.setupSource
         ? resolvePluginRuntimeArtifact({
@@ -2131,6 +2133,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             rootDir: pluginRoot,
             origin: candidate.origin,
             preferBuiltPluginArtifacts,
+            packageManifest: candidate.packageManifest,
           })
         : undefined;
 

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -2016,6 +2016,10 @@ export type OpenClawPackageCompat = {
   pluginApi?: string;
 };
 
+export type OpenClawPackageBuild = {
+  bundledDist?: boolean;
+};
+
 export type OpenClawPackageManifest = {
   extensions?: string[];
   runtimeExtensions?: string[];
@@ -2030,6 +2034,7 @@ export type OpenClawPackageManifest = {
   compat?: OpenClawPackageCompat;
   install?: PluginPackageInstall;
   startup?: OpenClawPackageStartup;
+  build?: OpenClawPackageBuild;
 };
 
 export const DEFAULT_PLUGIN_ENTRY_CANDIDATES = [

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { tryReadJsonSync } from "../infra/json-files.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
@@ -34,6 +35,7 @@ import {
   type RefreshInstalledPluginIndexParams,
 } from "./installed-plugin-index.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import { getPackageManifestMetadata, type PackageManifest } from "./manifest.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import type { PluginRegistrySnapshotSource } from "./plugin-registry-snapshot.types.js";
 import { fileFingerprint } from "./plugin-snapshot-fingerprint.js";
@@ -352,33 +354,37 @@ function hasMismatchedPersistedBundledPluginRoot(
   }
   let sourceOverlayDirs: string[] | undefined;
   return index.plugins.some((plugin) => {
-    if (plugin.origin !== "bundled" || isPathInsideOrEqual(plugin.rootDir, bundledPluginsDir)) {
+    if (plugin.origin !== "bundled") {
       return false;
     }
     sourceOverlayDirs ??= listBundledSourceOverlayDirs({
       bundledRoot: bundledPluginsDir,
       env,
     });
-    return !isAllowedPersistedBundledPluginRoot(
-      plugin.rootDir,
-      bundledPluginsDir,
-      sourceOverlayDirs,
-    );
+    return !isAllowedPersistedBundledPluginRoot(plugin, bundledPluginsDir, sourceOverlayDirs);
   });
 }
 
 function isAllowedPersistedBundledPluginRoot(
-  pluginRootDir: string,
+  plugin: InstalledPluginIndexRecord,
   bundledPluginsDir: string,
   sourceOverlayDirs: readonly string[],
 ): boolean {
+  const pluginRootDir = plugin.rootDir;
+  const legacyRoot = buildLegacyBundledRootPath(bundledPluginsDir);
   if (isPathInsideOrEqual(pluginRootDir, bundledPluginsDir)) {
-    return true;
+    if (!legacyRoot || !isSourceCheckoutBundledPluginRoot(legacyRoot)) {
+      return true;
+    }
+    const relativePluginRoot = path.relative(
+      resolveComparablePath(bundledPluginsDir),
+      resolveComparablePath(pluginRootDir),
+    );
+    return !sourcePluginOptsOutOfBundledDist(path.join(legacyRoot, relativePluginRoot));
   }
   if (sourceOverlayDirs.some((overlayDir) => isPathInsideOrEqual(pluginRootDir, overlayDir))) {
     return true;
   }
-  const legacyRoot = buildLegacyBundledRootPath(bundledPluginsDir);
   if (!legacyRoot || !isSourceCheckoutBundledPluginRoot(legacyRoot)) {
     return false;
   }
@@ -389,10 +395,23 @@ function isAllowedPersistedBundledPluginRoot(
   if (!isRelativePathInsideOrEqual(relativePluginRoot)) {
     return false;
   }
+  if (plugin.packageBuild?.bundledDist === false) {
+    return true;
+  }
+  if (sourcePluginOptsOutOfBundledDist(path.join(legacyRoot, relativePluginRoot))) {
+    // Older index records lack packageBuild. Re-derive once so runtime loading
+    // and Crestodian fingerprint the same source-only artifact.
+    return false;
+  }
   // Discovery prefers a built plugin whenever the same child exists in the
   // packaged root. Keep source-only bundled plugins, but invalidate stale
   // source records once their built peer appears.
   return !fs.existsSync(path.join(bundledPluginsDir, relativePluginRoot));
+}
+
+function sourcePluginOptsOutOfBundledDist(pluginRootDir: string): boolean {
+  const packageJson = tryReadJsonSync<PackageManifest>(path.join(pluginRootDir, "package.json"));
+  return getPackageManifestMetadata(packageJson ?? undefined)?.build?.bundledDist === false;
 }
 
 function isSourceCheckoutBundledPluginRoot(extensionsDir: string): boolean {

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -664,6 +664,83 @@ describe("plugin registry facade", () => {
     expectSnapshotPluginIds(result.snapshot, ["demo"]);
   });
 
+  it("refreshes stale built records and accepts source records for dist-opt-out plugins", async () => {
+    const tempRoot = makeTempDir();
+    const stateDir = path.join(tempRoot, "state");
+    const packageRoot = path.join(tempRoot, "openclaw");
+    const sourceRoot = path.join(packageRoot, "extensions", "demo");
+    const builtRoot = path.join(packageRoot, "dist", "extensions", "demo");
+    fs.mkdirSync(path.join(packageRoot, ".git"), { recursive: true });
+    fs.mkdirSync(path.join(packageRoot, "src"), { recursive: true });
+    fs.mkdirSync(sourceRoot, { recursive: true });
+    fs.mkdirSync(builtRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "pnpm-workspace.yaml"), "packages: []\n");
+    const sourceCandidate = {
+      ...createCandidate(sourceRoot),
+      origin: "bundled" as const,
+      packageDir: sourceRoot,
+      packageManifest: { extensions: ["./index.ts"], build: { bundledDist: false } },
+    } satisfies PluginCandidate;
+    const packageJson = JSON.stringify({
+      openclaw: sourceCandidate.packageManifest,
+    });
+    fs.writeFileSync(path.join(sourceRoot, "package.json"), packageJson);
+    fs.copyFileSync(
+      path.join(sourceRoot, "openclaw.plugin.json"),
+      path.join(builtRoot, "openclaw.plugin.json"),
+    );
+    fs.copyFileSync(path.join(sourceRoot, "index.ts"), path.join(builtRoot, "index.ts"));
+    fs.writeFileSync(path.join(builtRoot, "package.json"), packageJson);
+    const env = hermeticEnv({
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.dirname(builtRoot),
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+    });
+    const freshIndex = loadPluginRegistrySnapshot({
+      candidates: [sourceCandidate],
+      env,
+      preferPersisted: false,
+    });
+    await writePersistedInstalledPluginIndex(freshIndex, { stateDir });
+
+    const persisted = loadPluginRegistrySnapshotWithMetadata({
+      stateDir,
+      candidates: [sourceCandidate],
+      env,
+    });
+    expect(persisted.source).toBe("persisted");
+    expect(persisted.diagnostics).toStrictEqual([]);
+
+    const legacySourceIndex = structuredClone(freshIndex);
+    for (const plugin of legacySourceIndex.plugins) {
+      delete plugin.packageBuild;
+    }
+    await writePersistedInstalledPluginIndex(legacySourceIndex, { stateDir });
+    const migrated = loadPluginRegistrySnapshotWithMetadata({
+      stateDir,
+      candidates: [sourceCandidate],
+      env,
+    });
+    expect(migrated.source).toBe("derived");
+    expectDiagnosticCodes(migrated.diagnostics, ["persisted-registry-stale-source"]);
+
+    const staleBuiltIndex = structuredClone(freshIndex);
+    for (const plugin of staleBuiltIndex.plugins) {
+      plugin.rootDir = builtRoot;
+      plugin.source = path.join(builtRoot, "index.ts");
+      plugin.manifestPath = path.join(builtRoot, "openclaw.plugin.json");
+      delete plugin.packageBuild;
+    }
+    await writePersistedInstalledPluginIndex(staleBuiltIndex, { stateDir });
+    const refreshed = loadPluginRegistrySnapshotWithMetadata({
+      stateDir,
+      candidates: [sourceCandidate],
+      env,
+    });
+    expect(refreshed.source).toBe("derived");
+    expectDiagnosticCodes(refreshed.diagnostics, ["persisted-registry-stale-source"]);
+    expect(refreshed.snapshot.plugins[0]?.rootDir).toBe(sourceRoot);
+  });
+
   it("falls back to the derived registry when persisted policy is stale", async () => {
     const stateDir = makeTempDir();
     const rootDir = makeTempDir();

--- a/src/plugins/plugin-runtime-artifact-identity.test.ts
+++ b/src/plugins/plugin-runtime-artifact-identity.test.ts
@@ -75,4 +75,29 @@ describe("fingerprintPluginRuntimeArtifact", () => {
     fs.writeFileSync(canonicalSource, "export const revision = 'canonical-2';\n");
     expect(fingerprintPluginRuntimeArtifact(record)).not.toBe(first);
   });
+
+  it("hashes source when a bundled plugin opts out of core dist", () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-artifact-"));
+    tempDirs.push(rootDir);
+    const source = path.join(rootDir, "index.ts");
+    const staleDistSource = path.join(rootDir, "dist", "index.js");
+    fs.mkdirSync(path.dirname(staleDistSource), { recursive: true });
+    fs.writeFileSync(source, "export const revision = 'source-1';\n");
+    fs.writeFileSync(staleDistSource, "export const revision = 'stale-1';\n");
+    const record = {
+      pluginId: "fixture",
+      origin: "bundled" as const,
+      rootDir,
+      source,
+      packageBuild: { bundledDist: false },
+    };
+    const first = fingerprintPluginRuntimeArtifact(record);
+
+    fs.writeFileSync(staleDistSource, "export const revision = 'stale-2';\n");
+    expect(fingerprintPluginRuntimeArtifact(record)).not.toBe(first);
+
+    const afterStaleChange = fingerprintPluginRuntimeArtifact(record);
+    fs.writeFileSync(source, "export const revision = 'source-2';\n");
+    expect(fingerprintPluginRuntimeArtifact(record)).not.toBe(afterStaleChange);
+  });
 });

--- a/src/plugins/plugin-runtime-artifact-identity.ts
+++ b/src/plugins/plugin-runtime-artifact-identity.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { walkDirectorySync } from "../infra/fs-safe.js";
+import type { OpenClawPackageBuild } from "./manifest.js";
 import { safeRealpathSync } from "./path-safety.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 import { resolvePluginRuntimeArtifact } from "./plugin-runtime-artifact-resolution.js";
@@ -20,6 +21,7 @@ export type PluginRuntimeArtifactIdentitySource = Readonly<{
   origin: PluginOrigin;
   rootDir: string;
   source?: string;
+  packageBuild?: OpenClawPackageBuild;
 }>;
 
 function normalizeRelativePath(filePath: string): string {
@@ -122,6 +124,7 @@ export function fingerprintPluginRuntimeArtifact(
         origin: record.origin,
         // Gateway and standalone agent runtimes select built artifacts.
         preferBuiltPluginArtifacts: true,
+        ...(record.packageBuild ? { packageManifest: { build: record.packageBuild } } : {}),
       })
     : { rootDir: record.rootDir, source: undefined };
   const rootDir = path.resolve(runtimeArtifact.rootDir);

--- a/src/plugins/plugin-runtime-artifact-resolution.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.ts
@@ -1,6 +1,7 @@
 /** Resolves the exact root and entry selected by the plugin runtime loader. */
 import fs from "node:fs";
 import path from "node:path";
+import type { OpenClawPackageManifest } from "./manifest.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 
 function safeRealpathOrResolve(value: string): string {
@@ -101,6 +102,7 @@ export function resolvePreferredBuiltRuntimeArtifact(params: {
   rootDir: string;
   origin: PluginOrigin;
   preferBuiltPluginArtifacts: boolean;
+  packageManifest?: OpenClawPackageManifest;
 }): { source: string; rootDir: string } {
   const rootDir = safeRealpathOrResolve(params.rootDir);
   const source = safeRealpathOrResolve(params.source);
@@ -112,6 +114,9 @@ export function resolvePreferredBuiltRuntimeArtifact(params: {
     if (artifactSource) {
       return { source: artifactSource, rootDir };
     }
+    return { source, rootDir };
+  }
+  if (params.packageManifest?.build?.bundledDist === false) {
     return { source, rootDir };
   }
   const packageLocalArtifactSource = resolvePackageLocalDistRuntimeArtifact({ source, rootDir });
@@ -155,6 +160,7 @@ export function resolvePluginRuntimeArtifact(params: {
   rootDir: string;
   origin: PluginOrigin;
   preferBuiltPluginArtifacts: boolean;
+  packageManifest?: OpenClawPackageManifest;
 }): { source: string; rootDir: string } {
   const preferred = resolvePreferredBuiltRuntimeArtifact(params);
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where source-checkout gateways could repeatedly crash and restart Slack when stale plugin build output imported SDK symbols that no longer exist.

## Why This Change Was Made

Bundled plugins that declare `openclaw.build.bundledDist: false` now consistently execute from source across discovery, supplied manifest registries, persisted plugin indexes, runtime artifact selection, and Crestodian identity checks. Legacy persisted records without the new build metadata are rederived once, keeping runtime loading and artifact verification on the same canonical source.

## User Impact

`pnpm gateway:watch` can restart after shared SDK changes without Slack loading stale package-local or core-dist artifacts. Existing persisted plugin registries repair themselves by falling back to the derived index; no manual state deletion is required.

## Evidence

- Before: live gateway repeatedly exited Slack with `session-store-runtime does not provide an export named loadSessionStore`.
- After: live source-checkout gateway loaded 24 plugins; Slack logged `starting provider` and `socket mode connected` with no channel exit/restart. Voice-call SQLite state also initialized cleanly.
- Blacksmith Testbox `coral-hermit-2560`: 323 focused loader, discovery, plugin-registry, installed-index, and artifact-identity tests passed.
- Blacksmith Testbox: `pnpm check:changed` and `pnpm build` passed.
- Fresh Codex autoreview: no findings; overall patch correctness 0.91.
- AI-assisted: implementation and review performed with Codex; maintainer understands the code and evidence.
