### PR TITLE
feat(write): add capability-gated native append

### DIFF
--- a/src/agents/agent-tools.read.host-tilde-expansion.test.ts
+++ b/src/agents/agent-tools.read.host-tilde-expansion.test.ts
@@ -18,6 +18,7 @@ type CapturedEditOperations = {
 type CapturedWriteOperations = {
   mkdir: (dir: string) => Promise<void>;
   writeFile: (absolutePath: string, content: string) => Promise<void>;
+  appendFile: (absolutePath: string, content: string) => Promise<void>;
 };
 
 const mocks = vi.hoisted(() => ({
@@ -131,6 +132,17 @@ describe("host tool tilde expansion (non-workspace mode)", () => {
     await readWriteOps().writeFile(toTildePath(testFile), "written via tilde");
 
     expect(await fs.readFile(testFile, "utf8")).toBe("written via tilde");
+  });
+
+  it("write appendFile expands ~ to the OS home directory", async () => {
+    const dir = await createTempDir("openclaw-tilde-test-append-");
+    const testFile = path.join(dir, "tilde-append-test.txt");
+    await fs.writeFile(testFile, "seed", "utf8");
+
+    createHostWorkspaceWriteTool(dir, { workspaceOnly: false });
+    await readWriteOps().appendFile(toTildePath(testFile), "+next");
+
+    expect(await fs.readFile(testFile, "utf8")).toBe("seed+next");
   });
 
   it("write mkdir expands ~ to the OS home directory", async () => {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -33,6 +33,7 @@ import {
   wrapToolParamValidation,
 } from "./agent-tools.params.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
+import { createUncertainAppendOutcomeError } from "./append-outcome.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
 import type { AgentToolResult } from "./runtime/index.js";
@@ -670,6 +671,25 @@ async function appendMemoryFlushContent(params: {
     existing.length > 0 && !existing.endsWith("\n") && !params.content.startsWith("\n") ? "\n" : "";
   const next = `${existing}${separator}${params.content}`;
   if (params.sandbox) {
+    const appendFile = params.sandbox.bridge.appendFile?.bind(params.sandbox.bridge);
+    if (appendFile) {
+      if (params.signal?.aborted) {
+        throw new Error("Operation aborted");
+      }
+      try {
+        await appendFile({
+          filePath: params.relativePath,
+          cwd: params.sandbox.root,
+          data: `${separator}${params.content}`,
+          mkdir: true,
+          signal: params.signal,
+        });
+      } catch (error) {
+        throw createUncertainAppendOutcomeError(error);
+      }
+      return;
+    }
+    // Legacy bridges without native append retain the previous mirror rewrite behavior.
     const parent = path.posix.dirname(params.relativePath);
     if (parent && parent !== ".") {
       await params.sandbox.bridge.mkdirp({
@@ -1036,6 +1056,7 @@ function createSandboxReadOperations(params: SandboxToolParams) {
 }
 
 function createSandboxWriteOperations(params: SandboxToolParams) {
+  const appendFile = params.bridge.appendFile?.bind(params.bridge);
   return {
     mkdir: async (dir: string) => {
       await params.bridge.mkdirp({ filePath: dir, cwd: params.root });
@@ -1043,6 +1064,18 @@ function createSandboxWriteOperations(params: SandboxToolParams) {
     writeFile: async (absolutePath: string, content: string) => {
       await params.bridge.writeFile({ filePath: absolutePath, cwd: params.root, data: content });
     },
+    ...(appendFile
+      ? {
+          appendFile: async (absolutePath: string, content: string) => {
+            await appendFile({
+              filePath: absolutePath,
+              cwd: params.root,
+              data: content,
+              mkdir: true,
+            });
+          },
+        }
+      : {}),
     readFile: (absolutePath: string) =>
       params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
     statFile: (absolutePath: string) =>
@@ -1080,6 +1113,12 @@ async function writeHostFile(absolutePath: string, content: string) {
   const resolved = resolveHostPath(absolutePath);
   await fs.mkdir(path.dirname(resolved), { recursive: true });
   await fs.writeFile(resolved, content, "utf-8");
+}
+
+async function appendHostFile(absolutePath: string, content: string) {
+  const resolved = resolveHostPath(absolutePath);
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  await fs.appendFile(resolved, content, "utf-8");
 }
 
 async function statHostFile(absolutePath: string) {
@@ -1128,6 +1167,7 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
         await fs.mkdir(resolved, { recursive: true });
       },
       writeFile: writeHostFile,
+      appendFile: appendHostFile,
       readFile: async (absolutePath: string) =>
         fs.readFile(path.resolve(expandTildeToOsHome(absolutePath))),
       statFile: (absolutePath: string) =>
@@ -1150,6 +1190,10 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
     },
     writeFile: (absolutePath: string, content: string) =>
       writeWorkspaceFile(root, getRoot, absolutePath, content),
+    appendFile: async (absolutePath: string, content: string) => {
+      const relative = await toCanonicalRelativeWorkspacePath(root, absolutePath);
+      await (await getRoot()).append(relative, content, { mkdir: true });
+    },
     readFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
       return (await (await getRoot()).read(relative)).buffer;

--- a/src/agents/agent-tools.sandbox-mounted-paths.workspace-only.test.ts
+++ b/src/agents/agent-tools.sandbox-mounted-paths.workspace-only.test.ts
@@ -115,7 +115,12 @@ describe("tools.fs.workspaceOnly", () => {
       expect(getTextContent(readResult)).toContain("shh");
 
       await writeTool?.execute("t2", { path: "/agent/owned.txt", content: "x" });
-      expect(await fs.readFile(path.join(agentRoot, "owned.txt"), "utf8")).toBe("x");
+      await writeTool?.execute("t3", {
+        path: "/agent/owned.txt",
+        content: "+append",
+        append: true,
+      });
+      expect(await fs.readFile(path.join(agentRoot, "owned.txt"), "utf8")).toBe("x+append");
     });
   });
 
@@ -132,6 +137,13 @@ describe("tools.fs.workspaceOnly", () => {
 
       await expect(
         writeTool?.execute("t2", { path: "/agent/owned.txt", content: "x" }),
+      ).rejects.toThrow(/Path escapes sandbox root/i);
+      await expect(
+        writeTool?.execute("t2-append", {
+          path: "/agent/owned.txt",
+          content: "x",
+          append: true,
+        }),
       ).rejects.toThrow(/Path escapes sandbox root/i);
       const missingOwnedFile = await fs
         .stat(path.join(agentRoot, "owned.txt"))

--- a/src/agents/agent-tools.workspace-only-false.test.ts
+++ b/src/agents/agent-tools.workspace-only-false.test.ts
@@ -24,6 +24,7 @@ import {
   wrapToolMemoryFlushAppendOnlyWrite,
   wrapToolWorkspaceRootGuard,
 } from "./agent-tools.read.js";
+import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 describe("FS tools with workspaceOnly=false", () => {
@@ -92,6 +93,21 @@ describe("FS tools with workspaceOnly=false", () => {
     );
     const content = await fs.readFile(outsideFile, "utf-8");
     expect(content).toBe("test content");
+  });
+
+  it("should allow append outside workspace when workspaceOnly=false", async () => {
+    await fs.writeFile(outsideFile, "seed", "utf8");
+    await runFsTool(
+      "write",
+      "test-call-append-outside",
+      {
+        path: outsideFile,
+        content: "+next",
+        append: true,
+      },
+      false,
+    );
+    await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("seed+next");
   });
 
   it("should allow write outside workspace via ../ path when workspaceOnly=false", async () => {
@@ -238,6 +254,26 @@ describe("FS tools with workspaceOnly=false", () => {
     ).rejects.toThrow(/Path escapes (workspace|sandbox) root/);
   });
 
+  it("should append inside workspace and block outside append when workspaceOnly=true", async () => {
+    const insideFile = path.join(workspaceDir, "inside.txt");
+    await fs.writeFile(insideFile, "seed", "utf8");
+    const writeTool = requireTool(toolsFor(true), "write");
+
+    await writeTool.execute("test-call-append-inside", {
+      path: insideFile,
+      content: "+inside",
+      append: true,
+    });
+    await expect(fs.readFile(insideFile, "utf8")).resolves.toBe("seed+inside");
+    await expect(
+      writeTool.execute("test-call-append-outside-blocked", {
+        path: outsideFile,
+        content: "+outside",
+        append: true,
+      }),
+    ).rejects.toThrow(/Path escapes (workspace|sandbox) root/);
+  });
+
   it("restricts memory-triggered writes to append-only canonical memory files", async () => {
     const allowedRelativePath = "memory/2026-03-07.md";
     const allowedAbsolutePath = path.join(workspaceDir, allowedRelativePath);
@@ -264,6 +300,7 @@ describe("FS tools with workspaceOnly=false", () => {
     const result = await writeTool.execute("test-call-memory-append", {
       path: allowedRelativePath,
       content: "new note",
+      append: true,
     });
     expect(hasToolError(result)).toBe(false);
     expect(result).toStrictEqual({
@@ -274,6 +311,134 @@ describe("FS tools with workspaceOnly=false", () => {
       },
     });
     await expect(fs.readFile(allowedAbsolutePath, "utf-8")).resolves.toBe("seed\nnew note");
+  });
+
+  it("uses a sandbox bridge native append for memory-triggered writes when available", async () => {
+    const allowedRelativePath = "memory/2026-03-10.md";
+    const allowedAbsolutePath = path.join(workspaceDir, allowedRelativePath);
+    await fs.mkdir(path.dirname(allowedAbsolutePath), { recursive: true });
+    await fs.writeFile(allowedAbsolutePath, "seed", "utf8");
+    const bridge = createHostSandboxFsBridge(workspaceDir);
+    const appendSpy = vi.spyOn(bridge, "appendFile");
+    const writeSpy = vi.spyOn(bridge, "writeFile");
+    const writeTool = wrapToolMemoryFlushAppendOnlyWrite(
+      createHostWorkspaceWriteTool(workspaceDir),
+      {
+        root: workspaceDir,
+        relativePath: allowedRelativePath,
+        sandbox: { root: workspaceDir, bridge },
+      },
+    );
+
+    const result = await writeTool.execute("test-call-memory-sandbox-append", {
+      path: allowedRelativePath,
+      content: "native append",
+      append: true,
+    });
+
+    expect(hasToolError(result)).toBe(false);
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy).not.toHaveBeenCalled();
+    await expect(fs.readFile(allowedAbsolutePath, "utf8")).resolves.toBe("seed\nnative append");
+  });
+
+  it("marks a sandbox memory append uncertain when mutation precedes backend rejection", async () => {
+    const allowedRelativePath = "memory/2026-03-11.md";
+    const allowedAbsolutePath = path.join(workspaceDir, allowedRelativePath);
+    await fs.mkdir(path.dirname(allowedAbsolutePath), { recursive: true });
+    await fs.writeFile(allowedAbsolutePath, "seed", "utf8");
+    const bridge = createHostSandboxFsBridge(workspaceDir);
+    const appendFile = bridge.appendFile?.bind(bridge);
+    if (!appendFile) {
+      throw new Error("test bridge must support append");
+    }
+    bridge.appendFile = async (params) => {
+      await appendFile(params);
+      throw new Error("fsync timed out");
+    };
+    const writeTool = wrapToolMemoryFlushAppendOnlyWrite(
+      createHostWorkspaceWriteTool(workspaceDir),
+      {
+        root: workspaceDir,
+        relativePath: allowedRelativePath,
+        sandbox: { root: workspaceDir, bridge },
+      },
+    );
+
+    await expect(
+      writeTool.execute("test-call-memory-sandbox-uncertain-after", {
+        path: allowedRelativePath,
+        content: "durable note",
+        append: true,
+      }),
+    ).rejects.toThrow(/Append outcome is uncertain; do not retry automatically/);
+    await expect(fs.readFile(allowedAbsolutePath, "utf8")).resolves.toBe("seed\ndurable note");
+  });
+
+  it("marks a sandbox memory append uncertain when the backend rejects before persistence", async () => {
+    const allowedRelativePath = "memory/2026-03-12.md";
+    const allowedAbsolutePath = path.join(workspaceDir, allowedRelativePath);
+    await fs.mkdir(path.dirname(allowedAbsolutePath), { recursive: true });
+    await fs.writeFile(allowedAbsolutePath, "seed", "utf8");
+    const bridge = createHostSandboxFsBridge(workspaceDir);
+    bridge.appendFile = async () => {
+      throw new Error("remote append rejected");
+    };
+    const writeTool = wrapToolMemoryFlushAppendOnlyWrite(
+      createHostWorkspaceWriteTool(workspaceDir),
+      {
+        root: workspaceDir,
+        relativePath: allowedRelativePath,
+        sandbox: { root: workspaceDir, bridge },
+      },
+    );
+
+    await expect(
+      writeTool.execute("test-call-memory-sandbox-uncertain-before", {
+        path: allowedRelativePath,
+        content: "not persisted",
+        append: true,
+      }),
+    ).rejects.toThrow(/Append outcome is uncertain; do not retry automatically/);
+    await expect(fs.readFile(allowedAbsolutePath, "utf8")).resolves.toBe("seed");
+  });
+
+  it("accepts sandbox memory append acknowledgement before late cancellation", async () => {
+    const allowedRelativePath = "memory/2026-03-13.md";
+    const allowedAbsolutePath = path.join(workspaceDir, allowedRelativePath);
+    await fs.mkdir(path.dirname(allowedAbsolutePath), { recursive: true });
+    await fs.writeFile(allowedAbsolutePath, "seed", "utf8");
+    const bridge = createHostSandboxFsBridge(workspaceDir);
+    const appendFile = bridge.appendFile?.bind(bridge);
+    if (!appendFile) {
+      throw new Error("test bridge must support append");
+    }
+    const controller = new AbortController();
+    bridge.appendFile = async (params) => {
+      await appendFile(params);
+      controller.abort();
+    };
+    const writeTool = wrapToolMemoryFlushAppendOnlyWrite(
+      createHostWorkspaceWriteTool(workspaceDir),
+      {
+        root: workspaceDir,
+        relativePath: allowedRelativePath,
+        sandbox: { root: workspaceDir, bridge },
+      },
+    );
+
+    const result = await writeTool.execute(
+      "test-call-memory-sandbox-acknowledged",
+      {
+        path: allowedRelativePath,
+        content: "acknowledged",
+        append: true,
+      },
+      controller.signal,
+    );
+
+    expect(hasToolError(result)).toBe(false);
+    await expect(fs.readFile(allowedAbsolutePath, "utf8")).resolves.toBe("seed\nacknowledged");
   });
 
   it("accepts memory-triggered append-only writes with malformed XML arg-value path suffixes", async () => {

--- a/src/agents/append-outcome.ts
+++ b/src/agents/append-outcome.ts
@@ -1,0 +1,12 @@
+/**
+ * Build the fail-closed error used after an append backend starts but does not
+ * acknowledge completion. Readback cannot attribute bytes to one writer, and
+ * the backend may have persisted a prefix before rejecting.
+ */
+export function createUncertainAppendOutcomeError(error: unknown): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+  return new Error(
+    `Append outcome is uncertain; do not retry automatically. The backend did not acknowledge completion: ${detail}`,
+    { cause: error },
+  );
+}

--- a/src/agents/sandbox/fs-bridge-mutation-helper.test.ts
+++ b/src/agents/sandbox/fs-bridge-mutation-helper.test.ts
@@ -1,6 +1,6 @@
 // Pinned mutation helper tests cover the Python helper that performs sandbox
 // filesystem mutations through directory file descriptors.
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -10,7 +10,7 @@ import {
   SANDBOX_PINNED_MUTATION_PYTHON,
 } from "./fs-bridge-mutation-helper.js";
 
-function runMutation(args: string[], input?: string) {
+function runMutation(args: string[], input?: string | Buffer) {
   return spawnSync("python3", ["-c", SANDBOX_PINNED_MUTATION_PYTHON, ...args], {
     input,
     encoding: "utf8",
@@ -18,11 +18,17 @@ function runMutation(args: string[], input?: string) {
   });
 }
 
-function runMutationWithSource(source: string, args: string[], input?: string) {
+function runMutationWithSource(
+  source: string,
+  args: string[],
+  input?: string | Buffer,
+  timeout?: number,
+) {
   return spawnSync("python3", ["-c", source, ...args], {
     input,
     encoding: "utf8",
     stdio: ["pipe", "pipe", "pipe"],
+    timeout,
   });
 }
 
@@ -113,6 +119,89 @@ const FORCED_EXDEV_WITH_SOURCE_REPLACEMENT_MUTATION_PYTHON = FORCED_EXDEV_MUTATI
   ].join("\n"),
 );
 
+const SHORT_WRITE_APPEND_MUTATION_PYTHON = SANDBOX_PINNED_MUTATION_PYTHON.replace(
+  "operation = sys.argv[1]",
+  [
+    "_real_os_write = os.write",
+    "def _short_os_write(fd, data):",
+    "    return _real_os_write(fd, data[:7])",
+    "os.write = _short_os_write",
+    "",
+    "operation = sys.argv[1]",
+  ].join("\n"),
+);
+
+const PAUSED_APPEND_MUTATION_PYTHON = SANDBOX_PINNED_MUTATION_PYTHON.replace(
+  [
+    "    file_fd = os.open(basename, APPEND_FLAGS, 0o600, dir_fd=parent_fd)",
+    "    try:",
+    "        file_stat = os.fstat(file_fd)",
+  ].join("\n"),
+  [
+    "    file_fd = os.open(basename, APPEND_FLAGS, 0o600, dir_fd=parent_fd)",
+    "    try:",
+    "        os.write(2, b'APPEND_READY\\n')",
+    "        file_stat = os.fstat(file_fd)",
+  ].join("\n"),
+);
+
+const SWAPPED_TO_FIFO_APPEND_MUTATION_PYTHON = SANDBOX_PINNED_MUTATION_PYTHON.replace(
+  [
+    "    validate_append_target(parent_fd, basename)",
+    "    file_fd = os.open(basename, APPEND_FLAGS, 0o600, dir_fd=parent_fd)",
+  ].join("\n"),
+  [
+    "    validate_append_target(parent_fd, basename)",
+    "    os.unlink(basename, dir_fd=parent_fd)",
+    "    os.mkfifo(basename, 0o600, dir_fd=parent_fd)",
+    "    file_fd = os.open(basename, APPEND_FLAGS, 0o600, dir_fd=parent_fd)",
+  ].join("\n"),
+);
+
+function startPausedAppend(args: string[]) {
+  const child = spawn("python3", ["-c", PAUSED_APPEND_MUTATION_PYTHON, ...args], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  let readySettled = false;
+  let resolveReady: (() => void) | undefined;
+  let rejectReady: ((error: Error) => void) | undefined;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf8");
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString("utf8");
+    if (!readySettled && stderr.includes("APPEND_READY")) {
+      readySettled = true;
+      resolveReady?.();
+    }
+  });
+  const result = new Promise<{ status: number | null; stdout: string; stderr: string }>(
+    (resolve, reject) => {
+      child.once("error", (error) => {
+        if (!readySettled) {
+          readySettled = true;
+          rejectReady?.(error);
+        }
+        reject(error);
+      });
+      child.once("close", (status) => {
+        if (!readySettled) {
+          readySettled = true;
+          rejectReady?.(new Error(`append helper exited before ready: ${stderr}`));
+        }
+        resolve({ status, stdout, stderr });
+      });
+    },
+  );
+  return { child, ready, result };
+}
+
 describe("sandbox pinned mutation helper", () => {
   it("writes through a pinned directory fd", async () => {
     await withTempDir({ prefix: "openclaw-mutation-helper-" }, async (root) => {
@@ -164,6 +253,171 @@ describe("sandbox pinned mutation helper", () => {
         await expect(fs.readFile(filePath, "utf8")).resolves.toBe("after");
         const fileStat = await fs.stat(filePath);
         expect(fileStat.mode & 0o777).toBe(0o600);
+      });
+    },
+  );
+
+  it("appends bytes and creates missing parent directories through pinned descriptors", async () => {
+    await withTempDir({ prefix: "openclaw-mutation-helper-append-" }, async (root) => {
+      const workspace = path.join(root, "workspace");
+      await fs.mkdir(workspace, { recursive: true });
+      const seed = Buffer.from([0xff, 0xfe, 0x00]);
+      const suffix = Buffer.from([0x80, 0x81, 0x0a]);
+
+      expect(runMutation(["append", workspace, "nested", "bytes.bin", "1"], seed).status).toBe(0);
+      expect(runMutation(["append", workspace, "nested", "bytes.bin", "1"], suffix).status).toBe(0);
+
+      await expect(fs.readFile(path.join(workspace, "nested", "bytes.bin"))).resolves.toEqual(
+        Buffer.concat([seed, suffix]),
+      );
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "creates missing append targets with the same restrictive mode as write",
+    async () => {
+      await withTempDir({ prefix: "openclaw-mutation-helper-append-" }, async (root) => {
+        const workspace = path.join(root, "workspace");
+        const target = path.join(workspace, "created.txt");
+        await fs.mkdir(workspace, { recursive: true });
+
+        const result = runMutation(["append", workspace, "", "created.txt", "0"], "created");
+
+        expect(result.status).toBe(0);
+        const fileStat = await fs.stat(target);
+        expect(fileStat.mode & 0o777).toBe(0o600);
+      });
+    },
+  );
+
+  it("creates a missing file for an empty append and leaves an existing file unchanged", async () => {
+    await withTempDir({ prefix: "openclaw-mutation-helper-append-" }, async (root) => {
+      const workspace = path.join(root, "workspace");
+      await fs.mkdir(workspace, { recursive: true });
+      await fs.writeFile(path.join(workspace, "existing.txt"), "seed", "utf8");
+
+      expect(
+        runMutation(["append", workspace, "", "missing.txt", "0"], Buffer.alloc(0)).status,
+      ).toBe(0);
+      expect(
+        runMutation(["append", workspace, "", "existing.txt", "0"], Buffer.alloc(0)).status,
+      ).toBe(0);
+
+      await expect(fs.readFile(path.join(workspace, "missing.txt"))).resolves.toEqual(
+        Buffer.alloc(0),
+      );
+      await expect(fs.readFile(path.join(workspace, "existing.txt"), "utf8")).resolves.toBe("seed");
+    });
+  });
+
+  it("honors mkdir false for append targets", async () => {
+    await withTempDir({ prefix: "openclaw-mutation-helper-append-" }, async (root) => {
+      const workspace = path.join(root, "workspace");
+      await fs.mkdir(workspace, { recursive: true });
+
+      const result = runMutation(["append", workspace, "missing", "file.txt", "0"], "blocked");
+
+      expect(result.status).not.toBe(0);
+      await expectPathMissing(path.join(workspace, "missing"));
+    });
+  });
+
+  it("retries short append writes until the complete payload is persisted", async () => {
+    await withTempDir({ prefix: "openclaw-mutation-helper-append-" }, async (root) => {
+      const workspace = path.join(root, "workspace");
+      await fs.mkdir(workspace, { recursive: true });
+      const payload = Buffer.from(Array.from({ length: 257 }, (_, index) => index % 256));
+
+      const result = runMutationWithSource(
+        SHORT_WRITE_APPEND_MUTATION_PYTHON,
+        ["append", workspace, "", "short-write.bin", "1"],
+        payload,
+      );
+
+      expect(result.status).toBe(0);
+      await expect(fs.readFile(path.join(workspace, "short-write.bin"))).resolves.toEqual(payload);
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "preserves both independent process appends without a read-modify-write race",
+    async () => {
+      await withTempDir({ prefix: "openclaw-mutation-helper-append-race-" }, async (root) => {
+        const workspace = path.join(root, "workspace");
+        const target = path.join(workspace, "race.bin");
+        await fs.mkdir(workspace, { recursive: true });
+        const seed = Buffer.from("seed\n");
+        const leftPayload = Buffer.alloc(128 * 1024, 0xa1);
+        const rightPayload = Buffer.alloc(128 * 1024, 0xb2);
+        await fs.writeFile(target, seed);
+
+        const args = ["append", workspace, "", "race.bin", "1"];
+        const left = startPausedAppend(args);
+        const right = startPausedAppend(args);
+        await Promise.all([left.ready, right.ready]);
+        left.child.stdin.end(leftPayload);
+        right.child.stdin.end(rightPayload);
+        const [leftResult, rightResult] = await Promise.all([left.result, right.result]);
+
+        expect(leftResult.status, leftResult.stderr).toBe(0);
+        expect(rightResult.status, rightResult.stderr).toBe(0);
+        const actual = await fs.readFile(target);
+        const expectedLeftFirst = Buffer.concat([seed, leftPayload, rightPayload]);
+        const expectedRightFirst = Buffer.concat([seed, rightPayload, leftPayload]);
+        expect(
+          actual.equals(expectedLeftFirst) || actual.equals(expectedRightFirst),
+          "independent appends above the former 64 KiB chunk boundary must both survive",
+        ).toBe(true);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects FIFO targets and does not block when a validated file is swapped to a FIFO",
+    async () => {
+      await withTempDir({ prefix: "openclaw-mutation-helper-append-" }, async (root) => {
+        const workspace = path.join(root, "workspace");
+        const fifoPath = path.join(workspace, "target.pipe");
+        const swappedPath = path.join(workspace, "swapped.txt");
+        await fs.mkdir(workspace, { recursive: true });
+        expect(spawnSync("mkfifo", [fifoPath]).status).toBe(0);
+        await fs.writeFile(swappedPath, "seed", "utf8");
+
+        const directFifo = runMutation(["append", workspace, "", "target.pipe", "0"], "blocked");
+        const swappedFifo = runMutationWithSource(
+          SWAPPED_TO_FIFO_APPEND_MUTATION_PYTHON,
+          ["append", workspace, "", "swapped.txt", "0"],
+          "blocked",
+          2_000,
+        );
+
+        expect(directFifo.status).not.toBe(0);
+        expect(directFifo.stderr).toMatch(/regular files/i);
+        expect(swappedFifo.signal).not.toBe("SIGTERM");
+        expect(swappedFifo.status).not.toBe(0);
+        expect((await fs.lstat(swappedPath)).isFIFO()).toBe(true);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects hardlinked and symlink targets while appending",
+    async () => {
+      await withTempDir({ prefix: "openclaw-mutation-helper-append-" }, async (root) => {
+        const workspace = path.join(root, "workspace");
+        const outside = path.join(root, "outside.txt");
+        await fs.mkdir(workspace, { recursive: true });
+        await fs.writeFile(outside, "outside", "utf8");
+        await fs.link(outside, path.join(workspace, "hardlink.txt"));
+        await fs.symlink(outside, path.join(workspace, "symlink.txt"));
+
+        const hardlink = runMutation(["append", workspace, "", "hardlink.txt", "0"], "blocked");
+        const symlink = runMutation(["append", workspace, "", "symlink.txt", "0"], "blocked");
+
+        expect(hardlink.status).not.toBe(0);
+        expect(hardlink.stderr).toMatch(/hardlinked file/i);
+        expect(symlink.status).not.toBe(0);
+        await expect(fs.readFile(outside, "utf8")).resolves.toBe("outside");
       });
     },
   );

--- a/src/agents/sandbox/fs-bridge-mutation-helper.ts
+++ b/src/agents/sandbox/fs-bridge-mutation-helper.ts
@@ -1,7 +1,7 @@
 /**
  * Pinned Python mutation helper for sandbox filesystem writes.
  *
- * Performs symlink-resistant create/replace/delete operations inside a previously validated sandbox boundary.
+ * Performs symlink-resistant create/replace/append/delete operations inside a previously validated sandbox boundary.
  */
 import { PATH_ALIAS_POLICIES } from "../../infra/path-alias-guards.js";
 import type {
@@ -40,6 +40,12 @@ export const SANDBOX_PINNED_MUTATION_PYTHON = [
   "WRITE_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_EXCL",
   "if hasattr(os, 'O_NOFOLLOW'):",
   "    WRITE_FLAGS |= os.O_NOFOLLOW",
+  "",
+  "APPEND_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_APPEND",
+  "if hasattr(os, 'O_NOFOLLOW'):",
+  "    APPEND_FLAGS |= os.O_NOFOLLOW",
+  "if hasattr(os, 'O_NONBLOCK'):",
+  "    APPEND_FLAGS |= os.O_NONBLOCK",
   "",
   "def split_relative(path_value):",
   "    segments = []",
@@ -170,6 +176,16 @@ export const SANDBOX_PINNED_MUTATION_PYTHON = [
   "            except FileNotFoundError:",
   "                pass",
   "",
+  "def validate_append_target(parent_fd, basename):",
+  "    try:",
+  "        target_stat = os.lstat(basename, dir_fd=parent_fd)",
+  "    except FileNotFoundError:",
+  "        return",
+  "    if not stat.S_ISREG(target_stat.st_mode):",
+  "        raise OSError(errno.EPERM, 'only regular files are allowed', basename)",
+  "    if target_stat.st_nlink > 1:",
+  "        raise OSError(errno.EPERM, 'hardlinked file is not allowed', basename)",
+  "",
   "def write_atomic(parent_fd, basename, stdin_buffer):",
   "    target_mode = existing_regular_file_mode(parent_fd, basename)",
   "    temp_fd = None",
@@ -200,6 +216,22 @@ export const SANDBOX_PINNED_MUTATION_PYTHON = [
   "                os.unlink(temp_name, dir_fd=parent_fd)",
   "            except FileNotFoundError:",
   "                pass",
+  "",
+  "def append_file(parent_fd, basename, stdin_buffer):",
+  "    validate_append_target(parent_fd, basename)",
+  "    file_fd = os.open(basename, APPEND_FLAGS, 0o600, dir_fd=parent_fd)",
+  "    try:",
+  "        file_stat = os.fstat(file_fd)",
+  "        if not stat.S_ISREG(file_stat.st_mode):",
+  "            raise OSError(errno.EPERM, 'only regular files are allowed', basename)",
+  "        if file_stat.st_nlink > 1:",
+  "            raise OSError(errno.EPERM, 'hardlinked file is not allowed', basename)",
+  "        payload = stdin_buffer.read()",
+  "        write_all(file_fd, payload)",
+  "        os.fsync(file_fd)",
+  "    finally:",
+  "        os.close(file_fd)",
+  "    os.fsync(parent_fd)",
   "",
   "def read_file(parent_fd, basename):",
   "    file_fd = os.open(basename, READ_FLAGS, dir_fd=parent_fd)",
@@ -410,6 +442,16 @@ export const SANDBOX_PINNED_MUTATION_PYTHON = [
   "        if parent_fd is not None:",
   "            os.close(parent_fd)",
   "        os.close(root_fd)",
+  "elif operation == 'append':",
+  "    root_fd = open_dir(sys.argv[2])",
+  "    parent_fd = None",
+  "    try:",
+  "        parent_fd = walk_dir(root_fd, sys.argv[3], sys.argv[5] == '1')",
+  "        append_file(parent_fd, sys.argv[4], sys.stdin.buffer)",
+  "    finally:",
+  "        if parent_fd is not None:",
+  "            os.close(parent_fd)",
+  "        os.close(root_fd)",
   "elif operation == 'read':",
   "    root_fd = open_dir(sys.argv[2])",
   "    parent_fd = None",
@@ -535,6 +577,23 @@ export function buildPinnedCopyPlan(params: {
       params.destination.mountRootPath,
       params.destination.relativeParentPath,
       params.destination.basename,
+      params.mkdir ? "1" : "0",
+    ],
+  });
+}
+
+export function buildPinnedAppendPlan(params: {
+  check: PathSafetyCheck;
+  pinned: PinnedSandboxEntry;
+  mkdir: boolean;
+}): SandboxFsCommandPlan {
+  return buildPinnedMutationPlan({
+    checks: [params.check],
+    args: [
+      "append",
+      params.pinned.mountRootPath,
+      params.pinned.relativeParentPath,
+      params.pinned.basename,
       params.mkdir ? "1" : "0",
     ],
   });

--- a/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
+++ b/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
@@ -91,6 +91,16 @@ describe("sandbox fs bridge anchored ops", () => {
       forbiddenArgs: ["/workspace/nested/file.txt"],
     },
     {
+      name: "append pins canonical parent + basename",
+      invoke: (bridge: ReturnType<typeof createSandboxFsBridge>) =>
+        bridge.appendFile!({
+          filePath: "nested/file.txt",
+          data: Buffer.from([0xff, 0xfe, 0xfd]),
+        }),
+      expectedArgs: ["append", "/workspace", "nested", "file.txt", "1"],
+      forbiddenArgs: ["/workspace/nested/file.txt"],
+    },
+    {
       name: "mkdirp pins mount root + relative path",
       invoke: (bridge: ReturnType<typeof createSandboxFsBridge>) =>
         bridge.mkdirp({ filePath: "nested/leaf" }),

--- a/src/agents/sandbox/fs-bridge.boundary.test.ts
+++ b/src/agents/sandbox/fs-bridge.boundary.test.ts
@@ -32,6 +32,21 @@ describe("sandbox fs bridge boundary validation", () => {
     expect(mockedExecDockerRaw).not.toHaveBeenCalled();
   });
 
+  it("blocks appends into read-only bind mounts", async () => {
+    const sandbox = createSandbox({
+      docker: {
+        ...createSandbox().docker,
+        binds: ["/tmp/workspace-two:/workspace-two:ro"],
+      },
+    });
+    const bridge = createSandboxFsBridge({ sandbox });
+
+    await expect(
+      bridge.appendFile!({ filePath: "/workspace-two/new.txt", data: "hello" }),
+    ).rejects.toThrow(/read-only/);
+    expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+  });
+
   it("allows mkdirp for existing in-boundary subdirectories", async () => {
     await expectMkdirpAllowsExistingDirectory();
   });

--- a/src/agents/sandbox/fs-bridge.shell.test.ts
+++ b/src/agents/sandbox/fs-bridge.shell.test.ts
@@ -7,6 +7,7 @@ import {
   createSandbox,
   createSandboxFsBridge,
   createSeededSandboxFsBridge,
+  getDockerArg,
   getScriptsFromCalls,
   installFsBridgeTestHarness,
   mockedExecDockerRaw,
@@ -158,6 +159,24 @@ describe("sandbox fs bridge shell compatibility", () => {
     expectNoScriptsContaining(scripts, 'cat >"$1"');
     expectNoScriptsContaining(scripts, 'cat >"$tmp"');
     expectSomeScriptContaining(scripts, "os.replace(");
+  });
+
+  it("routes append through the pinned O_APPEND helper operation", async () => {
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+
+    await bridge.appendFile!({ filePath: "nested/binary.bin", data: Buffer.from([0xff, 0x00]) });
+
+    const call = mockedExecDockerRaw.mock.calls.find(
+      ([args]) => getDockerArg(args, 1) === "append",
+    );
+    expect(call).toBeDefined();
+    expect(getDockerArg(call![0], 2)).toBe("/workspace");
+    expect(getDockerArg(call![0], 3)).toBe("nested");
+    expect(getDockerArg(call![0], 4)).toBe("binary.bin");
+    expect(getDockerArg(call![0], 5)).toBe("1");
+    const scripts = getScriptsFromCalls();
+    expectSomeScriptContaining(scripts, "APPEND_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_APPEND");
+    expectSomeScriptContaining(scripts, "write_all(file_fd, payload)");
   });
 
   it("routes mkdirp, remove, and rename through the pinned mutation helper", async () => {

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -1,7 +1,7 @@
 /**
  * Sandbox filesystem bridge implementation.
  *
- * Resolves container paths to mounted host paths and executes guarded reads, writes, stats, renames, and deletes.
+ * Resolves container paths to mounted host paths and executes guarded reads, writes, appends, stats, renames, and deletes.
  */
 import fs from "node:fs";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
@@ -11,6 +11,7 @@ import type {
 } from "./backend-handle.types.js";
 import { runDockerSandboxShellCommand } from "./docker-backend.js";
 import {
+  buildPinnedAppendPlan,
   buildPinnedCopyPlan,
   buildPinnedMkdirpPlan,
   buildPinnedRemovePlan,
@@ -140,6 +141,36 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       ...buildPinnedWritePlan({
         check: writeCheck,
         pinned: pinnedWriteTarget,
+        mkdir: params.mkdir !== false,
+      }),
+      stdin: buffer,
+      signal: params.signal,
+    });
+  }
+
+  async appendFile(params: {
+    filePath: string;
+    cwd?: string;
+    data: Buffer | string;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const target = this.resolveResolvedPath(params);
+    this.ensureWriteAccess(target, "append to files");
+    const appendCheck = {
+      target,
+      options: { action: "append to files", requireWritable: true } as const,
+    };
+    await this.pathGuard.assertPathSafety(target, appendCheck.options);
+    const buffer = Buffer.isBuffer(params.data)
+      ? params.data
+      : Buffer.from(params.data, params.encoding ?? "utf8");
+    const pinnedTarget = await this.pathGuard.resolveAnchoredPinnedEntry(target, "append to files");
+    await this.runCheckedCommand({
+      ...buildPinnedAppendPlan({
+        check: appendCheck,
+        pinned: pinnedTarget,
         mkdir: params.mkdir !== false,
       }),
       stdin: buffer,

--- a/src/agents/sandbox/fs-bridge.types.ts
+++ b/src/agents/sandbox/fs-bridge.types.ts
@@ -38,6 +38,20 @@ export type SandboxFsBridge = {
     mkdir?: boolean;
     signal?: AbortSignal;
   }): Promise<void>;
+  /**
+   * Append at EOF without a userspace read-modify-write cycle.
+   * Optional because a backend must omit this capability unless its authoritative
+   * filesystem can provide native append semantics. One call is not a transactional
+   * record boundary if the kernel reports a short write.
+   */
+  appendFile?(params: {
+    filePath: string;
+    cwd?: string;
+    data: Buffer | string;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void>;
   mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void>;
   remove(params: {
     filePath: string;

--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -101,6 +101,31 @@ function createWorkspaceReadBridge(workspaceDir: string) {
 
 describe("remote sandbox fs bridge", () => {
   it.runIf(process.platform !== "win32")(
+    "appends bytes with the pinned mutation helper",
+    async () => {
+      await withTempDir("openclaw-remote-fs-bridge-append-", async (stateDir) => {
+        const workspaceDir = path.join(stateDir, "workspace");
+        const filePath = path.join(workspaceDir, "bytes.bin");
+        await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.writeFile(filePath, Buffer.from([0xff, 0x00]));
+        const { calls, runtime } = createLocalRemoteRuntime({
+          remoteWorkspaceDir: workspaceDir,
+          remoteAgentWorkspaceDir: workspaceDir,
+        });
+        const bridge = createRemoteShellSandboxFsBridge({
+          sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+          runtime,
+        });
+
+        await bridge.appendFile!({ filePath: "bytes.bin", data: Buffer.from([0x80, 0x0a]) });
+
+        await expect(fs.readFile(filePath)).resolves.toEqual(Buffer.from([0xff, 0x00, 0x80, 0x0a]));
+        expect(calls.at(-1)?.args?.[0]).toBe("append");
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "reads files with the pinned mutation helper",
     async () => {
       await withTempDir("openclaw-remote-fs-bridge-", async (stateDir) => {

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -146,25 +146,30 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
   }
 
-  async writeFile(params: {
-    filePath: string;
-    cwd?: string;
-    data: Buffer | string;
-    encoding?: BufferEncoding;
-    mkdir?: boolean;
-    signal?: AbortSignal;
-  }): Promise<void> {
+  async writeFile(params: Parameters<SandboxFsBridge["writeFile"]>[0]): Promise<void> {
+    await this.writeOrAppendFile("write", params);
+  }
+
+  async appendFile(params: Parameters<SandboxFsBridge["writeFile"]>[0]): Promise<void> {
+    await this.writeOrAppendFile("append", params);
+  }
+
+  private async writeOrAppendFile(
+    operation: "write" | "append",
+    params: Parameters<SandboxFsBridge["writeFile"]>[0],
+  ): Promise<void> {
+    const action = operation === "write" ? "write files" : "append to files";
     const target = this.resolveTarget(params);
-    await this.ensureRemoteWritable(target, "write files", params.signal);
+    await this.ensureRemoteWritable(target, action, params.signal);
     const pinned = await this.resolvePinnedParent({
       containerPath: target.containerPath,
-      action: "write files",
+      action,
       requireWritable: true,
       signal: params.signal,
     });
     await this.assertNoHardlinkedFile({
       containerPath: target.containerPath,
-      action: "write files",
+      action,
       signal: params.signal,
     });
     const buffer = Buffer.isBuffer(params.data)
@@ -172,7 +177,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       : Buffer.from(params.data, params.encoding ?? "utf8");
     await this.runMutation({
       args: [
-        "write",
+        operation,
         pinned.mountRootPath,
         pinned.relativeParentPath,
         pinned.basename,

--- a/src/agents/sessions/tools/tool-contracts.ts
+++ b/src/agents/sessions/tools/tool-contracts.ts
@@ -102,6 +102,8 @@ export type ReadToolDetails =
 export interface WriteToolInput {
   path: string;
   content: string;
+  /** Append at EOF when supported; avoids read-modify-write lost updates but is not transactional. */
+  append?: boolean;
 }
 
 export type WriteToolDetails =

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { generateDiffString, generateUnifiedPatch } from "./edit-diff.js";
 import { createWriteTool, type WriteOperations } from "./write.js";
 
@@ -24,10 +24,14 @@ describe("write tool", () => {
     return path.join(tmpDir, name);
   }
 
-  function createRecoverableOperations(writeFile: WriteOperations["writeFile"]): WriteOperations {
+  function createRecoverableOperations(
+    writeFile: WriteOperations["writeFile"],
+    appendFile?: NonNullable<WriteOperations["appendFile"]>,
+  ): WriteOperations {
     return {
       mkdir: (dir) => fs.mkdir(dir, { recursive: true }).then(() => {}),
       writeFile,
+      ...(appendFile ? { appendFile } : {}),
       readFile: (absolutePath) => fs.readFile(absolutePath),
       statFile: async (absolutePath) => {
         try {
@@ -324,5 +328,159 @@ describe("write tool", () => {
     );
 
     expect(result.details).toEqual({ changed: true });
+  });
+
+  it("appends natively without overwrite prechecks or duplicate-content suppression", async () => {
+    const filePath = await createTempPath("append.txt");
+    await fs.writeFile(filePath, "same\n", "utf8");
+    const statFile = vi.fn(async () => ({ type: "file" as const, size: 5, mtimeMs: 1 }));
+    const readFile = vi.fn(async () => Buffer.from("same\n"));
+    const appendFile = vi.fn(async (absolutePath: string, content: string) => {
+      await fs.appendFile(absolutePath, content, "utf8");
+    });
+    const tool = createWriteTool(tmpDir, {
+      operations: {
+        mkdir: (dir) => fs.mkdir(dir, { recursive: true }).then(() => {}),
+        writeFile: async () => {},
+        appendFile,
+        readFile,
+        statFile,
+      },
+    });
+
+    const result = await tool.execute(
+      "call-append",
+      { path: filePath, content: "same\n", append: true },
+      undefined,
+    );
+
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: `Successfully appended 5 bytes to ${filePath}`,
+    });
+    expect(result.details).toEqual({ changed: true });
+    expect(statFile).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(appendFile).toHaveBeenCalledTimes(1);
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("same\nsame\n");
+  });
+
+  it("creates a missing file in append mode", async () => {
+    const filePath = await createTempPath("nested/new.txt");
+    const tool = createWriteTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-append-create",
+      { path: filePath, content: "first\n", append: true },
+      undefined,
+    );
+
+    expect(result.details).toEqual({ changed: true });
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("first\n");
+  });
+
+  it("rejects an empty append instead of reporting a fabricated change", async () => {
+    const filePath = await createTempPath("empty-append.txt");
+    await fs.writeFile(filePath, "seed\n", "utf8");
+    const appendFile = vi.fn(async () => {});
+    const tool = createWriteTool(tmpDir, {
+      operations: createRecoverableOperations(async () => {}, appendFile),
+    });
+
+    await expect(
+      tool.execute("call-empty-append", { path: filePath, content: "", append: true }, undefined),
+    ).rejects.toThrow("Append content must not be empty");
+    expect(appendFile).not.toHaveBeenCalled();
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("seed\n");
+  });
+
+  it("hides and rejects append when an injected backend lacks native support", async () => {
+    const filePath = await createTempPath("unsupported/append.txt");
+    const mkdir = vi.fn(async () => {});
+    const tool = createWriteTool(tmpDir, {
+      operations: { mkdir, writeFile: async () => {} },
+    });
+
+    await expect(
+      tool.execute(
+        "call-append-unsupported",
+        { path: filePath, content: "extra\n", append: true },
+        undefined,
+      ),
+    ).rejects.toThrow("Append mode is not supported");
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(
+      (tool as unknown as { parameters: { properties: Record<string, unknown> } }).parameters
+        .properties,
+    ).not.toHaveProperty("append");
+  });
+
+  it("keeps append success authoritative when cancellation follows acknowledgement", async () => {
+    const filePath = await createTempPath("append-abort.txt");
+    await fs.writeFile(filePath, "seed\n", "utf8");
+    const controller = new AbortController();
+    const tool = createWriteTool(tmpDir, {
+      operations: createRecoverableOperations(
+        async () => {},
+        async (absolutePath, content) => {
+          await fs.appendFile(absolutePath, content, "utf8");
+          controller.abort();
+        },
+      ),
+    });
+
+    const result = await tool.execute(
+      "call-append-abort",
+      { path: filePath, content: "more\n", append: true },
+      controller.signal,
+    );
+
+    expect(result.content[0]?.type === "text" ? result.content[0].text : "").toContain(
+      "Successfully appended",
+    );
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("seed\nmore\n");
+  });
+
+  it("reports an uncertain outcome after append dispatch fails", async () => {
+    const filePath = await createTempPath("append-uncertain.txt");
+    await fs.writeFile(filePath, "seed\n", "utf8");
+    const tool = createWriteTool(tmpDir, {
+      operations: createRecoverableOperations(
+        async () => {},
+        async (absolutePath, content) => {
+          await fs.appendFile(absolutePath, content, "utf8");
+          throw new Error("remote append timed out");
+        },
+      ),
+    });
+
+    await expect(
+      tool.execute(
+        "call-append-uncertain",
+        { path: filePath, content: "more\n", append: true },
+        undefined,
+      ),
+    ).rejects.toThrow(/Append outcome is uncertain; do not retry automatically/);
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("seed\nmore\n");
+  });
+
+  it("keeps cancellation before append dispatch as a definite abort", async () => {
+    const filePath = await createTempPath("append-prestart.txt");
+    await fs.writeFile(filePath, "seed\n", "utf8");
+    const controller = new AbortController();
+    controller.abort();
+    const appendFile = vi.fn(async () => {});
+    const tool = createWriteTool(tmpDir, {
+      operations: createRecoverableOperations(async () => {}, appendFile),
+    });
+
+    await expect(
+      tool.execute(
+        "call-append-prestart",
+        { path: filePath, content: "more\n", append: true },
+        controller.signal,
+      ),
+    ).rejects.toThrow(/^Operation aborted$/);
+    expect(appendFile).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -4,6 +4,7 @@
  * Writes files through queued local or injected operations with readback/idempotency metadata.
  */
 import {
+  appendFile as fsAppendFile,
   mkdir as fsMkdir,
   readFile as fsReadFile,
   stat as fsStat,
@@ -13,6 +14,7 @@ import { dirname } from "node:path";
 import { Container, Text } from "@earendil-works/pi-tui";
 import { structuredPatch } from "diff";
 import { Type } from "typebox";
+import { createUncertainAppendOutcomeError } from "../../append-outcome.js";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import { getLanguageFromPath, highlightCode } from "../../modes/interactive/theme/theme.js";
 import type { AgentTool } from "../../runtime/index.js";
@@ -31,11 +33,22 @@ import {
 import type { WriteToolDetails } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
-const writeSchema = Type.Object({
+const writeSchemaProperties = {
   path: Type.String({
     description: "File path; relative/absolute.",
   }),
   content: Type.String({ description: "File content." }),
+} as const;
+
+const writeSchemaWithoutAppend = Type.Object(writeSchemaProperties);
+const writeSchema = Type.Object({
+  ...writeSchemaProperties,
+  append: Type.Optional(
+    Type.Boolean({
+      description:
+        "Append content at EOF instead of overwriting it. Native backends avoid lost updates, but an append is not a transactional record boundary after a short write.",
+    }),
+  ),
 });
 
 const WriteToolOutputSchema = Type.Union([
@@ -72,6 +85,8 @@ const WriteToolOutputSchema = Type.Union([
 export interface WriteOperations {
   /** Write content to a file */
   writeFile: (absolutePath: string, content: string) => Promise<void>;
+  /** Append content to a file. Omit unless the backend supports native append. */
+  appendFile?: (absolutePath: string, content: string) => Promise<void>;
   /** Create directory recursively */
   mkdir: (dir: string) => Promise<void>;
   /** Optional readback used to recover when a write succeeded but the tool aborted before returning */
@@ -82,6 +97,7 @@ export interface WriteOperations {
 
 const defaultWriteOperations: WriteOperations = {
   writeFile: (path, content) => fsWriteFile(path, content, "utf-8"),
+  appendFile: (path, content) => fsAppendFile(path, content, "utf-8"),
   mkdir: (dir) => fsMkdir(dir, { recursive: true }).then(() => {}),
   readFile: (path) => fsReadFile(path),
   statFile: async (path) => {
@@ -494,9 +510,14 @@ function isWriteRecoveryCandidate(error: unknown, signal: AbortSignal | undefine
   );
 }
 
-function successfulWriteResult(path: string, content: string, details: WriteToolDetails) {
+function successfulWriteResult(
+  path: string,
+  content: string,
+  details: WriteToolDetails,
+  operation: "wrote" | "appended" = "wrote",
+) {
   return textResult(
-    `Successfully wrote ${Buffer.byteLength(content, "utf8")} bytes to ${path}`,
+    `Successfully ${operation} ${Buffer.byteLength(content, "utf8")} bytes to ${path}`,
     details,
   );
 }
@@ -531,17 +552,24 @@ export function createWriteToolDefinition(
   options?: WriteToolOptions,
 ): ToolDefinition<typeof writeSchema, WriteToolDetails> {
   const ops = options?.operations ?? defaultWriteOperations;
+  const supportsAppend = Boolean(ops.appendFile);
   return {
     name: "write",
     label: "write",
-    description: "Write/overwrite file; creates parent directories.",
-    promptSnippet: "Create/overwrite files",
-    promptGuidelines: ["Use only new files/complete rewrites."],
-    parameters: writeSchema,
+    description: supportsAppend
+      ? "Write/overwrite/append file; creates parent directories."
+      : "Write/overwrite file; creates parent directories.",
+    promptSnippet: supportsAppend ? "Create/overwrite/append files" : "Create/overwrite files",
+    promptGuidelines: supportsAppend
+      ? [
+          "Use only new files/complete rewrites, or append: true to add at EOF without read-modify-write. Append is not a transactional record boundary after a short write.",
+        ]
+      : ["Use only new files/complete rewrites."],
+    parameters: (supportsAppend ? writeSchema : writeSchemaWithoutAppend) as typeof writeSchema,
     outputSchema: WriteToolOutputSchema,
     async execute(
       toolCallId,
-      { path, content }: { path: string; content: string },
+      input: { path: string; content: string; append?: unknown },
       signal?: AbortSignal,
       onUpdate?,
       ctx?,
@@ -549,15 +577,30 @@ export function createWriteToolDefinition(
       void toolCallId;
       void onUpdate;
       void ctx;
+      const { path, content } = input;
+      if (input.append !== undefined && typeof input.append !== "boolean") {
+        throw new Error("Invalid append parameter: expected boolean when provided");
+      }
+      const append = input.append === true;
+      if (append && !ops.appendFile) {
+        throw new Error("Append mode is not supported by this write tool backend");
+      }
+      if (append && content.length === 0) {
+        throw new Error("Append content must not be empty");
+      }
       const absolutePath = resolveToCwd(path, cwd);
       const dir = dirname(absolutePath);
       return withFileMutationQueue(absolutePath, async () => {
-        const precheck = await readOriginalWriteState(absolutePath, content, ops);
+        // Native append cannot use overwrite's identical-content precheck or readback recovery:
+        // duplicate payloads are intentional and readback cannot attribute bytes to one writer.
+        const precheck: WriteToolPrecheck = append
+          ? { state: "unknown" }
+          : await readOriginalWriteState(absolutePath, content, ops);
         if (signal?.aborted) {
           throw new Error("Operation aborted");
         }
-        // Terminal no-op: file already has identical content.
-        if (precheck.state === "same") {
+        // Terminal no-op applies only to overwrite mode; duplicate appends are intentional.
+        if (!append && precheck.state === "same") {
           return {
             ...textResult(`No changes made to ${path}. The file already has identical content.`, {
               changed: false,
@@ -565,18 +608,34 @@ export function createWriteToolDefinition(
             terminate: true,
           };
         }
-        const details = await resolveWriteDetails({ absolutePath, content, ops, path, precheck });
+        const details: WriteToolDetails = append
+          ? { changed: true }
+          : await resolveWriteDetails({ absolutePath, content, ops, path, precheck });
+        let appendStarted = false;
         try {
           await ops.mkdir(dir);
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }
-          await ops.writeFile(absolutePath, content);
-          if (signal?.aborted) {
+          if (append) {
+            appendStarted = true;
+            await ops.appendFile!(absolutePath, content);
+          } else {
+            await ops.writeFile(absolutePath, content);
+          }
+          // Returning from appendFile is the acknowledgement. A cancellation after that point
+          // must not turn a known success into an ambiguous failure.
+          if (!append && signal?.aborted) {
             throw new Error("Operation aborted");
           }
-          return successfulWriteResult(path, content, details);
+          return successfulWriteResult(path, content, details, append ? "appended" : "wrote");
         } catch (error: unknown) {
+          if (append) {
+            if (!appendStarted) {
+              throw error;
+            }
+            throw createUncertainAppendOutcomeError(error);
+          }
           const recovered = await recoverSuccessfulWrite({
             absolutePath,
             content,

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -774,7 +774,7 @@ export function buildAgentSystemPrompt(params: {
   const acpSpawnRuntimeEnabled = acpEnabled && !sandboxedRuntime;
   const coreToolSummaries: Record<string, string> = {
     read: "Read files",
-    write: "Write files",
+    write: "Write/overwrite; append if backend supports",
     edit: "Exact file edits",
     apply_patch: "Patch files",
     grep: "Search file contents",

--- a/src/agents/test-helpers/host-sandbox-fs-bridge.ts
+++ b/src/agents/test-helpers/host-sandbox-fs-bridge.ts
@@ -45,6 +45,17 @@ export function createSandboxFsBridgeFromResolver(
       const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
       await fs.writeFile(target.hostPath, buffer);
     },
+    appendFile: async ({ filePath, cwd, data, mkdir = true }) => {
+      const target = resolvePath(filePath, cwd);
+      if (!target.hostPath) {
+        throw new Error(`Expected hostPath for ${target.containerPath}`);
+      }
+      if (mkdir) {
+        await fs.mkdir(path.dirname(target.hostPath), { recursive: true });
+      }
+      const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
+      await fs.appendFile(target.hostPath, buffer);
+    },
     mkdirp: async ({ filePath, cwd }) => {
       const target = resolvePath(filePath, cwd);
       if (!target.hostPath) {

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -77,7 +77,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   {
     id: "write",
     label: "write",
-    description: "Create or overwrite files",
+    description: "Create, overwrite, or append at EOF when the active backend supports it",
     sectionId: "fs",
     profiles: ["coding"],
   },


### PR DESCRIPTION
## Summary

Adds capability-gated native append support to the built-in `write` tool for #40001.

- `append: true` is opt-in and appears only when the active backend supports it.
- Docker-style and remote-shell sandboxes use a pinned `O_APPEND` mutation rather than read-modify-write.
- OpenShell remains unsupported because its mirror-sync architecture cannot provide authoritative-target append semantics.
- Unacknowledged append outcomes are fail-closed and explicitly must not be retried automatically.
- The optional Plugin SDK bridge capability and baseline are updated.

## What Problem This Solves

Concurrent writers could lose data when append was emulated by reading the whole file and overwriting it with old content plus a suffix. This change gives supported sandbox backends a native append path so independent writers do not overwrite already-persisted content.

## Lineage

This is a fresh current-main successor to closed PRs #77127 and #102243. The latter was closed after review identified that a safe sandbox implementation required a native `SandboxFsBridge.appendFile` primitive; this candidate implements that boundary instead of preserving the sandbox read-modify-write path. A fresh issue/title/head search found no open append candidate for #40001.

## Evidence

**Real setup tested**

An isolated Docker container with networking disabled and a bind-mounted temporary workspace, exercised through the actual `SandboxFsBridge` and `docker exec` transport. No live gateway or production state was used.

**Current-head validation**

- Final candidate head: `056f4763ab9becd41f1ed0afe86389c76fa1bf84`, rebased onto `151a259f9a9f6fd96ace336416a3e024477cce8c`.
- All 10 changed test files passed: 153 tests across the agent and OpenShell Vitest shards.
- Core and extension source/test type gates passed on the final head.
- Plugin SDK API baseline and public surface checks passed; public wildcard reexports remained at 209.
- Full scripts lint, Control UI i18n, targeted type-aware lint, formatting, and `git diff --check` passed.
- The isolated Docker proof passed binary append, create-on-missing, two concurrent 128 KiB writers, restrictive `0600` creation mode, and read-only bind rejection without mutation. The append runtime blobs were verified unchanged by the subsequent base-only rebases.

**Observed result**

Supported sandbox backends append at EOF without a userspace read-modify-write cycle, and both independent writer payloads survived in the tested local-filesystem path.

**What was not tested**

- Network-filesystem append guarantees were not claimed or tested.
- OpenShell append remains intentionally unsupported.
- Append is not claimed to provide a transactional record boundary after a kernel short write.
- No idempotency key is provided; uncertain outcomes must not be automatically retried.

## Safety details

The pinned helper uses anchored directory traversal, `O_APPEND | O_CREAT | O_NOFOLLOW | O_NONBLOCK`, pre/post-open regular-file checks, hardlink rejection, full first write with EINTR/short-write completion, and file/parent fsync. Append bypasses overwrite prechecks and uses backend acknowledgement as the only success signal.

Addresses #40001.
