### PR TITLE
refactor(scripts): extract legacy-store path domain

### DIFF
--- a/scripts/check-database-first-legacy-stores.mjs
+++ b/scripts/check-database-first-legacy-stores.mjs
@@ -4,6 +4,14 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import ts from "typescript";
+import {
+  explicitUndefinedLegacyObjectPropertyValue,
+  mergeConditionalLegacyObjectPropertyValue,
+  mergeConditionalLiteralTexts,
+  mergeExhaustiveLiteralTexts,
+  mergeLegacyObjectPropertyValues,
+  mergeLegacyPathBranchAssignments,
+} from "./lib/legacy-store-path-domain.mjs";
 import { resolveRepoRoot, runAsScript, toLine, unwrapExpression } from "./lib/ts-guard-utils.mjs";
 
 const databaseFirstLegacyStoreSourceRoots = ["src", "extensions", "packages"];
@@ -1049,42 +1057,6 @@ export function collectDatabaseFirstLegacyStoreViolations(
     return element && !ts.isSpreadElement(element) ? element : null;
   }
 
-  function mergeConditionalLiteralTexts(previous, next) {
-    if (next.length === 0) {
-      return previous ?? null;
-    }
-    return [...new Set([...(previous ?? []), ...next])];
-  }
-
-  function mergeExhaustiveLiteralTexts(left, right) {
-    if (left.length === 0 && right.length === 0) {
-      return null;
-    }
-    return [...new Set([...left, ...right])];
-  }
-
-  function mergeLegacyObjectPropertyValues(left, right) {
-    if (left === true || right === true) {
-      return true;
-    }
-    if (
-      left === explicitUndefinedLegacyObjectPropertyValue ||
-      right === explicitUndefinedLegacyObjectPropertyValue ||
-      left === undefined ||
-      right === undefined
-    ) {
-      return explicitUndefinedLegacyObjectPropertyValue;
-    }
-    return false;
-  }
-
-  function mergeConditionalLegacyObjectPropertyValue(previous, next) {
-    if (previous === undefined && next === false) {
-      return null;
-    }
-    return mergeLegacyObjectPropertyValues(previous, next);
-  }
-
   function legacyObjectPropertyRewriteValues(objectName, initializer, existingScope) {
     const values = new Map();
     markLegacyObjectProperties(objectName, initializer, values, null);
@@ -1097,34 +1069,6 @@ export function collectDatabaseFirstLegacyStoreViolations(
       }
     }
     return values;
-  }
-
-  function branchAssignmentPropertyValue(assignment, propertyKey) {
-    if (assignment.objectProperties.has(propertyKey)) {
-      return { known: true, value: assignment.objectProperties.get(propertyKey) };
-    }
-    if (assignment.knownObjectLiteral) {
-      return { known: true, value: explicitUndefinedLegacyObjectPropertyValue };
-    }
-    return { known: false, value: null };
-  }
-
-  function mergeBranchLegacyObjectPropertyValue(leftAssignment, rightAssignment, propertyKey) {
-    const left = branchAssignmentPropertyValue(leftAssignment, propertyKey);
-    const right = branchAssignmentPropertyValue(rightAssignment, propertyKey);
-    if (!left.known && !right.known) {
-      return null;
-    }
-    if (left.value === true || right.value === true) {
-      return true;
-    }
-    if (
-      left.value === explicitUndefinedLegacyObjectPropertyValue ||
-      right.value === explicitUndefinedLegacyObjectPropertyValue
-    ) {
-      return explicitUndefinedLegacyObjectPropertyValue;
-    }
-    return left.known && right.known ? false : null;
   }
 
   function lookupLegacyObjectProperty(
@@ -2236,9 +2180,6 @@ export function collectDatabaseFirstLegacyStoreViolations(
   const unknownObjectLiteralPropertyInitializer = Symbol(
     "unknown object literal property initializer",
   );
-  const explicitUndefinedLegacyObjectPropertyValue = Symbol(
-    "explicit undefined legacy object property value",
-  );
   const explicitUndefinedNestedWrapperValue = Symbol("explicit undefined nested wrapper value");
   const knownObjectLiteralNestedWrapperValue = Symbol("known object literal nested wrapper value");
   const unknownNestedWrapperObjectValue = Symbol("unknown nested wrapper object value");
@@ -2634,37 +2575,7 @@ export function collectDatabaseFirstLegacyStoreViolations(
       }
       const { index, name } = thenAssignment;
       mergedIdentifierNames.add(branchIdentifierAssignmentKey(index, name));
-      const mergedValue = thenAssignment.value === true || elseAssignment.value === true;
-      const propertyKeys = new Set([
-        ...thenAssignment.objectProperties.keys(),
-        ...elseAssignment.objectProperties.keys(),
-      ]);
-      const mergedProperties = new Map();
-      for (const propertyKey of propertyKeys) {
-        const mergedPropertyValue = mergeBranchLegacyObjectPropertyValue(
-          thenAssignment,
-          elseAssignment,
-          propertyKey,
-        );
-        if (mergedPropertyValue !== null) {
-          mergedProperties.set(propertyKey, mergedPropertyValue);
-        }
-      }
-      const mergedKnownObjectLiteral =
-        thenAssignment.knownObjectLiteral && elseAssignment.knownObjectLiteral;
-      const mergedKnownUndefined = thenAssignment.knownUndefined || elseAssignment.knownUndefined;
-      const knownObjectLiteralKeys = new Set([
-        ...thenAssignment.knownObjectLiterals.keys(),
-        ...elseAssignment.knownObjectLiterals.keys(),
-      ]);
-      const mergedKnownObjectLiterals = new Map();
-      for (const knownObjectLiteralKey of knownObjectLiteralKeys) {
-        mergedKnownObjectLiterals.set(
-          knownObjectLiteralKey,
-          thenAssignment.knownObjectLiterals.get(knownObjectLiteralKey) === true &&
-            elseAssignment.knownObjectLiterals.get(knownObjectLiteralKey) === true,
-        );
-      }
+      const merged = mergeLegacyPathBranchAssignments(thenAssignment, elseAssignment);
       if (applyToTargetScopes) {
         const pathScope = legacyPathScopes[index];
         const literalScope = literalTextScopes[index];
@@ -2672,48 +2583,36 @@ export function collectDatabaseFirstLegacyStoreViolations(
         const propertyScope = legacyObjectPropertyScopes[index];
         const knownObjectLiteralScope = legacyKnownObjectLiteralScopes[index];
         clearKnownLegacyObjectLiterals(knownObjectLiteralScope, name);
-        knownObjectLiteralScope.set(name, mergedKnownObjectLiteral);
-        for (const [knownObjectLiteralKey, value] of mergedKnownObjectLiterals) {
+        knownObjectLiteralScope.set(name, merged.knownObjectLiteral);
+        for (const [knownObjectLiteralKey, value] of merged.knownObjectLiterals) {
           knownObjectLiteralScope.set(knownObjectLiteralKey, value);
         }
-        pathScope.set(name, mergedValue);
-        knownUndefinedScope.set(name, mergedKnownUndefined);
-        literalScope.set(
-          name,
-          mergeExhaustiveLiteralTexts(thenAssignment.literalTexts, elseAssignment.literalTexts),
-        );
+        pathScope.set(name, merged.value);
+        knownUndefinedScope.set(name, merged.knownUndefined);
+        literalScope.set(name, merged.literalTexts);
         clearLegacyObjectProperties(propertyScope, name);
-        for (const [propertyKey, value] of mergedProperties) {
+        for (const [propertyKey, value] of merged.objectProperties) {
           propertyScope.set(propertyKey, value);
         }
       }
       clearKnownLegacyObjectLiterals(currentLegacyKnownObjectLiteralScope(), name);
-      currentLegacyKnownObjectLiteralScope().set(name, mergedKnownObjectLiteral);
-      for (const [knownObjectLiteralKey, value] of mergedKnownObjectLiterals) {
+      currentLegacyKnownObjectLiteralScope().set(name, merged.knownObjectLiteral);
+      for (const [knownObjectLiteralKey, value] of merged.knownObjectLiterals) {
         currentLegacyKnownObjectLiteralScope().set(knownObjectLiteralKey, value);
       }
-      currentLegacyPathScope().set(name, mergedValue);
-      currentKnownUndefinedScope().set(name, mergedKnownUndefined);
-      currentLiteralTextScope().set(
-        name,
-        mergeExhaustiveLiteralTexts(thenAssignment.literalTexts, elseAssignment.literalTexts),
-      );
+      currentLegacyPathScope().set(name, merged.value);
+      currentKnownUndefinedScope().set(name, merged.knownUndefined);
+      currentLiteralTextScope().set(name, merged.literalTexts);
       clearLegacyObjectProperties(currentLegacyObjectPropertyScope(), name);
-      for (const [propertyKey, value] of mergedProperties) {
+      for (const [propertyKey, value] of merged.objectProperties) {
         currentLegacyObjectPropertyScope().set(propertyKey, value);
       }
       if (parentEffect) {
         parentEffect.identifierAssignments.set(branchIdentifierAssignmentKey(index, name), {
           index,
-          knownUndefined: mergedKnownUndefined,
-          knownObjectLiteral: mergedKnownObjectLiteral,
-          knownObjectLiterals: mergedKnownObjectLiterals,
-          literalTexts:
-            mergeExhaustiveLiteralTexts(thenAssignment.literalTexts, elseAssignment.literalTexts) ??
-            [],
+          ...merged,
+          literalTexts: merged.literalTexts ?? [],
           name,
-          value: mergedValue,
-          objectProperties: mergedProperties,
         });
       }
     }

--- a/scripts/lib/legacy-store-path-domain.mjs
+++ b/scripts/lib/legacy-store-path-domain.mjs
@@ -1,0 +1,99 @@
+export const explicitUndefinedLegacyObjectPropertyValue = Symbol(
+  "explicit undefined legacy object property value",
+);
+
+export function mergeConditionalLiteralTexts(previous, next) {
+  if (next.length === 0) {
+    return previous ?? null;
+  }
+  return [...new Set([...(previous ?? []), ...next])];
+}
+
+export function mergeExhaustiveLiteralTexts(left, right) {
+  if (left.length === 0 && right.length === 0) {
+    return null;
+  }
+  return [...new Set([...left, ...right])];
+}
+
+export function mergeLegacyObjectPropertyValues(left, right) {
+  if (left === true || right === true) {
+    return true;
+  }
+  if (
+    left === explicitUndefinedLegacyObjectPropertyValue ||
+    right === explicitUndefinedLegacyObjectPropertyValue ||
+    left === undefined ||
+    right === undefined
+  ) {
+    return explicitUndefinedLegacyObjectPropertyValue;
+  }
+  return false;
+}
+
+export function mergeConditionalLegacyObjectPropertyValue(previous, next) {
+  if (previous === undefined && next === false) {
+    return null;
+  }
+  return mergeLegacyObjectPropertyValues(previous, next);
+}
+
+function branchAssignmentPropertyValue(assignment, propertyKey) {
+  if (assignment.objectProperties.has(propertyKey)) {
+    return { known: true, value: assignment.objectProperties.get(propertyKey) };
+  }
+  if (assignment.knownObjectLiteral) {
+    return { known: true, value: explicitUndefinedLegacyObjectPropertyValue };
+  }
+  return { known: false, value: null };
+}
+
+function mergeBranchLegacyObjectPropertyValue(leftAssignment, rightAssignment, propertyKey) {
+  const left = branchAssignmentPropertyValue(leftAssignment, propertyKey);
+  const right = branchAssignmentPropertyValue(rightAssignment, propertyKey);
+  if (!left.known && !right.known) {
+    return null;
+  }
+  if (left.value === true || right.value === true) {
+    return true;
+  }
+  if (
+    left.value === explicitUndefinedLegacyObjectPropertyValue ||
+    right.value === explicitUndefinedLegacyObjectPropertyValue
+  ) {
+    return explicitUndefinedLegacyObjectPropertyValue;
+  }
+  return left.known && right.known ? false : null;
+}
+
+export function mergeLegacyPathBranchAssignments(left, right) {
+  const propertyKeys = new Set([...left.objectProperties.keys(), ...right.objectProperties.keys()]);
+  const objectProperties = new Map();
+  for (const propertyKey of propertyKeys) {
+    const value = mergeBranchLegacyObjectPropertyValue(left, right, propertyKey);
+    if (value !== null) {
+      objectProperties.set(propertyKey, value);
+    }
+  }
+
+  const knownObjectLiteralKeys = new Set([
+    ...left.knownObjectLiterals.keys(),
+    ...right.knownObjectLiterals.keys(),
+  ]);
+  const knownObjectLiterals = new Map();
+  for (const key of knownObjectLiteralKeys) {
+    knownObjectLiterals.set(
+      key,
+      left.knownObjectLiterals.get(key) === true && right.knownObjectLiterals.get(key) === true,
+    );
+  }
+
+  return {
+    knownObjectLiteral: left.knownObjectLiteral && right.knownObjectLiteral,
+    knownObjectLiterals,
+    knownUndefined: left.knownUndefined || right.knownUndefined,
+    literalTexts: mergeExhaustiveLiteralTexts(left.literalTexts, right.literalTexts),
+    objectProperties,
+    value: left.value === true || right.value === true,
+  };
+}


### PR DESCRIPTION
Related: #104871

## What Problem This Solves

The database-first legacy-store analyzer mixed TypeScript traversal with a dense set of value-domain merge rules. That made branch semantics difficult to audit and increased the cost of changing the analyzer safely.

## Why This Change Was Made

This extracts the pure literal, object-property, sentinel, and branch-assignment merge domain into one private script helper. The analyzer keeps the same inputs, outputs, CLI behavior, allowlists, and detection rules.

## User Impact

No user-visible behavior or public contract changes. Config, SDK, protocol, generated files, CLI options, and runtime storage behavior are unchanged. Maintainers and coding agents get a smaller analyzer core with one test-covered location for branch-value semantics.

## Evidence

- `corepack pnpm test:serial test/scripts/check-database-first-legacy-stores.test.ts`: 469 tests passed on Blacksmith Testbox `tbx_01kx9zzm3ethj75acmxgj7fa4b`.
- `corepack pnpm check:changed`: passed on the same Testbox.
- Fresh `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --base origin/main`: clean at 0.99 confidence.
- `oxfmt --check`, `node --check`, and `git diff --check`: passed.
