### PR TITLE
fix(channels): add idempotency guard to nack() callback (#104903)

### DIFF
--- a/scripts/verify-nack-idempotency.ts
+++ b/scripts/verify-nack-idempotency.ts
@@ -1,0 +1,111 @@
+/**
+ * Real-behavior verification for nack() idempotency guard.
+ *
+ * Runs the production receive module through the tsx loader to prove:
+ * 1. Duplicate sequential nack calls invoke onNack only once.
+ * 2. A rejected onNack callback leaves the context retryable.
+ * 3. The ack-to-nack transition is preserved.
+ *
+ * Usage: node --import tsx scripts/verify-nack-idempotency.ts
+ */
+import { createMessageReceiveContext } from "../src/channels/message/receive.js";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, label: string): void {
+  if (condition) {
+    passed += 1;
+    console.log(`  \x1b[32m✓\x1b[0m ${label}`);
+  } else {
+    failed += 1;
+    console.error(`  \x1b[31m✗ FAIL\x1b[0m: ${label}`);
+  }
+}
+
+async function main() {
+  console.log("\n=== nack() idempotency real-behavior verification ===\n");
+
+  // ── Test 1: duplicate sequential nack ──
+  console.log("Test 1: Duplicate sequential nack calls onNack only once");
+  {
+    let callCount = 0;
+    const ctx = createMessageReceiveContext({
+      id: "real-1",
+      channel: "telegram",
+      message: { text: "hello" },
+      onNack: async () => {
+        callCount += 1;
+      },
+    });
+
+    await ctx.nack(new Error("first"));
+    assert(callCount === 1, "onNack called once after first nack");
+    assert(ctx.ackState === "nacked", "ackState is 'nacked'");
+    assert(ctx.nackErrorMessage === "first", "nackErrorMessage preserved");
+
+    await ctx.nack(new Error("second"));
+    assert(callCount === 1, "onNack still called only once after duplicate nack");
+    assert(ctx.ackState === "nacked", "ackState remains 'nacked'");
+    assert(ctx.nackErrorMessage === "first", "first error message preserved");
+  }
+
+  // ── Test 2: rejected callback remains retryable ──
+  console.log("\nTest 2: Rejected onNack callback leaves context retryable");
+  {
+    let attempts = 0;
+    const ctx = createMessageReceiveContext({
+      id: "real-2",
+      channel: "telegram",
+      message: { text: "hello" },
+      onNack: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error("transient nack failure");
+        }
+      },
+    });
+
+    await ctx.nack(new Error("receive failed")).catch(() => {});
+    assert(attempts === 1, "onNack called once (first attempt rejected)");
+    assert(ctx.ackState === "pending", "ackState stays 'pending' after rejection");
+    assert(ctx.nackErrorMessage === undefined, "nackErrorMessage not set after rejection");
+
+    await ctx.nack(new Error("receive failed"));
+    assert(attempts === 2, "onNack called again on retry");
+    assert(ctx.ackState === "nacked", "ackState transitions to 'nacked' after success");
+    assert(ctx.nackErrorMessage === "receive failed", "nackErrorMessage set after success");
+  }
+
+  // ── Test 3: ack-to-nack transition preserved ──
+  console.log("\nTest 3: ack-to-nack transition preserved");
+  {
+    let nackCalls = 0;
+    const ctx = createMessageReceiveContext({
+      id: "real-3",
+      channel: "telegram",
+      message: { text: "hello" },
+      onAck: async () => {},
+      onNack: async () => {
+        nackCalls += 1;
+      },
+    });
+
+    await ctx.ack();
+    assert(ctx.ackState === "acked", "ackState is 'acked' after ack()");
+
+    await ctx.nack(new Error("post-ack failure"));
+    assert(nackCalls === 1, "onNack called once after ack-to-nack transition");
+    assert(ctx.ackState === "nacked", "ackState transitions to 'nacked' from 'acked'");
+    assert(ctx.nackErrorMessage === "post-ack failure", "nackErrorMessage set");
+  }
+
+  // ── Summary ──
+  console.log(`\n=== Results: ${passed} passed, ${failed} failed ===\n`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err: unknown) => {
+  console.error("Verification error:", err);
+  process.exit(1);
+});

--- a/src/channels/message/lifecycle.test.ts
+++ b/src/channels/message/lifecycle.test.ts
@@ -372,6 +372,60 @@ describe("message lifecycle primitives", () => {
     expect(ctx.nackErrorMessage).toBe("offset failed");
   });
 
+  it("nack is idempotent and does not re-trigger onNack callback", async () => {
+    const onNack = vi.fn(async () => undefined);
+    const ctx = createMessageReceiveContext({
+      id: "rx-nack-idempotent",
+      channel: "telegram",
+      message: { text: "hello" },
+      onNack,
+    });
+
+    const firstError = new Error("first nack");
+    await ctx.nack(firstError);
+    expect(onNack).toHaveBeenCalledTimes(1);
+    expect(onNack).toHaveBeenCalledWith(firstError);
+    expect(ctx.ackState).toBe("nacked");
+    expect(ctx.nackErrorMessage).toBe("first nack");
+
+    const secondError = new Error("second nack");
+    await ctx.nack(secondError);
+    // onNack must not fire again for duplicate nack calls
+    expect(onNack).toHaveBeenCalledTimes(1);
+    // First nack's error and state are preserved
+    expect(ctx.ackState).toBe("nacked");
+    expect(ctx.nackErrorMessage).toBe("first nack");
+  });
+
+  it("retries nack when onNack callback rejects", async () => {
+    let calls = 0;
+    const onNack = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("nack callback transient failure");
+      }
+    });
+    const ctx = createMessageReceiveContext({
+      id: "rx-nack-retry",
+      channel: "telegram",
+      message: { text: "hello" },
+      onNack,
+    });
+
+    const nackErr = new Error("receive failed");
+    await ctx.nack(nackErr).catch(() => undefined);
+    // onNack rejected → state must stay unchanged so callers can retry
+    expect(ctx.ackState).toBe("pending");
+    expect(ctx.nackErrorMessage).toBeUndefined();
+    expect(onNack).toHaveBeenCalledTimes(1);
+
+    // Retry: onNack succeeds this time → nack completes
+    await ctx.nack(nackErr);
+    expect(onNack).toHaveBeenCalledTimes(2);
+    expect(ctx.ackState).toBe("nacked");
+    expect(ctx.nackErrorMessage).toBe("receive failed");
+  });
+
   it("maps ack policies to lifecycle stages", () => {
     expect(shouldAckMessageAfterStage("after_receive_record", "receive_record")).toBe(true);
     expect(shouldAckMessageAfterStage("after_receive_record", "agent_dispatch")).toBe(false);

--- a/src/channels/message/receive.ts
+++ b/src/channels/message/receive.ts
@@ -88,6 +88,11 @@ export function createMessageReceiveContext<TMessage>(params: {
       delete ctx.nackErrorMessage;
     },
     nack: async (error) => {
+      // Nack callbacks must be idempotent because receive pipelines may
+      // revisit completed stages and retry after nack.
+      if (ctx.ackState === "nacked") {
+        return;
+      }
       await params.onNack?.(error);
       ctx.ackState = "nacked";
       ctx.nackErrorMessage = normalizeAckErrorMessage(error);


### PR DESCRIPTION
## Summary

Repeated sequential calls to a channel message receive context's `nack()` invoke `onNack` more than once. Add an already-nacked guard so completed nack side effects run once, while preserving the existing ack-to-nack transition and callback-retry contract.

- Problem: `nack()` unconditionally calls `await params.onNack?.(error)` and only sets `ackState = "nacked"` after the callback succeeds. A second sequential call repeats the completed callback.
- Solution: Add `if (ctx.ackState === "nacked") return;` before the callback — the narrowest guard that preserves ack-to-nack and retry-after-rejection.
- What changed: `src/channels/message/receive.ts` (+5 guard + comment), `src/channels/message/lifecycle.test.ts` (+54: duplicate-nack test, rejected-callback retry test), `scripts/verify-nack-idempotency.ts` (+109: standalone tsx verification script)
- What did NOT change: The ack-to-nack transition (ack → nack still works), retry-after-rejection (a rejected callback keeps the context pending), the public SDK contract shape

## Change Type & Scope

### Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

### Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue

- Fixes #104903
- [x] This PR fixes a bug or regression

## Motivation

The shared `nack()` implementation in the channel message receive context is part of the public plugin SDK used by bundled channels (Telegram, LINE) and third-party plugins. The `ack()` method already has an idempotency guard (`if (ctx.ackState === "acked") return;`), but `nack()` was shipped without equivalent protection. Receive pipelines that revisit a completed failed stage can trigger duplicate `onNack` callbacks, leading to repeated error handling, cleanup, or logging.

## Review Contract

```text
Ref: #104903 / PR #104919 (competing, needs proof)
Surface: channels / message receive lifecycle

Bug: Completed sequential nack() calls invoke onNack callback more than once.
Cause: nack() unconditionally calls await onNack before setting ackState to "nacked",
       with no already-nacked guard. Confirmed in both v2026.6.11 and current main.
Provenance:
  introduced by: 8bfabd6bb139 — 2026-05-06
  made visible by: v2026.6.11 (shipped)
  Confidence: clear

Best fix: Yes. The shared receive-context guard is the narrowest owner-level fix.
  A pending-only guard (ackState !== "pending") would be broader but breaks the
  existing ack-to-nack transition tested since introduction.
Refactor: No
Proof: Real terminal output (tsx production-module verification + vitest suite)
Risk: None — the guard gates only completed nack paths; the Telegram
  bot-update-tracker and LINE webhook callers all invoke nack() exactly once
  per context, so production behavior is unchanged.
```

## Real Behavior Proof

**Behavior addressed**: Completed sequential `nack()` calls invoked `onNack` repeatedly; a second call after a successful first nack would re-fire the callback.

**Real environment tested**: Linux x86_64, Node 24.13.1, `fix/nack-idempotency-guard-104903` branch, production TS module loaded via `node --import tsx`.

**Exact steps or command run after this patch**:

```bash
# Standalone production-module verification (no vitest)
$ node --import tsx scripts/verify-nack-idempotency.ts

# Focused lifecycle regression suite
$ node scripts/run-vitest.mjs src/channels/message/lifecycle.test.ts

# Real Telegram caller regression suite
$ node scripts/run-vitest.mjs extensions/telegram/src/bot-update-tracker.test.ts
```

**Evidence after fix**:

```console
$ node --import tsx scripts/verify-nack-idempotency.ts

=== nack() idempotency real-behavior verification ===

Test 1: Duplicate sequential nack calls onNack only once
  ✓ onNack called once after first nack
  ✓ ackState is 'nacked'
  ✓ nackErrorMessage preserved
  ✓ onNack still called only once after duplicate nack
  ✓ ackState remains 'nacked'
  ✓ first error message preserved

Test 2: Rejected onNack callback leaves context retryable
  ✓ onNack called once (first attempt rejected)
  ✓ ackState stays 'pending' after rejection
  ✓ nackErrorMessage not set after rejection
  ✓ onNack called again on retry
  ✓ ackState transitions to 'nacked' after success
  ✓ nackErrorMessage set after success

Test 3: ack-to-nack transition preserved
  ✓ ackState is 'acked' after ack()
  ✓ onNack called once after ack-to-nack transition
  ✓ ackState transitions to 'nacked' from 'acked'
  ✓ nackErrorMessage set

=== Results: 16 passed, 0 failed ===
```

```console
$ node scripts/run-vitest.mjs src/channels/message/lifecycle.test.ts

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Duration  852ms

[test] passed 1 Vitest shard in 6.11s
```

```console
$ node scripts/run-vitest.mjs extensions/telegram/src/bot-update-tracker.test.ts

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Duration  15.44s

[test] passed 1 Vitest shard in 21.48s
```

Matrix evidence:

```
nack call sequence                    => onNack calls  ackState
nack("err1")                          => 1             "nacked"
nack("err1") → nack("err2")          => 1             "nacked"
ack() → nack("err")                   => 1             "nacked"
nack("err") → reject → nack("err")   => 2             "nacked"
```

**Observed result after fix**:

- Duplicate successful sequential nack calls invoke `onNack` exactly once
- First nack's error message and state are preserved for duplicate calls
- A rejected `onNack` callback leaves `ackState` as "pending", allowing retry
- The ack-to-nack transition (tested since the SDK was introduced) still works

**What was not tested**:

- Live Telegram/LINE webhook end-to-end delivery (requires production bot tokens)
- Concurrent nack calls from separate async contexts (single-context by design)
- Broad remote changed-files gate (Blacksmith Testbox unavailable locally)

### Verification environment

- OS: Linux x86_64 (4.19.112-2.el8)
- Runtime: Node 24.13.1
- Integration/channel: Telegram tracker, LINE webhook (via vitest suites)
- Relevant config (redacted): N/A — no credentials needed for this code path

## Risks and Mitigations

- **Highest risk area**: None — the guard gates only already-completed nack paths. The three production callers (Telegram `bot-update-tracker.ts`, LINE `webhook.ts`, LINE `webhook-node.ts`) each call `nack()` exactly once per receive context, so no existing behavior changes.
- **Mitigation**: The guard intentionally preserves both the ack-to-nack transition and retry-after-rejection because state mutation remains after `await onNack`. All 26 focused tests (18 lifecycle + 8 Telegram tracker) pass.
- **Compatibility impact**: None. The public `MessageReceiveContext` type and `createMessageReceiveContext` factory signature are unchanged. Third-party plugins using the SDK see the same contract with fixed idempotency.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Human Verification

- **Verified scenarios**: Duplicate sequential nack, rejected callback retry, ack-to-nack transition, Telegram failure-completion path
- **Edge cases checked**: nack after ack, nack after nack, nack with throwing callback, nack with undefined error
- **What you did NOT verify**: Live channel webhook delivery (requires real bot credentials), concurrent multi-context nack scenarios

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Identified missing idempotency guard by comparing ack() vs nack() implementations in `src/channels/message/receive.ts`. ClawSweeper issue review confirmed the already-nacked approach over a broader pending-only guard.
