### PR TITLE
refactor(codex): unify protocol artifact staging

### DIFF
--- a/scripts/lib/codex-app-server-protocol-artifacts.ts
+++ b/scripts/lib/codex-app-server-protocol-artifacts.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type CodexProtocolArtifactRoots = {
+  jsonRoot: string;
+  typescriptRoot: string;
+};
+
+export async function stageCodexAppServerProtocolArtifacts(
+  sourceRoot: string,
+  roots: CodexProtocolArtifactRoots,
+): Promise<void> {
+  await stageGeneratedArtifactDirectory(sourceRoot, sourceRoot, roots);
+}
+
+async function stageGeneratedArtifactDirectory(
+  sourceRoot: string,
+  currentRoot: string,
+  roots: CodexProtocolArtifactRoots,
+): Promise<void> {
+  const entries = await fs.readdir(currentRoot, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      const sourcePath = path.join(currentRoot, entry.name);
+      if (entry.isDirectory()) {
+        await stageGeneratedArtifactDirectory(sourceRoot, sourcePath, roots);
+        return;
+      }
+      if (!entry.isFile()) {
+        return;
+      }
+
+      const kind = entry.name.endsWith(".ts")
+        ? "typescript"
+        : entry.name.endsWith(".json")
+          ? "json"
+          : undefined;
+      if (kind === undefined) {
+        return;
+      }
+
+      const targetRoot = kind === "typescript" ? roots.typescriptRoot : roots.jsonRoot;
+      const targetPath = path.join(targetRoot, path.relative(sourceRoot, sourcePath));
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      if (kind === "json") {
+        await fs.copyFile(sourcePath, targetPath);
+        return;
+      }
+
+      const source = await fs.readFile(sourcePath, "utf8");
+      await fs.writeFile(targetPath, normalizeGeneratedTypeScript(source));
+    }),
+  );
+}
+
+function normalizeGeneratedTypeScript(text: string): string {
+  // Codex emits TS-oriented relative imports; OpenClaw consumes the staged tree as NodeNext.
+  return text
+    .replace(/(from\s+["'])(\.{1,2}\/[^"']+?)(\.js)?(["'])/g, "$1$2.js$4")
+    .replace('export * as v2 from "./v2.js";', 'export * as v2 from "./v2/index.js";')
+    .replaceAll("| null | null", "| null");
+}

--- a/scripts/lib/codex-app-server-protocol-source.ts
+++ b/scripts/lib/codex-app-server-protocol-source.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolvePnpmRunner } from "../pnpm-runner.mjs";
+import { stageCodexAppServerProtocolArtifacts } from "./codex-app-server-protocol-artifacts.js";
 
 const PROTOCOL_SCHEMA_RELATIVE_PATH = "codex-rs/app-server-protocol/schema";
 const DEFAULT_PROTOCOL_GENERATION_MIN_FREE_BYTES = 10 * 1024 * 1024 * 1024;
@@ -171,8 +172,7 @@ export async function generateExperimentalCodexAppServerProtocolSource(
   try {
     await assertCodexProtocolGenerationHeadroom({ codexRepo, repoRoot });
     runCargoProtocolGenerator(codexRepo, buildCodexProtocolExportArgs(manifestPath, generatedRoot));
-    await splitGeneratedProtocolOutput(generatedRoot, { jsonRoot, typescriptRoot });
-    await rewriteTypeScriptImports(typescriptRoot);
+    await stageCodexAppServerProtocolArtifacts(generatedRoot, { jsonRoot, typescriptRoot });
     formatGeneratedTypeScript(repoRoot, typescriptRoot);
   } catch (error) {
     await cleanup();
@@ -316,47 +316,6 @@ async function resolveExistingStatfsPath(targetPath: string): Promise<string> {
   }
 }
 
-async function splitGeneratedProtocolOutput(
-  sourceRoot: string,
-  roots: { jsonRoot: string; typescriptRoot: string },
-): Promise<void> {
-  await copyGeneratedProtocolFiles(sourceRoot, sourceRoot, roots);
-}
-
-async function copyGeneratedProtocolFiles(
-  sourceRoot: string,
-  currentRoot: string,
-  roots: { jsonRoot: string; typescriptRoot: string },
-): Promise<void> {
-  const entries = await fs.readdir(currentRoot, { withFileTypes: true });
-  await Promise.all(
-    entries.map(async (entry) => {
-      const sourcePath = path.join(currentRoot, entry.name);
-      if (entry.isDirectory()) {
-        await copyGeneratedProtocolFiles(sourceRoot, sourcePath, roots);
-        return;
-      }
-      if (!entry.isFile()) {
-        return;
-      }
-
-      const relativePath = path.relative(sourceRoot, sourcePath);
-      const targetRoot = entry.name.endsWith(".ts")
-        ? roots.typescriptRoot
-        : entry.name.endsWith(".json")
-          ? roots.jsonRoot
-          : null;
-      if (targetRoot === null) {
-        return;
-      }
-
-      const targetPath = path.join(targetRoot, relativePath);
-      await fs.mkdir(path.dirname(targetPath), { recursive: true });
-      await fs.copyFile(sourcePath, targetPath);
-    }),
-  );
-}
-
 function runCargoProtocolGenerator(codexRepo: string, args: string[]): void {
   const result = spawnSync("cargo", args, {
     cwd: codexRepo,
@@ -397,31 +356,6 @@ function formatGeneratedTypeScript(repoRoot: string, root: string): void {
       }`,
     );
   }
-}
-
-async function rewriteTypeScriptImports(root: string): Promise<void> {
-  const entries = await fs.readdir(root, { withFileTypes: true });
-  await Promise.all(
-    entries.map(async (entry) => {
-      const fullPath = path.join(root, entry.name);
-      if (entry.isDirectory()) {
-        await rewriteTypeScriptImports(fullPath);
-        return;
-      }
-      if (!entry.isFile() || !entry.name.endsWith(".ts")) {
-        return;
-      }
-      const text = await fs.readFile(fullPath, "utf8");
-      await fs.writeFile(fullPath, normalizeGeneratedTypeScript(text));
-    }),
-  );
-}
-
-function normalizeGeneratedTypeScript(text: string): string {
-  return text
-    .replace(/(from\s+["'])(\.{1,2}\/[^"']+?)(\.js)?(["'])/g, "$1$2.js$4")
-    .replace('export * as v2 from "./v2.js";', 'export * as v2 from "./v2/index.js";')
-    .replaceAll("| null | null", "| null");
 }
 
 // Sort typed-object arrays for schema keywords whose item order does not affect

--- a/test/scripts/codex-app-server-protocol-source.test.ts
+++ b/test/scripts/codex-app-server-protocol-source.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { stageCodexAppServerProtocolArtifacts } from "../../scripts/lib/codex-app-server-protocol-artifacts.js";
 import {
   buildCodexProtocolExportArgs,
   canonicalizeCodexAppServerProtocolJson,
@@ -25,6 +26,48 @@ afterEach(() => {
   } else {
     process.env.OPENCLAW_CODEX_REPO = originalOpenClawCodexRepo;
   }
+});
+
+describe("Codex app-server generated artifact staging", () => {
+  it("copies JSON bytes and normalizes nested TypeScript files in one pass", async () => {
+    const sourceRoot = createTempDir("openclaw-protocol-artifacts-source-");
+    const targetRoot = createTempDir("openclaw-protocol-artifacts-target-");
+    const typescriptRoot = path.join(targetRoot, "typescript");
+    const jsonRoot = path.join(targetRoot, "json");
+    const rootTypeScript = [
+      'import type { Root } from "./Root";',
+      "export type { Parent } from '../Parent.js';",
+      'export * as v2 from "./v2.js";',
+      "export type Nullable = string | null | null;",
+      "",
+    ].join("\n");
+    const nestedTypeScript = 'export type { Shared } from "../Shared";\n';
+    const json = '{\n  "z": 1,\n  "a": 2\n}\n';
+    fs.mkdirSync(path.join(sourceRoot, "v2"), { recursive: true });
+    fs.writeFileSync(path.join(sourceRoot, "index.ts"), rootTypeScript);
+    fs.writeFileSync(path.join(sourceRoot, "v2/Thing.ts"), nestedTypeScript);
+    fs.writeFileSync(path.join(sourceRoot, "v2/Thing.json"), json);
+    fs.writeFileSync(path.join(sourceRoot, "README.md"), "ignored\n");
+
+    await stageCodexAppServerProtocolArtifacts(sourceRoot, { jsonRoot, typescriptRoot });
+
+    expect(fs.readFileSync(path.join(typescriptRoot, "index.ts"), "utf8")).toBe(
+      [
+        'import type { Root } from "./Root.js";',
+        "export type { Parent } from '../Parent.js';",
+        'export * as v2 from "./v2/index.js";',
+        "export type Nullable = string | null;",
+        "",
+      ].join("\n"),
+    );
+    expect(fs.readFileSync(path.join(typescriptRoot, "v2/Thing.ts"), "utf8")).toBe(
+      'export type { Shared } from "../Shared.js";\n',
+    );
+    expect(fs.readFileSync(path.join(jsonRoot, "v2/Thing.json"), "utf8")).toBe(json);
+    expect(fs.existsSync(path.join(typescriptRoot, "README.md"))).toBe(false);
+    expect(fs.existsSync(path.join(jsonRoot, "README.md"))).toBe(false);
+    expect(fs.readFileSync(path.join(sourceRoot, "index.ts"), "utf8")).toBe(rootTypeScript);
+  });
 });
 
 describe("codex app-server protocol source resolver", () => {


### PR DESCRIPTION
Related: #104871

## What Problem This Solves

Codex app-server protocol refreshes staged the same generated tree twice: one recursive pass copied TypeScript and JSON files, then another recursive pass reopened every TypeScript file to normalize NodeNext imports. That duplicated traversal and split one artifact-staging invariant across helpers.

## Why This Change Was Made

Replace the two passes with one focused internal staging module. JSON bytes are copied unchanged, TypeScript is normalized while it is staged, unsupported files stay ignored, and the existing formatter still runs only after staging completes.

The upstream contract was checked directly against the pinned Codex source: `codex-rs/app-server-protocol/src/bin/export.rs`, `codex-rs/app-server-protocol/src/export.rs`, `codex-rs/cli/src/main.rs`, and the workspace version in `codex-rs/Cargo.toml`.

## User Impact

No user-visible or protocol behavior changes. Maintainers and coding agents get one smaller, directly testable artifact-staging boundary for generated protocol refreshes.

## Evidence

- `pnpm test:serial test/scripts/codex-app-server-protocol-source.test.ts` on Blacksmith Testbox: 17 tests passed.
- `OPENCLAW_CODEX_REPO=/tmp/openai-codex-rust-v0.144.1 pnpm codex-app-server:protocol:check` on Testbox `tbx_01kxa7eaqw1dmsadagevpnamqb`: the real pinned Rust exporter regenerated and verified 671 files successfully.
- `pnpm check:changed` on the same Testbox: passed.
- Fresh structured autoreview: clean, 0.96 confidence.
- Production code is net -4 lines.
- Contract audit: no generated protocol/model/schema, config, Plugin SDK, CLI option, package, or environment surface changed.
