### PR TITLE
fix(tui): preserve terminal errors across history reloads

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -342,7 +342,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.dismissPendingSystem).toHaveBeenCalledWith("run-error");
     expect(chatLog.addSystem).toHaveBeenCalledWith("run error: provider exploded");
     expect(state.activeChatRunId).toBeNull();
-    expect(loadHistory).toHaveBeenCalled();
+    expect(loadHistory).not.toHaveBeenCalled();
     expect(tui.requestRender).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
   });
@@ -1682,8 +1682,8 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     );
   });
 
-  it("renders malformed streaming fragment text for chat error events", () => {
-    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+  it("renders malformed streaming fragment text for chat error events without reloading", () => {
+    const { state, chatLog, loadHistory, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
     });
 
@@ -1697,6 +1697,45 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.addSystem).toHaveBeenCalledWith(
       "run error: LLM streaming response contained a malformed fragment. Please try again.",
     );
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("restores a terminal error when another run delays a history reload", async () => {
+    const { state, chatLog, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-error" },
+    });
+    handleChatEvent({
+      runId: "run-other",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "still running" },
+    });
+    noteLocalRunId("run-local-empty");
+    handleChatEvent({
+      runId: "run-local-empty",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+    });
+    handleChatEvent({
+      runId: "run-error",
+      sessionKey: state.currentSessionKey,
+      state: "error",
+      errorMessage: "provider exploded",
+    });
+
+    expect(state.activeChatRunId).toBe("run-other");
+    expect(loadHistory).not.toHaveBeenCalled();
+
+    handleChatEvent({
+      runId: "run-other",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    await vi.waitFor(() => expect(chatLog.addSystem).toHaveBeenCalledTimes(2));
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+    expect(chatLog.addSystem).toHaveBeenLastCalledWith("run error: provider exploded");
   });
 
   it("shows a concise /auth hint for local auth failures", () => {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -109,6 +109,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   const historyReloadRunIds = new Set<string>();
   const historyOwnedReloadRunIds = new Set<string>();
   const historyDisplayedReloadRunIds = new Set<string>();
+  const liveTerminalErrorMessages = new Map<string, string>();
   const queuedHistoryReloadRunIds = new Set<string>();
   const deferredHistoryRunEvents = new Map<string, ChatEvent>();
   let historyReloadInFlight = false;
@@ -133,6 +134,29 @@ export function createEventHandlers(context: EventHandlerContext) {
   let streamingWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
   let streamingWatchdogRunId: string | null = null;
 
+  const reloadHistoryPreservingTerminalErrors = async (): Promise<TuiHistoryLoadResult> => {
+    if (!loadHistory) {
+      return { loaded: false };
+    }
+    const reloadGeneration = historyReloadGeneration;
+    const result = (await loadHistory()) ?? { loaded: false };
+    if (!result.loaded || reloadGeneration !== historyReloadGeneration) {
+      return result;
+    }
+    let restored = false;
+    for (const [runId, message] of liveTerminalErrorMessages) {
+      if (!finalizedRunsWithDisplay.has(runId)) {
+        continue;
+      }
+      chatLog.addSystem(message);
+      restored = true;
+    }
+    if (restored) {
+      tui.requestRender(true);
+    }
+    return result;
+  };
+
   const flushPendingHistoryRefreshIfIdle = () => {
     if (
       !pendingHistoryRefresh ||
@@ -143,7 +167,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
     pendingHistoryRefresh = false;
-    void loadHistory?.();
+    void reloadHistoryPreservingTerminalErrors();
   };
 
   const clearStreamingWatchdog = () => {
@@ -181,6 +205,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     historyReloadRunIds.clear();
     historyOwnedReloadRunIds.clear();
     historyDisplayedReloadRunIds.clear();
+    liveTerminalErrorMessages.clear();
     queuedHistoryReloadRunIds.clear();
     deferredHistoryRunEvents.clear();
     finalizedRuns.clear();
@@ -221,7 +246,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         state.activityStatus = "idle";
         setActivityStatus("idle");
         pendingHistoryRefresh = false;
-        void loadHistory?.();
+        void reloadHistoryPreservingTerminalErrors();
         tui.requestRender();
         return;
       }
@@ -337,6 +362,11 @@ export function createEventHandlers(context: EventHandlerContext) {
     pruneRunMap(finalizedRuns);
     pruneRunMap(finalizedRunsWithDisplay);
     pruneRunMap(completedRuns);
+    for (const retainedRunId of liveTerminalErrorMessages.keys()) {
+      if (!finalizedRunsWithDisplay.has(retainedRunId)) {
+        liveTerminalErrorMessages.delete(retainedRunId);
+      }
+    }
   };
 
   const notePostFinalizingRun = (runId: string) => {
@@ -472,10 +502,12 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const renderedError = formatRawAssistantErrorForUi(errorMessage);
     chatLog.dismissPendingSystem(runId);
-    chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
+    const displayMessage = resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`;
+    liveTerminalErrorMessages.set(runId, displayMessage);
+    chatLog.addSystem(displayMessage);
     noteFinalizedRun(runId, { displayedFinal: true });
     terminateRun({ runId, wasActiveRun, status: "error" });
-    maybeRefreshHistoryForRun(runId);
+    maybeRefreshHistoryForRun(runId, { hasDisplayableFinal: true });
     return true;
   };
 
@@ -539,7 +571,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
     pendingHistoryRefresh = false;
-    void loadHistory?.();
+    void reloadHistoryPreservingTerminalErrors();
   };
 
   const messageHasDisplayableNonTextContent = (message: unknown): boolean => {
@@ -813,7 +845,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         }
       }
     };
-    void loadHistory()
+    void reloadHistoryPreservingTerminalErrors()
       .then(finishReload, () => finishReload({ loaded: false }))
       .finally(() => {
         historyReloadInFlight = false;
@@ -942,7 +974,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (reloadingRunIds.size > 0) {
       queueHistoryReload(reloadingRunIds, finalizedRunIds, displayedRunIds);
     } else if (loadHistory) {
-      void loadHistory();
+      void reloadHistoryPreservingTerminalErrors();
     } else {
       void refreshSessionInfo?.();
     }
@@ -1143,6 +1175,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     historyReloadRunIds.clear();
     historyOwnedReloadRunIds.clear();
     historyDisplayedReloadRunIds.clear();
+    liveTerminalErrorMessages.clear();
     queuedHistoryReloadRunIds.clear();
     deferredHistoryRunEvents.clear();
     clearStreamingWatchdog();

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -1000,6 +1000,7 @@ describe("TUI PTY real backends", () => {
             ),
         });
         await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
+        const completedOffset = fixture.run.output().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
 
         await fixture.run.write("turn after queued followup\r");
         await waitFor({
@@ -1017,6 +1018,9 @@ describe("TUI PTY real backends", () => {
         expect(JSON.stringify(fixture.mockModel.requests()[2]?.body)).toContain(
           "turn after queued followup",
         );
+        await waitForOutputAfter(fixture.run, "FOLLOWUP_RUN_COMPLETE", completedOffset);
+        const finalResponseOffset = fixture.run.output().lastIndexOf("FOLLOWUP_RUN_COMPLETE");
+        await waitForOutputAfter(fixture.run, "| idle", finalResponseOffset);
 
         await fixture.run.write("/exit\r", { delay: false });
         expect((await fixture.run.waitForExit()).exitCode).toBe(0);


### PR DESCRIPTION
## What Problem This Solves

The full TUI PTY shard could erase a live terminal error during a same-session history rebuild. The empty-reply regression then waited the full 120-second output timeout even though the run had already reached its error state.

## Why This Change Was Made

Terminal error diagnostics are live-only and are not part of persisted chat history. Route every event-handler history reload through one wrapper that restores still-relevant terminal errors after a successful same-generation rebuild. Clear retained diagnostics with the existing session/reset lifecycle and prune them with finalized-run retention. The shared-Gateway followup test also waits for its final response and idle state before releasing the fixture.

## User Impact

TUI users keep the visible error explanation after history synchronization instead of seeing only an error status. The release CI shard no longer stalls for two minutes on this race.

## Evidence

- Blacksmith Testbox: `pnpm test src/tui/tui-event-handlers.test.ts src/tui/tui-pty-local.e2e.test.ts` — 97/97 handler tests and 8/8 PTY scenarios passed; former failure completed in 1.6s.
- Blacksmith Testbox: focused concurrent reload plus real Gateway/TUI regression — 2/2 passed.
- Blacksmith Testbox: `pnpm check:changed` — format, core/test typechecks, lint, import cycles, and repository guards passed.
- Fresh structured autoreview: no accepted/actionable findings.
