### PR TITLE
fix(agents): avoid splitting UTF-16 surrogate pairs when truncating persisted tool-result details

### DIFF
--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -2,7 +2,10 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { describe, expect, it } from "vitest";
-import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
+import {
+  installSessionToolResultGuard,
+  redactPersistedDetailString,
+} from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
 import { redactTranscriptMessage } from "./transcript-redact.js";
 
@@ -815,5 +818,43 @@ describe("installSessionToolResultGuard", () => {
       (m) => (m as { toolCallId?: string }).toolCallId === "call_error",
     );
     expect(syntheticForError).toHaveLength(0);
+  });
+});
+
+describe("redactPersistedDetailString", () => {
+  it("does not split UTF-16 surrogate pairs at the truncation boundary", () => {
+    // 517 ASCII chars followed by an astral emoji place code-unit 520 inside the surrogate pair.
+    const value = `${"x".repeat(517)}😀${"y".repeat(1_000)}`;
+    const result = redactPersistedDetailString(value, 520);
+
+    // Any isolated surrogate half would make encodeURIComponent throw.
+    expect(() => encodeURIComponent(result)).not.toThrow();
+    expect(result).toContain("truncated");
+    expect(result).not.toMatch(
+      /[\uD800-\uDFFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+    );
+  });
+
+  it("keeps short astral strings intact", () => {
+    const value = "start 🌍 end";
+    const result = redactPersistedDetailString(value, 2_000);
+    expect(result).toBe(value);
+    expect(() => encodeURIComponent(result)).not.toThrow();
+  });
+
+  it("emits well-formed output when the value is mostly astral characters", () => {
+    const value = "🎉".repeat(3_000);
+    const result = redactPersistedDetailString(value, 600);
+    expect(() => encodeURIComponent(result)).not.toThrow();
+    expect(result).toContain("truncated");
+    expect(result.length).toBeLessThan(value.length);
+  });
+
+  it("preserves ASCII truncation behavior", () => {
+    const value = "a".repeat(10_000);
+    const result = redactPersistedDetailString(value, 520);
+    expect(result).toContain("truncated");
+    expect(result).toMatch(/\[OpenClaw persisted detail truncated: \d+ original chars omitted\]$/);
+    expect(() => encodeURIComponent(result)).not.toThrow();
   });
 });

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -5,6 +5,7 @@
  */
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   boundedJsonUtf8Bytes,
   firstEnumerableOwnKeys,
@@ -151,7 +152,7 @@ function originalDetailsSizeFields(size: BoundedJsonUtf8Bytes): Record<string, n
     : { originalDetailsBytesAtLeast: size.bytes };
 }
 
-function redactPersistedDetailString(
+export function redactPersistedDetailString(
   value: string,
   maxChars = MAX_PERSISTED_DETAIL_STRING_CHARS,
   redactionConfig?: ToolResultDetailRedactionConfig,
@@ -160,9 +161,11 @@ function redactPersistedDetailString(
     return redactToolPayloadTextWithConfig(value, redactionConfig);
   }
 
-  const scan = `${value.slice(0, maxChars)}${PERSISTED_DETAIL_REDACTION_BOUNDARY}${value.slice(
-    maxChars,
-    maxChars + MAX_PERSISTED_DETAIL_REDACTION_LOOKAHEAD_CHARS,
+  const initialPrefix = sliceUtf16Safe(value, 0, maxChars);
+  const scan = `${initialPrefix}${PERSISTED_DETAIL_REDACTION_BOUNDARY}${sliceUtf16Safe(
+    value,
+    initialPrefix.length,
+    initialPrefix.length + MAX_PERSISTED_DETAIL_REDACTION_LOOKAHEAD_CHARS,
   )}`;
   const redactedScan = redactToolPayloadTextWithConfig(scan, redactionConfig);
   const boundaryIndex = redactedScan.indexOf(PERSISTED_DETAIL_REDACTION_BOUNDARY);
@@ -174,7 +177,7 @@ function redactPersistedDetailString(
     0,
     maxChars - Math.min(maxChars, MAX_PERSISTED_DETAIL_BOUNDARY_OVERLAP_CHARS),
   );
-  const initialPersistedPrefix = redactedPrefix.slice(0, safePrefixChars);
+  const initialPersistedPrefix = sliceUtf16Safe(redactedPrefix, 0, safePrefixChars);
   const persistedPrefix =
     PARTIAL_STRUCTURED_SECRET_VALUE_RE.test(initialPersistedPrefix) ||
     PARTIAL_PRIVATE_KEY_BLOCK_RE.test(initialPersistedPrefix)


### PR DESCRIPTION
## What Problem This Solves

Fixes a case where persisted tool-result detail strings could be truncated on an invalid UTF-16 boundary, producing isolated surrogate halves when the detail text contains astral characters (e.g., emoji).

## Why This Change Was Made

`redactPersistedDetailString` used raw `String.prototype.slice` for the persisted prefix and the redacted-prefix clamp. This can split surrogate pairs. The function now uses the repository's existing `sliceUtf16Safe` helper for both cuts, and the lookahead window starts from the actual safe prefix length rather than the raw `maxChars` cap. The helper is also exported so it can be covered by direct unit tests.

## User Impact

Persisted tool-result `details` metadata remains valid, well-formed UTF-16 even when the raw detail text contains non-BMP characters.

## Evidence

- Exported `redactPersistedDetailString` from `src/agents/session-tool-result-guard.ts`.
- Replaced raw `slice` calls with `sliceUtf16Safe` at the persisted-prefix and final-prefix clamp positions.
- Added regression tests in `src/agents/session-tool-result-guard.test.ts` covering a surrogate-pair split at the truncation boundary, short astral strings, mostly-astral inputs, and ASCII baseline behavior.
- Focused tests pass: `node scripts/run-vitest.mjs src/agents/session-tool-result-guard.test.ts`.
- Lint clean: `node scripts/run-oxlint.mjs src/agents/session-tool-result-guard.ts src/agents/session-tool-result-guard.test.ts`.

## Real behavior proof

- **Behavior addressed:** Before the patch, a detail string whose 520th UTF-16 code unit fell inside an emoji surrogate pair would have produced an isolated high or low surrogate in the persisted output. After the patch the prefix is clamped to the nearest safe boundary.
- **Real environment tested:** Local checkout of `fix/session-tool-result-guard-utf16` at `6b03629f4c`.
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx -e 'import { redactPersistedDetailString } from "./src/agents/session-tool-result-guard.ts"; const samples = ["short 🌍 end", "x".repeat(517) + "😀" + "y".repeat(1000), "a".repeat(10000)]; for (const v of samples) { const r = redactPersistedDetailString(v, 520); try { encodeURIComponent(r); console.log("encodeURIComponent ok"); } catch (e) { console.log("encodeURIComponent FAILED", e); } console.log(JSON.stringify(r)); }'
  ```
  And to verify the redacted output survives a real disk write/read round-trip:
  ```bash
  node --import tsx -e 'import { redactPersistedDetailString } from "./src/agents/session-tool-result-guard.ts"; import { writeFileSync, readFileSync, mkdtempSync } from "node:fs"; import { tmpdir } from "node:os"; import { join } from "node:path"; const f = join(mkdtempSync(join(tmpdir(), "pdg-")), "persisted.txt"); const samples = ["short 🌍 end", "x".repeat(517) + "😀" + "y".repeat(1000), "a".repeat(10000)]; const redacted = samples.map((v) => redactPersistedDetailString(v, 520)); writeFileSync(f, redacted.join("\n----\n"), "utf8"); const r = readFileSync(f, "utf8"); console.log(r); console.log("round-trip ok:", r === redacted.join("\n----\n"));'
  ```
- **Evidence after fix:**
  ```
  encodeURIComponent ok
  "short 🌍 end"
  encodeURIComponent ok
  "xxxxxxxx\n[OpenClaw persisted detail redacted: boundary overlap omitted]\n\n[OpenClaw persisted detail truncated: 999 original chars omitted]"
  encodeURIComponent ok
  "aaaaaaaa\n[OpenClaw persisted detail redacted: boundary overlap omitted]\n\n[OpenClaw persisted detail truncated: 9480 original chars omitted]"

  short 🌍 end
  ----
  xxxxxxxx
  [OpenClaw persisted detail redacted: boundary overlap omitted]

  [OpenClaw persisted detail truncated: 999 original chars omitted]
  ----
  aaaaaaaa
  [OpenClaw persisted detail redacted: boundary overlap omitted]

  [OpenClaw persisted detail truncated: 9480 original chars omitted]
  round-trip ok: true
  ```
- **Observed result after fix:** The regression test `does not split UTF-16 surrogate pairs at the truncation boundary` passes, `encodeURIComponent` succeeds on every redacted sample, and the redacted values survive a disk write/read round-trip.
- **What was not tested:** No live oversized tool-result ingestion path; change is a pure string-formatting helper inside the guard.

_AI-assisted PR: changes and tests were generated with AI assistance and manually reviewed._
