### PR TITLE
fix(channels): make nack callbacks idempotent

### DIFF
--- a/src/channels/message/lifecycle.test.ts
+++ b/src/channels/message/lifecycle.test.ts
@@ -397,6 +397,33 @@ describe("message lifecycle primitives", () => {
     expect(ctx.nackErrorMessage).toBe("retry failure");
   });
 
+  it("coalesces overlapping nack callbacks and retains the first error", async () => {
+    let resolveNack: (() => void) | undefined;
+    const onNack = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveNack = resolve;
+        }),
+    );
+    const ctx = createMessageReceiveContext({
+      id: "rx-nack-overlap",
+      channel: "telegram",
+      message: { text: "hello" },
+      onNack,
+    });
+    const firstError = new Error("first failure");
+
+    const first = ctx.nack(firstError);
+    const duplicate = ctx.nack(new Error("duplicate failure"));
+    await vi.waitFor(() => expect(onNack).toHaveBeenCalledOnce());
+    resolveNack?.();
+    await Promise.all([first, duplicate]);
+
+    expect(onNack).toHaveBeenCalledWith(firstError);
+    expect(ctx.ackState).toBe("nacked");
+    expect(ctx.nackErrorMessage).toBe("first failure");
+  });
+
   it("maps ack policies to lifecycle stages", () => {
     expect(shouldAckMessageAfterStage("after_receive_record", "receive_record")).toBe(true);
     expect(shouldAckMessageAfterStage("after_receive_record", "agent_dispatch")).toBe(false);

--- a/src/channels/message/lifecycle.test.ts
+++ b/src/channels/message/lifecycle.test.ts
@@ -367,9 +367,34 @@ describe("message lifecycle primitives", () => {
 
     const nackError = new Error("offset failed");
     await ctx.nack(nackError);
+    await ctx.nack(new Error("duplicate failure"));
+    expect(onNack).toHaveBeenCalledTimes(1);
     expect(onNack).toHaveBeenCalledWith(nackError);
     expect(ctx.ackState).toBe("nacked");
     expect(ctx.nackErrorMessage).toBe("offset failed");
+  });
+
+  it("retries nack callbacks after a failed attempt", async () => {
+    const onNack = vi
+      .fn<(error: unknown) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce();
+    const ctx = createMessageReceiveContext({
+      id: "rx-nack-retry",
+      channel: "telegram",
+      message: { text: "hello" },
+      onNack,
+    });
+
+    await expect(ctx.nack(new Error("first failure"))).rejects.toThrow("temporary failure");
+    expect(ctx.ackState).toBe("pending");
+
+    const retryError = new Error("retry failure");
+    await ctx.nack(retryError);
+
+    expect(onNack).toHaveBeenCalledTimes(2);
+    expect(ctx.ackState).toBe("nacked");
+    expect(ctx.nackErrorMessage).toBe("retry failure");
   });
 
   it("maps ack policies to lifecycle stages", () => {

--- a/src/channels/message/receive.ts
+++ b/src/channels/message/receive.ts
@@ -88,6 +88,10 @@ export function createMessageReceiveContext<TMessage>(params: {
       delete ctx.nackErrorMessage;
     },
     nack: async (error) => {
+      // Nack callbacks are idempotent after completion but remain retryable after failure.
+      if (ctx.ackState === "nacked") {
+        return;
+      }
       await params.onNack?.(error);
       ctx.ackState = "nacked";
       ctx.nackErrorMessage = normalizeAckErrorMessage(error);

--- a/src/channels/message/receive.ts
+++ b/src/channels/message/receive.ts
@@ -67,6 +67,7 @@ export function createMessageReceiveContext<TMessage>(params: {
   onAck?: () => Promise<void> | void;
   onNack?: (error: unknown) => Promise<void> | void;
 }): MessageReceiveContext<TMessage> {
+  let nackInFlight: Promise<void> | undefined;
   const ctx: MessageReceiveContext<TMessage> = {
     id: params.id,
     channel: params.channel,
@@ -88,13 +89,24 @@ export function createMessageReceiveContext<TMessage>(params: {
       delete ctx.nackErrorMessage;
     },
     nack: async (error) => {
-      // Nack callbacks are idempotent after completion but remain retryable after failure.
+      // Share overlapping callbacks; clear rejected work so a later call can retry.
       if (ctx.ackState === "nacked") {
         return;
       }
-      await params.onNack?.(error);
-      ctx.ackState = "nacked";
-      ctx.nackErrorMessage = normalizeAckErrorMessage(error);
+      if (nackInFlight) {
+        await nackInFlight;
+        return;
+      }
+      nackInFlight = (async () => {
+        await params.onNack?.(error);
+        ctx.ackState = "nacked";
+        ctx.nackErrorMessage = normalizeAckErrorMessage(error);
+      })();
+      try {
+        await nackInFlight;
+      } finally {
+        nackInFlight = undefined;
+      }
     },
   };
   return ctx;


### PR DESCRIPTION
## What Problem This Solves

Repeated or overlapping calls to a channel message receive context's `nack()` could invoke `onNack` more than once. That can duplicate failure handling when a receive pipeline revisits an already-failed stage or concurrent consumers report the same failure.

Closes #104903.

## Why This Change Was Made

Keep one in-flight nack callback on the shared receive context. Completed calls return immediately, overlapping calls await the same callback, and a rejected callback clears the in-flight slot so a later retry remains possible. The existing ack-to-nack transition is unchanged.

The focused tests cover sequential idempotency, overlapping callback coalescing, retained first-error semantics, and retry after a rejected callback.

## User Impact

Channel receive pipelines no longer repeat nack side effects for one message context, including when nack requests overlap. Transient nack callback failures can still be retried.

## Evidence

- Blacksmith Testbox `tbx_01kxbkevswvgdcwn72gx7azk77` / Actions `29200690926`: 18 lifecycle tests and 8 Telegram tracker tests passed
- Earlier Testbox `tbx_01kxb81fbdgwmxr5ywkmqvyy99` / Actions `29194361519`: 17 lifecycle tests and 8 Telegram tracker tests passed
- `pnpm exec oxfmt --check --threads=1 src/channels/message/receive.ts src/channels/message/lifecycle.test.ts`
- `node scripts/run-oxlint.mjs src/channels/message/receive.ts src/channels/message/lifecycle.test.ts`
- `git diff --check`
- Fresh whole-branch autoreview: clean, confidence 0.93
- Fix-only autoreview: clean, confidence 0.96

## Real behavior proof

Behavior addressed: Completed sequential `nack()` calls repeated `onNack`; overlapping calls could also run the callback concurrently.

Real environment tested: Node.js 24 directly imported the production `src/channels/message/receive.ts` module through the repository's `tsx` loader. The runtime harness used fresh receive contexts and `node:assert/strict`; it did not mock `createMessageReceiveContext`.

Observed result after fix: A completed nack callback runs once; overlapping calls share one callback; a callback that rejects leaves the context retryable; the first nack error remains authoritative.

What was not tested: Live external-channel delivery. The contract is transport-independent and is covered at the shared receive-context boundary plus the Telegram integration tracker.
