### PR TITLE
fix(codex): preserve MCP bindings after beta5 upgrades

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -483,6 +483,8 @@ export async function startOrResumeThread(params: {
                 error: formatErrorMessage(error),
               }),
           });
+    const legacyUserMcpServersFingerprint =
+      legacyFingerprintUserMcpServersConfigPatch(userMcpServersConfigPatch);
     const userMcpServersFingerprint =
       fingerprintUserMcpServersConfigPatch(userMcpServersConfigPatch);
     const environmentSelectionFingerprint = fingerprintEnvironmentSelection(
@@ -829,7 +831,14 @@ export async function startOrResumeThread(params: {
         rotatedContextEngineBinding = true;
       }
     }
-    if (binding?.threadId && binding.userMcpServersFingerprint !== userMcpServersFingerprint) {
+    if (
+      binding?.threadId &&
+      !areUserMcpServersFingerprintsCompatible({
+        previous: binding.userMcpServersFingerprint,
+        next: userMcpServersFingerprint,
+        nextLegacy: legacyUserMcpServersFingerprint,
+      })
+    ) {
       embeddedAgentLog.debug("codex app-server user MCP config changed; starting a new thread", {
         threadId: binding.threadId,
       });
@@ -2877,6 +2886,12 @@ function legacyFingerprintDynamicTools(dynamicTools: CodexDynamicToolSpec[]): st
   );
 }
 
+function legacyFingerprintUserMcpServersConfigPatch(
+  configPatch: JsonObject | undefined,
+): string | undefined {
+  return configPatch ? JSON.stringify(stabilizeJsonValue(configPatch)) : undefined;
+}
+
 function fingerprintUserMcpServersConfigPatch(
   configPatch: JsonObject | undefined,
 ): string | undefined {
@@ -2987,6 +3002,21 @@ function areDynamicToolFingerprintsCompatible(
   nextLegacy?: string,
 ): boolean {
   return !previous || previous === next || previous === nextLegacy;
+}
+
+function areUserMcpServersFingerprintsCompatible(params: {
+  previous?: string;
+  next?: string;
+  nextLegacy?: string;
+}): boolean {
+  // Beta 5 stored raw stabilized JSON, while doctor hashes those exact bytes.
+  // A successful resume rewrites either legacy form to the current redacted hash.
+  return (
+    params.previous === params.next ||
+    params.previous === params.nextLegacy ||
+    (params.nextLegacy !== undefined &&
+      params.previous === hashCodexAppServerBindingFingerprint(params.nextLegacy))
+  );
 }
 
 function shouldStartTransientNoToolThread(params: {

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -6,9 +6,11 @@ import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodexAppServerRuntimeOptions } from "./config.js";
 import {
+  hashCodexAppServerBindingFingerprint,
   readCodexAppServerBinding,
   registerCodexTestSessionIdentity,
   resetCodexTestBindingStore,
+  seedCodexTestBinding,
   testCodexAppServerBindingStore,
   writeCodexAppServerBinding,
 } from "./session-binding.test-helpers.js";
@@ -193,6 +195,85 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     expect(binding?.userMcpServersFingerprint?.length).toBe(71);
     expect(binding?.userMcpServersFingerprint).not.toContain("server_119");
   });
+
+  it.each(["raw", "doctor-hashed"] as const)(
+    "resumes beta5 user MCP bindings stored as %s fingerprints",
+    async (legacyForm) => {
+      const sessionFile = path.join(tempDir, "session.jsonl");
+      registerCodexTestSessionIdentity(sessionFile, "session-1", "agent:main:session-1");
+      const workspaceDir = path.join(tempDir, "workspace");
+      const authorization = "Bearer beta5-access-token";
+      const config = {
+        mcp: {
+          servers: {
+            ducktape: {
+              transport: "streamable-http",
+              url: "https://agents.ducktape.xyz/mcp",
+              headers: {
+                Authorization: authorization,
+                "x-tenant": "keep",
+              },
+            },
+          },
+        },
+      } as unknown as EmbeddedRunAttemptParams["config"];
+      const request = vi.fn(async (method: string, _params: unknown) => {
+        if (method === "thread/start") {
+          return threadStartResult("thread-beta5");
+        }
+        if (method === "thread/resume") {
+          return threadResumeResult("thread-beta5");
+        }
+        throw new Error(`unexpected method: ${method}`);
+      });
+      const run = () =>
+        startOrResumeThread({
+          client: { request } as never,
+          params: createParams(sessionFile, workspaceDir, config),
+          cwd: workspaceDir,
+          dynamicTools: [],
+          appServer: createAppServerOptions(),
+        });
+
+      await run();
+      const currentBinding = await readCodexAppServerBinding(sessionFile);
+      expect(currentBinding).toBeDefined();
+
+      const legacyFingerprint = JSON.stringify({
+        mcp_servers: {
+          ducktape: {
+            http_headers: {
+              Authorization: authorization,
+              "x-tenant": "keep",
+            },
+            url: "https://agents.ducktape.xyz/mcp",
+          },
+        },
+      });
+      seedCodexTestBinding(sessionFile, {
+        ...currentBinding!,
+        userMcpServersFingerprint:
+          legacyForm === "raw"
+            ? legacyFingerprint
+            : hashCodexAppServerBindingFingerprint(legacyFingerprint),
+      });
+
+      request.mockClear();
+      await run();
+      expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+      const convergedBinding = await readCodexAppServerBinding(sessionFile);
+      expect(convergedBinding?.userMcpServersFingerprint).toMatch(/^sha256:[a-f0-9]{64}$/);
+      expect(convergedBinding?.userMcpServersFingerprint).not.toContain("beta5-access-token");
+      expect(convergedBinding?.userMcpServersFingerprint).not.toBe(legacyFingerprint);
+      expect(convergedBinding?.userMcpServersFingerprint).not.toBe(
+        hashCodexAppServerBindingFingerprint(legacyFingerprint),
+      );
+
+      request.mockClear();
+      await run();
+      expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+    },
+  );
 
   it("projects only Codex user MCP servers scoped to the current agent", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");


### PR DESCRIPTION
Related: #104503

## What Problem This Solves

Fixes an issue where users upgrading from beta5 could lose continuity with an existing native Codex thread even when its user MCP bindings were unchanged. The stored beta5 fingerprint encoding no longer matched the current bounded, token-safe encoding, so OpenClaw unnecessarily rotated the thread.

## Why This Change Was Made

The Codex plugin now recognizes only the two shipped beta5 fingerprint forms alongside the current fingerprint, then converges the session row to the current redacted hash on resume. Actual MCP token or binding changes still rotate the native thread.

## User Impact

Existing beta5 Codex sessions keep their native thread continuity during the beta6 upgrade when MCP bindings have not changed, without retaining authorization tokens in the persisted fingerprint.

## Evidence

- Blacksmith Testbox `tbx_01kx9y16mzp7b5t6akyt9p8zfr` (`tidal-crayfish`): focused user MCP lifecycle suite, 15/15 passed.
- Same Testbox: path-scoped `pnpm check:changed` passed for both changed files, including extension/test typechecks, lint, formatting, repository guards, and import-cycle checks.
- Structured autoreview against the branch diff: no accepted/actionable findings.
- Upstream Codex contract checked in `codex-rs/app-server-protocol/src/protocol/v2/thread.rs` and `codex-rs/app-server/src/request_processors/thread_processor.rs`: resumed running threads can retain their original config, so changed bindings must still rotate while equivalent legacy encodings may safely resume.
