### PR TITLE
fix(llm): honor Retry-After header for Anthropic transport rate limits

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -319,6 +319,8 @@ export interface AssistantMessage {
   errorCode?: string;
   errorType?: string;
   errorBody?: string;
+  status?: number;
+  retryAfterSeconds?: number;
   timestamp: number; // Unix timestamp in milliseconds
 }
 

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -12,9 +12,13 @@ const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
   guardedFetchMock: vi.fn(),
 }));
 
-vi.mock("./provider-transport-fetch.js", () => ({
-  buildGuardedModelFetch: buildGuardedModelFetchMock,
-}));
+vi.mock("./provider-transport-fetch.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("./provider-transport-fetch.js")>();
+  return {
+    ...mod,
+    buildGuardedModelFetch: buildGuardedModelFetchMock,
+  };
+});
 
 let createAnthropicMessagesTransportStreamFn: typeof import("./anthropic-transport-stream.js").createAnthropicMessagesTransportStreamFn;
 
@@ -4060,5 +4064,27 @@ describe("anthropic transport stream", () => {
     // surfaces the SSE error as an explicit "error" event or silently ends the
     // stream (a timing artefact of synchronous mock SSE delivery).
     expect(eventTypes).not.toContain("start");
+  });
+
+  it("extracts status and retryAfterSeconds from 429 responses", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ error: { type: "rate_limit_error", message: "Rate limit exceeded" } }),
+        {
+          status: 429,
+          headers: { "content-type": "application/json", "retry-after-ms": "30000" },
+        },
+      ),
+    );
+
+    const streamPromise = runTransportStream(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    );
+    const result = await streamPromise;
+    expect(result.stopReason).toBe("error");
+    expect(result.status).toBe(429);
+    expect(result.retryAfterSeconds).toBe(30);
   });
 });

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -4087,4 +4087,27 @@ describe("anthropic transport stream", () => {
     expect(result.status).toBe(429);
     expect(result.retryAfterSeconds).toBe(30);
   });
+
+  it("ignores non-finite oversized Retry-After values", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ error: { type: "rate_limit_error", message: "Rate limit exceeded" } }),
+        {
+          status: 429,
+          headers: { "content-type": "application/json", "retry-after-ms": "9007199254740993" },
+        },
+      ),
+    );
+
+    const streamPromise = runTransportStream(
+      makeAnthropicTransportModel(),
+      { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+    );
+
+    const result = await streamPromise;
+    expect(result.stopReason).toBe("error");
+    expect(result.status).toBe(429);
+    expect(result.retryAfterSeconds).toBeUndefined();
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -72,7 +72,7 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dyn
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { unwrapModelHeaderSentinelsForProviderEgress } from "./provider-secret-egress.js";
-import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
+import { buildGuardedModelFetch, parseRetryAfterSeconds } from "./provider-transport-fetch.js";
 import type { StreamFn } from "./runtime/index.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
@@ -840,9 +840,15 @@ function createAnthropicMessagesClient(params: {
         });
         if (!response.ok) {
           const detail = await readAnthropicMessagesErrorBodySnippet(response);
-          throw new Error(
+          const error = new Error(
             detail || `Anthropic Messages request failed with HTTP ${response.status}`,
-          );
+          ) as Error & { status?: number; retryAfterSeconds?: number };
+          error.status = response.status;
+          const retryAfterSeconds = parseRetryAfterSeconds(response.headers);
+          if (retryAfterSeconds !== undefined) {
+            error.retryAfterSeconds = retryAfterSeconds;
+          }
+          throw error;
         }
         if (!response.body) {
           return;

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -845,7 +845,7 @@ function createAnthropicMessagesClient(params: {
           ) as Error & { status?: number; retryAfterSeconds?: number };
           error.status = response.status;
           const retryAfterSeconds = parseRetryAfterSeconds(response.headers);
-          if (retryAfterSeconds !== undefined) {
+          if (retryAfterSeconds !== undefined && Number.isFinite(retryAfterSeconds)) {
             error.retryAfterSeconds = retryAfterSeconds;
           }
           throw error;

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -483,7 +483,7 @@ export function parseRetryAfterSeconds(headers: Headers): number | undefined {
   return Math.max(0, (retryAt - Date.now()) / 1000);
 }
 
-function resolveMaxSdkRetryWaitSeconds(): number | undefined {
+export function resolveMaxSdkRetryWaitSeconds(): number | undefined {
   const raw = process.env.OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS?.trim();
   if (!raw) {
     return DEFAULT_MAX_SDK_RETRY_WAIT_SECONDS;

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -452,7 +452,7 @@ async function requestBodyHasStreamTrue(
   }
 }
 
-function parseRetryAfterSeconds(headers: Headers): number | undefined {
+export function parseRetryAfterSeconds(headers: Headers): number | undefined {
   const retryAfterMs = headers.get("retry-after-ms");
   if (retryAfterMs) {
     const trimmedRetryAfterMs = retryAfterMs.trim();

--- a/src/agents/sessions/agent-session.retry.test.ts
+++ b/src/agents/sessions/agent-session.retry.test.ts
@@ -101,4 +101,39 @@ describe("AgentSession retry delay", () => {
     expect(session.retryCount).toBe(0); // restored for failover
     expect(emittedDelay).toBe(-1); // no delay emitted
   });
+
+  it("surfaces immediately with a timer-safe bound if SDK max wait is disabled and retryAfter is huge", async () => {
+    let emittedDelay = -1;
+    const session = {
+      retryCount: 0,
+      settingsManager: {
+        getRetrySettings: () => ({ enabled: true, maxRetries: 3, baseDelayMs: 2000 }),
+      },
+      emit: (event: any) => {
+        if (event.type === "auto_retry_start") {
+          emittedDelay = event.delayMs;
+        }
+      },
+      delay: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      agent: { state: { messages: [] } },
+    } as unknown as AgentSession;
+
+    // Simulate disabling the max wait cap
+    process.env.OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS = "0";
+
+    const callPromise = AgentSession.prototype["prepareRetry"].call(session, {
+      role: "assistant",
+      stopReason: "error",
+      status: 429,
+      retryAfterSeconds: 2147484, // ~2.14m seconds (exceeds 2147483647 ms)
+    } as unknown as AssistantMessage);
+
+    const result = await callPromise;
+
+    expect(result).toBe(false); // abort retry immediately due to MAX_NODE_TIMEOUT
+    expect(session.retryCount).toBe(0); // restored for failover
+    expect(emittedDelay).toBe(-1); // no delay emitted
+
+    delete process.env.OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS;
+  });
 });

--- a/src/agents/sessions/agent-session.retry.test.ts
+++ b/src/agents/sessions/agent-session.retry.test.ts
@@ -71,4 +71,34 @@ describe("AgentSession retry delay", () => {
     expect(session.retryCount).toBe(1);
     expect(emittedDelay).toBe(2000); // Falls back to base delay since infinity is ignored
   });
+
+  it("surfaces immediately (returns false) if retryAfterSeconds exceeds max SDK wait", async () => {
+    let emittedDelay = -1;
+    const session = {
+      retryCount: 0,
+      settingsManager: {
+        getRetrySettings: () => ({ enabled: true, maxRetries: 3, baseDelayMs: 2000 }),
+      },
+      emit: (event: any) => {
+        if (event.type === "auto_retry_start") {
+          emittedDelay = event.delayMs;
+        }
+      },
+      delay: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      agent: { state: { messages: [] } },
+    } as unknown as AgentSession;
+
+    const callPromise = AgentSession.prototype["prepareRetry"].call(session, {
+      role: "assistant",
+      stopReason: "error",
+      status: 429,
+      retryAfterSeconds: 61, // default cap is 60s
+    } as unknown as AssistantMessage);
+
+    const result = await callPromise;
+
+    expect(result).toBe(false); // abort retry immediately
+    expect(session.retryCount).toBe(0); // restored for failover
+    expect(emittedDelay).toBe(-1); // no delay emitted
+  });
 });

--- a/src/agents/sessions/agent-session.retry.test.ts
+++ b/src/agents/sessions/agent-session.retry.test.ts
@@ -1,0 +1,74 @@
+import type { AssistantMessage } from "openclaw/llm-core";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { AgentSession } from "./agent-session.js";
+
+describe("AgentSession retry delay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+  it("uses the server-provided retryAfterSeconds when larger than base exponential backoff", async () => {
+    let emittedDelay = -1;
+    const session = {
+      retryCount: 0,
+      settingsManager: {
+        getRetrySettings: () => ({ enabled: true, maxRetries: 3, baseDelayMs: 2000 }),
+      },
+      emit: (event: any) => {
+        if (event.type === "auto_retry_start") {
+          emittedDelay = event.delayMs;
+        }
+      },
+      delay: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      agent: { state: { messages: [] } },
+    } as unknown as AgentSession;
+
+    const callPromise = AgentSession.prototype["prepareRetry"].call(session, {
+      role: "assistant",
+      stopReason: "error",
+      status: 429,
+      retryAfterSeconds: 30,
+    } as unknown as AssistantMessage);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    const result = await callPromise;
+
+    expect(result).toBe(true);
+    expect(session.retryCount).toBe(1);
+    expect(emittedDelay).toBe(30_000); // Should use server's 30s instead of base 2000ms
+  });
+
+  it("normalizes non-finite retryAfterSeconds back to base exponential backoff", async () => {
+    let emittedDelay = -1;
+    const session = {
+      retryCount: 0,
+      settingsManager: {
+        getRetrySettings: () => ({ enabled: true, maxRetries: 3, baseDelayMs: 2000 }),
+      },
+      emit: (event: any) => {
+        if (event.type === "auto_retry_start") {
+          emittedDelay = event.delayMs;
+        }
+      },
+      delay: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+      agent: { state: { messages: [] } },
+    } as unknown as AgentSession;
+
+    const callPromise = AgentSession.prototype["prepareRetry"].call(session, {
+      role: "assistant",
+      stopReason: "error",
+      status: 429,
+      retryAfterSeconds: Number.POSITIVE_INFINITY,
+    } as unknown as AssistantMessage);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await callPromise;
+
+    expect(result).toBe(true);
+    expect(session.retryCount).toBe(1);
+    expect(emittedDelay).toBe(2000); // Falls back to base delay since infinity is ignored
+  });
+});

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -39,6 +39,7 @@ import type {
   PersistedUserTurnMessage,
   UserTurnTranscriptRecorder,
 } from "../../sessions/user-turn-transcript.types.js";
+import { resolveMaxSdkRetryWaitSeconds } from "../provider-transport-fetch.js";
 import type {
   Agent,
   AgentEvent,
@@ -2691,6 +2692,13 @@ export class AgentSession {
       message.retryAfterSeconds > 0
     ) {
       const requestedDelayMs = message.retryAfterSeconds * 1000;
+      const maxWaitSeconds = resolveMaxSdkRetryWaitSeconds();
+
+      if (maxWaitSeconds !== undefined && requestedDelayMs > maxWaitSeconds * 1000) {
+        this.retryCount--;
+        return false;
+      }
+
       if (requestedDelayMs > delayMs) {
         delayMs = requestedDelayMs;
       }

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -2704,6 +2704,12 @@ export class AgentSession {
       }
     }
 
+    const MAX_NODE_TIMEOUT = 2147483647;
+    if (delayMs > MAX_NODE_TIMEOUT) {
+      this.retryCount--;
+      return false;
+    }
+
     this.emit({
       type: "auto_retry_start",
       attempt: this.retryCount,

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -2683,7 +2683,14 @@ export class AgentSession {
       return false;
     }
 
-    const delayMs = settings.baseDelayMs * 2 ** (this.retryCount - 1);
+    let delayMs = settings.baseDelayMs * 2 ** (this.retryCount - 1);
+
+    if (typeof message.retryAfterSeconds === "number" && message.retryAfterSeconds > 0) {
+      const requestedDelayMs = message.retryAfterSeconds * 1000;
+      if (requestedDelayMs > delayMs) {
+        delayMs = requestedDelayMs;
+      }
+    }
 
     this.emit({
       type: "auto_retry_start",

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -2685,7 +2685,11 @@ export class AgentSession {
 
     let delayMs = settings.baseDelayMs * 2 ** (this.retryCount - 1);
 
-    if (typeof message.retryAfterSeconds === "number" && message.retryAfterSeconds > 0) {
+    if (
+      typeof message.retryAfterSeconds === "number" &&
+      Number.isFinite(message.retryAfterSeconds) &&
+      message.retryAfterSeconds > 0
+    ) {
       const requestedDelayMs = message.retryAfterSeconds * 1000;
       if (requestedDelayMs > delayMs) {
         delayMs = requestedDelayMs;

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -30,6 +30,8 @@ type TransportOutputShape = {
   errorCode?: string;
   errorType?: string;
   errorBody?: string;
+  status?: number;
+  retryAfterSeconds?: number;
 };
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
@@ -149,6 +151,8 @@ type TransportErrorDetails = {
   errorCode?: string;
   errorType?: string;
   errorBody?: string;
+  status?: number;
+  retryAfterSeconds?: number;
 };
 
 function readStringLikeProperty(value: unknown, key: string): string | undefined {
@@ -230,10 +234,21 @@ function extractTransportErrorDetails(error: unknown): TransportErrorDetails {
     normalizeTransportErrorBody(readObjectProperty(errorObject, "body")) ??
     normalizeTransportErrorBody(nestedError);
 
+  const status =
+    typeof (errorObject as Record<string, unknown>)?.status === "number"
+      ? ((errorObject as Record<string, unknown>).status as number)
+      : undefined;
+  const retryAfterSeconds =
+    typeof (errorObject as Record<string, unknown>)?.retryAfterSeconds === "number"
+      ? ((errorObject as Record<string, unknown>).retryAfterSeconds as number)
+      : undefined;
+
   return {
     ...(errorCode ? { errorCode } : {}),
     ...(errorType ? { errorType } : {}),
     ...(errorBody ? { errorBody } : {}),
+    ...(status !== undefined ? { status } : {}),
+    ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Anthropic Messages transport would drop the `Retry-After` header and HTTP status on a 429 error, and ensures that AgentSession respects both invalid server values (non-finite) and the configured maximum wait time (`OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS`). 
Additionally, this provides a timer-safe session bound so that an oversized finite provider header does not cause Node.js timer overflow when SDK capping is disabled.

## Why This Change Was Made

- **Anthropic Transport (`src/agents/anthropic-transport-stream.ts`)**: The error handler now extracts `retryAfterSeconds` from the 429 response using `parseRetryAfterSeconds` and strictly filters out non-finite (`Infinity`) sentinel values before appending them to the thrown error.
- **AgentSession (`src/agents/sessions/agent-session.ts`)**: 
  1. As a secondary defense, `prepareRetry` now enforces `Number.isFinite()` on the requested delay to ensure that invalid non-finite delays do not normalize into immediate retries.
  2. `prepareRetry` now imports and honors `resolveMaxSdkRetryWaitSeconds()` (defaulting to 60s). If the server requests a cooldown exceeding the configured maximum wait, `AgentSession` will abort the retry (`return false`) to immediately trigger failover rotation (e.g., trying a different profile or model) rather than stalling the session for hours.
  3. Added an independent timer-safe boundary (`MAX_NODE_TIMEOUT` = 2147483647 ms) which surfaces for existing failover when the requested delay exceeds Node's timer capabilities (such as when `OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS` is disabled and the server requests a huge cooldown).

## User Impact

Anthropic model requests that hit rate limits now correctly respect the server's `Retry-After` header instead of repeatedly failing during the cooldown window. Oversized malformed Retry-After headers behave safely. If a server demands a cooldown longer than the configured maximum (default 60s), or longer than Node's max timer value when the cap is disabled, the system promptly fails over rather than blocking or recreating retry pressure.

## Evidence

Added new unit tests covering:
1. Extraction of `status: 429` and finite `retryAfterSeconds`.
2. Ignoring non-finite oversized values (`retry-after-ms: 9007199254740993`) at the transport boundary.
3. Direct AgentSession emitted-delay regression testing in `agent-session.retry.test.ts`.
4. Surface immediately (returns false) if `retryAfterSeconds` exceeds the max SDK wait (60s).
5. Timer-safe bound abortion when SDK max wait is disabled and `retryAfterSeconds` is extremely large.

<details>
<summary>Terminal Output: Session Retry Path Validation</summary>

```text
$ pnpm test src/agents/sessions/agent-session.retry.test.ts src/agents/anthropic-transport-stream.test.ts
[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.9 /Users/lustime/Documents/ai/openclaw

 ✓  agents  src/agents/sessions/agent-session.retry.test.ts (4 tests) 17ms
 ✓  agents  src/agents/anthropic-transport-stream.test.ts (109 tests) 378ms

 Test Files  2 passed (2)
      Tests  113 passed (113)
```
</details>

<details>
<summary>Terminal Output: Real Runtime Proof for Composed Transport and AgentSession Failover</summary>

Proof of Anthropic Transport and AgentSession interacting together through a local stub server returning 429 with `Retry-After: 100`:

```text
Starting local stub server...
[stub-server] listening on http://127.0.0.1:60831

--- 1. Testing Managed Transport Boundary ---
[provider-transport-fetch] [model-fetch] start provider=anthropic api=undefined model=test-anthropic method=POST url=http://127.0.0.1:60831/v1/messages timeoutMs=undefined proxy=none policy=custom
[stub-server] received request: POST /v1/messages
[provider-transport-fetch] [model-fetch] response provider=anthropic api=undefined model=test-anthropic status=429 elapsedMs=35 contentType=application/json
[Stream Event] error
Actual error: {
  "role": "assistant",
  "content": [],
  "api": "anthropic-messages",
  "provider": "anthropic",
  "model": "test-anthropic",
  "usage": {},
  "stopReason": "error",
  "timestamp": 1783827902468,
  "errorMessage": "{\"type\":\"error\",\"error\":{\"type\":\"rate_limit_error\",\"message\":\"Number of request tokens has exceeded your per-minute rate limit.\"}}",
  "status": 429,
  "retryAfterSeconds": 100
}
Resulting AssistantMessage from transport:
{
  "role": "assistant",
  "stopReason": "error",
  "errorMessage": "Unknown error",
  "status": 429,
  "retryAfterSeconds": 100
}

--- 2. Testing AgentSession Failover Path ---
Calling AgentSession.prepareRetry with the resulting message...
AgentSession.prepareRetry returned: false (false means it will failover instead of stalling)
```
</details>

@clawsweeper re-review
