### PR TITLE
fix(cli): allow agent-scoped message sends

### DIFF
--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -83,6 +83,16 @@ unresolved SecretRef on the selected channel/account fails the action closed.
 
 ### Send
 
+Use `--agent <id>` to select the configured agent that owns the destination
+session transcript. If omitted, OpenClaw uses the configured default agent.
+This matters when another agent sends through the CLI and later replies should
+retain that agent's conversation context.
+
+```bash
+openclaw message send --agent ops --channel whatsapp \
+  --target 120363000000000000@g.us --message "Was the replacement delivered?"
+```
+
 ```bash
 openclaw message send --channel discord \
   --target channel:123 --message "hi" --reply-to 456

--- a/src/cli/program/message/register.send.ts
+++ b/src/cli/program/message/register.send.ts
@@ -14,7 +14,8 @@ export function registerMessageSendCommand(message: Command, helpers: MessageCli
             .option(
               "-m, --message <text>",
               "Message body (required unless --media or --presentation is set)",
-            ),
+            )
+            .option("--agent <id>", "Agent that owns the destination session"),
         )
         .option(
           "--media <path-or-url>",

--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -303,6 +303,25 @@ describe("messageCommand", () => {
     expect(actionCall.params.pollQuestion).toBe("Ship it?");
   });
 
+  it("uses an explicitly selected configured agent for destination session ownership", async () => {
+    testConfig = {
+      agents: { list: [{ id: "main", default: true }, { id: "George" }] },
+    };
+
+    await runMessageCommand({ agent: "GEORGE" });
+
+    expect(readOnlyMessageActionCall().agentId).toBe("george");
+  });
+
+  it("rejects an unknown explicitly selected agent before dispatch", async () => {
+    testConfig = {
+      agents: { list: [{ id: "main", default: true }, { id: "george" }] },
+    };
+
+    await expect(runMessageCommand({ agent: "typo" })).rejects.toThrow('Unknown agent id "typo"');
+    expect(runMessageActionMock).not.toHaveBeenCalled();
+  });
+
   it("includes a stable top-level messageId in JSON output", async () => {
     runMessageActionMock.mockResolvedValueOnce({
       kind: "send",

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -7,7 +7,7 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { CHANNEL_MESSAGE_ACTION_NAMES } from "../channels/plugins/message-action-names.js";
 import type { ChannelMessageActionName } from "../channels/plugins/types.public.js";
 import { resolveCommandConfigWithSecrets } from "../cli/command-config-resolution.js";
@@ -20,6 +20,7 @@ import { withProgress } from "../cli/progress.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 
 function extractMessageId(payload: unknown): string | undefined {
@@ -93,6 +94,15 @@ export async function messageCommand(
     );
   }
   const action = actionMatch as ChannelMessageActionName;
+  const requestedAgentId = normalizeOptionalString(opts.agent);
+  const agentId = requestedAgentId
+    ? normalizeAgentId(requestedAgentId)
+    : resolveDefaultAgentId(cfg);
+  if (!listAgentIds(cfg).includes(agentId)) {
+    throw new Error(
+      `Unknown agent id "${requestedAgentId}". Use ${formatCliCommand("openclaw agents list")} to see configured agents.`,
+    );
+  }
 
   const outboundDeps: OutboundSendDeps = createOutboundSendDeps(deps);
 
@@ -104,7 +114,7 @@ export async function messageCommand(
       action,
       params: opts,
       deps: outboundDeps,
-      agentId: resolveDefaultAgentId(cfg),
+      agentId,
       senderIsOwner: opts.senderIsOwner !== false,
       conversationReadOrigin: "direct-operator",
       gateway: {


### PR DESCRIPTION
## Summary

- add `--agent <id>` to `openclaw message send`
- validate the selected agent against configured agent IDs
- preserve the configured default agent when the flag is omitted
- document agent-scoped outbound sends

## Why

Standalone CLI sends previously always used the configured default agent. When a message was sent operationally for another agent, the delivery mirror was written to the default agent's destination session while the recipient's reply could route to the bound agent. That split the outbound question and inbound answer across different session transcripts and deprived the reply handler of the immediate context.

The explicit flag keeps existing behavior backward-compatible while allowing callers to select the agent that owns the destination session and delivery mirror.

## Validation

- 49 focused Vitest tests passed across the message command and CLI mapping suites
- CLI help displays `--agent <id>`
- formatting check passed
- `git diff --check` passed
