### PR TITLE
test(plugins): move auth parity suite out of core

### DIFF
--- a/test/bundled-provider-auth-literal-parity.test.ts
+++ b/test/bundled-provider-auth-literal-parity.test.ts
@@ -3,8 +3,6 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { createNonExitingRuntime } from "../src/runtime.js";
-import { createCapturedPluginRegistration } from "../src/test-utils/plugin-registration.js";
 import { listBundledPluginMetadata } from "../src/plugins/bundled-plugin-metadata.js";
 import type { PluginManifestProviderAuthChoice } from "../src/plugins/manifest.js";
 import type {
@@ -12,9 +10,11 @@ import type {
   ProviderPlugin,
   ProviderResolveNonInteractiveApiKeyParams,
 } from "../src/plugins/types.js";
+import { createNonExitingRuntime } from "../src/runtime.js";
+import { createCapturedPluginRegistration } from "../src/test-utils/plugin-registration.js";
 
 const PARITY_TIMEOUT_MS = 120_000;
-const SENTINEL_API_KEY = "parity-sentinel-api-key";
+const SENTINEL_API_KEY = "parity-value";
 
 type ApiKeyStyleChoice = PluginManifestProviderAuthChoice & {
   optionKey: string;

--- a/test/bundled-provider-auth-literal-parity.test.ts
+++ b/test/bundled-provider-auth-literal-parity.test.ts
@@ -3,15 +3,15 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { createNonExitingRuntime } from "../runtime.js";
-import { createCapturedPluginRegistration } from "../test-utils/plugin-registration.js";
-import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
-import type { PluginManifestProviderAuthChoice } from "./manifest.js";
+import { createNonExitingRuntime } from "../src/runtime.js";
+import { createCapturedPluginRegistration } from "../src/test-utils/plugin-registration.js";
+import { listBundledPluginMetadata } from "../src/plugins/bundled-plugin-metadata.js";
+import type { PluginManifestProviderAuthChoice } from "../src/plugins/manifest.js";
 import type {
   ProviderAuthMethod,
   ProviderPlugin,
   ProviderResolveNonInteractiveApiKeyParams,
-} from "./types.js";
+} from "../src/plugins/types.js";
 
 const PARITY_TIMEOUT_MS = 120_000;
 const SENTINEL_API_KEY = "parity-sentinel-api-key";
@@ -70,11 +70,10 @@ function listParityCases(): ParityCase[] {
 async function loadPluginRegister(
   pluginId: string,
 ): Promise<(api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void> {
-  // Dynamic import keeps this file out of the unit-fast lane: loading built
-  // plugin dists pulls large module graphs into the shared worker cache and
-  // breaks co-resident vi.mock-based unit tests (observed with memory-host-sdk).
+  // Keep built plugin dists out of the shared worker until this suite runs;
+  // eager loading breaks co-resident vi.mock-based tests (observed with memory-host-sdk).
   const { loadBundledPluginPublicSurface, resolveBundledPluginPublicModulePath } =
-    await import("../test-utils/bundled-plugin-public-surface.js");
+    await import("../src/test-utils/bundled-plugin-public-surface.js");
   // Resolve first so unknown plugin ids fail with a clear path error before import.
   resolveBundledPluginPublicModulePath({
     pluginId,

--- a/test/bundled-provider-auth-literal-parity.test.ts
+++ b/test/bundled-provider-auth-literal-parity.test.ts
@@ -14,7 +14,7 @@ import { createNonExitingRuntime } from "../src/runtime.js";
 import { createCapturedPluginRegistration } from "../src/test-utils/plugin-registration.js";
 
 const PARITY_TIMEOUT_MS = 120_000;
-const SENTINEL_API_KEY = "parity-value";
+const SENTINEL_API_KEY = "placeholder";
 
 type ApiKeyStyleChoice = PluginManifestProviderAuthChoice & {
   optionKey: string;


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the `core-support-boundary` artifact check because the cross-plugin bundled provider auth parity suite lives under `src/plugins` while dynamically loading the bundled plugin public-surface test helper.

Baseline proof: CI run `29179975212`, `build-artifacts` job `86616116007`.

## Why This Change Was Made

Move the cross-plugin integration suite to the root `test/` surface and update only its relative imports. This preserves the manifest-to-runtime auth literal coverage without weakening the source ownership boundary.

The dummy credential value is also changed to the repository's recognized `placeholder` sentinel so review tooling does not treat test data as a live secret.

## User Impact

None. This repairs `main` CI and keeps the provider auth parity regression coverage intact.

## Evidence

- `git diff --check`
- static extension boundary inventory: clean
- exact hosted CI requested by this PR
- local Testbox proof was not accepted because the reused box had a stale delegated workspace and lockfile mismatch; hosted exact-head CI is authoritative here
