### PR TITLE
fix: bound ed25519 base64url decode input length

### DIFF
--- a/src/infra/ed25519-signature.test.ts
+++ b/src/infra/ed25519-signature.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { base64UrlDecode, base64UrlEncode } from "./ed25519-signature.ts";
+
+describe("base64UrlDecode", () => {
+  it("decodes a fixed-size ed25519 public key without throwing", () => {
+    const key = base64UrlEncode(Buffer.alloc(32, 7));
+    expect(base64UrlDecode(key).length).toBe(32);
+  });
+
+  it("throws on input exceeding the maximum allowed length", () => {
+    // MAX_BASE64URL_DECODE_INPUT_LENGTH is 4096; 5000 is safely over it.
+    const oversized = "A".repeat(5000);
+    expect(() => base64UrlDecode(oversized)).toThrow(/maximum allowed length/);
+  });
+});

--- a/src/infra/ed25519-signature.ts
+++ b/src/infra/ed25519-signature.ts
@@ -7,7 +7,15 @@ export function base64UrlEncode(buf: Buffer): string {
   return buf.toString("base64").replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "");
 }
 
+// Ed25519 public keys and signatures are fixed-size (<= ~86 base64url chars),
+// so a caller passing far larger input is almost certainly malformed or abusive.
+// Bound the decoded buffer to keep a single request from allocating arbitrary memory.
+const MAX_BASE64URL_DECODE_INPUT_LENGTH = 4096;
+
 export function base64UrlDecode(input: string): Buffer {
+  if (input.length > MAX_BASE64URL_DECODE_INPUT_LENGTH) {
+    throw new Error("base64url input exceeds the maximum allowed length");
+  }
   const normalized = input.replaceAll("-", "+").replaceAll("_", "/");
   const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
   return Buffer.from(padded, "base64");


### PR DESCRIPTION
## Summary

- Problem: `base64UrlDecode` in `src/infra/ed25519-signature.ts` previously decoded any input length into a `Buffer`, so a caller could pass an arbitrarily large string and force large memory allocation per request. These inputs flow from attacker-influenced values (public keys / signatures in device-identity and auth paths).
- Solution: Added `MAX_BASE64URL_DECODE_INPUT_LENGTH = 4096` and reject oversized input with a thrown error before decoding. Every real caller passes fixed-size ed25519 public keys, private keys, or signatures (≤ ~86 base64url chars), so 4096 is vastly generous and cannot affect legitimate use. The existing callers already wrap `base64UrlDecode` in `try/catch` (returning `null`/`false`), so the new throw is safely absorbed as a parse failure rather than a crash.
- What changed: `src/infra/ed25519-signature.ts` — `base64UrlDecode` now rejects input longer than the bound.
- What did NOT change: Valid key/signature decoding behavior; the error-handling contract (callers already treat a throw as a decode failure).

## Real behavior proof

- **Behavior or issue addressed:** Unbounded base64url decode could allocate arbitrary memory on attacker-influenced input; it is now bounded at 4096 characters.
- **Real environment tested:** Direct node function call against the patched module on branch `fix/ed25519-base64-length`, using `node --import tsx`; did not boot a full OpenClaw runtime (pure decode helper).
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx ed25519-evidence.ts
  # ed25519-evidence.ts decodes a valid 32-byte key and a 5000-char input via base64UrlDecode.
  ```
- **Evidence after fix:**
  ```text
  valid 32-byte key -> decoded length = 32 (expected 32) OK
  oversized 5000-char input -> throws: base64url input exceeds the maximum allowed length
  ```
- **Observed result after fix:** Valid keys decode to 32 bytes; oversized input throws before any large allocation.
- **What was not tested:** Did not start a live OpenClaw instance or exercise device-identity/auth paths end-to-end; only exercised the patched `base64UrlDecode` function locally (per guide §4 degradation for pure utility functions).

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `src/infra/ed25519-signature.test.ts`
- Scenario locked in: fixed-size key → 32 bytes; 5000-char input → throws `/maximum allowed length/`.
- Why this is the smallest reliable guardrail: Locks the exact length-guard contract at the decode entry point, which is the precise defect.

## Root Cause

- Root cause: `base64UrlDecode` performed no input-length bound before `Buffer.from`, allowing unbounded allocation on malformed or abusive input.
- Missing detection / guardrail: No maximum-input-length check on the decode entry point.
