### PR TITLE
fix(ci): stabilize bounded usage-cost retry coverage

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -335,9 +335,12 @@ describe("gateway-cli coverage", () => {
         const costCalls = callGateway.mock.calls.map(
           ([raw]) => raw as { method?: string; timeoutMs?: number },
         );
-        expect(costCalls.every((call) => call.method === "usage.cost")).toBe(true);
-        expect(costCalls.every((call) => (call.timeoutMs ?? 0) > 0)).toBe(true);
-        expect(costCalls.every((call) => (call.timeoutMs ?? 0) <= 10_000)).toBe(true);
+        for (const call of costCalls) {
+          expect(call.method).toBe("usage.cost");
+          expect(typeof call.timeoutMs).toBe("number");
+          expect(call.timeoutMs).toBeGreaterThan(0);
+          expect(call.timeoutMs).toBeLessThanOrEqual(10_000);
+        }
         expect(costCalls[0]?.timeoutMs).toBe(10_000);
         expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -372,9 +375,12 @@ describe("gateway-cli coverage", () => {
       const costCalls = callGateway.mock.calls.map(
         ([raw]) => raw as { method?: string; timeoutMs?: number },
       );
-      expect(costCalls.every((call) => call.method === "usage.cost")).toBe(true);
-      expect(costCalls.every((call) => (call.timeoutMs ?? 0) > 0)).toBe(true);
-      expect(costCalls.every((call) => (call.timeoutMs ?? 0) <= 50)).toBe(true);
+      for (const call of costCalls) {
+        expect(call.method).toBe("usage.cost");
+        expect(typeof call.timeoutMs).toBe("number");
+        expect(call.timeoutMs).toBeGreaterThan(0);
+        expect(call.timeoutMs).toBeLessThanOrEqual(50);
+      }
       expect(runtimeErrors.join("\n")).toContain("Timed out waiting for usage cost cache refresh");
     },
   );


### PR DESCRIPTION
Related: #104883

## What Problem This Solves

Closes the numeric assertion gap left after #104883 made bounded `gateway usage-cost` retry coverage scheduler-tolerant.

## Why This Change Was Made

Require every captured retry timeout to be a real positive number within the command budget in both the short-timeout and cache-refresh test surfaces. This is the smallest follow-up to the review finding on the now-merged #104883.

## User Impact

No runtime behavior changes. Main CI accepts scheduler-dependent bounded retries without weakening the numeric timeout contract.

## Evidence

- AWS Crabbox `run_e922e436e23b`: 31/31 focused CLI tests passed.
- AWS Crabbox `run_e922e436e23b`: path-scoped `pnpm check:changed` passed.
- Fresh `gpt-5.6-sol` autoreview: no accepted/actionable findings.
- `oxfmt --check` and `git diff --check` passed.

No transcript is attached because this release-coordination session contains unrelated private credential context and cannot be safely scoped for publication.
