### PR TITLE
fix(cron): preserve empty command argv arguments

### DIFF
--- a/packages/gateway-protocol/src/cron-validators.test.ts
+++ b/packages/gateway-protocol/src/cron-validators.test.ts
@@ -140,7 +140,7 @@ describe("cron protocol validators", () => {
         sessionTarget: "isolated",
         payload: {
           kind: "command",
-          argv: ["sh", "-lc", "echo ok"],
+          argv: ["node", "scripts/report.mjs", ""],
           cwd: "/srv/example",
           env: { FOO: "bar" },
           input: "stdin",
@@ -156,7 +156,7 @@ describe("cron protocol validators", () => {
         patch: {
           payload: {
             kind: "command",
-            argv: ["sh", "-lc", "echo updated"],
+            argv: ["sh", "-lc", "echo updated", ""],
           },
         },
       }),

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -149,6 +149,13 @@ const CronRunDiagnosticSeveritySchema = Type.Union([
   Type.Literal("warn"),
   Type.Literal("error"),
 ]);
+/** Command argv requires a non-empty executable, but later argv slots may be empty strings. */
+const CommandArgvSchema = Type.Unsafe<string[]>({
+  type: "array",
+  minItems: 1,
+  prefixItems: [{ type: "string", minLength: 1 }],
+  items: { type: "string" },
+});
 const CronRunDiagnosticSourceSchema = Type.Union([
   Type.Literal("cron-preflight"),
   Type.Literal("cron-setup"),
@@ -275,7 +282,7 @@ export const CronPayloadSchema = Type.Union([
     thinking: Type.String(),
   }),
   cronCommandPayloadSchema({
-    argv: Type.Array(NonEmptyString, { minItems: 1 }),
+    argv: CommandArgvSchema,
   }),
 ]);
 
@@ -296,7 +303,7 @@ export const CronPayloadPatchSchema = Type.Union([
     thinking: Type.Union([Type.String(), Type.Null()]),
   }),
   cronCommandPayloadSchema({
-    argv: Type.Optional(Type.Array(NonEmptyString, { minItems: 1 })),
+    argv: Type.Optional(CommandArgvSchema),
   }),
 ]);
 

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1156,14 +1156,14 @@ describe("cron cli", () => {
   it("converts cron edit payloads to command argv", async () => {
     const patch = await runCronEditAndGetPatch([
       "--command-argv",
-      '["node","scripts/report.mjs","  "]',
+      '["node","scripts/report.mjs",""]',
       "--command-cwd",
       "/srv/app",
     ]);
 
     expect(patch?.patch?.payload).toEqual({
       kind: "command",
-      argv: ["node", "scripts/report.mjs", "  "],
+      argv: ["node", "scripts/report.mjs", ""],
       cwd: "/srv/app",
     });
   });

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -38,9 +38,11 @@ export function parseCronCommandArgv(value: unknown): string[] | undefined {
   if (
     !Array.isArray(parsed) ||
     parsed.length === 0 ||
-    parsed.some((entry) => typeof entry !== "string" || entry.length === 0)
+    typeof parsed[0] !== "string" ||
+    parsed[0].length === 0 ||
+    parsed.some((entry) => typeof entry !== "string")
   ) {
-    throw new Error("--command-argv must be a non-empty JSON array of non-empty strings");
+    throw new Error("--command-argv must be a non-empty JSON array of strings with a command");
   }
   return parsed;
 }

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -468,13 +468,13 @@ describe("normalizeCronJobCreate", () => {
       schedule: { kind: "every", everyMs: 60_000 },
       payload: {
         kind: "command",
-        argv: ["printf", "%s", "  padded value  "],
+        argv: ["printf", "%s", "  padded value  ", ""],
       },
     }) as unknown as Record<string, unknown>;
 
     expect(normalized.payload).toMatchObject({
       kind: "command",
-      argv: ["printf", "%s", "  padded value  "],
+      argv: ["printf", "%s", "  padded value  ", ""],
     });
     expect(validateCronAddParams(normalized)).toBe(true);
   });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -74,7 +74,11 @@ function normalizeCommandArgv(value: unknown): string[] | undefined {
   if (!Array.isArray(value) || value.length === 0) {
     return undefined;
   }
-  if (value.some((entry) => typeof entry !== "string" || entry.length === 0)) {
+  if (
+    typeof value[0] !== "string" ||
+    value[0].length === 0 ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
     return undefined;
   }
   return [...value];

--- a/src/cron/persisted-shape.ts
+++ b/src/cron/persisted-shape.ts
@@ -105,7 +105,9 @@ export function getInvalidPersistedCronJobReason(
     if (
       !Array.isArray(argv) ||
       argv.length === 0 ||
-      argv.some((value) => typeof value !== "string" || value.length === 0)
+      typeof argv[0] !== "string" ||
+      argv[0].length === 0 ||
+      argv.some((value) => typeof value !== "string")
     ) {
       return "invalid-payload";
     }

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -574,7 +574,7 @@ describe("cron store", () => {
     payload.jobs[0].sessionTarget = "isolated";
     payload.jobs[0].payload = {
       kind: "command",
-      argv: ["sh", "-lc", 'printf %s "$1"', "  "],
+      argv: ["sh", "-lc", 'printf %s "$1"', ""],
       cwd: "/srv/example",
       env: { FOO: "bar" },
       input: "stdin",
@@ -587,7 +587,7 @@ describe("cron store", () => {
 
     expect((await loadCronStore(store.storePath)).jobs[0]?.payload).toEqual({
       kind: "command",
-      argv: ["sh", "-lc", 'printf %s "$1"', "  "],
+      argv: ["sh", "-lc", 'printf %s "$1"', ""],
       cwd: "/srv/example",
       env: { FOO: "bar" },
       input: "stdin",

--- a/src/cron/store/payload-codec.ts
+++ b/src/cron/store/payload-codec.ts
@@ -26,7 +26,9 @@ function parseCommandPayloadMessage(
   if (
     !Array.isArray(record.argv) ||
     record.argv.length === 0 ||
-    record.argv.some((value) => typeof value !== "string" || value.length === 0)
+    typeof record.argv[0] !== "string" ||
+    record.argv[0].length === 0 ||
+    record.argv.some((value) => typeof value !== "string")
   ) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating or editing command cron jobs with `--command-argv` could not pass an intentionally empty string argument after the command.

For process argv, `argv[0]` must identify the executable, but later entries are literal arguments and `""` is a valid value. Before this change, payloads such as `["node", "scripts/report.mjs", ""]` were rejected or dropped even though only the command slot needs to be non-empty.

## Why This Change Was Made

This keeps the executable guard in place while narrowing the non-empty requirement to `argv[0]`. The same small invariant is applied across the public protocol schema, CLI parser, normalization, persisted-shape validation, and SQLite payload decoding so command cron payloads do not change behavior depending on the entry point or storage path.

This is a narrowed replacement for #104890 with the proof scope reduced to a 20-line-class production fix plus compact fixture updates.

## User Impact

Users can now schedule command cron jobs that preserve exact argv bytes, including empty string arguments after the executable. Empty argv arrays, empty command names, and non-string argv entries remain rejected.

## Evidence

Before this change, the cron command argv contract treated every argv element as non-empty, so this valid command payload could not survive all cron validation/normalization/storage boundaries:

```json
{"kind":"command","argv":["node","scripts/report.mjs",""]}
```

This PR updates existing focused fixtures to cover empty string argv entries after the executable across the CLI, protocol validator, normalization, and store round trip paths.

Validation run locally:

```powershell
git diff --check
pnpm exec vitest run packages/gateway-protocol/src/cron-validators.test.ts src/cli/cron-cli.test.ts src/cron/normalize.test.ts src/cron/store.test.ts
pnpm exec oxfmt --check packages/gateway-protocol/src/cron-validators.test.ts packages/gateway-protocol/src/schema/cron.ts src/cli/cron-cli.test.ts src/cli/cron-cli/shared.ts src/cron/normalize.test.ts src/cron/normalize.ts src/cron/persisted-shape.ts src/cron/store.test.ts src/cron/store/payload-codec.ts
```

Results:

- `git diff --check`: passed
- focused Vitest run: `4 passed`, `230 tests passed`
- `oxfmt --check`: all 9 matched files use the correct format