### PR TITLE
fix(acpx): drain leased descendants when turns are aborted

### DIFF
--- a/docs/refactor/acp.md
+++ b/docs/refactor/acp.md
@@ -290,7 +290,7 @@ the next release window should eventually retire the fallback.
 
 - Closing an old or stale ACPX session cannot kill another Gateway's process.
 - Parent death does not leave stubborn adapter grandchildren running.
-- `cancel` aborts the active turn without closing reusable sessions.
+- `cancel` aborts the active turn, drains its process lease, and closes the live runtime handle while preserving resumable session metadata.
 - `sessions_list` can show requester-owned cross-agent ACP children under both
   `tree` and `all`.
 - Startup cleanup is driven by leases, not broad command-string scans.

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -155,9 +155,10 @@ Quick `/acp` flow from chat:
     - Task maintenance closes terminal or orphaned parent-owned one-shot ACP sessions. Persistent ACP sessions are preserved while an active conversation binding remains; stale persistent sessions without an active binding are closed so they cannot be silently resumed after the owning task is done or its task record is gone.
     - Bound follow-up messages go directly to the ACP session until the binding is closed, unfocused, reset, or expired.
     - Gateway commands stay local. `/acp ...`, `/status`, and `/unfocus` are never sent as normal prompt text to a bound ACP harness.
-    - `cancel` aborts the active turn when the backend supports cancellation; it does not delete the binding or session metadata.
+    - `cancel` aborts the active turn, starts protocol interruption without letting it gate containment, closes the live runtime handle, and keeps the binding/session metadata available so a later turn can reopen or resume safely.
     - `close` ends the ACP session from OpenClaw's point of view and removes the binding. A harness may still keep its own upstream history if it supports resume.
-    - The acpx plugin cleans up OpenClaw-owned wrapper and adapter process trees after `close`, and reaps stale OpenClaw-owned ACPX orphans during Gateway startup.
+    - The acpx plugin cleans up OpenClaw-owned wrapper, adapter, and detached descendant processes after `cancel` or `close`. Cleanup combines the live parent tree with inherited lease/gateway identity, escalates from `SIGTERM` to `SIGKILL`, and fails the cancellation instead of reporting success when ownership cannot be verified or drained. The same lease cleanup runs for stale ACPX work during Gateway startup.
+    - When ACP cleanup cannot be verified, `/stop` reports a containment failure instead of the normal “Agent was aborted” success text. Inspect the Gateway logs and stop the remaining owned process before continuing that session.
     - Idle runtime workers are eligible for cleanup after `acp.runtime.ttlMinutes`; stored session metadata remains available for `/acp sessions`.
 
   </Accordion>

--- a/extensions/acpx/src/process-reaper.real.test.ts
+++ b/extensions/acpx/src/process-reaper.real.test.ts
@@ -1,0 +1,111 @@
+import { spawn } from "node:child_process";
+// ACPX real-process tests cover lease cleanup after session detachment.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OPENCLAW_ACPX_LEASE_ID_ENV, OPENCLAW_GATEWAY_INSTANCE_ID_ENV } from "./process-lease.js";
+import { cleanupOpenClawOwnedAcpxProcessTree } from "./process-reaper.js";
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(process.platform === "win32")("ACPX lease process reaping", () => {
+  const cleanupDirs = new Set<string>();
+  const cleanupPids = new Set<number>();
+
+  afterEach(async () => {
+    for (const pid of cleanupPids) {
+      if (!isProcessAlive(pid)) {
+        continue;
+      }
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+    cleanupPids.clear();
+    await Promise.all(
+      Array.from(cleanupDirs, async (directory) => {
+        await fs.rm(directory, { force: true, recursive: true });
+      }),
+    );
+    cleanupDirs.clear();
+  });
+
+  it("reaps a reparented detached descendant by inherited lease identity", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acpx-lease-test-"));
+    cleanupDirs.add(tempDir);
+    const pidFile = path.join(tempDir, "child.pid");
+    const leaseId = `lease-${process.pid}-${Date.now()}`;
+    const gatewayInstanceId = `gateway-${process.pid}-${Date.now()}`;
+    const launcher = spawn(
+      process.execPath,
+      [
+        "-e",
+        [
+          'const fs = require("node:fs");',
+          'const { spawn } = require("node:child_process");',
+          'const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {',
+          "  detached: true,",
+          '  stdio: "ignore",',
+          "  env: process.env,",
+          "});",
+          "child.unref();",
+          "fs.writeFileSync(process.argv[1], String(child.pid));",
+        ].join(" "),
+        pidFile,
+      ],
+      {
+        env: {
+          ...process.env,
+          [OPENCLAW_ACPX_LEASE_ID_ENV]: leaseId,
+          [OPENCLAW_GATEWAY_INSTANCE_ID_ENV]: gatewayInstanceId,
+        },
+        stdio: "ignore",
+      },
+    );
+    const launcherPid = launcher.pid;
+    if (!launcherPid) {
+      throw new Error("launcher pid unavailable");
+    }
+    await new Promise<void>((resolve, reject) => {
+      launcher.once("error", reject);
+      launcher.once("exit", () => resolve());
+    });
+
+    await vi.waitFor(
+      async () => {
+        const value = await fs.readFile(pidFile, "utf8");
+        expect(value.trim()).toMatch(/^\d+$/);
+      },
+      { timeout: 5_000 },
+    );
+    const childPid = Number.parseInt((await fs.readFile(pidFile, "utf8")).trim(), 10);
+    cleanupPids.add(childPid);
+    expect(isProcessAlive(childPid)).toBe(true);
+
+    const result = await cleanupOpenClawOwnedAcpxProcessTree({
+      rootPid: launcherPid,
+      rootCommand: "node /tmp/openclaw/acpx/claude-agent-acp-wrapper.mjs",
+      expectedLeaseId: leaseId,
+      expectedGatewayInstanceId: gatewayInstanceId,
+      wrapperRoot: "/tmp/openclaw/acpx",
+    });
+
+    expect(result.inspectedPids).toContain(childPid);
+    expect(result.terminatedPids).toContain(childPid);
+    expect(result.survivingPids ?? []).toStrictEqual([]);
+    await vi.waitFor(() => expect(isProcessAlive(childPid)).toBe(false), { timeout: 5_000 });
+    cleanupPids.delete(childPid);
+    await fs.rm(tempDir, { recursive: true, force: true });
+    cleanupDirs.delete(tempDir);
+  }, 15_000);
+});

--- a/extensions/acpx/src/process-reaper.test.ts
+++ b/extensions/acpx/src/process-reaper.test.ts
@@ -1,12 +1,18 @@
 // ACPX tests cover process reaper plugin behavior.
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
+import {
+  OPENCLAW_ACPX_LEASE_ID_ARG,
+  OPENCLAW_ACPX_LEASE_ID_ENV,
+  OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
+  OPENCLAW_GATEWAY_INSTANCE_ID_ENV,
+} from "./process-lease.js";
 import {
   cleanupOpenClawOwnedAcpxProcessTree,
   isOpenClawLeaseAwareAcpxProcessCommand,
   isOpenClawOwnedAcpxProcessCommand,
   reapStaleOpenClawOwnedAcpxOrphans,
+  testing,
   type AcpxProcessInfo,
 } from "./process-reaper.js";
 
@@ -14,6 +20,7 @@ const WRAPPER_ROOT = "/tmp/openclaw-state/acpx";
 const CODEX_WRAPPER_COMMAND = `node ${WRAPPER_ROOT}/codex-acp-wrapper.mjs`;
 const CODEX_WRAPPER_COMMAND_WITH_LEASE = `${CODEX_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-1 ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-1`;
 const CLAUDE_WRAPPER_COMMAND = `node ${WRAPPER_ROOT}/claude-agent-acp-wrapper.mjs`;
+const LEASE_ENV = `${OPENCLAW_ACPX_LEASE_ID_ENV}=lease-1 ${OPENCLAW_GATEWAY_INSTANCE_ID_ENV}=gateway-1`;
 const PLUGIN_DEPS_CODEX_COMMAND =
   "node /tmp/openclaw/plugin-runtime-deps/node_modules/@zed-industries/codex-acp/bin/codex-acp.js";
 const LOCAL_NODE_MODULES_CODEX_COMMAND = `node ${path.resolve(
@@ -52,6 +59,30 @@ function collectMatching<T, U>(
 }
 
 describe("process reaper", () => {
+  it("parses Windows process inventory without depending on environment output", () => {
+    expect(
+      testing.parseWindowsProcessList(
+        JSON.stringify([
+          {
+            ProcessId: 41,
+            ParentProcessId: 7,
+            CommandLine: '"C:\\Program Files\\node.exe" wrapper.mjs',
+            ExecutablePath: "C:\\Program Files\\node.exe",
+          },
+          {
+            ProcessId: 42,
+            ParentProcessId: 41,
+            CommandLine: null,
+            ExecutablePath: "C:\\Windows\\System32\\conhost.exe",
+          },
+        ]),
+      ),
+    ).toEqual([
+      { pid: 41, ppid: 7, command: '"C:\\Program Files\\node.exe" wrapper.mjs' },
+      { pid: 42, ppid: 41, command: "C:\\Windows\\System32\\conhost.exe" },
+    ]);
+  });
+
   it("recognizes generated Codex and Claude wrappers only under the configured root", () => {
     expect(
       isOpenClawOwnedAcpxProcessCommand({
@@ -161,6 +192,229 @@ describe("process reaper", () => {
     expect(killed[0]).toEqual({ pid: 112, signal: "SIGTERM" });
   });
 
+  it("kills reparented descendants that retain the ACPX lease environment", async () => {
+    const { deps, killed } = cleanupDeps([
+      {
+        pid: 114,
+        ppid: 1,
+        command: `claude -p --permission-mode bypassPermissions ${LEASE_ENV}`,
+      },
+    ]);
+
+    const result = await cleanupOpenClawOwnedAcpxProcessTree({
+      rootPid: 112,
+      rootCommand: CODEX_WRAPPER_COMMAND,
+      expectedLeaseId: "lease-1",
+      expectedGatewayInstanceId: "gateway-1",
+      wrapperRoot: WRAPPER_ROOT,
+      deps,
+    });
+
+    expect(result).toEqual({ inspectedPids: [114], terminatedPids: [114] });
+    expect(killed[0]).toEqual({ pid: 114, signal: "SIGTERM" });
+  });
+
+  it("combines the live wrapper tree with detached lease descendants", async () => {
+    const { deps, killed } = cleanupDeps([
+      { pid: 115, ppid: 1, command: `${CODEX_WRAPPER_COMMAND_WITH_LEASE} ${LEASE_ENV}` },
+      { pid: 116, ppid: 115, command: `node adapter.js ${LEASE_ENV}` },
+      { pid: 117, ppid: 1, command: `claude -p ${LEASE_ENV}` },
+    ]);
+
+    const result = await cleanupOpenClawOwnedAcpxProcessTree({
+      rootPid: 115,
+      rootCommand: CODEX_WRAPPER_COMMAND,
+      expectedLeaseId: "lease-1",
+      expectedGatewayInstanceId: "gateway-1",
+      wrapperRoot: WRAPPER_ROOT,
+      deps,
+    });
+
+    expect(result.inspectedPids).toEqual([115, 116, 117]);
+    expect(
+      collectMatching(
+        killed,
+        (entry) => entry.signal === "SIGTERM",
+        (entry) => entry.pid,
+      ),
+    ).toEqual([117, 116, 115]);
+  });
+
+  it("does not trust a lease marker from another gateway instance", async () => {
+    const { deps, killed } = cleanupDeps([
+      {
+        pid: 118,
+        ppid: 1,
+        command: `${CODEX_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ENV}=lease-1 ${OPENCLAW_GATEWAY_INSTANCE_ID_ENV}=other-gateway`,
+      },
+    ]);
+
+    const result = await cleanupOpenClawOwnedAcpxProcessTree({
+      rootPid: 119,
+      rootCommand: CODEX_WRAPPER_COMMAND,
+      expectedLeaseId: "lease-1",
+      expectedGatewayInstanceId: "gateway-1",
+      wrapperRoot: WRAPPER_ROOT,
+      deps,
+    });
+
+    expect(result.skippedReason).toBe("missing-root");
+    expect(killed).toStrictEqual([]);
+  });
+
+  it("reports owned processes that survive SIGKILL", async () => {
+    const { deps: baseDeps } = cleanupDeps([
+      { pid: 120, ppid: 1, command: `${CODEX_WRAPPER_COMMAND_WITH_LEASE} ${LEASE_ENV}` },
+    ]);
+    const deps = { ...baseDeps, isProcessAlive: vi.fn(() => true) };
+
+    const result = await cleanupOpenClawOwnedAcpxProcessTree({
+      rootPid: 120,
+      rootCommand: CODEX_WRAPPER_COMMAND,
+      expectedLeaseId: "lease-1",
+      expectedGatewayInstanceId: "gateway-1",
+      wrapperRoot: WRAPPER_ROOT,
+      deps,
+    });
+
+    expect(result.survivingPids).toEqual([120]);
+  });
+
+  it("keeps a live PID in survivor verification when both signal calls fail", async () => {
+    const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const result = await cleanupOpenClawOwnedAcpxProcessTree({
+      rootPid: 122,
+      rootCommand: CODEX_WRAPPER_COMMAND,
+      expectedLeaseId: "lease-1",
+      expectedGatewayInstanceId: "gateway-1",
+      wrapperRoot: WRAPPER_ROOT,
+      deps: {
+        listProcesses: vi.fn(async () => [
+          { pid: 122, ppid: 1, command: `${CODEX_WRAPPER_COMMAND_WITH_LEASE} ${LEASE_ENV}` },
+        ]),
+        killProcess: vi.fn((pid, signal) => {
+          killed.push({ pid, signal });
+          throw new Error("signal failed");
+        }),
+        isProcessAlive: vi.fn(() => true),
+        sleep: vi.fn(async () => {}),
+      },
+    });
+
+    expect(killed).toEqual([
+      { pid: 122, signal: "SIGTERM" },
+      { pid: 122, signal: "SIGKILL" },
+    ]);
+    expect(result.terminatedPids).toStrictEqual([]);
+    expect(result.survivingPids).toEqual([122]);
+  });
+
+  it("does not SIGKILL a PID whose lease identity changes during the TERM grace period", async () => {
+    const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const ownedProcess = {
+      pid: 123,
+      ppid: 1,
+      command: `${CODEX_WRAPPER_COMMAND_WITH_LEASE} ${LEASE_ENV}`,
+    };
+    const reusedProcess = {
+      pid: 123,
+      ppid: 1,
+      command: "node unrelated-work.js",
+    };
+    let inventoryReads = 0;
+
+    const result = await cleanupOpenClawOwnedAcpxProcessTree({
+      rootPid: 123,
+      rootCommand: CODEX_WRAPPER_COMMAND,
+      expectedLeaseId: "lease-1",
+      expectedGatewayInstanceId: "gateway-1",
+      wrapperRoot: WRAPPER_ROOT,
+      deps: {
+        listProcesses: vi.fn(async () => {
+          inventoryReads += 1;
+          return inventoryReads === 1 ? [ownedProcess] : [reusedProcess];
+        }),
+        killProcess: vi.fn((pid, signal) => {
+          killed.push({ pid, signal });
+        }),
+        isProcessAlive: vi.fn(() => true),
+        sleep: vi.fn(async () => {}),
+      },
+    });
+
+    expect(killed).toEqual([{ pid: 123, signal: "SIGTERM" }]);
+    expect(result.terminatedPids).toEqual([123]);
+    expect(result.survivingPids ?? []).toStrictEqual([]);
+  });
+
+  it("revalidates a PPID-tree child without environment inventory before escalation", async () => {
+    const processes = [
+      { pid: 124, ppid: 1, command: CODEX_WRAPPER_COMMAND_WITH_LEASE },
+      { pid: 125, ppid: 124, command: "node adapter.js" },
+    ];
+    const alive = new Map([
+      [124, true],
+      [125, true],
+    ]);
+    const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+
+    const result = await cleanupOpenClawOwnedAcpxProcessTree({
+      rootPid: 124,
+      rootCommand: CODEX_WRAPPER_COMMAND,
+      expectedLeaseId: "lease-1",
+      expectedGatewayInstanceId: "gateway-1",
+      wrapperRoot: WRAPPER_ROOT,
+      deps: {
+        listProcesses: vi.fn(async () => processes),
+        killProcess: vi.fn((pid, signal) => {
+          killed.push({ pid, signal });
+          if (signal === "SIGTERM" && pid === 124) {
+            alive.set(pid, false);
+          }
+          if (signal === "SIGKILL") {
+            alive.set(pid, false);
+          }
+        }),
+        isProcessAlive: vi.fn((pid) => alive.get(pid) ?? false),
+        sleep: vi.fn(async () => {}),
+      },
+    });
+
+    expect(killed).toContainEqual({ pid: 125, signal: "SIGKILL" });
+    expect(result.survivingPids ?? []).toStrictEqual([]);
+  });
+
+  it("reports a drained lease after SIGKILL removes a TERM-resistant process", async () => {
+    const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    let processAlive = true;
+    const result = await cleanupOpenClawOwnedAcpxProcessTree({
+      rootPid: 121,
+      rootCommand: CODEX_WRAPPER_COMMAND,
+      expectedLeaseId: "lease-1",
+      expectedGatewayInstanceId: "gateway-1",
+      wrapperRoot: WRAPPER_ROOT,
+      deps: {
+        listProcesses: vi.fn(async () => [
+          { pid: 121, ppid: 1, command: `${CODEX_WRAPPER_COMMAND_WITH_LEASE} ${LEASE_ENV}` },
+        ]),
+        killProcess: vi.fn((pid, signal) => {
+          killed.push({ pid, signal });
+          if (signal === "SIGKILL") {
+            processAlive = false;
+          }
+        }),
+        isProcessAlive: vi.fn(() => processAlive),
+        sleep: vi.fn(async () => {}),
+      },
+    });
+
+    expect(killed).toEqual([
+      { pid: 121, signal: "SIGTERM" },
+      { pid: 121, signal: "SIGKILL" },
+    ]);
+    expect(result.survivingPids ?? []).toStrictEqual([]);
+  });
+
   it("does not kill a reused same-root wrapper pid with a different lease identity", async () => {
     const { deps, killed } = cleanupDeps([
       {
@@ -207,7 +461,7 @@ describe("process reaper", () => {
     expect(result).toEqual({
       inspectedPids: [],
       terminatedPids: [],
-      skippedReason: "unverified-root",
+      skippedReason: "process-list-unavailable",
     });
     expect(killed).toStrictEqual([]);
   });
@@ -293,6 +547,25 @@ describe("process reaper", () => {
         (entry) => entry.pid,
       ),
     ).toEqual([402, 401, 400, 404, 403, 405]);
+  });
+
+  it("reports broad startup reaper survivors after escalation", async () => {
+    const processes = [{ pid: 410, ppid: 1, command: CODEX_WRAPPER_COMMAND }];
+    const result = await reapStaleOpenClawOwnedAcpxOrphans({
+      wrapperRoot: WRAPPER_ROOT,
+      deps: {
+        listProcesses: vi.fn(async () => processes),
+        killProcess: vi.fn(),
+        isProcessAlive: vi.fn(() => true),
+        sleep: vi.fn(async () => {}),
+      },
+    });
+
+    expect(result).toEqual({
+      inspectedPids: [410],
+      terminatedPids: [],
+      survivingPids: [410],
+    });
   });
 
   it("reaps plugin-local Codex ACP adapter orphans when the generated wrapper is already gone", async () => {

--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 import { splitCommandParts } from "./command-line.js";
 import { resolveAcpxPluginRoot } from "./config.js";
 import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
+import { OPENCLAW_ACPX_LEASE_ID_ENV, OPENCLAW_GATEWAY_INSTANCE_ID_ENV } from "./process-lease.js";
 
 const execFileAsync = promisify(execFile);
 const requireFromHere = createRequire(import.meta.url);
@@ -44,6 +45,7 @@ export type AcpxProcessInfo = {
 export type AcpxProcessCleanupDeps = {
   listProcesses?: () => Promise<AcpxProcessInfo[]>;
   killProcess?: (pid: number, signal: NodeJS.Signals) => void;
+  isProcessAlive?: (pid: number) => boolean;
   sleep?: (ms: number) => Promise<void>;
 };
 
@@ -51,14 +53,20 @@ export type AcpxProcessCleanupDeps = {
 type AcpxProcessCleanupResult = {
   inspectedPids: number[];
   terminatedPids: number[];
-  skippedReason?: "missing-root" | "not-openclaw-owned" | "unverified-root";
+  survivingPids?: number[];
+  skippedReason?:
+    | "missing-root"
+    | "not-openclaw-owned"
+    | "process-list-unavailable"
+    | "unverified-root";
 };
 
 /** Result from startup orphan reaping. */
 type AcpxStartupReapResult = {
   inspectedPids: number[];
   terminatedPids: number[];
-  skippedReason?: "unsupported-platform" | "process-list-unavailable";
+  survivingPids?: number[];
+  skippedReason?: "process-list-unavailable";
 };
 
 function normalizePathLike(value: string): string {
@@ -216,12 +224,104 @@ function parseProcessList(stdout: string): AcpxProcessInfo[] {
 /** List host processes in the compact shape needed by ACPX cleanup. */
 async function listPlatformProcesses(): Promise<AcpxProcessInfo[]> {
   if (process.platform === "win32") {
-    return [];
+    const script = [
+      "Get-CimInstance Win32_Process",
+      "Select-Object ProcessId,ParentProcessId,CommandLine,ExecutablePath",
+      "ConvertTo-Json -Compress",
+    ].join(" | ");
+    const { stdout } = await execFileAsync(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", script],
+      { maxBuffer: 8 * 1024 * 1024 },
+    );
+    const raw = stdout.trim();
+    return parseWindowsProcessList(raw);
   }
-  const { stdout } = await execFileAsync("ps", ["-axo", "pid=,ppid=,command="], {
+  // `eww` includes inherited environment markers in the command column. Never
+  // log this output: it may contain unrelated process environment values.
+  const { stdout } = await execFileAsync("ps", ["eww", "-axo", "pid=,ppid=,command="], {
     maxBuffer: 8 * 1024 * 1024,
   });
   return parseProcessList(stdout);
+}
+
+function parseWindowsProcessList(raw: string): AcpxProcessInfo[] {
+  if (!raw) {
+    return [];
+  }
+  const parsed = JSON.parse(raw) as
+    | {
+        ProcessId?: number;
+        ParentProcessId?: number;
+        CommandLine?: string | null;
+        ExecutablePath?: string | null;
+      }
+    | Array<{
+        ProcessId?: number;
+        ParentProcessId?: number;
+        CommandLine?: string | null;
+        ExecutablePath?: string | null;
+      }>;
+  return (Array.isArray(parsed) ? parsed : [parsed]).flatMap((entry) => {
+    const pid = Number(entry.ProcessId);
+    const ppid = Number(entry.ParentProcessId);
+    if (!Number.isFinite(pid) || pid <= 0 || !Number.isFinite(ppid) || ppid < 0) {
+      return [];
+    }
+    return [
+      {
+        pid,
+        ppid,
+        command: entry.CommandLine?.trim() || entry.ExecutablePath?.trim() || "",
+      },
+    ];
+  });
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function commandHasEnvironmentValue(command: string, key: string, expected: string): boolean {
+  return new RegExp(`(?:^|\\s)${escapeRegExp(key)}=${escapeRegExp(expected)}(?:\\s|$)`).test(
+    command,
+  );
+}
+
+function processMatchesLeaseIdentity(params: {
+  processInfo: AcpxProcessInfo;
+  expectedLeaseId: string | undefined;
+  expectedGatewayInstanceId: string | undefined;
+}): boolean {
+  if (!params.expectedLeaseId || !params.expectedGatewayInstanceId) {
+    return false;
+  }
+  return (
+    commandHasEnvironmentValue(
+      params.processInfo.command,
+      OPENCLAW_ACPX_LEASE_ID_ENV,
+      params.expectedLeaseId,
+    ) &&
+    commandHasEnvironmentValue(
+      params.processInfo.command,
+      OPENCLAW_GATEWAY_INSTANCE_ID_ENV,
+      params.expectedGatewayInstanceId,
+    )
+  );
+}
+
+function collectLeaseProcesses(params: {
+  processes: AcpxProcessInfo[];
+  expectedLeaseId: string | undefined;
+  expectedGatewayInstanceId: string | undefined;
+}): AcpxProcessInfo[] {
+  return params.processes.filter((processInfo) =>
+    processMatchesLeaseIdentity({
+      processInfo,
+      expectedLeaseId: params.expectedLeaseId,
+      expectedGatewayInstanceId: params.expectedGatewayInstanceId,
+    }),
+  );
 }
 
 function collectProcessTree(processes: AcpxProcessInfo[], rootPid: number): AcpxProcessInfo[] {
@@ -262,6 +362,21 @@ function uniquePids(processes: AcpxProcessInfo[]): number[] {
   );
 }
 
+function uniqueProcesses(processes: AcpxProcessInfo[]): AcpxProcessInfo[] {
+  return Array.from(
+    new Map(
+      processes
+        .filter(
+          (processInfo) =>
+            Number.isInteger(processInfo.pid) &&
+            processInfo.pid > 0 &&
+            processInfo.pid !== process.pid,
+        )
+        .map((processInfo) => [processInfo.pid, processInfo]),
+    ).values(),
+  );
+}
+
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -271,41 +386,74 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-async function terminatePids(
-  pids: number[],
+async function terminateProcesses(
+  targets: AcpxProcessInfo[],
   deps: AcpxProcessCleanupDeps | undefined,
-): Promise<number[]> {
+  matchesIdentity: (current: AcpxProcessInfo, target: AcpxProcessInfo) => boolean,
+): Promise<{ terminatedPids: number[]; survivingPids: number[] }> {
   const killProcess = deps?.killProcess ?? ((pid, signal) => process.kill(pid, signal));
+  const checkAlive = deps?.isProcessAlive ?? isProcessAlive;
+  const listProcesses = deps?.listProcesses ?? listPlatformProcesses;
   const sleep =
     deps?.sleep ??
     ((ms) =>
       new Promise<void>((resolve) => {
         setTimeout(resolve, ms);
       }));
-  const terminated: number[] = [];
+  const targeted = uniqueProcesses(targets);
 
-  for (const pid of pids) {
+  for (const target of targeted) {
     try {
-      killProcess(pid, "SIGTERM");
-      terminated.push(pid);
+      killProcess(target.pid, "SIGTERM");
     } catch {
-      // The process may already be gone.
+      // Liveness verification below distinguishes already-gone processes from failures.
     }
   }
-  if (terminated.length === 0) {
-    return terminated;
+  if (targeted.length === 0) {
+    return { terminatedPids: [], survivingPids: [] };
   }
   await sleep(750);
-  for (const pid of terminated) {
-    if (deps?.killProcess || isProcessAlive(pid)) {
+  let escalationInventory: Map<number, AcpxProcessInfo> | undefined;
+  try {
+    escalationInventory = new Map((await listProcesses()).map((entry) => [entry.pid, entry]));
+  } catch {
+    // Without fresh identity evidence, do not escalate a numeric PID.
+  }
+  for (const target of targeted) {
+    const current = escalationInventory?.get(target.pid);
+    if (current && matchesIdentity(current, target) && checkAlive(target.pid)) {
       try {
-        killProcess(pid, "SIGKILL");
+        killProcess(target.pid, "SIGKILL");
       } catch {
         // Best-effort cleanup only.
       }
     }
   }
-  return terminated;
+  await sleep(250);
+  let finalInventory: Map<number, AcpxProcessInfo> | undefined;
+  try {
+    finalInventory = new Map((await listProcesses()).map((entry) => [entry.pid, entry]));
+  } catch {
+    // Numeric liveness below keeps unverifiable targets in the survivor set.
+  }
+  const survivingPids: number[] = [];
+  const terminatedPids: number[] = [];
+  for (const target of targeted) {
+    if (!checkAlive(target.pid)) {
+      terminatedPids.push(target.pid);
+      continue;
+    }
+    const current = finalInventory?.get(target.pid);
+    if (finalInventory && (!current || !matchesIdentity(current, target))) {
+      terminatedPids.push(target.pid);
+      continue;
+    }
+    survivingPids.push(target.pid);
+  }
+  return {
+    terminatedPids,
+    survivingPids,
+  };
 }
 
 /** Terminate one validated OpenClaw-owned ACPX wrapper process tree. */
@@ -326,15 +474,69 @@ export async function cleanupOpenClawOwnedAcpxProcessTree(params: {
   try {
     processes = await (params.deps?.listProcesses ?? listPlatformProcesses)();
   } catch {
-    processes = [];
+    return { inspectedPids: [], terminatedPids: [], skippedReason: "process-list-unavailable" };
   }
 
   const listedTree = collectProcessTree(processes, rootPid);
+  const leaseProcesses = collectLeaseProcesses({
+    processes,
+    expectedLeaseId: params.expectedLeaseId,
+    expectedGatewayInstanceId: params.expectedGatewayInstanceId,
+  });
+  const matchesCleanupIdentity = (current: AcpxProcessInfo, target: AcpxProcessInfo) => {
+    if (params.expectedLeaseId && params.expectedGatewayInstanceId) {
+      const targetHasLeaseIdentity =
+        processMatchesLeaseIdentity({
+          processInfo: target,
+          expectedLeaseId: params.expectedLeaseId,
+          expectedGatewayInstanceId: params.expectedGatewayInstanceId,
+        }) ||
+        liveCommandMatchesLeaseIdentity({
+          command: target.command,
+          expectedLeaseId: params.expectedLeaseId,
+          expectedGatewayInstanceId: params.expectedGatewayInstanceId,
+        });
+      if (targetHasLeaseIdentity) {
+        return (
+          processMatchesLeaseIdentity({
+            processInfo: current,
+            expectedLeaseId: params.expectedLeaseId,
+            expectedGatewayInstanceId: params.expectedGatewayInstanceId,
+          }) ||
+          liveCommandMatchesLeaseIdentity({
+            command: current.command,
+            expectedLeaseId: params.expectedLeaseId,
+            expectedGatewayInstanceId: params.expectedGatewayInstanceId,
+          })
+        );
+      }
+      // Windows process inventory cannot expose inherited environment values.
+      // Descendants discovered through a validated PPID tree therefore retain
+      // an exact command + parent identity check before delayed escalation.
+      return (
+        current.ppid === target.ppid &&
+        normalizePathLike(current.command).trim() === normalizePathLike(target.command).trim()
+      );
+    }
+    return normalizePathLike(current.command).trim() === normalizePathLike(target.command).trim();
+  };
   // Session-store PIDs are stale data. If the live process table cannot prove
   // that this PID still belongs to an OpenClaw-owned wrapper, fail closed to
   // avoid killing an unrelated process after PID reuse.
+  if (listedTree.length === 0 && leaseProcesses.length === 0) {
+    return { inspectedPids: [], terminatedPids: [], skippedReason: "missing-root" };
+  }
   if (listedTree.length === 0) {
-    return { inspectedPids: [], terminatedPids: [], skippedReason: "unverified-root" };
+    const termination = await terminateProcesses(
+      leaseProcesses.toReversed(),
+      params.deps,
+      matchesCleanupIdentity,
+    );
+    return {
+      inspectedPids: uniquePids(leaseProcesses),
+      terminatedPids: termination.terminatedPids,
+      ...(termination.survivingPids.length > 0 ? { survivingPids: termination.survivingPids } : {}),
+    };
   }
   const rootCommand = listedTree[0]?.command ?? params.rootCommand;
   const liveCommandWasGeneratedWrapper = commandMentionsGeneratedWrapper(
@@ -386,10 +588,20 @@ export async function cleanupOpenClawOwnedAcpxProcessTree(params: {
     };
   }
 
-  const pids = uniquePids(listedTree.toReversed());
+  const inspected = Array.from(
+    new Map(
+      [...listedTree, ...leaseProcesses].map((processInfo) => [processInfo.pid, processInfo]),
+    ).values(),
+  );
+  const targets = uniqueProcesses([
+    ...leaseProcesses.filter((processInfo) => processInfo.pid !== rootPid).toReversed(),
+    ...listedTree.toReversed(),
+  ]);
+  const termination = await terminateProcesses(targets, params.deps, matchesCleanupIdentity);
   return {
-    inspectedPids: uniquePids(listedTree),
-    terminatedPids: await terminatePids(pids, params.deps),
+    inspectedPids: uniquePids(inspected),
+    terminatedPids: termination.terminatedPids,
+    ...(termination.survivingPids.length > 0 ? { survivingPids: termination.survivingPids } : {}),
   };
 }
 
@@ -398,10 +610,6 @@ export async function reapStaleOpenClawOwnedAcpxOrphans(params: {
   wrapperRoot: string;
   deps?: AcpxProcessCleanupDeps;
 }): Promise<AcpxStartupReapResult> {
-  if (process.platform === "win32") {
-    return { inspectedPids: [], terminatedPids: [], skippedReason: "unsupported-platform" };
-  }
-
   let processes: AcpxProcessInfo[];
   try {
     processes = await (params.deps?.listProcesses ?? listPlatformProcesses)();
@@ -411,7 +619,7 @@ export async function reapStaleOpenClawOwnedAcpxOrphans(params: {
 
   const orphans = processes.filter(
     (processInfo) =>
-      processInfo.ppid === 1 &&
+      (process.platform === "win32" || processInfo.ppid === 1) &&
       isOpenClawOwnedAcpxProcessCommand({
         command: processInfo.command,
         wrapperRoot: params.wrapperRoot,
@@ -422,9 +630,20 @@ export async function reapStaleOpenClawOwnedAcpxOrphans(params: {
   // the wrapper root exits.
   const orphanTrees = orphans.map((orphan) => collectProcessTree(processes, orphan.pid));
   const inspectedPids = uniquePids(orphanTrees.flat());
-  const pids = uniquePids(orphanTrees.flatMap((tree) => tree.toReversed()));
+  const targets = uniqueProcesses(orphanTrees.flatMap((tree) => tree.toReversed()));
+  const termination = await terminateProcesses(
+    targets,
+    params.deps,
+    (current, target) =>
+      normalizePathLike(current.command).trim() === normalizePathLike(target.command).trim(),
+  );
   return {
     inspectedPids,
-    terminatedPids: await terminatePids(pids, params.deps),
+    terminatedPids: termination.terminatedPids,
+    ...(termination.survivingPids.length > 0 ? { survivingPids: termination.survivingPids } : {}),
   };
 }
+
+export const testing = {
+  parseWindowsProcessList,
+};

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -10,7 +10,12 @@ import {
   type AcpRuntimeEvent,
   type AcpRuntimeTurn,
 } from "../runtime-api.js";
-import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
+import {
+  OPENCLAW_ACPX_LEASE_ID_ARG,
+  OPENCLAW_ACPX_LEASE_ID_ENV,
+  OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
+  OPENCLAW_GATEWAY_INSTANCE_ID_ENV,
+} from "./process-lease.js";
 import { AcpxRuntime, testing, type AcpSessionStore } from "./runtime.js";
 
 type TestSessionStore = {
@@ -1663,6 +1668,70 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     ]);
     expect(leaseStore.store.markState).toHaveBeenCalledWith("lease-close", "closing");
     expect(leaseStore.store.markState).toHaveBeenLastCalledWith("lease-close", "closed");
+  });
+
+  it("fails close and marks the lease lost when owned descendants survive SIGKILL", async () => {
+    const leaseStore = makeLeaseStore();
+    leaseStore.leases.set("lease-close", {
+      leaseId: "lease-close",
+      gatewayInstanceId: "gateway-test",
+      sessionKey: "agent:codex:acp:binding:test",
+      wrapperRoot: "/tmp/openclaw/acpx",
+      wrapperPath: "/tmp/openclaw/acpx/codex-acp-wrapper.mjs",
+      rootPid: 950,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    });
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:binding:test",
+        agentCommand: CODEX_ACP_WRAPPER_COMMAND,
+        openclawLeaseId: "lease-close",
+        pid: 950,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const leaseEnv = `${OPENCLAW_ACPX_LEASE_ID_ENV}=lease-close ${OPENCLAW_GATEWAY_INSTANCE_ID_ENV}=gateway-test`;
+    const { runtime, delegate } = makeRuntime(
+      baseStore,
+      {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: leaseStore.store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+      },
+      {
+        openclawProcessCleanup: {
+          listProcesses: vi.fn(async () => [
+            {
+              pid: 950,
+              ppid: 1,
+              command: `${CODEX_ACP_WRAPPER_COMMAND_WITH_LEASE} ${leaseEnv}`,
+            },
+          ]),
+          killProcess: vi.fn(),
+          isProcessAlive: vi.fn(() => true),
+          sleep: vi.fn(async () => {}),
+        },
+      },
+    );
+    vi.spyOn(delegate, "close").mockResolvedValue(undefined);
+
+    await expect(
+      runtime.close({
+        handle: {
+          sessionKey: "agent:codex:acp:binding:test",
+          backend: "acpx",
+          runtimeSessionName: "agent:codex:acp:binding:test",
+        },
+        reason: "user-close",
+      }),
+    ).rejects.toThrow("ACPX process containment failed: 1 owned process(es) survived");
+
+    expect(leaseStore.store.markState.mock.calls).toEqual([
+      ["lease-close", "closing"],
+      ["lease-close", "lost"],
+    ]);
   });
 
   it("closes the current process lease when the saved lease id is stale", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1014,12 +1014,16 @@ export class AcpxRuntime implements AcpRuntime {
         wrapperRoot: lease.wrapperRoot,
         deps: this.processCleanupDeps,
       });
-      await this.processLeaseStore?.markState(
-        lease.leaseId,
-        result.terminatedPids.length > 0 || result.skippedReason === "missing-root"
-          ? "closed"
-          : "lost",
-      );
+      const cleanupDrained =
+        !result.survivingPids?.length &&
+        (result.terminatedPids.length > 0 || result.skippedReason === "missing-root");
+      await this.processLeaseStore?.markState(lease.leaseId, cleanupDrained ? "closed" : "lost");
+      if (!cleanupDrained) {
+        const detail = result.survivingPids?.length
+          ? `${result.survivingPids.length} owned process(es) survived`
+          : `cleanup was not verified (${result.skippedReason ?? "no owned process terminated"})`;
+        throw new AcpRuntimeError("ACP_TURN_FAILED", `ACPX process containment failed: ${detail}.`);
+      }
       return;
     }
 

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -23,6 +23,7 @@ const { cleanupOpenClawOwnedAcpxProcessTreeMock } = vi.hoisted(() => ({
     async (): Promise<{
       inspectedPids: number[];
       terminatedPids: number[];
+      survivingPids?: number[];
       skippedReason?: string;
     }> => ({
       inspectedPids: [],
@@ -35,6 +36,7 @@ const { reapStaleOpenClawOwnedAcpxOrphansMock } = vi.hoisted(() => ({
     async (): Promise<{
       inspectedPids: number[];
       terminatedPids: number[];
+      survivingPids?: number[];
       skippedReason?: string;
     }> => ({
       inspectedPids: [],
@@ -421,6 +423,42 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
+  it("fails ACPX startup when a stale owned lease does not drain", async () => {
+    const workspaceDir = await makeTempDir();
+    const ctx = createServiceContext(workspaceDir);
+    const runtime = createMockRuntime();
+    const wrapperRoot = path.join(ctx.stateDir, "acpx");
+    await openGatewayInstanceStore(ctx).register(ACPX_GATEWAY_INSTANCE_KEY, {
+      instanceId: "gw-test",
+      createdAt: 1,
+    });
+    const lease: AcpxProcessLease = {
+      leaseId: "lease-survivor",
+      gatewayInstanceId: "gw-test",
+      sessionKey: "agent:claude:acp:test",
+      wrapperRoot,
+      wrapperPath: path.join(wrapperRoot, "claude-agent-acp-wrapper.mjs"),
+      rootPid: 301,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    };
+    await openProcessLeaseStore(ctx).register(lease.leaseId, lease);
+    cleanupOpenClawOwnedAcpxProcessTreeMock.mockResolvedValueOnce({
+      inspectedPids: [301, 302],
+      terminatedPids: [301, 302],
+      survivingPids: [302],
+    });
+    const service = createAcpxRuntimeService(ctx, {
+      runtimeFactory: () => runtime as never,
+    });
+
+    await expect(service.start(ctx)).rejects.toThrow(
+      "ACPX process containment failed to drain 1 stale process lease(s) during startup",
+    );
+    expect(getAcpRuntimeBackend("acpx")).toBeUndefined();
+  });
+
   it("runs wrapper-root orphan cleanup before dropping pending ACPX leases", async () => {
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
@@ -464,6 +502,42 @@ describe("createAcpxRuntimeService", () => {
     await expect(openProcessLeaseStore(ctx).lookup("lease-pending")).resolves.toBeUndefined();
 
     await service.stop?.(ctx);
+  });
+
+  it("fails ACPX startup when broad cleanup leaves a pending-lease orphan alive", async () => {
+    const workspaceDir = await makeTempDir();
+    const ctx = createServiceContext(workspaceDir);
+    const runtime = createMockRuntime();
+    const runtimeFactory = vi.fn(() => runtime as never);
+    const wrapperRoot = path.join(ctx.stateDir, "acpx");
+    await openGatewayInstanceStore(ctx).register(ACPX_GATEWAY_INSTANCE_KEY, {
+      instanceId: "gw-test",
+      createdAt: 1,
+    });
+    const lease: AcpxProcessLease = {
+      leaseId: "lease-pending-survivor",
+      gatewayInstanceId: "gw-test",
+      sessionKey: "agent:codex:acp:test",
+      wrapperRoot,
+      wrapperPath: path.join(wrapperRoot, "codex-acp-wrapper.mjs"),
+      rootPid: 0,
+      commandHash: "hash",
+      startedAt: 1,
+      state: "open",
+    };
+    await openProcessLeaseStore(ctx).register(lease.leaseId, lease);
+    reapStaleOpenClawOwnedAcpxOrphansMock.mockResolvedValueOnce({
+      inspectedPids: [211],
+      terminatedPids: [],
+      survivingPids: [211],
+    });
+    const service = createAcpxRuntimeService(ctx, { runtimeFactory });
+
+    await expect(service.start(ctx)).rejects.toThrow(
+      "ACPX process containment failed to drain 1 stale process lease(s) during startup",
+    );
+    expect(runtimeFactory).not.toHaveBeenCalled();
+    expect(getAcpRuntimeBackend("acpx")).toBeUndefined();
   });
 
   it("keeps startup quiet when no process leases are open", async () => {

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -272,13 +272,19 @@ async function reapOpenAcpxProcessLeases(params: {
   gatewayInstanceId: string;
   leaseStore: AcpxProcessLeaseStore;
   deps?: AcpxProcessCleanupDeps;
-}): Promise<{ inspectedPids: number[]; terminatedPids: number[] }> {
+}): Promise<{ inspectedPids: number[]; terminatedPids: number[]; failedLeaseCount: number }> {
   const leases = await params.leaseStore.listOpen(params.gatewayInstanceId);
   const inspectedPids: number[] = [];
   const terminatedPids: number[] = [];
+  let failedLeaseCount = 0;
   const pendingLeaseRootResults = new Map<
     string,
-    { inspectedPids: number[]; terminatedPids: number[] }
+    {
+      inspectedPids: number[];
+      terminatedPids: number[];
+      survivingPids?: number[];
+      skippedReason?: "process-list-unavailable";
+    }
   >();
   for (const lease of leases) {
     if (lease.rootPid <= 0) {
@@ -293,10 +299,12 @@ async function reapOpenAcpxProcessLeases(params: {
         inspectedPids.push(...result.inspectedPids);
         terminatedPids.push(...result.terminatedPids);
       }
-      await params.leaseStore.markState(
-        lease.leaseId,
-        result.terminatedPids.length > 0 ? "closed" : "lost",
-      );
+      const pendingLeaseDrained =
+        !result.survivingPids?.length && result.skippedReason === undefined;
+      await params.leaseStore.markState(lease.leaseId, pendingLeaseDrained ? "closed" : "lost");
+      if (!pendingLeaseDrained) {
+        failedLeaseCount += 1;
+      }
       continue;
     }
     await params.leaseStore.markState(lease.leaseId, "closing");
@@ -309,12 +317,15 @@ async function reapOpenAcpxProcessLeases(params: {
     });
     inspectedPids.push(...result.inspectedPids);
     terminatedPids.push(...result.terminatedPids);
-    await params.leaseStore.markState(
-      lease.leaseId,
-      result.terminatedPids.length > 0 ? "closed" : "lost",
-    );
+    const drained =
+      !result.survivingPids?.length &&
+      (result.terminatedPids.length > 0 || result.skippedReason === "missing-root");
+    await params.leaseStore.markState(lease.leaseId, drained ? "closed" : "lost");
+    if (!drained) {
+      failedLeaseCount += 1;
+    }
   }
-  return { inspectedPids, terminatedPids };
+  return { inspectedPids, terminatedPids, failedLeaseCount };
 }
 
 /** Create the ACPX plugin service that owns runtime registration and cleanup. */
@@ -374,6 +385,11 @@ export function createAcpxRuntimeService(
       if (startupReap.terminatedPids.length > 0) {
         ctx.logger.info(
           `reaped ${startupReap.terminatedPids.length} stale OpenClaw-owned ACPX process${startupReap.terminatedPids.length === 1 ? "" : "es"}`,
+        );
+      }
+      if (startupReap.failedLeaseCount > 0) {
+        throw new Error(
+          `ACPX process containment failed to drain ${startupReap.failedLeaseCount} stale process lease(s) during startup`,
         );
       }
       warnOnIgnoredLegacyCompatibilityConfig({

--- a/src/acp/control-plane/manager.cancel-session.test.ts
+++ b/src/acp/control-plane/manager.cancel-session.test.ts
@@ -68,9 +68,11 @@ describe("AcpSessionManager cancelSession", () => {
       await runPromise;
 
       expect(runtimeState.cancel).toHaveBeenCalledTimes(1);
+      expect(runtimeState.close).toHaveBeenCalledTimes(1);
       expectRecordFields(mockCallArg(runtimeState.cancel), {
         reason: "manual-cancel",
       });
+      expect(manager.getObservabilitySnapshot(baseCfg).runtimeCache.activeSessions).toBe(0);
       expectRecordFields(requireTaskByRunId("run-1"), {
         ownerKey: "agent:main:main",
         childSessionKey: "agent:codex:acp:child-1",
@@ -80,6 +82,162 @@ describe("AcpSessionManager cancelSession", () => {
       expect(states).toContain("running");
       expect(states).toContain("idle");
       expect(states).not.toContain("error");
+    });
+  });
+
+  it("closes the runtime handle when protocol cancellation fails", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.cancel.mockRejectedValueOnce(new Error("protocol cancel failed"));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      mockParentedAcpSessionEntries({
+        childSessionKey: "agent:codex:acp:child-cancel-failure",
+        parentSessionKey: "agent:main:main",
+      });
+
+      let enteredRun = false;
+      runtimeState.runTurn.mockImplementation(async function* (input: { signal?: AbortSignal }) {
+        enteredRun = true;
+        await new Promise<void>((resolve) => {
+          if (input.signal?.aborted) {
+            resolve();
+            return;
+          }
+          input.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        yield { type: "done" as const, stopReason: "cancel" };
+      });
+
+      const manager = new AcpSessionManager();
+      const runPromise = manager.runTurn({
+        provenance: "system",
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-cancel-failure",
+        text: "long task",
+        mode: "prompt",
+        requestId: "run-cancel-failure",
+      });
+      await vi.waitFor(() => expect(enteredRun).toBe(true), { interval: 1 });
+
+      await manager.cancelSession({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-cancel-failure",
+        reason: "manual-cancel",
+      });
+      await runPromise;
+
+      expect(runtimeState.close).toHaveBeenCalledTimes(1);
+      expect(manager.getObservabilitySnapshot(baseCfg).runtimeCache.activeSessions).toBe(0);
+    });
+  });
+
+  it("does not let a never-settling protocol cancel block runtime close", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.cancel.mockImplementationOnce(async () => await new Promise<void>(() => {}));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      mockParentedAcpSessionEntries({
+        childSessionKey: "agent:codex:acp:child-hanging-cancel",
+        parentSessionKey: "agent:main:main",
+      });
+
+      let enteredRun = false;
+      runtimeState.runTurn.mockImplementation(async function* (input: { signal?: AbortSignal }) {
+        enteredRun = true;
+        await new Promise<void>((resolve) => {
+          if (input.signal?.aborted) {
+            resolve();
+            return;
+          }
+          input.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        yield { type: "done" as const, stopReason: "cancel" };
+      });
+
+      const manager = new AcpSessionManager();
+      const runPromise = manager.runTurn({
+        provenance: "system",
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-hanging-cancel",
+        text: "long task",
+        mode: "prompt",
+        requestId: "run-hanging-cancel",
+      });
+      await vi.waitFor(() => expect(enteredRun).toBe(true), { interval: 1 });
+
+      const cancelOutcome = await Promise.race([
+        manager
+          .cancelSession({
+            cfg: baseCfg,
+            sessionKey: "agent:codex:acp:child-hanging-cancel",
+            reason: "manual-cancel",
+          })
+          .then(() => "closed"),
+        new Promise<string>((resolve) => {
+          setTimeout(() => resolve("timed-out"), 1_000);
+        }),
+      ]);
+      await runPromise;
+
+      expect(cancelOutcome).toBe("closed");
+      expect(runtimeState.close).toHaveBeenCalledTimes(1);
+      expect(manager.getObservabilitySnapshot(baseCfg).runtimeCache.activeSessions).toBe(0);
+    });
+  });
+
+  it("surfaces runtime close failures and clears the cached handle", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.close.mockRejectedValueOnce(new Error("lease drain failed"));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      mockParentedAcpSessionEntries({
+        childSessionKey: "agent:codex:acp:child-close-failure",
+        parentSessionKey: "agent:main:main",
+      });
+
+      let enteredRun = false;
+      runtimeState.runTurn.mockImplementation(async function* (input: { signal?: AbortSignal }) {
+        enteredRun = true;
+        await new Promise<void>((resolve) => {
+          if (input.signal?.aborted) {
+            resolve();
+            return;
+          }
+          input.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        yield { type: "done" as const, stopReason: "cancel" };
+      });
+
+      const manager = new AcpSessionManager();
+      const runPromise = manager.runTurn({
+        provenance: "system",
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-close-failure",
+        text: "long task",
+        mode: "prompt",
+        requestId: "run-close-failure",
+      });
+      await vi.waitFor(() => expect(enteredRun).toBe(true), { interval: 1 });
+
+      await expect(
+        manager.cancelSession({
+          cfg: baseCfg,
+          sessionKey: "agent:codex:acp:child-close-failure",
+          reason: "manual-cancel",
+        }),
+      ).rejects.toThrow("lease drain failed");
+      await runPromise;
+
+      expect(manager.getObservabilitySnapshot(baseCfg).runtimeCache.activeSessions).toBe(0);
     });
   });
 });

--- a/src/acp/control-plane/manager.cancel-session.ts
+++ b/src/acp/control-plane/manager.cancel-session.ts
@@ -1,11 +1,14 @@
 /** Cancellation path for active ACP turns and idle runtime handles. */
 import type { AcpRuntime, AcpRuntimeHandle } from "@openclaw/acp-core/runtime/types";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { logVerbose } from "../../globals.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import {
   type AcpRuntimeError,
   toAcpRuntimeError,
   withAcpRuntimeErrorBoundary,
 } from "../runtime/errors.js";
+import type { ManagerRuntimeHandleCache } from "./manager.runtime-handle-cache.js";
 import type {
   ActiveTurnState,
   EnsureManagerRuntimeHandle,
@@ -24,15 +27,27 @@ export async function runManagerCancelSession(params: {
   withSessionActor: WithManagerSessionActor;
   resolveSession: ResolveManagerSession;
   ensureRuntimeHandle: EnsureManagerRuntimeHandle;
+  runtimeHandles: ManagerRuntimeHandleCache;
   setSessionState: SetManagerSessionState;
 }): Promise<void> {
   const actorKey = normalizeActorKey(params.sessionKey);
   const activeTurn = params.activeTurnBySession.get(actorKey);
   if (activeTurn) {
-    await cancelActiveTurn({
+    activeTurn.abortController.abort();
+    const closePromise = params.runtimeHandles.close({
+      sessionKey: params.sessionKey,
+      reason: params.reason ?? "turn-cancelled",
+      throwOnError: true,
+    });
+    void cancelActiveTurn({
       activeTurn,
       reason: params.reason,
+    }).catch((error: unknown) => {
+      logVerbose(
+        `acp-manager: protocol cancel failed while closing runtime for ${params.sessionKey}: ${formatErrorMessage(error)}`,
+      );
     });
+    await closePromise;
     return;
   }
 
@@ -48,11 +63,21 @@ export async function runManagerCancelSession(params: {
       meta: resolvedMeta,
     });
     try {
-      await cancelRuntimeHandle({
+      const closePromise = params.runtimeHandles.close({
+        sessionKey: params.sessionKey,
+        reason: params.reason ?? "session-cancelled",
+        throwOnError: true,
+      });
+      void cancelRuntimeHandle({
         runtime,
         handle,
         reason: params.reason,
+      }).catch((error: unknown) => {
+        logVerbose(
+          `acp-manager: protocol cancel failed while closing runtime for ${params.sessionKey}: ${formatErrorMessage(error)}`,
+        );
       });
+      await closePromise;
       await params.setSessionState({
         cfg: params.cfg,
         sessionKey: params.sessionKey,
@@ -76,7 +101,6 @@ async function cancelActiveTurn(params: {
   activeTurn: ActiveTurnState;
   reason?: string;
 }): Promise<void> {
-  params.activeTurn.abortController.abort();
   if (!params.activeTurn.cancelPromise) {
     params.activeTurn.cancelPromise = params.activeTurn.runtime.cancel({
       handle: params.activeTurn.handle,

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -336,6 +336,7 @@ export class AcpSessionManager {
       withSessionActor: this.withSessionActor.bind(this),
       resolveSession: this.resolveSession.bind(this),
       ensureRuntimeHandle: this.ensureRuntimeHandle.bind(this),
+      runtimeHandles: this.runtimeHandles,
       setSessionState: this.setSessionState.bind(this),
     });
   }

--- a/src/acp/control-plane/manager.runtime-handle-cache.ts
+++ b/src/acp/control-plane/manager.runtime-handle-cache.ts
@@ -54,7 +54,11 @@ export class ManagerRuntimeHandleCache {
   }
 
   /** Closes and removes one cached runtime handle when present. */
-  async close(params: { sessionKey: string; reason: string }): Promise<void> {
+  async close(params: {
+    sessionKey: string;
+    reason: string;
+    throwOnError?: boolean;
+  }): Promise<void> {
     const cached = this.get(params.sessionKey);
     if (!cached) {
       return;
@@ -68,6 +72,9 @@ export class ManagerRuntimeHandleCache {
       logVerbose(
         `acp-manager: cached runtime close failed for ${params.sessionKey}: ${String(error)}`,
       );
+      if (params.throwOnError) {
+        throw error;
+      }
     } finally {
       this.clear(params.sessionKey);
     }

--- a/src/auto-reply/reply/abort.runtime-types.ts
+++ b/src/auto-reply/reply/abort.runtime-types.ts
@@ -6,7 +6,7 @@ import type { FinalizedMsgContext } from "../templating.js";
 type FastAbortResult = {
   handled: boolean;
   aborted: boolean;
-  rejectionReason?: "finalizing";
+  rejectionReason?: "containment-failed" | "finalizing";
   stoppedSubagents?: number;
 };
 

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -752,6 +752,13 @@ describe("abort detection", () => {
     });
 
     expect(result.handled).toBe(true);
+    expect(result).toMatchObject({
+      aborted: false,
+      rejectionReason: "containment-failed",
+    });
+    expect(formatAbortReplyText(undefined, result.rejectionReason)).toContain(
+      "ACP process cleanup could not be verified",
+    );
     expect(getFollowupQueueDepth(sessionKey)).toBe(0);
     expectSessionLaneCleared(sessionKey);
   });

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -140,8 +140,11 @@ export function abortSessionRunTargetWithOutcome(params: { key?: string; session
 
 export function formatAbortReplyText(
   stoppedSubagents?: number,
-  rejectionReason?: "finalizing",
+  rejectionReason?: "containment-failed" | "finalizing",
 ): string {
+  if (rejectionReason === "containment-failed") {
+    return "Abort was requested, but ACP process cleanup could not be verified. Check Gateway logs and stop the remaining owned process before continuing.";
+  }
   if (rejectionReason === "finalizing") {
     const base = "Agent reply is already finalizing and can no longer be aborted.";
     if (typeof stoppedSubagents !== "number" || stoppedSubagents <= 0) {
@@ -331,7 +334,7 @@ export async function tryFastAbortFromMessage(params: {
 }): Promise<{
   handled: boolean;
   aborted: boolean;
-  rejectionReason?: "finalizing";
+  rejectionReason?: "containment-failed" | "finalizing";
   stoppedSubagents?: number;
 }> {
   const { ctx, cfg } = params;
@@ -411,6 +414,7 @@ export async function tryFastAbortFromMessage(params: {
       abortTargetKeys.push(boundAcpTargetKey);
     }
     const acpManager = abortDeps.getAcpSessionManager();
+    let acpContainmentFailed = false;
     for (const acpTargetKey of abortTargetKeys.filter(isAcpSessionKey)) {
       const acpResolution = acpManager.resolveSession({
         cfg,
@@ -426,6 +430,7 @@ export async function tryFastAbortFromMessage(params: {
           reason: "fast-abort",
         });
       } catch (error) {
+        acpContainmentFailed = true;
         logVerbose(`abort: ACP cancel failed for ${acpTargetKey}: ${formatErrorMessage(error)}`);
       }
     }
@@ -478,6 +483,14 @@ export async function tryFastAbortFromMessage(params: {
       );
     }
     const { stopped } = stopSubagentsForRequester({ cfg, requesterSessionKey });
+    if (acpContainmentFailed) {
+      return {
+        handled: true,
+        aborted: false,
+        rejectionReason: "containment-failed",
+        stoppedSubagents: stopped,
+      };
+    }
     if (activeAbortRejected && !aborted) {
       return {
         handled: true,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -56,7 +56,7 @@ import { buildTestCtx } from "./test-ctx.js";
 type AbortResult = {
   handled: boolean;
   aborted: boolean;
-  rejectionReason?: "finalizing";
+  rejectionReason?: "containment-failed" | "finalizing";
   stoppedSubagents?: number;
 };
 type ResolveInboundConversationParams = Parameters<


### PR DESCRIPTION
Refs #104847

## Current Status

The current head is the single ACPX-focused commit `be52e466068dd57e0f1f8c24d4ab8dd5612e5405`, rebased onto upstream `main` at `477f3af6883af1176fe88e9f8c561d6769097715`. Public exact-head macOS process, control-plane, abort-feedback, startup fail-closed, launchd service proof, and full CI pass. The previous current-head review reported one blocking P1 because the broad startup reaper dropped survivor evidence; this head propagates that evidence and adds the requested pending-lease regression. The PR remains Draft because technical review does not authorize the deliberate compatibility and availability policy; explicit ACPX/control-plane owner acceptance of the fail-closed contract is required.

## What Problem This Solves

Cancelling an ACP-backed turn could stop the visible reply while leaving an ACPX-owned worker alive after it detached from the wrapper's PPID tree. The existing reaper validated a wrapper process and walked its current parent/child tree, but `setsid`, double-fork, or later reparenting could move the autonomous worker outside that tree. The fast-abort path could also log cleanup failure and still report normal abort success.

## Root Cause

OpenClaw owned the outer ACPX runtime lifecycle but did not persist a process-ownership identity that survived PPID changes. Cancellation also treated cooperative ACP protocol cancellation as the lifecycle boundary, even though protocol cancel does not guarantee that detached host processes are gone.

The startup path had a second correctness gap: broad wrapper-root orphan cleanup called the survivor-aware termination helper but discarded `survivingPids`. A pending lease with `rootPid <= 0` could therefore be marked closed and allow ACPX registration even while an owned orphan remained alive.

## Code Path

1. `/stop` reaches the ACP manager cancellation path through `src/auto-reply/reply/abort.ts`.
2. `src/acp/control-plane/manager.cancel-session.ts` evicts the cached runtime handle and starts `close()` before best-effort protocol cancellation, so a rejected or never-settling protocol cancel cannot gate containment.
3. `extensions/acpx/src/runtime.ts` closes the ACPX turn owner and drains its process lease.
4. `extensions/acpx/src/process-reaper.ts` combines the live PPID tree with random lease and Gateway-instance markers, sends TERM, refreshes inventory, revalidates process identity before KILL, and performs a final survivor check.
5. `extensions/acpx/src/service.ts` drains stale open or pending leases before backend registration and now treats broad-reaper survivors as a startup failure.
6. Abort feedback reports containment failure instead of claiming success when cleanup cannot be verified.

## Behavior Changes

- ACP cancellation starts close and lease drain before best-effort protocol cancellation.
- Reparented descendants remain attributable by inherited random lease ID and Gateway instance ID.
- POSIX inventory uses bounded `ps eww` output only for in-memory matching and never logs process environments.
- Windows uses `Win32_Process` PID, PPID, command, and executable inventory; PPID-tree descendants use exact command and parent identity for delayed escalation.
- TERM-resistant targets are escalated only after fresh identity revalidation. A disappeared or reused PID is not signaled as the original target.
- Every targeted PID is included in final liveness verification even when TERM or KILL throws.
- Startup refuses ACPX registration when an open or pending lease cannot be verified or drained, including survivors returned by broad wrapper-root cleanup.
- Generic persistent `exec` and `process` background sessions are outside the ACPX lease path and keep their existing lifecycle.

## Compatibility And Migration

- No stored schema, config key, or user-data migration is introduced. Existing lease records keep the same shape.
- Cancellation now closes and evicts the reusable live ACP runtime handle; a later turn must reopen or resume instead of reusing that handle.
- Startup availability changes intentionally: an unverifiable or undrainable stale ACPX lease blocks backend registration until containment succeeds or an operator resolves the stale process.
- There is no compatibility fallback in this patch. Maintainer acceptance of this fail-closed policy is required before Ready status.

## Evidence

### Before: launchd and process-group boundary

Public GitHub-hosted `macos-14` proof demonstrates that `launchctl bootout` removes the launchd leader and plain child while a `start_new_session` child and double-fork daemon survive:

- Run: https://github.com/snowzlmbot/openclaw/actions/runs/29187863352
- Baseline job: https://github.com/snowzlmbot/openclaw/actions/runs/29187863352/job/86637125671
- Artifact: https://github.com/snowzlmbot/openclaw/actions/runs/29187863352/artifacts/8258570570
- Artifact SHA-256: `b7a13f5f39f456ffc5070f427e522c1678098c71afd190b33d32e162e4d913b3`
- Evidence-only PR: https://github.com/snowzlmbot/openclaw/pull/3

This is why launchd or process-group cleanup alone is not complete containment.

### After: exact-head candidate proof

Public GitHub-hosted `macos-14` proof checked out and verified `be52e466068dd57e0f1f8c24d4ab8dd5612e5405`:

- Run: https://github.com/snowzlmbot/openclaw/actions/runs/29187863352
- Candidate job: https://github.com/snowzlmbot/openclaw/actions/runs/29187863352/job/86637125683
- Artifact: https://github.com/snowzlmbot/openclaw/actions/runs/29187863352/artifacts/8258578919
- Artifact SHA-256: `4eb6a4389962505d62141adc0da2c326cef09426e3e7f5135cf80a1f939e4a72`
- ACPX process/runtime/service suites: 4 files, 104 tests passed.
- ACP manager cancellation: 1 file, 4 tests passed.
- Abort and operator feedback: 1 file, 33 tests passed.
- The new regressions prove broad startup survivor propagation and startup refusal for a `rootPid: 0` pending lease whose owned orphan remains alive.

### Service-managed ownership proof

The same exact-head job runs the production lease and reaper implementation under a launchd-managed service:

- Before abort: service alive, lease-owned reparented descendant alive, unrelated persistent background alive.
- After abort: service alive, lease-owned descendant gone, unrelated persistent background alive.
- Cleanup inspected and terminated the leased PID and reported no survivors.
- Every evidence pipeline uses `set -o pipefail`, so harness failure cannot be hidden by `tee`.

### Full CI

- Exact-head full CI: https://github.com/snowzlmbot/openclaw/actions/runs/29187865437
- Status: passed for exact head `be52e466068dd57e0f1f8c24d4ab8dd5612e5405`; all selected jobs completed successfully.
- Upstream PR checks: https://github.com/openclaw/openclaw/pull/104929/checks
- Local lightweight preflight: targeted `oxfmt` and `git diff --check` passed. Builds, type checks, lint, and test suites run in GitHub Actions.

## Tests Added Or Updated

- Real POSIX detached and reparented lease cleanup.
- Lease environment matching with Gateway-instance isolation.
- TERM-resistant escalation, signal failures, final survivor verification, and PID-reuse identity revalidation.
- Windows process inventory and delayed PPID-tree escalation identity.
- Broad startup reaper survivor propagation.
- Pending lease with `rootPid <= 0` blocks startup when an owned orphan survives.
- Runtime close failure marks containment lost and propagates failure.
- Cancellation starts close and lease drain before rejected or never-settling protocol cancel.
- `/stop` returns containment failure instead of false success.

## Performance

- Process inventory runs only during ACPX cancellation and startup stale-lease recovery, not on the steady-state turn path.
- POSIX process output is bounded to 8 MiB.
- Cleanup deduplicates target PIDs and reuses one broad-root result for pending leases sharing a wrapper root.

## Risk And Rollback

- The deliberate compatibility risk is loss of live-handle reuse after cancellation.
- The deliberate availability risk is startup refusal when stale ACPX containment cannot be proven.
- Process ownership matching is security-sensitive; PID reuse is handled by fresh identity checks before escalation and by final inventory verification.
- Reverting the commit restores cooperative cancel reuse, PPID-only cleanup, and the previous startup behavior.

## Maintainer Decision Required

Should OpenClaw intentionally override upstream ACPX cooperative-cancel semantics by closing and evicting the reusable runtime handle, and should any unverifiable or undrainable stale ACPX lease block backend startup?

Recommended policy: accept the fail-closed contract because the alternative can report a turn stopped while an autonomous credentialed worker remains alive. This PR will stay Draft until the relevant ACPX/runtime owner explicitly accepts that compatibility and availability tradeoff.

## Not Tested

- No private Claude credentials or paid-provider runtime were used.
- Public CI uses deterministic real host processes plus the production ACPX lease, reaper, control-plane, and abort-feedback implementations.