### PR TITLE
fix(ci): align session freshness fixtures with SQLite

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -11,6 +11,7 @@ import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
+  appendTranscriptEvent,
   listSessionEntries,
   loadSessionEntry,
   replaceSessionEntry,
@@ -385,17 +386,23 @@ async function writeTerminalTranscriptSessionStore(params: {
   omitStatus?: boolean;
   updatedAt: number;
   endedAt: number;
-  transcriptMtimeMs: number;
+  transcriptMutationOrder: "after-registry" | "before-registry";
 }): Promise<void> {
   const sessionFile = `${params.sessionId}.jsonl`;
-  const transcriptPath = path.join(path.dirname(params.storePath), sessionFile);
-  await fs.writeFile(
-    transcriptPath,
-    `${JSON.stringify({ type: "session", id: params.sessionId })}\n`,
-    "utf-8",
-  );
-  await fs.utimes(transcriptPath, params.transcriptMtimeMs / 1000, params.transcriptMtimeMs / 1000);
   const status = params.status ?? (params.omitStatus ? undefined : "done");
+  const appendTranscript = () =>
+    appendTranscriptEvent(
+      {
+        agentId: "main",
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+      },
+      { type: "custom", timestamp: "1970-01-01T00:00:00.001Z" },
+    );
+  if (params.transcriptMutationOrder === "before-registry") {
+    await appendTranscript();
+  }
   await writeSessionStoreFast(params.storePath, {
     [params.sessionKey]: {
       sessionId: params.sessionId,
@@ -407,6 +414,9 @@ async function writeTerminalTranscriptSessionStore(params: {
       ...(status ? { status } : {}),
     },
   });
+  if (params.transcriptMutationOrder === "after-registry") {
+    await appendTranscript();
+  }
 }
 
 function setMinimalCurrentConversationBindingRegistryForTests(): void {
@@ -2344,36 +2354,36 @@ describe("initSessionState reset policy", () => {
 
   it.each([
     {
-      name: "non-main terminal rows ignore transcript mtime",
+      name: "non-main terminal rows ignore later transcript mutations",
       sessionKey: "agent:main:whatsapp:dm:terminal-entry",
       updatedAtOffsetMs: -5_000,
       endedAtOffsetMs: -6_000,
-      transcriptMtimeOffsetMs: -3_000,
+      transcriptMutationOrder: "after-registry" as const,
       expectNewSession: false,
     },
     {
-      name: "main status-done terminal rows reuse when transcript is newer than updatedAt",
+      name: "main status-done terminal rows reuse after a later transcript mutation",
       sessionKey: "agent:main:main",
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
-      transcriptMtimeOffsetMs: 0,
+      transcriptMutationOrder: "after-registry" as const,
       expectNewSession: false,
     },
     {
-      name: "main killed terminal rows rotate when transcript is newer than updatedAt",
+      name: "main killed terminal rows rotate after a later transcript mutation",
       sessionKey: "agent:main:main",
       status: "killed" as const,
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
-      transcriptMtimeOffsetMs: 0,
+      transcriptMutationOrder: "after-registry" as const,
       expectNewSession: true,
     },
     {
-      name: "main endedAt-only rows rotate when transcript is newer than updatedAt",
+      name: "main endedAt-only rows rotate after a later transcript mutation",
       sessionKey: "agent:main:main",
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
-      transcriptMtimeOffsetMs: 0,
+      transcriptMutationOrder: "after-registry" as const,
       omitStatus: true,
       expectNewSession: true,
     },
@@ -2383,32 +2393,16 @@ describe("initSessionState reset policy", () => {
       status: "failed" as const,
       updatedAtOffsetMs: -10_000,
       endedAtOffsetMs: -11_000,
-      transcriptMtimeOffsetMs: 0,
+      transcriptMutationOrder: "after-registry" as const,
       expectNewSession: false,
       expectRecovered: true,
     },
     {
-      name: "main terminal rows reuse when updatedAt already reflects the transcript",
+      name: "main terminal rows reuse when the registry observes the transcript mutation",
       sessionKey: "agent:main:main",
       updatedAtOffsetMs: -1_000,
       endedAtOffsetMs: -6_000,
-      transcriptMtimeOffsetMs: -4_000,
-      expectNewSession: false,
-    },
-    {
-      name: "main terminal rows reuse when transcript mtime differs only by sub-millisecond precision",
-      sessionKey: "agent:main:main",
-      updatedAtOffsetMs: -4_000,
-      endedAtOffsetMs: -6_000,
-      transcriptMtimeOffsetMs: -3_999.5,
-      expectNewSession: false,
-    },
-    {
-      name: "main terminal rows reuse when transcript is not newer than updatedAt",
-      sessionKey: "agent:main:main",
-      updatedAtOffsetMs: -10_000,
-      endedAtOffsetMs: -11_000,
-      transcriptMtimeOffsetMs: -15_000,
+      transcriptMutationOrder: "before-registry" as const,
       expectNewSession: false,
     },
   ])("$name", async (scenario) => {
@@ -2427,7 +2421,7 @@ describe("initSessionState reset policy", () => {
       omitStatus: scenario.omitStatus,
       updatedAt: terminalUpdatedAt,
       endedAt: terminalEndedAt,
-      transcriptMtimeMs: now + scenario.transcriptMtimeOffsetMs,
+      transcriptMutationOrder: scenario.transcriptMutationOrder,
     });
 
     const cfg = { session: { store: storePath } } as OpenClawConfig;

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -1,12 +1,15 @@
 // Agent session command tests cover session resolution, agent scoping, and temp-home session stores.
-import fs from "node:fs";
 import path from "node:path";
 import { withTempHome as withTempHomeBase } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it } from "vitest";
 import { resolveAgentDir, resolveSessionAgentId } from "../agents/agent-scope.js";
 import { updateSessionStoreAfterAgentRun } from "../agents/command/session-store.js";
 import { resolveSession } from "../agents/command/session.js";
-import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  appendTranscriptEvent,
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
 import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -197,13 +200,6 @@ describe("agent session resolution", () => {
         const sessionFile = path.join(home, `session-${scenario.label.replaceAll(" ", "-")}.jsonl`);
         const sessionId = `stale-terminal-${scenario.label.replaceAll(" ", "-")}`;
         const registryUpdatedAt = Date.now() - 10_000;
-        fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
-        fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", id: sessionId }) + "\n");
-        fs.utimesSync(
-          sessionFile,
-          (registryUpdatedAt + 5_000) / 1000,
-          (registryUpdatedAt + 5_000) / 1000,
-        );
         await writeSessionStoreSeed(store, {
           [scenario.sessionKey]: {
             sessionId,
@@ -225,6 +221,15 @@ describe("agent session resolution", () => {
             claudeCliSessionId: "old-claude-cli-session",
           },
         });
+        await appendTranscriptEvent(
+          {
+            agentId: "main",
+            sessionId,
+            sessionKey: scenario.sessionKey,
+            storePath: store,
+          },
+          { type: "custom", timestamp: "1970-01-01T00:00:00.001Z" },
+        );
         const cfg = mockConfig(home, store);
         cfg.session = { ...cfg.session, mainKey: scenario.mainKey };
 
@@ -302,12 +307,6 @@ describe("agent session resolution", () => {
       const sessionFile = path.join(home, "explicit-terminal-main.jsonl");
       const sessionId = "explicit-terminal-main";
       const registryUpdatedAt = Date.now() - 10_000;
-      fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", id: sessionId }) + "\n");
-      fs.utimesSync(
-        sessionFile,
-        (registryUpdatedAt + 5_000) / 1000,
-        (registryUpdatedAt + 5_000) / 1000,
-      );
       await writeSessionStoreSeed(store, {
         "agent:main:main": {
           sessionId,
@@ -319,6 +318,15 @@ describe("agent session resolution", () => {
           runtimeMs: 900,
         },
       });
+      await appendTranscriptEvent(
+        {
+          agentId: "main",
+          sessionId,
+          sessionKey: "agent:main:main",
+          storePath: store,
+        },
+        { type: "custom", timestamp: "1970-01-01T00:00:00.001Z" },
+      );
       const cfg = mockConfig(home, store);
 
       const resolution = resolveSession({ cfg, sessionId });

--- a/src/config/sessions/lifecycle.test.ts
+++ b/src/config/sessions/lifecycle.test.ts
@@ -30,9 +30,10 @@ describe("terminal main session transcript freshness", () => {
   });
 
   async function createEntry(params: {
+    endedAt?: number;
     sessionFile?: string;
     sessionKey?: string;
-    status: SessionEntry["status"];
+    status?: SessionEntry["status"];
     updatedAt: number;
   }): Promise<{ entry: SessionEntry; sessionKey: string }> {
     const sessionKey = params.sessionKey ?? "agent:main:main";
@@ -45,8 +46,9 @@ describe("terminal main session transcript freshness", () => {
           env: { OPENCLAW_STATE_DIR: stateDir },
         })}`,
       sessionId,
-      status: params.status,
       updatedAt: params.updatedAt,
+      ...(params.endedAt !== undefined ? { endedAt: params.endedAt } : {}),
+      ...(params.status !== undefined ? { status: params.status } : {}),
     };
     await upsertSessionEntry({ agentId: "main", sessionKey, storePath }, sessionEntry);
     await appendTranscriptEvent(
@@ -64,8 +66,9 @@ describe("terminal main session transcript freshness", () => {
       entry: {
         ...storedEntry,
         sessionFile: sessionEntry.sessionFile,
-        status: params.status,
         updatedAt: params.updatedAt,
+        ...(params.endedAt !== undefined ? { endedAt: params.endedAt } : {}),
+        ...(params.status !== undefined ? { status: params.status } : {}),
       },
       sessionKey,
     };
@@ -106,6 +109,16 @@ describe("terminal main session transcript freshness", () => {
     });
 
     expect(check(entry, sessionKey)).toBe(false);
+  });
+
+  it("rotates endedAt-only main sessions after a later transcript mutation", async () => {
+    const { entry, sessionKey } = await createEntry({
+      endedAt: Date.now() - 20_000,
+      updatedAt: Date.now() - 10_000,
+    });
+
+    expect(entry.status).toBeUndefined();
+    expect(check(entry, sessionKey)).toBe(true);
   });
 
   it("uses SQLite freshness for entries that still contain legacy transcript paths", async () => {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -21,6 +21,7 @@ import {
   testing as subagentRegistryTesting,
 } from "../../agents/subagent-registry.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { SessionTranscriptStats } from "../../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import {
   onDiagnosticEvent,
@@ -71,7 +72,11 @@ const mocks = vi.hoisted(() => ({
   updateSessionStore: vi.fn(),
   applySessionEntryReplacements: vi.fn(),
   patchSessionEntryTarget: vi.fn(),
-  readTranscriptStatsSync: vi.fn(() => ({ eventCount: 0, maxSeq: 0, sizeBytes: 0 })),
+  readTranscriptStatsSync: vi.fn<() => SessionTranscriptStats>(() => ({
+    eventCount: 0,
+    maxSeq: 0,
+    sizeBytes: 0,
+  })),
   agentCommand: vi.fn(),
   clearAgentRunContext: vi.fn(),
   registerAgentRunContext: vi.fn(),
@@ -2154,18 +2159,17 @@ describe("gateway agent handler", () => {
       vi.useFakeTimers({ toFake: ["Date"] });
       dateOnlyFakeClockActive = true;
       vi.setSystemTime(now);
+      mocks.readTranscriptStatsSync.mockReturnValue({
+        eventCount: 1,
+        lastMutationAtMs: now - 1_000,
+        lastObservedMutationAtMs: now - 10_000,
+        maxSeq: 0,
+        sizeBytes: 64,
+      });
 
       await withTempDir({ prefix: "openclaw-gateway-terminal-main-newer-" }, async (root) => {
         const sessionsDir = `${root}/sessions`;
-        await fs.mkdir(sessionsDir, { recursive: true });
         const sessionFile = "terminal-main-session.jsonl";
-        const transcriptPath = `${sessionsDir}/${sessionFile}`;
-        await fs.writeFile(
-          transcriptPath,
-          `${JSON.stringify({ type: "session", id: "terminal-main-session" })}\n`,
-          "utf8",
-        );
-        await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
         mocks.loadSessionEntry.mockReturnValue({
           cfg: {},
           storePath: `${sessionsDir}/sessions.json`,


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI regression where terminal-session test shards fail after session transcript freshness moved from JSONL file mtimes to SQLite mutation metadata.

## Why This Change Was Made

Commit `2f946506bb` correctly restored SQLite-backed terminal freshness, but several caller fixtures still created JSONL files and adjusted their mtimes. This updates those fixtures to append transcript events through the session accessor, adds owner-level coverage for endedAt-only terminal rows, and types the gateway transcript-stats mock against the production contract.

No runtime behavior changes.

## User Impact

No user-visible change. Maintainers regain reliable terminal-session CI coverage, and unrelated PRs are no longer blocked by fixtures that model the retired JSONL-mtime behavior.

## Evidence

- Blacksmith Testbox `tbx_01kxa4v6a0wyee40bn8t6z50gs`
  - `pnpm test:serial src/config/sessions/lifecycle.test.ts src/commands/agent.session.test.ts src/auto-reply/reply/session.test.ts src/gateway/server-methods/agent.test.ts`
  - 4 Vitest shards passed, 623 tests total.
  - `pnpm check:changed -- <four changed files>` passed guards, formatting, core-test typecheck, and lint.
- `gpt-5.6-sol` autoreview at medium reasoning: no accepted/actionable findings, confidence 0.90.
- `git diff --check`

The direct Testbox sync mirrors sparse-checkout omissions as deletions, so the changed gate was intentionally path-scoped to the four real branch changes. The local branch diff contains no app changes.
