### PR TITLE
refactor(agents): centralize attempt terminal outcome

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -202,6 +202,122 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.meta?.livenessState).toBe("abandoned");
   });
 
+  it("does not route caller timeouts through provider failover", async () => {
+    const controller = new AbortController();
+    const timeoutError = new Error("caller deadline elapsed");
+    timeoutError.name = "TimeoutError";
+    const setTerminalLifecycleMeta = vi.fn();
+    const interruptedAssistant = {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "HTTP 429 Too Many Requests",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    mockedClassifyFailoverReason.mockReturnValue("rate_limit");
+    mockedIsRateLimitAssistantError.mockReturnValue(true);
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async () => {
+      controller.abort(timeoutError);
+      return makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: interruptedAssistant,
+        currentAttemptAssistant: interruptedAssistant,
+        setTerminalLifecycleMeta,
+      });
+    });
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-caller-timeout",
+      abortSignal: controller.signal,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.at(-1)?.text).toContain("timed out");
+    expect(result.meta?.aborted).toBe(false);
+    expect(result.meta?.timeoutPhase).toBeUndefined();
+    expect(result.meta?.providerStarted).toBeUndefined();
+    const lifecycleMeta = setTerminalLifecycleMeta.mock.lastCall?.[0];
+    expect(lifecycleMeta).toMatchObject({
+      aborted: false,
+      livenessState: "blocked",
+      stopReason: "timeout",
+    });
+    expect(lifecycleMeta).not.toHaveProperty("timeoutPhase");
+    expect(lifecycleMeta).not.toHaveProperty("providerStarted");
+  });
+
+  it("does not synthesize an incomplete turn for a caller abort before attempt flags settle", async () => {
+    const controller = new AbortController();
+    const abortError = new Error("caller cancelled");
+    abortError.name = "AbortError";
+    const setTerminalLifecycleMeta = vi.fn();
+    const lateAssistant = {
+      role: "assistant",
+      stopReason: "stop",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [{ type: "text", text: "Late answer" }],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async () => {
+      controller.abort(abortError);
+      return makeAttemptResult({
+        assistantTexts: ["Late answer"],
+        lastAssistant: lateAssistant,
+        currentAttemptAssistant: lateAssistant,
+        setTerminalLifecycleMeta,
+      });
+    });
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-caller-abort",
+      abortSignal: controller.signal,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads).toBeUndefined();
+    expect(result.meta?.aborted).toBe(true);
+    expect(result.meta?.error).toBeUndefined();
+    expectNoWarnMessageWith("incomplete turn detected");
+    expect(setTerminalLifecycleMeta.mock.lastCall?.[0]).toMatchObject({
+      aborted: true,
+      livenessState: "blocked",
+      stopReason: "aborted",
+    });
+  });
+
+  it("propagates canonical assistant aborts into terminal lifecycle metadata", async () => {
+    const setTerminalLifecycleMeta = vi.fn();
+    const abortedAssistant = {
+      role: "assistant",
+      stopReason: "aborted",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: abortedAssistant,
+        currentAttemptAssistant: abortedAssistant,
+        setTerminalLifecycleMeta,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-canonical-assistant-abort",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta?.aborted).toBe(true);
+    expect(setTerminalLifecycleMeta.mock.lastCall?.[0]).toMatchObject({
+      aborted: true,
+    });
+  });
+
   it("synthesizes a silent cron payload from a trailing current-attempt NO_REPLY tool result", () => {
     // Cron no-reply can be represented by a tool result rather than assistant
     // text, but only when it belongs to the current attempt.
@@ -992,12 +1108,19 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectWarnMessageWith("empty response detected");
   });
 
-  it("retries replay-safe missing terminal assistant turns once with the same prompt", async () => {
+  it("retries replay-safe missing turns despite a stale aborted transcript assistant", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
+    const staleAssistant = {
+      role: "assistant",
+      stopReason: "aborted",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [],
+    } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        lastAssistant: undefined,
+        lastAssistant: staleAssistant,
         currentAttemptAssistant: undefined,
       }),
     );
@@ -1024,10 +1147,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
-    expect(runAttemptCall(1).prompt).toBe(runAttemptCall(0).prompt);
+    expect(runAttemptCall(1).prompt).toContain(EMPTY_RESPONSE_RETRY_INSTRUCTION);
     expect(result.meta?.finalAssistantVisibleText).toBe("Recovered answer.");
-    expectWarnMessageWith("missing assistant terminal message detected");
-    expectNoWarnMessageWith("empty response detected");
+    expectWarnMessageWith("empty response detected");
+    expectNoWarnMessageWith("missing assistant terminal message detected");
     expectNoWarnMessageWith("incomplete turn detected");
   });
 

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -1040,7 +1040,7 @@ describe("overflow compaction in run loop", () => {
       livenessState: "abandoned",
       timeoutPhase: "provider",
       providerStarted: true,
-      aborted: true,
+      aborted: false,
     });
   });
 

--- a/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test.ts
@@ -188,6 +188,30 @@ describe("timeout-triggered compaction", () => {
     expect(result.meta.agentMeta?.compactionTokensAfter).toBe(80_000);
   });
 
+  it("does not compact for a caller-owned timeout before attempt flags settle", async () => {
+    const controller = new AbortController();
+    const timeoutError = new Error("caller deadline elapsed");
+    timeoutError.name = "TimeoutError";
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async () => {
+      controller.abort(timeoutError);
+      return makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          usage: { input: 150000 },
+        } as never,
+      });
+    });
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      abortSignal: controller.signal,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(result.payloads?.at(-1)?.text).toContain("timed out");
+  });
+
   it("leaves timeout recovery to a forced unlocked Codex compaction owner", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
     const pluginRunAttempt = vi.fn<AgentHarness["runAttempt"]>(async () =>

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -278,6 +278,12 @@ import {
   resolveHookModelSelection,
   resolveNativeModelOwnedHarnessId,
 } from "./run/setup.js";
+import {
+  isEmbeddedRunTerminalAbort,
+  isEmbeddedRunTerminalInterrupted,
+  isEmbeddedRunTerminalTimeout,
+  resolveEmbeddedRunAttemptTerminalOutcome,
+} from "./run/terminal-outcome.js";
 import { mergeAttemptToolMediaPayloads } from "./run/tool-media-payloads.js";
 import type { EmbeddedRunFastModeParam } from "./run/types.js";
 import {
@@ -2871,13 +2877,43 @@ async function runEmbeddedAgentInternal(
             lastAssistant: sessionLastAssistant,
             currentAttemptAssistant,
           } = attempt;
+          const timedOutDuringToolExecution = attempt.timedOutDuringToolExecution ?? false;
+          const timedOutByRunBudget = attempt.timedOutByRunBudget ?? false;
+          // Transcript fallback can outlive a provider or alias transition.
+          // Reuse it only when it reports the effective model for this attempt.
+          const sessionAssistantForCandidate =
+            !currentAttemptAssistant &&
+            !isAssistantForModelRef(sessionLastAssistant, {
+              provider: effectiveModel.provider,
+              model: effectiveModel.id,
+            })
+              ? undefined
+              : sessionLastAssistant;
+          const attemptAssistant = currentAttemptAssistant ?? sessionAssistantForCandidate;
+          const terminalOutcome = resolveEmbeddedRunAttemptTerminalOutcome({
+            attempt,
+            assistant: currentAttemptAssistant,
+            abortSignal: params.abortSignal,
+          });
+          const terminalAborted = isEmbeddedRunTerminalAbort(terminalOutcome);
+          const terminalTimedOut = isEmbeddedRunTerminalTimeout(terminalOutcome);
+          const terminalInterrupted = isEmbeddedRunTerminalInterrupted(terminalOutcome);
+          const signalOwnedInterruption =
+            terminalInterrupted && params.abortSignal?.aborted === true;
+          const terminalIdleTimedOut = terminalTimedOut && idleTimedOut;
           const setTerminalLifecycleMeta: NonNullable<typeof attempt.setTerminalLifecycleMeta> = (
             meta,
           ) => {
-            attempt.setTerminalLifecycleMeta?.({ ...meta, aborted });
+            const { stopReason, ...remainingMeta } = meta;
+            const terminalStopReason = terminalInterrupted
+              ? terminalOutcome.stopReason
+              : stopReason;
+            attempt.setTerminalLifecycleMeta?.({
+              ...remainingMeta,
+              ...(terminalStopReason ? { stopReason: terminalStopReason } : {}),
+              aborted: terminalAborted,
+            });
           };
-          const timedOutDuringToolExecution = attempt.timedOutDuringToolExecution ?? false;
-          const timedOutByRunBudget = attempt.timedOutByRunBudget ?? false;
           const previousActiveSessionId = activeSessionId;
           const previousActiveSessionFile = activeSessionFile;
           adoptActiveSessionId(sessionIdUsed);
@@ -2930,7 +2966,7 @@ async function runEmbeddedAgentInternal(
           // feeds it the latest attempt outcome and bails through the
           // existing retry-limit exhaustion path when the cap is hit.
           const breakerStep = stepIdleTimeoutBreaker(idleTimeoutBreakerState, {
-            idleTimedOut,
+            idleTimedOut: terminalIdleTimedOut,
             completedModelProgress: hasCompletedModelProgressForIdleBreaker(attempt),
             outputTokens: attemptUsage?.output,
           });
@@ -2987,17 +3023,6 @@ async function runEmbeddedAgentInternal(
           if (attempt.contextBudgetStatus) {
             lastContextBudgetStatus = attempt.contextBudgetStatus;
           }
-          // Transcript fallback can outlive a provider or alias transition.
-          // Reuse it only when it reports the effective model for this attempt.
-          const sessionAssistantForCandidate =
-            !currentAttemptAssistant &&
-            !isAssistantForModelRef(sessionLastAssistant, {
-              provider: effectiveModel.provider,
-              model: effectiveModel.id,
-            })
-              ? undefined
-              : sessionLastAssistant;
-          const attemptAssistant = currentAttemptAssistant ?? sessionAssistantForCandidate;
           const activeErrorContext = resolveActiveErrorContext({
             provider,
             model: modelId,
@@ -3037,7 +3062,7 @@ async function runEmbeddedAgentInternal(
             !attempt.lastToolError &&
             (attempt.toolMetas?.length ?? 0) === 0 &&
             (attempt.assistantTexts?.length ?? 0) === 0;
-          if (!nativeModelOwned && preflightRecovery?.handled) {
+          if (!signalOwnedInterruption && !nativeModelOwned && preflightRecovery?.handled) {
             const retryingFromTranscript = preflightRecovery.source === "mid-turn";
             log.info(
               `[context-overflow-precheck] early recovery route=${preflightRecovery.route} ` +
@@ -3061,7 +3086,7 @@ async function runEmbeddedAgentInternal(
             currentAuthProfileId: preferredProfileId,
             currentAuthProfileIdSource: params.authProfileIdSource,
           });
-          if (requestedSelection && canRestartForLiveSwitch) {
+          if (!signalOwnedInterruption && requestedSelection && canRestartForLiveSwitch) {
             await clearLiveModelSwitchPending({
               cfg: params.config,
               sessionKey: resolvedSessionKey,
@@ -3076,6 +3101,7 @@ async function runEmbeddedAgentInternal(
             genericCompactionRecoveryAllowed &&
             contextTokenBudget !== undefined &&
             timedOut &&
+            !signalOwnedInterruption &&
             !timedOutDuringCompaction &&
             !timedOutDuringToolExecution &&
             !timedOutByRunBudget
@@ -3236,26 +3262,27 @@ async function runEmbeddedAgentInternal(
             }
           }
 
-          const contextOverflowError = !aborted
-            ? (() => {
-                if (promptError) {
-                  const errorText = formatErrorMessage(promptError);
-                  if (isLikelyContextOverflowError(errorText)) {
-                    return { text: errorText, source: "promptError" as const };
+          const contextOverflowError =
+            !aborted && !signalOwnedInterruption
+              ? (() => {
+                  if (promptError) {
+                    const errorText = formatErrorMessage(promptError);
+                    if (isLikelyContextOverflowError(errorText)) {
+                      return { text: errorText, source: "promptError" as const };
+                    }
+                    // Prompt submission failed with a non-overflow error. Do not
+                    // inspect prior assistant errors from history for this attempt.
+                    return null;
                   }
-                  // Prompt submission failed with a non-overflow error. Do not
-                  // inspect prior assistant errors from history for this attempt.
+                  if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
+                    return {
+                      text: assistantErrorText,
+                      source: "assistantError" as const,
+                    };
+                  }
                   return null;
-                }
-                if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
-                  return {
-                    text: assistantErrorText,
-                    source: "assistantError" as const,
-                  };
-                }
-                return null;
-              })()
-            : null;
+                })()
+              : null;
 
           if (
             contextOverflowError &&
@@ -3633,7 +3660,7 @@ async function runEmbeddedAgentInternal(
             };
           }
 
-          if (promptErrorSource === "hook:before_agent_run" && !aborted) {
+          if (promptErrorSource === "hook:before_agent_run" && !terminalInterrupted) {
             const errorText = formatErrorMessage(promptError);
             const replayInvalid = resolveReplayInvalidForAttempt();
             setTerminalLifecycleMeta({
@@ -3703,7 +3730,7 @@ async function runEmbeddedAgentInternal(
 
           if (
             promptError &&
-            !aborted &&
+            !terminalInterrupted &&
             promptErrorSource !== "compaction" &&
             !hasRecoverableCodexAppServerTimeoutOutcome &&
             !shouldSurfaceCodexCompletionTimeout
@@ -3984,7 +4011,7 @@ async function runEmbeddedAgentInternal(
             message: attemptAssistant?.errorMessage,
             attempted: attemptedThinking,
           });
-          if (fallbackThinking && !aborted) {
+          if (fallbackThinking && !terminalInterrupted) {
             log.warn(
               `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
             );
@@ -3998,9 +4025,7 @@ async function runEmbeddedAgentInternal(
           const failoverFailure = isFailoverAssistantError(attemptAssistant);
           const assistantFailoverReason = classifyAssistantFailoverReason(attemptAssistant);
           const assistantProviderStarted =
-            Boolean(currentAttemptAssistant?.provider) ||
-            idleTimedOut ||
-            (timedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution);
+            Boolean(currentAttemptAssistant?.provider) || terminalOutcome.providerStarted === true;
           const assistantProfileFailoverReason =
             assistantFailoverReason ??
             (assistantProviderStarted && (timedOut || idleTimedOut) ? "timeout" : null);
@@ -4038,9 +4063,8 @@ async function runEmbeddedAgentInternal(
             !billingFailure &&
             !cloudCodeAssistFormatError &&
             !imageDimensionError &&
-            !aborted &&
+            !terminalInterrupted &&
             !promptError &&
-            !timedOut &&
             silentErrorRetryReason &&
             shouldRetrySilentErrorAssistantTurn({ attempt, assistant: attemptAssistant }) &&
             emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
@@ -4074,6 +4098,7 @@ async function runEmbeddedAgentInternal(
           });
 
           if (
+            !signalOwnedInterruption &&
             authFailure &&
             (await maybeRefreshRuntimeAuthForAuthError(
               attemptAssistant?.errorMessage ?? "",
@@ -4106,7 +4131,7 @@ async function runEmbeddedAgentInternal(
             stage: "assistant",
             allowFormatRetry: cloudCodeAssistFormatError,
             aborted,
-            externalAbort,
+            externalAbort: externalAbort || signalOwnedInterruption,
             fallbackConfigured,
             failoverFailure,
             failoverReason: assistantFailoverReason,
@@ -4121,7 +4146,7 @@ async function runEmbeddedAgentInternal(
           const assistantFailoverOutcome = await handleAssistantFailover({
             initialDecision: assistantFailoverDecision,
             aborted,
-            externalAbort,
+            externalAbort: externalAbort || signalOwnedInterruption,
             fallbackConfigured,
             failoverFailure,
             failoverReason: assistantFailoverReason,
@@ -4283,7 +4308,7 @@ async function runEmbeddedAgentInternal(
             sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
             agentId: params.agentId,
             runId: params.runId,
-            runAborted: aborted,
+            runAborted: terminalInterrupted,
             didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
             heartbeatToolResponse: attempt.heartbeatToolResponse,
           });
@@ -4295,7 +4320,7 @@ async function runEmbeddedAgentInternal(
             sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
           });
           const timedOutDuringPrompt =
-            timedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution;
+            terminalTimedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution;
           const finalAssistantStopReason = (attemptAssistant?.stopReason ?? "")
             .trim()
             .toLowerCase();
@@ -4365,18 +4390,23 @@ async function runEmbeddedAgentInternal(
               attempt.promptTimeoutOutcome?.livenessState ??
               resolveRunLivenessState({
                 payloadCount: hasPartialAssistantTextAfterPromptTimeout ? 0 : payloads.length,
-                aborted,
-                timedOut,
+                aborted: terminalAborted,
+                timedOut: terminalTimedOut,
                 attempt,
                 incompleteTurnText: null,
               });
-            const timeoutPhase = attempt.promptTimeoutOutcome?.timeoutPhase ?? "provider";
-            const providerStarted = attempt.promptTimeoutOutcome?.providerStarted ?? true;
+            const timeoutPhase =
+              attempt.promptTimeoutOutcome?.timeoutPhase ?? terminalOutcome.timeoutPhase;
+            const providerStarted =
+              attempt.promptTimeoutOutcome?.providerStarted ?? terminalOutcome.providerStarted;
+            const timeoutAttribution = {
+              ...(timeoutPhase ? { timeoutPhase } : {}),
+              ...(typeof providerStarted === "boolean" ? { providerStarted } : {}),
+            };
             setTerminalLifecycleMeta({
               replayInvalid,
               livenessState,
-              timeoutPhase,
-              providerStarted,
+              ...timeoutAttribution,
             });
             return {
               payloads: [
@@ -4389,15 +4419,14 @@ async function runEmbeddedAgentInternal(
               meta: {
                 durationMs: Date.now() - started,
                 agentMeta,
-                aborted,
+                aborted: terminalAborted,
                 systemPromptReport: attempt.systemPromptReport,
                 finalPromptText: attempt.finalPromptText,
                 finalAssistantVisibleText,
                 finalAssistantRawText,
                 replayInvalid,
                 livenessState,
-                timeoutPhase,
-                providerStarted,
+                ...timeoutAttribution,
                 // Completion-idle recovery is exhausted here. Keep this terminal so
                 // model fallback cannot replay a potentially still-active Codex turn.
                 ...(shouldSurfaceCodexCompletionTimeout
@@ -4430,8 +4459,8 @@ async function runEmbeddedAgentInternal(
           const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
             isCronTrigger: params.trigger === "cron",
             payloadCount: payloadsWithToolMedia?.length ?? 0,
-            aborted,
-            timedOut,
+            aborted: terminalAborted,
+            timedOut: terminalTimedOut,
             attempt,
           });
           const payloadsForTerminalPath = recoveredFinalAssistantPayloadsAfterPromptTimeout
@@ -4445,8 +4474,8 @@ async function runEmbeddedAgentInternal(
           const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
             allowEmptyAssistantReplyAsSilent: params.allowEmptyAssistantReplyAsSilent,
             payloadCount,
-            aborted,
-            timedOut,
+            aborted: terminalAborted,
+            timedOut: terminalTimedOut,
             attempt,
           });
           const nextReasoningOnlyRetryInstruction = emptyAssistantReplyIsSilent
@@ -4456,8 +4485,8 @@ async function runEmbeddedAgentInternal(
                 modelId: activeErrorContext.model,
                 modelApi: effectiveModel.api,
                 executionContract,
-                aborted,
-                timedOut,
+                aborted: terminalAborted,
+                timedOut: terminalTimedOut,
                 attempt,
               });
           const nextEmptyResponseRetryInstruction = emptyAssistantReplyIsSilent
@@ -4468,8 +4497,8 @@ async function runEmbeddedAgentInternal(
                 modelApi: effectiveModel.api,
                 executionContract,
                 payloadCount,
-                aborted,
-                timedOut,
+                aborted: terminalAborted,
+                timedOut: terminalTimedOut,
                 attempt,
               });
           if (
@@ -4492,9 +4521,9 @@ async function runEmbeddedAgentInternal(
             !emptyAssistantReplyIsSilent &&
             shouldRetryMissingAssistantTurn({
               payloadCount,
-              aborted,
+              aborted: terminalAborted,
               promptError,
-              timedOut,
+              timedOut: terminalTimedOut,
               attempt,
             }) &&
             missingAssistantRetryAttempts < MAX_MISSING_ASSISTANT_RETRIES
@@ -4524,15 +4553,14 @@ async function runEmbeddedAgentInternal(
             ? null
             : resolveIncompleteTurnPayloadText({
                 payloadCount,
-                aborted,
-                externalAbort,
-                timedOut,
+                aborted: terminalAborted,
+                externalAbort: externalAbort || signalOwnedInterruption,
+                timedOut: terminalTimedOut,
                 attempt,
               });
           const incompleteTurnFallbackSafe = Boolean(
             incompleteTurnText &&
-            !aborted &&
-            !timedOut &&
+            !terminalInterrupted &&
             !promptError &&
             !attempt.lastToolError &&
             !hasAttemptTerminalState(attempt) &&
@@ -4545,9 +4573,8 @@ async function runEmbeddedAgentInternal(
             !emptyAssistantReplyIsSilent &&
             attemptCompactionCount > 0 &&
             payloadCount === 0 &&
-            !aborted &&
+            !terminalInterrupted &&
             !promptError &&
-            !timedOut &&
             !attempt.clientToolCalls &&
             !attempt.yieldDetected &&
             !attempt.didSendDeterministicApprovalPrompt &&
@@ -4581,8 +4608,8 @@ async function runEmbeddedAgentInternal(
             const replayInvalid = resolveReplayInvalidForAttempt(incompletePayloadText);
             const livenessState = resolveRunLivenessState({
               payloadCount: 0,
-              aborted,
-              timedOut,
+              aborted: terminalAborted,
+              timedOut: terminalTimedOut,
               attempt,
               incompleteTurnText: incompletePayloadText,
             });
@@ -4607,7 +4634,7 @@ async function runEmbeddedAgentInternal(
               meta: {
                 durationMs: Date.now() - started,
                 agentMeta,
-                aborted,
+                aborted: terminalAborted,
                 systemPromptReport: attempt.systemPromptReport,
                 finalPromptText: attempt.finalPromptText,
                 finalAssistantVisibleText,
@@ -4651,8 +4678,8 @@ async function runEmbeddedAgentInternal(
             const replayInvalid = resolveReplayInvalidForAttempt(incompleteTurnText);
             const livenessState = resolveRunLivenessState({
               payloadCount,
-              aborted,
-              timedOut,
+              aborted: terminalAborted,
+              timedOut: terminalTimedOut,
               attempt,
               incompleteTurnText,
             });
@@ -4699,7 +4726,7 @@ async function runEmbeddedAgentInternal(
               meta: {
                 durationMs: Date.now() - started,
                 agentMeta,
-                aborted,
+                aborted: terminalAborted,
                 systemPromptReport: attempt.systemPromptReport,
                 finalPromptText: attempt.finalPromptText,
                 finalAssistantVisibleText,
@@ -4732,9 +4759,8 @@ async function runEmbeddedAgentInternal(
 
           const beforeAgentFinalizeRevisionReason = attempt.beforeAgentFinalizeRevisionReason;
           const shouldHonorBeforeAgentFinalizeRevision =
-            !aborted &&
+            !terminalInterrupted &&
             !promptError &&
-            !timedOut &&
             !attempt.clientToolCalls &&
             !attempt.yieldDetected &&
             !emptyAssistantReplyIsSilent;
@@ -4848,8 +4874,8 @@ async function runEmbeddedAgentInternal(
             ? "paused"
             : resolveRunLivenessState({
                 payloadCount,
-                aborted,
-                timedOut,
+                aborted: terminalAborted,
+                timedOut: terminalTimedOut,
                 attempt,
                 incompleteTurnText: null,
               });
@@ -4875,7 +4901,7 @@ async function runEmbeddedAgentInternal(
             meta: {
               durationMs: Date.now() - started,
               agentMeta,
-              aborted,
+              aborted: terminalAborted,
               systemPromptReport: attempt.systemPromptReport,
               finalPromptText: attempt.finalPromptText,
               finalAssistantVisibleText,

--- a/src/agents/embedded-agent-runner/run/terminal-outcome.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-outcome.test.ts
@@ -1,0 +1,172 @@
+import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { createAgentRunRestartAbortError } from "../../run-termination.js";
+import {
+  resolveEmbeddedRunAttemptTerminalOutcome,
+  type EmbeddedRunAttemptTerminalInput,
+} from "./terminal-outcome.js";
+
+function makeAttempt(
+  overrides: Partial<EmbeddedRunAttemptTerminalInput> = {},
+): EmbeddedRunAttemptTerminalInput {
+  return {
+    aborted: false,
+    idleTimedOut: false,
+    promptError: null,
+    promptTimeoutOutcome: undefined,
+    timedOut: false,
+    timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
+    ...overrides,
+  };
+}
+
+function makeAssistant(stopReason: AssistantMessage["stopReason"]): AssistantMessage {
+  return {
+    api: "responses",
+    provider: "openai",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    role: "assistant",
+    content: [],
+    timestamp: 0,
+    stopReason,
+  };
+}
+
+describe("embedded run attempt terminal outcome", () => {
+  it("keeps prompt timeout ownership ahead of generic abort metadata", () => {
+    const outcome = resolveEmbeddedRunAttemptTerminalOutcome({
+      attempt: makeAttempt({
+        aborted: true,
+        timedOut: true,
+      }),
+      assistant: makeAssistant("aborted"),
+    });
+
+    expect(outcome).toMatchObject({
+      reason: "hard_timeout",
+      status: "timeout",
+      timeoutPhase: "provider",
+      providerStarted: true,
+    });
+    expect(outcome).not.toHaveProperty("stopReason");
+  });
+
+  it("keeps restart cancellation ahead of generic abort metadata", () => {
+    const restartError = createAgentRunRestartAbortError();
+    const wrappedRestartError = new Error(restartError.message, { cause: restartError });
+    wrappedRestartError.name = "AbortError";
+
+    expect(
+      resolveEmbeddedRunAttemptTerminalOutcome({
+        attempt: makeAttempt({
+          aborted: true,
+          promptError: wrappedRestartError,
+        }),
+        assistant: makeAssistant("aborted"),
+      }),
+    ).toMatchObject({
+      reason: "cancelled",
+      status: "error",
+      stopReason: "restart",
+    });
+  });
+
+  it("keeps generic abort metadata ahead of a non-abort assistant stop reason", () => {
+    expect(
+      resolveEmbeddedRunAttemptTerminalOutcome({
+        attempt: makeAttempt({
+          aborted: true,
+        }),
+        assistant: makeAssistant("stop"),
+      }),
+    ).toMatchObject({
+      reason: "aborted",
+      status: "error",
+      stopReason: "aborted",
+    });
+  });
+
+  it("keeps an attributed prompt timeout ahead of restart cancellation", () => {
+    const controller = new AbortController();
+    controller.abort(createAgentRunRestartAbortError());
+
+    expect(
+      resolveEmbeddedRunAttemptTerminalOutcome({
+        attempt: makeAttempt({
+          aborted: true,
+          timedOut: true,
+        }),
+        assistant: undefined,
+        abortSignal: controller.signal,
+      }),
+    ).toMatchObject({
+      reason: "hard_timeout",
+      status: "timeout",
+      stopReason: "restart",
+      timeoutPhase: "provider",
+    });
+  });
+
+  it("classifies caller timeout aborts before attempt timeout flags settle", () => {
+    const controller = new AbortController();
+    const timeoutError = new Error("request timed out");
+    timeoutError.name = "TimeoutError";
+    controller.abort(timeoutError);
+
+    const outcome = resolveEmbeddedRunAttemptTerminalOutcome({
+      attempt: makeAttempt(),
+      assistant: undefined,
+      abortSignal: controller.signal,
+    });
+
+    expect(outcome).toMatchObject({
+      reason: "timed_out",
+      status: "timeout",
+      stopReason: "timeout",
+    });
+    expect(outcome).not.toHaveProperty("timeoutPhase");
+    expect(outcome).not.toHaveProperty("providerStarted");
+  });
+
+  it("ignores stale successful stop metadata when the current prompt failed", () => {
+    expect(
+      resolveEmbeddedRunAttemptTerminalOutcome({
+        attempt: makeAttempt({
+          promptError: new Error("prompt failed"),
+        }),
+        assistant: makeAssistant("stop"),
+      }),
+    ).toMatchObject({
+      reason: "failed",
+      status: "error",
+    });
+  });
+
+  it.each([{ timedOutDuringCompaction: true }, { timedOutDuringToolExecution: true }])(
+    "keeps non-provider timeouts ahead of their mechanical abort flag",
+    (timeoutPhase) => {
+      expect(
+        resolveEmbeddedRunAttemptTerminalOutcome({
+          attempt: makeAttempt({
+            aborted: true,
+            timedOut: true,
+            ...timeoutPhase,
+          }),
+          assistant: undefined,
+        }),
+      ).toMatchObject({
+        reason: "timed_out",
+        status: "timeout",
+      });
+    },
+  );
+});

--- a/src/agents/embedded-agent-runner/run/terminal-outcome.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-outcome.ts
@@ -1,0 +1,103 @@
+import {
+  buildAgentRunTerminalOutcome,
+  type AgentRunTerminalOutcome,
+} from "../../agent-run-terminal-outcome.js";
+import {
+  AGENT_RUN_RESTART_ABORT_STOP_REASON,
+  isAgentRunRestartAbortReason,
+  resolveAgentRunAbortLifecycleFields,
+} from "../../run-termination.js";
+import type { EmbeddedRunAttemptResult } from "./types.js";
+
+export type EmbeddedRunAttemptTerminalInput = Pick<
+  EmbeddedRunAttemptResult,
+  | "aborted"
+  | "idleTimedOut"
+  | "promptError"
+  | "promptTimeoutOutcome"
+  | "timedOut"
+  | "timedOutDuringCompaction"
+  | "timedOutDuringToolExecution"
+>;
+
+function hasRestartAbortReason(value: unknown): boolean {
+  let candidate = value;
+  for (let depth = 0; depth < 3; depth += 1) {
+    if (isAgentRunRestartAbortReason(candidate)) {
+      return true;
+    }
+    if (!(candidate instanceof Error)) {
+      return false;
+    }
+    try {
+      if (candidate.cause === undefined) {
+        return false;
+      }
+      candidate = candidate.cause;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/** Projects private attempt metadata into the canonical agent terminal outcome. */
+export function resolveEmbeddedRunAttemptTerminalOutcome(params: {
+  attempt: EmbeddedRunAttemptTerminalInput;
+  assistant: EmbeddedRunAttemptResult["lastAssistant"];
+  abortSignal?: AbortSignal;
+}): AgentRunTerminalOutcome {
+  const { attempt } = params;
+  const abortFields = resolveAgentRunAbortLifecycleFields(params.abortSignal);
+  const attemptTimedOut = attempt.timedOut || attempt.idleTimedOut;
+  const timedOut = attemptTimedOut || abortFields.stopReason === "timeout";
+  const timedOutDuringPrompt =
+    attemptTimedOut &&
+    !attempt.timedOutDuringCompaction &&
+    attempt.timedOutDuringToolExecution !== true;
+  const timeoutPhase =
+    attempt.promptTimeoutOutcome?.timeoutPhase ?? (timedOutDuringPrompt ? "provider" : undefined);
+  const providerStarted =
+    attempt.promptTimeoutOutcome?.providerStarted ?? (timedOutDuringPrompt ? true : undefined);
+  // Internal queue restarts are wrapped by the attempt's abortable prompt race,
+  // so promptError must preserve restart ownership when no parent signal exists.
+  const restartAborted = hasRestartAbortReason(attempt.promptError);
+  const assistantStopReason = attempt.promptError ? undefined : params.assistant?.stopReason;
+  const unattributedAttemptTimeout =
+    attemptTimedOut && timeoutPhase === undefined && providerStarted !== true;
+  const stopReason = unattributedAttemptTimeout
+    ? undefined
+    : (abortFields.stopReason ??
+      (restartAborted ? AGENT_RUN_RESTART_ABORT_STOP_REASON : undefined) ??
+      (!timedOut && attempt.aborted ? "aborted" : undefined) ??
+      (!timedOut ? assistantStopReason : undefined));
+  const status = timedOut
+    ? "timeout"
+    : abortFields.aborted ||
+        attempt.aborted ||
+        attempt.promptError ||
+        assistantStopReason === "error"
+      ? "error"
+      : "ok";
+
+  return buildAgentRunTerminalOutcome({
+    status,
+    error: attempt.promptError ?? params.assistant?.errorMessage,
+    stopReason,
+    livenessState: attempt.promptTimeoutOutcome?.livenessState,
+    timeoutPhase,
+    providerStarted,
+  });
+}
+
+export function isEmbeddedRunTerminalTimeout(outcome: AgentRunTerminalOutcome): boolean {
+  return outcome.reason === "hard_timeout" || outcome.reason === "timed_out";
+}
+
+export function isEmbeddedRunTerminalAbort(outcome: AgentRunTerminalOutcome): boolean {
+  return outcome.reason === "aborted" || outcome.reason === "cancelled";
+}
+
+export function isEmbeddedRunTerminalInterrupted(outcome: AgentRunTerminalOutcome): boolean {
+  return isEmbeddedRunTerminalTimeout(outcome) || isEmbeddedRunTerminalAbort(outcome);
+}


### PR DESCRIPTION
## What Problem This Solves

Embedded agent attempts derived timeout, abort, cancellation, and retry behavior from overlapping raw flags in the main run loop. That made ownership and precedence difficult to reason about, especially when parent abort signals settled before attempt-local flags.

Related #104871

## Why This Change Was Made

This extracts one private terminal-outcome projection backed by the existing canonical agent-run outcome model. The run loop consumes that projection for terminal guards, lifecycle metadata, payload suppression, liveness, and returned metadata while retaining attempt-owned facts for provider recovery and failover.

Caller-owned cancellation and timeout signals now suppress retries, profile rotation, model switching, compaction recovery, and late assistant payloads without being attributed to provider health. Provider, compaction, tool, restart, and idle timeout precedence remains explicit and covered.

## User Impact

No config, SDK, CLI option, protocol, schema, generated artifact, or public result shape changes.

Internal terminal-state handling is more consistent. Caller cancellation cannot launch another billed provider attempt or surface a late assistant reply, and timeout outcomes no longer conflict with lifecycle or returned `aborted` metadata.

## Evidence

- Blacksmith Testbox `tbx_01kxa5tp9jgm395vnpp0zn292j`
- 351 focused tests passed across terminal outcome, failover policy, assistant failover, incomplete-turn safety, timeout compaction, overflow loop, and live model switching
- `pnpm check:changed` passed for `core, coreTests`
- `oxfmt --check` passed on all six changed files
- `git diff --check` passed
- Fresh autoreview: clean, no accepted/actionable findings, 0.84 confidence
