### PR TITLE
fix: rebuild live mac app after protocol model changes

### DIFF
--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -118,7 +118,13 @@ export function classifyActions(
   changedPaths,
   { buildProvenanceKnown, buildRequired, nodeModulesPresent },
 ) {
-  const runMacos = changedPaths.length > 0 && detectChangedScope(changedPaths).runMacos;
+  // CI skips generated protocol-only macOS jobs, but the live app embeds these Swift sources.
+  const generatedMacProtocolChanged = changedPaths.some((changedPath) =>
+    /^apps\/shared\/OpenClawKit\/Sources\/OpenClawProtocol\//u.test(changedPath),
+  );
+  const runMacos =
+    changedPaths.length > 0 &&
+    (detectChangedScope(changedPaths).runMacos || generatedMacProtocolChanged);
   const macUiVerification =
     runMacos &&
     changedPaths.some((changedPath) =>

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -337,6 +337,21 @@ describe("openclaw live updater", () => {
       macAppRebuild: true,
       macUiVerification: true,
     });
+    expect(
+      classifyActions(["apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift"], {
+        buildProvenanceKnown: true,
+        buildRequired: true,
+        nodeModulesPresent: true,
+      }),
+    ).toEqual({
+      dependencyInstall: false,
+      gatewayBuild: true,
+      gatewayProbe: true,
+      gatewayRestart: true,
+      gatewaySelfHeal: false,
+      macAppRebuild: true,
+      macUiVerification: true,
+    });
   });
 
   test("accepts only the delayed exact target bundle process", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the live updater could leave the signed macOS app on an older bundle when generated Swift gateway protocol models changed. The updater reused CI's intentionally narrower macOS scope, which skips generated protocol-only changes to reduce CI work even though those Swift sources are embedded in the app.

## Why This Change Was Made

The live updater now overrides that CI-only exclusion for `apps/shared/OpenClawKit/Sources/OpenClawProtocol/**`. CI routing remains unchanged, while deployment classification correctly rebuilds and verifies the signed app for every embedded protocol input change.

## User Impact

Operators using the live updater can expect the running macOS app to match current `main` after generated gateway protocol changes instead of retaining a stale signed bundle.

## Evidence

- Blacksmith Testbox `tbx_01kx9wetyf6t478j8kb4chr9jj` (`silver-lobster-4805`): focused updater suite passed, 35/35 tests.
- Same Testbox: `pnpm check:changed` passed all selected typecheck, lint, guard, and import-cycle lanes.
- Added regression coverage for `GatewayModels.swift` requiring `macAppRebuild=true` and `macUiVerification=true`.
- Codex autoreview: clean; no accepted/actionable findings.
- Live observation at `82667a66e57a5df27275ad769550257530c699cd`: the generated Swift model changed while the pre-fix classifier returned `macAppRebuild=false`.

AI-assisted: yes.
