### PR TITLE
fix(infra): avoid splitting UTF-16 surrogate pairs in approval fallback short code

### DIFF
--- a/src/infra/approval-native-route-notice.test.ts
+++ b/src/infra/approval-native-route-notice.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   describeApprovalDeliveryDestination,
+  resolveApprovalDeliveryFailedNoticeText,
   resolveApprovalRoutedElsewhereNoticeText,
 } from "./approval-native-route-notice.js";
 
@@ -48,5 +49,36 @@ describe("resolveApprovalRoutedElsewhereNoticeText", () => {
 
   it("suppresses the notice when there are no destinations", () => {
     expect(resolveApprovalRoutedElsewhereNoticeText([])).toBeNull();
+  });
+});
+
+describe("resolveApprovalDeliveryFailedNoticeText", () => {
+  it("truncates long exec approval ids to 8 chars", () => {
+    const notice = resolveApprovalDeliveryFailedNoticeText({
+      approvalId: "exec-1234567890",
+      approvalKind: "exec",
+    });
+    expect(notice).toContain("/approve exec-123 allow-once|allow-always|deny");
+  });
+
+  it("keeps short plugin approval ids intact", () => {
+    const notice = resolveApprovalDeliveryFailedNoticeText({
+      approvalId: "deploy",
+      approvalKind: "plugin",
+    });
+    expect(notice).toContain("/approve deploy allow-once|allow-always|deny");
+  });
+
+  it("does not split UTF-16 surrogate pairs when truncating exec ids", () => {
+    const id = "exec-12😀34567890";
+    const notice = resolveApprovalDeliveryFailedNoticeText({
+      approvalId: id,
+      approvalKind: "exec",
+    });
+    expect(() => encodeURIComponent(notice)).not.toThrow();
+    expect(notice).not.toMatch(
+      /[\uD800-\uDFFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+    );
+    expect(notice).toContain("use the full id in /approve");
   });
 });

--- a/src/infra/approval-native-route-notice.ts
+++ b/src/infra/approval-native-route-notice.ts
@@ -1,5 +1,7 @@
 // Formats native-route approval notices shown when command approvals leave the current channel.
+
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatHumanList } from "../shared/human-list.js";
 import type { ChannelApprovalNativePlannedTarget } from "./approval-native-delivery.js";
 
@@ -37,7 +39,7 @@ export function resolveApprovalDeliveryFailedNoticeText(params: {
 }): string {
   const commandId =
     params.approvalKind === "exec" && params.approvalId.length > 8
-      ? params.approvalId.slice(0, 8)
+      ? sliceUtf16Safe(params.approvalId, 0, 8)
       : params.approvalId;
   // Exec approval ids are long command ids in chat UX; plugin ids can be short
   // semantic ids, so only shorten exec ids and keep the full-id fallback visible.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the fallback `/approve <short-code>` notice could emit isolated UTF-16 surrogate halves when an exec approval id contains astral characters (e.g., emoji).

## Why This Change Was Made

`resolveApprovalDeliveryFailedNoticeText` truncated long exec approval ids with raw `String.prototype.slice(0, 8)`, which can bisect surrogate pairs. It now uses the repository's existing `sliceUtf16Safe` helper so the short code always falls on a valid UTF-16 boundary.

## User Impact

The native-approval fallback notice shown in chat remains well-formed when approval/command ids contain non-BMP characters.

## Evidence

- Replaced `params.approvalId.slice(0, 8)` with `sliceUtf16Safe(params.approvalId, 0, 8)` in `src/infra/approval-native-route-notice.ts`.
- Added regression tests in `src/infra/approval-native-route-notice.test.ts` covering ASCII truncation, short plugin ids, and astral boundary cases.
- Focused tests pass: `node scripts/run-vitest.mjs src/infra/approval-native-route-notice.test.ts`.
- Lint clean: `node scripts/run-oxlint.mjs src/infra/approval-native-route-notice.ts src/infra/approval-native-route-notice.test.ts`.

## Real behavior proof

- **Behavior addressed:** Before the patch, an exec approval id like `"exec-12😀34567890"` would have produced a short code containing an isolated surrogate half. After the patch it returns `"exec-12"`.
- **Real environment tested:** Local checkout of `fix/approval-fallback-utf16` at `40c501cd06`.
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx -e 'import { resolveApprovalDeliveryFailedNoticeText } from "./src/infra/approval-native-route-notice.ts"; const samples = [{id:"exec-1234567890",kind:"exec"}, {id:"deploy",kind:"plugin"}, {id:"exec-12😀34567890",kind:"exec"}]; for (const s of samples) { const n = resolveApprovalDeliveryFailedNoticeText({approvalId:s.id, approvalKind:s.kind}); try { encodeURIComponent(n); console.log("encodeURIComponent ok"); } catch(e){ console.log("FAIL", e); } console.log(n); console.log("---"); }'
  ```
  And to verify the notices survive a real disk write/read round-trip:
  ```bash
  node --import tsx -e 'import { resolveApprovalDeliveryFailedNoticeText } from "./src/infra/approval-native-route-notice.ts"; import { writeFileSync, readFileSync, mkdtempSync } from "node:fs"; import { tmpdir } from "node:os"; import { join } from "node:path"; const f = join(mkdtempSync(join(tmpdir(), "apr-")), "notice.txt"); const samples = [{id:"exec-1234567890",kind:"exec"}, {id:"deploy",kind:"plugin"}, {id:"exec-12😀34567890",kind:"exec"}]; const notices = samples.map((s) => resolveApprovalDeliveryFailedNoticeText({approvalId:s.id, approvalKind:s.kind})); writeFileSync(f, notices.join("\n====\n"), "utf8"); const r = readFileSync(f, "utf8"); console.log(r); console.log("round-trip ok:", r === notices.join("\n====\n"));'
  ```
- **Evidence after fix:**
  ```
  encodeURIComponent ok
  Approval required. I could not deliver the native approval request.
  Reply with: /approve exec-123 allow-once|allow-always|deny
  If the short code is ambiguous, use the full id in /approve.
  ---
  encodeURIComponent ok
  Approval required. I could not deliver the native approval request.
  Reply with: /approve deploy allow-once|allow-always|deny
  If the short code is ambiguous, use the full id in /approve.
  ---
  encodeURIComponent ok
  Approval required. I could not deliver the native approval request.
  Reply with: /approve exec-12 allow-once|allow-always|deny
  If the short code is ambiguous, use the full id in /approve.
  ---

  Approval required. I could not deliver the native approval request.
  Reply with: /approve exec-123 allow-once|allow-always|deny
  If the short code is ambiguous, use the full id in /approve.
  ====
  Approval required. I could not deliver the native approval request.
  Reply with: /approve deploy allow-once|allow-always|deny
  If the short code is ambiguous, use the full id in /approve.
  ====
  Approval required. I could not deliver the native approval request.
  Reply with: /approve exec-12 allow-once|allow-always|deny
  If the short code is ambiguous, use the full id in /approve.
  round-trip ok: true
  ```
- **Observed result after fix:** The regression test `does not split UTF-16 surrogate pairs when truncating exec ids` passes, `encodeURIComponent` succeeds on every notice, and the notices survive a disk write/read round-trip.
- **What was not tested:** No live native-approval delivery failure path; change is a pure string-formatting helper.

_AI-assisted PR: changes and tests were generated with AI assistance and manually reviewed._
