### PR TITLE
fix: retry Discord draft preview cleanup after transient delete failure

### DIFF
--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -325,7 +325,7 @@ export function createDiscordDraftPreviewController(params: {
         if (!finalReplyDelivered) {
           await draftStream?.discardPending();
         }
-        if (!finalReplyDelivered && !finalizedViaPreviewMessage && draftStream?.messageId()) {
+        if (draftStream && !finalizedViaPreviewMessage && draftStream.messageId()) {
           await draftStream.clear();
         }
       } catch (err) {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2197,6 +2197,21 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
+  it("retries stale preview cleanup at teardown after fresh final delivery", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    draftStream.clear.mockImplementationOnce(async () => {});
+
+    await runSingleChunkFinalScenario({
+      streaming: { mode: "partial" },
+      maxLinesPerMessage: 5,
+    });
+
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(getDeliveredFinalTexts()).toEqual(["Hello\nWorld"]);
+    expect(draftStream.clear).toHaveBeenCalledTimes(2);
+    expect(draftStream.messageId()).toBeUndefined();
+  });
+
   it("streams Discord tool progress by default when streaming is unset", async () => {
     const draftStream = createMockDraftStreamForTest();
 

--- a/src/channels/draft-stream-controls.test.ts
+++ b/src/channels/draft-stream-controls.test.ts
@@ -82,6 +82,69 @@ describe("draft-stream-controls", () => {
     expect(warn).toHaveBeenCalledWith("cleanup failed: boom");
   });
 
+  it("clearFinalizableDraftMessage keeps failed deletes available for retry", async () => {
+    const warn = vi.fn();
+    let messageId: string | undefined = "m-6";
+    const deleteMessage = vi
+      .fn<(messageId: string) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(undefined);
+
+    const clear = async () => {
+      await clearFinalizableDraftMessage({
+        stopForClear: async () => {},
+        readMessageId: () => messageId,
+        clearMessageId: () => {
+          messageId = undefined;
+        },
+        isValidMessageId: (value): value is string => typeof value === "string",
+        deleteMessage,
+        warn,
+        warnPrefix: "cleanup failed",
+      });
+    };
+
+    await clear();
+
+    expect(messageId).toBe("m-6");
+    expect(deleteMessage).toHaveBeenCalledTimes(1);
+    expect(deleteMessage).toHaveBeenCalledWith("m-6");
+    expect(warn).toHaveBeenCalledWith("cleanup failed: boom");
+
+    await clear();
+
+    expect(messageId).toBeUndefined();
+    expect(deleteMessage).toHaveBeenCalledTimes(2);
+    expect(deleteMessage).toHaveBeenLastCalledWith("m-6");
+  });
+
+  it("clearFinalizableDraftMessage preserves a replacement id while delete is in flight", async () => {
+    let messageId: string | undefined = "preview-old";
+    let resolveDelete: () => void = () => {};
+    const pendingDelete = new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    });
+    const deleteMessage = vi.fn<(messageId: string) => Promise<void>>(async () => pendingDelete);
+
+    const clearPromise = clearFinalizableDraftMessage({
+      stopForClear: async () => {},
+      readMessageId: () => messageId,
+      clearMessageId: () => {
+        messageId = undefined;
+      },
+      isValidMessageId: (value): value is string => typeof value === "string",
+      deleteMessage,
+      warnPrefix: "cleanup failed",
+    });
+
+    await vi.waitFor(() => expect(deleteMessage).toHaveBeenCalledWith("preview-old"));
+    messageId = "preview-new";
+    resolveDelete();
+    await clearPromise;
+
+    expect(messageId).toBe("preview-new");
+  });
+
   it("controls ignore updates after final", async () => {
     const sendOrEditStreamMessage = vi.fn(async () => true);
     const controls = createFinalizableDraftStreamControlsForState({

--- a/src/channels/draft-stream-controls.ts
+++ b/src/channels/draft-stream-controls.ts
@@ -133,16 +133,19 @@ export async function takeMessageIdAfterStop<T>(
 export async function clearFinalizableDraftMessage<T>(
   params: ClearFinalizableDraftMessageParams<T>,
 ): Promise<void> {
-  const messageId = await takeMessageIdAfterStop({
-    stopForClear: params.stopForClear,
-    readMessageId: params.readMessageId,
-    clearMessageId: params.clearMessageId,
-  });
+  await params.stopForClear();
+  const messageId = params.readMessageId();
   if (!params.isValidMessageId(messageId)) {
+    params.clearMessageId();
     return;
   }
   try {
+    // Keep ownership until DELETE succeeds so transient cleanup failures can retry later.
     await params.deleteMessage(messageId);
+    // A new preview may replace the old id while DELETE is in flight.
+    if (Object.is(params.readMessageId(), messageId)) {
+      params.clearMessageId();
+    }
     params.onDeleteSuccess?.(messageId);
   } catch (err) {
     params.warn?.(`${params.warnPrefix}: ${formatErrorMessage(err)}`);


### PR DESCRIPTION
Fixes #104865

## What Problem This Solves

Fixes a Discord partial-streaming cleanup regression where a fresh final reply can land while the old preview remains visible after a transient preview DELETE failure. The old implementation also cleared preview ownership too early, so a later cleanup could not retry the same message.

## Why This Change Was Made

The shared finalizable draft cleanup now keeps ownership until DELETE succeeds, then clears the stored id only if that same id is still current. That preserves retryability and avoids erasing a replacement preview that was created while the old DELETE was in flight.

Discord teardown now performs the missing bounded cleanup retry for an unfinalized preview even after a fresh final reply was delivered. It still protects previews finalized in place, and it does not add timers, retry loops, configuration, or extra final-message delivery.

## User Impact

Discord users with partial/progress preview streaming should no longer get stuck with an unrecoverable stale preview beside the final answer after a transient DELETE failure. Shared cleanup users such as Mattermost inherit the safer delete-then-compare-clear ownership behavior.

## Evidence

- `node scripts/run-vitest.mjs src/channels/draft-stream-controls.test.ts -t "keeps failed deletes available for retry"` (passed)
- `node scripts/run-vitest.mjs src/channels/draft-stream-controls.test.ts -t "preserves a replacement id while delete is in flight"` (passed)
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.test.ts -t "retries stale preview cleanup at teardown after fresh final delivery"` (passed)
- `pnpm exec oxfmt --check --threads=1 src/channels/draft-stream-controls.ts src/channels/draft-stream-controls.test.ts extensions/discord/src/monitor/message-handler.draft-preview.ts extensions/discord/src/monitor/message-handler.process.test.ts` (passed)
- `git diff --check` (passed)
- `python .agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.5` (clean: no accepted/actionable findings)

Remote proof note: this local machine does not have a usable Crabbox binary or sibling Crabbox checkout, so Testbox-backed `check:changed` could not be started here. A direct local `pnpm check:test-types` also did not complete in this Windows worktree after several minutes with no stage output; the pushed head `e6ebf380a61418017148273fa51853d71e96b609` is now relying on GitHub CI for the broad type/check matrix.
