### PR TITLE
fix: derive heap pressure thresholds from V8 heap limit

### DIFF
--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -2,14 +2,20 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import v8 from "node:v8";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
   type DiagnosticEventPayload,
+  type DiagnosticMemoryPressureEvent,
 } from "../infra/diagnostic-events.js";
-import { emitDiagnosticMemorySample, resetDiagnosticMemoryForTest } from "./diagnostic-memory.js";
+import {
+  emitDiagnosticMemorySample,
+  resetDiagnosticMemoryForTest,
+  resolveAdaptiveHeapThresholdBytes,
+} from "./diagnostic-memory.js";
 import {
   readLatestDiagnosticStabilityBundleSync,
   resetDiagnosticStabilityBundleForTest,
@@ -225,6 +231,130 @@ describe("diagnostic memory", () => {
         0,
       ),
     ).toBe(1);
+  });
+
+  it("keeps historic heap floors on constrained V8 limits (#104631)", () => {
+    // Sub-default V8 limit: 60%/75% ratios fall below historic floors → clamp to 1 GiB / 2 GiB.
+    expect(resolveAdaptiveHeapThresholdBytes(1536 * 1024 * 1024)).toEqual({
+      heapUsedWarningBytes: 1024 * 1024 * 1024,
+      heapUsedCriticalBytes: 2048 * 1024 * 1024,
+    });
+    // Default-ish 2 GiB limit: warning ratio (1.2 GiB) is already above the 1 GiB floor;
+    // critical still floors to 2 GiB because 75% of 2 GiB is only 1.5 GiB.
+    expect(resolveAdaptiveHeapThresholdBytes(2 * 1024 * 1024 * 1024)).toEqual({
+      heapUsedWarningBytes: Math.floor(2 * 1024 * 1024 * 1024 * 0.6),
+      heapUsedCriticalBytes: 2048 * 1024 * 1024,
+    });
+  });
+
+  it("scales heap thresholds with enlarged V8 limits (#104631)", () => {
+    // 8 GiB limit: warning 60% = 4.8 GiB, critical 75% = 6 GiB (above floors).
+    const eightGib = 8 * 1024 * 1024 * 1024;
+    expect(resolveAdaptiveHeapThresholdBytes(eightGib)).toEqual({
+      heapUsedWarningBytes: Math.floor(eightGib * 0.6),
+      heapUsedCriticalBytes: Math.floor(eightGib * 0.75),
+    });
+  });
+
+  it("does not emit critical heap_threshold at 2 GiB when adaptive critical is higher (#104631)", () => {
+    // Reproduces the reported false positive: 2 GiB heapUsed on an 8 GiB V8 limit must not
+    // fire critical under adaptive defaults. Inject the enlarged thresholds directly (same
+    // values resolveAdaptiveHeapThresholdBytes produces for an 8 GiB limit).
+    const eightGib = 8 * 1024 * 1024 * 1024;
+    const adaptive = resolveAdaptiveHeapThresholdBytes(eightGib);
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onDiagnosticEvent((event) => events.push(event));
+
+    emitDiagnosticMemorySample({
+      now: 1000,
+      memoryUsage: memoryUsage({
+        rss: 500 * 1024 * 1024,
+        heapUsed: 2 * 1024 * 1024 * 1024,
+      }),
+      thresholds: {
+        // Keep RSS out of the way; only heap adaptive defaults under test.
+        rssWarningBytes: 10 * 1024 * 1024 * 1024,
+        rssCriticalBytes: 20 * 1024 * 1024 * 1024,
+        heapUsedWarningBytes: adaptive.heapUsedWarningBytes,
+        heapUsedCriticalBytes: adaptive.heapUsedCriticalBytes,
+        pressureRepeatMs: 60_000,
+      },
+    });
+    stop();
+
+    const pressureEvents = events.filter(
+      (event): event is DiagnosticMemoryPressureEvent =>
+        event.type === "diagnostic.memory.pressure",
+    );
+    expect(pressureEvents).toHaveLength(0);
+    expect(adaptive.heapUsedCriticalBytes).toBeGreaterThan(2 * 1024 * 1024 * 1024);
+  });
+
+  it("emits critical heap_threshold when heapUsed crosses adaptive critical (#104631)", () => {
+    const eightGib = 8 * 1024 * 1024 * 1024;
+    const adaptive = resolveAdaptiveHeapThresholdBytes(eightGib);
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onDiagnosticEvent((event) => events.push(event));
+
+    emitDiagnosticMemorySample({
+      now: 1000,
+      memoryUsage: memoryUsage({
+        rss: 500 * 1024 * 1024,
+        heapUsed: adaptive.heapUsedCriticalBytes + 1,
+      }),
+      thresholds: {
+        rssWarningBytes: 10 * 1024 * 1024 * 1024,
+        rssCriticalBytes: 20 * 1024 * 1024 * 1024,
+        heapUsedWarningBytes: adaptive.heapUsedWarningBytes,
+        heapUsedCriticalBytes: adaptive.heapUsedCriticalBytes,
+        pressureRepeatMs: 60_000,
+      },
+    });
+    stop();
+
+    const pressureEvents = events.filter(
+      (event): event is DiagnosticMemoryPressureEvent =>
+        event.type === "diagnostic.memory.pressure",
+    );
+    expect(pressureEvents).toHaveLength(1);
+    expect(pressureEvents[0]).toMatchObject({
+      level: "critical",
+      reason: "heap_threshold",
+      thresholdBytes: adaptive.heapUsedCriticalBytes,
+    });
+  });
+
+  it("emits default adaptive heap_threshold from process V8 limit (#104631)", () => {
+    // Match production path: resolveThresholds reads process V8 heap_size_limit.
+    const adaptive = resolveAdaptiveHeapThresholdBytes(v8.getHeapStatistics().heap_size_limit);
+    const events: DiagnosticEventPayload[] = [];
+    const stop = onDiagnosticEvent((event) => events.push(event));
+
+    emitDiagnosticMemorySample({
+      now: 1000,
+      memoryUsage: memoryUsage({
+        rss: 100 * 1024 * 1024,
+        heapUsed: adaptive.heapUsedWarningBytes + 1,
+      }),
+      // Omit heap overrides so production resolveThresholds uses adaptive V8 defaults.
+      thresholds: {
+        rssWarningBytes: 10 * 1024 * 1024 * 1024,
+        rssCriticalBytes: 20 * 1024 * 1024 * 1024,
+        pressureRepeatMs: 60_000,
+      },
+    });
+    stop();
+
+    const pressureEvents = events.filter(
+      (event): event is DiagnosticMemoryPressureEvent =>
+        event.type === "diagnostic.memory.pressure",
+    );
+    expect(pressureEvents).toHaveLength(1);
+    expect(pressureEvents[0]).toMatchObject({
+      level: "warning",
+      reason: "heap_threshold",
+      thresholdBytes: adaptive.heapUsedWarningBytes,
+    });
   });
 
   it("resolves session store paths only for enabled critical bundle writes", () => {

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -1,4 +1,5 @@
 // Diagnostic memory helpers capture process memory facts for support diagnostics.
+import v8 from "node:v8";
 import {
   emitInternalDiagnosticEvent as emitDiagnosticEvent,
   type DiagnosticMemoryPressureEvent,
@@ -11,8 +12,11 @@ import { createSubsystemLogger } from "./subsystem.js";
 const MB = 1024 * 1024;
 const DEFAULT_RSS_WARNING_BYTES = 1536 * MB;
 const DEFAULT_RSS_CRITICAL_BYTES = 3072 * MB;
+// Floors keep small-host protection when V8's effective limit is at or near the historic defaults.
 const DEFAULT_HEAP_WARNING_BYTES = 1024 * MB;
 const DEFAULT_HEAP_CRITICAL_BYTES = 2048 * MB;
+const HEAP_WARNING_OF_LIMIT = 0.6;
+const HEAP_CRITICAL_OF_LIMIT = 0.75;
 const DEFAULT_RSS_GROWTH_WARNING_BYTES = 512 * MB;
 const DEFAULT_RSS_GROWTH_CRITICAL_BYTES = 1024 * MB;
 const DEFAULT_GROWTH_WINDOW_MS = 10 * 60 * 1000;
@@ -58,14 +62,58 @@ function normalizeMemoryUsage(memory: NodeJS.MemoryUsage): DiagnosticMemoryUsage
   };
 }
 
+/**
+ * Derive default heap pressure thresholds from V8's effective heap limit.
+ * Scales with `--max-old-space-size` while keeping historic 1 GiB / 2 GiB floors
+ * so constrained hosts stay protected (issue #104631).
+ */
+export function resolveAdaptiveHeapThresholdBytes(heapSizeLimitBytes: number): {
+  heapUsedWarningBytes: number;
+  heapUsedCriticalBytes: number;
+} {
+  const limit =
+    typeof heapSizeLimitBytes === "number" &&
+    Number.isFinite(heapSizeLimitBytes) &&
+    heapSizeLimitBytes > 0
+      ? heapSizeLimitBytes
+      : DEFAULT_HEAP_CRITICAL_BYTES;
+  return {
+    heapUsedWarningBytes: Math.max(
+      Math.floor(limit * HEAP_WARNING_OF_LIMIT),
+      DEFAULT_HEAP_WARNING_BYTES,
+    ),
+    heapUsedCriticalBytes: Math.max(
+      Math.floor(limit * HEAP_CRITICAL_OF_LIMIT),
+      DEFAULT_HEAP_CRITICAL_BYTES,
+    ),
+  };
+}
+
+function resolveDefaultHeapThresholdBytes(): {
+  heapUsedWarningBytes: number;
+  heapUsedCriticalBytes: number;
+} {
+  return resolveAdaptiveHeapThresholdBytes(v8.getHeapStatistics().heap_size_limit);
+}
+
 function resolveThresholds(
   thresholds?: DiagnosticMemoryThresholds,
 ): Required<DiagnosticMemoryThresholds> {
+  const needsAdaptiveHeap =
+    thresholds?.heapUsedWarningBytes === undefined ||
+    thresholds?.heapUsedCriticalBytes === undefined;
+  const adaptiveHeap = needsAdaptiveHeap ? resolveDefaultHeapThresholdBytes() : undefined;
   return {
     rssWarningBytes: thresholds?.rssWarningBytes ?? DEFAULT_RSS_WARNING_BYTES,
     rssCriticalBytes: thresholds?.rssCriticalBytes ?? DEFAULT_RSS_CRITICAL_BYTES,
-    heapUsedWarningBytes: thresholds?.heapUsedWarningBytes ?? DEFAULT_HEAP_WARNING_BYTES,
-    heapUsedCriticalBytes: thresholds?.heapUsedCriticalBytes ?? DEFAULT_HEAP_CRITICAL_BYTES,
+    heapUsedWarningBytes:
+      thresholds?.heapUsedWarningBytes ??
+      adaptiveHeap?.heapUsedWarningBytes ??
+      DEFAULT_HEAP_WARNING_BYTES,
+    heapUsedCriticalBytes:
+      thresholds?.heapUsedCriticalBytes ??
+      adaptiveHeap?.heapUsedCriticalBytes ??
+      DEFAULT_HEAP_CRITICAL_BYTES,
     rssGrowthWarningBytes: thresholds?.rssGrowthWarningBytes ?? DEFAULT_RSS_GROWTH_WARNING_BYTES,
     rssGrowthCriticalBytes: thresholds?.rssGrowthCriticalBytes ?? DEFAULT_RSS_GROWTH_CRITICAL_BYTES,
     growthWindowMs: thresholds?.growthWindowMs ?? DEFAULT_GROWTH_WINDOW_MS,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running the gateway with an enlarged V8 heap (for example `NODE_OPTIONS=--max-old-space-size=8192`) receive a false-positive **critical** `heap_threshold` memory-pressure diagnostic as soon as `heapUsed` crosses **2 GiB**, even when the process still has substantial remaining heap headroom and the host has free RAM.

## Why This Change Was Made

Default heap warning/critical thresholds were fixed at 1 GiB / 2 GiB and did not scale with V8’s effective `heap_size_limit`. This change derives those defaults from `v8.getHeapStatistics().heap_size_limit` (60% warning / 75% critical) while keeping the historic 1 GiB / 2 GiB floors so constrained hosts stay protected. RSS thresholds and RSS-growth detection are unchanged. No new config surface is added.

## User Impact

Gateways configured with larger `--max-old-space-size` no longer emit critical heap-pressure diagnostics merely because heap used crossed the old hard 2 GiB line. Small-host defaults remain at least as strict as before. Explicit threshold overrides still work when provided by callers.

## Evidence

Verification host: local macOS (Crabbox bypass)

```text
node scripts/run-vitest.mjs src/logging/diagnostic-memory.test.ts
# 16 tests passed

pnpm check:changed -- src/logging/diagnostic-memory.ts src/logging/diagnostic-memory.test.ts
# exit 0 (format, tsgo core/core-test, oxlint, import-cycle, guards)
```

Production-path transcript via `emitDiagnosticMemorySample` (gateway diagnostics/memory logger):

```text
=== Real behavior proof (#104631) production emitDiagnosticMemorySample ===
host darwin arm64 v24.17.0
heap_size_limit 4496293888
adaptive_process {"heapUsedWarningBytes":2697776332,"heapUsedCriticalBytes":3372220416}
adaptive_8gib {"heapUsedWarningBytes":5153960755,"heapUsedCriticalBytes":6442450944}
CASE_A: 2GiB heapUsed with 8GiB adaptive thresholds (expect NO pressure log)
CASE_B: main hardcoded 2GiB critical at heapUsed=2GiB+1 (expect critical log)
[diagnostics/memory] memory pressure: level=critical reason=heap_threshold ... heap=2 GiB threshold=2 GiB ...
CASE_C: process adaptive warning at warning+1 (expect warning log)
[diagnostics/memory] memory pressure: level=warning reason=heap_threshold ... threshold=2.51 GiB ...
CASE_D: process adaptive critical at critical+1 (expect critical log)
[diagnostics/memory] memory pressure: level=critical reason=heap_threshold ... threshold=3.14 GiB ...
PROOF_DONE
```

## Real behavior proof

- Behavior addressed: False-positive critical `heap_threshold` at 2 GiB heapUsed on enlarged-heap hosts; adaptive V8-relative defaults with historic floors.
- Environment: local macOS arm64, Node v24.17.0, openclaw checkout at this PR head; production `emitDiagnosticMemorySample` + focused Vitest.
- Current-main contrast: main hardcodes `DEFAULT_HEAP_CRITICAL_BYTES = 2048 * MB`, so heapUsed just over 2 GiB emits critical even when the process heap limit is ~4–8 GiB.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/logging/diagnostic-memory.test.ts`
  2. `node --import tsx` script calling production `emitDiagnosticMemorySample` for enlarged-safe, main-hardcoded, adaptive warning, and adaptive critical cases.
- Evidence after fix: CASE_A produced no pressure log at 2 GiB under 8 GiB adaptive thresholds; CASE_B still fires critical under main-style 2 GiB hardcoded thresholds; CASE_C/D fire warning/critical only at process adaptive thresholds (~2.51 / ~3.14 GiB on this host’s ~4.2 GiB V8 limit). Focused tests cover constrained floors, enlarged scaling, and classifier emission.
- Control check: RSS thresholds kept high in harness cases so only heap_threshold is under test; explicit threshold overrides still take precedence when provided.
- Observed result after fix: Enlarged-heap 2 GiB usage is no longer critical by default; genuine pressure still fires when heapUsed crosses the adaptive critical line.
- What was not tested: Full long-running gateway under multi-GB live heap accumulation, deployment supervisor restart chains outside OpenClaw source, and non-macOS hosts.

Fixes #104631

Related open candidate PR (not ready for maintainer look; this PR follows the same ClawSweeper fix shape with expanded unit + production-path proof): #104681

### AI disclosure

This fix was authored with AI assistance (Grok / xAI agent). Human operator ran the auto find→fix pipeline; proof commands and review of the resulting diff were agent-executed on the local macOS checkout.
