### PR TITLE
refactor(qa): isolate scenario command lifecycle

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
@@ -1,0 +1,179 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+import {
+  resetQaScenarioCommandCleanupTimings,
+  runQaScenarioCommandLifecycle,
+  setQaScenarioCommandCleanupTimings,
+} from "./test-file-scenario-command-lifecycle.js";
+
+type ParentSignal = "SIGINT" | "SIGTERM";
+type ParentHandler = (() => void) | ((signal: ParentSignal) => void);
+
+function spyOnProcessKill() {
+  return vi.spyOn(process, "kill");
+}
+
+function createChild(pid = 42) {
+  const child = new EventEmitter() as ChildProcess;
+  Object.defineProperty(child, "pid", { value: pid });
+  child.stdout = new EventEmitter() as NonNullable<ChildProcess["stdout"]>;
+  child.stderr = new EventEmitter() as NonNullable<ChildProcess["stderr"]>;
+  child.kill = vi.fn(() => true) as ChildProcess["kill"];
+  spawnMock.mockReturnValue(child);
+  return child;
+}
+
+function runCommand(timeoutMs?: number) {
+  return runQaScenarioCommandLifecycle({
+    command: "/usr/local/bin/scenario-command",
+    args: ["--run"],
+    cwd: "/tmp/qa",
+    env: { OPENCLAW_QA_REF: "test" },
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  });
+}
+
+describe.skipIf(process.platform === "win32")("qa scenario command lifecycle", () => {
+  const parentHandlers = new Map<ParentSignal | "exit", ParentHandler>();
+  let processKill: ReturnType<typeof spyOnProcessKill>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    spawnMock.mockReset();
+    vi.spyOn(process, "once").mockImplementation((event, listener) => {
+      parentHandlers.set(event as ParentSignal | "exit", listener as ParentHandler);
+      return process;
+    });
+    vi.spyOn(process, "removeListener").mockImplementation((event, listener) => {
+      if (parentHandlers.get(event as ParentSignal | "exit") === listener) {
+        parentHandlers.delete(event as ParentSignal | "exit");
+      }
+      return process;
+    });
+    processKill = spyOnProcessKill().mockImplementation((pid, signal) => {
+      if (pid === -42 && signal === 0) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    resetQaScenarioCommandCleanupTimings();
+    parentHandlers.clear();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("preserves the exact close result and removes parent handlers", async () => {
+    const child = createChild();
+    const resultPromise = runCommand(5_000);
+
+    child.stdout?.emit("data", Buffer.from("out\n"));
+    child.stderr?.emit("data", Buffer.from("err\n"));
+    child.emit("close", 3, null);
+
+    await expect(resultPromise).resolves.toEqual({
+      exitCode: 3,
+      signal: null,
+      stdout: "out\n",
+      stderr: "err\n",
+    });
+    expect(spawnMock).toHaveBeenCalledWith("/usr/local/bin/scenario-command", ["--run"], {
+      cwd: "/tmp/qa",
+      detached: true,
+      env: { OPENCLAW_QA_REF: "test" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    expect(parentHandlers.size).toBe(0);
+    expect(processKill).toHaveBeenCalledWith(-42, 0);
+    processKill.mockClear();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(processKill).not.toHaveBeenCalled();
+  });
+
+  it("preserves spawn rejection without installing lifecycle handlers", async () => {
+    const error = new Error("spawn failed");
+    spawnMock.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    await expect(runCommand()).rejects.toBe(error);
+    expect(parentHandlers.size).toBe(0);
+  });
+
+  it("escalates timed-out commands and preserves the timeout result", async () => {
+    createChild();
+    setQaScenarioCommandCleanupTimings({ killGraceMs: 20, forceSettleMs: 10 });
+    let processGroupAlive = true;
+    processKill.mockImplementation((pid, signal) => {
+      if (pid === -42 && signal === "SIGKILL") {
+        processGroupAlive = false;
+      }
+      if (pid === -42 && signal === 0 && !processGroupAlive) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+      return true;
+    });
+
+    const resultPromise = runCommand(100);
+    await vi.advanceTimersByTimeAsync(130);
+
+    await expect(resultPromise).resolves.toEqual({
+      exitCode: 1,
+      failureMessage: "scenario-command timed out after 100ms",
+      signal: null,
+      stdout: "",
+      stderr: "",
+    });
+    expect(processKill).toHaveBeenCalledWith(-42, "SIGTERM");
+    expect(processKill).toHaveBeenCalledWith(-42, "SIGKILL");
+    expect(parentHandlers.size).toBe(0);
+  });
+
+  it("forwards parent signals, cleans handlers, and preserves interruption details", async () => {
+    createChild();
+    setQaScenarioCommandCleanupTimings({ killGraceMs: 20, forceSettleMs: 10 });
+    let processGroupAlive = true;
+    processKill.mockImplementation((pid, signal) => {
+      if (pid === -42 && signal === "SIGKILL") {
+        processGroupAlive = false;
+      }
+      if (pid === -42 && signal === 0 && !processGroupAlive) {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+      return true;
+    });
+
+    const resultPromise = runCommand();
+    const signalHandler = parentHandlers.get("SIGTERM") as
+      | ((signal: ParentSignal) => void)
+      | undefined;
+    expect(signalHandler).toBeDefined();
+    signalHandler?.("SIGTERM");
+    await vi.advanceTimersByTimeAsync(30);
+
+    await expect(resultPromise).resolves.toEqual({
+      exitCode: 1,
+      failureMessage: "scenario-command interrupted by SIGTERM",
+      signal: "SIGTERM",
+      stdout: "",
+      stderr: "",
+    });
+    expect(processKill).toHaveBeenCalledWith(-42, "SIGTERM");
+    expect(processKill).toHaveBeenCalledWith(process.pid, "SIGTERM");
+    expect(parentHandlers.size).toBe(0);
+  });
+});

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.ts
@@ -1,0 +1,280 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { resolveQaWindowsSystem32ExePath } from "./windows-system-tools.js";
+
+export type QaScenarioCommandExecution = {
+  args: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+};
+
+export type QaScenarioCommandResult = {
+  exitCode: number;
+  failureMessage?: string;
+  signal?: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+};
+
+type QaScenarioCommandTerminalResult = Pick<
+  QaScenarioCommandResult,
+  "exitCode" | "failureMessage" | "signal"
+>;
+
+type QaScenarioTaskkillRunner = typeof spawnSync;
+type QaScenarioCommandTimers = Partial<
+  Record<"timeout" | "forceKill" | "forceSettle", NodeJS.Timeout>
+>;
+
+const QA_SCENARIO_COMMAND_TIMEOUT_KILL_GRACE_MS = 2_000;
+const QA_SCENARIO_COMMAND_TIMEOUT_FORCE_SETTLE_MS = 500;
+const QA_SCENARIO_COMMAND_PARENT_SIGNALS = ["SIGINT", "SIGTERM"] as const;
+type QaScenarioParentSignal = (typeof QA_SCENARIO_COMMAND_PARENT_SIGNALS)[number];
+let timeoutKillGraceMs = QA_SCENARIO_COMMAND_TIMEOUT_KILL_GRACE_MS;
+let timeoutForceSettleMs = QA_SCENARIO_COMMAND_TIMEOUT_FORCE_SETTLE_MS;
+
+export function killQaScenarioWindowsProcessTree(
+  pid: number | undefined,
+  signal: NodeJS.Signals,
+  runTaskkill: QaScenarioTaskkillRunner = spawnSync,
+) {
+  if (pid === undefined) {
+    return false;
+  }
+  const taskkillPath = resolveQaWindowsSystem32ExePath("taskkill.exe");
+  const args = ["/pid", String(pid), "/T"];
+  const run = (force: boolean) => {
+    const result = runTaskkill(taskkillPath, force ? [...args, "/F"] : args, {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    return !result.error && result.status === 0;
+  };
+  return signal === "SIGKILL" ? run(true) : run(false) || run(true);
+}
+
+// One owner keeps timers, parent handlers, child signals, and final result
+// settlement symmetric across every command exit path.
+class QaScenarioCommandLifecycle {
+  private readonly stderr: Buffer[] = [];
+  private readonly stdout: Buffer[] = [];
+  private resolve: ((result: QaScenarioCommandResult) => void) | undefined;
+  private settled = false;
+  private timers: QaScenarioCommandTimers = {};
+  private timedOut = false;
+
+  constructor(
+    private readonly execution: QaScenarioCommandExecution,
+    private readonly child: ChildProcess,
+    private readonly useProcessGroup: boolean,
+  ) {}
+
+  start(resolve: (result: QaScenarioCommandResult) => void, reject: (reason?: unknown) => void) {
+    this.resolve = resolve;
+    this.armTimeout();
+    this.child.stdout?.on("data", (chunk: Buffer) => this.stdout.push(chunk));
+    this.child.stderr?.on("data", (chunk: Buffer) => this.stderr.push(chunk));
+    process.once("exit", this.handleParentExit);
+    for (const signal of QA_SCENARIO_COMMAND_PARENT_SIGNALS) {
+      process.once(signal, this.handleParentSignal);
+    }
+    this.child.on("error", (error) => {
+      if (this.settled) {
+        return;
+      }
+      this.clearTimers();
+      this.cleanupParentHandlers();
+      reject(error);
+    });
+    this.child.on("close", this.handleClose);
+  }
+
+  private readonly handleParentExit = () => {
+    this.signalChild("SIGKILL");
+  };
+
+  private readonly handleParentSignal = (signal: QaScenarioParentSignal) => {
+    this.removeParentSignalHandlers();
+    this.signalChild(signal);
+    this.scheduleForcedCleanup({
+      exitCode: 1,
+      failureMessage: `${this.commandLabel()} interrupted by ${signal}`,
+      signal,
+    });
+    process.kill(process.pid, signal);
+  };
+
+  private readonly handleClose = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+    if (this.settled) {
+      return;
+    }
+    if (!this.timedOut) {
+      this.clearTimeoutTimer();
+    }
+    const result = {
+      exitCode: this.timedOut ? 1 : (exitCode ?? (signal ? 1 : 0)),
+      signal,
+      ...(this.timedOut
+        ? {
+            failureMessage: `${this.commandLabel()} timed out after ${this.execution.timeoutMs}ms`,
+          }
+        : {}),
+    };
+    if (
+      this.timedOut &&
+      !this.useProcessGroup &&
+      (this.timers.forceKill || this.timers.forceSettle)
+    ) {
+      return;
+    }
+    if (this.isProcessGroupRunning()) {
+      if (!this.timedOut) {
+        this.signalChild("SIGTERM");
+      }
+      this.scheduleForcedCleanup(result);
+      return;
+    }
+    this.finish(result);
+  };
+
+  private armTimeout() {
+    const timeoutMs = this.execution.timeoutMs;
+    if (timeoutMs === undefined) {
+      return;
+    }
+    this.timers.timeout = setTimeout(() => {
+      delete this.timers.timeout;
+      this.timedOut = true;
+      this.signalChild("SIGTERM");
+      this.scheduleForcedCleanup({
+        exitCode: 1,
+        failureMessage: `${this.commandLabel()} timed out after ${timeoutMs}ms`,
+        signal: null,
+      });
+    }, timeoutMs);
+  }
+
+  private signalChild(signal: NodeJS.Signals) {
+    if (this.useProcessGroup && this.child.pid) {
+      try {
+        process.kill(-this.child.pid, signal);
+        return;
+      } catch {
+        // The process group may already be gone; fall back to the direct child.
+      }
+    }
+    if (!this.useProcessGroup && process.platform === "win32") {
+      if (killQaScenarioWindowsProcessTree(this.child.pid, signal)) {
+        return;
+      }
+    }
+    this.child.kill(signal);
+  }
+
+  private isProcessGroupRunning() {
+    if (!this.useProcessGroup || !this.child.pid) {
+      return false;
+    }
+    try {
+      process.kill(-this.child.pid, 0);
+      return true;
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code === "EPERM";
+    }
+  }
+
+  private scheduleForcedCleanup(result: QaScenarioCommandTerminalResult) {
+    if (this.timers.forceKill || this.timers.forceSettle) {
+      return;
+    }
+    this.timers.forceKill = setTimeout(() => {
+      delete this.timers.forceKill;
+      this.signalChild("SIGKILL");
+      this.timers.forceSettle = setTimeout(() => {
+        delete this.timers.forceSettle;
+        const stillRunning = this.isProcessGroupRunning();
+        const failureMessage =
+          result.failureMessage ??
+          (stillRunning ? `${this.commandLabel()} left background processes running` : undefined);
+        this.finish({
+          exitCode: stillRunning ? 1 : result.exitCode,
+          signal: result.signal,
+          ...(failureMessage ? { failureMessage } : {}),
+        });
+      }, timeoutForceSettleMs);
+    }, timeoutKillGraceMs);
+  }
+
+  private finish(result: QaScenarioCommandTerminalResult) {
+    if (this.settled) {
+      return;
+    }
+    this.settled = true;
+    this.clearTimers();
+    this.cleanupParentHandlers();
+    this.resolve?.({
+      ...result,
+      stdout: Buffer.concat(this.stdout).toString("utf8"),
+      stderr: Buffer.concat(this.stderr).toString("utf8"),
+    });
+  }
+
+  private commandLabel() {
+    return path.basename(this.execution.command);
+  }
+
+  private clearTimeoutTimer() {
+    if (this.timers.timeout) {
+      clearTimeout(this.timers.timeout);
+      delete this.timers.timeout;
+    }
+  }
+
+  private clearTimers() {
+    for (const timer of Object.values(this.timers)) {
+      clearTimeout(timer);
+    }
+    this.timers = {};
+  }
+
+  private removeParentSignalHandlers() {
+    for (const signal of QA_SCENARIO_COMMAND_PARENT_SIGNALS) {
+      process.removeListener(signal, this.handleParentSignal);
+    }
+  }
+
+  private cleanupParentHandlers() {
+    this.removeParentSignalHandlers();
+    process.removeListener("exit", this.handleParentExit);
+  }
+}
+
+export function runQaScenarioCommandLifecycle(
+  execution: QaScenarioCommandExecution,
+): Promise<QaScenarioCommandResult> {
+  return new Promise((resolve, reject) => {
+    const useProcessGroup = process.platform !== "win32";
+    const child = spawn(execution.command, execution.args, {
+      cwd: execution.cwd,
+      detached: useProcessGroup,
+      env: execution.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    new QaScenarioCommandLifecycle(execution, child, useProcessGroup).start(resolve, reject);
+  });
+}
+
+export function resetQaScenarioCommandCleanupTimings() {
+  timeoutKillGraceMs = QA_SCENARIO_COMMAND_TIMEOUT_KILL_GRACE_MS;
+  timeoutForceSettleMs = QA_SCENARIO_COMMAND_TIMEOUT_FORCE_SETTLE_MS;
+}
+
+export function setQaScenarioCommandCleanupTimings(params: {
+  forceSettleMs: number;
+  killGraceMs: number;
+}) {
+  timeoutKillGraceMs = params.killGraceMs;
+  timeoutForceSettleMs = params.forceSettleMs;
+}

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -1,4 +1,3 @@
-import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -21,7 +20,15 @@ import type { QaProviderMode } from "./providers/index.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import type { QaScorecardEvidenceMode } from "./scorecard-taxonomy.js";
 import { shellQuote } from "./shell-quote.js";
-import { resolveQaWindowsSystem32ExePath } from "./windows-system-tools.js";
+import {
+  killQaScenarioWindowsProcessTree,
+  resetQaScenarioCommandCleanupTimings,
+  runQaScenarioCommandLifecycle,
+  setQaScenarioCommandCleanupTimings,
+  type QaScenarioCommandExecution,
+  type QaScenarioCommandResult,
+} from "./test-file-scenario-command-lifecycle.js";
+export type { QaScenarioCommandExecution } from "./test-file-scenario-command-lifecycle.js";
 
 export type QaTestFileScenario = QaSeedScenarioWithSource & {
   execution: Extract<
@@ -43,22 +50,6 @@ type QaTestFileScenarioRunParams = {
   runCommand?: QaScenarioCommandRunner;
   scenarios: readonly QaSeedScenarioWithSource[];
   writeEvidenceFile?: boolean;
-};
-
-export type QaScenarioCommandExecution = {
-  args: string[];
-  command: string;
-  cwd: string;
-  env: NodeJS.ProcessEnv;
-  timeoutMs?: number;
-};
-
-type QaScenarioCommandResult = {
-  exitCode: number;
-  failureMessage?: string;
-  signal?: NodeJS.Signals | null;
-  stdout: string;
-  stderr: string;
 };
 
 type QaScenarioCommandRunner = (
@@ -94,12 +85,6 @@ type QaTestFileRunnerDefinition = {
 };
 
 const DEFAULT_QA_TEST_FILE_COMMAND_TIMEOUT_MS = 30 * 60_000;
-const QA_TEST_FILE_COMMAND_TIMEOUT_KILL_GRACE_MS = 2_000;
-const QA_TEST_FILE_COMMAND_TIMEOUT_FORCE_SETTLE_MS = 500;
-let qaTestFileCommandTimeoutKillGraceMs = QA_TEST_FILE_COMMAND_TIMEOUT_KILL_GRACE_MS;
-let qaTestFileCommandTimeoutForceSettleMs = QA_TEST_FILE_COMMAND_TIMEOUT_FORCE_SETTLE_MS;
-const QA_TEST_FILE_COMMAND_PARENT_SIGNALS = ["SIGINT", "SIGTERM"] as const;
-
 export function isQaTestFileScenario(
   scenario: QaSeedScenarioWithSource,
 ): scenario is QaTestFileScenario {
@@ -193,218 +178,6 @@ const testFileRunnerDefinitions: Record<QaTestFileExecutionKind, QaTestFileRunne
 
 function formatCommand(step: QaScenarioCommandStep) {
   return [step.command, ...step.args].map(shellQuote).join(" ");
-}
-
-type QaScenarioTaskkillRunner = typeof spawnSync;
-
-function killQaScenarioWindowsProcessTree(
-  pid: number | undefined,
-  signal: NodeJS.Signals,
-  runTaskkill: QaScenarioTaskkillRunner = spawnSync,
-) {
-  if (pid === undefined) {
-    return false;
-  }
-  const taskkillPath = resolveQaWindowsSystem32ExePath("taskkill.exe");
-  const args = ["/pid", String(pid), "/T"];
-  if (signal === "SIGKILL") {
-    args.push("/F");
-  }
-  const result = runTaskkill(taskkillPath, args, {
-    stdio: "ignore",
-    windowsHide: true,
-  });
-  if (!result.error && result.status === 0) {
-    return true;
-  }
-  if (signal !== "SIGKILL") {
-    const forceResult = runTaskkill(taskkillPath, [...args, "/F"], {
-      stdio: "ignore",
-      windowsHide: true,
-    });
-    return !forceResult.error && forceResult.status === 0;
-  }
-  return false;
-}
-
-function runQaScenarioCommand(
-  execution: QaScenarioCommandExecution,
-): Promise<QaScenarioCommandResult> {
-  return new Promise((resolve, reject) => {
-    const useProcessGroup = process.platform !== "win32";
-    const child = spawn(execution.command, execution.args, {
-      cwd: execution.cwd,
-      detached: useProcessGroup,
-      env: execution.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-    const timeoutMs = execution.timeoutMs;
-    let forceKillTimer: NodeJS.Timeout | undefined;
-    let forceSettleTimer: NodeJS.Timeout | undefined;
-    let settled = false;
-    let timedOut = false;
-    let timeoutTimer: NodeJS.Timeout | undefined;
-    const readOutput = () => ({
-      stdout: Buffer.concat(stdout).toString("utf8"),
-      stderr: Buffer.concat(stderr).toString("utf8"),
-    });
-    const commandLabel = () => path.basename(execution.command);
-    const clearForcedTimers = () => {
-      if (forceKillTimer) {
-        clearTimeout(forceKillTimer);
-        forceKillTimer = undefined;
-      }
-      if (forceSettleTimer) {
-        clearTimeout(forceSettleTimer);
-        forceSettleTimer = undefined;
-      }
-    };
-    const clearTimers = () => {
-      if (timeoutTimer) {
-        clearTimeout(timeoutTimer);
-        timeoutTimer = undefined;
-      }
-      clearForcedTimers();
-    };
-    const signalChild = (signal: NodeJS.Signals) => {
-      if (useProcessGroup && child.pid) {
-        try {
-          process.kill(-child.pid, signal);
-          return;
-        } catch {
-          // The process group may already be gone; fall back to the direct child.
-        }
-      }
-      if (!useProcessGroup && process.platform === "win32") {
-        if (killQaScenarioWindowsProcessTree(child.pid, signal)) {
-          return;
-        }
-      }
-      child.kill(signal);
-    };
-    const handleParentExit = () => {
-      signalChild("SIGKILL");
-    };
-    const removeParentSignalHandlers = () => {
-      for (const signal of QA_TEST_FILE_COMMAND_PARENT_SIGNALS) {
-        process.removeListener(signal, handleParentSignal);
-      }
-    };
-    const cleanupParentHandlers = () => {
-      removeParentSignalHandlers();
-      process.removeListener("exit", handleParentExit);
-    };
-    const handleParentSignal = (signal: (typeof QA_TEST_FILE_COMMAND_PARENT_SIGNALS)[number]) => {
-      removeParentSignalHandlers();
-      signalChild(signal);
-      scheduleForcedCleanup({
-        exitCode: 1,
-        failureMessage: `${commandLabel()} interrupted by ${signal}`,
-        signal,
-      });
-      process.kill(process.pid, signal);
-    };
-    const isProcessGroupRunning = () => {
-      if (!useProcessGroup || !child.pid) {
-        return false;
-      }
-      try {
-        process.kill(-child.pid, 0);
-        return true;
-      } catch (error) {
-        return (error as NodeJS.ErrnoException).code === "EPERM";
-      }
-    };
-    const finish = (
-      result: Pick<QaScenarioCommandResult, "exitCode" | "failureMessage" | "signal">,
-    ) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimers();
-      cleanupParentHandlers();
-      resolve({
-        ...result,
-        ...readOutput(),
-      });
-    };
-    const scheduleForcedCleanup = (
-      result: Pick<QaScenarioCommandResult, "exitCode" | "failureMessage" | "signal">,
-    ) => {
-      if (forceKillTimer || forceSettleTimer) {
-        return;
-      }
-      forceKillTimer = setTimeout(() => {
-        forceKillTimer = undefined;
-        signalChild("SIGKILL");
-        forceSettleTimer = setTimeout(() => {
-          forceSettleTimer = undefined;
-          const stillRunning = isProcessGroupRunning();
-          const failureMessage =
-            result.failureMessage ??
-            (stillRunning ? `${commandLabel()} left background processes running` : undefined);
-          finish({
-            exitCode: stillRunning ? 1 : result.exitCode,
-            signal: result.signal,
-            ...(failureMessage ? { failureMessage } : {}),
-          });
-        }, qaTestFileCommandTimeoutForceSettleMs);
-      }, qaTestFileCommandTimeoutKillGraceMs);
-    };
-    timeoutTimer =
-      timeoutMs === undefined
-        ? undefined
-        : setTimeout(() => {
-            timeoutTimer = undefined;
-            timedOut = true;
-            signalChild("SIGTERM");
-            scheduleForcedCleanup({
-              exitCode: 1,
-              failureMessage: `${commandLabel()} timed out after ${timeoutMs}ms`,
-              signal: null,
-            });
-          }, timeoutMs);
-    child.stdout?.on("data", (chunk: Buffer) => {
-      stdout.push(chunk);
-    });
-    child.stderr?.on("data", (chunk: Buffer) => {
-      stderr.push(chunk);
-    });
-    process.once("exit", handleParentExit);
-    for (const signal of QA_TEST_FILE_COMMAND_PARENT_SIGNALS) {
-      process.once(signal, handleParentSignal);
-    }
-    child.on("error", (error) => {
-      clearTimers();
-      cleanupParentHandlers();
-      reject(error);
-    });
-    child.on("close", (exitCode, signal) => {
-      if (!timedOut && timeoutTimer) {
-        clearTimeout(timeoutTimer);
-        timeoutTimer = undefined;
-      }
-      const result = {
-        exitCode: timedOut ? 1 : (exitCode ?? (signal ? 1 : 0)),
-        signal,
-        ...(timedOut ? { failureMessage: `${commandLabel()} timed out after ${timeoutMs}ms` } : {}),
-      };
-      if (timedOut && !useProcessGroup && (forceKillTimer || forceSettleTimer)) {
-        return;
-      }
-      if (isProcessGroupRunning()) {
-        if (!timedOut) {
-          signalChild("SIGTERM");
-        }
-        scheduleForcedCleanup(result);
-        return;
-      }
-      finish(result);
-    });
-  });
 }
 
 function buildScenarioEvidenceTarget(scenario: QaTestFileScenario) {
@@ -778,7 +551,7 @@ export async function runQaTestFileScenarios(
     throw new Error("qa suite found no script, Vitest, or Playwright scenarios to run.");
   }
   await fs.mkdir(params.outputDir, { recursive: true });
-  const runCommand = params.runCommand ?? runQaScenarioCommand;
+  const runCommand = params.runCommand ?? runQaScenarioCommandLifecycle;
   const commandTimeoutMs = resolvePositiveTimerTimeoutMs(
     params.commandTimeoutMs,
     DEFAULT_QA_TEST_FILE_COMMAND_TIMEOUT_MS,
@@ -833,11 +606,9 @@ export async function runQaTestFileScenarios(
 export const qaTestFileScenarioRunnerTesting = {
   killQaScenarioWindowsProcessTree,
   resetTimeoutCleanupTimings() {
-    qaTestFileCommandTimeoutKillGraceMs = QA_TEST_FILE_COMMAND_TIMEOUT_KILL_GRACE_MS;
-    qaTestFileCommandTimeoutForceSettleMs = QA_TEST_FILE_COMMAND_TIMEOUT_FORCE_SETTLE_MS;
+    resetQaScenarioCommandCleanupTimings();
   },
   setTimeoutCleanupTimings(params: { forceSettleMs: number; killGraceMs: number }) {
-    qaTestFileCommandTimeoutKillGraceMs = params.killGraceMs;
-    qaTestFileCommandTimeoutForceSettleMs = params.forceSettleMs;
+    setQaScenarioCommandCleanupTimings(params);
   },
 };


### PR DESCRIPTION
Related: #104871

## What Problem This Solves

The QA file-scenario runner mixed command spawning, process-group cleanup, timeout escalation, parent signal forwarding, output capture, and result settlement into the same module as scenario orchestration. That made a high-risk lifecycle path harder for maintainers and coding agents to reason about safely.

## Why This Change Was Made

Extract the command lifecycle into one plugin-internal owner while preserving the runner's existing exported execution type, command behavior, timeout values, signal semantics, Windows `taskkill` fallback, and evidence flow. Focused tests cover normal close, synchronous spawn rejection, timeout escalation, and parent-signal forwarding.

No config, SDK, CLI option, protocol, schema, generated artifact, or package surface changes.

## User Impact

No user-visible behavior changes. QA scenario command execution is easier to inspect and modify without crossing unrelated runner concerns.

## Evidence

- Blacksmith Testbox `tbx_01kxa8jr2xx9d4hmsqqf73hxks`: 19 focused tests passed across the existing runner and extracted lifecycle suites.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` passed.
- Scoped extension oxlint passed for all three touched files.
- Database-first legacy-store, media-download, runtime-sidecar, and import-cycle guards passed; runtime value cycles: 0.
- `git diff --check` and oxfmt passed.
- Fresh autoreview: clean, 0.98 confidence.
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 104958` passed hosted current-head gates for `e624ec88979813ab7c94b682449ac6c1d59f7874` at `2026-07-12T04:26:57Z`.
