### PR TITLE
fix(tavily): forward abort signal when web search runs are canceled

### DIFF
--- a/extensions/tavily/proof/abort-guarded-fetch-proof.test.ts
+++ b/extensions/tavily/proof/abort-guarded-fetch-proof.test.ts
@@ -51,8 +51,8 @@ describe("tavily abort signal proof", () => {
     }
 
     const startedAt = Date.now();
-    let errorType: string;
-    let errorMessage: string;
+    let errorType = "unknown";
+    let errorMessage = "unknown";
     try {
       await tool.execute({ query: "openclaw test" }, { signal: controller.signal });
       throw new Error("Expected execute() to reject with aborted signal");
@@ -107,8 +107,8 @@ describe("tavily abort signal proof", () => {
     await expect(searchPromise).rejects.toThrow();
     const elapsed = Date.now() - startedAt;
 
-    let errorType: string;
-    let errorMessage: string;
+    let errorType = "unknown";
+    let errorMessage = "unknown";
     try {
       await searchPromise;
     } catch (err) {

--- a/extensions/tavily/proof/abort-guarded-fetch-proof.test.ts
+++ b/extensions/tavily/proof/abort-guarded-fetch-proof.test.ts
@@ -1,30 +1,72 @@
 /**
- * Real behavior proof: Tavily abort signal through the guarded-fetch stack.
+ * Real behavior proof: abort signal through Tavily's full provider→fetch chain.
  *
  * Tavily production code path:
- *   runTavilySearch (tavily-client.ts)
+ *   createTavilyWebSearchProvider().createTool(ctx).execute(args, context)
+ *   → runTavilySearch({ signal: context?.signal })
  *   → postTavilyJson({ signal }) → postTrustedWebToolsJson({ signal })
- *   → withTrustedWebToolsEndpoint({ signal }) (web-guarded-fetch.ts:82)
+ *   → withTrustedWebToolsEndpoint({ signal })
  *   → withWebToolsNetworkGuard({ useEnvProxy: true })
- *   → fetchWithSsrFGuard({ signal }) (fetch-guard.ts:460)
- *   → buildTimeoutAbortSignal({ signal }) (fetch-guard.ts:496)
+ *   → fetchWithSsrFGuard({ signal })
+ *   → buildTimeoutAbortSignal({ signal })
  *   → fetch()
  *
- * This proof uses withSelfHostedWebToolsEndpoint — the localhost-allowed
- * sibling of withTrustedWebToolsEndpoint. Both share identical
- * fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch() code paths;
- * only the SSRF policy object differs.
- *
- * A stalled HTTP server (never sends headers) simulates a remote endpoint
- * that accepts the TCP connection but withholds response headers forever.
- * The AbortController aborts after 100ms. If signal forwarding works,
- * the fetch rejects instead of hanging.
+ * Two-part proof:
+ * 1. Pre-aborted signal through provider path — proves signal flows from
+ *    provider.execute() through all intermediate layers to fetch().
+ *    buildTimeoutAbortSignal sees the already-aborted parent signal and
+ *    immediately aborts its controller, so no network I/O occurs.
+ * 2. Stalled-server proof through withSelfHostedWebToolsEndpoint — proves the
+ *    common guarded-fetch stack cancels real in-flight HTTP requests.
+ *    Self-hosted variant allows localhost; both variants share identical
+ *    fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch() code paths.
  */
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { describe, expect, it, vi } from "vitest";
+import { createTavilyWebSearchProvider } from "../src/tavily-search-provider.js";
 
 describe("tavily abort signal proof", () => {
+  it("propagates pre-aborted signal from provider execute through full client path", async () => {
+    // Pre-abort the signal before calling execute(). This exercises the full
+    // signal chain: execute → runTavilySearch → postTavilyJson →
+    // postTrustedWebToolsJson → withTrustedWebToolsEndpoint →
+    // fetchWithSsrFGuard → buildTimeoutAbortSignal.
+    // Since the parent signal is already aborted, buildTimeoutAbortSignal
+    // immediately aborts its own controller, and fetch() rejects before any
+    // network I/O — proving signal handoff through all changed layers.
+    // Provide a fake API key so the provider passes the apiKey check
+    // and the signal reaches the fetch layer. With a pre-aborted signal,
+    // buildTimeoutAbortSignal immediately aborts its controller, and
+    // fetch() rejects before any network I/O — no real API call occurs.
+    vi.stubEnv("TAVILY_API_KEY", "proof-test-key");
+
+    const controller = new AbortController();
+    controller.abort(new Error("proof: pre-aborted signal"));
+
+    const provider = createTavilyWebSearchProvider();
+    const tool = provider.createTool({ config: {} as never });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const startedAt = Date.now();
+    let errorType: string;
+    let errorMessage: string;
+    try {
+      await tool.execute({ query: "openclaw test" }, { signal: controller.signal });
+      throw new Error("Expected execute() to reject with aborted signal");
+    } catch (err) {
+      errorType = err?.constructor?.name ?? "unknown";
+      errorMessage = err instanceof Error ? err.message : String(err);
+    }
+    const elapsed = Date.now() - startedAt;
+
+    console.log(`[proof] Pre-aborted signal propagated through Tavily provider in ${elapsed}ms`);
+    console.log(`[proof] error: ${errorType}: ${errorMessage}`);
+    expect(elapsed).toBeLessThan(5000);
+  }, 15000);
+
   it("propagates abort signal through the guarded-fetch stack used by Tavily", async () => {
     const { withSelfHostedWebToolsEndpoint } = await vi.importActual<
       typeof import("openclaw/plugin-sdk/provider-web-search")
@@ -34,7 +76,11 @@ describe("tavily abort signal proof", () => {
     const server = createServer((_req, res) => {
       res.socket?.setTimeout(0);
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        resolve();
+      });
+    });
     const { port } = server.address() as AddressInfo;
 
     const controller = new AbortController();
@@ -51,14 +97,18 @@ describe("tavily abort signal proof", () => {
     );
 
     // Abort after 100ms.
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 100);
+    });
     controller.abort("proof: cancellation");
 
     await expect(searchPromise).rejects.toThrow();
     const elapsed = Date.now() - startedAt;
 
-    let errorType = "unknown";
-    let errorMessage = "";
+    let errorType: string;
+    let errorMessage: string;
     try {
       await searchPromise;
     } catch (err) {

--- a/extensions/tavily/proof/abort-guarded-fetch-proof.test.ts
+++ b/extensions/tavily/proof/abort-guarded-fetch-proof.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Real behavior proof: Tavily abort signal through the guarded-fetch stack.
+ *
+ * Tavily production code path:
+ *   runTavilySearch (tavily-client.ts)
+ *   → postTavilyJson({ signal }) → postTrustedWebToolsJson({ signal })
+ *   → withTrustedWebToolsEndpoint({ signal }) (web-guarded-fetch.ts:82)
+ *   → withWebToolsNetworkGuard({ useEnvProxy: true })
+ *   → fetchWithSsrFGuard({ signal }) (fetch-guard.ts:460)
+ *   → buildTimeoutAbortSignal({ signal }) (fetch-guard.ts:496)
+ *   → fetch()
+ *
+ * This proof uses withSelfHostedWebToolsEndpoint — the localhost-allowed
+ * sibling of withTrustedWebToolsEndpoint. Both share identical
+ * fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch() code paths;
+ * only the SSRF policy object differs.
+ *
+ * A stalled HTTP server (never sends headers) simulates a remote endpoint
+ * that accepts the TCP connection but withholds response headers forever.
+ * The AbortController aborts after 100ms. If signal forwarding works,
+ * the fetch rejects instead of hanging.
+ */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+
+describe("tavily abort signal proof", () => {
+  it("propagates abort signal through the guarded-fetch stack used by Tavily", async () => {
+    const { withSelfHostedWebToolsEndpoint } = await vi.importActual<
+      typeof import("openclaw/plugin-sdk/provider-web-search")
+    >("openclaw/plugin-sdk/provider-web-search");
+
+    // Create a stalled server — never calls res.writeHead().
+    const server = createServer((_req, res) => {
+      res.socket?.setTimeout(0);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+
+    const controller = new AbortController();
+    const startedAt = Date.now();
+
+    const searchPromise = withSelfHostedWebToolsEndpoint(
+      {
+        url: `http://127.0.0.1:${port}/stall`,
+        timeoutSeconds: 30,
+        init: { method: "GET" },
+        signal: controller.signal,
+      },
+      async (_result) => ({ ok: true }),
+    );
+
+    // Abort after 100ms.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    controller.abort("proof: cancellation");
+
+    await expect(searchPromise).rejects.toThrow();
+    const elapsed = Date.now() - startedAt;
+
+    let errorType = "unknown";
+    let errorMessage = "";
+    try {
+      await searchPromise;
+    } catch (err) {
+      errorType = err?.constructor?.name ?? "unknown";
+      errorMessage = err instanceof Error ? err.message : String(err);
+    }
+
+    console.log(
+      `[proof] Signal propagated in ${elapsed}ms through guarded-fetch stack ` +
+        `(withSelfHostedWebToolsEndpoint → fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch)`,
+    );
+    console.log(`[proof] stalled server: http://127.0.0.1:${port}/stall`);
+    console.log(`[proof] abort: controller.abort("proof: cancellation") @ ~100ms`);
+    console.log(`[proof] error: ${errorType}: ${errorMessage}`);
+
+    server.close();
+    expect(elapsed).toBeLessThan(5000);
+  }, 15000);
+});

--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -40,6 +40,7 @@ export type TavilySearchParams = {
   includeDomains?: string[];
   excludeDomains?: string[];
   timeoutSeconds?: number;
+  signal?: AbortSignal;
 };
 
 export type TavilyExtractParams = {
@@ -76,6 +77,7 @@ async function postTavilyJson(params: {
   body: Record<string, unknown>;
   errorLabel: string;
   responseMaxBytes?: number;
+  signal?: AbortSignal;
 }): Promise<Record<string, unknown>> {
   return postTrustedWebToolsJson(
     {
@@ -85,6 +87,7 @@ async function postTavilyJson(params: {
       body: params.body,
       errorLabel: params.errorLabel,
       extraHeaders: { "X-Client-Source": "openclaw" },
+      signal: params.signal,
     },
     async (response) =>
       readTavilyJsonResponse(response, params.errorLabel, {
@@ -167,6 +170,7 @@ export async function runTavilySearch(
     apiKey,
     body,
     errorLabel: "Tavily Search",
+    signal: params.signal,
   });
 
   const rawResults = Array.isArray(payload.results) ? payload.results : [];

--- a/extensions/tavily/src/tavily-search-provider.ts
+++ b/extensions/tavily/src/tavily-search-provider.ts
@@ -16,7 +16,7 @@ export function createTavilyWebSearchProvider(): WebSearchProviderPlugin {
     createTool: (ctx) => ({
       description: TAVILY_GENERIC_SEARCH_DESCRIPTION,
       parameters: TAVILY_GENERIC_SEARCH_SCHEMA,
-      execute: async (args) => {
+      execute: async (args, context) => {
         const { runTavilySearch } = await loadTavilyClientModule();
         return await runTavilySearch({
           cfg: ctx.config,
@@ -25,6 +25,7 @@ export function createTavilyWebSearchProvider(): WebSearchProviderPlugin {
             message: "count must be an integer from 1 to 20",
             max: 20,
           }),
+          signal: context?.signal,
         });
       },
     }),

--- a/extensions/tavily/src/tavily-tools.test.ts
+++ b/extensions/tavily/src/tavily-tools.test.ts
@@ -113,6 +113,26 @@ describe("tavily tools", () => {
     });
   });
 
+  it("forwards the execution abort signal to the Tavily client", async () => {
+    const provider = createTavilyWebSearchProvider();
+    const tool = provider.createTool({
+      config: { test: true },
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const controller = new AbortController();
+
+    await tool.execute({ query: "weather sf" }, { signal: controller.signal });
+
+    expect(runTavilySearch).toHaveBeenCalledWith({
+      cfg: { test: true },
+      query: "weather sf",
+      maxResults: undefined,
+      signal: controller.signal,
+    });
+  });
+
   it("keeps the contract web search provider executable", async () => {
     const provider = createTavilyContractWebSearchProvider();
     const tool = provider.createTool({

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -266,6 +266,49 @@ describe("web search runtime", () => {
     );
   });
 
+  it("does not fall back to another provider after parent cancellation", async () => {
+    const controller = new AbortController();
+    const firstExecute = vi.fn(
+      async (_args: Record<string, unknown>, _context?: { signal?: AbortSignal }) => {
+        controller.abort();
+        throw controller.signal.reason;
+      },
+    );
+    const fallbackExecute = vi.fn(async () => ({ ok: true }));
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
+      createCustomSearchProvider({
+        credentialPath: "",
+        createTool: () => ({
+          description: "first",
+          parameters: {},
+          execute: firstExecute,
+        }),
+      }),
+      createCustomSearchProvider({
+        pluginId: "fallback-search",
+        id: "fallback",
+        credentialPath: "",
+        autoDetectOrder: 2,
+        getConfiguredCredentialValue: () => "configured",
+        createTool: () => ({
+          description: "fallback",
+          parameters: {},
+          execute: fallbackExecute,
+        }),
+      }),
+    ]);
+
+    await expect(
+      runWebSearch({
+        config: createCustomSearchConfig("custom-config-key"),
+        args: { query: "abort fallback" },
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(firstExecute).toHaveBeenCalledOnce();
+    expect(fallbackExecute).not.toHaveBeenCalled();
+  });
+
   it("auto-detects a provider from canonical plugin-owned credentials", async () => {
     const provider = createCustomSearchProvider();
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -472,6 +472,7 @@ export async function runWebSearch(params: RunWebSearchParams): Promise<RunWebSe
   let sawUnavailableProvider = false;
 
   for (const candidate of candidates) {
+    params.signal?.throwIfAborted();
     try {
       const definition = candidate.createTool({
         config,
@@ -499,7 +500,7 @@ export async function runWebSearch(params: RunWebSearchParams): Promise<RunWebSe
       };
     } catch (error) {
       lastError = error;
-      if (!allowFallback) {
+      if (params.signal?.aborted || !allowFallback) {
         throw error;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Two cancellations bugs in the Tavily web search path:

1. **Dropped abort signal** — Tavily is one of the web search providers that discards the caller's `AbortSignal`. The web search runtime threads `signal` into `execute(args, { signal })`, but the Tavily provider ignored it — so aborted runs left Tavily requests open until their configured timeout.

2. **Fallback after cancellation** — Even after forwarding the signal, an aborted Tavily request caught by `runWebSearch`'s catch block can start the next auto-detected provider. Canceling one provider should not trigger unintended fallback work.

## Why This Change Was Made

**Tavily signal forwarding** (provider + client): Forward `context?.signal` through the Tavily provider and client to `postTrustedWebToolsJson` (which already supports `signal?: AbortSignal` at line 141). The pattern matches the searxng fix in #104216 and the DuckDuckGo fix in #104899 — one provider per PR, no new SDK surface.

**Shared runtime abort guard** (`src/web-search/runtime.ts`): Add `params.signal?.throwIfAborted()` at the top of the provider loop and `params.signal?.aborted` in the catch block so a parent cancellation stops fallback immediately. This is the canonical pattern from #104216 — without it, forwarding the signal into a provider that then rejects on abort would still trigger the next auto-detected provider.

## Evidence

### Real behavior proof — abort through the guarded-fetch stack

A real stalled HTTP server (never sends headers) exercises the exact code path Tavily uses:
- Production: `postTrustedWebToolsJson({ signal })` → `withTrustedWebToolsEndpoint` → `fetchWithSsrFGuard` → `buildTimeoutAbortSignal` → `fetch()`
- Proof: `withSelfHostedWebToolsEndpoint` — same `fetchWithSsrFGuard` → `buildTimeoutAbortSignal` → `fetch()` code path; only the SSRF policy differs (selfHosted allows localhost for proof).

```
[proof] Signal propagated in 122ms through guarded-fetch stack
        (withSelfHostedWebToolsEndpoint → fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch)
[proof] stalled server: http://127.0.0.1:44061/stall
[proof] abort: controller.abort("proof: cancellation") @ ~100ms
[proof] error: DOMException: This operation was aborted
```

Proof script: `extensions/tavily/proof/abort-guarded-fetch-proof.test.ts`

### Signal chain — full path (source verified)

| Layer | File | Line | Mechanism |
|---|---|---|---|
| Web search runtime | `src/web-search/runtime.ts` | 475 | `params.signal?.throwIfAborted()` — terminal guard (new) |
| Web search runtime | `src/web-search/runtime.ts` | 489 | `definition.execute(params.args, { signal: params.signal })` |
| Web search runtime | `src/web-search/runtime.ts` | 503 | `params.signal?.aborted \|\| !allowFallback` — catch guard (new) |
| Tavily provider tool | `extensions/tavily/src/tavily-search-provider.ts` | 28 | `signal: context?.signal` (new) |
| Tavily POST helper | `extensions/tavily/src/tavily-client.ts` | 90 | `signal: params.signal` (new) |
| Trusted POST endpoint | `src/agents/tools/web-search-provider-common.ts` | 150 | `signal: params.signal` — native support |

No new SDK surface is needed — `postTrustedWebToolsJson` already accepts `signal?: AbortSignal` at line 141.

### Test suite

```
$ node scripts/run-vitest.mjs run extensions/tavily/ src/web-search/runtime.test.ts
 ✓ tavily tools: 15/15 passed (including signal forwarding test)
 ✓ tavily client: 5/5 passed
 ✓ runtime: 31/31 passed (including "does not fall back after parent cancellation")
```

### Lint

```
$ node scripts/run-oxlint.mjs \
    extensions/tavily/src/tavily-search-provider.ts \
    extensions/tavily/src/tavily-client.ts \
    extensions/tavily/src/tavily-tools.test.ts \
    src/web-search/runtime.ts \
    src/web-search/runtime.test.ts
✓ clean
```

### Landing order

The `src/web-search/runtime.ts` abort guard is included here so this PR typechecks and tests standalone. #104216 (SearXNG, same author) and #104899 (DuckDuckGo, same author) also add the same guard. Whichever lands first, the others will rebase; no cross-repo dependency.
