### PR TITLE
Recover cron tool warnings with final text

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -796,6 +796,10 @@ describe("slackPlugin outbound", () => {
     ).toBe(false);
   });
 
+  it("prefers final assistant text for text-only cron announce delivery", () => {
+    expect(slackPlugin.outbound?.preferFinalAssistantVisibleText).toBe(true);
+  });
+
   it("advertises the 8000-character Slack default chunk limit", () => {
     expect(slackOutbound.textChunkLimit).toBe(8000);
     expect(slackPlugin.outbound?.textChunkLimit).toBe(8000);

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -485,6 +485,7 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
     },
   },
   shouldTreatDeliveredTextAsVisible: shouldTreatSlackDeliveredTextAsVisible,
+  preferFinalAssistantVisibleText: true,
   shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload }) =>
     shouldSuppressLocalSlackExecApprovalPrompt({
       cfg,

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -50,6 +50,31 @@ describe("resolveCronPayloadOutcome", () => {
     ]);
   });
 
+  it("lets final assistant text recover multiple plain tool warnings globally", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        {
+          text: "⚠️ 🛠️ zsh (agent) failed",
+          isError: true,
+        },
+        {
+          text: "⚠️ 🛠️ node (agent) failed",
+          isError: true,
+        },
+      ],
+      finalAssistantVisibleText: "**Daily GTM analytics**\nPostHog and revenue summary complete.",
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.embeddedRunError).toBeUndefined();
+    expect(result.outputText).toBe(
+      "**Daily GTM analytics**\nPostHog and revenue summary complete.",
+    );
+    expect(result.deliveryPayloads).toEqual([
+      { text: "**Daily GTM analytics**\nPostHog and revenue summary complete." },
+    ]);
+  });
+
   it("treats transient error payloads as non-fatal when a later success exists", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -289,7 +289,6 @@ export function resolveCronPayloadOutcome(params: {
   const hasRecoveredToolWarning =
     !params.runLevelError &&
     params.failureSignal?.fatalForCron !== true &&
-    params.preferFinalAssistantVisibleText === true &&
     normalizedFinalAssistantVisibleText !== undefined &&
     !hasStructuredDeliveryPayloads &&
     errorPayloads.length > 0 &&
@@ -309,7 +308,7 @@ export function resolveCronPayloadOutcome(params: {
   // A final assistant answer can replace textual warning payloads, but never
   // structured/media payloads that carry the actual delivery content.
   const shouldUseFinalAssistantVisibleText =
-    params.preferFinalAssistantVisibleText === true &&
+    (params.preferFinalAssistantVisibleText === true || hasRecoveredToolWarning) &&
     normalizedFinalAssistantVisibleText !== undefined &&
     !hasFatalStructuredErrorPayload &&
     !hasStructuredDeliveryPayloads;


### PR DESCRIPTION
## Summary

Recovered isolated cron runs can produce one or more plain tool-warning payloads before the agent emits a final assistant-visible report. Previously, those warning payloads could still make the cron run look fatal unless the delivery channel explicitly preferred final assistant text.

This change makes the cron payload resolver treat final assistant-visible text as recovery evidence for plain tool warnings globally, while preserving fatal handling for run-level errors and structured/media payloads. Slack also opts into final assistant text for text-only cron announce delivery, matching Discord and Telegram behavior.

## Impact

Text-only cron reports that recover from intermediate shell/tool mistakes should persist as successful runs instead of incrementing cron error backoff or sending false failure alerts.

## Validation

```sh
node scripts/test-projects.mjs src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent.direct-delivery-core-channels.test.ts extensions/slack/src/channel.test.ts
```

Passed: 2 Vitest shards, 101 tests.

Also attempted:

```sh
pnpm test:docker:cron-cli
```

The Docker e2e built and packed OpenClaw successfully, including package tarball integrity, but did not reach the cron scenario because Docker failed resolving `docker.io/docker/dockerfile:1.7` with `DeadlineExceeded: context deadline exceeded`.