### PR TITLE
refactor(pr): centralize prepare gate planning

### DIFF
--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -224,6 +224,22 @@ write_gates_env_stamp() {
     > .local/gates.env
 }
 
+derive_prepare_gate_change_plan() {
+  PREPARE_GATE_CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+  PREPARE_GATE_DOCS_ONLY=false
+  if file_list_is_docsish_only "$PREPARE_GATE_CHANGED_FILES"; then
+    PREPARE_GATE_DOCS_ONLY=true
+  fi
+  PREPARE_GATE_CHANGELOG_ONLY=false
+  if [ "$PREPARE_GATE_CHANGED_FILES" = "CHANGELOG.md" ]; then
+    PREPARE_GATE_CHANGELOG_ONLY=true
+  fi
+  PREPARE_GATE_CHANGELOG_REQUIRED=false
+  if changelog_required_for_changed_files "$PREPARE_GATE_CHANGED_FILES"; then
+    PREPARE_GATE_CHANGELOG_REQUIRED=true
+  fi
+}
+
 run_prepare_push_retry_gates() {
   local docs_only="${1:-false}"
 
@@ -306,29 +322,11 @@ prepare_gates() {
   # shellcheck disable=SC1091
   source .local/pr-meta.env
 
-  local changed_files
-  changed_files=$(git diff --name-only origin/main...HEAD)
-  local non_docs
-  non_docs=$(printf '%s\n' "$changed_files" | while IFS= read -r path; do
-    [ -n "$path" ] || continue
-    if ! path_is_docsish "$path"; then
-      printf '%s\n' "$path"
-    fi
-  done)
-
-  local docs_only=false
-  if [ -n "$changed_files" ] && [ -z "$non_docs" ]; then
-    docs_only=true
-  fi
-  local changelog_only=false
-  if [ "$changed_files" = "CHANGELOG.md" ]; then
-    changelog_only=true
-  fi
-
-  local changelog_required=false
-  if changelog_required_for_changed_files "$changed_files"; then
-    changelog_required=true
-  fi
+  derive_prepare_gate_change_plan
+  local changed_files="$PREPARE_GATE_CHANGED_FILES"
+  local docs_only="$PREPARE_GATE_DOCS_ONLY"
+  local changelog_only="$PREPARE_GATE_CHANGELOG_ONLY"
+  local changelog_required="$PREPARE_GATE_CHANGELOG_REQUIRED"
 
   local has_changelog_update=false
   local unsupported_changelog_fragments=""

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -250,6 +250,50 @@ describe("resolve_pr_gates_remote_mode", () => {
   });
 });
 
+describe("prepare gate changed-file plan", () => {
+  it.each([
+    { paths: [] as string[], docsOnly: false, changelogOnly: false },
+    { paths: ["docs/guide.md"], docsOnly: true, changelogOnly: false },
+    { paths: ["CHANGELOG.md"], docsOnly: true, changelogOnly: true },
+    { paths: ["src/index.ts"], docsOnly: false, changelogOnly: false },
+    {
+      paths: ["docs/guide.md", "src/index.ts"],
+      docsOnly: false,
+      changelogOnly: false,
+    },
+  ])("derives the coupled plan for $paths", ({ paths, docsOnly, changelogOnly }) => {
+    const gitStub =
+      paths.length === 0
+        ? "git() { :; }"
+        : `git() { printf '%s\\n' ${paths.map((path) => `'${path}'`).join(" ")}; }`;
+    const result = runGatesBash(
+      [
+        gitStub,
+        "derive_prepare_gate_change_plan",
+        'printf "%s\\t%s\\t%s\\t%s\\n" "$PREPARE_GATE_CHANGED_FILES" "$PREPARE_GATE_DOCS_ONLY" "$PREPARE_GATE_CHANGELOG_ONLY" "$PREPARE_GATE_CHANGELOG_REQUIRED"',
+      ].join("\n"),
+    );
+
+    expect(result.status).toBe(0);
+    const fields = result.stdout.trimEnd().split("\t");
+    expect(fields).toEqual([paths.join("\n"), String(docsOnly), String(changelogOnly), "false"]);
+  });
+
+  it("carries the changelog policy decision into the plan", () => {
+    const result = runGatesBash(
+      [
+        "git() { printf 'src/index.ts\\n'; }",
+        "changelog_required_for_changed_files() { return 0; }",
+        "derive_prepare_gate_change_plan",
+        'printf "%s\\n" "$PREPARE_GATE_CHANGELOG_REQUIRED"',
+      ].join("\n"),
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("true");
+  });
+});
+
 describe("remote testbox gate delegation", () => {
   it("runs the full pnpm test through the worktree crabbox wrapper", () => {
     const dir = makeTempDir("openclaw-pr-gates-remote-");


### PR DESCRIPTION
Related: #104871

## What Problem This Solves

`scripts/pr prepare-gates` derived its coupled changed-file decisions inline with separate loops and conditionals. That made the gate-selection path harder to inspect, test directly, and modify without accidentally desynchronizing docs-only, changelog-only, and changelog-required behavior.

## Why This Change Was Made

Extract one internal change-plan helper that computes the existing changed-file list and all three policy decisions using the canonical docs/changelog helpers. `prepare_gates` consumes that plan without changing command flags, gate modes, changelog policy, output, or artifact shapes.

No config, SDK, CLI option, protocol, schema, generated artifact, package, or environment surface changes.

## User Impact

No user-visible behavior changes. Maintainers and coding agents get a smaller, directly tested gate-selection unit in the PR landing machinery.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/pr-prepare-gates.test.ts`: 33 tests passed.
- `bash -n scripts/pr-lib/gates.sh` and `shellcheck --shell=bash scripts/pr-lib/gates.sh` passed.
- oxfmt and `git diff --check` passed.
- Docker E2E boundary and raw `node:http2` guards passed.
- Full scripts oxlint passed.
- Fresh autoreview: clean, 0.98 confidence.
- Production shell diff: 21 additions / 23 deletions.
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 104961` passed hosted current-head gates for `5a8f2aac3ada2804d0aec3df79b06f4787cb3df5` at `2026-07-12T04:31:52Z`.
- A manual Testbox lease was unavailable before command execution and the sparse worktree omitted two unrelated root-test modules; hosted prepare gates closed both infrastructure-only proof gaps against a full checkout.
