### PR TITLE
test(sessions): seed SQLite transcript freshness

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -11,6 +11,7 @@ import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
+  appendTranscriptEvent,
   listSessionEntries,
   loadSessionEntry,
   replaceSessionEntry,
@@ -385,18 +386,11 @@ async function writeTerminalTranscriptSessionStore(params: {
   omitStatus?: boolean;
   updatedAt: number;
   endedAt: number;
-  transcriptMtimeMs: number;
+  transcriptNewerThanRegistry: boolean;
 }): Promise<void> {
   const sessionFile = `${params.sessionId}.jsonl`;
-  const transcriptPath = path.join(path.dirname(params.storePath), sessionFile);
-  await fs.writeFile(
-    transcriptPath,
-    `${JSON.stringify({ type: "session", id: params.sessionId })}\n`,
-    "utf-8",
-  );
-  await fs.utimes(transcriptPath, params.transcriptMtimeMs / 1000, params.transcriptMtimeMs / 1000);
   const status = params.status ?? (params.omitStatus ? undefined : "done");
-  await writeSessionStoreFast(params.storePath, {
+  const sessions = {
     [params.sessionKey]: {
       sessionId: params.sessionId,
       sessionFile,
@@ -406,7 +400,26 @@ async function writeTerminalTranscriptSessionStore(params: {
       runtimeMs: 9_000,
       ...(status ? { status } : {}),
     },
-  });
+  };
+  const transcriptScope = {
+    agentId: "main",
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    storePath: params.storePath,
+  };
+  const appendTranscript = () =>
+    appendTranscriptEvent(transcriptScope, {
+      type: "custom",
+      timestamp: new Date().toISOString(),
+    });
+
+  if (!params.transcriptNewerThanRegistry) {
+    await appendTranscript();
+  }
+  await writeSessionStoreFast(params.storePath, sessions);
+  if (params.transcriptNewerThanRegistry) {
+    await appendTranscript();
+  }
 }
 
 function setMinimalCurrentConversationBindingRegistryForTests(): void {
@@ -2344,11 +2357,11 @@ describe("initSessionState reset policy", () => {
 
   it.each([
     {
-      name: "non-main terminal rows ignore transcript mtime",
+      name: "non-main terminal rows ignore transcript freshness",
       sessionKey: "agent:main:whatsapp:dm:terminal-entry",
       updatedAtOffsetMs: -5_000,
       endedAtOffsetMs: -6_000,
-      transcriptMtimeOffsetMs: -3_000,
+      transcriptNewerThanRegistry: true,
       expectNewSession: false,
     },
     {
@@ -2356,7 +2369,7 @@ describe("initSessionState reset policy", () => {
       sessionKey: "agent:main:main",
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
-      transcriptMtimeOffsetMs: 0,
+      transcriptNewerThanRegistry: true,
       expectNewSession: false,
     },
     {
@@ -2365,7 +2378,7 @@ describe("initSessionState reset policy", () => {
       status: "killed" as const,
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
-      transcriptMtimeOffsetMs: 0,
+      transcriptNewerThanRegistry: true,
       expectNewSession: true,
     },
     {
@@ -2373,7 +2386,7 @@ describe("initSessionState reset policy", () => {
       sessionKey: "agent:main:main",
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
-      transcriptMtimeOffsetMs: 0,
+      transcriptNewerThanRegistry: true,
       omitStatus: true,
       expectNewSession: true,
     },
@@ -2383,7 +2396,7 @@ describe("initSessionState reset policy", () => {
       status: "failed" as const,
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
-      transcriptMtimeOffsetMs: 0,
+      transcriptNewerThanRegistry: true,
       expectNewSession: false,
       expectRecovered: true,
     },
@@ -2392,23 +2405,15 @@ describe("initSessionState reset policy", () => {
       sessionKey: "agent:main:main",
       updatedAtOffsetMs: -1_000,
       endedAtOffsetMs: -6_000,
-      transcriptMtimeOffsetMs: -4_000,
+      transcriptNewerThanRegistry: false,
       expectNewSession: false,
     },
     {
-      name: "main terminal rows reuse when transcript mtime differs only by sub-millisecond precision",
-      sessionKey: "agent:main:main",
-      updatedAtOffsetMs: -4_000,
-      endedAtOffsetMs: -6_000,
-      transcriptMtimeOffsetMs: -3_999.5,
-      expectNewSession: false,
-    },
-    {
-      name: "main terminal rows reuse when transcript is not newer than updatedAt",
+      name: "main terminal rows reuse when the registry observed the transcript mutation",
       sessionKey: "agent:main:main",
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
-      transcriptMtimeOffsetMs: -15_000,
+      transcriptNewerThanRegistry: false,
       expectNewSession: false,
     },
   ])("$name", async (scenario) => {
@@ -2427,7 +2432,7 @@ describe("initSessionState reset policy", () => {
       omitStatus: scenario.omitStatus,
       updatedAt: terminalUpdatedAt,
       endedAt: terminalEndedAt,
-      transcriptMtimeMs: now + scenario.transcriptMtimeOffsetMs,
+      transcriptNewerThanRegistry: scenario.transcriptNewerThanRegistry,
     });
 
     const cfg = { session: { store: storePath } } as OpenClawConfig;

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -1,12 +1,15 @@
 // Agent session command tests cover session resolution, agent scoping, and temp-home session stores.
-import fs from "node:fs";
 import path from "node:path";
 import { withTempHome as withTempHomeBase } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it } from "vitest";
 import { resolveAgentDir, resolveSessionAgentId } from "../agents/agent-scope.js";
 import { updateSessionStoreAfterAgentRun } from "../agents/command/session-store.js";
 import { resolveSession } from "../agents/command/session.js";
-import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  appendTranscriptEvent,
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
 import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -197,13 +200,6 @@ describe("agent session resolution", () => {
         const sessionFile = path.join(home, `session-${scenario.label.replaceAll(" ", "-")}.jsonl`);
         const sessionId = `stale-terminal-${scenario.label.replaceAll(" ", "-")}`;
         const registryUpdatedAt = Date.now() - 10_000;
-        fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
-        fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", id: sessionId }) + "\n");
-        fs.utimesSync(
-          sessionFile,
-          (registryUpdatedAt + 5_000) / 1000,
-          (registryUpdatedAt + 5_000) / 1000,
-        );
         await writeSessionStoreSeed(store, {
           [scenario.sessionKey]: {
             sessionId,
@@ -225,6 +221,10 @@ describe("agent session resolution", () => {
             claudeCliSessionId: "old-claude-cli-session",
           },
         });
+        await appendTranscriptEvent(
+          { agentId: "main", sessionId, sessionKey: scenario.sessionKey, storePath: store },
+          { type: "custom", timestamp: new Date(registryUpdatedAt + 5_000).toISOString() },
+        );
         const cfg = mockConfig(home, store);
         cfg.session = { ...cfg.session, mainKey: scenario.mainKey };
 
@@ -302,12 +302,6 @@ describe("agent session resolution", () => {
       const sessionFile = path.join(home, "explicit-terminal-main.jsonl");
       const sessionId = "explicit-terminal-main";
       const registryUpdatedAt = Date.now() - 10_000;
-      fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", id: sessionId }) + "\n");
-      fs.utimesSync(
-        sessionFile,
-        (registryUpdatedAt + 5_000) / 1000,
-        (registryUpdatedAt + 5_000) / 1000,
-      );
       await writeSessionStoreSeed(store, {
         "agent:main:main": {
           sessionId,
@@ -319,6 +313,10 @@ describe("agent session resolution", () => {
           runtimeMs: 900,
         },
       });
+      await appendTranscriptEvent(
+        { agentId: "main", sessionId, sessionKey: "agent:main:main", storePath: store },
+        { type: "custom", timestamp: new Date(registryUpdatedAt + 5_000).toISOString() },
+      );
       const cfg = mockConfig(home, store);
 
       const resolution = resolveSession({ cfg, sessionId });

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -21,6 +21,7 @@ import {
   testing as subagentRegistryTesting,
 } from "../../agents/subagent-registry.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { readTranscriptStatsSync } from "../../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import {
   onDiagnosticEvent,
@@ -71,7 +72,11 @@ const mocks = vi.hoisted(() => ({
   updateSessionStore: vi.fn(),
   applySessionEntryReplacements: vi.fn(),
   patchSessionEntryTarget: vi.fn(),
-  readTranscriptStatsSync: vi.fn(() => ({ eventCount: 0, maxSeq: 0, sizeBytes: 0 })),
+  readTranscriptStatsSync: vi.fn<typeof readTranscriptStatsSync>(() => ({
+    eventCount: 0,
+    maxSeq: 0,
+    sizeBytes: 0,
+  })),
   agentCommand: vi.fn(),
   clearAgentRunContext: vi.fn(),
   registerAgentRunContext: vi.fn(),

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -2157,15 +2157,14 @@ describe("gateway agent handler", () => {
 
       await withTempDir({ prefix: "openclaw-gateway-terminal-main-newer-" }, async (root) => {
         const sessionsDir = `${root}/sessions`;
-        await fs.mkdir(sessionsDir, { recursive: true });
         const sessionFile = "terminal-main-session.jsonl";
-        const transcriptPath = `${sessionsDir}/${sessionFile}`;
-        await fs.writeFile(
-          transcriptPath,
-          `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
-          "utf8",
-        );
-        await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+        mocks.readTranscriptStatsSync.mockReturnValue({
+          eventCount: 1,
+          lastMutationAtMs: now - 1_000,
+          lastObservedMutationAtMs: now - 10_000,
+          maxSeq: 1,
+          sizeBytes: 1,
+        });
         mocks.loadSessionEntry.mockReturnValue({
           cfg: {},
           storePath: `${sessionsDir}/sessions.json`,


### PR DESCRIPTION
## What Problem This Solves

Current main CI deterministically fails three terminal-session integration surfaces after transcript freshness moved from JSONL file mtimes to SQLite mutation watermarks. The command, gateway, and auto-reply fixtures still touched legacy JSONL files, so they no longer created the transcript state the production reader checks.

## Why This Change Was Made

Seed real-store transcript activity through `appendTranscriptEvent`, the same storage-neutral session accessor used by runtime code and lifecycle tests. Model registry observation by ordering the transcript append before or after the registry write, and model the gateway owner boundary with explicit mutation/observed watermarks. Keep legacy-looking `sessionFile` values so reset/resume assertions still cover those fields without treating them as freshness sources.

## User Impact

No runtime behavior changes. Main CI now tests the SQLite-backed terminal-session contract instead of an obsolete filesystem implementation detail.

## Evidence

- Exact main failure: https://github.com/openclaw/openclaw/actions/runs/29177284308/job/86608682983
- Blacksmith Testbox: three consecutive runs across command, gateway, auto-reply, and lifecycle suites — 1,869/1,869 assertions passed.
- Blacksmith Testbox final focused rerun after type hardening — 623/623 assertions passed.
- Blacksmith Testbox changed-surface gate — passed.
- Fresh autoreview — no actionable findings.

No agent transcript attached, per maintainer instruction.
