### PR TITLE
test: stabilize reply initialization timestamps

### DIFF
--- a/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
+++ b/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
@@ -161,18 +161,24 @@ describe("reply session initialization concurrency", () => {
     const readyPath = path.join(tempDir, "snapshot-ready.json");
     const proceedPath = path.join(tempDir, "proceed");
     const resultPath = path.join(tempDir, "result.json");
-    const baseTime = Date.now();
-    const activeTurnUpdatedAt = baseTime + 20;
-    const preparedUpdatedAt = baseTime + 30;
-
     try {
       await upsertSessionEntry(
         { sessionKey: SESSION_KEY, storePath },
         {
           sessionId: "existing-session",
-          updatedAt: baseTime,
+          updatedAt: Date.now(),
         },
       );
+      const initialUpdatedAt = loadSessionEntry({
+        readConsistency: "latest",
+        sessionKey: SESSION_KEY,
+        storePath,
+      })?.updatedAt;
+      if (typeof initialUpdatedAt !== "number") {
+        throw new Error("initial session timestamp was not persisted");
+      }
+      const activeTurnUpdatedAt = initialUpdatedAt + 20;
+      const preparedUpdatedAt = initialUpdatedAt + 30;
 
       const child = spawn(
         process.execPath,


### PR DESCRIPTION
## What Problem This Solves

Resolves a flaky main CI assertion in reply-session initialization concurrency coverage. SQLite timestamp normalization can make a precomputed synthetic timestamp collide with the initial persisted value, causing the test to exercise the wrong merge branch and reject correct behavior.

## Why This Change Was Made

The test now derives its synthetic concurrent-activity and prepared-entry timestamps from the initial value actually persisted by the session store. Exact assertions remain unchanged, so the test still proves that an explicitly changed prepared timestamp wins while unrelated same-session activity is accepted.

## User Impact

No user-visible behavior change. Main CI gains deterministic concurrency coverage across SQLite initialization timing.

## Evidence

- Blacksmith Testbox: 20 consecutive focused test runs passed.
- Remote `pnpm check:changed` passed, including formatting, core test types, lint, and guards.
- Fresh autoreview: no accepted or actionable findings.
