### PR TITLE
Test recovered cron tool warning delivery

### DIFF
--- a/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
@@ -337,6 +337,31 @@ describe("runCronIsolatedAgentTurn core-channel direct delivery", () => {
       });
     });
 
+    if (testCase.channel === "slack") {
+      it("delivers final assistant text after recovered tool warnings without channel opt-in", async () => {
+        await expectCoreChannelAnnounceDelivery({
+          testCase,
+          payloads: [
+            { text: "⚠️ 🛠️ zsh (agent) failed", isError: true },
+            { text: "⚠️ 🛠️ node (agent) failed", isError: true },
+          ],
+          meta: {
+            meta: makeRunMeta("**Daily GTM analytics**\nPostHog and revenue summary complete."),
+          },
+          assertSend: (sendFn, cfg) => {
+            expect(sendFn).toHaveBeenCalledTimes(1);
+            expectCoreChannelSendCall({
+              cfg,
+              expectedText: "**Daily GTM analytics**\nPostHog and revenue summary complete.",
+              expectedTo: testCase.expectedTo,
+              sendFn,
+              sentAt: 0,
+            });
+          },
+        });
+      });
+    }
+
     if (testCase.channel === "discord") {
       it("keeps isolated Discord delivery on the active runtime snapshot after agent-default derivation", async () => {
         await withTempCronHome(async (home) => {


### PR DESCRIPTION
## Summary

Adds follow-up coverage for recovered isolated cron runs that emit plain tool-warning payloads before a final assistant-visible report.

The regression runs through `runCronIsolatedAgentTurn` and verifies a Slack-like direct-delivery channel without final-text opt-in still completes `ok`, delivers once, and sends the final assistant report after recovered tool warnings.

## Context

The functional fix landed separately in #104908. This PR adds the requested e2e-style cron delivery-path coverage for that behavior.

## Validation

```sh
node scripts/test-projects.mjs src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent.direct-delivery-core-channels.test.ts extensions/slack/src/channel.test.ts
```

Passed: 2 Vitest shards, 101 tests.

Also attempted:

```sh
pnpm test:docker:cron-cli
```

The Docker e2e built and packed OpenClaw successfully, including package tarball integrity, but did not reach the cron scenario because Docker failed resolving `docker.io/docker/dockerfile:1.7` with `DeadlineExceeded: context deadline exceeded`.