### PR TITLE
fix(discord): retry stale preview cleanup after final delivery

### DIFF
--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -326,7 +326,7 @@ export function createDiscordDraftPreviewController(params: {
         if (!finalReplyDelivered) {
           await draftStream?.discardPending();
         }
-        if (!finalReplyDelivered && !finalizedViaPreviewMessage && draftStream?.messageId()) {
+        if (!finalizedViaPreviewMessage && draftStream?.messageId()) {
           await draftStream.clear();
         }
       } catch (err) {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2097,6 +2097,21 @@ describe("processDiscordMessage draft streaming", () => {
     expectFreshFinalText("Hello\nWorld");
   });
 
+  it("retries stale preview cleanup at teardown after fresh final delivery", async () => {
+    const draftStream = createMockDraftStream();
+    draftStream.clear.mockImplementationOnce(async () => {});
+    createDiscordDraftStream.mockReturnValueOnce(draftStream);
+
+    await runSingleChunkFinalScenario({
+      streaming: { mode: "partial" },
+      maxLinesPerMessage: 5,
+    });
+
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(2);
+    expect(draftStream.messageId()).toBeUndefined();
+  });
+
   it("delivers a fresh message instead of a preview edit when the final reply resolves a mention alias", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "On it @Sentinel" });

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -1,8 +1,5 @@
 // Mattermost plugin module implements draft stream behavior.
-import {
-  clearFinalizableDraftMessage,
-  createFinalizableDraftLifecycle,
-} from "openclaw/plugin-sdk/channel-outbound";
+import { createFinalizableDraftLifecycle } from "openclaw/plugin-sdk/channel-outbound";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -165,6 +162,7 @@ export function createMattermostDraftStream(params: {
     update: updateLifecycle,
     stop: stopLifecycle,
     stopForClear,
+    clearWithStop,
     seal: sealLifecycle,
   } = createFinalizableDraftLifecycle({
     throttleMs,
@@ -250,15 +248,7 @@ export function createMattermostDraftStream(params: {
     await currentGeneration.ready;
   };
   const clear = async () => {
-    await clearFinalizableDraftMessage({
-      stopForClear: discardPending,
-      readMessageId: () => currentGeneration.postId,
-      clearMessageId,
-      isValidMessageId,
-      deleteMessage,
-      warn: params.warn,
-      warnPrefix: "mattermost stream preview cleanup failed",
-    });
+    await clearWithStop(discardPending);
   };
   const seal = async () => {
     await sealLifecycle();

--- a/src/channels/draft-stream-controls.test.ts
+++ b/src/channels/draft-stream-controls.test.ts
@@ -64,22 +64,61 @@ describe("draft-stream-controls", () => {
     expect(deleteMessage).not.toHaveBeenCalled();
   });
 
-  it("clearFinalizableDraftMessage warns when delete fails", async () => {
+  it("clearFinalizableDraftMessage retains failed deletes for retry", async () => {
     const warn = vi.fn();
+    let messageId: string | undefined = "m-3";
+    const deleteMessage = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(undefined);
+    const clear = async () => {
+      await clearFinalizableDraftMessage({
+        stopForClear: async () => {},
+        readMessageId: () => messageId,
+        clearMessageId: () => {
+          messageId = undefined;
+        },
+        isValidMessageId: (value): value is string => typeof value === "string",
+        deleteMessage,
+        warn,
+        warnPrefix: "cleanup failed",
+      });
+    };
 
-    await clearFinalizableDraftMessage({
+    await clear();
+
+    expect(messageId).toBe("m-3");
+    expect(warn).toHaveBeenCalledWith("cleanup failed: boom");
+
+    await clear();
+
+    expect(deleteMessage).toHaveBeenCalledTimes(2);
+    expect(messageId).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearFinalizableDraftMessage preserves a replacement id while delete is in flight", async () => {
+    let messageId: string | undefined = "preview-old";
+    const pendingDelete = Promise.withResolvers<void>();
+    const deleteMessage = vi.fn(() => pendingDelete.promise);
+
+    const clearPromise = clearFinalizableDraftMessage({
       stopForClear: async () => {},
-      readMessageId: () => "m-3",
-      clearMessageId: () => {},
-      isValidMessageId: (value): value is string => typeof value === "string",
-      deleteMessage: async () => {
-        throw new Error("boom");
+      readMessageId: () => messageId,
+      clearMessageId: () => {
+        messageId = undefined;
       },
-      warn,
+      isValidMessageId: (value): value is string => typeof value === "string",
+      deleteMessage,
       warnPrefix: "cleanup failed",
     });
+    await vi.waitFor(() => expect(deleteMessage).toHaveBeenCalledWith("preview-old"));
 
-    expect(warn).toHaveBeenCalledWith("cleanup failed: boom");
+    messageId = "preview-new";
+    pendingDelete.resolve();
+    await clearPromise;
+
+    expect(messageId).toBe("preview-new");
   });
 
   it("controls ignore updates after final", async () => {

--- a/src/channels/draft-stream-controls.test.ts
+++ b/src/channels/draft-stream-controls.test.ts
@@ -100,7 +100,7 @@ describe("draft-stream-controls", () => {
 
   it("clearFinalizableDraftMessage preserves a replacement id while delete is in flight", async () => {
     let messageId: string | undefined = "preview-old";
-    const pendingDelete = createDeferred<void>();
+    const pendingDelete = createDeferred();
     const deleteMessage = vi.fn(() => pendingDelete.promise);
 
     const clearPromise = clearFinalizableDraftMessage({

--- a/src/channels/draft-stream-controls.test.ts
+++ b/src/channels/draft-stream-controls.test.ts
@@ -122,6 +122,74 @@ describe("draft-stream-controls", () => {
     expect(messageId).toBe("preview-new");
   });
 
+  it("clearFinalizableDraftMessage reports the failed target after its id is replaced", async () => {
+    let messageId: string | undefined = "preview-old";
+    const pendingDelete = createDeferred();
+    const onDeleteFailure = vi.fn();
+    const deleteMessage = vi.fn(() => pendingDelete.promise);
+    const clearPromise = clearFinalizableDraftMessage({
+      stopForClear: async () => {},
+      readMessageId: () => messageId,
+      clearMessageId: () => {
+        messageId = undefined;
+      },
+      isValidMessageId: (value): value is string => typeof value === "string",
+      deleteMessage,
+      onDeleteFailure,
+      warnPrefix: "cleanup failed",
+    });
+    await vi.waitFor(() => expect(deleteMessage).toHaveBeenCalledWith("preview-old"));
+
+    messageId = "preview-new";
+    pendingDelete.reject(new Error("boom"));
+    await clearPromise;
+
+    expect(onDeleteFailure).toHaveBeenCalledWith("preview-old");
+    expect(messageId).toBe("preview-new");
+  });
+
+  it("lifecycle retries a failed old deletion after the current id is replaced", async () => {
+    const state = { stopped: false, final: false };
+    let messageId: string | undefined = "preview-old";
+    const pendingDelete = createDeferred();
+    const warn = vi.fn();
+    const deleteMessage = vi
+      .fn<(messageId: string) => Promise<void>>()
+      .mockImplementationOnce(() => pendingDelete.promise)
+      .mockResolvedValue(undefined);
+    const lifecycle = createFinalizableDraftLifecycle({
+      throttleMs: 250,
+      state,
+      sendOrEditStreamMessage: async () => true,
+      readMessageId: () => messageId,
+      clearMessageId: () => {
+        messageId = undefined;
+      },
+      isValidMessageId: (value): value is string => typeof value === "string",
+      deleteMessage,
+      warn,
+      warnPrefix: "cleanup failed",
+    });
+
+    const firstClear = lifecycle.clear();
+    await vi.waitFor(() => expect(deleteMessage).toHaveBeenCalledWith("preview-old"));
+    messageId = "preview-new";
+    pendingDelete.reject(new Error("boom"));
+    await firstClear;
+
+    expect(messageId).toBe("preview-new");
+    expect(warn).toHaveBeenCalledWith("cleanup failed: boom");
+
+    await lifecycle.clear();
+
+    expect(deleteMessage.mock.calls.map(([id]) => id)).toEqual([
+      "preview-old",
+      "preview-old",
+      "preview-new",
+    ]);
+    expect(messageId).toBeUndefined();
+  });
+
   it("controls ignore updates after final", async () => {
     const sendOrEditStreamMessage = vi.fn(async () => true);
     const controls = createFinalizableDraftStreamControlsForState({

--- a/src/channels/draft-stream-controls.test.ts
+++ b/src/channels/draft-stream-controls.test.ts
@@ -65,15 +65,38 @@ describe("draft-stream-controls", () => {
     expect(deleteMessage).not.toHaveBeenCalled();
   });
 
-  it("clearFinalizableDraftMessage retains failed deletes for retry", async () => {
+  it("clearFinalizableDraftMessage claims a failed delete and reports its retry target", async () => {
     const warn = vi.fn();
     let messageId: string | undefined = "m-3";
-    const deleteMessage = vi
-      .fn<() => Promise<void>>()
-      .mockRejectedValueOnce(new Error("boom"))
-      .mockResolvedValueOnce(undefined);
-    const clear = async () => {
-      await clearFinalizableDraftMessage({
+    const onDeleteFailure = vi.fn();
+    const deleteMessage = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await clearFinalizableDraftMessage({
+      stopForClear: async () => {},
+      readMessageId: () => messageId,
+      clearMessageId: () => {
+        messageId = undefined;
+      },
+      isValidMessageId: (value): value is string => typeof value === "string",
+      deleteMessage,
+      onDeleteFailure,
+      warn,
+      warnPrefix: "cleanup failed",
+    });
+
+    expect(messageId).toBeUndefined();
+    expect(onDeleteFailure).toHaveBeenCalledWith("m-3");
+    expect(warn).toHaveBeenCalledWith("cleanup failed: boom");
+  });
+
+  it("clearFinalizableDraftMessage claims an id before concurrent clears", async () => {
+    let messageId: string | undefined = "m-3";
+    const pendingDelete = createDeferred();
+    const deleteMessage = vi.fn(() => pendingDelete.promise);
+    const clear = () =>
+      clearFinalizableDraftMessage({
         stopForClear: async () => {},
         readMessageId: () => messageId,
         clearMessageId: () => {
@@ -81,21 +104,16 @@ describe("draft-stream-controls", () => {
         },
         isValidMessageId: (value): value is string => typeof value === "string",
         deleteMessage,
-        warn,
         warnPrefix: "cleanup failed",
       });
-    };
 
+    const firstClear = clear();
+    await vi.waitFor(() => expect(deleteMessage).toHaveBeenCalledWith("m-3"));
     await clear();
+    pendingDelete.resolve();
+    await firstClear;
 
-    expect(messageId).toBe("m-3");
-    expect(warn).toHaveBeenCalledWith("cleanup failed: boom");
-
-    await clear();
-
-    expect(deleteMessage).toHaveBeenCalledTimes(2);
-    expect(messageId).toBeUndefined();
-    expect(warn).toHaveBeenCalledTimes(1);
+    expect(deleteMessage).toHaveBeenCalledTimes(1);
   });
 
   it("clearFinalizableDraftMessage preserves a replacement id while delete is in flight", async () => {

--- a/src/channels/draft-stream-controls.test.ts
+++ b/src/channels/draft-stream-controls.test.ts
@@ -1,5 +1,6 @@
 // Draft stream control tests cover pause, resume, and cancellation handling for channel drafts.
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../shared/deferred.js";
 import {
   clearFinalizableDraftMessage,
   createFinalizableDraftLifecycle,
@@ -99,7 +100,7 @@ describe("draft-stream-controls", () => {
 
   it("clearFinalizableDraftMessage preserves a replacement id while delete is in flight", async () => {
     let messageId: string | undefined = "preview-old";
-    const pendingDelete = Promise.withResolvers<void>();
+    const pendingDelete = createDeferred<void>();
     const deleteMessage = vi.fn(() => pendingDelete.promise);
 
     const clearPromise = clearFinalizableDraftMessage({

--- a/src/channels/draft-stream-controls.test.ts
+++ b/src/channels/draft-stream-controls.test.ts
@@ -190,6 +190,36 @@ describe("draft-stream-controls", () => {
     expect(messageId).toBeUndefined();
   });
 
+  it("lifecycle does not retry a successful delete when its success callback fails", async () => {
+    const state = { stopped: false, final: false };
+    let messageId: string | undefined = "preview-old";
+    const deleteMessage = vi.fn(async () => {});
+    const warn = vi.fn();
+    const lifecycle = createFinalizableDraftLifecycle({
+      throttleMs: 250,
+      state,
+      sendOrEditStreamMessage: async () => true,
+      readMessageId: () => messageId,
+      clearMessageId: () => {
+        messageId = undefined;
+      },
+      isValidMessageId: (value): value is string => typeof value === "string",
+      deleteMessage,
+      onDeleteSuccess: () => {
+        throw new Error("callback boom");
+      },
+      warn,
+      warnPrefix: "cleanup failed",
+    });
+
+    await lifecycle.clear();
+    await lifecycle.clear();
+
+    expect(deleteMessage).toHaveBeenCalledTimes(1);
+    expect(messageId).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith("cleanup failed after delete: callback boom");
+  });
+
   it("controls ignore updates after final", async () => {
     const sendOrEditStreamMessage = vi.fn(async () => true);
     const controls = createFinalizableDraftStreamControlsForState({

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -133,16 +133,17 @@ export async function takeMessageIdAfterStop<T>(
 export async function clearFinalizableDraftMessage<T>(
   params: ClearFinalizableDraftMessageParams<T>,
 ): Promise<void> {
-  const messageId = await takeMessageIdAfterStop({
-    stopForClear: params.stopForClear,
-    readMessageId: params.readMessageId,
-    clearMessageId: params.clearMessageId,
-  });
+  await params.stopForClear();
+  const messageId = params.readMessageId();
   if (!params.isValidMessageId(messageId)) {
+    params.clearMessageId();
     return;
   }
   try {
     await params.deleteMessage(messageId);
+    if (Object.is(params.readMessageId(), messageId)) {
+      params.clearMessageId();
+    }
     params.onDeleteSuccess?.(messageId);
   } catch (err) {
     params.warn?.(`${params.warnPrefix}: ${formatErrorMessage(err)}`);

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -157,15 +157,16 @@ async function deleteFinalizableDraftMessage<T>(
 
 /**
  * Stops a draft stream and deletes its preview message when the stored id is valid.
- * Stateful callers can retain the exact failed target through onDeleteFailure.
+ * Claims the current id before deletion; stateful callers can retain failures through
+ * onDeleteFailure without making overlapping clears delete the same message twice.
  */
 export async function clearFinalizableDraftMessage<T>(
   params: ClearFinalizableDraftMessageParams<T>,
 ): Promise<void> {
   await params.stopForClear();
   const messageId = params.readMessageId();
+  params.clearMessageId();
   if (!params.isValidMessageId(messageId)) {
-    params.clearMessageId();
     return;
   }
   const deleted = await deleteFinalizableDraftMessage(params, messageId);

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -23,14 +23,20 @@ type StopAndClearMessageIdParams<T> = {
 type ClearFinalizableDraftMessageParams<T> = StopAndClearMessageIdParams<T> & {
   isValidMessageId: (value: unknown) => value is T;
   deleteMessage: (messageId: T) => Promise<void>;
+  onDeleteFailure?: (messageId: T) => void;
   onDeleteSuccess?: (messageId: T) => void;
   warn?: (message: string) => void;
   warnPrefix: string;
 };
 
+type DeleteFinalizableDraftMessageParams<T> = Omit<
+  ClearFinalizableDraftMessageParams<T>,
+  "isValidMessageId" | "onDeleteFailure" | "stopForClear"
+>;
+
 type FinalizableDraftLifecycleParams<T> = Omit<
   ClearFinalizableDraftMessageParams<T>,
-  "stopForClear"
+  "onDeleteFailure" | "stopForClear"
 > & {
   throttleMs: number;
   state: FinalizableDraftStreamState;
@@ -127,8 +133,27 @@ export async function takeMessageIdAfterStop<T>(
   return messageId;
 }
 
+async function deleteFinalizableDraftMessage<T>(
+  params: DeleteFinalizableDraftMessageParams<T>,
+  messageId: T,
+): Promise<boolean> {
+  try {
+    await params.deleteMessage(messageId);
+    // A replacement preview may become current while deletion is in flight; never clear its ID.
+    if (Object.is(params.readMessageId(), messageId)) {
+      params.clearMessageId();
+    }
+    params.onDeleteSuccess?.(messageId);
+    return true;
+  } catch (err) {
+    params.warn?.(`${params.warnPrefix}: ${formatErrorMessage(err)}`);
+    return false;
+  }
+}
+
 /**
  * Stops a draft stream and deletes its preview message when the stored id is valid.
+ * Stateful callers can retain the exact failed target through onDeleteFailure.
  */
 export async function clearFinalizableDraftMessage<T>(
   params: ClearFinalizableDraftMessageParams<T>,
@@ -139,15 +164,9 @@ export async function clearFinalizableDraftMessage<T>(
     params.clearMessageId();
     return;
   }
-  try {
-    await params.deleteMessage(messageId);
-    // A replacement preview may become current while deletion is in flight; never clear its ID.
-    if (Object.is(params.readMessageId(), messageId)) {
-      params.clearMessageId();
-    }
-    params.onDeleteSuccess?.(messageId);
-  } catch (err) {
-    params.warn?.(`${params.warnPrefix}: ${formatErrorMessage(err)}`);
+  const deleted = await deleteFinalizableDraftMessage(params, messageId);
+  if (!deleted) {
+    params.onDeleteFailure?.(messageId);
   }
 }
 
@@ -161,21 +180,39 @@ export function createFinalizableDraftLifecycle<T>(params: FinalizableDraftLifec
     sendOrEditStreamMessage: params.sendOrEditStreamMessage,
   });
 
-  const clear = async () => {
-    await clearFinalizableDraftMessage({
-      stopForClear: controls.stopForClear,
-      readMessageId: params.readMessageId,
-      clearMessageId: params.clearMessageId,
-      isValidMessageId: params.isValidMessageId,
-      deleteMessage: params.deleteMessage,
-      onDeleteSuccess: params.onDeleteSuccess,
-      warn: params.warn,
-      warnPrefix: params.warnPrefix,
-    });
+  let pendingDeleteIds: T[] = [];
+  let clearTail = Promise.resolve();
+
+  const clearOnce = async (stopForClear: () => Promise<void>) => {
+    await stopForClear();
+    const currentMessageId = params.readMessageId();
+    const deleteIds = pendingDeleteIds;
+    pendingDeleteIds = [];
+    if (!params.isValidMessageId(currentMessageId)) {
+      params.clearMessageId();
+    } else if (!deleteIds.some((messageId) => Object.is(messageId, currentMessageId))) {
+      deleteIds.push(currentMessageId);
+    }
+
+    for (const messageId of deleteIds) {
+      const deleted = await deleteFinalizableDraftMessage(params, messageId);
+      if (!deleted && !pendingDeleteIds.some((pendingId) => Object.is(pendingId, messageId))) {
+        pendingDeleteIds.push(messageId);
+      }
+    }
   };
+
+  const clearWithStop = (stopForClear: () => Promise<void>) => {
+    // Custom channel stops share the same serialized retry ownership as the default clear path.
+    const clearRun = clearTail.catch(() => {}).then(() => clearOnce(stopForClear));
+    clearTail = clearRun;
+    return clearRun;
+  };
+  const clear = () => clearWithStop(controls.stopForClear);
 
   return {
     ...controls,
     clear,
+    clearWithStop,
   };
 }

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -139,16 +139,20 @@ async function deleteFinalizableDraftMessage<T>(
 ): Promise<boolean> {
   try {
     await params.deleteMessage(messageId);
+  } catch (err) {
+    params.warn?.(`${params.warnPrefix}: ${formatErrorMessage(err)}`);
+    return false;
+  }
+  try {
     // A replacement preview may become current while deletion is in flight; never clear its ID.
     if (Object.is(params.readMessageId(), messageId)) {
       params.clearMessageId();
     }
     params.onDeleteSuccess?.(messageId);
-    return true;
   } catch (err) {
-    params.warn?.(`${params.warnPrefix}: ${formatErrorMessage(err)}`);
-    return false;
+    params.warn?.(`${params.warnPrefix} after delete: ${formatErrorMessage(err)}`);
   }
+  return true;
 }
 
 /**

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -141,6 +141,7 @@ export async function clearFinalizableDraftMessage<T>(
   }
   try {
     await params.deleteMessage(messageId);
+    // A replacement preview may become current while deletion is in flight; never clear its ID.
     if (Object.is(params.readMessageId(), messageId)) {
       params.clearMessageId();
     }


### PR DESCRIPTION
Closes #104865

## What Problem This Solves

Discord partial streaming can leave a stale preview beside the fresh final reply when preview deletion fails transiently. The old lifecycle released the only retry target before awaiting Discord's DELETE.

## Why This Change Was Made

The shared finalizable-draft lifecycle now owns failed deletion targets until a later clear succeeds. Cleanup is serialized, replacement IDs survive an in-flight clear, and post-DELETE bookkeeping failures are not mistaken for remote deletion failures.

Discord keeps one bounded teardown retry after successful fresh-final delivery. Mattermost now uses the same lifecycle-owned clear path. Finalized-in-place previews remain untouched.

## User Impact

A transient Discord preview cleanup failure receives one recovery attempt during normal teardown. The final reply is still sent exactly once. No timer, configuration, background queue, or extra final-message send was added.

## Evidence

- Prepared head: `574cc1ea367cc3c24fd81334833988cfc4dd86c3`.
- Rebase patch identity: pre/post-rebase stable patch ID `1a9061321745a1d8468932d252b515c5a968d4ac`.
- Blacksmith Testbox `tbx_01kxcr0r94tc3rrmzk1g3j7rxg` ([run](https://github.com/openclaw/openclaw/actions/runs/29221590638)): 169/169 focused tests passed across shared draft controls, Discord draft/process handling, and Mattermost draft handling.
- Targeted `oxfmt --check` and `git diff --check` passed.
- Fresh autoreview completed with no accepted/actionable finding after the shared lifecycle refactor.
- Exact-head CI: [run 29241946883](https://github.com/openclaw/openclaw/actions/runs/29241946883) on `574cc1ea367cc3c24fd81334833988cfc4dd86c3`.
- Live Discord fault injection: [Crabbox run `run_4627a4bad139`](https://crabbox.openclaw.ai/portal/runs/run_4627a4bad139) forced the first preview DELETE to HTTP 500, observed exactly one real final reply, forwarded one teardown retry to Discord, then observed preview GET 404 and final GET 200.
- The live run exercised the unchanged Discord HTTP sequence on ancestor `5582df93dfe17ac4ec3d8c39dc3d9a857a9f5bf5`. Later maintainer commits strengthened shared ownership and concurrency semantics; focused tests cover failed-target retention, overlapping clears, replacement IDs, successful-DELETE callback failures, bounded Discord retry, and finalized-in-place preservation.
- Source-blind behavior validation passed all three exercised clauses. The finalized-in-place branch was not repeated live; focused tests cover it.

The live artifact omits credentials, broker data, guild/channel/application/message IDs, endpoints, and message content. The first 500 is controlled fault injection because a transient Discord 5xx cannot be requested deterministically; the retry and both postconditions are live Discord API results.

## AI Assistance

AI-assisted by Cad from Arca. Maintainer review, refactor, focused proof, source-blind validation, and exact-head landing checks were completed independently.
