### PR TITLE
fix(doctor): prevent broken emoji in session migration failure reports

### DIFF
--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -946,11 +946,11 @@ function renderFailureMarkdown(payload: {
 }
 
 function sanitizeFailureReportText(value: string): string {
-  return value
+  const sanitized = value
     .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "[redacted-email]")
     .replace(/(api[_-]?key|token|secret|password)[=-][A-Za-z0-9._-]+/gi, "$1-[redacted]")
-    .replace(/(api[_-]?key|token|secret|password)=\S+/gi, "$1=[redacted]")
-    .slice(0, 500);
+    .replace(/(api[_-]?key|token|secret|password)=\S+/gi, "$1=[redacted]");
+  return truncateUtf16Safe(sanitized, 500);
 }
 
 function shortenFailureReportPath(filePath: string): string {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1566,6 +1566,8 @@ describe("runDoctorSessionSqlite", () => {
   it("keeps truncated GitHub issue bodies on a valid UTF-16 boundary", () => {
     const store = createLegacyStore();
     const manifestPath = path.join(store.tempDir, "failed-migration.json");
+    const unpairedSurrogate =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
     const writeManifest = (messages: string[], targetCount = 1) => {
       const manifest: SessionSqliteMigrationManifest = {
         failedAt: "2030-01-01T00:00:00.000Z",
@@ -1591,6 +1593,11 @@ describe("runDoctorSessionSqlite", () => {
       };
       fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
     };
+
+    writeManifest([`${"x".repeat(499)}🎉tail`]);
+    const fieldIssue = createSessionSqliteMigrationFailureIssue(manifestPath);
+    expect(fieldIssue?.body).not.toMatch(unpairedSurrogate);
+    expect(new URL(fieldIssue?.url ?? "").searchParams.get("body")).not.toContain("�");
 
     const baseMessages = Array.from({ length: 9 }, () => "x".repeat(500));
     writeManifest([...baseMessages, "MESSAGE_START"]);
@@ -1622,9 +1629,7 @@ describe("runDoctorSessionSqlite", () => {
 
     writeManifest([`${"x".repeat(19_999 - bodyMessageOffset)}🎉tail`], bodyTargetCount);
     const bodyIssue = createSessionSqliteMigrationFailureIssue(manifestPath);
-    expect(bodyIssue?.body).not.toMatch(
-      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u,
-    );
+    expect(bodyIssue?.body).not.toMatch(unpairedSurrogate);
   });
 
   it("recovers only manifests matching an explicit store selector", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators recovering a failed session SQLite migration could see a broken emoji or replacement character in the generated sanitized failure report or its prefilled GitHub issue link when text crossed a report length boundary.

## Why This Change Was Made

The doctor-owned failure-report builder uses the shared UTF-16-safe prefix helper at its existing 500-character field, 20,000-character issue-body, and 6,000-character URL-body limits. Redaction rules, report schema, CLI flags, file formats, URLs, and maximum lengths are unchanged.

The branch has also been rebased across the current migration-manifest hardening: the resolution preserves main's Zod parsing and path-safety behavior while retaining only the Unicode-safe truncation change. The regression fixture now uses a schema-valid non-empty agent ID.

## User Impact

Session migration recovery reports and support links keep complete Unicode characters at their truncation boundaries, so diagnostic text no longer turns boundary emoji into `�`.

## Evidence

- Stock-main red proof: a real failed migration manifest produced a report containing a lone high surrogate (`\\ud83e`), and decoding the generated GitHub issue URL produced a replacement character.
- Fresh production runtime proof on the rebased head through `createSessionSqliteMigrationFailureIssue`:

  ```json
  {
    "commandPath": "doctor session-SQLite failed manifest -> sanitized report -> support issue URL",
    "field500": {
      "bodyHasUnpairedSurrogate": false,
      "urlContainsReplacementCharacter": false
    },
    "body20000": {
      "length": 19999,
      "hasUnpairedSurrogate": false
    },
    "url6000": {
      "decodedBodyHasUnpairedSurrogate": false,
      "decodedBodyContainsReplacementCharacter": false,
      "generatedPrefilledIssueUrl": true
    }
  }
  ```

- Dedicated regression plus affected doctor session SQLite suite: 63 passed, 2 skipped.
- Changed-file Oxlint passed.
- Oxfmt check passed.
- The added regression test passes the strict TypeScript no-excuse audit.

