### PR TITLE
fix(exec): apply askFallback inline for no-route approvals on every trigger

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -622,7 +622,7 @@ describe("processGatewayAllowlist", () => {
       "./bash-tools.exec-host-shared.js",
     );
     shouldResolveExecApprovalUnavailableInlineMock.mockImplementation(
-      actualShared.shouldResolveExecApprovalUnavailableInline,
+      actualShared.shouldResolveExecApprovalUnavailableInline as () => boolean,
     );
     createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
       approvalId: "approval-cli-no-route",
@@ -651,7 +651,7 @@ describe("processGatewayAllowlist", () => {
           command: "echo askfallback-proof",
           agentId: "agent-1",
           ask: "on-miss",
-          askFallback: "deny",
+          // askFallback=deny comes from resolveExecHostApprovalContextMock's default.
           // trigger intentionally omitted — a plain CLI `openclaw agent` run.
         }),
       ).rejects.toThrow("denied");

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -612,6 +612,62 @@ describe("processGatewayAllowlist", () => {
     expect(serialized).not.toContain("agent-1");
   });
 
+  it("resolves a triggerless CLI no-route approval to a completed denial via the real gate (#104413)", async () => {
+    // Drive the REAL shouldResolveExecApprovalUnavailableInline (not the mock)
+    // so the composed gateway host path is proven end to end: a CLI
+    // `openclaw agent` turn has no trigger and no approval route, the gateway
+    // pre-resolves decision:null after expiring the record, and the host must
+    // apply askFallback inline instead of hanging on an already-finished record.
+    const actualShared = await vi.importActual<typeof import("./bash-tools.exec-host-shared.js")>(
+      "./bash-tools.exec-host-shared.js",
+    );
+    shouldResolveExecApprovalUnavailableInlineMock.mockImplementation(
+      actualShared.shouldResolveExecApprovalUnavailableInline,
+    );
+    createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
+      approvalId: "approval-cli-no-route",
+      approvalSlug: "slug",
+      warningText: "",
+      expiresAtMs: 0,
+      preResolvedDecision: null,
+      initiatingSurface: { kind: "unsupported" },
+      sentApproverDms: false,
+      unavailableReason: "no-approval-route",
+    });
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: true },
+      approvedByAsk: false,
+      deniedReason: "approval-timeout",
+    });
+    enforceStrictInlineEvalApprovalBoundaryMock.mockReturnValue({
+      approvedByAsk: false,
+      deniedReason: "approval-timeout",
+    });
+    const captured = captureSecurityEvents();
+
+    try {
+      await expect(
+        runGatewayAllowlist({
+          command: "echo askfallback-proof",
+          agentId: "agent-1",
+          ask: "on-miss",
+          askFallback: "deny",
+          // trigger intentionally omitted — a plain CLI `openclaw agent` run.
+        }),
+      ).rejects.toThrow("denied");
+    } finally {
+      captured.stop();
+    }
+
+    // The real gate returned true for the triggerless no-route/null state, so
+    // the host reached the inline denial instead of the async pending wait.
+    expect(shouldResolveExecApprovalUnavailableInlineMock).toHaveReturnedWith(true);
+    expect(captured.events.at(-1)).toMatchObject({
+      action: "exec.approval.denied",
+      outcome: "denied",
+    });
+  });
+
   it("emits an approved security event for inline unavailable approval approvals", async () => {
     shouldResolveExecApprovalUnavailableInlineMock.mockReturnValue(true);
     createExecApprovalDecisionStateMock.mockReturnValue({

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -859,7 +859,6 @@ export async function processGatewayAllowlist(
     });
     if (
       shouldResolveExecApprovalUnavailableInline({
-        trigger: params.trigger,
         unavailableReason,
         preResolvedDecision,
       })

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -435,7 +435,6 @@ export async function executeNodeHostCommand(
       });
       if (
         execHostShared.shouldResolveExecApprovalUnavailableInline({
-          trigger: params.trigger,
           unavailableReason,
           preResolvedDecision,
         })

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -20,6 +20,7 @@ import {
   resolveExecApprovalUnavailableState,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
+  shouldResolveExecApprovalUnavailableInline,
 } from "./bash-tools.exec-host-shared.js";
 
 const mocks = vi.hoisted(() => ({
@@ -576,6 +577,46 @@ describe("buildExecApprovalPendingToolResult", () => {
     });
     expect(state.sentApproverDms).toBe(false);
     expect(state.unavailableReason).toBe("no-approval-route");
+  });
+
+  it("resolves no-route approvals inline for every trigger, not just cron (#104413)", () => {
+    // The gateway only pre-resolves `decision: null` after expiring the record
+    // for lack of any approval route; nothing can approve it afterwards, so a
+    // CLI `openclaw agent` turn must apply askFallback promptly instead of
+    // hanging until the turn abort.
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        unavailableReason: "no-approval-route",
+        preResolvedDecision: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps waiting when a route exists or a real decision arrived", () => {
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        unavailableReason: null,
+        preResolvedDecision: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        unavailableReason: "no-approval-route",
+        preResolvedDecision: "allow-once",
+      }),
+    ).toBe(false);
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        unavailableReason: "no-approval-route",
+        preResolvedDecision: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      shouldResolveExecApprovalUnavailableInline({
+        unavailableReason: "initiating-platform-disabled",
+        preResolvedDecision: null,
+      }),
+    ).toBe(false);
   });
 
   it("keeps a local /approve prompt when the initiating Discord surface is disabled", () => {

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -83,10 +83,6 @@ export type ExecApprovalUnavailableReason =
   | "initiating-platform-disabled"
   | "initiating-platform-unsupported";
 
-function isHeadlessExecTrigger(trigger?: string): boolean {
-  return trigger === "cron";
-}
-
 /** Context returned after a default approval request is registered. */
 export type RegisteredExecApprovalRequestContext = {
   approvalId: string;
@@ -416,15 +412,15 @@ export function enforceStrictInlineEvalApprovalBoundary(params: {
 
 /** Returns true when a headless run should resolve an unavailable approval inline. */
 export function shouldResolveExecApprovalUnavailableInline(params: {
-  trigger?: string;
   unavailableReason: ExecApprovalUnavailableReason | null;
   preResolvedDecision: string | null | undefined;
 }): boolean {
-  return (
-    isHeadlessExecTrigger(params.trigger) &&
-    params.unavailableReason === "no-approval-route" &&
-    params.preResolvedDecision === null
-  );
+  // The gateway answers `decision: null` at registration only after expiring
+  // the record for lack of any approval route (no approval client, no
+  // turn-source route, no forwarder) — nothing can approve it afterwards.
+  // Waiting would burn the whole turn timeout with no logged decision
+  // (#104413), so apply askFallback inline for every trigger, not just cron.
+  return params.unavailableReason === "no-approval-route" && params.preResolvedDecision === null;
 }
 
 /** Builds the denial copy for headless runs that cannot wait for approval. */


### PR DESCRIPTION
## What Problem This Solves

With exec policy `security=allowlist, ask=on-miss, askFallback=deny`, an exec tool call that misses the allowlist during a CLI-initiated agent turn (`openclaw agent`, host=auto→gateway) does not fall back to deny. It hangs silently until the ~600s turn abort with no ask/deny/approval event logged, then returns `status:"timeout"`, `stopReason:"toolUse"`, empty payloads (#104413).

## Why This Change Was Made

Root cause is a trigger gate on the inline no-route resolution.

The gateway registers the approval, then in `handleApprovalRequest` (`src/gateway/server-methods/approval-shared.ts`) finds no delivery route for a CLI turn — no approval client connected, no turn-source channel (CLI runs have none), no forwarder — so it **expires the record with `no-approval-route` and responds `decision: null`** at registration time. Nothing can approve it afterward; the record is already gone.

The CLI exec-host is supposed to notice this and apply `askFallback` immediately via `shouldResolveExecApprovalUnavailableInline` (`src/agents/bash-tools.exec-host-shared.ts`). But that gate was `isHeadlessExecTrigger(trigger) && unavailableReason === "no-approval-route" && preResolvedDecision === null`, and `isHeadlessExecTrigger` only matched `trigger === "cron"` (added in #58792 for headless cron). A normal `openclaw agent` run has `trigger === undefined`, so the gate returned false and exec fell through to the async approval-pending path — waiting on a decision that the server already resolved as null-and-expired, until the turn times out.

The fix drops the trigger gate. The `no-approval-route` + `preResolvedDecision === null` registration state alone already proves waiting is futile — that state is only produced *after* the server expired the record for lack of any route, regardless of what initiated the turn. Cron keeps its #58792 behavior through the same gate. Net −5 prod lines (the `isHeadlessExecTrigger` helper and its `trigger` param are removed).

## User Impact

- CLI / headless `openclaw agent` turns (and any trigger without a native approval channel) now apply `askFallback` promptly on an allowlist miss: `askFallback=deny` returns a fast `approval-timeout` denial to the model, which completes the turn in text instead of burning the full turn timeout with no operator-visible signal.
- `askFallback=full` inline-approves as before; cron behavior is unchanged.

## Evidence

**Executed real-source before/after** (tsx over the actual `bash-tools.exec-host-shared.ts` functions — server-unavailable-state → CLI inline gate → askFallback resolution — for a CLI-shaped turn with `trigger` undefined and the server's expired `decision: null`):

Before (main):
```
unavailableReason: no-approval-route
inline-resolve gate (trigger=undefined CLI run): false
=> gate false: exec falls through to the async approval-pending path → the turn hangs until the ~600s abort with no logged decision (the #104413 bug).
```

After (this PR):
```
unavailableReason: no-approval-route
inline-resolve gate (trigger=undefined CLI run): true
applied decision: {"approvedByAsk":false,"deniedReason":"approval-timeout"}
=> exec is DENIED promptly; the turn completes instead of hanging to timeout.
```

**Live symptom reproduction** (main dist, temp `OPENCLAW_STATE_DIR`, `security=allowlist ask=on-miss askFallback=deny`, mock OpenAI provider that emits a non-allowlisted `exec` tool call, `openclaw agent --json`): the turn hangs and aborts at **67s** (the configured 60s turn budget + overhead) with `status:"timeout"`, `stopReason:"toolUse"`, empty payloads, and **zero exec/approval lines** in the gateway log — matching the issue's reported `livenessState:"blocked"` / silent ~600s abort exactly.

**Regression tests** (`node scripts/run-vitest.mjs run src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-approval-request.test.ts` → 104/104):

- `bash-tools.exec-host-shared.test.ts`: new cases assert the gate resolves inline for a no-route + null-decision registration regardless of trigger, and stays false when a route exists, a real decision arrived, the decision is still `undefined` (registration in flight), or the surface is a disabled/unsupported platform.
- Reverting only `bash-tools.exec-host-shared.ts` fails the new "every trigger" case, confirming the gate change is what fixes the hang. The gateway/node integration suites (`shouldResolveExecApprovalUnavailableInline` call sites) stay green.

Fixes #104413
