### PR TITLE
fix(duckduckgo): forward abort signal when web search runs are canceled

### DIFF
--- a/extensions/duckduckgo/proof/abort-guarded-fetch-proof.test.ts
+++ b/extensions/duckduckgo/proof/abort-guarded-fetch-proof.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Real behavior proof: abort signal through the guarded-fetch stack.
+ *
+ * Exercises the EXACT code path that DuckDuckGo client calls:
+ *   runDuckDuckGoSearch (ddg-client.ts)
+ *   → withTrustedWebSearchEndpoint (web-search-provider-common.ts)
+ *   → withTrustedWebToolsEndpoint (web-guarded-fetch.ts)
+ *   → withWebToolsNetworkGuard → fetchWithWebToolsNetworkGuard
+ *   → fetchWithSsrFGuard (fetch-guard.ts)
+ *   → buildTimeoutAbortSignal → globalThis.fetch
+ *
+ * This proof uses withSelfHostedWebSearchEndpoint (same guarded-fetch stack,
+ * same signal chain; the only difference is the SSRF policy — self-hosted
+ * variant allows localhost so we can run a stalled server). Both variants
+ * share identical fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch()
+ * code paths.
+ *
+ * A stalled HTTP server (never sends headers) simulates a remote endpoint
+ * that accepts the TCP connection but withholds response headers forever.
+ * The AbortController aborts after 100ms. If signal forwarding works,
+ * the fetch rejects with AbortError / TimeoutError instead of hanging.
+ */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+
+describe("ddg abort signal proof", () => {
+  it("propagates abort signal through the guarded-fetch stack used by DDG", async () => {
+    // Load the real guarded-fetch stack at the withSelfHostedWebSearchEndpoint
+    // seam. This is the same code path DDG uses (same fetchWithSsrFGuard,
+    // same buildTimeoutAbortSignal, same fetch). The only difference is
+    // SSRF policy: self-hosted allows localhost for this proof.
+    const { withSelfHostedWebSearchEndpoint } = await vi.importActual<
+      typeof import("openclaw/plugin-sdk/provider-web-search")
+    >("openclaw/plugin-sdk/provider-web-search");
+
+    // Create a stalled server — never calls res.writeHead(), so the TCP
+    // connection is accepted but fetch() never resolves.
+    const server = createServer((_req, res) => {
+      res.socket?.setTimeout(0);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    const controller = new AbortController();
+    const startedAt = Date.now();
+
+    const searchPromise = withSelfHostedWebSearchEndpoint(
+      {
+        url: `http://127.0.0.1:${port}/stall`,
+        timeoutSeconds: 30,
+        init: { method: "GET" },
+        signal: controller.signal,
+      },
+      async (_result) => ({ ok: true }),
+    );
+
+    // Abort after 100ms — simulates user cancellation or timeout.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    controller.abort("proof: cancellation");
+
+    await expect(searchPromise).rejects.toThrow();
+    const elapsed = Date.now() - startedAt;
+
+    // Capture the exact error for the PR body.
+    let errorType = "unknown";
+    let errorMessage = "";
+    try {
+      await searchPromise;
+    } catch (err) {
+      errorType = err?.constructor?.name ?? "unknown";
+      errorMessage = err instanceof Error ? err.message : String(err);
+    }
+
+    console.log(
+      `[proof] Signal propagated in ${elapsed}ms through guarded-fetch stack ` +
+        `(withSelfHostedWebSearchEndpoint → fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch)`,
+    );
+    console.log(`[proof] stalled server: http://127.0.0.1:${port}/stall`);
+    console.log(`[proof] abort: controller.abort("proof: cancellation") @ ~100ms`);
+    console.log(`[proof] error: ${errorType}: ${errorMessage}`);
+
+    server.close();
+    expect(elapsed).toBeLessThan(5000);
+  }, 15000);
+});

--- a/extensions/duckduckgo/proof/abort-guarded-fetch-proof.test.ts
+++ b/extensions/duckduckgo/proof/abort-guarded-fetch-proof.test.ts
@@ -1,30 +1,64 @@
 /**
- * Real behavior proof: abort signal through the guarded-fetch stack.
+ * Real behavior proof: abort signal through DuckDuckGo's full provider→fetch chain.
  *
- * Exercises the EXACT code path that DuckDuckGo client calls:
- *   runDuckDuckGoSearch (ddg-client.ts)
- *   → withTrustedWebSearchEndpoint (web-search-provider-common.ts)
- *   → withTrustedWebToolsEndpoint (web-guarded-fetch.ts)
- *   → withWebToolsNetworkGuard → fetchWithWebToolsNetworkGuard
- *   → fetchWithSsrFGuard (fetch-guard.ts)
- *   → buildTimeoutAbortSignal → globalThis.fetch
+ * Production code path:
+ *   createDuckDuckGoWebSearchProvider().createTool(ctx).execute(args, context)
+ *   → runDuckDuckGoSearch({ signal: context?.signal })
+ *   → withTrustedWebSearchEndpoint({ signal: params.signal })
+ *   → withTrustedWebToolsEndpoint({ signal })
+ *   → fetchWithSsrFGuard({ signal })
+ *   → buildTimeoutAbortSignal({ signal })
+ *   → fetch(url, { signal })
  *
- * This proof uses withSelfHostedWebSearchEndpoint (same guarded-fetch stack,
- * same signal chain; the only difference is the SSRF policy — self-hosted
- * variant allows localhost so we can run a stalled server). Both variants
- * share identical fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch()
- * code paths.
- *
- * A stalled HTTP server (never sends headers) simulates a remote endpoint
- * that accepts the TCP connection but withholds response headers forever.
- * The AbortController aborts after 100ms. If signal forwarding works,
- * the fetch rejects with AbortError / TimeoutError instead of hanging.
+ * Two-part proof:
+ * 1. Pre-aborted signal through provider path — proves signal flows from
+ *    provider.execute() through all intermediate layers to fetch().
+ *    buildTimeoutAbortSignal sees the already-aborted parent signal and
+ *    immediately aborts its controller, so no network I/O occurs.
+ * 2. Stalled-server proof through withSelfHostedWebSearchEndpoint — proves the
+ *    common guarded-fetch stack cancels real in-flight HTTP requests.
+ *    Self-hosted variant allows localhost; both variants share identical
+ *    fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch() code paths.
  */
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { describe, expect, it, vi } from "vitest";
+import { createDuckDuckGoWebSearchProvider } from "../src/ddg-search-provider.js";
 
 describe("ddg abort signal proof", () => {
+  it("propagates pre-aborted signal from provider execute through full client path", async () => {
+    // Pre-abort the signal before calling execute(). This exercises the full
+    // signal chain: execute → runDuckDuckGoSearch → withTrustedWebSearchEndpoint
+    // → withTrustedWebToolsEndpoint → fetchWithSsrFGuard → buildTimeoutAbortSignal.
+    // Since the parent signal is already aborted, buildTimeoutAbortSignal
+    // immediately aborts its own controller, and fetch() rejects before any
+    // network I/O — proving signal handoff through all changed layers.
+    const controller = new AbortController();
+    controller.abort(new Error("proof: pre-aborted signal"));
+
+    const provider = createDuckDuckGoWebSearchProvider();
+    const tool = provider.createTool({ config: {} as never });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const startedAt = Date.now();
+    let errorType: string;
+    let errorMessage: string;
+    try {
+      await tool.execute({ query: "openclaw test" }, { signal: controller.signal });
+      throw new Error("Expected execute() to reject with aborted signal");
+    } catch (err) {
+      errorType = err?.constructor?.name ?? "unknown";
+      errorMessage = err instanceof Error ? err.message : String(err);
+    }
+    const elapsed = Date.now() - startedAt;
+
+    console.log(`[proof] Pre-aborted signal propagated through DDG provider in ${elapsed}ms`);
+    console.log(`[proof] error: ${errorType}: ${errorMessage}`);
+    expect(elapsed).toBeLessThan(5000);
+  }, 15000);
+
   it("propagates abort signal through the guarded-fetch stack used by DDG", async () => {
     // Load the real guarded-fetch stack at the withSelfHostedWebSearchEndpoint
     // seam. This is the same code path DDG uses (same fetchWithSsrFGuard,
@@ -39,7 +73,11 @@ describe("ddg abort signal proof", () => {
     const server = createServer((_req, res) => {
       res.socket?.setTimeout(0);
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        resolve();
+      });
+    });
     const { port } = server.address() as AddressInfo;
 
     const controller = new AbortController();
@@ -56,15 +94,19 @@ describe("ddg abort signal proof", () => {
     );
 
     // Abort after 100ms — simulates user cancellation or timeout.
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 100);
+    });
     controller.abort("proof: cancellation");
 
     await expect(searchPromise).rejects.toThrow();
     const elapsed = Date.now() - startedAt;
 
     // Capture the exact error for the PR body.
-    let errorType = "unknown";
-    let errorMessage = "";
+    let errorType: string;
+    let errorMessage: string;
     try {
       await searchPromise;
     } catch (err) {

--- a/extensions/duckduckgo/proof/abort-guarded-fetch-proof.test.ts
+++ b/extensions/duckduckgo/proof/abort-guarded-fetch-proof.test.ts
@@ -43,8 +43,8 @@ describe("ddg abort signal proof", () => {
     }
 
     const startedAt = Date.now();
-    let errorType: string;
-    let errorMessage: string;
+    let errorType = "unknown";
+    let errorMessage = "unknown";
     try {
       await tool.execute({ query: "openclaw test" }, { signal: controller.signal });
       throw new Error("Expected execute() to reject with aborted signal");
@@ -105,8 +105,8 @@ describe("ddg abort signal proof", () => {
     const elapsed = Date.now() - startedAt;
 
     // Capture the exact error for the PR body.
-    let errorType: string;
-    let errorMessage: string;
+    let errorType = "unknown";
+    let errorMessage = "unknown";
     try {
       await searchPromise;
     } catch (err) {

--- a/extensions/duckduckgo/src/ddg-client.ts
+++ b/extensions/duckduckgo/src/ddg-client.ts
@@ -160,6 +160,7 @@ export async function runDuckDuckGoSearch(params: {
   safeSearch?: DdgSafeSearch;
   timeoutSeconds?: number;
   cacheTtlMinutes?: number;
+  signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
   const count = resolveSearchCount(params.count, DEFAULT_SEARCH_COUNT);
   const region = params.region ?? resolveDdgRegion(params.config);
@@ -197,6 +198,7 @@ export async function runDuckDuckGoSearch(params: {
     {
       url: url.toString(),
       timeoutSeconds,
+      signal: params.signal,
       init: {
         method: "GET",
         headers: {

--- a/extensions/duckduckgo/src/ddg-search-provider.test.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.test.ts
@@ -87,6 +87,28 @@ describe("duckduckgo web search provider", () => {
     });
   });
 
+  it("forwards the execution abort signal to the DuckDuckGo client", async () => {
+    const provider = createDuckDuckGoWebSearchProvider();
+    const tool = provider.createTool({
+      config: { test: true },
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const controller = new AbortController();
+
+    await tool.execute({ query: "openclaw docs" }, { signal: controller.signal });
+
+    expect(runDuckDuckGoSearch).toHaveBeenCalledWith({
+      config: { test: true },
+      query: "openclaw docs",
+      count: undefined,
+      region: undefined,
+      safeSearch: undefined,
+      signal: controller.signal,
+    });
+  });
+
   it("rejects fractional and out-of-range counts before searching", async () => {
     const provider = createDuckDuckGoWebSearchProvider();
     const tool = provider.createTool({

--- a/extensions/duckduckgo/src/ddg-search-provider.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.ts
@@ -35,7 +35,7 @@ export function createDuckDuckGoWebSearchProvider(): WebSearchProviderPlugin {
       description:
         "Search the web using DuckDuckGo. Returns titles, URLs, and snippets with no API key required.",
       parameters: DuckDuckGoSearchSchema,
-      execute: async (args) => {
+      execute: async (args, context) => {
         const { runDuckDuckGoSearch } = await loadDuckDuckGoClientModule();
         return await runDuckDuckGoSearch({
           config: ctx.config,
@@ -50,6 +50,7 @@ export function createDuckDuckGoWebSearchProvider(): WebSearchProviderPlugin {
             | "moderate"
             | "off"
             | undefined,
+          signal: context?.signal,
         });
       },
     }),

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -266,6 +266,49 @@ describe("web search runtime", () => {
     );
   });
 
+  it("does not fall back to another provider after parent cancellation", async () => {
+    const controller = new AbortController();
+    const firstExecute = vi.fn(
+      async (_args: Record<string, unknown>, _context?: { signal?: AbortSignal }) => {
+        controller.abort();
+        throw controller.signal.reason;
+      },
+    );
+    const fallbackExecute = vi.fn(async () => ({ ok: true }));
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
+      createCustomSearchProvider({
+        credentialPath: "",
+        createTool: () => ({
+          description: "first",
+          parameters: {},
+          execute: firstExecute,
+        }),
+      }),
+      createCustomSearchProvider({
+        pluginId: "fallback-search",
+        id: "fallback",
+        credentialPath: "",
+        autoDetectOrder: 2,
+        getConfiguredCredentialValue: () => "configured",
+        createTool: () => ({
+          description: "fallback",
+          parameters: {},
+          execute: fallbackExecute,
+        }),
+      }),
+    ]);
+
+    await expect(
+      runWebSearch({
+        config: createCustomSearchConfig("custom-config-key"),
+        args: { query: "abort fallback" },
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(firstExecute).toHaveBeenCalledOnce();
+    expect(fallbackExecute).not.toHaveBeenCalled();
+  });
+
   it("auto-detects a provider from canonical plugin-owned credentials", async () => {
     const provider = createCustomSearchProvider();
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -472,6 +472,7 @@ export async function runWebSearch(params: RunWebSearchParams): Promise<RunWebSe
   let sawUnavailableProvider = false;
 
   for (const candidate of candidates) {
+    params.signal?.throwIfAborted();
     try {
       const definition = candidate.createTool({
         config,
@@ -499,7 +500,7 @@ export async function runWebSearch(params: RunWebSearchParams): Promise<RunWebSe
       };
     } catch (error) {
       lastError = error;
-      if (!allowFallback) {
+      if (params.signal?.aborted || !allowFallback) {
         throw error;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Two cancellations bugs in the DuckDuckGo web search path:

1. **Dropped abort signal** — DuckDuckGo is the only web search provider that discards the caller's `AbortSignal`. While every other provider forwards `context?.signal` to its HTTP client, DDG drops it at the provider boundary. A canceled run leaves the DDG request open until its 20-second timeout expires.

2. **Fallback after cancellation** — Even after forwarding the signal, an aborted DDG request is caught by the shared `runWebSearch` catch block, which can start the next auto-detected provider. Canceling one provider should not trigger unintended fallback work.

## Why This Change Was Made

**DDG signal forwarding** (provider + client): Forward `context?.signal` through the DDG provider and client to `withTrustedWebSearchEndpoint`, matching the pattern every other web search provider already uses (tavily #104965, searxng #104216, brave, exa, firecrawl, etc.). The entire chain already supports `signal?: AbortSignal` — DDG was simply the last provider not using it.

**Shared runtime abort guard** (`src/web-search/runtime.ts`): Add `params.signal?.throwIfAborted()` at the top of the provider loop and `params.signal?.aborted` in the catch block so a parent cancellation stops fallback immediately. This is the canonical pattern from #104216 — without it, forwarding the signal into a provider that then rejects on abort would still trigger the next auto-detected provider.

## Evidence

### Real behavior proof — abort through the guarded-fetch stack

A real stalled HTTP server (never sends headers) exercises the exact code path DDG uses: `withSelfHostedWebSearchEndpoint` → `fetchWithSsrFGuard` → `buildTimeoutAbortSignal` → `fetch()`. Both `withTrustedWebSearchEndpoint` (DDG's actual call) and `withSelfHostedWebSearchEndpoint` (used in this proof to allow localhost) share identical `fetchWithSsrFGuard` → `buildTimeoutAbortSignal({ signal })` → `fetch()` code paths; the only difference is the SSRF policy object.

```
[proof] Signal propagated in 123ms through guarded-fetch stack
        (withSelfHostedWebSearchEndpoint → fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch)
[proof] stalled server: http://127.0.0.1:33563/stall
[proof] abort: controller.abort("proof: cancellation") @ ~100ms
[proof] error: DOMException: This operation was aborted
```

A held-open TCP connection is cancelled promptly (123ms) when the signal fires, rather than waiting for the configured 20-second timeout.

Proof script: `extensions/duckduckgo/proof/abort-guarded-fetch-proof.test.ts`

### Signal chain — full path (source verified)

| Layer | File | Line | Mechanism |
|---|---|---|---|
| Web search runtime | `src/web-search/runtime.ts` | 475 | `params.signal?.throwIfAborted()` — terminal guard (new) |
| Web search runtime | `src/web-search/runtime.ts` | 489 | `definition.execute(params.args, { signal: params.signal })` |
| Web search runtime | `src/web-search/runtime.ts` | 503 | `params.signal?.aborted \|\| !allowFallback` — catch guard (new) |
| DDG provider tool | `extensions/duckduckgo/src/ddg-search-provider.ts` | 53 | `signal: context?.signal` (new) |
| DDG client | `extensions/duckduckgo/src/ddg-client.ts` | 201 | `signal: params.signal` (new) |
| Trusted endpoint wrapper | `src/agents/tools/web-search-provider-common.ts` | 105 | `signal: params.signal` → `withTrustedWebToolsEndpoint` |
| Guarded fetch router | `src/agents/tools/web-guarded-fetch.ts` | 88 | Spread `...params` → `withWebToolsNetworkGuard` |
| SSRF guard | `src/infra/net/fetch-guard.ts` | 496-498 | `buildTimeoutAbortSignal({ signal: params.signal })` |

No new SDK surface is needed — the entire chain already accepts `AbortSignal`.

### Test suite

```
$ node scripts/run-vitest.mjs run extensions/duckduckgo/ src/web-search/runtime.test.ts
 ✓ DDG: 12/12 passed (including signal forwarding test)
 ✓ runtime: 31/31 passed (including "does not fall back after parent cancellation")
```

### Lint

```
$ node scripts/run-oxlint.mjs \
    extensions/duckduckgo/src/ddg-search-provider.ts \
    extensions/duckduckgo/src/ddg-client.ts \
    extensions/duckduckgo/src/ddg-search-provider.test.ts \
    src/web-search/runtime.ts \
    src/web-search/runtime.test.ts
✓ clean
```

### Landing order

The `src/web-search/runtime.ts` abort guard is included here so this PR typechecks and tests standalone. #104216 (SearXNG, same author) also adds the same guard. Whichever PR lands first, the other will rebase; no cross-repo dependency.
