### PR TITLE
fix(sqlite): refuse backups and compaction with corrupt indexes

### DIFF
--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -8,6 +8,7 @@ import * as tar from "tar";
 import { loadSqliteVecExtension } from "../../packages/memory-host-sdk/src/engine-storage.js";
 import { formatDiskSpaceBytes, tryReadDiskSpace } from "../infra/disk-space.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { isRecord, resolveUserPath } from "../utils.js";
 import { buildBackupArchivePath } from "./backup-shared.js";
@@ -607,21 +608,6 @@ function assertSqliteExtractionBudget(params: {
   }
 }
 
-function assertSqliteCheckOk(params: {
-  database: DatabaseSync;
-  archivePath: string;
-  pragma: "integrity_check" | "quick_check";
-}): void {
-  const rows = params.database.prepare(`PRAGMA ${params.pragma}`).all() as Array<
-    Record<string, unknown>
-  >;
-  const results = rows.map((row) => row[params.pragma]);
-  if (results.length === 0 || results.some((result) => result !== "ok")) {
-    const details = results.map((result) => String(result)).join("; ") || "no result";
-    throw new Error(`SQLite ${params.pragma} failed for ${params.archivePath}: ${details}`);
-  }
-}
-
 function assertExpectedSqliteRole(
   database: DatabaseSync,
   archivePath: string,
@@ -748,16 +734,7 @@ async function verifySqliteSnapshots(params: {
         });
         database.exec("PRAGMA query_only = ON; PRAGMA trusted_schema = OFF;");
         await loadSqliteVecExtension({ db: database });
-        assertSqliteCheckOk({
-          database,
-          archivePath: entry.normalized,
-          pragma: "quick_check",
-        });
-        assertSqliteCheckOk({
-          database,
-          archivePath: entry.normalized,
-          pragma: "integrity_check",
-        });
+        assertSqliteIntegrity(database, entry.normalized);
         assertExpectedSqliteRole(database, entry.normalized, expectedRole);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/commands/doctor-sqlite-compact.ts
+++ b/src/commands/doctor-sqlite-compact.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../state/openclaw-state-db.js";
 
 export type DoctorSqliteCompactSnapshot = {
@@ -46,13 +47,13 @@ export function compactDoctorSqliteFile(
     database.exec("PRAGMA trusted_schema = OFF;");
     options.validateBeforeMutation?.(database);
     const before = readCompactSnapshot(database, options.sqlitePath);
+    assertSqliteIntegrity(database, options.sqlitePath);
     mutationStarted = true;
     checkpointTruncate(database, options.sqlitePath);
     database.exec("PRAGMA auto_vacuum = INCREMENTAL;");
     database.exec("VACUUM;");
     checkpointTruncate(database, options.sqlitePath);
-    const quickCheck = runDatabaseCheck(database, "quick_check");
-    const integrityCheck = runDatabaseCheck(database, "integrity_check");
+    const { quickCheck, integrityCheck } = assertSqliteIntegrity(database, options.sqlitePath);
     const after = readCompactSnapshot(database, options.sqlitePath);
     const beforeBytes = before.dbSizeBytes + before.walSizeBytes;
     const afterBytes = after.dbSizeBytes + after.walSizeBytes;
@@ -100,19 +101,6 @@ function checkpointTruncate(database: DatabaseSync, sqlitePath: string): void {
   if (busy !== 0) {
     throw new Error(`SQLite checkpoint remained busy for ${sqlitePath}. Stop OpenClaw and retry.`);
   }
-}
-
-function runDatabaseCheck(database: DatabaseSync, pragma: "integrity_check" | "quick_check"): "ok" {
-  const rows = database.prepare(`PRAGMA ${pragma};`).all() as Array<Record<string, unknown>>;
-  const results = rows.map((row) => readTextValue(row[pragma] ?? Object.values(row)[0]));
-  if (results.length === 1 && results[0] === "ok") {
-    return "ok";
-  }
-  throw new Error(`SQLite ${pragma} failed: ${results.filter(Boolean).join("; ") || "no result"}`);
-}
-
-function readTextValue(value: unknown): string {
-  return typeof value === "string" ? value : "";
 }
 
 function readCompactSnapshot(

--- a/src/commands/doctor-state-sqlite-compact.test.ts
+++ b/src/commands/doctor-state-sqlite-compact.test.ts
@@ -82,6 +82,34 @@ function readPragma(database: DatabaseSync, name: string): number {
   return Number(row[name] ?? Object.values(row)[0]);
 }
 
+function createUnsafeIndexDrift(sqlitePath: string): void {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(sqlitePath);
+  try {
+    database.exec(`
+      CREATE TABLE unsafe_index_records (
+        id INTEGER PRIMARY KEY,
+        indexed_value TEXT NOT NULL,
+        alternate_value TEXT NOT NULL
+      );
+      CREATE INDEX unsafe_index_records_value ON unsafe_index_records(indexed_value);
+      INSERT INTO unsafe_index_records (indexed_value, alternate_value)
+      VALUES ('alpha', 'zeta'), ('beta', 'eta'), ('gamma', 'theta');
+    `);
+    database.enableDefensive?.(false);
+    database.exec("PRAGMA writable_schema = ON;");
+    database
+      .prepare(
+        "UPDATE sqlite_schema SET sql = 'CREATE INDEX unsafe_index_records_value ON unsafe_index_records(alternate_value)' WHERE name = 'unsafe_index_records_value'",
+      )
+      .run();
+    database.exec("PRAGMA writable_schema = OFF;");
+    database.exec(`PRAGMA schema_version = ${readPragma(database, "schema_version") + 1};`);
+  } finally {
+    database.close();
+  }
+}
+
 function expectCompletedReport(
   report: DoctorStateSqliteCompactReport,
 ): asserts report is CompletedStateSqliteCompactReport {
@@ -215,6 +243,45 @@ describe("runDoctorStateSqliteCompact", () => {
       reader.exec("ROLLBACK;");
       reader.close();
       writer.close();
+    }
+  });
+
+  it("rejects stale secondary indexes before mutating the database", () => {
+    const env = createStateEnv();
+    const sqlitePath = seedStateDatabase({ env, withBloat: true });
+    createUnsafeIndexDrift(sqlitePath);
+    const sqlite = requireNodeSqlite();
+    const before = new sqlite.DatabaseSync(sqlitePath, { readOnly: true });
+    try {
+      expect(before.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
+      expect(before.prepare("PRAGMA integrity_check").all()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            integrity_check: expect.stringMatching(/missing from index unsafe_index_records_value/),
+          }),
+        ]),
+      );
+    } finally {
+      before.close();
+    }
+
+    expect(() => runDoctorStateSqliteCompact({ env })).toThrow(
+      /integrity_check failed.*missing from index unsafe_index_records_value/iu,
+    );
+
+    const after = new sqlite.DatabaseSync(sqlitePath, { readOnly: true });
+    try {
+      expect(readPragma(after, "auto_vacuum")).toBe(0);
+      expect(readPragma(after, "freelist_count")).toBeGreaterThan(0);
+      expect(after.prepare("PRAGMA integrity_check").all()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            integrity_check: expect.stringMatching(/missing from index unsafe_index_records_value/),
+          }),
+        ]),
+      );
+    } finally {
+      after.close();
     }
   });
 });

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -13,6 +13,7 @@ import {
   closeOpenClawStateDatabase,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   testApi as backupCreateInternals,
@@ -70,6 +71,36 @@ async function listArchiveEntryDetails(
     },
   });
   return entries;
+}
+
+function createUnsafeIndexDrift(sqlitePath: string): void {
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(sqlitePath);
+  try {
+    database.exec(`
+      CREATE TABLE unsafe_index_records (
+        id INTEGER PRIMARY KEY,
+        indexed_value TEXT NOT NULL,
+        alternate_value TEXT NOT NULL
+      );
+      CREATE INDEX unsafe_index_records_value ON unsafe_index_records(indexed_value);
+      INSERT INTO unsafe_index_records (indexed_value, alternate_value)
+      VALUES ('alpha', 'zeta'), ('beta', 'eta'), ('gamma', 'theta');
+    `);
+    database.enableDefensive?.(false);
+    database.exec("PRAGMA writable_schema = ON;");
+    database
+      .prepare(
+        "UPDATE sqlite_schema SET sql = 'CREATE INDEX unsafe_index_records_value ON unsafe_index_records(alternate_value)' WHERE name = 'unsafe_index_records_value'",
+      )
+      .run();
+    const schemaVersion = Number(
+      Object.values(database.prepare("PRAGMA schema_version;").get() as Record<string, unknown>)[0],
+    );
+    database.exec(`PRAGMA writable_schema = OFF; PRAGMA schema_version = ${schemaVersion + 1};`);
+  } finally {
+    database.close();
+  }
 }
 
 describe("formatBackupCreateSummary", () => {
@@ -607,6 +638,34 @@ describe("createBackupArchive", () => {
         } finally {
           closeOpenClawStateDatabase();
         }
+      },
+    );
+  });
+
+  it("rejects stale secondary indexes before creating a backup archive", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-unsafe-index-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+        openOpenClawStateDatabase({ env: state.env });
+        closeOpenClawStateDatabase();
+        createUnsafeIndexDrift(resolveOpenClawStateSqlitePath(state.env));
+
+        await expect(
+          createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: Date.UTC(2026, 4, 9, 8, 30, 30),
+          }),
+        ).rejects.toThrow(
+          /integrity_check failed.*missing from index unsafe_index_records_value/iu,
+        );
+        expect(await fs.readdir(outputDir)).toEqual([]);
       },
     );
   });

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -22,8 +22,10 @@ import { resolveHomeDir, resolveUserPath } from "../utils.js";
 import { sleep } from "../utils/sleep.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import { isVolatileBackupPath } from "./backup-volatile-filter.js";
+import { formatErrorMessage } from "./errors.js";
 import { writeJson } from "./json-files.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
+import { assertSqliteIntegrity } from "./sqlite-integrity.js";
 
 const loadTarRuntime = createLazyRuntimeModule(() => import("tar"));
 
@@ -759,10 +761,11 @@ async function createStateSqliteBackupPlan(params: {
         // the archive. Load known bundled extensions, but fail closed when an
         // owner schema needs capabilities core cannot safely reproduce.
         await loadSqliteVecExtension({ db: source });
+        assertSqliteIntegrity(source, archiveSourcePath);
         source.prepare("VACUUM INTO ?").run(sourcePath);
       } catch (err) {
         throw new Error(
-          `SQLite database cannot be compacted safely for backup: ${archiveSourcePath}. Required SQLite capabilities are unavailable; raw page backup was refused because it can retain deleted data.`,
+          `SQLite database cannot be compacted safely for backup: ${archiveSourcePath}. ${formatErrorMessage(err)}. The source must pass full integrity checks and VACUUM INTO with its required SQLite capabilities; raw page backup was refused because it can retain deleted data.`,
           { cause: err },
         );
       }
@@ -770,13 +773,20 @@ async function createStateSqliteBackupPlan(params: {
       source.close();
     }
     await fs.chmod(sourcePath, 0o600);
-    if (path.resolve(archiveSourcePath) === globalStateSqlitePath) {
-      const snapshot = new sqlite.DatabaseSync(sourcePath);
-      try {
+    const snapshot = new sqlite.DatabaseSync(sourcePath, { allowExtension: true });
+    try {
+      await loadSqliteVecExtension({ db: snapshot });
+      if (path.resolve(archiveSourcePath) === globalStateSqlitePath) {
         sanitizeGlobalStateSqliteSnapshot(snapshot);
-      } finally {
-        snapshot.close();
       }
+      assertSqliteIntegrity(snapshot, sourcePath);
+    } catch (err) {
+      throw new Error(
+        `SQLite backup snapshot failed verification for ${archiveSourcePath}: ${formatErrorMessage(err)}`,
+        { cause: err },
+      );
+    } finally {
+      snapshot.close();
     }
     snapshots.push({
       sourcePath,

--- a/src/infra/sqlite-integrity.ts
+++ b/src/infra/sqlite-integrity.ts
@@ -1,0 +1,33 @@
+import type { DatabaseSync } from "node:sqlite";
+
+export type SqliteIntegrityChecks = {
+  integrityCheck: "ok";
+  quickCheck: "ok";
+};
+
+type SqliteCheckPragma = "integrity_check" | "quick_check";
+
+/** Require both structural and table/index consistency before trusting a database. */
+export function assertSqliteIntegrity(
+  database: DatabaseSync,
+  databaseLabel: string,
+): SqliteIntegrityChecks {
+  return {
+    quickCheck: runSqliteCheck(database, databaseLabel, "quick_check"),
+    integrityCheck: runSqliteCheck(database, databaseLabel, "integrity_check"),
+  };
+}
+
+function runSqliteCheck(
+  database: DatabaseSync,
+  databaseLabel: string,
+  pragma: SqliteCheckPragma,
+): "ok" {
+  const rows = database.prepare(`PRAGMA ${pragma};`).all() as Array<Record<string, unknown>>;
+  const results = rows.map((row) => row[pragma] ?? Object.values(row)[0]);
+  if (results.length === 1 && results[0] === "ok") {
+    return "ok";
+  }
+  const details = results.map((result) => String(result)).join("; ") || "no result";
+  throw new Error(`SQLite ${pragma} failed for ${databaseLabel}: ${details}`);
+}


### PR DESCRIPTION
Related: #71689

## What Problem This Solves

Fixes an issue where operators could create a backup archive or start doctor compaction from a SQLite database whose page structure passed `quick_check` but whose secondary indexes no longer matched table rows. That unsafe state could enter a restore archive or be mutated before the corruption was reported.

## Why This Change Was Made

Require both SQLite structural and table/index consistency checks before `VACUUM INTO` or the first doctor checkpoint, then verify the staged snapshot again after sanitization. The checks share one implementation so backup creation, archive verification, and doctor compaction enforce the same contract.

## User Impact

Backups and explicit SQLite compaction now fail closed with the corrupt index details instead of publishing or mutating an unreliable database. Healthy snapshots continue to be compact, scrubbed, and verified.

## Evidence

- Destructive stale-index fixture: `PRAGMA quick_check` returns `ok`, while `PRAGMA integrity_check` reports rows missing from the rewritten secondary index.
- Testbox-through-Crabbox `tbx_01kxa6e4swf41shtp5v1v0f428`: 84 focused tests passed across backup creation, archive verification, and doctor compaction.
- Two fresh structured autoreviews returned no accepted/actionable findings; final confidence 0.91.
- `pnpm check:changed` reached the Plugin SDK API baseline gate and reproduced the same unrelated baseline hash mismatch on a clean `origin/main` archive; this branch has no Plugin SDK or baseline diff.