### PR TITLE
fix(ci): repair typed approval main gates

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -204,7 +204,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5298,
+      5267,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -11,7 +11,6 @@ import type {
 } from "../infra/exec-approvals.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
-import { resolveApprovalSessionAudience } from "./approval-session-audience.js";
 import {
   consumeOperatorApprovalAllowOnce,
   forceDenyOperatorApproval,
@@ -259,14 +258,14 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       const source = resolveApprovalSource(record.request);
       let audienceSessionKeys: string[] = [];
       if (source.sessionKey) {
-        try {
-          audienceSessionKeys = (
-            this.options.resolveAudienceSessionKeys ?? resolveApprovalSessionAudience
-          )(source.sessionKey);
-        } catch {
-          // Lineage is routing metadata, not an approval safety prerequisite.
-          // Preserve at least the source audience when session stores are unavailable.
-          audienceSessionKeys = [source.sessionKey];
+        audienceSessionKeys = [source.sessionKey];
+        if (this.options.resolveAudienceSessionKeys) {
+          try {
+            audienceSessionKeys = this.options.resolveAudienceSessionKeys(source.sessionKey);
+          } catch {
+            // Lineage is routing metadata, not an approval safety prerequisite.
+            // Preserve at least the source audience when session stores are unavailable.
+          }
         }
       }
       const inserted = insertOperatorApproval({

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -21,6 +21,7 @@ import {
   type PreparedSecretsRuntimeSnapshot,
 } from "../secrets/runtime-state.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
+import { resolveApprovalSessionAudience } from "./approval-session-audience.js";
 import { diffConfigPaths } from "./config-diff.js";
 import {
   buildGatewayReloadPlan,
@@ -103,6 +104,7 @@ export function createGatewayAuxHandlers(params: {
     approvalKind: "exec",
     persistence: approvalPersistence,
     resolveAllowedDecisions: resolveExecApprovalRequestAllowedDecisions,
+    resolveAudienceSessionKeys: resolveApprovalSessionAudience,
     onError: (error, context) => {
       params.log.error?.(
         `${context.approvalKind} approval ${context.operation} failed for ${context.approvalId}: ${String(error)}`,
@@ -126,6 +128,7 @@ export function createGatewayAuxHandlers(params: {
     approvalKind: "plugin",
     persistence: approvalPersistence,
     resolveAllowedDecisions: (request) => resolvePluginApprovalRequestAllowedDecisions(request),
+    resolveAudienceSessionKeys: resolveApprovalSessionAudience,
     onError: (error, context) => {
       params.log.error?.(
         `${context.approvalKind} approval ${context.operation} failed for ${context.approvalId}: ${String(error)}`,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1,7 +1,7 @@
 // Gateway chat runtime projects agent events into chat/session subscriber
 // streams, lifecycle persistence, heartbeat visibility, and live UI updates.
 import { performance } from "node:perf_hooks";
-import type { ChatEvent } from "../../packages/gateway-protocol/src/schema/types.js";
+import type { ChatEvent } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { buildAgentRunTerminalOutcome } from "../agents/agent-run-terminal-outcome.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { isTimeoutError, resolveFailoverReasonFromError } from "../agents/failover-error.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where current `main` failed build, type, dependency, extension lint, architecture, and tooling-test gates after the typed approval merge.

## Why This Change Was Made

Route the remaining chat event import to its schema owner, restore approval audience resolution through Gateway dependency injection to avoid a runtime import cycle, and pin the Plugin SDK callable-export budget to the measured source count.

## User Impact

Maintainers can build and validate current `main` again. Approval audience behavior remains unchanged in the running Gateway.

## Evidence

- `pnpm test test/scripts/plugin-sdk-surface-report.test.ts`
- `pnpm tsgo:prod`
- `pnpm test:extensions:package-boundary:compile`
- `pnpm check:architecture`
- `pnpm build:ci-artifacts`
- `pnpm lint:extensions:channels`
- `pnpm lint:extensions:bundled`
- Autoreview substantive findings: none; rejected one false positive because `logs-chat.ts` directly exports `ChatEvent` and exact compiler/build proof passes
