### PR TITLE
Subagent Health v1 — health classification + sweep-driven recovery

### DIFF
--- a/packages/gateway-protocol/src/schema/tasks.ts
+++ b/packages/gateway-protocol/src/schema/tasks.ts
@@ -20,6 +20,37 @@ export const TaskLedgerStatusSchema = Type.Union([
 
 const TimestampSchema = Type.Union([Type.String(), Type.Integer({ minimum: 0 })]);
 
+export const SubagentHealthStatusSchema = Type.Union([
+  Type.Literal("active"),
+  Type.Literal("stale"),
+  Type.Literal("timed_out"),
+  Type.Literal("delivery_pending"),
+  Type.Literal("delivery_failed"),
+  Type.Literal("cleanup_pending"),
+  Type.Literal("orphaned"),
+  Type.Literal("cancel_reconciling"),
+  Type.Literal("terminal"),
+]);
+
+export const SubagentHealthNextActionSchema = Type.Union([
+  Type.Literal("none"),
+  Type.Literal("recover_orphan"),
+  Type.Literal("finalize_timeout"),
+  Type.Literal("retry_delivery"),
+  Type.Literal("resume_cleanup"),
+  Type.Literal("wait_cancel_reconciliation"),
+]);
+
+export const SubagentHealthSchema = Type.Object(
+  {
+    status: SubagentHealthStatusSchema,
+    nextAction: SubagentHealthNextActionSchema,
+    retryable: Type.Boolean(),
+    reason: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
 /** Public task summary returned by task list/get/cancel responses. */
 export const TaskSummarySchema = Type.Object(
   {
@@ -44,6 +75,7 @@ export const TaskSummarySchema = Type.Object(
     progressSummary: Type.Optional(Type.String()),
     terminalSummary: Type.Optional(Type.String()),
     error: Type.Optional(Type.String()),
+    subagentHealth: Type.Optional(SubagentHealthSchema),
   },
   { additionalProperties: false },
 );

--- a/packages/gateway-protocol/src/schema/tasks.ts
+++ b/packages/gateway-protocol/src/schema/tasks.ts
@@ -51,6 +51,16 @@ export const SubagentHealthSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const TaskSubagentHealthSummarySchema = Type.Object(
+  {
+    total: Type.Integer({ minimum: 0 }),
+    retryable: Type.Integer({ minimum: 0 }),
+    byStatus: Type.Record(Type.String(), Type.Integer({ minimum: 0 })),
+    byNextAction: Type.Record(Type.String(), Type.Integer({ minimum: 0 })),
+  },
+  { additionalProperties: false },
+);
+
 /** Public task summary returned by task list/get/cancel responses. */
 export const TaskSummarySchema = Type.Object(
   {
@@ -96,6 +106,7 @@ export const TasksListParamsSchema = Type.Object(
 export const TasksListResultSchema = Type.Object(
   {
     tasks: Type.Array(TaskSummarySchema),
+    subagentHealthSummary: Type.Optional(TaskSubagentHealthSummarySchema),
     nextCursor: Type.Optional(Type.String()),
   },
   { additionalProperties: false },

--- a/src/agents/subagent-health.test.ts
+++ b/src/agents/subagent-health.test.ts
@@ -150,6 +150,68 @@ describe("classifySubagentHealth", () => {
     });
   });
 
+  it("keeps fresh pending delivery non-retryable", () => {
+    const health = classifySubagentHealth({
+      run: makeRun({
+        endedAt: NOW - 10_000,
+        outcome: { status: "ok" },
+        delivery: {
+          status: "pending",
+          createdAt: NOW - 10_000,
+          lastAttemptAt: NOW - 5_000,
+        },
+      }),
+      task: makeTask({ status: "succeeded", deliveryStatus: "pending", endedAt: NOW - 10_000 }),
+      now: NOW,
+      staleAfterMs: 60_000,
+      deliveryStaleAfterMs: 30_000,
+    });
+
+    expect(health).toEqual({
+      status: "delivery_pending",
+      retryable: false,
+      nextAction: "none",
+    });
+  });
+
+  it("marks failed delivery for retry with the delivery error", () => {
+    const health = classifySubagentHealth({
+      run: makeRun({
+        endedAt: NOW - 10_000,
+        outcome: { status: "ok" },
+        delivery: {
+          status: "failed",
+          lastError: "gateway disconnected",
+          lastAttemptAt: NOW - 1_000,
+        },
+      }),
+      task: makeTask({ status: "succeeded", deliveryStatus: "failed", endedAt: NOW - 10_000 }),
+      now: NOW,
+      staleAfterMs: 60_000,
+    });
+
+    expect(health).toEqual({
+      status: "delivery_failed",
+      reason: "gateway disconnected",
+      retryable: true,
+      nextAction: "retry_delivery",
+    });
+  });
+
+  it("marks active runs without a task projection as orphaned", () => {
+    const health = classifySubagentHealth({
+      run: makeRun({ startedAt: NOW - 10_000, execution: { status: "running" } }),
+      now: NOW,
+      staleAfterMs: 60_000,
+    });
+
+    expect(health).toMatchObject({
+      status: "orphaned",
+      retryable: true,
+      nextAction: "recover_orphan",
+    });
+  });
+
   it("marks ended runs without completed cleanup as cleanup pending", () => {
     const health = classifySubagentHealth({
       run: makeRun({

--- a/src/agents/subagent-health.test.ts
+++ b/src/agents/subagent-health.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import { classifySubagentHealth } from "./subagent-health.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+const NOW = 1_700_000_000_000;
+
+function makeRun(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
+  return {
+    runId: "run-1",
+    childSessionKey: "agent:main:subagent:worker",
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    task: "Do useful work",
+    cleanup: "keep",
+    createdAt: NOW - 60_000,
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: "task-1",
+    runtime: "subagent",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    childSessionKey: "agent:main:subagent:worker",
+    runId: "run-1",
+    task: "Do useful work",
+    status: "running",
+    deliveryStatus: "not_applicable",
+    notifyPolicy: "done_only",
+    createdAt: NOW - 60_000,
+    startedAt: NOW - 59_000,
+    lastEventAt: NOW - 5_000,
+    ...overrides,
+  };
+}
+
+describe("classifySubagentHealth", () => {
+  it("keeps a running subagent active when its task recently emitted an event", () => {
+    const health = classifySubagentHealth({
+      run: makeRun({ startedAt: NOW - 59_000, execution: { status: "running" } }),
+      task: makeTask(),
+      now: NOW,
+      staleAfterMs: 60_000,
+    });
+
+    expect(health).toEqual({
+      status: "active",
+      retryable: false,
+      nextAction: "none",
+    });
+  });
+
+  it("marks a running subagent stale when no task activity has arrived within the stale window", () => {
+    const health = classifySubagentHealth({
+      run: makeRun({ startedAt: NOW - 10 * 60_000, execution: { status: "running" } }),
+      task: makeTask({ lastEventAt: NOW - 2 * 60_000 }),
+      now: NOW,
+      staleAfterMs: 60_000,
+    });
+
+    expect(health).toMatchObject({
+      status: "stale",
+      retryable: true,
+      nextAction: "recover_orphan",
+    });
+    expect(health.reason).toContain("no subagent activity");
+  });
+
+  it("marks a running subagent timed out when its explicit deadline has passed", () => {
+    const health = classifySubagentHealth({
+      run: makeRun({
+        createdAt: NOW - 10_000,
+        startedAt: NOW - 10_000,
+        runTimeoutSeconds: 5,
+        execution: { status: "running" },
+      }),
+      task: makeTask({ startedAt: NOW - 10_000, lastEventAt: NOW - 1_000 }),
+      now: NOW,
+      staleAfterMs: 60_000,
+    });
+
+    expect(health).toMatchObject({
+      status: "timed_out",
+      retryable: true,
+      nextAction: "finalize_timeout",
+    });
+  });
+
+  it("keeps killed runs in cancel reconciliation", () => {
+    const health = classifySubagentHealth({
+      run: makeRun({ killReconciliation: { killedAt: NOW - 1_000 } }),
+      task: makeTask({ status: "cancelled", endedAt: NOW - 1_000 }),
+      now: NOW,
+      staleAfterMs: 60_000,
+    });
+
+    expect(health).toEqual({
+      status: "cancel_reconciling",
+      reason: "subagent cancellation is awaiting reconciliation",
+      retryable: true,
+      nextAction: "wait_cancel_reconciliation",
+    });
+  });
+
+  it("marks terminal runs with completed cleanup as terminal", () => {
+    const health = classifySubagentHealth({
+      run: makeRun({
+        endedAt: NOW - 5_000,
+        cleanupCompletedAt: NOW - 1_000,
+        outcome: { status: "ok" },
+        execution: { status: "terminal", endedAt: NOW - 5_000, outcome: { status: "ok" } },
+      }),
+      task: makeTask({ status: "succeeded", endedAt: NOW - 5_000, lastEventAt: NOW - 5_000 }),
+      now: NOW,
+      staleAfterMs: 60_000,
+    });
+
+    expect(health).toEqual({
+      status: "terminal",
+      retryable: false,
+      nextAction: "none",
+    });
+  });
+
+  it("marks stale pending delivery for retry", () => {
+    const health = classifySubagentHealth({
+      run: makeRun({
+        endedAt: NOW - 2 * 60_000,
+        outcome: { status: "ok" },
+        delivery: {
+          status: "pending",
+          createdAt: NOW - 2 * 60_000,
+          lastAttemptAt: NOW - 2 * 60_000,
+        },
+      }),
+      task: makeTask({ status: "succeeded", deliveryStatus: "pending", endedAt: NOW - 2 * 60_000 }),
+      now: NOW,
+      staleAfterMs: 60_000,
+      deliveryStaleAfterMs: 30_000,
+    });
+
+    expect(health).toMatchObject({
+      status: "delivery_pending",
+      retryable: true,
+      nextAction: "retry_delivery",
+    });
+  });
+
+  it("marks ended runs without completed cleanup as cleanup pending", () => {
+    const health = classifySubagentHealth({
+      run: makeRun({
+        endedAt: NOW - 2 * 60_000,
+        outcome: { status: "ok" },
+        delivery: { status: "delivered", deliveredAt: NOW - 90_000 },
+      }),
+      task: makeTask({ status: "succeeded", deliveryStatus: "delivered", endedAt: NOW - 2 * 60_000 }),
+      now: NOW,
+      staleAfterMs: 60_000,
+      cleanupStaleAfterMs: 30_000,
+    });
+
+    expect(health).toMatchObject({
+      status: "cleanup_pending",
+      retryable: true,
+      nextAction: "resume_cleanup",
+    });
+  });
+});

--- a/src/agents/subagent-health.ts
+++ b/src/agents/subagent-health.ts
@@ -2,6 +2,9 @@ import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { resolveSubagentRunDeadlineMs } from "./subagent-run-timeout.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
+export const SUBAGENT_HEALTH_STALE_AFTER_MS =
+  process.env.OPENCLAW_TEST_FAST === "1" ? 1_000 : 60_000;
+
 export type SubagentHealthStatus =
   | "active"
   | "stale"

--- a/src/agents/subagent-health.ts
+++ b/src/agents/subagent-health.ts
@@ -1,0 +1,174 @@
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import { resolveSubagentRunDeadlineMs } from "./subagent-run-timeout.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+export type SubagentHealthStatus =
+  | "active"
+  | "stale"
+  | "timed_out"
+  | "delivery_pending"
+  | "delivery_failed"
+  | "cleanup_pending"
+  | "orphaned"
+  | "cancel_reconciling"
+  | "terminal";
+
+export type SubagentHealthNextAction =
+  | "none"
+  | "recover_orphan"
+  | "finalize_timeout"
+  | "retry_delivery"
+  | "resume_cleanup"
+  | "wait_cancel_reconciliation";
+
+export type SubagentHealth = {
+  status: SubagentHealthStatus;
+  reason?: string;
+  retryable: boolean;
+  nextAction: SubagentHealthNextAction;
+};
+
+export type ClassifySubagentHealthParams = {
+  run: SubagentRunRecord;
+  task?: TaskRecord;
+  now: number;
+  staleAfterMs: number;
+  deliveryStaleAfterMs?: number;
+  cleanupStaleAfterMs?: number;
+};
+
+function hasFiniteTimestamp(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function ageMs(now: number, at: unknown): number | undefined {
+  return hasFiniteTimestamp(at) ? now - at : undefined;
+}
+
+function lastObservedActivityAt(run: SubagentRunRecord, task: TaskRecord | undefined): number {
+  return Math.max(
+    run.startedAt ?? run.createdAt,
+    run.sessionStartedAt ?? run.createdAt,
+    task?.lastEventAt ?? task?.startedAt ?? task?.createdAt ?? run.createdAt,
+  );
+}
+
+function deliveryLastActivityAt(run: SubagentRunRecord): number | undefined {
+  return (
+    run.delivery?.lastAttemptAt ??
+    run.delivery?.enqueuedAt ??
+    run.delivery?.createdAt ??
+    run.delivery?.deliveredAt ??
+    run.delivery?.announcedAt
+  );
+}
+
+function isTerminalCleanupComplete(run: SubagentRunRecord): boolean {
+  return (
+    hasFiniteTimestamp(run.endedAt) &&
+    hasFiniteTimestamp(run.cleanupCompletedAt) &&
+    run.execution?.status === "terminal"
+  );
+}
+
+export function classifySubagentHealth(params: ClassifySubagentHealthParams): SubagentHealth {
+  const { run, task, now } = params;
+
+  if (run.killReconciliation) {
+    return {
+      status: "cancel_reconciling",
+      reason: "subagent cancellation is awaiting reconciliation",
+      retryable: true,
+      nextAction: "wait_cancel_reconciliation",
+    };
+  }
+
+  if (isTerminalCleanupComplete(run)) {
+    return {
+      status: "terminal",
+      retryable: false,
+      nextAction: "none",
+    };
+  }
+
+  const deadlineMs = resolveSubagentRunDeadlineMs(run, task?.startedAt);
+  if (!hasFiniteTimestamp(run.endedAt) && deadlineMs !== undefined && now >= deadlineMs) {
+    return {
+      status: "timed_out",
+      reason: "subagent run exceeded its configured timeout",
+      retryable: true,
+      nextAction: "finalize_timeout",
+    };
+  }
+
+  const deliveryStatus = run.delivery?.status;
+  if (deliveryStatus === "failed" || deliveryStatus === "suspended") {
+    return {
+      status: "delivery_failed",
+      reason: run.delivery?.lastError ?? "subagent completion delivery failed",
+      retryable: deliveryStatus === "failed",
+      nextAction: deliveryStatus === "failed" ? "retry_delivery" : "none",
+    };
+  }
+
+  if (deliveryStatus === "pending" || deliveryStatus === "in_progress") {
+    const staleAfterMs = params.deliveryStaleAfterMs ?? params.staleAfterMs;
+    const lastDeliveryActivityAgeMs = ageMs(now, deliveryLastActivityAt(run));
+    if (lastDeliveryActivityAgeMs === undefined || lastDeliveryActivityAgeMs >= staleAfterMs) {
+      return {
+        status: "delivery_pending",
+        reason: "subagent completion delivery has not settled",
+        retryable: true,
+        nextAction: "retry_delivery",
+      };
+    }
+    return {
+      status: "delivery_pending",
+      retryable: false,
+      nextAction: "none",
+    };
+  }
+
+  if (hasFiniteTimestamp(run.endedAt) && !hasFiniteTimestamp(run.cleanupCompletedAt)) {
+    const staleAfterMs = params.cleanupStaleAfterMs ?? params.staleAfterMs;
+    const cleanupAgeMs = ageMs(now, run.endedAt);
+    if (cleanupAgeMs === undefined || cleanupAgeMs >= staleAfterMs) {
+      return {
+        status: "cleanup_pending",
+        reason: "subagent cleanup has not completed",
+        retryable: true,
+        nextAction: "resume_cleanup",
+      };
+    }
+    return {
+      status: "cleanup_pending",
+      retryable: false,
+      nextAction: "none",
+    };
+  }
+
+  if (!task) {
+    return {
+      status: "orphaned",
+      reason: "subagent has no task projection",
+      retryable: true,
+      nextAction: "recover_orphan",
+    };
+  }
+
+  const activeAgeMs = ageMs(now, lastObservedActivityAt(run, task));
+  if (activeAgeMs !== undefined && activeAgeMs >= params.staleAfterMs) {
+    return {
+      status: "stale",
+      reason: "no subagent activity observed within the stale window",
+      retryable: true,
+      nextAction: "recover_orphan",
+    };
+  }
+
+  return {
+    status: "active",
+    retryable: false,
+    nextAction: "none",
+  };
+}

--- a/src/agents/subagent-orphan-recovery.test.ts
+++ b/src/agents/subagent-orphan-recovery.test.ts
@@ -814,6 +814,48 @@ describe("subagent-orphan-recovery", () => {
     expect(sessions.updateSessionStore).toHaveBeenCalledOnce();
   });
 
+  it("does not double-resume the same session from two independent concurrent recovery scans", async () => {
+    // resumedSessionKeys is per-scheduleOrphanRecovery-invocation, not global —
+    // two independent triggers (e.g. cold-start restore and a later completion
+    // -retry-triggered scan) each get their own fresh Set. Both would read
+    // abortedLastRun as true and both attempt resume before either write clears
+    // it, unless a scan-independent guard exists. Pause readSessionMessagesAsync
+    // to hold the first scan mid-flight (past the abortedLastRun check, before
+    // the resume call) while the second scan runs concurrently against it.
+    mockSingleAbortedSession();
+    let releaseFirstScan: (() => void) | undefined;
+    const firstScanReachedReadMessages = new Promise<void>((resolveReached) => {
+      vi.mocked(sessionUtils.readSessionMessagesAsync).mockImplementationOnce(async () => {
+        resolveReached();
+        return await new Promise((resolve) => {
+          releaseFirstScan = () => resolve([]);
+        });
+      });
+    });
+    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "new-run" } as never);
+
+    const activeRuns = createActiveRuns(createTestRunRecord());
+
+    const firstScan = recoverOrphanedSubagentSessions({ getActiveRuns: () => activeRuns });
+    await firstScanReachedReadMessages;
+
+    // A second, fully independent scan (its own fresh resumedSessionKeys Set)
+    // starts while the first is still mid-flight and has not yet cleared
+    // abortedLastRun or called callGateway.
+    const secondScan = recoverOrphanedSubagentSessions({ getActiveRuns: () => activeRuns });
+    const second = await secondScan;
+
+    expect(second.skipped).toBe(1);
+    expect(second.recovered).toBe(0);
+    expect(gateway.callGateway).not.toHaveBeenCalled();
+
+    releaseFirstScan?.();
+    const first = await firstScan;
+
+    expect(first.recovered).toBe(1);
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+  });
+
   it("finalizes interrupted runs with a readable failure after recovery retries are exhausted", async () => {
     vi.mocked(sessions.loadSessionStore).mockReturnValue({
       "agent:main:subagent:test-session-1": {

--- a/src/agents/subagent-orphan-recovery.test.ts
+++ b/src/agents/subagent-orphan-recovery.test.ts
@@ -856,6 +856,47 @@ describe("subagent-orphan-recovery", () => {
     expect(gateway.callGateway).toHaveBeenCalledOnce();
   });
 
+  it("does not double-resume while the first scan's successful resume is still clearing abortedLastRun", async () => {
+    // resumeOrphanedSession() resolving does not mean the session is safe to
+    // re-scan yet: abortedLastRun is only cleared by the subsequent
+    // updateSessionStore() write. If the in-flight guard released right after
+    // resumeOrphanedSession() returns, a second scan starting in that window
+    // would still read abortedLastRun: true and call callGateway again.
+    mockSingleAbortedSession();
+    let releaseUpdateSessionStore: (() => void) | undefined;
+    const reachedUpdateSessionStore = new Promise<void>((resolveReached) => {
+      vi.mocked(sessions.updateSessionStore).mockImplementationOnce(async () => {
+        resolveReached();
+        return await new Promise<void>((resolve) => {
+          releaseUpdateSessionStore = resolve;
+        });
+      });
+    });
+    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "new-run" } as never);
+
+    const activeRuns = createActiveRuns(createTestRunRecord());
+
+    const firstScan = recoverOrphanedSubagentSessions({ getActiveRuns: () => activeRuns });
+    await reachedUpdateSessionStore;
+
+    // resumeOrphanedSession() has already resolved (resumed: true) by this
+    // point — only the persisted abortedLastRun clear is still pending.
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+
+    const secondScan = recoverOrphanedSubagentSessions({ getActiveRuns: () => activeRuns });
+    const second = await secondScan;
+
+    expect(second.skipped).toBe(1);
+    expect(second.recovered).toBe(0);
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+
+    releaseUpdateSessionStore?.();
+    const first = await firstScan;
+
+    expect(first.recovered).toBe(1);
+    expect(gateway.callGateway).toHaveBeenCalledOnce();
+  });
+
   it("finalizes interrupted runs with a readable failure after recovery retries are exhausted", async () => {
     vi.mocked(sessions.loadSessionStore).mockReturnValue({
       "agent:main:subagent:test-session-1": {

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -44,6 +44,18 @@ const log = createSubsystemLogger("subagent-interrupted-resume");
 /** Delay before attempting recovery to let the gateway finish bootstrapping. */
 const DEFAULT_RECOVERY_DELAY_MS = 5_000;
 
+/**
+ * Module-level (not per-scan) guard against two independent scheduleOrphanRecovery
+ * invocations resuming the same child session concurrently. Debounce only covers
+ * scheduling within ORPHAN_RECOVERY_DEBOUNCE_MS of each other; two triggers spaced
+ * further apart (e.g. cold-start restore and a later completion-retry failure) each
+ * get their own resumedSessionKeys/pendingStaleFinalizations closures and would
+ * otherwise both read entry.abortedLastRun as true and both call resumeOrphanedSession
+ * before either write clears the flag — each with its own crypto.randomUUID()
+ * idempotencyKey, so the gateway's own agent-call dedup cannot catch the duplicate.
+ */
+const sessionKeysWithRecoveryInFlight = new Set<string>();
+
 function isLegacyRestartInterruptedTimeout(
   runRecord: SubagentRunRecord,
   entry: SessionEntry | undefined,
@@ -402,47 +414,61 @@ export async function recoverOrphanedSubagentSessions(params: {
           continue;
         }
 
-        log.info(`found orphaned subagent session: ${childSessionKey} (run=${runId})`);
+        if (sessionKeysWithRecoveryInFlight.has(childSessionKey)) {
+          // A different scheduleOrphanRecovery invocation (e.g. a cold-start
+          // scan and a later completion-retry-triggered scan) is already
+          // resuming this exact session. Skip rather than double-fire.
+          result.skipped++;
+          continue;
+        }
+        sessionKeysWithRecoveryInFlight.add(childSessionKey);
 
-        const messages = await readSessionMessagesAsync(
-          {
-            agentId: resolveAgentIdFromSessionKey(childSessionKey),
-            sessionEntry: entry,
-            sessionId: entry.sessionId,
+        let resumeResult: { resumed: boolean; error?: string };
+        try {
+          log.info(`found orphaned subagent session: ${childSessionKey} (run=${runId})`);
+
+          const messages = await readSessionMessagesAsync(
+            {
+              agentId: resolveAgentIdFromSessionKey(childSessionKey),
+              sessionEntry: entry,
+              sessionId: entry.sessionId,
+              sessionKey: childSessionKey,
+              storePath,
+            },
+            {
+              mode: "recent",
+              maxMessages: 200,
+              maxBytes: 1024 * 1024,
+            },
+          );
+          const lastHumanMessage = [...messages]
+            .toReversed()
+            .find((msg) => (msg as { role?: unknown } | null)?.role === "user");
+          const configChangeDetected = messages.some((msg) => {
+            if ((msg as { role?: unknown } | null)?.role !== "assistant") {
+              return false;
+            }
+            const text = extractMessageText(msg);
+            return typeof text === "string" && configChangePattern.test(text);
+          });
+
+          // Resume the session with the original task context.
+          // We intentionally do NOT clear abortedLastRun before attempting
+          // the resume — if callGateway fails (e.g. gateway still booting),
+          // the flag stays true so the next restart can retry.
+          resumeResult = await resumeOrphanedSession({
             sessionKey: childSessionKey,
-            storePath,
-          },
-          {
-            mode: "recent",
-            maxMessages: 200,
-            maxBytes: 1024 * 1024,
-          },
-        );
-        const lastHumanMessage = [...messages]
-          .toReversed()
-          .find((msg) => (msg as { role?: unknown } | null)?.role === "user");
-        const configChangeDetected = messages.some((msg) => {
-          if ((msg as { role?: unknown } | null)?.role !== "assistant") {
-            return false;
-          }
-          const text = extractMessageText(msg);
-          return typeof text === "string" && configChangePattern.test(text);
-        });
-
-        // Resume the session with the original task context.
-        // We intentionally do NOT clear abortedLastRun before attempting
-        // the resume — if callGateway fails (e.g. gateway still booting),
-        // the flag stays true so the next restart can retry.
-        const resumeResult = await resumeOrphanedSession({
-          sessionKey: childSessionKey,
-          task: runRecord.task,
-          lastHumanMessage: extractMessageText(lastHumanMessage),
-          configChangeHint: configChangeDetected
-            ? "\n\n[config changes from your previous run were already applied — do not re-modify openclaw.json or restart the gateway]"
-            : undefined,
-          originalRunId: runId,
-          originalRun: runRecord,
-        });
+            task: runRecord.task,
+            lastHumanMessage: extractMessageText(lastHumanMessage),
+            configChangeHint: configChangeDetected
+              ? "\n\n[config changes from your previous run were already applied — do not re-modify openclaw.json or restart the gateway]"
+              : undefined,
+            originalRunId: runId,
+            originalRun: runRecord,
+          });
+        } finally {
+          sessionKeysWithRecoveryInFlight.delete(childSessionKey);
+        }
 
         if (resumeResult.resumed) {
           resumedSessionKeys.add(childSessionKey);

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -423,7 +423,6 @@ export async function recoverOrphanedSubagentSessions(params: {
         }
         sessionKeysWithRecoveryInFlight.add(childSessionKey);
 
-        let resumeResult: { resumed: boolean; error?: string };
         try {
           log.info(`found orphaned subagent session: ${childSessionKey} (run=${runId})`);
 
@@ -456,7 +455,7 @@ export async function recoverOrphanedSubagentSessions(params: {
           // We intentionally do NOT clear abortedLastRun before attempting
           // the resume — if callGateway fails (e.g. gateway still booting),
           // the flag stays true so the next restart can retry.
-          resumeResult = await resumeOrphanedSession({
+          const resumeResult = await resumeOrphanedSession({
             sessionKey: childSessionKey,
             task: runRecord.task,
             lastHumanMessage: extractMessageText(lastHumanMessage),
@@ -466,45 +465,49 @@ export async function recoverOrphanedSubagentSessions(params: {
             originalRunId: runId,
             originalRun: runRecord,
           });
+
+          if (resumeResult.resumed) {
+            resumedSessionKeys.add(childSessionKey);
+            // Only clear the aborted flag after confirmed successful resume.
+            // The in-flight guard stays claimed through this write — releasing
+            // it right after resumeOrphanedSession() returns would leave a
+            // window where a second scan reads the still-true abortedLastRun
+            // flag and double-resumes before this write lands.
+            try {
+              await updateSessionStore(storePath, (currentStore) => {
+                const current = currentStore[childSessionKey];
+                if (current) {
+                  current.abortedLastRun = false;
+                  markSubagentRecoveryAttempt({
+                    entry: current,
+                    now: Date.now(),
+                    runId,
+                    attempt: recoveryGate.nextAttempt,
+                  });
+                  current.updatedAt = Date.now();
+                  currentStore[childSessionKey] = current;
+                }
+              });
+            } catch (err) {
+              log.warn(
+                `resume succeeded but failed to update session store for ${childSessionKey}: ${String(err)}`,
+              );
+            }
+            result.recovered++;
+          } else {
+            // Flag stays as abortedLastRun=true so next restart can retry
+            log.warn(
+              `resume failed for ${childSessionKey}; abortedLastRun flag preserved for retry on next restart`,
+            );
+            result.failed++;
+            result.failedRuns.push({
+              runId,
+              childSessionKey,
+              error: resumeResult.error,
+            });
+          }
         } finally {
           sessionKeysWithRecoveryInFlight.delete(childSessionKey);
-        }
-
-        if (resumeResult.resumed) {
-          resumedSessionKeys.add(childSessionKey);
-          // Only clear the aborted flag after confirmed successful resume.
-          try {
-            await updateSessionStore(storePath, (currentStore) => {
-              const current = currentStore[childSessionKey];
-              if (current) {
-                current.abortedLastRun = false;
-                markSubagentRecoveryAttempt({
-                  entry: current,
-                  now: Date.now(),
-                  runId,
-                  attempt: recoveryGate.nextAttempt,
-                });
-                current.updatedAt = Date.now();
-                currentStore[childSessionKey] = current;
-              }
-            });
-          } catch (err) {
-            log.warn(
-              `resume succeeded but failed to update session store for ${childSessionKey}: ${String(err)}`,
-            );
-          }
-          result.recovered++;
-        } else {
-          // Flag stays as abortedLastRun=true so next restart can retry
-          log.warn(
-            `resume failed for ${childSessionKey}; abortedLastRun flag preserved for retry on next restart`,
-          );
-          result.failed++;
-          result.failedRuns.push({
-            runId,
-            childSessionKey,
-            error: resumeResult.error,
-          });
         }
       } catch (err) {
         const error = formatErrorMessage(err);

--- a/src/agents/subagent-registry-helpers.test.ts
+++ b/src/agents/subagent-registry-helpers.test.ts
@@ -68,6 +68,52 @@ describe("reconcileOrphanedRun", () => {
     expect(runs.has(entry.runId)).toBe(false);
     expect(resumedRuns.has(entry.runId)).toBe(false);
   });
+
+  it("is a safe no-op when invoked twice for the same run (concurrent resume + sweep triggers)", () => {
+    // The registry has no lock around orphan reconciliation: the sweep loop's
+    // inline orphan check and a directly-triggered resumeSubagentRun() call
+    // can both observe the same live entry reference and independently
+    // decide to reconcile it before either has run. Pin down that a second
+    // call — same object reference, same reason, later timestamp — does not
+    // re-stamp timing/outcome or throw, and leaves the map/set state stable.
+    vi.useFakeTimers();
+    vi.setSystemTime(4_000);
+    const entry = createRunEntry();
+    const runs = new Map([[entry.runId, entry]]);
+    const resumedRuns = new Set([entry.runId]);
+
+    const firstResult = reconcileOrphanedRun({
+      runId: entry.runId,
+      entry,
+      reason: "missing-session-id",
+      source: "resume",
+      runs,
+      resumedRuns,
+    });
+    expect(firstResult).toBe(true);
+    const outcomeAfterFirstCall = { ...entry.outcome };
+    const endedAtAfterFirstCall = entry.endedAt;
+
+    vi.setSystemTime(9_000);
+    resumedRuns.add(entry.runId);
+    let secondResult: boolean | undefined;
+    expect(() => {
+      secondResult = reconcileOrphanedRun({
+        runId: entry.runId,
+        entry,
+        reason: "missing-session-id",
+        source: "resume",
+        runs,
+        resumedRuns,
+      });
+    }).not.toThrow();
+
+    expect(secondResult).toBe(false);
+    expect(entry.endedAt).toBe(endedAtAfterFirstCall);
+    expect(entry.outcome).toEqual(outcomeAfterFirstCall);
+    expect(runs.has(entry.runId)).toBe(false);
+    expect(resumedRuns.has(entry.runId)).toBe(false);
+  });
 });
 
 describe("logAnnounceGiveUp", () => {

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -1445,6 +1445,12 @@ export function createSubagentRegistryLifecycleController(params: {
     suppressSessionEffects?: boolean;
     completionSnapshot?: { resultText: string | null; capturedAt: number };
     recoverInterrupted?: true;
+    /**
+     * Marks a sweeper-synthesized timeout (no provider/session evidence, only
+     * an expired deadline with no live run context). A real terminal result
+     * that already reached the registry under this same lock always wins.
+     */
+    isSyntheticTimeout?: true;
   };
 
   const completeSubagentRunAttempt = async (completeParams: CompleteSubagentRunParams) => {
@@ -1462,6 +1468,12 @@ export function createSubagentRegistryLifecycleController(params: {
       params.clearPendingLifecycleError(completeParams.runId);
       entry = params.runs.get(completeParams.runId);
       if (!entry) {
+        return;
+      }
+      if (completeParams.isSyntheticTimeout === true && typeof entry.endedAt === "number") {
+        // Whatever finalized this run first under the terminal lock — a real
+        // provider/session completion or an earlier finalize attempt — is
+        // canonical. A synthetic sweeper timeout must never clobber it.
         return;
       }
       const currentEntry = entry;

--- a/src/agents/subagent-registry-read.ts
+++ b/src/agents/subagent-registry-read.ts
@@ -4,6 +4,7 @@
  * Combines persisted snapshots with in-memory live runs for UI, announce, control, and recovery paths.
  */
 import { getAgentRunContext } from "../infra/agent-events.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
 import {
   buildSubagentRunReadIndexFromRuns,
@@ -15,6 +16,11 @@ import {
 } from "./subagent-registry-queries.js";
 import { getSubagentRunsSnapshotForRead } from "./subagent-registry-state.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import {
+  SUBAGENT_HEALTH_STALE_AFTER_MS,
+  classifySubagentHealth,
+  type SubagentHealth,
+} from "./subagent-health.js";
 import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
 
 export {
@@ -113,6 +119,50 @@ export function getSessionDisplaySubagentRunByChildSessionKey(
   }
 
   return getSubagentRunByChildSessionKey(key);
+}
+
+function getSubagentRunForTask(
+  task: TaskRecord,
+  runs: Map<string, SubagentRunRecord> = getSubagentRunsSnapshotForRead(subagentRuns),
+): SubagentRunRecord | null {
+  if (task.runtime !== "subagent") {
+    return null;
+  }
+  if (task.runId) {
+    const exact = runs.get(task.runId);
+    if (exact) {
+      return exact;
+    }
+  }
+  return task.childSessionKey
+    ? getSubagentRunByChildSessionKeyFromRuns(runs, task.childSessionKey)
+    : null;
+}
+
+export function createSubagentHealthResolver(
+  now = Date.now(),
+): (task: TaskRecord) => SubagentHealth | undefined {
+  const runs = getSubagentRunsSnapshotForRead(subagentRuns);
+  return (task) => {
+    const run = getSubagentRunForTask(task, runs);
+    if (!run) {
+      return undefined;
+    }
+    return classifySubagentHealth({
+      run,
+      task,
+      now,
+      staleAfterMs: SUBAGENT_HEALTH_STALE_AFTER_MS,
+    });
+  };
+}
+
+/** Returns the current diagnostic health for a subagent-backed task. */
+export function resolveSubagentHealthForTask(
+  task: TaskRecord,
+  now = Date.now(),
+): SubagentHealth | undefined {
+  return createSubagentHealthResolver(now)(task);
 }
 
 /** Returns the most recently created run for a child session from readable registry state. */

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -5339,6 +5339,111 @@ describe("subagent registry seam flow", () => {
     expect(run?.endedAt).toBe(startedAt + 2_000);
   });
 
+  it("preserves an already-finalized explicit timeout over a late real completion arriving through the synthetic-timeout call shape", async () => {
+    const now = Date.parse("2026-03-24T12:00:00Z");
+    const startedAt = now - 60_000;
+    const endedAt = startedAt + 5_000;
+    const runId = "run-sweep-synthetic-timeout-then-late-ok";
+    // Construct the state the synthetic-timeout branch itself produces once
+    // fully processed (outcome: timeout, past deadline, cleanup/delivery
+    // done) directly, rather than racing the sweeper's detached cleanup tail
+    // to completion — the prior test already proves the synthetic branch
+    // issues this exact completion shape (reason: COMPLETE, outcome:
+    // timeout, triggerCleanup: true) through the shared completion pipeline.
+    mod.addSubagentRunForTests({
+      runId,
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "synthetic timeout already fully finalized",
+      cleanup: "keep",
+      createdAt: startedAt,
+      startedAt,
+      endedAt,
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      outcome: { status: "timeout" },
+      runTimeoutSeconds: 5,
+      cleanupHandled: true,
+      cleanupCompletedAt: endedAt,
+      delivery: { status: "delivered", deliveredAt: endedAt, announcedAt: endedAt },
+      execution: {
+        status: "terminal",
+        startedAt,
+        endedAt,
+        outcome: { status: "timeout" },
+      },
+    });
+
+    // A real completion for the same run arrives after the timeout has
+    // already been fully processed (cleanup/delivery done) — this must be
+    // rejected by the pre-existing shouldPreservePublishedExplicitRunTimeout
+    // guard, exactly like the already-tested live-path equivalent ("keeps
+    // explicit run timeout terminal when late lifecycle success arrives").
+    await mod.completeSubagentRunForTests({
+      runId,
+      startedAt,
+      endedAt: now + 5_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      sendFarewell: true,
+      triggerCleanup: true,
+    });
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === runId);
+    expectRecordFields(
+      run?.outcome,
+      { status: "timeout" },
+      "finalized synthetic timeout must outlive a late real completion",
+    );
+    expect(run?.endedAt).toBe(endedAt);
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
+  it("rescues an entry with endedAt set but outcome incomplete via cleanup_pending, not synthetic timeout", async () => {
+    const now = Date.parse("2026-03-24T12:00:00Z");
+    const startedAt = now - 60_000;
+    const runId = "run-sweep-endedat-without-outcome";
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+    // This shape (endedAt set, outcome absent) should not occur through the
+    // normal completion pipeline — endedAt and outcome are always written
+    // together, in the same synchronous section, under the terminal lock.
+    // The sweeper's outer "typeof entry.endedAt !== 'number'" precondition
+    // does exclude this entry from the synthetic-timeout branch (and from
+    // the generic still-running/orphan branch below it) — but it is not
+    // left stuck: classifyHealthForSweep reports it as cleanup_pending
+    // (ended, cleanup === "keep", no archiveAtMs yet), and the pre-existing
+    // resume_cleanup branch (unrelated to this change) picks it up anyway.
+    mod.addSubagentRunForTests({
+      runId,
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "endedAt set without a matching outcome",
+      cleanup: "keep",
+      createdAt: startedAt,
+      startedAt,
+      endedAt: startedAt + 500,
+      runTimeoutSeconds: 5,
+      execution: { status: "running" },
+    });
+
+    await mod.testing.sweepOnceForTests();
+    await waitForFast(() => expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1));
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === runId);
+    expect(run?.endedAt).toBe(startedAt + 500);
+  });
+
   it("suspends retry-budgeted successful keep-mode completion deliveries during resume", async () => {
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
       runs: Map<string, unknown>;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -5200,6 +5200,87 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
   });
 
+  it("finalizes a subagent as timed out once its deadline passes with no live run context", async () => {
+    const now = Date.parse("2026-03-24T12:00:00Z");
+    const startedAt = now - 60_000;
+    const runId = "run-sweep-finalize-timeout";
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+    mod.addSubagentRunForTests({
+      runId,
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "explicit timeout with no live context",
+      cleanup: "keep",
+      createdAt: startedAt,
+      startedAt,
+      runTimeoutSeconds: 5,
+      execution: { status: "running" },
+    });
+
+    await mod.testing.sweepOnceForTests();
+
+    await waitForFast(() => expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1));
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "swept finalize timeout"),
+      { childRunId: runId },
+      "swept finalize timeout",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      { status: "timeout" },
+      "swept finalize timeout outcome",
+    );
+  });
+
+  it("honors a persisted session completion instead of forcing a timeout when both race", async () => {
+    const now = Date.parse("2026-03-24T12:00:00Z");
+    const startedAt = now - 60_000;
+    const persistedEndedAt = startedAt + 2_000;
+    const runId = "run-sweep-timeout-race-completion";
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: persistedEndedAt,
+        status: "done",
+        startedAt,
+        endedAt: persistedEndedAt,
+      },
+    });
+    mod.addSubagentRunForTests({
+      runId,
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "late persisted completion beats synthetic timeout",
+      cleanup: "keep",
+      createdAt: startedAt,
+      startedAt,
+      runTimeoutSeconds: 5,
+      execution: { status: "running" },
+    });
+
+    await mod.testing.sweepOnceForTests();
+
+    await waitForFast(() => expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1));
+    const announceParams = expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "swept timeout race completion"),
+      { childRunId: runId },
+      "swept timeout race completion",
+    );
+    expectRecordFields(
+      announceParams.outcome,
+      { status: "ok", endedAt: persistedEndedAt },
+      "swept timeout race completion outcome",
+    );
+  });
+
   it("suspends retry-budgeted successful keep-mode completion deliveries during resume", async () => {
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
       runs: Map<string, unknown>;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -5070,6 +5070,53 @@ describe("subagent registry seam flow", () => {
     ).toBeUndefined();
   });
 
+  it("retries failed keep-mode completion delivery during sweep", async () => {
+    const now = Date.parse("2026-03-24T12:00:00Z");
+    const runId = "run-sweep-retry-delivery";
+    mod.addSubagentRunForTests({
+      runId,
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "retry failed completion delivery",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+      createdAt: now - 10_000,
+      startedAt: now - 9_000,
+      endedAt: now - 1_000,
+      outcome: { status: "ok" },
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      completion: { required: true, resultText: "finished", capturedAt: now - 1_000 },
+      delivery: {
+        status: "failed",
+        createdAt: now - 1_000,
+        lastAttemptAt: now - 1_000,
+        attemptCount: 1,
+        lastError: "delivery failed",
+      },
+      execution: {
+        status: "terminal",
+        startedAt: now - 9_000,
+        endedAt: now - 1_000,
+        outcome: { status: "ok" },
+      },
+    });
+
+    await mod.testing.sweepOnceForTests();
+
+    await waitForFast(() => expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1));
+    expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "swept delivery retry"),
+      {
+        childRunId: runId,
+        childSessionKey: "agent:main:subagent:child",
+        requesterSessionKey: "agent:main:main",
+        roundOneReply: "finished",
+      },
+      "swept delivery retry",
+    );
+  });
+
   it("suspends retry-budgeted successful keep-mode completion deliveries during resume", async () => {
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
       runs: Map<string, unknown>;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -5117,6 +5117,43 @@ describe("subagent registry seam flow", () => {
     );
   });
 
+  it("resumes stale keep-mode cleanup during sweep", async () => {
+    const now = Date.parse("2026-03-24T12:00:00Z");
+    const runId = "run-sweep-resume-cleanup";
+    mod.addSubagentRunForTests({
+      runId,
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "resume stale cleanup",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+      createdAt: now - 120_000,
+      startedAt: now - 119_000,
+      endedAt: now - 90_000,
+      outcome: { status: "ok" },
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      completion: { required: true, resultText: "finished", capturedAt: now - 90_000 },
+      delivery: { status: "delivered", deliveredAt: now - 89_000, announcedAt: now - 89_000 },
+      execution: {
+        status: "terminal",
+        startedAt: now - 119_000,
+        endedAt: now - 90_000,
+        outcome: { status: "ok" },
+      },
+    });
+
+    await mod.testing.sweepOnceForTests();
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === runId);
+      expect(run?.cleanupCompletedAt).toBeTypeOf("number");
+    });
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
   it("suspends retry-budgeted successful keep-mode completion deliveries during resume", async () => {
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
       runs: Map<string, unknown>;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -5281,6 +5281,64 @@ describe("subagent registry seam flow", () => {
     );
   });
 
+  it("does not let a synthetic sweeper timeout overwrite a real completion won under the same lock", async () => {
+    const now = Date.parse("2026-03-24T12:00:00Z");
+    const startedAt = now - 60_000;
+    const runId = "run-sweep-timeout-vs-real-completion-race";
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+    mod.addSubagentRunForTests({
+      runId,
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "real completion must win the terminal lock over a synthetic timeout",
+      cleanup: "keep",
+      createdAt: startedAt,
+      startedAt,
+      runTimeoutSeconds: 5,
+      execution: { status: "running" },
+    });
+
+    // Both calls are issued synchronously, back to back, with no await in
+    // between. The real completion claims the terminal completion lock
+    // first (registering it synchronously before its own first await), so
+    // the sweeper's synthetic timeout call — issued a moment later while
+    // entry.endedAt is still unset — synchronously passes its own
+    // precondition check and then queues behind the real completion's lock.
+    // Only once the real completion resumes, writes entry.endedAt/outcome,
+    // and releases the lock does the queued synthetic call resume and find
+    // the run already terminal.
+    const realCompletion = mod.completeSubagentRunForTests({
+      runId,
+      startedAt,
+      endedAt: startedAt + 2_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      sendFarewell: true,
+      triggerCleanup: true,
+    });
+    const sweep = mod.testing.sweepOnceForTests();
+
+    await realCompletion;
+    await sweep;
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === runId);
+    expectRecordFields(
+      run?.outcome,
+      { status: "ok", endedAt: startedAt + 2_000 },
+      "real completion outcome must survive the queued synthetic timeout",
+    );
+    expect(run?.endedAt).toBe(startedAt + 2_000);
+  });
+
   it("suspends retry-budgeted successful keep-mode completion deliveries during resume", async () => {
     mocks.restoreSubagentRunsFromDisk.mockImplementation(((params: {
       runs: Map<string, unknown>;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -5117,6 +5117,52 @@ describe("subagent registry seam flow", () => {
     );
   });
 
+  it("retries stale pending keep-mode completion delivery during sweep", async () => {
+    const now = Date.parse("2026-03-24T12:00:00Z");
+    const runId = "run-sweep-retry-pending-delivery";
+    mod.addSubagentRunForTests({
+      runId,
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "retry stale pending delivery",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+      createdAt: now - 120_000,
+      startedAt: now - 119_000,
+      endedAt: now - 90_000,
+      outcome: { status: "ok" },
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      completion: { required: true, resultText: "finished", capturedAt: now - 90_000 },
+      delivery: {
+        status: "pending",
+        createdAt: now - 90_000,
+        lastAttemptAt: now - 90_000,
+        attemptCount: 1,
+      },
+      execution: {
+        status: "terminal",
+        startedAt: now - 119_000,
+        endedAt: now - 90_000,
+        outcome: { status: "ok" },
+      },
+    });
+
+    await mod.testing.sweepOnceForTests();
+
+    await waitForFast(() => expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1));
+    expectRecordFields(
+      getMockCallArg(mocks.runSubagentAnnounceFlow, 0, 0, "swept pending delivery retry"),
+      {
+        childRunId: runId,
+        childSessionKey: "agent:main:subagent:child",
+        requesterSessionKey: "agent:main:main",
+        roundOneReply: "finished",
+      },
+      "swept pending delivery retry",
+    );
+  });
+
   it("resumes stale keep-mode cleanup during sweep", async () => {
     const now = Date.parse("2026-03-24T12:00:00Z");
     const runId = "run-sweep-resume-cleanup";

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../tasks/detached-task-runtime.js";
 import { resetTaskFlowRegistryForTests } from "../tasks/task-flow-registry.js";
 import { resetTaskRegistryForTests } from "../tasks/task-registry.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { findTaskByRunIdForStatus } from "../tasks/task-status-access.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
@@ -322,6 +323,48 @@ describe("subagent registry seam flow", () => {
     mod.testing.setDepsForTest();
     mod.resetSubagentRegistryForTests({ persist: false });
     vi.useRealTimers();
+  });
+
+  it("classifies subagent health for sweeper observation", () => {
+    const now = Date.now();
+    const task: TaskRecord = {
+      taskId: "task-health",
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:child",
+      runId: "run-health",
+      task: "observe health",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "done_only",
+      createdAt: now - 120_000,
+      startedAt: now - 119_000,
+      lastEventAt: now - 120_000,
+    };
+
+    const health = mod.testing.classifyHealthForSweepForTests({
+      run: {
+        runId: "run-health",
+        childSessionKey: "agent:main:subagent:child",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "observe health",
+        cleanup: "keep",
+        createdAt: now - 120_000,
+        startedAt: now - 119_000,
+        execution: { status: "running" },
+      },
+      task,
+      now,
+    });
+
+    expect(health).toMatchObject({
+      status: "stale",
+      retryable: true,
+      nextAction: "recover_orphan",
+    });
   });
 
   it("keeps a sweeper archive mutation root-admitted until deletion settles", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1194,6 +1194,14 @@ async function sweepSubagentRuns() {
         }
         continue;
       }
+      const deliveryHealth = classifyHealthForSweep({ run: entry, now });
+      if (
+        deliveryHealth.status === "delivery_failed" &&
+        deliveryHealth.nextAction === "retry_delivery"
+      ) {
+        resumeSubagentRun(runId);
+        continue;
+      }
       if (typeof entry.endedAt !== "number") {
         const hasLiveRunContext = Boolean(getAgentRunContext(runId));
         const activeAgeMs = now - (entry.startedAt ?? entry.createdAt);

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1203,6 +1203,14 @@ async function sweepSubagentRuns() {
         continue;
       }
       if (
+        typeof entry.endedAt === "number" &&
+        deliveryHealth.status === "delivery_pending" &&
+        deliveryHealth.nextAction === "retry_delivery"
+      ) {
+        resumeSubagentRun(runId);
+        continue;
+      }
+      if (
         deliveryHealth.status === "cleanup_pending" &&
         deliveryHealth.nextAction === "resume_cleanup" &&
         entry.cleanup === "keep" &&

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1202,6 +1202,15 @@ async function sweepSubagentRuns() {
         resumeSubagentRun(runId);
         continue;
       }
+      if (
+        deliveryHealth.status === "cleanup_pending" &&
+        deliveryHealth.nextAction === "resume_cleanup" &&
+        entry.cleanup === "keep" &&
+        !entry.archiveAtMs
+      ) {
+        resumeSubagentRun(runId);
+        continue;
+      }
       if (typeof entry.endedAt !== "number") {
         const hasLiveRunContext = Boolean(getAgentRunContext(runId));
         const activeAgeMs = now - (entry.startedAt ?? entry.createdAt);

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1195,6 +1195,12 @@ async function sweepSubagentRuns() {
         continue;
       }
       const deliveryHealth = classifyHealthForSweep({ run: entry, now });
+      // Subagent health actions consumed by the sweeper are intentionally narrow:
+      // - retry failed or stale terminal delivery through the existing resume path;
+      // - resume stale keep-mode cleanup that has no archive/delete owner.
+      // Higher-risk actions remain observational here: timeouts can race with
+      // persisted session completion, orphan recovery has its own scheduler, and
+      // cancellation reconciliation owns a bounded provider/task evidence window.
       if (
         deliveryHealth.status === "delivery_failed" &&
         deliveryHealth.nextAction === "retry_delivery"

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -58,7 +58,11 @@ import {
   emitSubagentEndedHookOnce,
   resolveLifecycleOutcomeFromRunOutcome,
 } from "./subagent-registry-completion.js";
-import { classifySubagentHealth, type SubagentHealth } from "./subagent-health.js";
+import {
+  SUBAGENT_HEALTH_STALE_AFTER_MS,
+  classifySubagentHealth,
+  type SubagentHealth,
+} from "./subagent-health.js";
 import {
   ANNOUNCE_EXPIRY_MS,
   MAX_ANNOUNCE_RETRY_COUNT,
@@ -249,7 +253,7 @@ const SESSION_RUN_TTL_MS = 5 * 60_000; // 5 minutes
 /** Absolute TTL for orphaned pendingLifecycleError / pendingLifecycleTimeout entries. */
 const PENDING_LIFECYCLE_TERMINAL_TTL_MS = 5 * 60_000; // 5 minutes
 /** Grace period before treating a "running" subagent without a live run context as stale. */
-const STALE_ACTIVE_SUBAGENT_GRACE_MS = process.env.OPENCLAW_TEST_FAST === "1" ? 1_000 : 60_000;
+const STALE_ACTIVE_SUBAGENT_GRACE_MS = SUBAGENT_HEALTH_STALE_AFTER_MS;
 const SUSPENDED_DELIVERY_CRON_EXPIRY_MS = 2 * 60 * 60_000;
 const SUSPENDED_DELIVERY_SUBAGENT_EXPIRY_MS = 6 * 60 * 60_000;
 const SUSPENDED_DELIVERY_INTERACTIVE_EXPIRY_MS = 24 * 60 * 60_000;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -504,6 +504,12 @@ type CompleteSubagentRunParams = {
   startedAt?: number;
   suppressSessionEffects?: boolean;
   recoverInterrupted?: true;
+  /**
+   * Marks a sweeper-synthesized timeout (no provider/session evidence, only
+   * an expired deadline with no live run context). A real terminal result
+   * that already reached the registry under this same lock always wins.
+   */
+  isSyntheticTimeout?: true;
 };
 
 async function completeSubagentRunWithRecoveryAttempt(
@@ -1262,6 +1268,7 @@ async function sweepSubagentRuns() {
                 sendFarewell: true,
                 accountId: entry.requesterOrigin?.accountId,
                 triggerCleanup: true,
+                isSyntheticTimeout: true,
               },
           completion ? "sweeper-timeout-session-completion" : "sweeper-finalize-timeout",
         );
@@ -1894,6 +1901,10 @@ export const testing = {
 
 export function addSubagentRunForTests(entry: SubagentRunRecord) {
   subagentRuns.set(entry.runId, entry);
+}
+
+export async function completeSubagentRunForTests(params: CompleteSubagentRunParams) {
+  await completeSubagentRunWithRecovery(params, "test-direct-completion");
 }
 
 export function releaseSubagentRun(runId: string) {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1197,10 +1197,13 @@ async function sweepSubagentRuns() {
       const deliveryHealth = classifyHealthForSweep({ run: entry, now });
       // Subagent health actions consumed by the sweeper are intentionally narrow:
       // - retry failed or stale terminal delivery through the existing resume path;
-      // - resume stale keep-mode cleanup that has no archive/delete owner.
-      // Higher-risk actions remain observational here: timeouts can race with
-      // persisted session completion, orphan recovery has its own scheduler, and
-      // cancellation reconciliation owns a bounded provider/task evidence window.
+      // - resume stale keep-mode cleanup that has no archive/delete owner;
+      // - finalize an explicit run-timeout deadline, but only once the live run
+      //   context is gone (a still-connected child may legitimately finish late)
+      //   and only after checking for a persisted completion that already arrived.
+      // Higher-risk actions remain observational here: orphan recovery has its own
+      // scheduler, and cancellation reconciliation owns a bounded provider/task
+      // evidence window.
       if (
         deliveryHealth.status === "delivery_failed" &&
         deliveryHealth.nextAction === "retry_delivery"
@@ -1223,6 +1226,46 @@ async function sweepSubagentRuns() {
         !entry.archiveAtMs
       ) {
         resumeSubagentRun(runId);
+        continue;
+      }
+      if (
+        typeof entry.endedAt !== "number" &&
+        deliveryHealth.status === "timed_out" &&
+        deliveryHealth.nextAction === "finalize_timeout" &&
+        !getAgentRunContext(runId)
+      ) {
+        const sessionEntry = loadSubagentSessionEntry({
+          childSessionKey: entry.childSessionKey,
+          storeCache,
+        });
+        const completion = resolveCompletionFromSessionEntry(sessionEntry, now, {
+          notBeforeMs: entry.startedAt ?? entry.createdAt,
+        });
+        await completeSubagentRunWithRecovery(
+          completion
+            ? {
+                runId,
+                startedAt: completion.startedAt,
+                endedAt: completion.endedAt,
+                outcome: completion.outcome,
+                reason: completion.reason,
+                sendFarewell: true,
+                accountId: entry.requesterOrigin?.accountId,
+                triggerCleanup: true,
+              }
+            : {
+                runId,
+                startedAt: entry.startedAt,
+                endedAt: now,
+                outcome: { status: "timeout" },
+                reason: SUBAGENT_ENDED_REASON_COMPLETE,
+                sendFarewell: true,
+                accountId: entry.requesterOrigin?.accountId,
+                triggerCleanup: true,
+              },
+          completion ? "sweeper-timeout-session-completion" : "sweeper-finalize-timeout",
+        );
+        mutated = true;
         continue;
       }
       if (typeof entry.endedAt !== "number") {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -58,6 +58,7 @@ import {
   emitSubagentEndedHookOnce,
   resolveLifecycleOutcomeFromRunOutcome,
 } from "./subagent-registry-completion.js";
+import { classifySubagentHealth, type SubagentHealth } from "./subagent-health.js";
 import {
   ANNOUNCE_EXPIRY_MS,
   MAX_ANNOUNCE_RETRY_COUNT,
@@ -319,6 +320,44 @@ function findSubagentTaskForRun(entry: SubagentRunRecord) {
       entry.taskRunId === undefined &&
       typeof entry.sessionStartedAt === "number" &&
       entry.sessionStartedAt < entry.createdAt,
+  });
+}
+
+function classifyHealthForSweep(params: {
+  run: SubagentRunRecord;
+  task?: TaskRecord;
+  now: number;
+}): SubagentHealth {
+  return classifySubagentHealth({
+    run: params.run,
+    task: params.task,
+    now: params.now,
+    staleAfterMs: STALE_ACTIVE_SUBAGENT_GRACE_MS,
+  });
+}
+
+function observeSubagentHealthDuringSweep(runId: string, entry: SubagentRunRecord, now: number) {
+  if (!log.isEnabled("debug")) {
+    return;
+  }
+  const taskResolution = findSubagentTaskForRun(entry);
+  const health = classifyHealthForSweep({
+    run: entry,
+    task: taskResolution.task,
+    now,
+  });
+  if (health.status === "active" || health.status === "terminal") {
+    return;
+  }
+  log.debug("subagent health observed during sweep", {
+    runId,
+    childSessionKey: entry.childSessionKey,
+    status: health.status,
+    nextAction: health.nextAction,
+    retryable: health.retryable,
+    reason: health.reason,
+    taskLookup: taskResolution.lookup,
+    taskId: taskResolution.task?.taskId,
   });
 }
 
@@ -1136,6 +1175,7 @@ async function sweepSubagentRuns() {
       });
     }
     for (const [runId, entry] of subagentRuns.entries()) {
+      observeSubagentHealthDuringSweep(runId, entry, now);
       if (isSuspendedPendingFinalDelivery(entry)) {
         const suspendedAgeMs = now - (entry.delivery?.suspendedAt ?? now);
         const expired = suspendedAgeMs >= resolveSuspendedDeliveryExpiryMs(entry);
@@ -1763,6 +1803,7 @@ export const testing = {
   async runSweeperTickForTests() {
     await runSubagentSweep();
   },
+  classifyHealthForSweepForTests: classifyHealthForSweep,
   setDepsForTest(overrides?: Partial<SubagentRegistryDeps>) {
     subagentRegistryDeps = overrides
       ? {

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -5,6 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { saveCronStore } from "../cron/store.js";
 import type { RuntimeEnv } from "../runtime.js";
+import {
+  addSubagentRunForTests,
+  resetSubagentRegistryForTests,
+} from "../agents/subagent-registry.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { resetDetachedTaskLifecycleRuntimeForTests } from "../tasks/detached-task-runtime.js";
 import {
@@ -97,6 +101,7 @@ async function withTaskCommandStateDir(
       resetTaskRegistryDeliveryRuntimeForTests();
       resetTaskRegistryForTests({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
+      resetSubagentRegistryForTests({ persist: false });
       closeOpenClawAgentDatabasesForTest();
       try {
         await run(state);
@@ -108,6 +113,7 @@ async function withTaskCommandStateDir(
         resetTaskRegistryDeliveryRuntimeForTests();
         resetTaskRegistryForTests({ persist: false });
         resetTaskFlowRegistryForTests({ persist: false });
+        resetSubagentRegistryForTests({ persist: false });
         closeOpenClawAgentDatabasesForTest();
       }
     },
@@ -128,6 +134,7 @@ describe("tasks commands", () => {
     resetTaskRegistryDeliveryRuntimeForTests();
     resetTaskRegistryForTests({ persist: false });
     resetTaskFlowRegistryForTests({ persist: false });
+    resetSubagentRegistryForTests({ persist: false });
     closeOpenClawAgentDatabasesForTest();
     mocks.callGateway.mockReset();
   });
@@ -222,6 +229,82 @@ describe("tasks commands", () => {
         status: null,
         tasks: [jsonRoundTrip(task)],
       });
+    });
+  });
+
+  it("includes subagent health summary in task list JSON and text output", async () => {
+    await withTaskCommandStateDir(async () => {
+      const now = Date.now();
+      createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:stale-cli",
+        runId: "run-health-stale-cli",
+        status: "running",
+        task: "Stale CLI subagent",
+        deliveryStatus: "pending",
+        lastEventAt: now - 120_000,
+      });
+      addSubagentRunForTests({
+        runId: "run-health-stale-cli",
+        childSessionKey: "agent:main:subagent:stale-cli",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "Stale CLI subagent",
+        cleanup: "keep",
+        createdAt: now - 120_000,
+        startedAt: now - 119_000,
+        execution: { status: "running" },
+      });
+      createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:delivery-cli",
+        runId: "run-health-delivery-cli",
+        status: "succeeded",
+        task: "Delivery failed CLI subagent",
+        deliveryStatus: "failed",
+        lastEventAt: now - 10_000,
+      });
+      addSubagentRunForTests({
+        runId: "run-health-delivery-cli",
+        childSessionKey: "agent:main:subagent:delivery-cli",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "Delivery failed CLI subagent",
+        cleanup: "keep",
+        createdAt: now - 10_000,
+        startedAt: now - 9_000,
+        endedAt: now - 1_000,
+        outcome: { status: "ok" },
+        delivery: { status: "failed", lastError: "send failed" },
+        execution: { status: "terminal", endedAt: now - 1_000, outcome: { status: "ok" } },
+      });
+
+      const jsonRuntime = createRuntime();
+      await tasksListCommand({ json: true }, jsonRuntime);
+
+      expect(readFirstJsonLog(jsonRuntime)).toMatchObject({
+        subagentHealthSummary: {
+          total: 2,
+          retryable: 2,
+          byStatus: { stale: 1, delivery_failed: 1 },
+          byNextAction: { recover_orphan: 1, retry_delivery: 1 },
+        },
+      });
+
+      const textRuntime = createRuntime();
+      await tasksListCommand({}, textRuntime);
+
+      const output = vi
+        .mocked(textRuntime.log)
+        .mock.calls.map(([line]) => String(line))
+        .join("\n");
+      expect(output).toContain(
+        "Subagent health: 2 observed · 2 retryable · stale 1 · delivery_failed 1 · recover_orphan 1 · retry_delivery 1",
+      );
     });
   });
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -5,6 +5,8 @@ import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coer
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
+import type { SubagentHealth } from "../agents/subagent-health.js";
+import { createSubagentHealthResolver } from "../agents/subagent-registry-read.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { formatLookupMiss } from "../cli/error-format.js";
 import { getRuntimeConfig } from "../config/config.js";
@@ -55,6 +57,25 @@ const DELIVERY_PAD = 14;
 const ID_PAD = 10;
 const RUN_PAD = 10;
 const SESSION_REGISTRY_RETENTION_MS = 7 * 24 * 60 * 60_000;
+const SUBAGENT_HEALTH_STATUS_ORDER = [
+  "active",
+  "stale",
+  "timed_out",
+  "delivery_pending",
+  "delivery_failed",
+  "cleanup_pending",
+  "orphaned",
+  "cancel_reconciling",
+  "terminal",
+] as const;
+const SUBAGENT_HEALTH_NEXT_ACTION_ORDER = [
+  "recover_orphan",
+  "finalize_timeout",
+  "retry_delivery",
+  "resume_cleanup",
+  "wait_cancel_reconciliation",
+  "none",
+] as const;
 
 const info = theme.info;
 
@@ -272,6 +293,56 @@ function formatTaskListSummary(tasks: TaskRecord[]) {
   return `${summary.byStatus.queued} queued · ${summary.byStatus.running} running · ${summary.failures} issues`;
 }
 
+type TaskSubagentHealthSummary = {
+  total: number;
+  retryable: number;
+  byStatus: Partial<Record<SubagentHealth["status"], number>>;
+  byNextAction: Partial<Record<SubagentHealth["nextAction"], number>>;
+};
+
+function buildTaskSubagentHealthSummary(
+  tasks: TaskRecord[],
+  resolveSubagentHealth: ReturnType<typeof createSubagentHealthResolver>,
+): TaskSubagentHealthSummary | undefined {
+  const summary: TaskSubagentHealthSummary = {
+    total: 0,
+    retryable: 0,
+    byStatus: {},
+    byNextAction: {},
+  };
+  for (const task of tasks) {
+    const health = resolveSubagentHealth(task);
+    if (!health) {
+      continue;
+    }
+    summary.total += 1;
+    if (health.retryable) {
+      summary.retryable += 1;
+    }
+    summary.byStatus[health.status] = (summary.byStatus[health.status] ?? 0) + 1;
+    summary.byNextAction[health.nextAction] =
+      (summary.byNextAction[health.nextAction] ?? 0) + 1;
+  }
+  return summary.total > 0 ? summary : undefined;
+}
+
+function formatTaskSubagentHealthSummary(summary: TaskSubagentHealthSummary): string {
+  const statusParts = SUBAGENT_HEALTH_STATUS_ORDER.flatMap((status) => {
+    const count = summary.byStatus[status];
+    return count ? [`${status} ${count}`] : [];
+  });
+  const actionParts = SUBAGENT_HEALTH_NEXT_ACTION_ORDER.flatMap((nextAction) => {
+    const count = summary.byNextAction[nextAction];
+    return count ? [`${nextAction} ${count}`] : [];
+  });
+  return [
+    `${summary.total} observed`,
+    `${summary.retryable} retryable`,
+    ...statusParts,
+    ...actionParts,
+  ].join(" · ");
+}
+
 function formatAgeMs(ageMs: number | undefined): string {
   if (typeof ageMs !== "number" || ageMs < 1000) {
     return "fresh";
@@ -360,6 +431,8 @@ export async function tasksListCommand(
     }
     return true;
   });
+  const resolveSubagentHealth = createSubagentHealthResolver();
+  const subagentHealthSummary = buildTaskSubagentHealthSummary(tasks, resolveSubagentHealth);
 
   if (opts.json) {
     runtime.log(
@@ -368,6 +441,7 @@ export async function tasksListCommand(
           count: tasks.length,
           runtime: runtimeFilter ?? null,
           status: statusFilter ?? null,
+          subagentHealthSummary,
           tasks,
         },
         null,
@@ -379,6 +453,9 @@ export async function tasksListCommand(
 
   runtime.log(info(`Background tasks: ${tasks.length}`));
   runtime.log(info(`Task pressure: ${formatTaskListSummary(tasks)}`));
+  if (subagentHealthSummary) {
+    runtime.log(info(`Subagent health: ${formatTaskSubagentHealthSummary(subagentHealthSummary)}`));
+  }
   if (runtimeFilter) {
     runtime.log(info(`Runtime filter: ${runtimeFilter}`));
   }

--- a/src/gateway/server-methods/task-summary.ts
+++ b/src/gateway/server-methods/task-summary.ts
@@ -1,6 +1,10 @@
 // Public task summaries keep task-registry internals and unbounded status text
 // out of gateway responses and events.
 import type { TaskSummary } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  createSubagentHealthResolver,
+  resolveSubagentHealthForTask,
+} from "../../agents/subagent-registry-read.js";
 import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
 import {
   TASK_STATUS_DETAIL_MAX_CHARS,
@@ -9,6 +13,9 @@ import {
 } from "../../tasks/task-status.js";
 
 type TaskLedgerStatus = TaskSummary["status"];
+type MapTaskSummaryOptions = {
+  resolveSubagentHealth?: ReturnType<typeof createSubagentHealthResolver>;
+};
 
 const TASK_STATUS_TO_LEDGER_STATUS: Record<TaskStatus, TaskLedgerStatus> = {
   queued: "queued",
@@ -40,10 +47,12 @@ function sanitizeOptionalTaskText(
   return sanitized || undefined;
 }
 
-export function mapTaskSummary(task: TaskRecord): TaskSummary {
+export function mapTaskSummary(task: TaskRecord, options: MapTaskSummaryOptions = {}): TaskSummary {
   const progressSummary = sanitizeOptionalTaskText(task.progressSummary);
   const terminalSummary = sanitizeOptionalTaskText(task.terminalSummary, { errorContext: true });
   const error = sanitizeOptionalTaskText(task.error, { errorContext: true });
+  const subagentHealth =
+    options.resolveSubagentHealth?.(task) ?? resolveSubagentHealthForTask(task);
   return {
     id: task.taskId,
     taskId: task.taskId,
@@ -66,5 +75,6 @@ export function mapTaskSummary(task: TaskRecord): TaskSummary {
     ...(progressSummary ? { progressSummary } : {}),
     ...(terminalSummary ? { terminalSummary } : {}),
     ...(error ? { error } : {}),
+    ...(subagentHealth ? { subagentHealth } : {}),
   };
 }

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -18,6 +18,10 @@ import {
 import { saveTaskRegistryStateToSqlite } from "../../tasks/task-registry.store.sqlite.js";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
+import {
+  addSubagentRunForTests,
+  resetSubagentRegistryForTests,
+} from "../../agents/subagent-registry.js";
 import { tasksHandlers } from "./tasks.js";
 import type { RespondFn } from "./types.js";
 
@@ -59,6 +63,7 @@ beforeEach(async () => {
 afterEach(async () => {
   resetTaskRegistryControlRuntimeForTests();
   resetTaskRegistryForTests();
+  resetSubagentRegistryForTests({ persist: false });
   stateDirEnvSnapshot.restore();
   await fs.rm(stateDir, { recursive: true, force: true });
 });
@@ -263,6 +268,48 @@ describe("tasks gateway handlers", () => {
 
     const workerView = await runTaskHandler("tasks.list", { agentId: "worker" });
     expect(workerView.payload?.tasks?.map((task) => task.taskId)).toEqual([workerTask.taskId]);
+  });
+
+  it("includes subagent health in task list and get summaries", async () => {
+    const now = Date.now();
+    const task = createTaskRecord({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:child-health",
+      runId: "run-health-visible",
+      task: "Observe subagent health",
+      status: "running",
+      deliveryStatus: "pending",
+      lastEventAt: now - 120_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-health-visible",
+      childSessionKey: "agent:main:subagent:child-health",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "Observe subagent health",
+      cleanup: "keep",
+      createdAt: now - 120_000,
+      startedAt: now - 119_000,
+      execution: { status: "running" },
+    });
+
+    const list = await runTaskHandler("tasks.list", { agentId: "main" });
+    const listedTask = list.payload?.tasks?.find((item) => item.taskId === task.taskId);
+    expect(listedTask?.subagentHealth).toMatchObject({
+      status: "stale",
+      retryable: true,
+      nextAction: "recover_orphan",
+    });
+
+    const { payload } = await getTaskPayload(task.taskId);
+    expect(payload?.task?.subagentHealth).toMatchObject({
+      status: "stale",
+      retryable: true,
+      nextAction: "recover_orphan",
+    });
   });
 
   it("gets completed tasks with stable completed status", async () => {

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -31,6 +31,7 @@ const killSubagentRunAdminMock = vi.fn();
 type TaskResponsePayload = {
   tasks?: Array<Record<string, unknown>>;
   task?: Record<string, unknown>;
+  subagentHealthSummary?: Record<string, unknown>;
   found?: boolean;
   cancelled?: boolean;
   nextCursor?: string;
@@ -309,6 +310,78 @@ describe("tasks gateway handlers", () => {
       status: "stale",
       retryable: true,
       nextAction: "recover_orphan",
+    });
+  });
+
+  it("summarizes subagent health across the filtered task list", async () => {
+    const now = Date.now();
+    createTaskRecord({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:stale",
+      runId: "run-health-stale",
+      task: "Stale subagent",
+      status: "running",
+      deliveryStatus: "pending",
+      lastEventAt: now - 120_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-health-stale",
+      childSessionKey: "agent:main:subagent:stale",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "Stale subagent",
+      cleanup: "keep",
+      createdAt: now - 120_000,
+      startedAt: now - 119_000,
+      execution: { status: "running" },
+    });
+    createTaskRecord({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:delivery",
+      runId: "run-health-delivery",
+      task: "Delivery failed subagent",
+      status: "succeeded",
+      deliveryStatus: "failed",
+      lastEventAt: now - 10_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-health-delivery",
+      childSessionKey: "agent:main:subagent:delivery",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "Delivery failed subagent",
+      cleanup: "keep",
+      createdAt: now - 10_000,
+      startedAt: now - 9_000,
+      endedAt: now - 1_000,
+      outcome: { status: "ok" },
+      delivery: { status: "failed", lastError: "send failed" },
+      execution: { status: "terminal", endedAt: now - 1_000, outcome: { status: "ok" } },
+    });
+    createTaskRecord({
+      runtime: "cli",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      runId: "run-cli",
+      task: "CLI task",
+      status: "running",
+      deliveryStatus: "not_applicable",
+    });
+
+    const { payload } = await runTaskHandler("tasks.list", { agentId: "main", limit: 1 });
+
+    expect(payload?.subagentHealthSummary).toMatchObject({
+      total: 2,
+      retryable: 2,
+      byStatus: { stale: 1, delivery_failed: 1 },
+      byNextAction: { recover_orphan: 1, retry_delivery: 1 },
     });
   });
 

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -12,6 +12,7 @@ import {
   validateTasksListParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
+import { createSubagentHealthResolver } from "../../agents/subagent-registry-read.js";
 import { cancelDetachedTaskRunById } from "../../tasks/detached-task-runtime.js";
 import { getTaskById, listTaskRecordsUnsorted } from "../../tasks/runtime-internal.js";
 import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
@@ -131,8 +132,9 @@ export const tasksHandlers: GatewayRequestHandlers = {
       });
     const page = filtered.slice(cursor, cursor + limit);
     const nextOffset = cursor + page.length;
+    const resolveSubagentHealth = createSubagentHealthResolver();
     respond(true, {
-      tasks: page.map((task) => mapTaskSummary(task)),
+      tasks: page.map((task) => mapTaskSummary(task, { resolveSubagentHealth })),
       ...(nextOffset < filtered.length ? { nextCursor: String(nextOffset) } : {}),
     });
   },

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -23,6 +23,12 @@ const DEFAULT_TASKS_LIST_LIMIT = 100;
 const MAX_TASKS_LIST_LIMIT = 500;
 
 type TaskLedgerStatus = TaskSummary["status"];
+type TaskSubagentHealthSummary = {
+  total: number;
+  retryable: number;
+  byStatus: Record<string, number>;
+  byNextAction: Record<string, number>;
+};
 
 const LEDGER_STATUS_TO_TASK_STATUSES: Record<TaskLedgerStatus, TaskStatus[]> = {
   queued: ["queued"],
@@ -84,6 +90,35 @@ function parseCursor(cursor: string | undefined): number | null {
   return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
+function incrementCount(target: Record<string, number>, key: string) {
+  target[key] = (target[key] ?? 0) + 1;
+}
+
+function buildSubagentHealthSummary(
+  tasks: TaskRecord[],
+  resolveSubagentHealth: ReturnType<typeof createSubagentHealthResolver>,
+): TaskSubagentHealthSummary | undefined {
+  const summary: TaskSubagentHealthSummary = {
+    total: 0,
+    retryable: 0,
+    byStatus: {},
+    byNextAction: {},
+  };
+  for (const task of tasks) {
+    const health = resolveSubagentHealth(task);
+    if (!health) {
+      continue;
+    }
+    summary.total += 1;
+    if (health.retryable) {
+      summary.retryable += 1;
+    }
+    incrementCount(summary.byStatus, health.status);
+    incrementCount(summary.byNextAction, health.nextAction);
+  }
+  return summary.total > 0 ? summary : undefined;
+}
+
 // Control UI task methods expose the stable gateway protocol shape; helpers
 // above keep runtime registry details out of the wire result.
 export const tasksHandlers: GatewayRequestHandlers = {
@@ -133,8 +168,11 @@ export const tasksHandlers: GatewayRequestHandlers = {
     const page = filtered.slice(cursor, cursor + limit);
     const nextOffset = cursor + page.length;
     const resolveSubagentHealth = createSubagentHealthResolver();
+    const subagentHealthSummary = buildSubagentHealthSummary(filtered, resolveSubagentHealth);
+    const tasks = page.map((task) => mapTaskSummary(task, { resolveSubagentHealth }));
     respond(true, {
-      tasks: page.map((task) => mapTaskSummary(task, { resolveSubagentHealth })),
+      tasks,
+      ...(subagentHealthSummary ? { subagentHealthSummary } : {}),
       ...(nextOffset < filtered.length ? { nextCursor: String(nextOffset) } : {}),
     });
   },


### PR DESCRIPTION
## Summary
- Adds `classifySubagentHealth()`, classifying subagent runs into `active/stale/timed_out/delivery_pending/delivery_failed/cleanup_pending/orphaned/cancel_reconciling/terminal`, surfaced on `task list`/`task summary`.
- The sweeper now acts on low-risk health states: retrying failed deliveries, resuming stale keep-mode cleanup, and finalizing timed-out subagents (only once their live run context is gone; the synthetic timeout never overwrites a real completion already won under the terminal lock).
- Three higher-risk stability tracks were hardened with dedicated regression tests:
  - **timed_out**: fixed a race where a synthetic sweeper timeout could overwrite a real completion result that reached the terminal lock around the same time.
  - **orphaned**: fixed a race where two independent `scheduleOrphanRecovery()` invocations (spaced further apart than the 1s debounce) could both resume the same orphaned session before either cleared `abortedLastRun`.
  - **cancel_reconciling**: audited for the same class of race; found the existing implementation already sound (task-registry arbitration by `endedAt` precedence, identity re-checks after every await) — no code change needed.

## Test plan
- [x] 351 relevant unit tests pass across all 10 touched test files
- [x] Full `tsconfig.core.json` typecheck passes (the one remaining error, `src/secrets/config-io.ts:12` TS4058, is pre-existing on `main` at the merge-base and unrelated to this branch)
- [x] `subagent-orphan-recovery.restart-integration.test.ts` has one known-flaky test (`EBUSY` on Windows SQLite teardown) — reproduced identically on an unmodified baseline, confirmed environmental, not a regression