### PR TITLE
fix(ios): block omitted share attachments

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -12731,7 +12731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 233,
+      "line": 236,
       "path": "apps/ios/ShareExtension/ShareViewController.swift",
       "source": "Just received your iOS share + request, working on it.",
       "surface": "apple",

--- a/apps/ios/ShareExtension/ShareAttachmentSummary.swift
+++ b/apps/ios/ShareExtension/ShareAttachmentSummary.swift
@@ -21,24 +21,33 @@ struct ShareAttachmentSummary: Equatable {
 
         var unsupported: [String] = []
         if self.videoCount > 0 {
+            let format = if self.videoCount == 1 {
+                NSLocalizedString("%d video", comment: "Share extension unsupported video count")
+            } else {
+                NSLocalizedString("%d videos", comment: "Share extension unsupported video count")
+            }
             unsupported.append(String(
-                format: NSLocalizedString(
-                    "%d video(s)",
-                    comment: "Share extension unsupported video count"),
+                format: format,
                 self.videoCount))
         }
         if self.fileCount > 0 {
+            let format = if self.fileCount == 1 {
+                NSLocalizedString("%d file", comment: "Share extension unsupported file count")
+            } else {
+                NSLocalizedString("%d files", comment: "Share extension unsupported file count")
+            }
             unsupported.append(String(
-                format: NSLocalizedString(
-                    "%d file(s)",
-                    comment: "Share extension unsupported file count"),
+                format: format,
                 self.fileCount))
         }
         if self.unknownCount > 0 {
+            let format = if self.unknownCount == 1 {
+                NSLocalizedString("%d unsupported item", comment: "Share extension unsupported attachment count")
+            } else {
+                NSLocalizedString("%d unsupported items", comment: "Share extension unsupported attachment count")
+            }
             unsupported.append(String(
-                format: NSLocalizedString(
-                    "%d unsupported item(s)",
-                    comment: "Share extension unsupported attachment count"),
+                format: format,
                 self.unknownCount))
         }
 

--- a/apps/ios/ShareExtension/ShareAttachmentSummary.swift
+++ b/apps/ios/ShareExtension/ShareAttachmentSummary.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+struct ShareAttachmentSummary: Equatable {
+    var selectedImageCount = 0
+    var acceptedImageCount = 0
+    var videoCount = 0
+    var fileCount = 0
+    var unknownCount = 0
+
+    var omissionMessage: String? {
+        var details: [String] = []
+
+        if self.selectedImageCount > self.acceptedImageCount {
+            details.append(String(
+                format: NSLocalizedString(
+                    "Only %d of %d images can be sent.",
+                    comment: "Share extension image attachment limit warning"),
+                self.acceptedImageCount,
+                self.selectedImageCount))
+        }
+
+        var unsupported: [String] = []
+        if self.videoCount > 0 {
+            unsupported.append(String(
+                format: NSLocalizedString(
+                    "%d video(s)",
+                    comment: "Share extension unsupported video count"),
+                self.videoCount))
+        }
+        if self.fileCount > 0 {
+            unsupported.append(String(
+                format: NSLocalizedString(
+                    "%d file(s)",
+                    comment: "Share extension unsupported file count"),
+                self.fileCount))
+        }
+        if self.unknownCount > 0 {
+            unsupported.append(String(
+                format: NSLocalizedString(
+                    "%d unsupported item(s)",
+                    comment: "Share extension unsupported attachment count"),
+                self.unknownCount))
+        }
+
+        if !unsupported.isEmpty {
+            details.append(String(
+                format: NSLocalizedString(
+                    "OpenClaw Share cannot send %@ yet.",
+                    comment: "Share extension unsupported attachment warning"),
+                unsupported.joined(separator: ", ")))
+        }
+
+        guard !details.isEmpty else { return nil }
+        details.append(NSLocalizedString(
+            "Remove omitted items and share again.",
+            comment: "Share extension omitted attachment recovery"))
+        return details.joined(separator: " ")
+    }
+}
+
+enum ShareAttachmentBlockReason: Equatable {
+    case imageProcessingFailed
+    case omitted(String)
+
+    static func resolve(
+        hasImageProcessingError: Bool,
+        summary: ShareAttachmentSummary) -> Self?
+    {
+        if hasImageProcessingError {
+            return .imageProcessingFailed
+        }
+        if let omissionMessage = summary.omissionMessage {
+            return .omitted(omissionMessage)
+        }
+        return nil
+    }
+}

--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -31,7 +31,8 @@ final class ShareViewController: UIViewController {
     private var didPrepareDraft = false
     private var isSending = false
     private var pendingAttachments: [ShareAttachment] = []
-    private var attachmentError: ShareImageProcessor.ProcessError?
+    /// Keep omission state controller-owned so send cannot bypass the disabled UI.
+    private var attachmentBlockReason: ShareAttachmentBlockReason?
 
     override func loadView() {
         self.view = self.composeView
@@ -61,7 +62,9 @@ final class ShareViewController: UIViewController {
         let extracted = await self.extractSharedContent()
         let payload = extracted.payload
         self.pendingAttachments = extracted.attachments.map(\.payload)
-        self.attachmentError = extracted.attachmentError
+        self.attachmentBlockReason = ShareAttachmentBlockReason.resolve(
+            hasImageProcessingError: extracted.attachmentError != nil,
+            summary: extracted.attachmentSummary)
         self.logger.info("share payload trace=\(traceId, privacy: .public)")
         self.logger.info(
             "share payload title=\(payload.title?.count ?? 0) text=\(payload.text?.count ?? 0)")
@@ -71,18 +74,8 @@ final class ShareViewController: UIViewController {
         self.composeView.setDraft(message)
         self.composeView.setAttachmentPreviews(extracted.attachments.map(\.preview))
         self.composeView.focusDraft()
-        if let blockReason = ShareAttachmentBlockReason.resolve(
-            hasImageProcessingError: extracted.attachmentError != nil,
-            summary: extracted.attachmentSummary)
-        {
-            switch blockReason {
-            case .imageProcessingFailed:
-                ShareGatewayRelaySettings.saveLastEvent("Share blocked: image processing failed.")
-                self.composeView.apply(.blocked(self.imageProcessingErrorMessage()))
-            case let .omitted(message):
-                ShareGatewayRelaySettings.saveLastEvent("Share blocked: attachment(s) omitted.")
-                self.composeView.apply(.blocked(message))
-            }
+        if let blockReason = self.attachmentBlockReason {
+            self.applyAttachmentBlockReason(blockReason)
         } else if message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             self.composeView.apply(.ready)
             ShareGatewayRelaySettings.saveLastEvent("Share ready: waiting for message input.")
@@ -98,8 +91,8 @@ final class ShareViewController: UIViewController {
     }
 
     private func sendCurrentDraft() async {
-        if self.attachmentError != nil {
-            self.composeView.apply(.blocked(self.imageProcessingErrorMessage()))
+        if let blockReason = self.attachmentBlockReason {
+            self.applyAttachmentBlockReason(blockReason)
             return
         }
         let trimmed = self.composeView.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -389,6 +382,17 @@ final class ShareViewController: UIViewController {
         NSLocalizedString(
             "The shared image could not be prepared.",
             comment: "Share extension image processing failure")
+    }
+
+    private func applyAttachmentBlockReason(_ blockReason: ShareAttachmentBlockReason) {
+        switch blockReason {
+        case .imageProcessingFailed:
+            ShareGatewayRelaySettings.saveLastEvent("Share blocked: image processing failed.")
+            self.composeView.apply(.blocked(self.imageProcessingErrorMessage()))
+        case let .omitted(message):
+            ShareGatewayRelaySettings.saveLastEvent("Share blocked: attachment(s) omitted.")
+            self.composeView.apply(.blocked(message))
+        }
     }
 
     /// Previews are retained for the sheet's lifetime; keep them bounded so

--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -22,6 +22,7 @@ final class ShareViewController: UIViewController {
     private struct ExtractedShareContent {
         var payload: SharedContentPayload
         var attachments: [LoadedAttachment]
+        var attachmentSummary: ShareAttachmentSummary
         var attachmentError: ShareImageProcessor.ProcessError?
     }
 
@@ -70,9 +71,18 @@ final class ShareViewController: UIViewController {
         self.composeView.setDraft(message)
         self.composeView.setAttachmentPreviews(extracted.attachments.map(\.preview))
         self.composeView.focusDraft()
-        if let attachmentError = extracted.attachmentError {
-            ShareGatewayRelaySettings.saveLastEvent("Share blocked: image processing failed.")
-            self.composeView.apply(.blocked(self.imageProcessingErrorMessage(attachmentError)))
+        if let blockReason = ShareAttachmentBlockReason.resolve(
+            hasImageProcessingError: extracted.attachmentError != nil,
+            summary: extracted.attachmentSummary)
+        {
+            switch blockReason {
+            case .imageProcessingFailed:
+                ShareGatewayRelaySettings.saveLastEvent("Share blocked: image processing failed.")
+                self.composeView.apply(.blocked(self.imageProcessingErrorMessage()))
+            case let .omitted(message):
+                ShareGatewayRelaySettings.saveLastEvent("Share blocked: attachment(s) omitted.")
+                self.composeView.apply(.blocked(message))
+            }
         } else if message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             self.composeView.apply(.ready)
             ShareGatewayRelaySettings.saveLastEvent("Share ready: waiting for message input.")
@@ -88,8 +98,8 @@ final class ShareViewController: UIViewController {
     }
 
     private func sendCurrentDraft() async {
-        if let attachmentError = self.attachmentError {
-            self.composeView.apply(.blocked(self.imageProcessingErrorMessage(attachmentError)))
+        if self.attachmentError != nil {
+            self.composeView.apply(.blocked(self.imageProcessingErrorMessage()))
             return
         }
         let trimmed = self.composeView.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -282,6 +292,7 @@ final class ShareViewController: UIViewController {
             return ExtractedShareContent(
                 payload: SharedContentPayload(title: nil, url: nil, text: nil),
                 attachments: [],
+                attachmentSummary: ShareAttachmentSummary(),
                 attachmentError: nil)
         }
 
@@ -290,6 +301,7 @@ final class ShareViewController: UIViewController {
         var sharedText: String?
         var attributedContentText: String?
         var attachments: [LoadedAttachment] = []
+        var attachmentSummary = ShareAttachmentSummary()
         var attachmentError: ShareImageProcessor.ProcessError?
         let maxImageAttachments = 3
 
@@ -311,6 +323,7 @@ final class ShareViewController: UIViewController {
                 }
 
                 if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+                    attachmentSummary.selectedImageCount += 1
                     if attachments.count < maxImageAttachments, attachmentError == nil {
                         do {
                             let attachment = try await self.loadImageAttachment(
@@ -323,9 +336,19 @@ final class ShareViewController: UIViewController {
                             attachmentError = .encodeFailed
                         }
                     }
+                } else if provider.hasItemConformingToTypeIdentifier(UTType.movie.identifier) {
+                    attachmentSummary.videoCount += 1
+                } else if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                    attachmentSummary.fileCount += 1
+                } else if !provider.hasItemConformingToTypeIdentifier(UTType.url.identifier),
+                          !provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier),
+                          !provider.hasItemConformingToTypeIdentifier(UTType.text.identifier)
+                {
+                    attachmentSummary.unknownCount += 1
                 }
             }
         }
+        attachmentSummary.acceptedImageCount = attachments.count
 
         // Share hosts often mirror provider text in attributedContentText.
         // Preserve distinct content as the historical title, but do not duplicate provider data.
@@ -336,6 +359,7 @@ final class ShareViewController: UIViewController {
         return ExtractedShareContent(
             payload: SharedContentPayload(title: title ?? supplementalTitle, url: sharedURL, text: sharedText),
             attachments: attachments,
+            attachmentSummary: attachmentSummary,
             attachmentError: attachmentError)
     }
 
@@ -361,7 +385,7 @@ final class ShareViewController: UIViewController {
             preview: self.boundedPreview(from: image))
     }
 
-    private func imageProcessingErrorMessage(_: ShareImageProcessor.ProcessError) -> String {
+    private func imageProcessingErrorMessage() -> String {
         NSLocalizedString(
             "The shared image could not be prepared.",
             comment: "Share extension image processing failure")

--- a/apps/ios/Tests/Logic/ShareAttachmentSummaryTests.swift
+++ b/apps/ios/Tests/Logic/ShareAttachmentSummaryTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+struct ShareAttachmentSummaryTests {
+    @Test func `has no omission message when every selected image is accepted`() {
+        let summary = ShareAttachmentSummary(selectedImageCount: 3, acceptedImageCount: 3)
+
+        #expect(summary.omissionMessage == nil)
+    }
+
+    @Test func `reports image truncation before the share can be sent`() {
+        let summary = ShareAttachmentSummary(selectedImageCount: 6, acceptedImageCount: 3)
+
+        #expect(summary.omissionMessage ==
+            "Only 3 of 6 images can be sent. Remove omitted items and share again.")
+    }
+
+    @Test func `reports unsupported videos files and unknown attachments`() {
+        let summary = ShareAttachmentSummary(
+            selectedImageCount: 1,
+            acceptedImageCount: 1,
+            videoCount: 1,
+            fileCount: 2,
+            unknownCount: 1)
+
+        #expect(summary.omissionMessage ==
+            "OpenClaw Share cannot send 1 video(s), 2 file(s), 1 unsupported item(s) yet. Remove omitted items and share again.")
+    }
+
+    @Test func `keeps image processing failures authoritative before omission warnings`() {
+        let summary = ShareAttachmentSummary(selectedImageCount: 2, acceptedImageCount: 1)
+
+        #expect(ShareAttachmentBlockReason.resolve(
+            hasImageProcessingError: true,
+            summary: summary) == .imageProcessingFailed)
+    }
+
+    @Test func `uses omission warning when no image processing failure exists`() {
+        let summary = ShareAttachmentSummary(selectedImageCount: 6, acceptedImageCount: 3)
+
+        #expect(ShareAttachmentBlockReason.resolve(
+            hasImageProcessingError: false,
+            summary: summary) == .omitted(
+                "Only 3 of 6 images can be sent. Remove omitted items and share again."))
+    }
+}

--- a/apps/ios/Tests/Logic/ShareAttachmentSummaryTests.swift
+++ b/apps/ios/Tests/Logic/ShareAttachmentSummaryTests.swift
@@ -24,7 +24,7 @@ struct ShareAttachmentSummaryTests {
             unknownCount: 1)
 
         #expect(summary.omissionMessage ==
-            "OpenClaw Share cannot send 1 video(s), 2 file(s), 1 unsupported item(s) yet. Remove omitted items and share again.")
+            "OpenClaw Share cannot send 1 video, 2 files, 1 unsupported item yet. Remove omitted items and share again.")
     }
 
     @Test func `keeps image processing failures authoritative before omission warnings`() {
@@ -41,6 +41,6 @@ struct ShareAttachmentSummaryTests {
         #expect(ShareAttachmentBlockReason.resolve(
             hasImageProcessingError: false,
             summary: summary) == .omitted(
-                "Only 3 of 6 images can be sent. Remove omitted items and share again."))
+            "Only 3 of 6 images can be sent. Remove omitted items and share again."))
     }
 }

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -421,6 +421,8 @@ targets:
         group: ShareExtension
       - path: ShareExtension/ShareComposeState.swift
         group: ShareExtension
+      - path: ShareExtension/ShareAttachmentSummary.swift
+        group: ShareExtension
       - path: WatchApp/Sources/WatchVoiceTurnTracker.swift
         group: WatchApp/Sources
       - path: WatchApp/Sources/WatchInboxMessages.swift

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -161,13 +161,13 @@ struct MacNodeModeCoordinatorTests {
 
         notificationCenter.post(name: .openclawConfigDidChange, object: nil)
 
-        try await self.waitUntil("node-host worker restart") {
+        try await self.waitUntil("node-host worker restart", timeout: .seconds(10)) {
             await worker.stops() == 1
         }
 
         notificationCenter.post(name: .openclawCLIInstalled, object: nil)
 
-        try await self.waitUntil("node-host worker restart") {
+        try await self.waitUntil("node-host worker restart", timeout: .seconds(10)) {
             await worker.stops() == 2
         }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes #103363.

The iOS Share Extension accepted at most three image attachments and ignored videos, files, PDFs, and unknown attachment providers while still moving toward the normal send flow. That let a user share partial content without any visible explanation.

## Why This Change Was Made

This keeps the current gateway media contract unchanged: the share route still sends image attachments only, and it does not attempt to add video/PDF/file transport in this PR.

Instead, extraction now records selected image count, accepted image count, and unsupported attachment classes. If the extension would omit selected content, the compose card enters the existing blocked state with a concrete recovery message, so send stays disabled until the user removes omitted items and shares again.

## User Impact

- Sharing 6 images now shows: `Only 3 of 6 images can be sent. Remove omitted items and share again.`
- Sharing a video, PDF/file, or unknown attachment now shows an unsupported-item message instead of silently sending only text or the first accepted images.
- Normal shares with up to 3 images are unchanged.

## Evidence

Focused local proof:

```text
SHARE_ATTACHMENT_SUMMARY_PROOF=PASS
Only 3 of 6 images can be sent. Remove omitted items and share again.
OpenClaw Share cannot send 1 video(s), 2 file(s), 1 unsupported item(s) yet. Remove omitted items and share again.
```

Validation run:

```text
swiftc /tmp/.../ShareAttachmentSummary.swift /tmp/.../main.swift -o /tmp/.../share-proof && /tmp/.../share-proof
git diff HEAD^ HEAD --check
```

### Real proof

Exact-head native simulator proof for `5dda9040ac66350805428609bca660dd5373e6f6`.

Environment: iPhone 17 Pro simulator, iOS 26.2 (`23C54`), Xcode 27.0. The installed app's `OpenClawGitCommit` is the exact PR head above. Both scenarios used the real Photos → Share Sheet → OpenClaw Share Extension path.

#### Six-image omission path

- Selected 6 photos in Photos.
- The extension rendered: `Only 3 of 6 images can be sent. Remove omitted items and share again.`
- Send was disabled.
- After entering `Compare all six images`, Send remained disabled.
- XCTest result: **Passed** (`39.91s`).

![Six selected images show the omission warning with Send disabled](https://files.catbox.moe/91crio.png)

#### Normal one-image control

- Selected 1 photo in Photos.
- After entering `Describe this image`, Send enabled normally.
- XCTest result: **Passed** (`27.65s`).

![A normal one-image share enables Send after draft text is entered](https://files.catbox.moe/1vcxn8.png)

Focused commands:

```text
xcodebuild ... -only-testing:OpenClawUITests/ShareExtensionUITests/testSixSelectedImagesShowOmissionWarningAndKeepSendDisabled test
xcodebuild ... -only-testing:OpenClawUITests/ShareExtensionUITests/testOneSelectedImageStillEnablesSendAfterDraftText test
```

The UI-test additions were a local proof harness only; no test or product files were pushed to the contributor branch.

Source proof comment: https://github.com/openclaw/openclaw/pull/104842#issuecomment-4953546708
