### PR TITLE
test(live): retry GPT-5.6 nonce mismatches on LTS

### DIFF
--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1631,6 +1631,18 @@ function shouldSkipToolNonceProbeMissForLiveModel(modelKey?: string): boolean {
   return GATEWAY_LIVE_TOOL_NONCE_MISS_SKIP_MODEL_KEYS.has(normalizedKey);
 }
 
+function shouldRetryToolNonceProbeMissForLiveModel(modelKey?: string): boolean {
+  if (shouldSkipToolNonceProbeMissForLiveModel(modelKey)) {
+    return true;
+  }
+  if (!modelKey) {
+    return false;
+  }
+  const [provider, ...rest] = modelKey.split("/");
+  const modelId = rest.join("/");
+  return provider === "openai" && (modelId === "gpt-5.6" || modelId.startsWith("gpt-5.6-"));
+}
+
 describe("shouldSkipToolNonceProbeMissForLiveModel", () => {
   it.each([
     { modelKey: "anthropic/claude-opus-4-6", expected: true },
@@ -1645,8 +1657,21 @@ describe("shouldSkipToolNonceProbeMissForLiveModel", () => {
     { modelKey: "google/gemini-3-flash-preview", expected: true },
     { modelKey: "google/gemini-3.1-pro-preview", expected: true },
     { modelKey: "openai/gpt-5.4", expected: false },
+    { modelKey: "openai/gpt-5.6-sol", expected: false },
   ])("returns $expected for $modelKey", ({ modelKey, expected }) => {
     expect(shouldSkipToolNonceProbeMissForLiveModel(modelKey)).toBe(expected);
+  });
+});
+
+describe("shouldRetryToolNonceProbeMissForLiveModel", () => {
+  it.each([
+    { modelKey: "openai/gpt-5.6", expected: true },
+    { modelKey: "openai/gpt-5.6-luna", expected: true },
+    { modelKey: "openai/gpt-5.6-sol", expected: true },
+    { modelKey: "openai/gpt-5.5", expected: false },
+    { modelKey: "openai/gpt-5.60", expected: false },
+  ])("returns $expected for $modelKey", ({ modelKey, expected }) => {
+    expect(shouldRetryToolNonceProbeMissForLiveModel(modelKey)).toBe(expected);
   });
 });
 
@@ -3146,9 +3171,9 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
               logProgress(`${progressLabel}: tool-read`);
               const runIdTool = randomUUID();
               const maxToolReadAttempts = 3;
-              // Known-variable models already skip after exhausted nonce misses.
-              // Use the stricter follow-up prompts before conceding that coverage.
-              const retryKnownToolNonceMiss = shouldSkipToolNonceProbeMissForLiveModel(modelKey);
+              // Some known-variable models may skip after exhausted nonce misses;
+              // GPT-5.6 variants retry but still fail closed after the final attempt.
+              const retryKnownToolNonceMiss = shouldRetryToolNonceProbeMissForLiveModel(modelKey);
               let toolText = "";
               for (
                 let toolReadAttempt = 0;


### PR DESCRIPTION
## What Problem This Solves

The LTS OpenAI API-default live lane can fail on a well-formed but incorrect GPT-5.6 tool nonce response. The exact same candidate has both passed and failed, but LTS did not retry this mismatch class for GPT-5.6 variants.

## Why This Change Was Made

Backport the narrowly scoped GPT-5.6 retry policy from main. LTS already contains the three-attempt framework through `ec44bb12243e`; this change only classifies exact `openai/gpt-5.6` and `openai/gpt-5.6-*` model IDs for bounded retries. GPT-5.6 is not added to the exhausted-miss skip set, so three failed attempts still fail closed.

## User Impact

No product runtime change. LTS live-provider validation tolerates a demonstrated one-attempt model variance without hiding persistent regressions.

## Evidence

- Prior intermittent failure: https://github.com/openclaw/openclaw/actions/runs/29173852864/job/86599663109
- Same exact candidate previously passed the lane: https://github.com/openclaw/openclaw/actions/runs/29172868666/job/86597054073
- Blacksmith Testbox live-config unit surface: 99 passed, 2 live cases skipped.
- `git diff --check` passed.
- Fresh autoreview: no actionable findings.

No agent transcript attached, per maintainer instruction.
