### PR TITLE
fix(clawrouter): correct usage resetAt month off-by-one error

### DIFF
--- a/extensions/clawrouter/usage.test.ts
+++ b/extensions/clawrouter/usage.test.ts
@@ -151,7 +151,7 @@ describe("ClawRouter usage", () => {
         {
           label: "Monthly budget",
           usedPercent: 25,
-          resetAt: Date.UTC(2026, 7, 1),
+          resetAt: Date.UTC(2026, 6, 1),
         },
       ],
       billing: [
@@ -161,7 +161,7 @@ describe("ClawRouter usage", () => {
           limit: 100,
           unit: "USD",
           period: "month",
-          resetAt: Date.UTC(2026, 7, 1),
+          resetAt: Date.UTC(2026, 6, 1),
         },
       ],
       summary: "12 requests · 34,567 tokens · $25.00 used",

--- a/extensions/clawrouter/usage.ts
+++ b/extensions/clawrouter/usage.ts
@@ -55,7 +55,8 @@ function resolveMonthlyResetAt(windowKey: unknown): number | undefined {
   const year = Number(match[1]);
   const month = Number(match[2]);
   return Number.isSafeInteger(year) && month >= 1 && month <= 12
-    ? Date.UTC(year, month, 1)
+    ? // windowKey uses 1-based months; Date.UTC expects a zero-based month index.
+      Date.UTC(year, month - 1, 1)
     : undefined;
 }
 


### PR DESCRIPTION
Closes #104870

## What Problem This Solves

`resolveMonthlyResetAt` in `extensions/clawrouter/usage.ts` parses a `windowKey` ending in `/YYYY-MM` and passes the captured 1-based month directly to `Date.UTC(year, month, 1)`. `Date.UTC` expects a zero-based month index, so a window key such as `default/test-policy/2026-07` (July 2026) was converted to `Date.UTC(2026, 7, 1)`, which is **August 1, 2026** instead of July 1, 2026. This shifted every displayed budget reset date forward by one month.

## Why This Change Was Made

The fix subtracts 1 from the parsed month before passing it to `Date.UTC`, aligning the 1-based `windowKey` format with JavaScript's 0-based month index. The existing test expectation is updated to match the correct timestamp.

## User Impact

ClawRouter usage snapshots now report the correct monthly budget reset date. A July 2026 window key now resolves to July 1, 2026 instead of August 1, 2026.

## Evidence

### Unit-test proof

- Added a clarifying comment explaining the 1-based vs. 0-based month conversion.
- Updated `extensions/clawrouter/usage.test.ts` to expect `Date.UTC(2026, 6, 1)` for the `2026-07` window key.
- Verified the test fails with the old implementation and new expectation (received `1785542400000` / August 1, 2026; expected `1782864000000` / July 1, 2026).
- Verified the full `extensions/clawrouter/usage.test.ts` suite passes with the fix (7/7 tests).

### Live behavior proof

Ran a local HTTP server returning a real ClawRouter-shaped monthly usage response and called the actual `fetchClawRouterUsage` function against it. The redacted output shows the corrected reset timestamp:

```text
windowKey: default/test-policy/2026-07
old logic resetAt: 1785542400000 = 2026-08-01T00:00:00.000Z
new logic resetAt: 1782864000000 = 2026-07-01T00:00:00.000Z
live call resetAt: 1782864000000 = 2026-07-01T00:00:00.000Z
```

The live call exercises the real `fetchClawRouterUsage` code path (HTTP request, JSON parse, budget extraction, `resolveMonthlyResetAt`) and confirms the returned `resetAt` is July 1, 2026. The token was redacted.

### CI

- Rebased onto latest `origin/main`; architecture and plugin-sdk-surface checks now pass.
- `extensions/clawrouter/usage.test.ts` passes locally and in CI.
- One unrelated flaky timing test in `src/cli/gateway-cli.coverage.test.ts` occasionally fails in CI but passes locally.