### PR TITLE
fix(codex): prevent missing_tool_result from masking real abort/interrupt/failure outcomes

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -3525,6 +3525,133 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.assistantTexts).toEqual([]);
   });
 
+  it("does not promote missing_tool_result to promptError when aborted mid-exec", async () => {
+    const trajectoryRecorder = {
+      filePath: "trajectory.jsonl",
+      recordEvent: vi.fn(),
+      flush: vi.fn(async () => undefined),
+    };
+    const projector = await createProjector(undefined, { trajectoryRecorder });
+    projector.markAborted();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-still-running",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(turnWithStatus("interrupted"));
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.aborted).toBe(true);
+    expect(result.promptError).toBeNull();
+    expect(result.promptErrorSource).toBeNull();
+    expect(result.lastToolError?.error).toContain("without a matching tool.result");
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith(
+      "tool.result",
+      expect.objectContaining({
+        toolCallId: "cmd-still-running",
+        status: "failed",
+        isError: true,
+        result: { status: "failed", reason: "missing_tool_result" },
+      }),
+    );
+  });
+
+  it("does not promote missing_tool_result to promptError for interrupted turns with pending tools", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-interrupted-pending",
+          command: "/bin/bash -lc 'sleep 600'",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnWithStatus("interrupted", [
+        {
+          type: "agentMessage",
+          id: "msg-partial",
+          text: "still working on the long command",
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.aborted).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(result.promptErrorSource).toBeNull();
+    expect(result.assistantTexts).toEqual(["still working on the long command"]);
+    expect(result.lastToolError?.error).toContain("without a matching tool.result");
+    expect(result.lastAssistant?.stopReason).toBe("stop");
+  });
+
+  it("prefers real turn error over synthesized missing-tool-result when both are present", async () => {
+    const projector = await createProjector(await createParams());
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-failed-turn",
+          command: "node long-script.js",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    // Turn fails with a real stream error while the tool is still running.
+    await projector.handleNotification({
+      method: "turn/completed",
+      params: {
+        threadId: THREAD_ID,
+        turn: {
+          id: TURN_ID,
+          status: "failed",
+          error: { message: "stream connection reset" },
+          items: [],
+        },
+      },
+    } as ProjectorNotification);
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    // The real turn error must be the headline, not the synthesized message.
+    expect(result.promptError).toBe("stream connection reset");
+    expect(result.promptError).not.toContain("without a matching tool.result");
+    expect(result.promptErrorSource).toBe("prompt");
+  });
+
   it("uses streamed command output when final command snapshots omit aggregated output", async () => {
     const onAgentEvent = vi.fn();
     const trajectoryRecorder = {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -782,9 +782,18 @@ export class CodexAppServerEventProjector {
     const hasDeliverableAssistantOnCompletedTurn =
       this.completedTurn?.status === "completed" &&
       assistantTexts.some((text) => text.trim().length > 0);
+    // Keep synthetic tool.result rows for transcript integrity, but do not
+    // promote missing_tool_result to the run promptError when the authoritative
+    // outcome is already an abort/interrupt. Otherwise mid-exec cancel paths
+    // kill the attempt with a generic invariant error (#104898).
+    const authoritativeAbortOrInterrupt =
+      this.aborted || this.completedTurn?.status === "interrupted";
     this.synthesizeMissingToolResults({
       synthesize: legacyFailClosed,
-      recordPromptError: legacyFailClosed && !hasDeliverableAssistantOnCompletedTurn,
+      recordPromptError:
+        legacyFailClosed &&
+        !hasDeliverableAssistantOnCompletedTurn &&
+        !authoritativeAbortOrInterrupt,
     });
     const lastAssistant =
       assistantTexts.length > 0
@@ -830,8 +839,10 @@ export class CodexAppServerEventProjector {
     const turnFailed = this.completedTurn?.status === "failed";
     const promptError =
       this.promptError ??
-      this.synthesizedMissingToolResultError ??
-      (turnFailed ? (this.completedTurn?.error?.message ?? "codex app-server turn failed") : null);
+      (turnFailed
+        ? (this.completedTurn?.error?.message ?? "codex app-server turn failed")
+        : null) ??
+      this.synthesizedMissingToolResultError;
     const agentHarnessResultClassification = classifyAgentHarnessTerminalOutcome({
       assistantTexts,
       reasoningText,


### PR DESCRIPTION
## What Problem This Solves

Fixes #104898.

When a Codex turn ends mid-exec (user abort, steer/interrupt, or stream failure) while a native `commandExecution` is still running, the synthesized `missing_tool_result` invariant was promoted to the run-level `promptError`. Operators saw a generic tool-invariant failure instead of abort/interrupt classification, and any partial assistant text was treated as a failed run.

## Root Cause

Two gaps combined to mask real outcomes:

1. `synthesizeMissingToolResults()` unconditionally promoted missing-tool errors to `promptError` for any non-completed turn, even when the authoritative outcome was already abort or interrupted.
2. In `buildResult()`, `synthesizedMissingToolResultError` took priority over `completedTurn.error.message`, so even for genuinely failed turns the real error could be masked.

## Fix — Two-layer defense

**Layer 1 (input guard):** In `synthesizeMissingToolResults()`, skip `recordPromptError` when the projector is aborted or the turn status is `interrupted`. Synthetic `tool.result` records are still written for transcript integrity.

**Layer 2 (output preference):** In `buildResult()`, prefer `completedTurn.error.message` over `synthesizedMissingToolResultError` so real failure reasons always surface as the headline.

| Scenario | Before | After |
|----------|--------|-------|
| Abort + pending tool | `promptError`: missing_tool_result | `promptError`: null, `aborted: true` |
| Interrupt + pending tool | `promptError`: missing_tool_result | `promptError`: null, partial text preserved |
| Failed turn + pending tool | `promptError`: missing_tool_result | `promptError`: real turn error message |

## Testing / Proof

```
node scripts/run-vitest.mjs run extensions/codex/src/app-server/event-projector.test.ts
```

**149 passed** — 3 new regression tests:

| Test | Scenario |
|------|----------|
| "does not promote missing_tool_result to promptError when aborted mid-exec" | Aborted + orphan commandExecution → null promptError, synthetic tool.result in trajectory |
| "does not promote missing_tool_result to promptError for interrupted turns with pending tools" | Interrupted + partial assistant text → null promptError, text preserved |
| "prefers real turn error over synthesized missing-tool-result when both are present" | Failed turn with real error + orphan tool → real error is promptError |