### PR TITLE
fix(ui): avoid splitting UTF-16 surrogate pairs in session display peer-id tail

### DIFF
--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -27,11 +27,8 @@ describe("resolveSessionDisplayName", () => {
   });
 
   it("does not split UTF-16 surrogate pairs when shortening peer ids", () => {
-    const name = resolveSessionDisplayName("agent:main:telegram:direct:12345😀67890");
-    expect(() => encodeURIComponent(name)).not.toThrow();
-    expect(name).toContain("Telegram · …");
-    expect(name).not.toMatch(
-      /[\uD800-\uDFFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+    expect(resolveSessionDisplayName("agent:main:telegram:direct:12345😀67890")).toBe(
+      "Telegram · …67890",
     );
   });
 

--- a/ui/src/lib/session-display.test.ts
+++ b/ui/src/lib/session-display.test.ts
@@ -26,6 +26,15 @@ describe("resolveSessionDisplayName", () => {
     expect(resolveSessionDisplayName("agent:main:imessage:direct:+4912")).toBe("iMessage · +4912");
   });
 
+  it("does not split UTF-16 surrogate pairs when shortening peer ids", () => {
+    const name = resolveSessionDisplayName("agent:main:telegram:direct:12345😀67890");
+    expect(() => encodeURIComponent(name)).not.toThrow();
+    expect(name).toContain("Telegram · …");
+    expect(name).not.toMatch(
+      /[\uD800-\uDFFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+    );
+  });
+
   it("falls back to a friendly name for dashboard sessions instead of the uuid key", () => {
     expect(
       resolveSessionDisplayName("agent:main:dashboard:0f9d5c1e-6d0f-4c9a-9d84-1c2f3a4b5c6d"),

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -1,4 +1,5 @@
 // Control UI module implements session display behavior.
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.ts";
 
 const CHANNEL_LABELS: Record<string, string> = {
@@ -18,7 +19,7 @@ const KNOWN_CHANNEL_KEYS = Object.keys(CHANNEL_LABELS);
 /** Raw peer ids stay out of the sidebar; keep a short recognizable tail only. */
 function shortenPeerId(identifier: string): string {
   const trimmed = identifier.trim();
-  return trimmed.length <= 10 ? trimmed : `…${trimmed.slice(-6)}`;
+  return trimmed.length <= 10 ? trimmed : `…${sliceUtf16Safe(trimmed, -6)}`;
 }
 
 // Long hex/uuid runs inside keys and node ids are machine ids, not names;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the sidebar display name for an unnamed direct-message session could emit isolated UTF-16 surrogate halves when the peer id contains astral characters (e.g., emoji).

## Why This Change Was Made

`shortenPeerId` sliced the tail of the identifier with raw `String.prototype.slice(-6)`, which can bisect surrogate pairs. It now uses the repository's existing `sliceUtf16Safe` helper so the shortened tail always falls on a valid UTF-16 boundary.

## User Impact

Session labels in the Control UI sidebar remain well-formed when peer identifiers contain non-BMP characters.

## Evidence

- Replaced `trimmed.slice(-6)` with `sliceUtf16Safe(trimmed, -6)` in `ui/src/lib/session-display.ts`.
- Added a regression test in `ui/src/lib/session-display.test.ts` covering an astral character at the tail boundary.
- Focused tests pass: `node scripts/run-vitest.mjs ui/src/lib/session-display.test.ts`.
- Lint clean: `node scripts/run-oxlint.mjs ui/src/lib/session-display.ts ui/src/lib/session-display.test.ts`.

## Real behavior proof

- **Behavior addressed:** Before the patch, a peer id like `"12345😀67890"` would have produced a tail containing an isolated surrogate half. After the patch it returns `"…67890"`.
- **Real environment tested:** Local checkout of `fix/session-display-peer-id-utf16` at `8996aa6b8a`.
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx -e 'import { resolveSessionDisplayName } from "./ui/src/lib/session-display.ts"; const samples = ["agent:main:telegram:direct:491234567890", "agent:main:telegram:direct:12345😀67890"]; for (const k of samples) { const n = resolveSessionDisplayName(k); try { encodeURIComponent(n); console.log("ok"); } catch(e){ console.log("FAIL", e); } console.log(JSON.stringify(n)); }'
  ```
  And to verify the display names survive a real disk write/read round-trip:
  ```bash
  node --import tsx -e 'import { resolveSessionDisplayName } from "./ui/src/lib/session-display.ts"; import { writeFileSync, readFileSync, mkdtempSync } from "node:fs"; import { tmpdir } from "node:os"; import { join } from "node:path"; const f = join(mkdtempSync(join(tmpdir(), "sd-")), "names.txt"); const samples = ["agent:main:telegram:direct:491234567890", "agent:main:telegram:direct:12345😀67890"]; const names = samples.map(resolveSessionDisplayName); writeFileSync(f, names.join("\n"), "utf8"); const r = readFileSync(f, "utf8"); console.log(r); console.log("round-trip ok:", r === names.join("\n"));'
  ```
- **Evidence after fix:**
  ```
  ok
  "Telegram · …567890"
  ok
  "Telegram · …67890"

  Telegram · …567890
  Telegram · …67890
  round-trip ok: true
  ```
- **Observed result after fix:** The regression test `does not split UTF-16 surrogate pairs when shortening peer ids` passes, `encodeURIComponent` succeeds on every display name, and the names survive a disk write/read round-trip.
- **What was not tested:** No live Control UI sidebar render; change is a pure string-formatting helper.

_AI-assisted PR: changes and tests were generated with AI assistance and manually reviewed._
