### PR TITLE
fix: omit model.maxTokens as default completions output reservation

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -9110,7 +9110,7 @@ describe("openai transport stream", () => {
       undefined,
     );
 
-    expect(params.max_completion_tokens).toBe(65_536);
+    expect(params).not.toHaveProperty("max_completion_tokens");
     expect(params).not.toHaveProperty("max_tokens");
   });
 
@@ -9273,7 +9273,7 @@ describe("openai transport stream", () => {
       undefined,
     );
 
-    expect(params.max_tokens).toBe(65_536);
+    expect(params).not.toHaveProperty("max_tokens");
     expect(params).not.toHaveProperty("max_completion_tokens");
   });
 
@@ -9513,7 +9513,7 @@ describe("openai transport stream", () => {
         messages: [],
         tools: [],
       } as never,
-      undefined,
+      { maxTokens: 200_000 },
     );
 
     expect(params.max_completion_tokens).toBe(200_000);

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -4121,17 +4121,17 @@ function shouldEmitOpenAICompletionsReasoningForModel(
 function resolveOpenAICompletionsMaxTokens(
   model: OpenAIModeModel,
   options: OpenAICompletionsOptions | undefined,
-): { maxTokens: number | undefined; clampToModelMaxTokens: boolean } {
+): { maxTokens: number | undefined; clampToModelMaxTokens: boolean; isExplicit: boolean } {
   if (options?.maxTokens) {
-    return { maxTokens: options.maxTokens, clampToModelMaxTokens: true };
+    return { maxTokens: options.maxTokens, clampToModelMaxTokens: true, isExplicit: true };
   }
   const paramsMaxTokens = resolveMaxTokensParam(
     (model as { params?: Record<string, unknown> }).params,
   );
   if (paramsMaxTokens) {
-    return { maxTokens: paramsMaxTokens, clampToModelMaxTokens: false };
+    return { maxTokens: paramsMaxTokens, clampToModelMaxTokens: false, isExplicit: true };
   }
-  return { maxTokens: model.maxTokens, clampToModelMaxTokens: false };
+  return { maxTokens: model.maxTokens, clampToModelMaxTokens: false, isExplicit: false };
 }
 
 function resolveOpenAICompletionsModelMaxTokens(model: OpenAIModeModel): number | undefined {
@@ -4784,7 +4784,11 @@ export function buildOpenAICompletionsParams(
     const maxTokenBudget = resolveOpenAICompletionsMaxTokens(model, options);
     const effectiveMaxTokens = maxTokenBudget.maxTokens;
     const effectiveContextTokens = resolveOpenAICompletionsEffectiveContextTokens(model);
+
     let clampedMaxTokens = effectiveMaxTokens;
+    if (!maxTokenBudget.isExplicit && !compatDetection.capabilities.usesExplicitProxyLikeEndpoint) {
+      clampedMaxTokens = undefined;
+    }
     const modelMaxTokens = resolveOpenAICompletionsModelMaxTokens(model);
     if (
       maxTokenBudget.clampToModelMaxTokens &&


### PR DESCRIPTION
## What Problem This Solves
Resolves #104783 by separating a model's maximum output capability from its default per-request reservation. Previously, the transport sent `model.maxTokens` as `max_tokens` for all completions requests. For models with very large context windows (like Groq's llama-3.3-70b-versatile with 32k), this caused requests to be rejected due to TPM (Tokens Per Minute) limit calculations which count requested output tokens.

## Evidence
- `pnpm test src/agents/openai-transport-stream.test.ts src/agents/embedded-agent-runner/model.static-catalog.test.ts` all passed. (349 passed)
- Tests updated to verify that `max_tokens`/`max_completion_tokens` are omitted when not explicitly passed, except for proxy-like endpoints that require clamping.