### PR TITLE
fix(release): restore pnpm package artifacts

### DIFF
--- a/scripts/package-openclaw-for-docker.mjs
+++ b/scripts/package-openclaw-for-docker.mjs
@@ -135,6 +135,7 @@ export function parseArgs(argv) {
     outputDir: "",
     outputName: "",
     packJson: "",
+    pnpmPack: false,
     skipBuild: false,
     sourceDir: ROOT_DIR,
   };
@@ -177,6 +178,8 @@ export function parseArgs(argv) {
         "packJson",
         readEqualsOptionValue(arg.slice("--pack-json=".length), "--pack-json"),
       );
+    } else if (arg === "--pnpm-pack") {
+      setOnce(arg, "pnpmPack", true);
     } else if (arg === "--skip-build") {
       setOnce(arg, "skipBuild", true);
     } else if (arg === "--source-dir") {
@@ -194,6 +197,9 @@ export function parseArgs(argv) {
   }
   if (options.outputName) {
     validateOutputName(options.outputName);
+  }
+  if (options.packJson && options.pnpmPack) {
+    throw new Error("--pack-json cannot be combined with --pnpm-pack");
   }
   return options;
 }
@@ -646,6 +652,10 @@ export async function packOpenClawPackageForDocker(sourceDir, outputDir, options
       }));
   const restoreChangelog = options.restoreChangelog ?? restorePackageChangelog;
   const prepareBundledAiRuntime = options.prepareBundledAiRuntime ?? prepareBundledAiRuntimePackage;
+  const packTool = options.pnpmPack ? "pnpm" : "npm";
+  if (options.packJsonPath && options.pnpmPack) {
+    throw new Error("packJsonPath cannot be combined with pnpmPack");
+  }
   console.error("==> Packing OpenClaw package");
   await prepareChangelog(sourceDir);
   let packOutput;
@@ -653,26 +663,24 @@ export async function packOpenClawPackageForDocker(sourceDir, outputDir, options
   try {
     await cleanPackedOpenClawTarballs(outputDir);
     cleanupBundledAiRuntime = await prepareBundledAiRuntime(sourceDir, outputDir, runCaptureImpl);
-    const packArgs = [
-      "pack",
-      ...(options.packJsonPath ? ["--json"] : []),
-      "--silent",
-      "--ignore-scripts",
-      "--pack-destination",
-      outputDir,
-    ];
-    packOutput = await runCaptureImpl(
-      "npm",
-      packArgs,
-      sourceDir,
-      {
-        deferForwardedSignalExit: true,
-        timeoutMs: resolveTimeoutMs(
-          "OPENCLAW_DOCKER_PACKAGE_PACK_TIMEOUT_MS",
-          DEFAULT_PACKAGE_PACK_TIMEOUT_MS,
-        ),
-      },
-    );
+    const packArgs =
+      packTool === "pnpm"
+        ? ["pack", "--silent", "--config.ignore-scripts=true", "--pack-destination", outputDir]
+        : [
+            "pack",
+            ...(options.packJsonPath ? ["--json"] : []),
+            "--silent",
+            "--ignore-scripts",
+            "--pack-destination",
+            outputDir,
+          ];
+    packOutput = await runCaptureImpl(packTool, packArgs, sourceDir, {
+      deferForwardedSignalExit: true,
+      timeoutMs: resolveTimeoutMs(
+        "OPENCLAW_DOCKER_PACKAGE_PACK_TIMEOUT_MS",
+        DEFAULT_PACKAGE_PACK_TIMEOUT_MS,
+      ),
+    });
   } finally {
     try {
       await cleanupBundledAiRuntime();
@@ -680,7 +688,9 @@ export async function packOpenClawPackageForDocker(sourceDir, outputDir, options
       await restoreChangelog(sourceDir);
     }
   }
-  let tarball = await newestOpenClawTarball(outputDir, packOutput);
+  // pnpm reports an absolute destination path. Scan the freshly emptied output directory
+  // instead of accepting that command output as an artifact path.
+  let tarball = await newestOpenClawTarball(outputDir, options.pnpmPack ? "" : packOutput);
   if (options.outputName) {
     const target = path.join(outputDir, options.outputName);
     if (target !== tarball) {
@@ -729,6 +739,7 @@ async function main() {
     allowUnreleasedChangelog: options.allowUnreleasedChangelog,
     outputName: options.outputName,
     packJsonPath: options.packJson,
+    pnpmPack: options.pnpmPack,
   });
 
   console.error("==> Checking OpenClaw package tarball");

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -98,6 +98,7 @@ describe("package-openclaw-for-docker", () => {
       outputDir: ".artifacts/docker",
       outputName: "openclaw-current.tgz",
       packJson: ".artifacts/docker/pack.json",
+      pnpmPack: false,
       skipBuild: true,
       sourceDir: "/repo",
     });
@@ -130,6 +131,19 @@ describe("package-openclaw-for-docker", () => {
     for (const [flag, args] of duplicateCases) {
       expect(() => parseArgs(args), flag).toThrow(`${flag} was provided more than once`);
     }
+  });
+
+  it("rejects pnpm pack with npm metadata output", async () => {
+    expect(parseArgs(["--pnpm-pack"]).pnpmPack).toBe(true);
+    expect(() => parseArgs(["--pnpm-pack", "--pack-json", "pack.json"])).toThrow(
+      "--pack-json cannot be combined with --pnpm-pack",
+    );
+    await expect(
+      packOpenClawPackageForDocker("/repo", "/out", {
+        packJsonPath: "pack.json",
+        pnpmPack: true,
+      }),
+    ).rejects.toThrow("packJsonPath cannot be combined with pnpmPack");
   });
 
   it("rejects package artifact output names that escape the output directory", () => {


### PR DESCRIPTION
## What Problem This Solves

The July release branch invokes `scripts/package-openclaw-for-docker.mjs --pnpm-pack` for Parallels package artifacts, but the helper implementation was omitted from the backport. Beta release checks therefore reject the flag and cannot produce the package artifact.

## Why This Change Was Made

Restore the already-proven main implementation on `release/2026.7.1`, while preserving the July-only unreleased-changelog option. The helper now parses the flag, invokes `pnpm pack`, discovers the tarball only inside the freshly emptied output directory, and rejects incompatible npm metadata output.

## User Impact

July and subsequent beta candidates can build the self-contained Parallels package artifact again. Existing npm-based package paths are unchanged.

## Evidence

- Blacksmith Testbox through Crabbox run 29180153340 (`tbx_01kxaa8b2439146164hqbychp4`): package helper 25/25 passed.
- Same Testbox lease: Parallels smoke model 80/80 and package helper 25/25 passed.
- Fresh autoreview: clean, no actionable findings.
- `git diff --check` passed.

Fixes the deterministic package failures in beta release-check run 29179313396.
