### PR TITLE
refactor: remove dead core and extension exports

### DIFF
--- a/extensions/diffs/src/viewer-client.test.ts
+++ b/extensions/diffs/src/viewer-client.test.ts
@@ -135,13 +135,12 @@ describe("hydrateViewer", () => {
     fileDiffHydrateMock.mockImplementationOnce(() => {
       throw new Error("broken card");
     });
-    const { controllers, hydrateViewer } = await import("./viewer-client.js");
-    controllers.splice(0);
+    const { hydrateViewer } = await import("./viewer-client.js");
 
     await hydrateViewer();
 
     expect(fileDiffHydrateMock).toHaveBeenCalledTimes(2);
-    expect(controllers).toHaveLength(1);
+    expect(fileDiffRerenderMock).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
       "Skipping diff card that failed to hydrate",
       expect.any(Error),
@@ -157,14 +156,13 @@ describe("hydrateViewer", () => {
     fileDiffSetOptionsMock.mockImplementationOnce(() => {
       throw new Error("broken options");
     });
-    const { controllers, hydrateViewer } = await import("./viewer-client.js");
-    controllers.splice(0);
+    const { hydrateViewer } = await import("./viewer-client.js");
 
     await hydrateViewer();
 
     expect(fileDiffHydrateMock).toHaveBeenCalledTimes(2);
     expect(fileDiffSetOptionsMock).toHaveBeenCalledTimes(2);
-    expect(controllers).toHaveLength(1);
+    expect(fileDiffRerenderMock).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
       "Skipping diff card that failed to hydrate",
       expect.any(Error),
@@ -175,30 +173,22 @@ describe("hydrateViewer", () => {
 
   it("replaces stale controllers when hydrating the current cards again", async () => {
     renderCard();
-    const { controllers, hydrateViewer } = await import("./viewer-client.js");
-    controllers.splice(0);
+    const { hydrateViewer } = await import("./viewer-client.js");
 
     await hydrateViewer();
-    expect(controllers).toHaveLength(1);
-    const firstController = controllers[0];
 
     document.body.innerHTML = "";
     renderCard();
     await hydrateViewer();
 
-    expect(controllers).toHaveLength(1);
-    expect(controllers[0]).not.toBe(firstController);
     expect(fileDiffHydrateMock).toHaveBeenCalledTimes(2);
-  });
-});
+    const currentOptions = fileDiffSetOptionsMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    const renderHeaderMetadata = currentOptions.renderHeaderMetadata as () => HTMLElement;
+    fileDiffRerenderMock.mockClear();
 
-describe("resolveViewerLanguagePackAvailability", () => {
-  it("resolves defined and undefined build flags", async () => {
-    const { resolveViewerLanguagePackAvailability } = await import("./viewer-client.js");
+    renderHeaderMetadata().querySelector<HTMLButtonElement>("button")?.click();
 
-    expect(resolveViewerLanguagePackAvailability(true)).toBe(true);
-    expect(resolveViewerLanguagePackAvailability(false)).toBe(false);
-    expect(resolveViewerLanguagePackAvailability(undefined)).toBe(false);
+    expect(fileDiffRerenderMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -447,12 +437,10 @@ describe("header metadata", () => {
       '<nav class="oc-diff-card oc-diff-nav" aria-label="Changed files"><ol></ol></nav>',
     );
     renderCard();
-    const { controllers, hydrateViewer } = await import("./viewer-client.js");
-    controllers.splice(0);
+    const { hydrateViewer } = await import("./viewer-client.js");
 
     await hydrateViewer();
 
-    expect(controllers).toHaveLength(1);
     expect(fileDiffHydrateMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/diffs/src/viewer-client.ts
+++ b/extensions/diffs/src/viewer-client.ts
@@ -21,7 +21,7 @@ function readInjectedLanguagePackFlag(): boolean | undefined {
     : undefined;
 }
 
-export function resolveViewerLanguagePackAvailability(
+function resolveViewerLanguagePackAvailability(
   buildFlag: boolean | undefined = readInjectedLanguagePackFlag(),
 ): boolean {
   return buildFlag === true;
@@ -39,7 +39,7 @@ type DiffController = {
   diff: FileDiff;
 };
 
-export const controllers: DiffController[] = [];
+const controllers: DiffController[] = [];
 
 const viewerState: ViewerState = {
   theme: "dark",
@@ -372,7 +372,7 @@ async function main(): Promise<void> {
   }
 }
 
-export const disableAutoStartKey = Symbol.for("openclaw.diffs.disableAutoStart");
+const disableAutoStartKey = Symbol.for("openclaw.diffs.disableAutoStart");
 
 const autoStartDisabled = Boolean(
   (globalThis as typeof globalThis & Record<symbol, unknown>)[disableAutoStartKey],

--- a/extensions/qa-lab/src/cron-run-wait.test.ts
+++ b/extensions/qa-lab/src/cron-run-wait.test.ts
@@ -1,7 +1,6 @@
 // Qa Lab tests cover cron run wait plugin behavior.
-import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
-import { resolveCronRunPollIntervalMs, waitForCronRunCompletion } from "./cron-run-wait.js";
+import { waitForCronRunCompletion } from "./cron-run-wait.js";
 
 describe("waitForCronRunCompletion", () => {
   it("ignores older entries and returns the newly finished run", async () => {
@@ -51,10 +50,6 @@ describe("waitForCronRunCompletion", () => {
         intervalMs: 0,
       }),
     ).rejects.toThrow(/timed out waiting for cron run completion/);
-  });
-
-  it("clamps oversized poll intervals before sleeping", () => {
-    expect(resolveCronRunPollIntervalMs(Number.MAX_SAFE_INTEGER)).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 
   it("keeps oversized poll intervals within the overall timeout", async () => {

--- a/extensions/qa-lab/src/cron-run-wait.ts
+++ b/extensions/qa-lab/src/cron-run-wait.ts
@@ -15,7 +15,7 @@ type QaCronRunsPage = {
   entries?: QaCronRunLogEntry[];
 };
 
-export function resolveCronRunPollIntervalMs(intervalMs: number | undefined): number {
+function resolveCronRunPollIntervalMs(intervalMs: number | undefined): number {
   return resolveTimerTimeoutMs(intervalMs ?? 1_000, 1_000, 0);
 }
 

--- a/extensions/qa-lab/src/evidence-gallery.test.ts
+++ b/extensions/qa-lab/src/evidence-gallery.test.ts
@@ -8,7 +8,6 @@ import {
   resolveQaEvidenceArtifactFileByIndex,
   resolveQaEvidenceArtifactFile,
   resolveQaEvidenceProducerFile,
-  resolveQaEvidenceFile,
 } from "./evidence-gallery.js";
 import {
   QA_EVIDENCE_FILENAME,
@@ -616,9 +615,11 @@ describe("evidence gallery", () => {
       }),
     );
 
-    await expect(resolveQaEvidenceFile({ inputPath: outputDir, repoRoot })).resolves.toBe(
-      await fs.realpath(evidencePath),
-    );
+    await expect(
+      buildQaEvidenceGalleryModel({ evidencePath: outputDir, repoRoot }),
+    ).resolves.toMatchObject({
+      counts: { blocked: 0, fail: 0, pass: 1, skipped: 0 },
+    });
     await expect(
       resolveQaEvidenceArtifactFile({
         artifactPath: "artifact.log",
@@ -694,7 +695,10 @@ describe("evidence gallery", () => {
       }),
     ).rejects.toThrow("Evidence artifact not found.");
     await expect(
-      resolveQaEvidenceFile({ inputPath: "/tmp/not-openclaw-evidence.json", repoRoot }),
+      buildQaEvidenceGalleryModel({
+        evidencePath: "/tmp/not-openclaw-evidence.json",
+        repoRoot,
+      }),
     ).rejects.toThrow("Evidence path not found.");
   });
 });

--- a/extensions/qa-lab/src/evidence-gallery.ts
+++ b/extensions/qa-lab/src/evidence-gallery.ts
@@ -148,7 +148,7 @@ async function resolveContainedFileIfExists(
   return stats?.isFile() ? realFile : null;
 }
 
-export async function resolveQaEvidenceFile(params: {
+async function resolveQaEvidenceFile(params: {
   inputPath: string;
   repoRoot: string;
 }): Promise<string> {

--- a/extensions/qa-lab/src/jsonl-replay.test.ts
+++ b/extensions/qa-lab/src/jsonl-replay.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   createMockJsonlReplayCellRunner,
-  extractJsonlReplayUserTurns,
   renderJsonlReplayMarkdownReport,
   runJsonlReplay,
   type JsonlReplayCellRunner,
@@ -56,8 +55,10 @@ afterEach(async () => {
 });
 
 describe("jsonl replay", () => {
-  it("extracts user-turn boundaries while ignoring system, tool-only, empty, and malformed rows", () => {
-    const turns = extractJsonlReplayUserTurns(
+  it("extracts user-turn boundaries while ignoring system, tool-only, empty, and malformed rows", async () => {
+    const transcriptDir = await makeTempDir();
+    await fs.writeFile(
+      path.join(transcriptDir, "turns.jsonl"),
       [
         `{"message":{"role":"system","content":"System setup"}}`,
         `{"message":{"role":"tool","content":"tool-only prelude"}}`,
@@ -67,6 +68,21 @@ describe("jsonl replay", () => {
         `{"message":{"role":"user","content":[{"type":"text","text":"Plan the release"},{"type":"tool_result","content":"ignored"}]}}`,
         `{"role":"user","content":[{"type":"input_text","text":"Check the follow-up"}]}`,
       ].join("\n"),
+      "utf8",
+    );
+    let turns: readonly Parameters<JsonlReplayCellRunner>[0]["turn"][] = [];
+    const runCell: JsonlReplayCellRunner = async (params) => {
+      turns = params.turns;
+      return createMockJsonlReplayCellRunner()(params);
+    };
+
+    await runJsonlReplay(
+      {
+        directory: transcriptDir,
+        runtimePair: ["openclaw", "codex"],
+        providerMode: "mock-openai",
+      },
+      { runCell },
     );
 
     expect(turns).toEqual([

--- a/extensions/qa-lab/src/jsonl-replay.ts
+++ b/extensions/qa-lab/src/jsonl-replay.ts
@@ -105,7 +105,7 @@ function extractTextContent(content: unknown): string {
   return parts.join("\n").trim();
 }
 
-export function extractJsonlReplayUserTurns(transcriptBytes: string): JsonlReplayTurn[] {
+function extractJsonlReplayUserTurns(transcriptBytes: string): JsonlReplayTurn[] {
   const turns: JsonlReplayTurn[] = [];
   const acceptedLines: string[] = [];
   for (const [lineIndex, rawLine] of transcriptBytes.split(/\r?\n/u).entries()) {

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -5,13 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { readQaJsonBody } from "./bus-server.js";
 import { resolveUiAssetVersion } from "./lab-server-ui.js";
-import {
-  startQaLabServer,
-  writeQaLabServerError,
-  type QaLabServerStartParams,
-} from "./lab-server.js";
+import { startQaLabServer, type QaLabServerStartParams } from "./lab-server.js";
 
 const qaChannelMock = vi.hoisted(() => ({
   resolveAccount: vi.fn(),
@@ -605,38 +600,6 @@ describe("qa-lab server", () => {
     outsideUrl.searchParams.set("artifactPath", outsideArtifact);
     const outsideResponse = await fetchWithRetry(outsideUrl.toString());
     expect(outsideResponse.status).toBe(404);
-  });
-
-  it("returns controlled errors for oversized JSON body reads", async () => {
-    const req = {
-      headers: { "content-length": String(1024 * 1024 + 1) },
-      destroyed: false,
-      destroy() {
-        this.destroyed = true;
-      },
-    };
-    const res = {
-      statusCode: 0,
-      body: "",
-      writeHead(statusCode: number) {
-        this.statusCode = statusCode;
-      },
-      end(payload: string) {
-        this.body = payload;
-      },
-    };
-
-    let error: unknown;
-    try {
-      await readQaJsonBody(req as never);
-    } catch (caught) {
-      error = caught;
-    }
-
-    writeQaLabServerError(res as never, error);
-
-    expect(res.statusCode).toBe(413);
-    expect(JSON.parse(res.body)).toEqual({ error: "Payload too large" });
   });
 
   it("returns controlled errors for malformed JSON body reads", async () => {

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -73,7 +73,7 @@ export type {
   QaLabServerStartParams,
 } from "./lab-server.types.js";
 
-export function writeQaLabServerError(res: Parameters<typeof writeError>[0], error: unknown): void {
+function writeQaLabServerError(res: Parameters<typeof writeError>[0], error: unknown): void {
   if (writeQaRequestBodyLimitError(res, error)) {
     return;
   }

--- a/extensions/qa-lab/src/model-catalog.runtime.test.ts
+++ b/extensions/qa-lab/src/model-catalog.runtime.test.ts
@@ -2,11 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  loadQaRunnerModelOptions,
-  parseQaRunnerModelOptionsOutput,
-  selectQaRunnerModelOptions,
-} from "./model-catalog.runtime.js";
+import { loadQaRunnerModelOptions } from "./model-catalog.runtime.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const { cleanup, makeTempDir } = createTempDirHarness();
@@ -51,46 +47,22 @@ async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
 }
 
 describe("qa runner model catalog", () => {
-  it("filters to available rows and prefers gpt-5.6-luna first", () => {
-    expect(
-      selectQaRunnerModelOptions([
-        {
-          key: "anthropic/claude-sonnet-4-6",
-          name: "Claude Sonnet 4.6",
-          input: "text",
-          available: true,
-          missing: false,
-        },
-        {
-          key: "openai/gpt-5.6-luna",
-          name: "gpt-5.6-luna",
-          input: "text,image",
-          available: true,
-          missing: false,
-        },
-        {
-          key: "openrouter/auto",
-          name: "OpenRouter Auto",
-          input: "text",
-          available: false,
-          missing: false,
-        },
-      ]).map((entry) => entry.key),
-    ).toEqual(["openai/gpt-5.6-luna", "anthropic/claude-sonnet-4-6"]);
-  });
-
-  it("reports malformed catalog JSON with an owned error", () => {
-    expect(() => parseQaRunnerModelOptionsOutput("{not json")).toThrow(
-      "qa model catalog returned malformed JSON",
-    );
-  });
-
-  it("ignores invalid catalog rows without failing the model picker", () => {
-    expect(
-      parseQaRunnerModelOptionsOutput(
+  it("filters catalog output and prefers gpt-5.6-luna first", async () => {
+    const repoRoot = await makeTempDir("openclaw-qa-model-catalog-output-");
+    await fs.mkdir(path.join(repoRoot, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, "dist", "index.js"),
+      `process.stdout.write(${JSON.stringify(
         JSON.stringify({
           models: [
             null,
+            {
+              key: "anthropic/claude-sonnet-4-6",
+              name: "Claude Sonnet 4.6",
+              input: "text",
+              available: true,
+              missing: false,
+            },
             {
               key: "openai/gpt-5.6-luna",
               name: "gpt-5.6-luna",
@@ -98,10 +70,37 @@ describe("qa runner model catalog", () => {
               available: true,
               missing: false,
             },
+            {
+              key: "openrouter/auto",
+              name: "OpenRouter Auto",
+              input: "text",
+              available: false,
+              missing: false,
+            },
           ],
         }),
-      ).map((entry) => entry.key),
-    ).toEqual(["openai/gpt-5.6-luna"]);
+      )});\n`,
+      "utf8",
+    );
+
+    await expect(loadQaRunnerModelOptions({ repoRoot })).resolves.toEqual([
+      expect.objectContaining({ key: "openai/gpt-5.6-luna" }),
+      expect.objectContaining({ key: "anthropic/claude-sonnet-4-6" }),
+    ]);
+  });
+
+  it("reports malformed catalog JSON with an owned error", async () => {
+    const repoRoot = await makeTempDir("openclaw-qa-model-catalog-malformed-");
+    await fs.mkdir(path.join(repoRoot, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, "dist", "index.js"),
+      `process.stdout.write("{not json");\n`,
+      "utf8",
+    );
+
+    await expect(loadQaRunnerModelOptions({ repoRoot })).rejects.toThrow(
+      "qa model catalog returned malformed JSON",
+    );
   });
 
   it.runIf(process.platform !== "win32")(

--- a/extensions/qa-lab/src/model-catalog.runtime.ts
+++ b/extensions/qa-lab/src/model-catalog.runtime.ts
@@ -53,7 +53,7 @@ function splitModelKey(key: string) {
   };
 }
 
-export function selectQaRunnerModelOptions(rows: ModelRow[]): QaRunnerModelOption[] {
+function selectQaRunnerModelOptions(rows: ModelRow[]): QaRunnerModelOption[] {
   const options = rows
     .filter((row) => row.available === true && !row.missing)
     .map((row) => {
@@ -93,7 +93,7 @@ function isModelRow(value: unknown): value is ModelRow {
   );
 }
 
-export function parseQaRunnerModelOptionsOutput(stdout: string): QaRunnerModelOption[] {
+function parseQaRunnerModelOptionsOutput(stdout: string): QaRunnerModelOption[] {
   let payload: unknown;
   try {
     payload = JSON.parse(stdout) as unknown;

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -343,7 +343,6 @@ const qaScenarioPackFileSchema = z.object({
 export type QaScenarioExecution = z.infer<typeof qaScenarioExecutionSchema>;
 export type QaScenarioFlow = z.infer<typeof qaFlowSchema>;
 export type QaRuntimeParityTier = z.infer<typeof qaRuntimeParityTierSchema>;
-export type QaRuntimeParityUsage = z.infer<typeof qaRuntimeParityUsageSchema>;
 export type QaSeedScenario = z.infer<typeof qaSeedScenarioSchema>;
 export type QaSeedScenarioWithSource = QaSeedScenario & {
   sourcePath: string;

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -125,7 +125,6 @@ vi.mock("../skills/runtime/session-snapshot.js", () => ({
 }));
 
 vi.mock("./exec-defaults.js", () => ({
-  canExecRequestNode: () => false,
   resolveNodeExecEligibility: () => ({ canExec: false }),
 }));
 

--- a/src/agents/exec-defaults.test.ts
+++ b/src/agents/exec-defaults.test.ts
@@ -2,11 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import * as execApprovals from "../infra/exec-approvals.js";
-import {
-  canExecRequestNode,
-  resolveExecDefaults,
-  resolveNodeExecEligibility,
-} from "./exec-defaults.js";
+import { resolveExecDefaults, resolveNodeExecEligibility } from "./exec-defaults.js";
 
 describe("resolveExecDefaults", () => {
   beforeEach(() => {
@@ -296,21 +292,6 @@ describe("resolveExecDefaults", () => {
       security: "allowlist",
       ask: "off",
     });
-  });
-
-  it("blocks node advertising in helper calls when sandbox is available", () => {
-    expect(
-      canExecRequestNode({
-        cfg: {
-          tools: {
-            exec: {
-              host: "auto",
-            },
-          },
-        },
-        sandboxAvailable: true,
-      }),
-    ).toBe(false);
   });
 
   it("blocks node skill eligibility for deny policy and preserves node bindings", () => {

--- a/src/agents/exec-defaults.ts
+++ b/src/agents/exec-defaults.ts
@@ -65,8 +65,8 @@ function applySessionLegacyExecPolicyLayer(
   return base;
 }
 
-// Gather the shared config state once so canExecRequestNode and
-// resolveExecDefaults stay aligned on agent/global/session precedence.
+// Gather the shared config state once so exec resolution applies one
+// agent/global/session precedence order.
 function resolveExecConfigState(params: {
   cfg?: OpenClawConfig;
   sessionEntry?: ExecSessionDefaults;
@@ -104,34 +104,6 @@ function resolveExecConfigState(params: {
     agentExec,
     globalExec,
   };
-}
-
-function resolveExecSandboxAvailability(params: {
-  cfg: OpenClawConfig;
-  sessionKey?: string;
-  sandboxAvailable?: boolean;
-}) {
-  return (
-    params.sandboxAvailable ??
-    (params.sessionKey
-      ? resolveSandboxRuntimeStatus({
-          cfg: params.cfg,
-          sessionKey: params.sessionKey,
-        }).sandboxed
-      : false)
-  );
-}
-
-/** Returns whether the current exec policy allows requesting host node execution. */
-export function canExecRequestNode(params: {
-  cfg?: OpenClawConfig;
-  sessionEntry?: ExecSessionDefaults;
-  execOverrides?: ExecPolicyOverrides;
-  agentId?: string;
-  sessionKey?: string;
-  sandboxAvailable?: boolean;
-}): boolean {
-  return resolveNodeExecEligibility(params).canExec;
 }
 
 /** Resolves whether node exec is usable and any effective node binding. */
@@ -178,11 +150,14 @@ export function resolveExecDefaults(params: {
     agentExec,
     globalExec,
   } = resolveExecConfigState(params);
-  const sandboxAvailable = resolveExecSandboxAvailability({
-    cfg,
-    sessionKey: params.sessionKey,
-    sandboxAvailable: params.sandboxAvailable,
-  });
+  const sandboxAvailable =
+    params.sandboxAvailable ??
+    (params.sessionKey
+      ? resolveSandboxRuntimeStatus({
+          cfg,
+          sessionKey: params.sessionKey,
+        }).sandboxed
+      : false);
   const resolved = resolveExecTarget({
     configuredTarget: host,
     elevatedRequested: params.elevatedRequested === true,

--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -39,7 +39,6 @@ vi.mock("../plugin-sdk/browser-control-auth.js", () => browserControlAuthMock);
 vi.mock("../plugin-sdk/browser-profiles.js", () => browserProfilesMock);
 
 vi.mock("./exec-defaults.js", () => ({
-  canExecRequestNode: vi.fn(() => false),
   resolveNodeExecEligibility: resolveNodeExecEligibilityMock,
 }));
 

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -280,6 +280,5 @@ vi.mock("../skills/runtime/session-snapshot.js", () => ({
 }));
 
 vi.mock("../agents/exec-defaults.js", () => ({
-  canExecRequestNode: vi.fn(() => false),
   resolveNodeExecEligibility: vi.fn(() => ({ canExec: false })),
 }));

--- a/src/commands/status-all/report-data.test.ts
+++ b/src/commands/status-all/report-data.test.ts
@@ -6,7 +6,6 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../agents/exec-defaults.js", () => ({
-  canExecRequestNode: () => false,
   resolveNodeExecEligibility: () => ({ canExec: false }),
 }));
 vi.mock("../../config/config.js", () => ({

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -192,7 +192,6 @@ vi.mock("../../web-search/runtime.js", () => ({
 }));
 
 vi.mock("../../skills/runtime/cron-snapshot.runtime.js", () => ({
-  canExecRequestNode: vi.fn(() => false),
   resolveNodeExecEligibility: vi.fn(() => ({ canExec: false })),
   getRemoteSkillEligibility: getRemoteSkillEligibilityMock,
   resolveEffectiveAgentSkillFilter: resolveAgentSkillsFilterMock,


### PR DESCRIPTION
## What Problem This Solves

Removes redundant internal exports, stale test mocks, and direct implementation-helper tests found during a maintainer-directed dead-code audit. These symbols made private implementation details look reusable while duplicating or bypassing the actual public behavior paths.

## Why This Change Was Made

Deletes the obsolete agent exec eligibility wrapper and its stale mocks, makes Diffs viewer state private, and internalizes QA Lab helpers while moving their coverage through the owning public workflows. The patch preserves runtime behavior and removes 85 net lines across 20 files.

## User Impact

No intended user-visible behavior change. Maintainers get a smaller public-looking surface, fewer stale mocks, and tests that exercise the real entry points instead of private helpers.

## Evidence

- Exact head `ffbde886fc22bd5b8113750f24e190521b386f3c`: CI run `29180470055`, CodeQL run `29180470008`, CodeQL Critical Quality run `29180470040`, and OpenGrep run `29180470050` all passed.
- Blacksmith Testbox `tbx_01kxa88f5x2v394ydaxb8q518p`: exact-head extension boundary suite passed 11/11 tests.
- Patch-equivalent pre-rebase head `ecc464bb765bf1c17846f051f18d5109c569dd28`: focused `pnpm test:serial` passed 7 Vitest shards, 16 files, and 125 tests; `pnpm check:changed` passed all selected core/core-test/extension/extension-test gates.
- `git range-diff` marked all three rebased commits equivalent, and the aggregate stable patch ID remained `7491f9036879649431d13936e5ed14544a976253`.
- Fresh exact-head `gpt-5.6-sol` medium branch autoreview reported no findings, patch correct, confidence 0.97.
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 104963` passed with hosted exact-or-recent-rebase gates.
- `git diff --check` passed. No known proof gaps.

AI-assisted maintenance change. No transcript attached.
