### PR TITLE
fix(auto-reply): adopt the target run slot when command turns continue into agent turns

### DIFF
--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -126,6 +126,7 @@ function createReplyOperation(): ReplyOperation {
     markWaitingForDeferredMaintenance: vi.fn(),
     markDeferredMaintenanceWaitEnded: vi.fn(),
     updateSessionId: vi.fn(),
+    updateSessionKey: vi.fn(),
     hasOwnedSessionId: vi.fn(() => false),
     attachBackend: vi.fn(),
     detachBackend: vi.fn(),

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -523,6 +523,7 @@ function createMockReplyOperation(): {
       markWaitingForDeferredMaintenance: vi.fn(),
       markDeferredMaintenanceWaitEnded: vi.fn(),
       updateSessionId: updateSessionIdMock,
+      updateSessionKey: vi.fn(),
       attachBackend: vi.fn(),
       detachBackend: vi.fn(),
       freezeAbort: freezeAbortMock,

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -59,6 +59,7 @@ function createReplyOperation(): TestReplyOperation {
     hasOwnedSessionId: vi.fn((sessionId: string) => sessionId === "session"),
     setPhase: vi.fn<ReplyOperation["setPhase"]>(),
     updateSessionId: vi.fn<ReplyOperation["updateSessionId"]>(),
+    updateSessionKey: vi.fn<ReplyOperation["updateSessionKey"]>(),
     attachBackend: vi.fn(),
     detachBackend: vi.fn(),
     freezeAbort: vi.fn(),

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -30,7 +30,11 @@ import {
   type ReplyOperationRunState,
   type ReplyOptionsWithOperationRunState,
 } from "./reply-operation-run-state.js";
-import { createReplyOperation, testing as replyRunTesting } from "./reply-run-registry.js";
+import {
+  createReplyOperation,
+  testing as replyRunTesting,
+  type ReplyOperation,
+} from "./reply-run-registry.js";
 import { consumeReplyUsageState } from "./reply-usage-state.js";
 import { createMockTypingController } from "./test-helpers.js";
 
@@ -214,6 +218,7 @@ function createMinimalRun(params?: {
   shouldSteer?: boolean;
   shouldFollowup?: boolean;
   resolvedQueueMode?: string;
+  replyOperation?: ReplyOperation;
   currentInboundEventKind?: FollowupRun["currentInboundEventKind"];
   sessionCtx?: Partial<TemplateContext>;
   runOverrides?: Partial<FollowupRun["run"]>;
@@ -289,6 +294,7 @@ function createMinimalRun(params?: {
         resolvedBlockStreamingBreak: "message_end",
         shouldInjectGroupIntro: false,
         typingMode: params?.typingMode ?? "instant",
+        replyOperation: params?.replyOperation,
       });
     },
   };
@@ -322,6 +328,42 @@ describe("runReplyAgent active steering", () => {
         userTurnTranscriptRecorder: recorder,
       }),
     );
+  });
+
+  it("steers against the session's registered run owner, not a source-keyed reservation", async () => {
+    // A native command continuation whose target-slot adoption was skipped
+    // (#104844) still carries its slash-source reservation; steering must
+    // target the operation that owns this session's run slot.
+    state.queueEmbeddedAgentMessageMock.mockReturnValueOnce(true);
+    const targetOwner = createReplyOperation({
+      sessionKey: "main",
+      sessionId: "target-active-session",
+      resetTriggered: false,
+    });
+    targetOwner.setPhase("running");
+    const sourceReservation = createReplyOperation({
+      sessionKey: "agent:main:telegram:slash:steer-user",
+      sessionId: "source-reservation-session",
+      resetTriggered: false,
+    });
+    const { run } = createMinimalRun({
+      isActive: true,
+      isStreaming: true,
+      shouldSteer: true,
+      resolvedQueueMode: "steer",
+      replyOperation: sourceReservation,
+    });
+
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledWith(
+      "target-active-session",
+      "hello",
+      expect.objectContaining({ steeringMode: "all" }),
+    );
+
+    targetOwner.complete();
+    sourceReservation.complete();
   });
 
   it("waits for transcript commit and keeps a rejected adoption finalizer irrevocably adopted", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1264,8 +1264,15 @@ export async function runReplyAgent(params: {
 
   let shouldQueueAfterSteerRejection = false;
   if (effectiveShouldSteer && isActive) {
+    // Steer against the operation that owns THIS session's run slot. A native
+    // command continuation whose slot adoption was skipped (#104844) still
+    // carries a source-keyed reservation; steering by its stale sessionId
+    // would miss the live target run.
+    const registeredReplyOperation = sessionKey ? replyRunRegistry.get(sessionKey) : undefined;
     const activeReplyOperation =
-      providedReplyOperation ?? (sessionKey ? replyRunRegistry.get(sessionKey) : undefined);
+      providedReplyOperation?.key === sessionKey
+        ? providedReplyOperation
+        : (registeredReplyOperation ?? providedReplyOperation);
     const steerSessionId = activeReplyOperation?.sessionId ?? followupRun.run.sessionId;
     const steerOutcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
       steerSessionId,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -113,6 +113,7 @@ import {
   type ReplyOperation,
 } from "./reply-run-registry.js";
 import { resolveReplyToMode } from "./reply-threading.js";
+import { admitReplyTurn } from "./reply-turn-admission.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import type { ReplySessionEntryHandle } from "./session-entry-handle.js";
@@ -1077,7 +1078,23 @@ export async function runPreparedReply(
     }
   }
   const providedReplyOperation = opts?.replyOperation;
+  // Native command turns reserve their operation under the slash SOURCE key so
+  // commands never contend with the target's active run (#104144). When such a
+  // turn continues into a full agent turn (/steer fallback, /goal, /learn,
+  // unhandled body), it mutates the TARGET session: it must adopt the target's
+  // run slot before running or concurrent target inbounds double-admit and
+  // split the session (#104844).
+  const commandTurnContinuationTargetKey =
+    providedReplyOperation !== undefined &&
+    providedReplyOperation.result === null &&
+    providedReplyOperation.phase === "queued" &&
+    sessionKey !== undefined &&
+    providedReplyOperation.key !== sessionKey &&
+    resolveCommandTurnTargetSessionKey(ctx) !== undefined
+      ? sessionKey
+      : undefined;
   if (
+    commandTurnContinuationTargetKey === undefined &&
     providedReplyOperation !== undefined &&
     providedReplyOperation.result === null &&
     providedReplyOperation.phase === "queued" &&
@@ -1086,7 +1103,9 @@ export async function runPreparedReply(
   ) {
     // Dispatch reserves a queued operation before session init. If stale init
     // rotates the session, move the reservation so later steer/abort paths
-    // target the session that will actually run.
+    // target the session that will actually run. Command-turn continuations
+    // rebind after slot adoption below: rebinding first would collide with a
+    // still-active target operation that owns the same session ID.
     providedReplyOperation.updateSessionId(sessionId);
   }
   const isOwnPreDispatchOperationSession = (candidateSessionId: string | undefined): boolean =>
@@ -1289,6 +1308,35 @@ export async function runPreparedReply(
           isReplyRunStreamingForSessionId(replyOperationActiveSessionId)),
     };
   };
+  if (commandTurnContinuationTargetKey && providedReplyOperation) {
+    const adoption = await admitReplyTurn({
+      sessionKey: commandTurnContinuationTargetKey,
+      sessionId: providedReplyOperation.sessionId,
+      expectedSessionId: preparedSessionState.sessionEntry?.sessionId,
+      storePath,
+      kind: "visible",
+      resetTriggered: effectiveResetTriggered,
+      routeThreadId: currentRouteThreadId,
+      upstreamAbortSignal: opts?.abortSignal,
+      // Never wait on the target's active turn: a blocked continuation would
+      // re-create the #104142 command-lane wedge. When the slot is owned, the
+      // queue policy below sees the target-keyed owner and steers/queues this
+      // turn instead of running it concurrently.
+      waitForActive: false,
+      adoptOperation: providedReplyOperation,
+    });
+    if (adoption.status === "skipped" && adoption.reason === "aborted") {
+      typing.cleanup();
+      return undefined;
+    }
+    if (
+      adoption.status === "owned" &&
+      sessionId !== undefined &&
+      sessionId !== providedReplyOperation.sessionId
+    ) {
+      providedReplyOperation.updateSessionId(sessionId);
+    }
+  }
   const { activeSessionId, isActive, isStreaming } = resolveQueueBusyState();
   const activeRunAcceptsCurrentThread = resolveActiveRunAcceptsCurrentThread({ isActive });
   const isHeartbeatRun = opts?.isHeartbeat === true;

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -21,6 +21,7 @@ import {
   queueReplyRunMessage,
   REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
   REPLY_RUN_TERMINAL_SETTLE_TIMEOUT_MS,
+  ReplyRunAlreadyActiveError,
   replyRunRegistry,
   runAfterReplyOperationClear,
   resolveActiveReplyRunSessionId,
@@ -1059,5 +1060,67 @@ describe("reply run registry", () => {
     expect(abortActiveReplyRuns({ mode: "compacting" })).toBe(true);
     expect(compactingOperation.result).toEqual({ kind: "aborted", code: "aborted_for_restart" });
     expect(runningOperation.result).toBeNull();
+  });
+
+  it("moves a queued reservation to the target slot and frees the source", async () => {
+    const sourceSessionKey = "agent:main:telegram:slash:rekey-user";
+    const targetSessionKey = "agent:main:telegram:group:rekey-target";
+    const operation = createReplyOperation({
+      sessionKey: sourceSessionKey,
+      sessionId: "rekey-session",
+      resetTriggered: false,
+    });
+    const sourceIdle = replyRunRegistry.waitForIdle(sourceSessionKey, 1_000);
+
+    operation.updateSessionKey(targetSessionKey);
+
+    expect(operation.key).toBe(targetSessionKey);
+    expect(replyRunRegistry.get(sourceSessionKey)).toBeUndefined();
+    expect(replyRunRegistry.get(targetSessionKey)).toBe(operation);
+    expect(resolveActiveReplyRunSessionId(targetSessionKey)).toBe("rekey-session");
+    await expect(sourceIdle).resolves.toBe(true);
+
+    const targetWait = waitForReplyRunEndBySessionId("rekey-session", 1_000);
+    operation.complete();
+    await expect(targetWait).resolves.toBe(true);
+    expect(replyRunRegistry.get(targetSessionKey)).toBeUndefined();
+  });
+
+  it("refuses to rekey onto an owned target slot and keeps the source slot", () => {
+    const targetSessionKey = "agent:main:telegram:group:rekey-owned";
+    const sourceSessionKey = "agent:main:telegram:slash:rekey-blocked";
+    const blocker = createReplyOperation({
+      sessionKey: targetSessionKey,
+      sessionId: "owned-session",
+      resetTriggered: false,
+    });
+    const operation = createReplyOperation({
+      sessionKey: sourceSessionKey,
+      sessionId: "blocked-session",
+      resetTriggered: false,
+    });
+
+    expect(() => operation.updateSessionKey(targetSessionKey)).toThrow(ReplyRunAlreadyActiveError);
+    expect(operation.key).toBe(sourceSessionKey);
+    expect(replyRunRegistry.get(sourceSessionKey)).toBe(operation);
+    expect(replyRunRegistry.get(targetSessionKey)).toBe(blocker);
+
+    blocker.complete();
+    operation.complete();
+  });
+
+  it("refuses to rekey after the run leaves the queued phase", () => {
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:telegram:slash:rekey-late",
+      sessionId: "late-session",
+      resetTriggered: false,
+    });
+    operation.setPhase("running");
+
+    expect(() => operation.updateSessionKey("agent:main:telegram:group:rekey-late")).toThrow(
+      /Cannot rekey reply operation/,
+    );
+
+    operation.complete();
   });
 });

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -146,6 +146,14 @@ export type ReplyOperation = {
   markTerminalRecovery(): void;
   markAcceptedSteeredInboundAudio(): void;
   updateSessionId(nextSessionId: string): void;
+  /**
+   * Move this queued operation to another session key's run slot. Native command
+   * turns admit under the slash SOURCE key; when the command continues into a full
+   * agent turn it must own the TARGET session's slot so concurrent target inbounds
+   * queue/steer instead of double-admitting. Throws ReplyRunAlreadyActiveError when
+   * the target slot is owned.
+   */
+  updateSessionKey(nextSessionKey: string): void;
   attachBackend(handle: ReplyBackendHandle): void;
   detachBackend(handle: ReplyBackendHandle): void;
   /** Reject later aborts after the backend has committed its terminal outcome. */
@@ -535,6 +543,9 @@ export function createReplyOperation(params: {
   }
 
   const controller = new AbortController();
+  // Mutable so updateSessionKey can move the run slot (command-turn continuation
+  // adoption); every closure below must read this, never params.sessionKey.
+  let currentSessionKey = sessionKey;
   let currentSessionId = sessionId;
   let phase: ReplyOperationPhase = "queued";
   let result: ReplyOperationResult | null = null;
@@ -575,20 +586,20 @@ export function createReplyOperation(params: {
     detachUpstreamAbort();
     const registeredBarrier = afterClearBarrier
       ? registerFollowupAdmissionBarrier(
-          sessionKey,
+          currentSessionKey,
           currentSessionId,
           afterClearBarrier,
           followupAdmissionBarrierTimeout,
         )
       : undefined;
-    updateFollowupAdmissionSessionId(sessionKey, currentSessionId);
+    updateFollowupAdmissionSessionId(currentSessionKey, currentSessionId);
     markReplyRunDiagnosticProgress({
-      sessionKey,
+      sessionKey: currentSessionKey,
       sessionId: currentSessionId,
       reason: "reply_operation:ended",
     });
     clearReplyRunState({
-      sessionKey,
+      sessionKey: currentSessionKey,
       sessionId: currentSessionId,
     });
     if (!registeredBarrier) {
@@ -615,12 +626,12 @@ export function createReplyOperation(params: {
     // including skipping any delivery barrier the owner never got to register;
     // followups may then interleave with a still-draining terminal delivery.
     const timer = setTimeout(() => {
-      if (replyRunState.activeRunsByKey.get(sessionKey) !== operation) {
+      if (replyRunState.activeRunsByKey.get(currentSessionKey) !== operation) {
         clearTerminalSettleTimer(operation);
         return;
       }
       diag.warn(
-        `reply run terminal settle: forced release sessionKey=${sessionKey} phase=${phase} result=${formatReplyOperationResult(
+        `reply run terminal settle: forced release sessionKey=${currentSessionKey} phase=${phase} result=${formatReplyOperationResult(
           result,
         )} ageMs=${Date.now() - lastActivityAtMs} ranForMs=${Date.now() - startedAtMs}`,
       );
@@ -647,7 +658,7 @@ export function createReplyOperation(params: {
 
   const operation: ReplyOperation = {
     get key() {
-      return sessionKey;
+      return currentSessionKey;
     },
     get sessionId() {
       return currentSessionId;
@@ -699,7 +710,7 @@ export function createReplyOperation(params: {
       }
       phase = "waiting_for_deferred_maintenance";
       markReplyRunDiagnosticProgress({
-        sessionKey,
+        sessionKey: currentSessionKey,
         sessionId: currentSessionId,
         reason: "deferred_maintenance:waiting",
       });
@@ -710,7 +721,7 @@ export function createReplyOperation(params: {
       }
       phase = "queued";
       markReplyRunDiagnosticProgress({
-        sessionKey,
+        sessionKey: currentSessionKey,
         sessionId: currentSessionId,
         reason: "deferred_maintenance:wait_ended",
       });
@@ -732,24 +743,63 @@ export function createReplyOperation(params: {
       recordActivity();
       if (
         replyRunState.activeKeysBySessionId.has(normalizedNextSessionId) &&
-        replyRunState.activeKeysBySessionId.get(normalizedNextSessionId) !== sessionKey
+        replyRunState.activeKeysBySessionId.get(normalizedNextSessionId) !== currentSessionKey
       ) {
         throw new Error(
-          `Cannot rebind reply operation ${sessionKey} to active session ${normalizedNextSessionId}`,
+          `Cannot rebind reply operation ${currentSessionKey} to active session ${normalizedNextSessionId}`,
         );
       }
       replyRunState.activeKeysBySessionId.delete(currentSessionId);
-      registerWaitSessionId(sessionKey, currentSessionId);
+      registerWaitSessionId(currentSessionKey, currentSessionId);
       currentSessionId = normalizedNextSessionId;
       ownedSessionIds.add(currentSessionId);
-      updateFollowupAdmissionSessionId(sessionKey, currentSessionId);
-      replyRunState.activeSessionIdsByKey.set(sessionKey, currentSessionId);
-      replyRunState.activeKeysBySessionId.set(currentSessionId, sessionKey);
-      registerWaitSessionId(sessionKey, currentSessionId);
+      updateFollowupAdmissionSessionId(currentSessionKey, currentSessionId);
+      replyRunState.activeSessionIdsByKey.set(currentSessionKey, currentSessionId);
+      replyRunState.activeKeysBySessionId.set(currentSessionId, currentSessionKey);
+      registerWaitSessionId(currentSessionKey, currentSessionId);
       markReplyRunDiagnosticProgress({
-        sessionKey,
+        sessionKey: currentSessionKey,
         sessionId: currentSessionId,
         reason: "reply_operation:session_updated",
+      });
+    },
+    updateSessionKey(nextSessionKey) {
+      const normalizedNextKey = normalizeOptionalString(nextSessionKey);
+      if (!normalizedNextKey) {
+        throw new Error("Reply operations require a canonical sessionKey");
+      }
+      if (normalizedNextKey === currentSessionKey) {
+        return;
+      }
+      // Only a queued reservation may move slots: once the run started (or the
+      // operation settled), abort/steer/wait paths already resolved this key.
+      if (result || stateCleared || phase !== "queued") {
+        throw new Error(`Cannot rekey reply operation ${currentSessionKey} in phase ${phase}`);
+      }
+      if (replyRunState.activeRunsByKey.has(normalizedNextKey)) {
+        throw new ReplyRunAlreadyActiveError(normalizedNextKey);
+      }
+      recordActivity();
+      const previousKey = currentSessionKey;
+      replyRunState.activeRunsByKey.delete(previousKey);
+      replyRunState.activeSessionIdsByKey.delete(previousKey);
+      currentSessionKey = normalizedNextKey;
+      replyRunState.activeRunsByKey.set(currentSessionKey, operation);
+      replyRunState.activeSessionIdsByKey.set(currentSessionKey, currentSessionId);
+      replyRunState.activeKeysBySessionId.set(currentSessionId, currentSessionKey);
+      // Wait/abort lookups resolve keys via owned session IDs; move them so
+      // waitForReplyRunEndBySessionId keeps finding this operation.
+      for (const ownedSessionId of ownedSessionIds) {
+        if (replyRunState.waitKeysBySessionId.get(ownedSessionId) === previousKey) {
+          replyRunState.waitKeysBySessionId.set(ownedSessionId, currentSessionKey);
+        }
+      }
+      // The previous key's slot is idle now; wake turns waiting on it.
+      notifyReplyRunEnded(previousKey);
+      markReplyRunDiagnosticProgress({
+        sessionKey: currentSessionKey,
+        sessionId: currentSessionId,
+        reason: "reply_operation:session_key_adopted",
       });
     },
     attachBackend(handle) {
@@ -851,7 +901,7 @@ export function createReplyOperation(params: {
   };
 
   expireReplyOperationByOperation.set(operation, (reason) => {
-    if (replyRunState.activeRunsByKey.get(sessionKey) !== operation) {
+    if (replyRunState.activeRunsByKey.get(currentSessionKey) !== operation) {
       return false;
     }
     // Set the terminal result BEFORE cancelling the backend: cancel can
@@ -866,7 +916,7 @@ export function createReplyOperation(params: {
     getAttachedBackend(operation)?.cancel("superseded");
     abortInternally(createAbortError("Reply operation expired as stale"));
     diag.warn(
-      `reply run stale takeover: forced release sessionKey=${sessionKey} reason=${reason} phase=${phase} result=${formatReplyOperationResult(
+      `reply run stale takeover: forced release sessionKey=${currentSessionKey} reason=${reason} phase=${phase} result=${formatReplyOperationResult(
         result,
       )} ageMs=${Date.now() - lastActivityAtMs} ranForMs=${Date.now() - startedAtMs}`,
     );

--- a/src/auto-reply/reply/reply-turn-admission.test.ts
+++ b/src/auto-reply/reply/reply-turn-admission.test.ts
@@ -1170,4 +1170,111 @@ describe("reply turn admission", () => {
     });
     active.complete();
   });
+
+  it("adopts a source-keyed command reservation into the target run slot", async () => {
+    const sourceSessionKey = "agent:main:telegram:slash:adopt-user";
+    const targetSessionKey = "agent:main:telegram:group:adopt-target";
+    const targetSessionId = "target-session-adopt";
+    const storePath = createSessionStore({
+      [targetSessionKey]: { sessionId: targetSessionId, updatedAt: Date.now() },
+    });
+    const reservation = createReplyOperation({
+      sessionKey: sourceSessionKey,
+      sessionId: "source-reservation-adopt",
+      resetTriggered: false,
+    });
+
+    const admission = await admitReplyTurn({
+      sessionKey: targetSessionKey,
+      sessionId: reservation.sessionId,
+      expectedSessionId: targetSessionId,
+      storePath,
+      kind: "visible",
+      resetTriggered: false,
+      waitForActive: false,
+      adoptOperation: reservation,
+    });
+
+    expect(admission.status).toBe("owned");
+    if (admission.status !== "owned") {
+      return;
+    }
+    expect(admission.operation).toBe(reservation);
+    expect(reservation.key).toBe(targetSessionKey);
+    expect(replyRunRegistry.get(sourceSessionKey)).toBeUndefined();
+    expect(replyRunRegistry.get(targetSessionKey)).toBe(reservation);
+
+    // Target lifecycle interrupts must reach the adopted operation: reset or
+    // delete on the target session interlocks with the continuation run.
+    reservation.setPhase("running");
+    let mutationRan = false;
+    const mutation = runExclusiveSessionLifecycleMutation({
+      scope: storePath,
+      identities: [targetSessionKey, targetSessionId],
+      prepare: async () => {
+        await interruptSessionWorkAdmissions({
+          scope: storePath,
+          identities: [targetSessionKey, targetSessionId],
+        });
+      },
+      run: async () => {
+        mutationRan = true;
+      },
+    });
+    await vi.waitFor(() => {
+      expect(reservation.abortSignal.aborted).toBe(true);
+    });
+    expect(reservation.result).toEqual({ kind: "aborted", code: "aborted_for_restart" });
+    expect(mutationRan).toBe(false);
+
+    reservation.complete();
+    await mutation;
+    expect(mutationRan).toBe(true);
+  });
+
+  it("skips adoption without waiting when the target run slot is owned", async () => {
+    const sourceSessionKey = "agent:main:telegram:slash:busy-user";
+    const targetSessionKey = "agent:main:telegram:group:busy-target";
+    const targetSessionId = "target-session-busy";
+    const storePath = createSessionStore({
+      [targetSessionKey]: { sessionId: targetSessionId, updatedAt: Date.now() },
+    });
+    const blocker = createReplyOperation({
+      sessionKey: targetSessionKey,
+      sessionId: targetSessionId,
+      resetTriggered: false,
+    });
+    blocker.setPhase("running");
+    const reservation = createReplyOperation({
+      sessionKey: sourceSessionKey,
+      sessionId: "source-reservation-busy",
+      resetTriggered: false,
+    });
+
+    const admission = await admitReplyTurn({
+      sessionKey: targetSessionKey,
+      sessionId: reservation.sessionId,
+      expectedSessionId: targetSessionId,
+      storePath,
+      kind: "visible",
+      resetTriggered: false,
+      waitForActive: false,
+      adoptOperation: reservation,
+    });
+
+    expect(admission).toMatchObject({
+      status: "skipped",
+      reason: "active-run",
+      activeOperation: blocker,
+    });
+    // The reservation stays source-keyed so the command turn's own delivery
+    // lifecycle is unaffected; queue policy handles the busy target.
+    expect(reservation.key).toBe(sourceSessionKey);
+    expect(replyRunRegistry.get(sourceSessionKey)).toBe(reservation);
+    expect(replyRunRegistry.get(targetSessionKey)).toBe(blocker);
+    expect(reservation.result).toBeNull();
+
+    blocker.complete();
+    reservation.complete();
+  });
 });

--- a/src/auto-reply/reply/reply-turn-admission.ts
+++ b/src/auto-reply/reply/reply-turn-admission.ts
@@ -101,6 +101,12 @@ export async function admitReplyTurn(params: {
   kind: ReplyTurnKind;
   resetTriggered: boolean;
   routeThreadId?: string | number;
+  /**
+   * Move this already-held operation into sessionKey's run slot instead of
+   * creating a new one. Used when a native command turn (admitted under its
+   * slash source key) continues into a full agent turn on the target session.
+   */
+  adoptOperation?: ReplyOperation;
   upstreamAbortSignal?: AbortSignal;
   waitTimeoutMs?: number;
   waitForActive?: boolean;
@@ -211,15 +217,23 @@ export async function admitReplyTurn(params: {
         });
       }
       try {
-        operation = createReplyOperation({
-          sessionKey: params.sessionKey,
-          sessionId,
-          resetTriggered: params.resetTriggered,
-          routeThreadId: params.routeThreadId,
-          upstreamAbortSignal: params.upstreamAbortSignal,
-          respectFollowupAdmissionBarrier:
-            params.kind === "queued_followup" || params.kind === "heartbeat",
-        });
+        if (params.adoptOperation) {
+          // The dispatch closures own this object's abort/delivery lifecycle,
+          // so the reservation must move rather than be recreated. Throws
+          // ReplyRunAlreadyActiveError into the shared busy handling below.
+          params.adoptOperation.updateSessionKey(params.sessionKey);
+          operation = params.adoptOperation;
+        } else {
+          operation = createReplyOperation({
+            sessionKey: params.sessionKey,
+            sessionId,
+            resetTriggered: params.resetTriggered,
+            routeThreadId: params.routeThreadId,
+            upstreamAbortSignal: params.upstreamAbortSignal,
+            respectFollowupAdmissionBarrier:
+              params.kind === "queued_followup" || params.kind === "heartbeat",
+          });
+        }
       } catch (error) {
         if (
           error instanceof ReplyRunAlreadyActiveError &&
@@ -240,6 +254,9 @@ export async function admitReplyTurn(params: {
         // The lifecycle fence follows hooks, media work, agent execution, and
         // final delivery. Reset/delete interrupts the operation and waits until
         // its actual owner clears it before mutating the persisted session.
+        // Adoption rebinds the map to this target lease; the source-key lease
+        // stays registered via its own after-clear callback (release is
+        // idempotent), so both identities free on operation clear.
         retainReplyOperationUntilComplete(operation);
         lifecycleAdmissionByOperation.set(operation, admission);
         runAfterReplyOperationClear(operation, () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes #104844.

#104144 keys native command turns' reply operations to the slash SOURCE session so commands never dead-wait on the target's active run (#104142). But command turns that **continue into a full agent turn** — `/steer` fallback when no active run is found, `/goal`, `/learn`, or any body no handler claims — mutate the TARGET session while their run-slot reservation and session-lifecycle lease stay keyed to the slash source identity. Concurrent target inbounds miss the source-keyed operation in every target-keyed lookup, admit in parallel, and racing session init can rotate the target sessionId — splitting one chat into two conversation families ("telegram desyncs sessions as well and does 2 sessions"). Reset/delete on the target also never interlocked with such a run. A second latent break: continuing during an active target run made the pre-run `updateSessionId` reconciliation throw `Cannot rebind reply operation`, because the target sessionId is actively mapped to the target key.

## Why This Change Was Made

The continuation seam is generic (four `shouldContinue: true` producers, plus the fast path funnels continuations back through the full pipeline), so the fix moves run ownership at that seam instead of patching individual commands:

- `reply-run-registry.ts`: new `ReplyOperation.updateSessionKey` moves a still-queued reservation into another session's run slot — same operation object (dispatch closures own its abort/delivery lifecycle), indexes and wait registrations move with it, waiters on the vacated source slot wake, and an owned target slot throws `ReplyRunAlreadyActiveError`.
- `reply-turn-admission.ts`: `admitReplyTurn` accepts `adoptOperation`, reusing the existing lifecycle-lease acquisition, stale-owner expiry, and busy handling; the target lease binds to the adopted operation so target reset/delete interlocks with the continuation run (the source lease still releases on operation clear; release is idempotent).
- `get-reply-run.ts`: before the queue-busy decision, a native-command continuation (`CommandTargetSessionKey` set, operation key ≠ run session key) adopts the target slot with `waitForActive: false` — waiting would re-create the #104142 command-lane wedge. If the target slot is owned, adoption is skipped and the existing queue policy sees the target-keyed owner and steers/queues the turn. SessionId reconciliation for continuation turns now happens after adoption, fixing the `Cannot rebind` throw.
- `agent-runner.ts`: the active-run steering block now steers against the operation registered under the run's session key instead of unconditionally preferring the provided reservation, so a skipped-adoption continuation steers into the live target run rather than its own stale reservation sessionId.

Pure command turns keep #104144's instant source-keyed admission unchanged.

## User Impact

After steering (or `/goal`, `/learn`) into an idle session, a message sent while the agent is answering no longer risks starting a second parallel run on the same chat, so sessions stop desyncing and splitting into two transcript families. Resetting or deleting a session now also correctly interrupts an in-flight run started from a command continuation.

## Evidence

- New regression tests: rekey slot move/wake/collision/phase-guard (`reply-run-registry.test.ts`), adoption + target lifecycle interlock and busy-skip keeping the source reservation (`reply-turn-admission.test.ts`), steering targets the registered run owner over a source-keyed reservation (`agent-runner.runreplyagent.e2e.test.ts`).
- Blacksmith Testbox (`tbx_01kx9yjhn81br6x9qfdmefnrdh`):
  - `pnpm test src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts src/auto-reply/reply/reply-run-registry.test.ts src/auto-reply/reply/reply-turn-admission.test.ts src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts` — all passed (includes the #104144 contract tests).
  - `pnpm test src/auto-reply` — 156 files / 3526 tests passed.
  - `pnpm tsgo:core && pnpm tsgo:core:test && pnpm check:import-cycles` — clean (0 runtime cycles).
- Structured review (Codex/gpt-5.5): first pass found the steering-precedence gap (fixed above); final pass clean — "patch is correct", no actionable findings.
- **Live gateway proof** (real `openclaw gateway` built from this branch + mock Telegram Bot API + mock OpenAI provider, per-scenario fresh state dir): [full verdicts and logs](https://github.com/openclaw/openclaw/pull/104866#issuecomment-4949577365).
  - Concurrency: `/steer` fallback continuation + concurrent group inbound mid-run → `maxConcurrentStreams: 1`, second message steered into the live run (request #2 transcript carries both user messages), session store ends with exactly one session family for the chat key.
  - Reset interlock: `/new` mid-continuation → in-flight completion stream client-aborted within ~30ms, `reason=reply_operation_aborted` on the continuation turn, target lane `AbortError: agent run aborted for restart`, old family `killed`, fresh sessionId routed, no stale final delivered; the `/new` command itself ran instantly (no #104142 wedge).
