### PR TITLE
ci: accept trusted unsigned release merge heads

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -320,7 +320,7 @@ jobs:
                     trusted_reason="release-tag"
                     break
                   fi
-                done < <(git -C .candidate for-each-ref --format='%(refname)' refs/tags/v)
+                done < <(git -C .candidate for-each-ref --format='%(refname)' 'refs/tags/v*')
               fi
             fi
           fi
@@ -339,18 +339,27 @@ jobs:
                 -f name="$repository_name" \
                 -f oid="$candidate_sha"
             )"
-            signer="$(
+            signature_status="$(
               jq -er \
                 --arg sha "$candidate_sha" \
                 '.data.repository.object |
-                 select(.oid == $sha and .signature.isValid == true and .signature.state == "VALID") |
-                 .signature.signer.login' \
+                 select(.oid == $sha) |
+                 if .signature == null then "missing"
+                 elif .signature.isValid == true and .signature.state == "VALID" and
+                   (.signature.signer.login // "") != "" then "valid"
+                 else "invalid"
+                 end' \
                 <<<"$signature_json"
             )"
+            if [[ "$signature_status" == "invalid" ]]; then
+              echo "Release candidate ${candidate_sha} has an invalid commit signature." >&2
+              exit 1
+            fi
+            signer="$(jq -r '.data.repository.object.signature.signer.login // ""' <<<"$signature_json")"
             permission_actor="$signer"
-            if [[ "$signer" == "web-flow" ]]; then
+            if [[ "$signature_status" == "missing" || "$signer" == "web-flow" ]]; then
               if [[ "$trusted_reason" != "release-branch-head" || -z "$trusted_release_branch" ]]; then
-                echo "GitHub web-flow candidates require an exact release branch head." >&2
+                echo "Unsigned or GitHub web-flow candidates require an exact release branch head." >&2
                 exit 1
               fi
               permission_actor="$(
@@ -1002,7 +1011,7 @@ jobs:
                     trusted_reason="release-tag"
                     break
                   fi
-                done < <(git for-each-ref --format='%(refname)' refs/tags/v)
+                done < <(git for-each-ref --format='%(refname)' 'refs/tags/v*')
               fi
             fi
           fi
@@ -1018,18 +1027,27 @@ jobs:
                 -f name="$repository_name" \
                 -f oid="$candidate_sha"
             )"
-            signer="$(
+            signature_status="$(
               jq -er \
                 --arg sha "$candidate_sha" \
                 '.data.repository.object |
-                 select(.oid == $sha and .signature.isValid == true and .signature.state == "VALID") |
-                 .signature.signer.login' \
+                 select(.oid == $sha) |
+                 if .signature == null then "missing"
+                 elif .signature.isValid == true and .signature.state == "VALID" and
+                   (.signature.signer.login // "") != "" then "valid"
+                 else "invalid"
+                 end' \
                 <<<"$signature_json"
             )"
+            if [[ "$signature_status" == "invalid" ]]; then
+              echo "Release candidate ${candidate_sha} has an invalid commit signature." >&2
+              exit 1
+            fi
+            signer="$(jq -r '.data.repository.object.signature.signer.login // ""' <<<"$signature_json")"
             permission_actor="$signer"
-            if [[ "$signer" == "web-flow" ]]; then
+            if [[ "$signature_status" == "missing" || "$signer" == "web-flow" ]]; then
               if [[ "$trusted_reason" != "release-branch-head" || -z "$trusted_release_branch" ]]; then
-                echo "GitHub web-flow candidates require an exact release branch head." >&2
+                echo "Unsigned or GitHub web-flow candidates require an exact release branch head." >&2
                 exit 1
               fi
               permission_actor="$(

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -207,10 +207,18 @@ function runAdvisoryStatus(overrides: Record<string, string> = {}) {
 }
 
 describe("release Telegram QA workflow", () => {
-  it("attributes GitHub web-flow release merges to their exact maintainer merger", () => {
+  it("attributes GitHub web-flow and unsigned release merges to their exact maintainer merger", () => {
     const source = readFileSync(WORKFLOW_PATH, "utf8");
 
     expect(source.match(/associatedPullRequests\(first:10\)/gu)).toHaveLength(2);
+    expect(source.match(/for-each-ref --format='%\(refname\)' 'refs\/tags\/v\*'/gu)).toHaveLength(
+      2,
+    );
+    expect(source.match(/if \.signature == null then "missing"/gu)).toHaveLength(2);
+    expect(source.match(/\$signature_status" == "invalid"/gu)).toHaveLength(2);
+    expect(
+      source.match(/\$signature_status" == "missing" \|\| "\$signer" == "web-flow"/gu),
+    ).toHaveLength(2);
     expect(source.match(/\.mergeCommit\.oid == \$sha/gu)).toHaveLength(2);
     expect(source.match(/\.baseRefName == \$base/gu)).toHaveLength(2);
     expect(source.match(/\.baseRepository\.nameWithOwner == \$repo/gu)).toHaveLength(2);


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation rejected two valid frozen candidates before Telegram QA could build them:

- the July branch head is an unsigned merge commit from an exact merged PR by a maintainer;
- SHA-targeted beta validation could not discover its matching annotated release tag because the ref pattern matched no tags.

## Why This Change Was Made

Allow a missing signature only for an exact canonical release-branch head with one exact merged PR whose merger still has maintain/admin permission. Present-but-invalid signatures remain rejected, and unsigned tags remain rejected. Correct tag discovery to use the `refs/tags/v*` pattern.

## User Impact

Beta, July, and LTS release validation can authenticate valid frozen candidates without weakening the existing fail-closed provenance boundary.

## Evidence

- Failure: July Telegram QA run 29173908085 exited on `signature: null` before candidate build.
- Failure: beta Telegram QA run 29173923756 classified tagged SHA `b6387afd` as untrusted because `refs/tags/v` matched nothing.
- Blacksmith Testbox run 29174071706: focused workflow tests, 17/17 green before the expanded tag assertion; final rerun also 17/17 green on kept lease `tbx_01kx9w8kcw8e4d51x3nac3dh13`.
- Kept-lease `check:changed`: format, test-root typecheck, scripts lint, and guards green.
- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- `git diff --check`
- Fresh autoreview: no accepted/actionable findings.
