### PR TITLE
fix(openrouter): apply request policy to music generation requests

### DIFF
--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -297,6 +297,45 @@ describe("openrouter music generation provider", () => {
     );
   });
 
+  it("applies configured OpenRouter request policy without allowing private networks", async () => {
+    const requestPolicy = {
+      allowPrivateNetwork: true,
+      headers: { "X-OpenRouter-Trace": "trace-1" },
+      proxy: { mode: "env-proxy" as const },
+    };
+    postJsonRequestMock.mockResolvedValue({
+      response: sseResponse([
+        `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: Buffer.from("wav").toString("base64") } } }] })}\n`,
+        "data: [DONE]\n",
+      ]),
+      release: vi.fn(async () => {}),
+    });
+
+    await buildOpenRouterMusicGenerationProvider().generateMusic({
+      provider: "openrouter",
+      model: "google/lyria-3-pro-preview",
+      prompt: "policy soundtrack",
+      cfg: {
+        models: {
+          providers: {
+            openrouter: {
+              request: requestPolicy,
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openrouter",
+        capability: "audio",
+        allowPrivateNetwork: false,
+        request: requestPolicy,
+      }),
+    );
+  });
+
   it("times out stalled OpenRouter audio streams after headers", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: stalledSseResponse(

--- a/extensions/openrouter/music-generation-provider.transport.test.ts
+++ b/extensions/openrouter/music-generation-provider.transport.test.ts
@@ -1,0 +1,97 @@
+// OpenRouter transport tests cover real provider-http request policy enforcement.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const resolveApiKeyForProviderMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    apiKey: "test",
+    source: "profile",
+    mode: "api-key",
+  })),
+);
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
+async function buildTransportProofProvider() {
+  vi.resetModules();
+  vi.doUnmock("openclaw/plugin-sdk/provider-http");
+  vi.doMock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+    resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+  }));
+  const { buildOpenRouterMusicGenerationProvider } = await import("./music-generation-provider.js");
+  return buildOpenRouterMusicGenerationProvider();
+}
+
+const openServers: Server[] = [];
+
+async function startPrivateMusicServer(): Promise<{
+  baseUrl: string;
+  requestCount: () => number;
+}> {
+  let requests = 0;
+  const server = createServer((_request, response) => {
+    requests += 1;
+    response.writeHead(204);
+    response.end();
+  });
+  openServers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/api/v1`,
+    requestCount: () => requests,
+  };
+}
+
+async function closeOpenServers() {
+  await Promise.all(
+    openServers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        }),
+    ),
+  );
+}
+
+describe("openrouter music generation provider transport", () => {
+  afterEach(async () => {
+    await closeOpenServers();
+  });
+
+  it("denies private destinations even when the configured request policy opts in", async () => {
+    const server = await startPrivateMusicServer();
+
+    const provider = await buildTransportProofProvider();
+    await expect(
+      provider.generateMusic({
+        provider: "openrouter",
+        model: "google/lyria-3-pro-preview",
+        prompt: "transport denial proof",
+        cfg: {
+          models: {
+            providers: {
+              openrouter: {
+                baseUrl: server.baseUrl,
+                request: {
+                  allowPrivateNetwork: true,
+                  headers: { "X-OpenRouter-Trace": "transport-proof" },
+                },
+              },
+            },
+          },
+        } as never,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(server.requestCount()).toBe(0);
+  });
+});

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -15,6 +15,7 @@ import {
   postJsonRequest,
   resolveProviderHttpRequestConfig,
   resolveProviderOperationTimeoutMs,
+  sanitizeConfiguredModelProviderRequest,
   type ProviderOperationDeadline,
 } from "openclaw/plugin-sdk/provider-http";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -393,6 +394,9 @@ export function buildOpenRouterMusicGenerationProvider(): MusicGenerationProvide
             "HTTP-Referer": "https://openclaw.ai",
             "X-OpenRouter-Title": "OpenClaw",
           },
+          request: sanitizeConfiguredModelProviderRequest(
+            req.cfg?.models?.providers?.openrouter?.request,
+          ),
           provider: "openrouter",
           capability: "audio",
           transport: "http",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenRouter music generation ignored configured provider request policy, including custom headers, proxy settings, and TLS options.

## Why This Change Was Made

The music provider now passes the sanitized OpenRouter request policy into the shared provider HTTP resolver, matching the existing OpenRouter video path. Its explicit `allowPrivateNetwork: false` override remains authoritative, so provider configuration cannot opt music requests into private-network access.

## User Impact

OpenRouter music generation now honors supported provider transport settings. The existing private-network denial remains unchanged, including when `cfg.models.providers.openrouter.request.allowPrivateNetwork` is `true`.

## Evidence

- Exact tested head: `f643e7a657c16aa6b8cf551e4b6cd30d2de21dc7`.
- Focused remote proof: `pnpm test extensions/openrouter/music-generation-provider.transport.test.ts extensions/openrouter/music-generation-provider.test.ts` passed 2 files and 15 tests.
- The transport regression starts a loopback server, configures `allowPrivateNetwork: true`, calls the real provider HTTP transport, expects a private-network denial, and asserts the server received zero requests.
- Changed-surface gate passed: formatting, extension production/test typechecks, lint, plugin boundaries, SDK baseline, sidecar/storage guards, and runtime import-cycle checks.
- `git diff --check` passed.
- Fresh autoreview reported no accepted or actionable findings.

This is controlled local transport proof only. No live OpenRouter API call, real account, external proxy or TLS route, or generated music artifact was exercised.
