### PR TITLE
fix(release): preserve original PRs for named backports

### DIFF
--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -750,6 +750,12 @@ function contributionRecordMetadataReferences(record) {
   return references;
 }
 
+export function renderedContributionRecordReferences(record, writeLedger) {
+  // Write mode replaces the existing generated record. Validating stale record
+  // references here would make the verifier unable to repair its own output.
+  return writeLedger ? [] : contributionRecordMetadataReferences(record);
+}
+
 export function contaminatingPullRequestReferences({
   noteReferences,
   recordedReferences,
@@ -2155,11 +2161,10 @@ function main() {
     ...source.revertedReferences,
     ...shippedExclusions.pullRequests,
   ]);
-  const effectiveRenderedRecord = options.writeLedger
-    ? withoutExcludedContributionRecords(renderedRecord, excludedRecordedReferences)
-    : renderedRecord;
-  const effectiveRenderedRecordReferences =
-    contributionRecordMetadataReferences(effectiveRenderedRecord);
+  const effectiveRenderedRecordReferences = renderedContributionRecordReferences(
+    renderedRecord,
+    options.writeLedger,
+  );
   let priorRecord = { legacyIssues: new Map(), pullRequests: new Map() };
   if (options.seedRef) {
     const seedChangelog = git(["show", `${options.seedRef}:CHANGELOG.md`]);

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -793,6 +793,12 @@ function cherryPickOrigins(message) {
   );
 }
 
+function backportPullRequestOrigins(message) {
+  return [
+    ...message.matchAll(/^Backport of #(\d+) to release\/[A-Za-z0-9._/-]+(?:\.)?\s*$/gim),
+  ].map((match) => Number(match[1]));
+}
+
 function changedPathsForCommit(hash) {
   return new Set(
     git(["diff-tree", "--root", "--no-commit-id", "--name-only", "-r", hash, "--"])
@@ -836,6 +842,22 @@ export function canonicalMainCommitMatches(commit, candidates) {
     return [...new Set(explicit)];
   }
 
+  const pullRequestOrigins = new Set(backportPullRequestOrigins(commit.body));
+  const pullRequestMatches = candidates.filter(
+    (candidate) =>
+      referencesIn(`${candidate.subject}\n${candidate.body ?? ""}`).some((number) =>
+        pullRequestOrigins.has(number),
+      ) &&
+      authorsMatch(commit, candidate) &&
+      pathsOverlap(commit.changedPaths, candidate.changedPaths),
+  );
+  if (pullRequestMatches.length === 1) {
+    return [pullRequestMatches[0].hash];
+  }
+  if (pullRequestMatches.length > 1) {
+    return [];
+  }
+
   const subject = normalizedCommitSubject(commit.subject);
   const matches = candidates.filter(
     (candidate) =>
@@ -864,7 +886,7 @@ function canonicalMainCommits(base, mainRef) {
   const output = git([
     "log",
     "--reverse",
-    "--format=%H%x1f%s%x1f%an%x1f%ae%x1e",
+    "--format=%H%x1f%s%x1f%an%x1f%ae%x1f%B%x1e",
     `${mainBase}..${mainCommit}`,
   ]);
   const commits = [];
@@ -872,11 +894,12 @@ function canonicalMainCommits(base, mainRef) {
     if (!record) {
       continue;
     }
-    const [rawHash, subject, authorName, authorEmail] = record.split("\x1f");
+    const [rawHash, subject, authorName, authorEmail, ...bodyParts] = record.split("\x1f");
     const hash = rawHash.trim();
     commits.push({
       authorEmail,
       authorName,
+      body: bodyParts.join("\x1f"),
       hash,
       subject,
     });
@@ -1059,11 +1082,17 @@ function sourceCommits(base, target, mainRef) {
   const mainCommits = canonicalMainCommits(base, mainRef);
   const mainCommitsByHash = new Map(mainCommits.map((commit) => [commit.hash, commit]));
   const mainCommitsBySubject = new Map();
+  const mainCommitsByPullRequest = new Map();
   for (const commit of mainCommits) {
     const subject = normalizedCommitSubject(commit.subject);
     const matches = mainCommitsBySubject.get(subject) ?? [];
     matches.push(commit);
     mainCommitsBySubject.set(subject, matches);
+    for (const number of referencesIn(`${commit.subject}\n${commit.body}`)) {
+      const pullRequestMatches = mainCommitsByPullRequest.get(number) ?? [];
+      pullRequestMatches.push(commit);
+      mainCommitsByPullRequest.set(number, pullRequestMatches);
+    }
   }
   const canonicalMainCommitsByReleaseCommit = new Map();
   const canonicalMainHashes = new Set();
@@ -1083,14 +1112,20 @@ function sourceCommits(base, target, mainRef) {
     const explicit = cherryPickOrigins(commit.body)
       .map((origin) => mainCommitsByHash.get(origin))
       .filter(Boolean);
+    const candidates = new Map(
+      [
+        ...(mainCommitsBySubject.get(normalizedCommitSubject(commit.subject)) ?? []),
+        ...backportPullRequestOrigins(commit.body).flatMap(
+          (number) => mainCommitsByPullRequest.get(number) ?? [],
+        ),
+      ].map((candidate) => [candidate.hash, candidate]),
+    );
     const matches =
       explicit.length > 0
         ? [...new Set(explicit.map((candidate) => candidate.hash))]
         : canonicalMainCommitMatches(
             withChangedPaths(commit),
-            (mainCommitsBySubject.get(normalizedCommitSubject(commit.subject)) ?? []).map(
-              withChangedPaths,
-            ),
+            [...candidates.values()].map(withChangedPaths),
           );
     canonicalMainCommitsByReleaseCommit.set(commit.hash, matches);
     for (const hash of matches) {

--- a/test/external-script-modules.d.ts
+++ b/test/external-script-modules.d.ts
@@ -92,6 +92,13 @@ declare module "*openclaw-changelog-update/scripts/verify-release-notes.mjs" {
     legacyIssues: Map<number, ContributionRecord>;
     pullRequests: Map<number, ContributionRecord>;
   };
+  export function renderedContributionRecordReferences(
+    record: {
+      legacyIssues: Map<number, ContributionRecord>;
+      pullRequests: Map<number, ContributionRecord>;
+    },
+    writeLedger: boolean,
+  ): number[];
   export function contaminatingPullRequestReferences(params: Record<string, unknown>): unknown[];
   export function canonicalMainCommitMatches(commit: unknown, candidates: unknown[]): unknown[];
   export function canonicalPullRequests(

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -74,9 +74,50 @@ describe("release-note verification", () => {
       hash: "c".repeat(40),
       subject: "fix(channel): preserve durable replies",
     };
+    const pullRequestBackport = {
+      authorEmail: mainCommit.authorEmail,
+      authorName: mainCommit.authorName,
+      body: "Backport of #123 to release/2026.7.1.",
+      changedPaths: new Set(["src/channel.ts"]),
+      hash: "d".repeat(40),
+      subject: "fix(channel): keep replies after renewal",
+    };
 
     expect(canonicalMainCommitMatches(explicitBackport, [mainCommit])).toEqual([mainCommit.hash]);
     expect(canonicalMainCommitMatches(integratedBackport, [mainCommit])).toEqual([mainCommit.hash]);
+    expect(canonicalMainCommitMatches(pullRequestBackport, [mainCommit])).toEqual([
+      mainCommit.hash,
+    ]);
+    expect(
+      canonicalMainCommitMatches(pullRequestBackport, [
+        {
+          ...mainCommit,
+          body: "Original main PR #123.",
+          subject: "fix(channel): preserve durable replies",
+        },
+      ]),
+    ).toEqual([mainCommit.hash]);
+    expect(
+      canonicalMainCommitMatches(
+        { ...pullRequestBackport, authorEmail: "other@example.com", authorName: "Other" },
+        [mainCommit],
+      ),
+    ).toEqual([]);
+    expect(
+      canonicalMainCommitMatches(
+        { ...pullRequestBackport, changedPaths: new Set(["src/other.ts"]) },
+        [mainCommit],
+      ),
+    ).toEqual([]);
+    expect(
+      canonicalMainCommitMatches({ ...pullRequestBackport, body: "Related #123." }, [mainCommit]),
+    ).toEqual([]);
+    expect(
+      canonicalMainCommitMatches(pullRequestBackport, [
+        mainCommit,
+        { ...mainCommit, hash: "e".repeat(40) },
+      ]),
+    ).toEqual([]);
     expect(canonicalPullRequests([456], [123])).toEqual([123]);
   });
 

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -15,6 +15,7 @@ import {
   highlightCountError,
   persistGithubSnapshot,
   releaseNoteReferences,
+  renderedContributionRecordReferences,
   standardRevertedHash,
   subtractShippedPullRequests,
   withoutExcludedContributionRecords,
@@ -375,6 +376,18 @@ describe("release-note verification", () => {
         seededPullRequests: new Set([97118]),
       }),
     ).toEqual([]);
+  });
+
+  it("ignores the stale generated record while rewriting it", () => {
+    const record = {
+      pullRequests: new Map([
+        [104732, { references: [102289], thanks: ["fuller-stack-dev"] }],
+      ]),
+      legacyIssues: new Map(),
+    };
+
+    expect(renderedContributionRecordReferences(record, true)).toEqual([]);
+    expect(renderedContributionRecordReferences(record, false)).toEqual([104732, 102289]);
   });
 
   it("excludes Unreleased records from a cumulative shipped tag boundary", () => {

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -380,9 +380,7 @@ describe("release-note verification", () => {
 
   it("ignores the stale generated record while rewriting it", () => {
     const record = {
-      pullRequests: new Map([
-        [104732, { references: [102289], thanks: ["fuller-stack-dev"] }],
-      ]),
+      pullRequests: new Map([[104732, { references: [102289], thanks: ["fuller-stack-dev"] }]]),
       legacyIssues: new Map(),
     };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release notes could list both a release-branch backport PR and its original main PR when the backport commit explicitly named the original PR but used a different title.

## Why This Change Was Made

The verifier now recognizes a standalone `Backport of #<PR> to release/<version>.` marker, then accepts the referenced main commit only when author identity and changed paths overlap and the match is unambiguous. Incidental issue references, different authors, disjoint patches, and ambiguous matches continue to retain the release PR.

## User Impact

Release changelogs keep the canonical original main PR link and contributor provenance instead of exposing duplicate backport PR records.

## Evidence

- AWS Crabbox `run_66a1ff31a3f1`: 19/19 focused verifier tests passed.
- AWS Crabbox `run_5ef20abbc36b`: 19/19 verifier tests and the exact `pnpm tsgo:test` lane passed after adding the ambient module declaration. The lease reached its fixed expiry during the later all-project changed gate; exact-head GitHub CI remains the broad gate.
- `oxfmt --check` and `git diff --check` passed.
- Fresh autoreview: clean, no accepted/actionable findings.
