### PR TITLE
test(sqlite): allow schema version pragma

### DIFF
--- a/src/infra/sqlite-pragma.test-support.ts
+++ b/src/infra/sqlite-pragma.test-support.ts
@@ -6,6 +6,7 @@ export type SqliteNumberPragma =
   | "auto_vacuum"
   | "busy_timeout"
   | "foreign_keys"
+  | "schema_version"
   | "synchronous"
   | "user_version"
   | "wal_autocheckpoint";


### PR DESCRIPTION
Related: #104952

## What Problem This Solves

Fixes the current `main` test-type failure where the new state database recovery fixture reads SQLite's numeric `schema_version` pragma through a helper whose literal allowlist omitted that valid pragma.

## Why This Change Was Made

Add `schema_version` to the existing numeric pragma union. The helper remains a narrow dynamic-SQL allowlist; it is not widened to arbitrary strings.

## User Impact

No runtime behavior changes. Current-main `check-test-types` and dependent PR landing gates can complete again.

## Evidence

- Blacksmith Testbox `tbx_01kxa895c529skwrtdan6cwr7a`: full `pnpm tsgo:test` passed.
- The same Testbox passed `src/state/openclaw-state-db.test.ts`: 40/40.
- Fresh autoreview reported no accepted or actionable findings.
- `git diff --check` passed.
