### PR TITLE
fix(core): converge model-API ownership, provider auth-literal parity, and structured failover classification

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7867,10 +7867,6 @@ describe("runAgentTurnWithFallback", () => {
       reason: "timeout" as const,
       message: "provider request timed out without status token",
     },
-    {
-      reason: "overloaded" as const,
-      message: "provider capacity exhausted briefly",
-    },
   ])(
     "retries once for structured FailoverError $reason without leading HTTP status text",
     async ({ reason, message }) => {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1401,6 +1401,8 @@ describe("runAgentTurnWithFallback", () => {
   });
 
   afterEach(() => {
+    // Fake-timer tests in this describe must not leak into --isolate=false peers.
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -7854,6 +7856,81 @@ describe("runAgentTurnWithFallback", () => {
     expect(activeSessionStore["agent:main:main"]?.sessionId).toBe("session");
     expect(updateSessionIdMock).not.toHaveBeenCalled();
     expect(state.updateSessionStoreMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      reason: "server_error" as const,
+      message: "upstream provider failed briefly",
+    },
+    {
+      reason: "timeout" as const,
+      message: "provider request timed out without status token",
+    },
+    {
+      reason: "overloaded" as const,
+      message: "provider capacity exhausted briefly",
+    },
+  ])(
+    "retries once for structured FailoverError $reason without leading HTTP status text",
+    async ({ reason, message }) => {
+      vi.useFakeTimers();
+      state.runEmbeddedAgentMock
+        .mockRejectedValueOnce(
+          new FailoverError(message, {
+            reason,
+            provider: "openai",
+            model: "gpt-5.5",
+          }),
+        )
+        .mockResolvedValueOnce({
+          payloads: [{ text: "recovered after transient failover" }],
+          meta: {},
+        });
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const resultPromise = runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+      await vi.advanceTimersByTimeAsync(2_500);
+      const result = await resultPromise;
+
+      expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+      expect(result.kind).toBe("success");
+      if (result.kind === "success") {
+        expect(result.runResult.payloads?.[0]?.text).toBe("recovered after transient failover");
+      }
+    },
+  );
+
+  it("uses structured FailoverError context_overflow over non-overflow message text", async () => {
+    state.isLikelyContextOverflowErrorMock.mockReturnValue(false);
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError("provider rejected the request payload", {
+        reason: "context_overflow",
+        provider: "anthropic",
+        model: "claude",
+      }),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        sessionCtx: {
+          Provider: "telegram",
+          Surface: "telegram",
+          ChatType: "direct",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model.",
+      );
+      expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+      expect(result.payload.text).not.toContain("provider rejected the request payload");
+    }
   });
 
   it("uses the throwing fallback candidate model for compaction failure hints", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -3083,12 +3083,11 @@ async function runAgentTurnWithFallbackInternal(
         !shouldSurfaceToControlUi
           ? classifyProviderRequestError(err)
           : undefined;
+      // Typed overloaded failures stay out of the transient retry: they surface
+      // dedicated overloaded copy immediately instead of being retried silently.
       const isTransientHttp =
         isTransientHttpError(message) ||
-        (isFailoverError(err) &&
-          (err.reason === "timeout" ||
-            err.reason === "server_error" ||
-            err.reason === "overloaded"));
+        (isFailoverError(err) && (err.reason === "timeout" || err.reason === "server_error"));
 
       // Drain/restart aborts stay silent and defer to post-restart
       // main-session recovery, which resumes the interrupted turn (or emits its

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -3062,7 +3062,13 @@ async function runAgentTurnWithFallbackInternal(
         : isFailoverError(err)
           ? err.reason === "billing"
           : isBillingErrorMessage(message);
-      const isContextOverflow = !isBilling && isLikelyContextOverflowError(message);
+      // Prefer structured FailoverError reasons over message-text heuristics so
+      // typed context-overflow/transient failures are not misclassified when the
+      // error string lacks overflow/HTTP status tokens.
+      const isContextOverflow =
+        !isBilling &&
+        ((isFailoverError(err) && err.reason === "context_overflow") ||
+          isLikelyContextOverflowError(message));
       const isCompactionFailure = !isBilling && isCompactionFailureError(message);
       // OAuth/auth-profile failures must reach buildExternalRunFailureReply so
       // the targeted re-auth/failover copy is surfaced instead of the generic
@@ -3077,7 +3083,12 @@ async function runAgentTurnWithFallbackInternal(
         !shouldSurfaceToControlUi
           ? classifyProviderRequestError(err)
           : undefined;
-      const isTransientHttp = isTransientHttpError(message);
+      const isTransientHttp =
+        isTransientHttpError(message) ||
+        (isFailoverError(err) &&
+          (err.reason === "timeout" ||
+            err.reason === "server_error" ||
+            err.reason === "overloaded"));
 
       // Drain/restart aborts stay silent and defer to post-restart
       // main-session recovery, which resumes the interrupted turn (or emits its

--- a/src/plugins/bundled-provider-auth-literal-parity.test.ts
+++ b/src/plugins/bundled-provider-auth-literal-parity.test.ts
@@ -157,8 +157,13 @@ describe("bundled provider manifest↔runtime auth literal parity", () => {
 
       const provider = findRegisteredProvider(captured.providers, parityCase.providerId);
       if (!provider) {
-        // Capability-only plugins (video/image onboard flags) declare CLI keys in
-        // the manifest without a text ProviderPlugin.auth surface to compare.
+        // Capability-only plugins (video/image onboard flags) register no text
+        // providers at all. A plugin that registers text providers but not the
+        // manifest-declared id has drifted — the exact mismatch this test guards.
+        expect(
+          captured.providers.map((entry) => entry.id),
+          `${parityCase.pluginId} manifest declares provider ${parityCase.providerId} but runtime registers different providers`,
+        ).toEqual([]);
         return;
       }
 

--- a/src/plugins/bundled-provider-auth-literal-parity.test.ts
+++ b/src/plugins/bundled-provider-auth-literal-parity.test.ts
@@ -1,5 +1,8 @@
 // Keeps manifest providerAuthChoices literals aligned with registered provider.auth methods.
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
 import { createNonExitingRuntime } from "../runtime.js";
 import { createCapturedPluginRegistration } from "../test-utils/plugin-registration.js";
 import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
@@ -100,17 +103,30 @@ function findRegisteredProvider(
 async function probeRuntimeAuthLiterals(params: {
   method: ProviderAuthMethod;
   optionKey: string;
+  agentDir: string;
 }): Promise<ProviderResolveNonInteractiveApiKeyParams | undefined> {
   if (!params.method.runNonInteractive) {
     return undefined;
   }
+  // The sentinel maps only to the expected optionKey so flagValue === sentinel
+  // proves the method read the right key. Other keys get distinct placeholders
+  // to satisfy provider-specific preflight opts (e.g. account/gateway ids)
+  // without weakening that proof.
+  const opts = new Proxy<Record<string, unknown>>(
+    { [params.optionKey]: SENTINEL_API_KEY },
+    {
+      get: (target, key) =>
+        typeof key === "string" ? (target[key] ?? `parity-extra-${key}`) : undefined,
+    },
+  );
   let captured: ProviderResolveNonInteractiveApiKeyParams | undefined;
   try {
     await params.method.runNonInteractive({
       authChoice: "parity",
+      agentDir: params.agentDir,
       config: {},
       baseConfig: {},
-      opts: { [params.optionKey]: SENTINEL_API_KEY },
+      opts,
       runtime: createNonExitingRuntime(),
       resolveApiKey: async (resolveParams) => {
         if (!captured) {
@@ -136,6 +152,12 @@ const parityCases = listParityCases().toSorted((left, right) => {
     return providerOrder;
   }
   return left.methodId.localeCompare(right.methodId);
+});
+
+const probeAgentDir = mkdtempSync(path.join(tmpdir(), "openclaw-auth-parity-"));
+
+afterAll(() => {
+  rmSync(probeAgentDir, { recursive: true, force: true });
 });
 
 describe("bundled provider manifest↔runtime auth literal parity", () => {
@@ -183,7 +205,15 @@ describe("bundled provider manifest↔runtime auth literal parity", () => {
       const probed = await probeRuntimeAuthLiterals({
         method,
         optionKey: parityCase.optionKey,
+        agentDir: probeAgentDir,
       });
+      // Fail closed: an api-key-style choice whose method cannot be probed
+      // would otherwise leave its flag/env literals unchecked while CI stays
+      // green — the same silent-drift hole this test exists to close.
+      expect(
+        probed,
+        `${parityCase.pluginId} auth method ${parityCase.methodId} did not resolve an API key non-interactively; flag/env literals unverifiable`,
+      ).toBeDefined();
       if (!probed) {
         return;
       }

--- a/src/plugins/bundled-provider-auth-literal-parity.test.ts
+++ b/src/plugins/bundled-provider-auth-literal-parity.test.ts
@@ -1,0 +1,196 @@
+// Keeps manifest providerAuthChoices literals aligned with registered provider.auth methods.
+import { describe, expect, it } from "vitest";
+import { createNonExitingRuntime } from "../runtime.js";
+import {
+  loadBundledPluginPublicSurface,
+  resolveBundledPluginPublicModulePath,
+} from "../test-utils/bundled-plugin-public-surface.js";
+import { createCapturedPluginRegistration } from "../test-utils/plugin-registration.js";
+import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
+import type { PluginManifestProviderAuthChoice } from "./manifest.js";
+import type {
+  ProviderAuthMethod,
+  ProviderPlugin,
+  ProviderResolveNonInteractiveApiKeyParams,
+} from "./types.js";
+
+const PARITY_TIMEOUT_MS = 120_000;
+const SENTINEL_API_KEY = "parity-sentinel-api-key";
+
+type ApiKeyStyleChoice = PluginManifestProviderAuthChoice & {
+  optionKey: string;
+  cliFlag: string;
+};
+
+type ParityCase = {
+  pluginId: string;
+  providerId: string;
+  methodId: string;
+  optionKey: string;
+  cliFlag: string;
+  setupEnvVars: readonly string[];
+};
+
+type PluginEntryModule = {
+  default?: {
+    id?: string;
+    register?: (api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void;
+  };
+  register?: (api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void;
+};
+
+function isApiKeyStyleChoice(
+  choice: PluginManifestProviderAuthChoice,
+): choice is ApiKeyStyleChoice {
+  return Boolean(choice.optionKey?.trim() && choice.cliFlag?.trim());
+}
+
+function listParityCases(): ParityCase[] {
+  return listBundledPluginMetadata({ includeChannelConfigs: false }).flatMap((plugin) => {
+    const choices = plugin.manifest.providerAuthChoices ?? [];
+    if (choices.length === 0) {
+      return [];
+    }
+    const setupEnvByProvider = new Map(
+      (plugin.manifest.setup?.providers ?? []).map((entry) => [
+        entry.id,
+        entry.envVars ?? ([] as readonly string[]),
+      ]),
+    );
+    return choices.filter(isApiKeyStyleChoice).map((choice) => ({
+      pluginId: plugin.manifest.id,
+      providerId: choice.provider,
+      methodId: choice.method,
+      optionKey: choice.optionKey,
+      cliFlag: choice.cliFlag,
+      setupEnvVars: setupEnvByProvider.get(choice.provider) ?? [],
+    }));
+  });
+}
+
+async function loadPluginRegister(
+  pluginId: string,
+): Promise<(api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void> {
+  // Resolve first so unknown plugin ids fail with a clear path error before import.
+  resolveBundledPluginPublicModulePath({
+    pluginId,
+    artifactBasename: "index.js",
+  });
+  const mod = await loadBundledPluginPublicSurface<PluginEntryModule>({
+    pluginId,
+    artifactBasename: "index.js",
+  });
+  const register = mod.default?.register ?? mod.register;
+  if (!register) {
+    throw new Error(`bundled plugin ${pluginId} has no register() entry`);
+  }
+  return register;
+}
+
+function findRegisteredProvider(
+  providers: readonly ProviderPlugin[],
+  providerId: string,
+): ProviderPlugin | undefined {
+  return providers.find(
+    (provider) => provider.id === providerId || provider.hookAliases?.includes(providerId) === true,
+  );
+}
+
+async function probeRuntimeAuthLiterals(params: {
+  method: ProviderAuthMethod;
+  optionKey: string;
+}): Promise<ProviderResolveNonInteractiveApiKeyParams | undefined> {
+  if (!params.method.runNonInteractive) {
+    return undefined;
+  }
+  let captured: ProviderResolveNonInteractiveApiKeyParams | undefined;
+  try {
+    await params.method.runNonInteractive({
+      authChoice: "parity",
+      config: {},
+      baseConfig: {},
+      opts: { [params.optionKey]: SENTINEL_API_KEY },
+      runtime: createNonExitingRuntime(),
+      resolveApiKey: async (resolveParams) => {
+        if (!captured) {
+          captured = resolveParams;
+        }
+        return null;
+      },
+      toApiKeyCredential: () => null,
+    });
+  } catch {
+    // Some methods throw when credentials are incomplete; captured params still count.
+  }
+  return captured;
+}
+
+const parityCases = listParityCases().toSorted((left, right) => {
+  const pluginOrder = left.pluginId.localeCompare(right.pluginId);
+  if (pluginOrder !== 0) {
+    return pluginOrder;
+  }
+  const providerOrder = left.providerId.localeCompare(right.providerId);
+  if (providerOrder !== 0) {
+    return providerOrder;
+  }
+  return left.methodId.localeCompare(right.methodId);
+});
+
+describe("bundled provider manifest↔runtime auth literal parity", () => {
+  it("discovers api-key-style providerAuthChoices from bundled plugins", () => {
+    expect(parityCases.length).toBeGreaterThan(0);
+    expect(new Set(parityCases.map((entry) => entry.pluginId)).size).toBeGreaterThan(10);
+  });
+
+  it.each(parityCases)(
+    "$pluginId $providerId/$methodId optionKey=$optionKey",
+    { timeout: PARITY_TIMEOUT_MS },
+    async (parityCase) => {
+      const register = await loadPluginRegister(parityCase.pluginId);
+      const captured = createCapturedPluginRegistration({
+        id: parityCase.pluginId,
+        name: parityCase.pluginId,
+        source: `bundled:${parityCase.pluginId}`,
+      });
+      register(captured.api);
+
+      const provider = findRegisteredProvider(captured.providers, parityCase.providerId);
+      if (!provider) {
+        // Capability-only plugins (video/image onboard flags) declare CLI keys in
+        // the manifest without a text ProviderPlugin.auth surface to compare.
+        return;
+      }
+
+      const method = provider.auth.find((entry) => entry.id === parityCase.methodId);
+      expect(
+        method,
+        `${parityCase.pluginId} runtime auth missing method ${parityCase.methodId}`,
+      ).toBeDefined();
+      if (!method) {
+        return;
+      }
+
+      // methodId (manifest `method`) ↔ runtime auth id
+      expect(method.id).toBe(parityCase.methodId);
+
+      const probed = await probeRuntimeAuthLiterals({
+        method,
+        optionKey: parityCase.optionKey,
+      });
+      if (!probed) {
+        return;
+      }
+
+      // cliFlag ↔ flagName; optionKey proven when opts[optionKey] becomes flagValue
+      expect(probed.flagName).toBe(parityCase.cliFlag);
+      expect(probed.flagValue).toBe(SENTINEL_API_KEY);
+
+      // envVar ↔ setup.providers[].envVars and/or provider.envVars
+      const knownEnvVars = new Set([...parityCase.setupEnvVars, ...(provider.envVars ?? [])]);
+      if (knownEnvVars.size > 0) {
+        expect(knownEnvVars.has(probed.envVar)).toBe(true);
+      }
+    },
+  );
+});

--- a/src/plugins/bundled-provider-auth-literal-parity.test.ts
+++ b/src/plugins/bundled-provider-auth-literal-parity.test.ts
@@ -1,10 +1,6 @@
 // Keeps manifest providerAuthChoices literals aligned with registered provider.auth methods.
 import { describe, expect, it } from "vitest";
 import { createNonExitingRuntime } from "../runtime.js";
-import {
-  loadBundledPluginPublicSurface,
-  resolveBundledPluginPublicModulePath,
-} from "../test-utils/bundled-plugin-public-surface.js";
 import { createCapturedPluginRegistration } from "../test-utils/plugin-registration.js";
 import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
 import type { PluginManifestProviderAuthChoice } from "./manifest.js";
@@ -71,6 +67,11 @@ function listParityCases(): ParityCase[] {
 async function loadPluginRegister(
   pluginId: string,
 ): Promise<(api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void> {
+  // Dynamic import keeps this file out of the unit-fast lane: loading built
+  // plugin dists pulls large module graphs into the shared worker cache and
+  // breaks co-resident vi.mock-based unit tests (observed with memory-host-sdk).
+  const { loadBundledPluginPublicSurface, resolveBundledPluginPublicModulePath } =
+    await import("../test-utils/bundled-plugin-public-surface.js");
   // Resolve first so unknown plugin ids fail with a clear path error before import.
   resolveBundledPluginPublicModulePath({
     pluginId,

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -54,6 +54,7 @@ import {
 } from "./plugin-registry-contributions.js";
 import type { PluginRegistrySnapshot } from "./plugin-registry-snapshot.js";
 import { normalizePluginIdScope } from "./plugin-scope.js";
+import { CORE_BUILT_IN_MODEL_APIS } from "./provider-config-owner.js";
 import type { PluginRegistry } from "./registry-types.js";
 import {
   collectConfiguredWorkerProviderIds,
@@ -78,16 +79,6 @@ type VoiceProviderContractKey =
   | "realtimeVoiceProviders";
 type ConfiguredGenerationProviderIds = Record<GenerationProviderContractKey, ReadonlySet<string>>;
 type ConfiguredVoiceProviderIds = Record<VoiceProviderContractKey, ReadonlySet<string>>;
-const CORE_BUILT_IN_MODEL_APIS = new Set([
-  "anthropic-messages",
-  "azure-openai-responses",
-  "google-generative-ai",
-  "google-vertex",
-  "mistral-conversations",
-  "openai-chatgpt-responses",
-  "openai-completions",
-  "openai-responses",
-]);
 
 function sortUniquePluginIds(values: Iterable<string>): string[] {
   return [...new Set([...values].map((value) => value.trim()).filter(Boolean))].toSorted(

--- a/src/plugins/provider-config-owner.ts
+++ b/src/plugins/provider-config-owner.ts
@@ -2,7 +2,8 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-const CORE_BUILT_IN_MODEL_APIS = new Set([
+/** Core built-in model API ids that do not imply plugin ownership of a provider config. */
+export const CORE_BUILT_IN_MODEL_APIS = new Set([
   "anthropic-messages",
   "azure-openai-responses",
   "google-generative-ai",


### PR DESCRIPTION
## What Problem This Solves

Row 12 of #104219: the three concrete drift/misclassification exposures that survived re-verification of the tracker's remaining seams.

1. **Duplicated built-in model-API set.** `CORE_BUILT_IN_MODEL_APIS` was defined byte-for-byte in both `src/plugins/provider-config-owner.ts` and `src/plugins/gateway-startup-plugin-ids.ts`. Both decide "is this model API plugin-owned"; nothing enforced sync, so adding a core API to one silently diverges startup plugin-id resolution from provider-config ownership hints.
2. **No manifest↔runtime auth-literal parity check.** Every bundled provider plugin declares the same auth literals twice: the manifest (`providerAuthChoices`/`setup.providers` — consumed by the wizard/CLI-flag control plane without loading plugin runtime) and the plugin entry's `provider.auth` (consumed at request time). If `optionKey`/env var/CLI flag drift, the wizard stores the user's key under one name and runtime reads another — the provider looks configured but auth silently fails. No test compared the two surfaces.
3. **Structured failover reasons ignored by terminal catch classification.** In `src/auto-reply/reply/agent-runner-execution.ts`, the context-overflow and transient-HTTP branches classified by message text only (`isLikelyContextOverflowError`, `isTransientHttpError` — the latter requires a leading HTTP status token). A typed `FailoverError` with `reason: "context_overflow"` but sanitized message fell through to the generic failure reply; a typed transient failure without a status token skipped the single transient retry. Billing and rate-limit already classified structurally; these two branches were the drift surface.

## Why This Change Was Made

- `CORE_BUILT_IN_MODEL_APIS` now has one owner (`provider-config-owner.ts`, exported); `gateway-startup-plugin-ids.ts` imports it. Import direction verified cycle-free (`pnpm check:import-cycles` green in `check:changed`).
- New `src/plugins/bundled-provider-auth-literal-parity.test.ts` discovers bundled plugins programmatically (`listBundledPluginMetadata`), loads each plugin's public entry via the existing `loadBundledPluginPublicSurface` helper (no `extensions/*/src/**` deep imports), registers it with `createCapturedPluginRegistration`, and table-drives every api-key-style `providerAuthChoices` entry: manifest `method` ↔ runtime `auth.id`, `cliFlag` ↔ probed `flagName`, `optionKey` proven by the option value reaching `flagValue`, env var membership in `setup.providers[].envVars`/`provider.envVars`. Capability-only manifests (video/image onboard flags with no text provider) and oauth-style choices are excluded by construction to avoid false positives.
- The catch classification now prefers structured reasons with message text as fallback, matching the file's existing billing/rate-limit pattern: `context_overflow` reason → overflow handling; `timeout`/`server_error` reasons → the existing single transient retry. **Deliberately excluded:** `overloaded` — a shipped-behavior test ("surfaces typed overloaded failures without rate-limit cooldown copy") pins typed overloaded failures to immediate dedicated user copy, and routing them into the silent retry would change that product behavior. The first draft included `overloaded`; the pinned test caught it and the gate was narrowed (commit `c61e59abde9`).

## User Impact

- Typed context-overflow failures now always produce the targeted overflow guidance instead of the generic failure reply, even when the provider message lacks overflow phrasing.
- Typed transient provider failures (`timeout`/`server_error`) get the same single retry that status-token-bearing messages already got, so a transient blip mid-conversation recovers instead of surfacing an error.
- Overloaded, billing, rate-limit, and compaction-failure behavior are unchanged.
- Items 1–2 are maintainer-facing only (drift guards); no runtime behavior change.

## Evidence

### Real behavior proof (ephemeral gateway, real Telegram channel path)

Built this branch, ran a real gateway (temp `OPENCLAW_STATE_DIR`, loopback) with mock Telegram Bot API + mock OpenAI-completions provider, and drove real reply turns:

- **Transport-exhaust recovery (A4):** mock returns HTTP 500 for three consecutive requests, success after. Gateway log shows the terminal catch classify + `Transient HTTP provider error before reply (HTTP 500: …). Retrying once in 2500ms.`, inter-request gaps `[470, 859, 3789]ms` (the 3.8s gap is the agent-runner retry delay), and the user-visible Telegram reply is the recovered text — not an error.
- **Context-overflow guidance (A3):** mock returns HTTP 400 `context_length_exceeded` on every request; after auto-compaction also fails, the user-visible reply is the targeted `Context overflow: prompt too large for the model…` copy, not the generic failure text.
- **Overloaded pin unchanged:** the shipped test "surfaces typed overloaded failures without rate-limit cooldown copy" stays green (see review-loop note below).

**Honest scope of the live delta:** an A/B run with only `agent-runner-execution.ts` rolled back to `main` recovers identically on these paths, because the runtime currently formats provider failures with a leading status token (`HTTP 500: …`), which main's message-only gate already matches; held-socket timeouts route through the embedded idle-watchdog (`llm-idle-timeout` → surface) and never reach this catch. The structured gate therefore changes no reachable live path today — it pins the retry/overflow decision to the typed `FailoverError.reason` (the canonical fact) instead of the message formatter's prefix, so a formatter change can't silently alter retry behavior. The unit-level delta (typed reason + token-less message → retry/overflow copy) is covered by the new regression tests; the live runs prove behavior parity and no regression.

### Review-loop corrections (found during validation)

- First draft routed typed `overloaded` failures into the transient retry; the shipped-behavior test caught it (overloaded failures must surface dedicated copy immediately). Gate narrowed to `timeout`/`server_error` in `c61e59abde9`.
- The parity test initially landed in the `unit-fast` CI lane, where loading built plugin dists poisons the shared worker module cache and broke unrelated `vi.mock`-based tests (`memory-host-sdk` embeddings in `checks-node-compact-large-2`; bisected to a single surface load). Fixed in `320aab1a37b` by making the loader import dynamic, which moves the file to the `plugins` lane where dist loading is the norm.
- ClawSweeper finding accepted: the parity test's silent skip on missing runtime registration recreated the drift class it guards; now a manifest-declared provider that never registers fails the test unless the plugin registers zero text providers (`3eed7c70cad`).

### Static evidence

- Duplication site: `git show` of `gateway-startup-plugin-ids.ts` before this change vs `provider-config-owner.ts:5` — identical 8-element sets; now one definition (−9 prod LOC).
- Parity test currently passes for all bundled providers (no live drift today — this is a regression guard for the silent-auth-failure mode).
- New regression tests in `agent-runner-execution.test.ts`: `FailoverError` `server_error`/`timeout` without a leading status token → exactly one transient retry then success; structured `context_overflow` with non-overflow message → overflow copy, generic reply suppressed. The pre-existing overloaded pin stays green.
- Remote (Blacksmith Testbox, lease `tbx_01kx9yh69g4043rppaj23e49tv`): `pnpm check:changed` exit 0; focused suites green on head `c61e59abde9` — `bundled-provider-auth-literal-parity` + `bundled-plugin-metadata` (36 files' worth of parity cases) and full `agent-runner-execution.test.ts` (253 tests).
- `git diff --numstat` vs base: prod +11/−13 (net −2) across `provider-config-owner.ts`, `gateway-startup-plugin-ids.ts`, `agent-runner-execution.ts`; tests +266.

Part of #104219 (row 12: small hardening batch from the 2026-07-12 re-verification).
