### PR TITLE
chore: refresh plugin SDK API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-af04c051b9697ffc27468c0948aa51c122366e7b97b93cf66f19b1b87f846caf  plugin-sdk-api-baseline.json
-7dbae052b16721a5af5c011d1add527af028cc8f32dc84f2dfc4534004e22d69  plugin-sdk-api-baseline.jsonl
+484dbb1fe72a0c5188767bb368a0be5b1ab04566d16e8de274a8d753fd800c70  plugin-sdk-api-baseline.json
+4571b249d41a808a817f3bc8b3fce4ffc26373b9078327f2188681a056a9fa21  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Resolves a maintainer check failure where the committed Plugin SDK API baseline hashes no longer match the repository generator output on current `main`. This causes unrelated `pnpm check:changed` runs to stop at the API baseline gate.

## Why This Change Was Made

Regenerates the tracked SHA manifest from current source. The corresponding JSON and JSONL baselines remain intentionally gitignored local artifacts, as documented by the generator and `docs/.generated/README.md`.

## User Impact

No runtime or user-visible behavior changes. Maintainer changed-surface validation can distinguish real Plugin SDK drift again.

## Evidence

- Blacksmith Testbox `tbx_01kxa88f5x2v394ydaxb8q518p`: `generate-plugin-sdk-api-baseline.ts --check` passes on the refreshed manifest.
- `git diff --check` passes.
- Fresh `gpt-5.6-sol` medium autoreview completed. Its only finding assumed the JSON/JSONL artifacts were tracked; rejected because `.gitignore`, the generator output, and `docs/.generated/README.md` explicitly define them as local-only while the SHA manifest is the tracked contract.

AI-assisted maintenance change. No transcript attached.
