### PR TITLE
chore: ignore local trajectory exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ USER.md
 .antigravitycli/
 .serena/
 .crabbox/
+/.openclaw/trajectory-exports/
 
 # local QA evidence mirrors; CI publishes canonical Mantis files as Actions artifacts
 /mantis/


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using a clean OpenClaw checkout as a workspace would have updater maintenance fail closed after trajectory exports were generated.

## Why This Change Was Made

Ignore only the repo-root generated trajectory export directory. Other `.openclaw` workspace state and similarly named nested directories remain visible to Git.

## User Impact

Clean-checkout automation can continue updating after local trajectory exports are created, without deleting the exported evidence.

## Evidence

- `git check-ignore --no-index -v .openclaw/trajectory-exports/pr972-d0c55502/manifest.json`
- `git diff --check`
- Autoreview: clean, no accepted or actionable findings
