### PR TITLE
ci: bound QA smoke profile runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1202,7 +1202,7 @@ jobs:
             for scenario_id in "${scenario_ids[@]}"; do
               scenario_args+=(--scenario "$scenario_id")
             done
-            node openclaw.mjs qa run \
+            timeout --signal=TERM --kill-after=15s 10m node openclaw.mjs qa run \
               --repo-root . \
               --qa-profile smoke-ci \
               --concurrency 10 \

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2630,6 +2630,9 @@ describe("ci workflow guards", () => {
     expect(smokeRunStep.run).toContain("No QA smoke runs assigned");
     expect(smokeRunStep.run).toContain("node openclaw.mjs qa run");
     expect(smokeRunStep.run).not.toContain("pnpm openclaw qa run");
+    expect(smokeRunStep.run).toContain(
+      "timeout --signal=TERM --kill-after=15s 10m node openclaw.mjs qa run",
+    );
     expect(smokeRunStep.run).toContain("--qa-profile smoke-ci");
     expect(smokeRunStep.run).toContain("--concurrency 10");
     expect(smokeRunStep.env.OPENCLAW_QA_SUITE_WORKER_START_STAGGER_MS).toContain(


### PR DESCRIPTION
## What Problem This Solves

The QA smoke profile can hang after scenario completion and occupy a CI runner until the one-hour job timeout. A recent release-validation run remained stuck for more than 23 minutes even though healthy smoke steps finish in under four minutes.

## Why This Change Was Made

Bound each Linux QA smoke invocation with a ten-minute TERM/KILL deadline. The existing exit-code capture and always-run artifact upload remain intact, so a timeout fails visibly and preserves evidence instead of silently masking the scenario.

## User Impact

Release validation no longer spends most of an hour on this hang class. Healthy runs keep their existing behavior; an unhealthy smoke profile fails after ten minutes plus a 15-second cleanup window.

## Evidence

- Blacksmith Testbox: `pnpm test test/scripts/ci-workflow-guards.test.ts` — 51 passed.
- Blacksmith Testbox: changed-surface check — passed.
- Fresh autoreview after rebase onto current `origin/main` — no actionable findings.
- Healthy-run audit: 185 profile jobs; p95 242s, p99 334s, longest observed smoke step 205s.

No agent transcript attached, per maintainer instruction.
