### PR TITLE
refactor(sessions): route get-reply-run session refresh through the accessor

### DIFF
--- a/scripts/lib/session-accessor-debt-baseline.json
+++ b/scripts/lib/session-accessor-debt-baseline.json
@@ -8,7 +8,6 @@
     "src/agents/subagent-announce.test-support.ts": 2,
     "src/agents/tools/transcripts-tool.ts": 2,
     "src/auto-reply/reply/commands-session-store.ts": 2,
-    "src/auto-reply/reply/get-reply-run.ts": 2,
     "src/commands/doctor-heartbeat-session-target.ts": 2,
     "src/commands/doctor-state-integrity.ts": 2,
     "src/commands/doctor/shared/codex-route-warnings.ts": 3,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -35,8 +35,6 @@ vi.mock("../../config/sessions/paths.js", () => ({
   resolveSessionFilePathOptions: vi.fn().mockReturnValue({}),
 }));
 
-const storeRuntimeLoads = vi.hoisted(() => vi.fn());
-const updateSessionStore = vi.hoisted(() => vi.fn());
 const loadSessionEntryMock = vi.hoisted(() => vi.fn());
 const updateAmbientTranscriptWatermarkMock = vi.hoisted(() => vi.fn().mockResolvedValue(null));
 const consumeSessionSkillSuggestionMock = vi.hoisted(() => vi.fn());
@@ -56,13 +54,6 @@ vi.mock("../../config/sessions/ambient-transcript-watermark.js", () => ({
 vi.mock("../../config/sessions/skill-suggestions.js", () => ({
   consumeSessionSkillSuggestion: consumeSessionSkillSuggestionMock,
 }));
-
-vi.mock("../../config/sessions/store.runtime.js", () => {
-  storeRuntimeLoads();
-  return {
-    updateSessionStore,
-  };
-});
 
 vi.mock("../../globals.js", () => ({
   logVerbose: vi.fn(),
@@ -310,8 +301,6 @@ describe("runPreparedReply media-only handling", () => {
   });
 
   beforeEach(async () => {
-    storeRuntimeLoads.mockClear();
-    updateSessionStore.mockReset();
     loadSessionEntryMock.mockReset();
     consumeSessionSkillSuggestionMock.mockReset();
     updateAmbientTranscriptWatermarkMock.mockClear();

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -33,7 +33,6 @@ import {
   formatSqliteSessionFileMarker,
   sqliteSessionFileMarkerMatchesSession,
 } from "../../config/sessions/sqlite-marker.js";
-import { resolveSessionStoreEntry } from "../../config/sessions/store.js";
 import type { PendingSkillSuggestion, SessionEntry } from "../../config/sessions/types.js";
 import { resolveSilentReplySettings } from "../../config/silent-reply.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -1101,12 +1100,19 @@ export async function runPreparedReply(
     sessionId: string;
     sessionFile: string;
   } => {
+    // Working-set exact key first; disk alias resolve only when storePath known.
+    // No whole-map scan — that encodes the store layout the accessor hides.
     const latestSessionEntry =
       sessionStore && sessionKey
-        ? (resolveSessionStoreEntry({
-            store: sessionStore,
-            sessionKey,
-          }).existing ?? sessionEntry)
+        ? (sessionStore[sessionKey] ??
+          (storePath
+            ? loadSessionEntry({
+                storePath,
+                sessionKey,
+                readConsistency: "latest",
+              })
+            : undefined) ??
+          sessionEntry)
         : sessionEntry;
     const latestSessionId = latestSessionEntry?.sessionId ?? sessionIdFinal;
     opts?.onSessionPrepared?.({


### PR DESCRIPTION
## What Problem This Solves

`src/config/sessions/session-accessor.ts` is the storage-neutral session boundary (ownership contract #88838), and most historical bypasses were already rerouted by #98236/#101179. One non-doctor whole-store read remained in the reply pipeline: `runPreparedReply` (`src/auto-reply/reply/get-reply-run.ts`) still imported `resolveSessionStoreEntry` from `sessions/store.js` and alias-scanned the in-memory session map to refresh the entry before `onSessionPrepared`. That is the layout-encoding pattern (whole `Record` + map-shape alias walk) the accessor exists to hide, and it kept `get-reply-run.ts` on the session-accessor debt baseline.

This is seam 8 of #104219 (session store accessor bypass), scoped to the residual mechanical caller. Re-verification against current `main` showed the seam is mostly complete upstream; the remaining bypasses are named owners (doctor whole-store scan/repair, `state-migrations.ts`) or shipped public surfaces (`library.ts` root exports, `plugin-sdk/session-store-runtime.ts`) that need their own compatibility decision, not a mechanical reroute.

## Why This Change Was Made

The refresh now reads the working set by exact key and falls back to the accessor disk read, matching the two sibling refresh sites in the same function (`get-reply-run.ts:852`, `:865-867`) and the exact-key write at `:842`:

- `sessionStore[sessionKey]` — the reply working set is exact-keyed everywhere else in `runPreparedReply`, so the old alias walk over the map had no live dependency.
- `loadSessionEntry({ storePath, sessionKey, readConsistency: "latest" })` — the accessor read performs full canonical-key and legacy-alias resolution internally (`session-accessor.sqlite.ts` `readSessionEntryRow` → `collectSessionEntryLookupKeys`), so legacy lowercase-alias repair is preserved whenever a store path is known.
- Prepared `sessionEntry` remains the terminal fallback, unchanged.

The dead `store.runtime.js` mock in `get-reply-run.media-only.test.ts` is deleted (prod stopped importing it before this change; verified zero `updateSessionStore` references on `main`). The session-accessor debt baseline is regenerated because the ratchet fails on improvements (`get-reply-run.ts` drops off the debt list).

## User Impact

None intended — pure boundary refactor; same reads, same fallback order for live states. Reply handling, session refresh, and `onSessionPrepared` payloads behave identically. Maintainer impact: the reply pipeline no longer imports whole-store file APIs, and the debt ratchet shrinks by one file.

## Evidence

- Sibling-idiom proof: exact-key reads/writes at `src/auto-reply/reply/get-reply-run.ts:842,852,865-867` predate this change; the replaced call was the only alias-walking access in the function.
- Alias-resolution parity: `loadSessionEntry` → `loadSqliteSessionEntry` → `readSessionEntryRow` builds plural lookup keys (`collectSessionEntryLookupKeys`), covering normalized + folded-legacy candidates the deleted `resolveSessionStoreEntry` handled.
- `git diff --numstat`: +11/−17 (net −6), no new accessor surface, no behavior branches added.
- Boundary guard: `pnpm lint:tmp:session-accessor-boundary` passes with the regenerated baseline (one-line deletion: `get-reply-run.ts` leaves the debt list).
- Remote (Blacksmith Testbox): `pnpm check:changed` exit 0 on commit f6a64961427; the six covering shards (incl. full `auto-reply-reply`: 141 files / 3,071 tests, and `gateway-server`) pass in isolated reruns on the same lease. The two failing PR checks are current-`main` breakage, reproduced on clean `origin/main` `dfa580e9` — see the CI-triage comment.

### Real behavior proof (ephemeral gateway, real Telegram channel path)

Built this branch (`f6a64961427`), ran a real gateway (temp `OPENCLAW_STATE_DIR`, loopback) with a mock Telegram Bot API (`:18931`) and mock OpenAI-completions provider (`:18932`), and drove two consecutive real reply turns through the Telegram channel into `runPreparedReply`:

- Both turns delivered replies (`sendMessage` texts `session-proof-reply-1`, `session-proof-reply-2` captured from the Bot API mock — ground truth).
- One sessions row for the chat after both turns (SQLite dump of `agents/main/agent/openclaw-agent.sqlite`): `sessionKey agent:main:telegram:group:-100777001`, same `sessionId` `ef4af902-…` across both run traces, `updatedAt` advanced `1783824157995 → 1783824162754`.
- Gateway debug trace shows both turns' `session turn created` / `embedded run start` / `message processed … outcome=completed` on the same sessionId — the refreshed prepared-session binding (the changed accessor-backed read) held across turns.

Part of #104219 (seam 8: session store accessor bypass — residual mechanical caller; doctor and public-surface bypasses excluded as named owners).
