### PR TITLE
test(sessions): seed SQLite transcript freshness fixtures

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -11,6 +11,7 @@ import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
+  appendTranscriptEvent,
   listSessionEntries,
   loadSessionEntry,
   replaceSessionEntry,
@@ -396,7 +397,7 @@ async function writeTerminalTranscriptSessionStore(params: {
   );
   await fs.utimes(transcriptPath, params.transcriptMtimeMs / 1000, params.transcriptMtimeMs / 1000);
   const status = params.status ?? (params.omitStatus ? undefined : "done");
-  await writeSessionStoreFast(params.storePath, {
+  const sessionStore = {
     [params.sessionKey]: {
       sessionId: params.sessionId,
       sessionFile,
@@ -406,7 +407,31 @@ async function writeTerminalTranscriptSessionStore(params: {
       runtimeMs: 9_000,
       ...(status ? { status } : {}),
     },
-  });
+  };
+  const appendMutation = async () => {
+    const currentTime = Date.now();
+    vi.setSystemTime(params.transcriptMtimeMs);
+    try {
+      await appendTranscriptEvent(
+        {
+          agentId: "main",
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          storePath: params.storePath,
+        },
+        { type: "custom", timestamp: new Date(params.transcriptMtimeMs).toISOString() },
+      );
+    } finally {
+      vi.setSystemTime(currentTime);
+    }
+  };
+  if (Math.floor(params.transcriptMtimeMs) > Math.floor(params.updatedAt)) {
+    await writeSessionStoreFast(params.storePath, sessionStore);
+    await appendMutation();
+  } else {
+    await appendMutation();
+    await writeSessionStoreFast(params.storePath, sessionStore);
+  }
 }
 
 function setMinimalCurrentConversationBindingRegistryForTests(): void {

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -6,7 +6,11 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { resolveAgentDir, resolveSessionAgentId } from "../agents/agent-scope.js";
 import { updateSessionStoreAfterAgentRun } from "../agents/command/session-store.js";
 import { resolveSession } from "../agents/command/session.js";
-import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  appendTranscriptEvent,
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
 import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -225,6 +229,15 @@ describe("agent session resolution", () => {
             claudeCliSessionId: "old-claude-cli-session",
           },
         });
+        await appendTranscriptEvent(
+          {
+            agentId: "main",
+            sessionId,
+            sessionKey: scenario.sessionKey,
+            storePath: store,
+          },
+          { type: "custom", timestamp: new Date(registryUpdatedAt + 5_000).toISOString() },
+        );
         const cfg = mockConfig(home, store);
         cfg.session = { ...cfg.session, mainKey: scenario.mainKey };
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -21,6 +21,7 @@ import {
   testing as subagentRegistryTesting,
 } from "../../agents/subagent-registry.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { SessionTranscriptStats } from "../../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import {
   onDiagnosticEvent,
@@ -71,7 +72,11 @@ const mocks = vi.hoisted(() => ({
   updateSessionStore: vi.fn(),
   applySessionEntryReplacements: vi.fn(),
   patchSessionEntryTarget: vi.fn(),
-  readTranscriptStatsSync: vi.fn(() => ({ eventCount: 0, maxSeq: 0, sizeBytes: 0 })),
+  readTranscriptStatsSync: vi.fn<() => SessionTranscriptStats>(() => ({
+    eventCount: 0,
+    maxSeq: 0,
+    sizeBytes: 0,
+  })),
   agentCommand: vi.fn(),
   clearAgentRunContext: vi.fn(),
   registerAgentRunContext: vi.fn(),

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -2166,6 +2166,12 @@ describe("gateway agent handler", () => {
           "utf8",
         );
         await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+        mocks.readTranscriptStatsSync.mockReturnValue({
+          eventCount: 1,
+          maxSeq: 1,
+          sizeBytes: 32,
+          lastMutationAtMs: now - 1_000,
+        });
         mocks.loadSessionEntry.mockReturnValue({
           cfg: {},
           storePath: `${sessionsDir}/sessions.json`,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where current-main CI failed three terminal-session rollover suites after transcripts moved to SQLite, because those fixtures still changed legacy JSONL mtimes instead of SQLite transcript mutation watermarks.

## Why This Change Was Made

Seed SQLite transcript events in the command and auto-reply fixtures, and provide the SQLite freshness watermark in the Gateway mock. The shared fixture preserves both causal orderings: mutations written after the registry remain newer, while mutations written first are recorded as observed.

## User Impact

No product behavior change. Restores deterministic coverage of terminal main-session rollover and unblocks required main CI.

## Evidence

- Failing current-main CI: https://github.com/openclaw/openclaw/actions/runs/29177284308
- Exact affected shards on Blacksmith Testbox `tbx_01kxa4dk4wvmk96wq1htke4jzy`: 618 tests passed across the Gateway, command, and auto-reply files.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29177649945
- `git diff --check`
- Fresh autoreview: clean, no accepted/actionable findings.
