### PR TITLE
test: move provider auth parity coverage out of core source

### DIFF
--- a/test/bundled-provider-auth-literal-parity.test.ts
+++ b/test/bundled-provider-auth-literal-parity.test.ts
@@ -3,15 +3,15 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { createNonExitingRuntime } from "../runtime.js";
-import { createCapturedPluginRegistration } from "../test-utils/plugin-registration.js";
-import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
-import type { PluginManifestProviderAuthChoice } from "./manifest.js";
+import { listBundledPluginMetadata } from "../src/plugins/bundled-plugin-metadata.js";
+import type { PluginManifestProviderAuthChoice } from "../src/plugins/manifest.js";
 import type {
   ProviderAuthMethod,
   ProviderPlugin,
   ProviderResolveNonInteractiveApiKeyParams,
-} from "./types.js";
+} from "../src/plugins/types.js";
+import { createNonExitingRuntime } from "../src/runtime.js";
+import { createCapturedPluginRegistration } from "../src/test-utils/plugin-registration.js";
 
 const PARITY_TIMEOUT_MS = 120_000;
 const SENTINEL_API_KEY = "parity-sentinel-api-key";
@@ -74,7 +74,7 @@ async function loadPluginRegister(
   // plugin dists pulls large module graphs into the shared worker cache and
   // breaks co-resident vi.mock-based unit tests (observed with memory-host-sdk).
   const { loadBundledPluginPublicSurface, resolveBundledPluginPublicModulePath } =
-    await import("../test-utils/bundled-plugin-public-surface.js");
+    await import("../src/test-utils/bundled-plugin-public-surface.js");
   // Resolve first so unknown plugin ids fail with a clear path error before import.
   resolveBundledPluginPublicModulePath({
     pluginId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where current-main `build-artifacts` fails the core extension boundary because the bundled provider-auth parity integration test was placed under `src/` while intentionally loading bundled plugin public surfaces.

## Why This Change Was Made

The test moves to the root integration-test owner and updates only its relative core imports. The core boundary remains strict; no allowlist or production behavior changes are added.

## User Impact

Maintainers regain a green core-support boundary while preserving the full 72-case provider-auth parity coverage. No shipped runtime or release behavior changes.

## Evidence

- `node scripts/run-vitest.mjs test/extension-test-boundary.test.ts test/bundled-provider-auth-literal-parity.test.ts` — 11 boundary tests and 72 parity tests passed.
- Targeted oxfmt and `git diff --check` — clean.
- Reproduced on PR #104964 exact-head CI run 29179984173: `build-artifacts` reported only `src/plugins/bundled-provider-auth-literal-parity.test.ts` as the boundary offender.
