### PR TITLE
feat: improve assistant message actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI session workspace shortcut:** expand or collapse the active Chat pane's session workspace rail with ⇧⌘B without changing the main app sidebar or the separate detail and Canvas preview panel. Thanks @shakkernerd.
 - **Control UI Settings shortcut:** open Settings with ⇧⌘, while leaving the browser-owned ⌘, shortcut unchanged. Thanks @shakkernerd.
 - **Control UI chat layout:** center the transcript on the composer axis, keep assistant and tool output left and user bubbles right within the same readable frame, and preserve custom message-width overrides. (#104474) Thanks @shakkernerd.
+- **Control UI assistant actions:** keep assistant name and time first while placing hover actions beside them on the left instead of at the far edge. Thanks @shakkernerd.
 - **Cron model selection:** choose an agent-turn model in Control UI Quick Create and show configured or default models in cron job rows and details. (#95341) Thanks @ly85206559.
 - **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards. (#100434)
 - **Logbook work journal:** add a disabled-by-default bundled plugin that turns paired-node screen snapshots into a private timeline, daily standup, and timeline-grounded Q&A in a plugin-contributed Control UI tab. (#99930)

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -579,7 +579,7 @@ details.msg-meta:not([open]) .msg-meta__details {
   left: 0;
   z-index: 30;
   width: max-content;
-  max-width: min(28rem, calc(100vw - 32px));
+  max-width: min(36rem, calc(100vw - 32px));
   padding: 3px 7px;
   border: 1px solid var(--border);
   border-radius: var(--radius-full);

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -100,6 +100,12 @@
   flex: 0 0 auto;
 }
 
+.chat-group.assistant .chat-group-footer-actions,
+.chat-group.assistant .chat-message-actions-row {
+  justify-content: flex-start;
+  margin-left: 0;
+}
+
 .chat-message-actions-row {
   align-self: stretch;
   margin-top: 4px;


### PR DESCRIPTION
Closes #104881

## What Problem This Solves

Assistant message actions appeared at the far edge of the message footer, disconnected from the assistant name and timestamp. Longer message-context previews could also wrap onto a second row and look oversized.

## Why This Change Was Made

This places assistant hover actions directly after the assistant metadata while preserving their existing order and hover behavior. It also gives message-context previews enough width to remain a compact single row while retaining the viewport constraint for narrow screens.

## User Impact

Assistant response controls are easier to find, and message-context previews remain visually compact when they contain longer model and token metadata.

## Evidence

- Verified the updated action placement and message-context preview in the live Control UI.
- `corepack pnpm test ui/src/pages/chat/chat-responsive.browser.test.ts`
  - 61 tests passed.
  - Blacksmith Testbox through Crabbox: `tbx_01kx9zwna047kpcn8jqwcknrrp`
- Autoreview completed with no actionable findings.
