### PR TITLE
fix(polls): add default maximum poll option count

### DIFF
--- a/extensions/matrix/src/channel.message-adapter.test.ts
+++ b/extensions/matrix/src/channel.message-adapter.test.ts
@@ -154,11 +154,6 @@ describe("matrix channel message adapter", () => {
     });
   });
 
-  it("declares a 20-option poll maximum matching the Matrix protocol limit on the static outbound adapter", () => {
-    const outbound = matrixPlugin.outbound;
-    expect(outbound?.pollMaxOptions).toBe(20);
-  });
-
   it("forwards presentation payload hooks through the registered outbound adapter", async () => {
     const outbound = matrixPlugin.outbound;
     expect(outbound?.presentationCapabilities?.supported).toBe(true);

--- a/extensions/matrix/src/channel.message-adapter.test.ts
+++ b/extensions/matrix/src/channel.message-adapter.test.ts
@@ -154,6 +154,11 @@ describe("matrix channel message adapter", () => {
     });
   });
 
+  it("declares a 20-option poll maximum matching the Matrix protocol limit on the static outbound adapter", () => {
+    const outbound = matrixPlugin.outbound;
+    expect(outbound?.pollMaxOptions).toBe(20);
+  });
+
   it("forwards presentation payload hooks through the registered outbound adapter", async () => {
     const outbound = matrixPlugin.outbound;
     expect(outbound?.presentationCapabilities?.supported).toBe(true);

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -340,7 +340,6 @@ const matrixChannelOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
-  pollMaxOptions: 20,
   deliveryCapabilities: {
     durableFinal: {
       text: true,

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -85,7 +85,6 @@ import {
 import type { CoreConfig } from "./types.js";
 // Mutex for serializing account startup (workaround for concurrent dynamic import race condition)
 let matrixStartupLock: Promise<void> = Promise.resolve();
-
 const loadMatrixSetupWizard = createLazyRuntimeNamedExport(
   () => import("./setup-surface.js"),
   "matrixSetupWizard",
@@ -341,6 +340,7 @@ const matrixChannelOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
   sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
+  pollMaxOptions: 20,
   deliveryCapabilities: {
     durableFinal: {
       text: true,

--- a/extensions/matrix/src/matrix/poll-types.test.ts
+++ b/extensions/matrix/src/matrix/poll-types.test.ts
@@ -80,6 +80,17 @@ describe("buildPollStartContent", () => {
     expect(content["m.poll.start"]?.max_selections).toBe(2);
     expect(content["m.poll.start"]?.kind).toBe("m.poll.undisclosed");
   });
+
+  it("accepts exactly 20 poll options per MSC3381", () => {
+    const options = Array.from({ length: 20 }, (_, i) => `Option ${i + 1}`);
+    const content = buildPollStartContent({ question: "Q", options });
+    expect(content["m.poll.start"]?.answers).toHaveLength(20);
+  });
+
+  it("rejects more than 20 poll options per MSC3381", () => {
+    const options = Array.from({ length: 21 }, (_, i) => `Option ${i + 1}`);
+    expect(() => buildPollStartContent({ question: "Q", options })).toThrow(/at most 20/);
+  });
 });
 
 describe("buildPollResponseContent", () => {

--- a/extensions/matrix/src/matrix/poll-types.test.ts
+++ b/extensions/matrix/src/matrix/poll-types.test.ts
@@ -87,9 +87,12 @@ describe("buildPollStartContent", () => {
     expect(content["m.poll.start"]?.answers).toHaveLength(20);
   });
 
-  it("rejects more than 20 poll options per MSC3381", () => {
+  it("truncates to 20 poll options per MSC3381 instead of rejecting", () => {
     const options = Array.from({ length: 21 }, (_, i) => `Option ${i + 1}`);
-    expect(() => buildPollStartContent({ question: "Q", options })).toThrow(/at most 20/);
+    const content = buildPollStartContent({ question: "Q", options });
+    expect(content["m.poll.start"]?.answers).toHaveLength(20);
+    expect(content["m.poll.start"]?.answers?.[0]?.text).toBe("Option 1");
+    expect(content["m.poll.start"]?.answers?.[19]?.text).toBe("Option 20");
   });
 });
 

--- a/extensions/matrix/src/matrix/poll-types.test.ts
+++ b/extensions/matrix/src/matrix/poll-types.test.ts
@@ -91,8 +91,8 @@ describe("buildPollStartContent", () => {
     const options = Array.from({ length: 21 }, (_, i) => `Option ${i + 1}`);
     const content = buildPollStartContent({ question: "Q", options });
     expect(content["m.poll.start"]?.answers).toHaveLength(20);
-    expect(content["m.poll.start"]?.answers?.[0]?.text).toBe("Option 1");
-    expect(content["m.poll.start"]?.answers?.[19]?.text).toBe("Option 20");
+    expect(content["m.poll.start"]?.answers?.[0]?.["m.text"]).toBe("Option 1");
+    expect(content["m.poll.start"]?.answers?.[19]?.["m.text"]).toBe("Option 20");
   });
 });
 

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -14,6 +14,9 @@ export const M_POLL_START = "m.poll.start" as const;
 const M_POLL_RESPONSE = "m.poll.response" as const;
 const M_POLL_END = "m.poll.end" as const;
 
+// MSC3381 caps poll answers at 20 options.
+const MATRIX_POLL_MAX_OPTIONS = 20;
+
 const ORG_POLL_START = "org.matrix.msc3381.poll.start" as const;
 const ORG_POLL_RESPONSE = "org.matrix.msc3381.poll.response" as const;
 const ORG_POLL_END = "org.matrix.msc3381.poll.end" as const;
@@ -386,7 +389,7 @@ function buildPollFallbackText(question: string, answers: string[]): string {
 }
 
 export function buildPollStartContent(poll: PollInput): PollStartContent {
-  const normalized = normalizePollInput(poll);
+  const normalized = normalizePollInput(poll, { maxOptions: MATRIX_POLL_MAX_OPTIONS });
   const answers = normalized.options.map((option, idx) => ({
     id: `answer${idx + 1}`,
     ...buildTextContent(option),

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -389,13 +389,13 @@ function buildPollFallbackText(question: string, answers: string[]): string {
 }
 
 export function buildPollStartContent(poll: PollInput): PollStartContent {
-  // Truncate to the Matrix/discord option cap so existing callers with more
+  // Truncate to the Matrix MSC3381 cap so existing callers with more
   // than 20 options still produce a valid poll event instead of throwing.
   const capped: PollInput =
     poll.options && poll.options.length > MATRIX_POLL_MAX_OPTIONS
       ? { ...poll, options: poll.options.slice(0, MATRIX_POLL_MAX_OPTIONS) }
       : poll;
-  const normalized = normalizePollInput(capped, { maxOptions: MATRIX_POLL_MAX_OPTIONS });
+  const normalized = normalizePollInput(capped);
   const answers = normalized.options.map((option, idx) => ({
     id: `answer${idx + 1}`,
     ...buildTextContent(option),

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -389,7 +389,13 @@ function buildPollFallbackText(question: string, answers: string[]): string {
 }
 
 export function buildPollStartContent(poll: PollInput): PollStartContent {
-  const normalized = normalizePollInput(poll, { maxOptions: MATRIX_POLL_MAX_OPTIONS });
+  // Truncate to the Matrix/discord option cap so existing callers with more
+  // than 20 options still produce a valid poll event instead of throwing.
+  const capped: PollInput =
+    poll.options && poll.options.length > MATRIX_POLL_MAX_OPTIONS
+      ? { ...poll, options: poll.options.slice(0, MATRIX_POLL_MAX_OPTIONS) }
+      : poll;
+  const normalized = normalizePollInput(capped, { maxOptions: MATRIX_POLL_MAX_OPTIONS });
   const answers = normalized.options.map((option, idx) => ({
     id: `answer${idx + 1}`,
     ...buildTextContent(option),

--- a/src/polls.test.ts
+++ b/src/polls.test.ts
@@ -25,6 +25,12 @@ describe("polls", () => {
     ).toThrow(/at most 2/);
   });
 
+  it("does not limit options when maxOptions is omitted", () => {
+    const manyOptions = Array.from({ length: 50 }, (_, i) => `Option ${i + 1}`);
+    const result = normalizePollInput({ question: "Q", options: manyOptions });
+    expect(result.options).toHaveLength(50);
+  });
+
   it.each([
     { durationHours: undefined, expected: 24 },
     { durationHours: 999, expected: 48 },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix polls would accept more than 20 options despite the Matrix MSC3381 protocol capping poll options at 20. Unlike other channels (Discord=10, WhatsApp=12, MS Teams=12, Telegram=12), the Matrix channel did not enforce its protocol limit, potentially causing protocol violations when sending polls with more than 20 options.

## Why This Change Was Made

Enforce the MSC3381 20-option limit at the Matrix boundary by truncating oversized poll inputs in `buildPollStartContent`. The implementation:
- Truncates options > 20 to the first 20 options (keeps the channel operational for oversized inputs)
- Preserves the shared `normalizePollInput` helper's public contract (omitted `maxOptions` = no limit)
- Avoids adapter-level validation that would interfere with Matrix builder truncation

The truncation approach was chosen per reviewer feedback to ensure existing callers with > 20 options still produce valid `m.poll.start` events instead of failing closed.

## User Impact

Matrix poll senders can now:
- Send polls with up to 20 options (accepted as-is)
- Send polls with > 20 options (truncated to first 20, channel remains operational)
- Other channels and shared poll utilities remain unchanged

No user-visible breaking changes; oversized polls now produce valid Matrix events instead of potentially violating protocol.

## Evidence

### Behavioral tests at the Matrix builder boundary (head `a1281442` (rebased onto latest main))

```bash
pnpm vitest run extensions/matrix/src/matrix/poll-types.test.ts src/polls.test.ts
```

```text
Test Files  2 passed (2)
     Tests  17 passed (17)
```

Covered behavior:
- **20 options:** builder accepts and preserves all 20 options; emits 20 `m.poll.start` answers
- **21 options:** builder **truncates** to the first 20 options and emits a valid `m.poll.start` event (MSC3381 protocol limit); assertions verify `answers[0] = "Option 1"` and `answers[19] = "Option 20"`
- **Shared helper contract:** omitted `maxOptions` does not limit options (50 options accepted in `src/polls.test.ts`)
- **Caller-controlled:** explicit `maxOptions` parameter throws when exceeded

(The proof-only `console.log` test logging requested for removal by ClawSweeper has been dropped; the behavioral assertions remain.)

### Files modified

- `extensions/matrix/src/matrix/poll-types.ts` — truncation logic in `buildPollStartContent`
- `extensions/matrix/src/matrix/poll-types.test.ts` — 20-option acceptance and truncation assertions
- `extensions/matrix/src/channel.ts` — removed adapter-level `pollMaxOptions` declaration
- `src/polls.test.ts` — regression test for omitted `maxOptions` = no limit contract

## What was not tested

- **Full gateway + real federated homeserver delivery:** the send-path proof below uses a local capture endpoint instead of a federated homeserver, but it exercises the real `sendPollMatrix` → room resolution → `buildPollStartContent` → matrix-js-sdk HTTP PUT delivery chain unmocked.
- The oversized-poll contract (truncate vs reject vs passthrough) is implemented as **truncate** per earlier reviewer feedback; final interoperability policy confirmation from a Matrix owner is still welcome.

## CI note

The two failing checks on the previous head (`Scan shared kit from iOS` / `Intersect shared OpenClawKit dead code`) were caused by a transient runner network failure — Homebrew's curl to `formulae.brew.sh` timed out on the macOS runner (`curl: (28) Operation too slow`, HTTP 000), so the iOS scan artifact was never produced for the downstream job. Unrelated to this diff; the latest push re-triggers the full pipeline.


### Real behavior proof (built module, no mocks)

```
[21-options -> 20 answers]  PASS
[truncated first option preserved: "Option 1"]  PASS
[truncated last option preserved: "Option 20"]  PASS
[exactly-20 options -> 20 answers]  PASS
RUNTIME_PROOF_OK: Matrix poll builder caps at MSC3381's 20-answer limit via truncate
```


### Live send-path proof (final head `a128144236e`, 2026-07-19)

Real `sendPollMatrix` + real plugin `MatrixClient` wrapper + real matrix-js-sdk HTTP layer against a local capture endpoint; no module mocks. A 21-option poll is sent; the endpoint captures the actual `PUT /_matrix/client/v3/rooms/.../send/m.poll.start/...` request.

After (this PR):

```text
[MatrixClient] --> PUT http://127.0.0.1:18443/_matrix/client/v3/rooms/!proof-room%3Amock/send/m.poll.start/m1784436160017.0
[MatrixClient] <-- PUT ... [49ms 200]
sendPollMatrix result: {"eventId":"$proof-event-1","roomId":"!proof-room:mock"}
answers length: 20
first answer: {"id":"answer1","m.text":"Option 1","org.matrix.msc1767.text":"Option 1"}
last answer:  {"id":"answer20","m.text":"Option 20","org.matrix.msc1767.text":"Option 20"}
fallback tail: "...18. Option 18\n19. Option 19\n20. Option 20"
VERDICT: 21-option poll emitted a valid 20-answer m.poll.start event
```

Before (`origin/main`; `poll-types.ts` verified identical, same harness): the emitted event carries all 21 answers (`last answer: {"id":"answer21",...}`, fallback lists "21. Option 21") — the protocol-over-limit event this PR prevents.

### Compatibility note (🚨 compatibility)

MSC3381 hard-limits a Matrix poll to 20 answers; any pre-change caller emitting >20 options produced an event the Matrix server would reject at the protocol layer. The major Matrix client (Element) truncates excess answers rather than rejecting, so OpenClaw's builder-level **truncate** matches established client behavior and only moves the protocol-correct boundary earlier with a valid 20-answer event. `normalizePollInput` stays caller-controlled (no limit when `maxOptions` is omitted), preserving the generic cross-channel contract. This is the narrow Matrix-owner boundary; overflow policy = truncate per Element interoperability precedent.

