### PR TITLE
chore(i18n): refresh native locale artifacts

### DIFF
--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -24,6 +24,71 @@
       "translated": "افتراضي"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "تمت الموافقة والحفظ."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "تمت الموافقة مرة واحدة."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "سمح رد سابق بهذا الأمر بالفعل وحفظ الاختيار."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "سمح رد سابق بهذا الأمر مرة واحدة بالفعل."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "سجّل Gateway الموافقة وحفظ الاختيار."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "سجّل Gateway الموافقة مرة واحدة."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "تم رفض الموافقة."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "رفض رد سابق هذه الموافقة بالفعل."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "سجّل Gateway رفضًا."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "انتهت صلاحية هذه الموافقة قبل أن يتم حلها."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "تم إلغاء هذه الموافقة قبل أن يتم حلها."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "حلّ رد سابق هذه الموافقة بالفعل."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "طلب أمر"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "جاهز"
@@ -94,6 +159,11 @@
       "translated": "قم بتكوين ${issue.providerLabel} على Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "عدد كبير جدًا من المشاركات في انتظار الإضافة."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · الميكروفون: قيد الانتظار"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "نتيجة الحل غير معروفة. تبقى الإجراءات معطلة حتى يتم التحقق من سجل Gateway."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "لا يزال Gateway يعرض هذه الموافقة كمعلّقة. راجعها قبل المحاولة مرة أخرى."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "تعذّر تحميل تفاصيل الموافقة. حدّث وحاول مرة أخرى."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "تعذّر تحميل الموافقات."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "تعذّر حل الموافقة. حدّث وحاول مرة أخرى."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount مزوّدين جاهزين"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "توفر المزوّد غير معروف"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "راجع جاهزية الموفرين\nوالنماذج المكوّنة."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "الموفرون المتصلون"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "الموفرون والنماذج المُهيأة"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway غير متصل"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "يتطلب الانتباه"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "جاهز"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "النماذج"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "يحتاج إلى"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "غير معروف"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount نماذج مُهيأة. حدّث لإعادة فحص التوفر."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "وصّل Gateway لعرض جاهزية الموفرين."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "حدّث لإعادة التحقق من جاهزية الموفرين من Gateway الخاص بك."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "جارٍ التحديث"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} من النماذج"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} نماذج مُهيأة"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "الجلسات"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "عكس ترتيب فرز الجلسات"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "البحث في الجلسات"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "الأحدث"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "الأحدث أولاً"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "الأقدم"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "الأقدم أولاً"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "فتح الإعدادات"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "مشاركة معلومات التطبيقات المثبَّتة؟"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "يجمع OpenClaw ويرسل أسماء التطبيقات ومعرّفات الحزم وحالتها الظاهرة على هذا الهاتف عندما يطلبها Gateway المقترن بـ OpenClaw. يتيح ذلك لمساعدك الإجابة عن الأسئلة واتخاذ الإجراءات باستخدام التطبيقات المثبَّتة."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "يرسل هاتفك هذه المعلومات إلى Gateway الخاص بك، وليس إلى خادم تديره OpenClaw. قد يُضمّنها Gateway في الطلبات المُرسَلة إلى موفر الذكاء الاصطناعي الذي اخترته."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "الموافقة والتمكين"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "ليس الآن"
@@ -2599,39 +2709,24 @@
       "translated": "رجوع"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "الموافقة على الأمر"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "جارٍ الإرسال"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "السماح مرة واحدة"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "الموافقة ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "جارٍ السماح"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "دائمًا"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "جارٍ الحفظ"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "رفض"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "جارٍ الرفض"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "تجاهل إشعار الموافقة"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "البحث في الإعدادات"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount جاهز"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "مراجعة الجاهزية"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "لا يوجد تطبيق يمكنه مشاركة هذه الرسالة"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "الانتقال إلى الأحدث"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "جارٍ تحميل الجلسة"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "لا توجد رسائل بعد"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "جارٍ تحضير الصوت…"
@@ -3649,6 +3719,11 @@
       "translated": "أنت"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "إعادة المحاولة"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "فتح معاينة الصورة"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "إغلاق معاينة الصورة"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw يجهّز ردًا."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "تجاهل تحذير الصورة المشتركة"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "إيقاف"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway غير متصل"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "إغلاق محدد مستوى التفكير"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "فتح محدد مستوى التفكير"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "ستظهر طلبات Gateway هنا."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 في الانتظار"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) في الانتظار"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "مرتفع"
@@ -6544,14 +6654,9 @@
       "translated": "لا توجد إجراءات Gateway بانتظار المراجعة."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "راجع إجراء Gateway المعلّق."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 بانتظار"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "مراجعة إجراءات Gateway المعلّقة."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "فتح الإشعارات"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "السماح"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "الموافقات المعلّقة"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "مراجعة موافقة التنفيذ"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "قيد المراجعة"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "السماح مرة واحدة"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "السماح دائمًا"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "رفض"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "تجاهل"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "السماح دائمًا"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "تجاهل"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "رفض"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "غير متصل"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "الموافقة"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "تمت هذه الموافقة بالفعل"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "تم ضبط الموافقة على السماح دائمًا."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "تم ضبط هذه الموافقة بالفعل على السماح دائمًا."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "الموافقة مطلوبة"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "يفتح الأمر الكامل قبل توفّر القرارات"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "جارٍ التحميل"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "جارٍ تحميل الموافقة"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "غير متاح"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "لم يتم تحميل الموافقة"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "المراجعة مرة أخرى"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "الأمر"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "الأمر المراد مراجعته"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "أنت"
@@ -9314,24 +9499,24 @@
       "translated": "الموافقة"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "جارٍ إرسال القرار..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "مراجعة الأمر"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "موافقة"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "تنفيذ الأمر"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "السماح مرة واحدة"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "رفض"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw على GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "تعذّر تثبيت OpenClaw في التطبيقات. انقله إلى هناك يدويًا، ثم افتح تلك النسخة."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "تثبيت OpenClaw في التطبيقات؟"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "استبدال النسخة الأقدم من OpenClaw في التطبيقات؟"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "سيقوم OpenClaw بنسخ نفسه إلى التطبيقات وإعادة الفتح هناك للحفاظ على موثوقية التحديثات والتشغيل عند تسجيل الدخول."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "هذه النسخة أحدث من التطبيق المثبَّت. سيستبدلها OpenClaw ويعيد الفتح من التطبيقات."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "تثبيت وإعادة التشغيل"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "استبدال وإعادة التشغيل"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "تم تثبيت OpenClaw في التطبيقات، لكن تعذّرت إعادة فتحه تلقائيًا. افتحه هناك يدويًا."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "استخدم عمليات تسجيل الدخول في متصفحك"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "انسخ ملفات تعريف الارتباط من \\(browsers) إلى ملف تعريف عميل معزول. لا يتم المساس بكلمات المرور أبدًا."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "جارٍ استيراد ملفات تعريف الارتباط من المتصفح…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "جارٍ نسخ \\(profile.displayName) إلى “\\(target)”. قد يلزم استخدام Touch ID."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "تم استيراد عمليات تسجيل الدخول من المتصفح"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "تم نسخ \\(result.cookies.imported) من \\(result.cookies.total) من ملفات تعريف الارتباط إلى “\\(result.into)” — وهو الآن ملف التعريف الافتراضي لتصفح العميل."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "فشل استيراد المتصفح"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "متصفحك"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "استيراد"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "إعادة المحاولة"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "تجاهل"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "يتطلب استيراد المتصفح وضع Local"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "بدّل تطبيق Mac هذا إلى Gateway محلي قبل استيراد ملفات تعريف الارتباط الخاصة بالمتصفح."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "لم يتم العثور على أي ملف تعريف لـ Chrome أو Brave أو Edge أو Chromium يحتوي على ملفات تعريف ارتباط على هذا الـ Mac."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "استيراد ملف تعريف متصفح النظام معطّل في إعدادات Gateway المحلي."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "لا يوجد تسجيل دخول متاح عبر المتصفح"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "استيراد المتصفح غير متاح"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "فشل تثبيت CLI"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "انتهى تثبيت CLI"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "مستقر"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "تجريبي"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "لا يوجد تسليم"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "إعادة اتصال لوحة التحكم"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "تغيّر Gateway المحدد."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "في انتظار اتصال مصادق جديد."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "لوحة التحكم غير متاحة"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "تحقق من الإعدادات ← الاتصال أو استخدم تصحيح الأخطاء ← إعادة تعيين النفق البعيد، ثم حاول مرة أخرى."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "إنهاء \\(listener.command) (\\(listener.pid))؟"
@@ -10704,6 +11069,16 @@
       "translated": "أنماط المسارات فقط. ضمّن '/' أو '~' أو '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "إدخال قائمة السماح هذا موروث. عدّل النطاق الذي يملكه ثم أعد المحاولة."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "تعذّر حفظ موافقات التنفيذ. تُعرض آخر الإعدادات المعروفة؛ أعد محاولة التغيير."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "ابدأ OpenClaw تلقائيًا بعد تسجيل دخولك."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "انقل OpenClaw إلى Applications قبل تمكين التشغيل عند تسجيل الدخول."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "إظهار أيقونة Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "السماح للأدوات الموقّعة (مثل `peekaboo`) بتشغيل أتمتة واجهة المستخدم عبر PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "المتصفح"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "تسجيل الدخول عبر المتصفح"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "انسخ ملفات تعريف الارتباط من ملف تعريف عائلة Chrome إلى ملف تعريف مُدار معزول."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "استيراد…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "الإعدادات..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "رجوع"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "تقديم"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "موافقات التنفيذ"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "جارٍ تحميل موافقات التنفيذ…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "إعادة محاولة موافقات التنفيذ"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "الاستخدام"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "يتطلّب approvalSource وجود systemRunPlan مطابق"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "تتطلّب الموافقة الصريحة وجود systemRunPlan مطابق"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "تمت الموافقة على إقران العقدة"
@@ -11729,137 +12159,272 @@
       "translated": "التالي"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
-      "source": "Looking for AI you already use…",
-      "translated": "جارٍ البحث عن AI تستخدمه بالفعل…"
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "فشل طلب إعداد Gateway."
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "فشل طلب إعداد Gateway. اعرض التفاصيل لفحص الخطأ أو نسخه."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "تعذّر على \\(label) إكمال الاختبار."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "تعذّر على \\(label) إكمال الاختبار. اعرض التفاصيل لفحص الخطأ أو نسخه."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "جارٍ البحث عن أدوات ذكاء اصطناعي تستخدمها بالفعل…"
+    },
+    {
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "في انتظار انتهاء اختبار الذكاء الاصطناعي السابق…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "translated": "جارٍ التحقق من Claude Code وCodex وGemini ومفاتيح API المحفوظة."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
-      "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "تعذّر التحقق من حسابات AI على هذا Mac"
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "سيتحقق OpenClaw مرة أخرى قبل تغيير أي من إعدادات الاستدلال."
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "تعذّر التحقق من وجود حسابات ذكاء اصطناعي على هذا الـ Gateway"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
+      "source": "Couldn’t check this Mac for AI accounts",
+      "translated": "تعذّر التحقق من وجود حسابات ذكاء اصطناعي على هذا الـ Mac"
+    },
+    {
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "تعذّر تحميل قائمة المزوّدين الكاملة"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "حاول مرة أخرى"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
-      "translated": "لم ينجح أي من الخيارات التي تم العثور عليها"
+      "translated": "لم ينجح أي من الخيارات المكتشفة"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "التفاصيل مدرجة في كل خيار أعلاه. يمكنك إصلاح تسجيل الدخول وإعادة المحاولة، أو الاتصال باستخدام مفتاح API أو رمز مميّز أدناه."
+      "translated": "التفاصيل مدرجة على كل خيار أعلاه. يمكنك إصلاح تسجيل الدخول وإعادة المحاولة، أو الاتصال باستخدام مفتاح API أو رمز مميز أدناه."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
-      "translated": "هل تحتاج إلى مساعدة؟ دردش مع Crestodian"
+      "translated": "بحاجة إلى مساعدة؟ تحدّث مع Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
-      "translated": "AI الخاص بك جاهز"
+      "translated": "الذكاء الاصطناعي الخاص بك جاهز"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "تفاصيل الإعداد"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "نسخ تفاصيل الإعداد"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "لم يتم العثور على حسابات AI على هذا Mac"
+      "translated": "لم يُعثر على حسابات ذكاء اصطناعي على هذا الـ Mac"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "لا بأس — يمكنك الاتصال بأحدها باستخدام مفتاح API أو رمز مميّز. إذا كنت تستخدم Claude Code أو Codex أو Gemini CLI على هذا الـMac، فسجّل الدخول هناك أولاً ثم اضغط على \"تحقق مرة أخرى\"."
+      "translated": "لا بأس — يمكنك الاتصال بواحد باستخدام مفتاح API أو رمز مميز. إذا كنت تستخدم Claude Code أو Codex أو Gemini CLI على هذا الـ Mac، فسجّل الدخول هناك أولاً ثم اضغط \"تحقق مرة أخرى\"."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "موصى به"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "لا يتوفّر أي مزوّد يعتمد على المفاتيح"
+      "translated": "لا يتوفر أي مزوّدين قائمين على المفاتيح"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "فعّل أو ثبّت مكوّن مزوّد استنتاج نصي على هذا الـGateway، ثم تحقق مرة أخرى."
+      "translated": "قم بتمكين أو تثبيت مكوّن إضافي لمزوّد استدلال نصي على هذا الـ Gateway، ثم تحقق مرة أخرى."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "تحقق مرة أخرى"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "الاتصال باستخدام مفتاح API أو رمز مميّز بدلاً من ذلك…"
+      "translated": "الاتصال باستخدام مفتاح API أو رمز مميز بدلاً من ذلك…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "تسجيل الدخول باستخدام مزوّد"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "استخدم اشتراكًا أو حساب مزوّد موجودًا. يفتح OpenClaw مسار تسجيل الدخول الخاص بالمزوّد، ثم يتحقق منه بردّ حقيقي."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "المزيد من خيارات تسجيل الدخول"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "إقران"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "تسجيل الدخول"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "تبقى بيانات الاعتماد على هذا الـ Gateway ولا يتم حفظها إلا بعد نجاح الاختبار المباشر."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "فتح صفحة تسجيل الدخول…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "جارٍ بدء تسجيل الدخول الآمن…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "لم يكتمل تسجيل الدخول"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "إلغاء"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "أكمل في متصفحك"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "نسخ"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "تنتهي الصلاحية خلال \\(minutes) دقيقة"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "فتح صفحة تسجيل الدخول"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "خيار"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "تأكيد"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "لقد سجّلت الدخول"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "متابعة"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "إرسال"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
-      "translated": "الاتصال باستخدام مفتاح API أو رمز مميّز"
+      "translated": "الاتصال باستخدام مفتاح API أو رمز"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
-      "translated": "المزوّد"
+      "translated": "المزود"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
-      "translated": "مفتاح API أو رمز مميّز"
+      "translated": "مفتاح API أو رمز"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "اتصال"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
-      "translated": "لم يعمل ذلك المفتاح"
+      "translated": "لم يعمل هذا المفتاح"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — مساعد الإعداد"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "تم"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "فتح المساعدة…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "إخفاء التفاصيل"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
-      "translated": "إظهار التفاصيل"
+      "translated": "عرض التفاصيل"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "نسخ الخطأ"
     },
@@ -12209,71 +12774,6 @@
       "translated": "حاول مرة أخرى"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "مساحة عمل الوكيل"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "يشغّل OpenClaw الوكيل من مساحة عمل مخصصة حتى يتمكن من تحميل `AGENTS.md` وكتابة الملفات هناك دون خلطها مع مشاريعك الأخرى."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "تم اكتشاف Gateway بعيد"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "أنشئ مساحة العمل على المضيف البعيد (سجّل الدخول عبر SSH أولًا). لا يمكن لتطبيق macOS كتابة الملفات على Gateway الخاص بك عبر SSH حتى الآن."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "تم النسخ"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "نسخ أمر الإعداد"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "مجلد مساحة العمل"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "إنشاء مساحة عمل"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "فتح مجلد"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "حفظ في الإعدادات"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "نصيحة: عدّل AGENTS.md في هذا المجلد لتشكيل سلوك المساعد. للنسخ الاحتياطي، اجعل مساحة العمل مستودع git خاصًا بحيث تكون «ذاكرة» وكيلك ذات إصدارات."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "تعرّف إلى وكيلك"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "يعرّف وكيلك عن نفسه، ويختار اسمًا معك، ويساعدك على توصيل WhatsApp أو Telegram أو قناة أخرى — فقط ابدأ الدردشة."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "أنت جاهز تمامًا!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "ليس الآن"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "رفض الكل"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "الموافقة على الكل"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "تحكّم في كيفية الموافقة على أوامر صدفة الوكيل على هذا الـ Mac."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "جارٍ تحميل الإعدادات…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "قراءة السياسة المحفوظة."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "موافقات التنفيذ غير متاحة"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "تعذّر قراءة الإعدادات"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "إعادة المحاولة"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "تم اتصال الـ Gateway"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -3539,6 +3539,11 @@
       "translated": "تفعيل الميكروفون"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "تحديث"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "الملفات غير متاحة"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "خطأ في الدردشة"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "إيقاف"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -3539,6 +3539,11 @@
       "translated": "Mikrofon aktivieren"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Aktualisieren"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Dateien nicht verfügbar"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Chatfehler"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Aus"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -24,6 +24,71 @@
       "translated": "Standard"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Genehmigung erteilt und gespeichert."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Genehmigung einmalig erteilt."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Eine frühere Antwort hat diesen Befehl bereits erlaubt und die Auswahl gespeichert."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Eine frühere Antwort hat diesen Befehl bereits einmalig erlaubt."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway hat die Genehmigung erfasst und die Auswahl gespeichert."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway hat die Genehmigung einmalig erfasst."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Genehmigung verweigert."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Eine frühere Antwort hat diese Genehmigung bereits verweigert."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway hat eine Ablehnung erfasst."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Diese Genehmigung ist abgelaufen, bevor sie bearbeitet werden konnte."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Diese Genehmigung wurde abgebrochen, bevor sie bearbeitet werden konnte."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Eine frühere Antwort hat diese Genehmigung bereits bearbeitet."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Befehlsanfrage"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Bereit"
@@ -94,6 +159,11 @@
       "translated": "Konfigurieren Sie ${issue.providerLabel} auf dem Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Zu viele Freigaben warten darauf, hinzugefügt zu werden."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Mikrofon: Ausstehend"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Ergebnis der Bearbeitung unbekannt. Aktionen bleiben deaktiviert, bis der Gateway-Eintrag überprüft ist."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Das Gateway zeigt diese Genehmigung weiterhin als ausstehend an. Überprüfen Sie sie, bevor Sie es erneut versuchen."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Genehmigungsdetails konnten nicht geladen werden. Aktualisieren Sie und versuchen Sie es erneut."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Genehmigungen konnten nicht geladen werden."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Genehmigung konnte nicht bearbeitet werden. Aktualisieren Sie und versuchen Sie es erneut."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount Anbieter bereit"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Anbieterverfügbarkeit unbekannt"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Anbieterbereitschaft\nund konfigurierte Modelle prüfen."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Verbundene Anbieter"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Anbieter und konfigurierte Modelle"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway offline"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Aufmerksamkeit erforderlich"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Bereit"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Modelle"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Erforderlich"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Unbekannt"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount konfigurierte Modelle. Aktualisieren, um die Verfügbarkeit erneut zu prüfen."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Verbinden Sie Ihre Gateway, um die Anbieterbereitschaft anzuzeigen."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Aktualisieren, um die Anbieterbereitschaft von Ihrer Gateway erneut zu prüfen."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Wird aktualisiert"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} Modelle"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} konfigurierte Modelle"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sitzungen"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Sortierung der Sitzungen umkehren"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Sitzungen suchen"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Neueste"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Neueste zuerst"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Älteste"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Älteste zuerst"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Einstellungen öffnen"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Informationen zu installierten Apps teilen?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw erfasst und sendet die Namen, Paket-IDs und den Status der auf diesem Telefon sichtbaren Apps, wenn dein gekoppeltes OpenClaw Gateway danach fragt. So kann dein Assistent Fragen beantworten und Aktionen mit installierten Apps ausführen."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Dein Telefon sendet diese Informationen an dein Gateway, nicht an einen von OpenClaw betriebenen Server. Dein Gateway kann sie in Anfragen an den von dir gewählten KI-Anbieter einbeziehen."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Zustimmen und aktivieren"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Nicht jetzt"
@@ -2599,39 +2709,24 @@
       "translated": "Zurück"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Befehlsgenehmigung"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Wird gesendet"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Einmal erlauben"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Genehmigung ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Wird erlaubt"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Immer"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Wird gespeichert"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Ablehnen"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Wird abgelehnt"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Genehmigungshinweis schließen"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Einstellungen suchen"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount bereit"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Bereitschaft prüfen"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Keine App kann diese Nachricht teilen"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Zum neuesten springen"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Sitzung wird geladen"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Noch keine Nachrichten"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Audio wird vorbereitet…"
@@ -3649,6 +3719,11 @@
       "translated": "Du"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Erneut versuchen"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Bildvorschau öffnen"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Bildvorschau schließen"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw bereitet eine Antwort vor."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Warnung zu geteiltem Bild schließen"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Stopp"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway offline"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Auswahl der Denkstufe schließen"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Auswahl der Denkstufe öffnen"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Gateway-Anfragen werden hier angezeigt."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 wartet"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) warten"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Hoch"
@@ -6544,14 +6654,9 @@
       "translated": "Keine Gateway-Aktionen warten auf Überprüfung."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Überprüfen Sie die ausstehende Gateway-Aktion."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 ausstehend"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Ausstehende Gateway-Aktionen prüfen."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Benachrichtigungen öffnen"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Zulassen"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Ausstehende Genehmigungen"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
-      "translated": "Immer erlauben"
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Exec-Genehmigung prüfen"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Wird geprüft"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Einmal zulassen"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
+      "translated": "Immer zulassen"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Ablehnen"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Verwerfen"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Immer erlauben"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Verwerfen"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Ablehnen"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Offline"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Genehmigung"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Diese Genehmigung wurde bereits"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Genehmigung auf „Immer zulassen“ gesetzt."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Diese Genehmigung wurde bereits auf „Immer zulassen“ gesetzt."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Genehmigung erforderlich"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Öffnet den vollständigen Befehl, bevor Entscheidungen verfügbar sind"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Wird geladen"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Genehmigung wird geladen"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Nicht verfügbar"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Genehmigung nicht geladen"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Erneut prüfen"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Befehl"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Zu prüfender Befehl"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Du"
@@ -9314,24 +9499,24 @@
       "translated": "Genehmigung"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Entscheidung wird gesendet..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Befehl überprüfen"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Genehmigen"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Befehlsausführung"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Einmal zulassen"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Ablehnen"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw auf GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw konnte nicht im Ordner „Programme“ installiert werden. Verschiebe es manuell dorthin und öffne dann diese Kopie."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw im Ordner „Programme“ installieren?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Das ältere OpenClaw im Ordner „Programme“ ersetzen?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw kopiert sich selbst in den Ordner „Programme“ und öffnet sich dort erneut, damit Updates und der Start beim Anmelden zuverlässig funktionieren."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Diese Kopie ist neuer als die installierte App. OpenClaw ersetzt sie und öffnet sich erneut aus dem Ordner „Programme“."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Installieren und neu starten"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Ersetzen und neu starten"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw ist im Ordner „Programme“ installiert, konnte aber nicht automatisch erneut geöffnet werden. Öffne es dort manuell."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Deine Browser-Logins verwenden"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Cookies aus \\(browsers) in ein isoliertes Agentenprofil kopieren. Passwörter werden nie berührt."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Browser-Cookies werden importiert…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "\\(profile.displayName) wird nach „\\(target)“ kopiert. Touch ID kann erforderlich sein."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Browser-Logins importiert"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) von \\(result.cookies.total) Cookies nach „\\(result.into)“ kopiert – jetzt das Standardprofil für das Agenten-Browsing."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Browser-Import fehlgeschlagen"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "dein Browser"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Importieren"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Wiederholen"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Schließen"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "Browser-Import erfordert den lokalen Modus"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Wechseln Sie diese Mac-App zu einem lokalen Gateway, bevor Sie Browser-Cookies importieren."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "Auf diesem Mac wurde kein Chrome-, Brave-, Edge- oder Chromium-Profil mit Cookies gefunden."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "Der Import von Systembrowser-Profilen ist in der lokalen Gateway-Konfiguration deaktiviert."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Keine Browser-Anmeldung verfügbar"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Browser-Import nicht verfügbar"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "CLI-Installation fehlgeschlagen"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "CLI-Installation abgeschlossen"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Stabil"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "keine Zustellung"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Dashboard wird neu verbunden"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Das ausgewählte Gateway wurde geändert."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Warten auf eine neue authentifizierte Verbindung."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Dashboard nicht verfügbar"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Prüfen Sie Einstellungen → Verbindung oder verwenden Sie Debug → Remote-Tunnel zurücksetzen und versuchen Sie es erneut."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) beenden?"
@@ -10704,6 +11069,16 @@
       "translated": "Nur Pfadmuster. „/“, „~“ oder „\\\\“ einschließen."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Dieser Zulassungslisteneintrag wird geerbt. Bearbeiten Sie den zugehörigen Geltungsbereich und versuchen Sie es erneut."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Exec-Genehmigungen konnten nicht gespeichert werden. Die zuletzt bekannten Einstellungen werden angezeigt; wiederholen Sie die Änderung."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "OpenClaw nach der Anmeldung automatisch starten."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Verschieben Sie OpenClaw nach „Programme“, bevor Sie den Start bei der Anmeldung aktivieren."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Dock-Symbol anzeigen"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Signierten Tools (z. B. `peekaboo`) erlauben, die UI-Automatisierung über PeekabooBridge zu steuern."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Browser"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Browser-Anmeldung"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Kopieren Sie Cookies aus einem Chrome-Familienprofil in ein isoliertes verwaltetes Profil."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Importieren…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Einstellungen..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Zurück"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Vorwärts"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Ausführungsgenehmigungen"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Exec-Genehmigungen werden geladen…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Exec-Genehmigungen erneut versuchen"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Nutzung"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource erfordert einen passenden systemRunPlan"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "Eine explizite Genehmigung erfordert einen passenden systemRunPlan"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Node-Kopplung genehmigt"
@@ -11729,137 +12159,272 @@
       "translated": "Weiter"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Die Gateway-Einrichtungsanfrage ist fehlgeschlagen."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Die Gateway-Einrichtungsanfrage ist fehlgeschlagen. Zeigen Sie die Details an, um den Fehler zu prüfen oder zu kopieren."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) konnte den Test nicht abschließen."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) konnte den Test nicht abschließen. Zeigen Sie die Details an, um den Fehler zu prüfen oder zu kopieren."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
-      "translated": "Es wird nach KI gesucht, die Sie bereits verwenden …"
+      "translated": "Es wird nach bereits von Ihnen genutzter KI gesucht…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Warten auf den Abschluss des vorherigen KI-Tests…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Claude Code, Codex, Gemini und gespeicherte API-Schlüssel werden geprüft."
+      "translated": "Es wird nach Claude Code, Codex, Gemini und gespeicherten API-Schlüsseln gesucht."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw prüft erneut, bevor Inferenzeinstellungen geändert werden."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Dieses Gateway konnte nicht auf KI-Konten geprüft werden"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
       "translated": "Dieser Mac konnte nicht auf KI-Konten geprüft werden"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "Die vollständige Anbieterliste konnte nicht geladen werden"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "Erneut versuchen"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Keine der gefundenen Optionen hat funktioniert"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "Die Details sind bei jeder Option oben aufgeführt. Sie können die Anmeldung korrigieren und es erneut versuchen oder sich unten mit einem API-Schlüssel oder Token verbinden."
+      "translated": "Die Details sind bei jeder Option oben aufgeführt. Du kannst die Anmeldung korrigieren und es erneut versuchen oder dich unten mit einem API-Schlüssel oder Token verbinden."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
-      "translated": "Brauchen Sie Hilfe? Chatten Sie mit Crestodian"
+      "translated": "Brauchst du Hilfe? Chatte mit Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
-      "translated": "Ihre KI ist bereit"
+      "translated": "Deine KI ist bereit"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Einrichtungsdetails"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Einrichtungsdetails kopieren"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "Auf diesem Mac wurden keine KI-Konten gefunden"
+      "translated": "Keine KI-Konten auf diesem Mac gefunden"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Das ist in Ordnung – Sie können einen mit einem API-Schlüssel oder Token verbinden. Wenn Sie Claude Code, Codex oder die Gemini CLI auf diesem Mac verwenden, melden Sie sich dort zuerst an und klicken Sie auf „Erneut prüfen“."
+      "translated": "Das ist in Ordnung – du kannst eines mit einem API-Schlüssel oder Token verbinden. Wenn du Claude Code, Codex oder die Gemini CLI auf diesem Mac verwendest, melde dich dort zuerst an und tippe auf „Erneut prüfen“."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Empfohlen"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
       "translated": "Keine schlüsselbasierten Anbieter verfügbar"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "Aktivieren oder installieren Sie ein Text-Inferenz-Anbieter-Plugin auf diesem Gateway und prüfen Sie es dann erneut."
+      "translated": "Aktiviere oder installiere ein Plugin für einen Text-Inferenz-Anbieter auf diesem Gateway und prüfe dann erneut."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Erneut prüfen"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
       "translated": "Stattdessen mit einem API-Schlüssel oder Token verbinden…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
-      "source": "Connect with an API key or token",
-      "translated": "Mit einem API-Schlüssel oder Token verbinden"
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Mit einem Anbieter anmelden"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Verwende ein bestehendes Abonnement oder Anbieterkonto. OpenClaw öffnet den eigenen Anmeldevorgang des Anbieters und verifiziert ihn dann mit einer echten Antwort."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Weitere Anmeldeoptionen"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Koppeln"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Anmelden"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Die Anmeldedaten verbleiben auf diesem Gateway und werden erst gespeichert, wenn der Live-Test erfolgreich war."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Anmeldeseite öffnen…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Sichere Anmeldung wird gestartet…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "Anmeldung nicht abgeschlossen"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Abbrechen"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Im Browser abschließen"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Kopieren"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Läuft in \\(minutes) Minuten ab"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Anmeldeseite öffnen"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Option"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Bestätigen"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Ich habe mich angemeldet"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Weiter"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Absenden"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
+      "source": "Connect with an API key or token",
+      "translated": "Mit API-Schlüssel oder Token verbinden"
+    },
+    {
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Anbieter"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "API-Schlüssel oder Token"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Verbinden"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Dieser Schlüssel hat nicht funktioniert"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
-      "translated": "Crestodian — Einrichtungsassistent"
+      "translated": "Crestodian — Einrichtungshelfer"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Fertig"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Hilfe öffnen…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Details ausblenden"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Details anzeigen"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Fehler kopieren"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Erneut versuchen"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Agent-Arbeitsbereich"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw führt den Agenten aus einem dedizierten Arbeitsbereich aus, damit er `AGENTS.md` laden und dort Dateien schreiben kann, ohne sich mit Ihren anderen Projekten zu vermischen."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Remote-Gateway erkannt"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Erstellen Sie den Arbeitsbereich auf dem Remote-Host (zuerst per SSH anmelden). Die macOS-App kann noch keine Dateien per SSH auf Ihre Gateway schreiben."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Kopiert"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Einrichtungsbefehl kopieren"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Workspace-Ordner"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Workspace erstellen"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Ordner öffnen"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "In der Konfiguration speichern"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Tipp: Bearbeite AGENTS.md in diesem Ordner, um das Verhalten des Assistenten zu gestalten. Erstelle zur Sicherung ein privates git-Repository aus dem Workspace, damit der „Speicher“ deines Agenten versioniert ist."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Lerne deinen Agenten kennen"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Ihr Agent stellt sich vor, wählt gemeinsam mit Ihnen einen Namen aus und hilft Ihnen, WhatsApp, Telegram oder einen anderen Kanal zu verbinden — einfach chatten."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Alles bereit!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Nicht jetzt"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Alle ablehnen"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Alle genehmigen"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Steuern Sie, wie Agent-Shell-Befehle auf diesem Mac genehmigt werden."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Einstellungen werden geladen…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Persistierte Richtlinie wird gelesen."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Ausführungsgenehmigungen nicht verfügbar"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Einstellungen konnten nicht gelesen werden"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Wiederholen"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway verbunden"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -3539,6 +3539,11 @@
       "translated": "Activar micrófono"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Actualizar"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Archivos no disponibles"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Error de chat"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Desactivado"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -24,6 +24,71 @@
       "translated": "Predeterminado"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Aprobación permitida y guardada."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Aprobación permitida una vez."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Una respuesta anterior ya permitió este comando y guardó la elección."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Una respuesta anterior ya permitió este comando una vez."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway registró la aprobación y guardó la elección."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway registró la aprobación una vez."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Aprobación denegada."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Una respuesta anterior ya denegó esta aprobación."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway registró una denegación."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Esta aprobación caducó antes de poder resolverse."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Esta aprobación se canceló antes de poder resolverse."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Una respuesta anterior ya resolvió esta aprobación."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Solicitud de comando"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Listo"
@@ -94,6 +159,11 @@
       "translated": "Configura ${issue.providerLabel} en el Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Hay demasiados recursos compartidos esperando para agregarse."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Micrófono: pendiente"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Resultado de la resolución desconocido. Las acciones permanecen deshabilitadas hasta verificar el registro del Gateway."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "El Gateway aún muestra esta aprobación como pendiente. Revísala antes de volver a intentarlo."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "No se pudieron cargar los detalles de la aprobación. Actualiza e inténtalo de nuevo."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "No se pudieron cargar las aprobaciones."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "No se pudo resolver la aprobación. Actualiza e inténtalo de nuevo."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount proveedores listos"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Disponibilidad del proveedor desconocida"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Revisa la preparación de los proveedores\ny los modelos configurados."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Proveedores conectados"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Proveedores y modelos configurados"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway sin conexión"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Requiere atención"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Listo"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Modelos"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Necesita"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Desconocido"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount modelos configurados. Actualiza para volver a comprobar la disponibilidad."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Conecta tu Gateway para ver la preparación de los proveedores."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Actualiza para volver a comprobar la preparación de los proveedores desde tu Gateway."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Actualizando"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} modelos"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} modelos configurados"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sesiones"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Invertir orden de sesiones"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Buscar sesiones"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Más reciente"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Más recientes primero"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Más antigua"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Más antiguos primero"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Abrir ajustes"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "¿Compartir información de las aplicaciones instaladas?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw recopila y envía los nombres, los ID de paquete y el estado de las aplicaciones visibles en este teléfono cuando tu Gateway de OpenClaw vinculado lo solicita. Esto permite que tu asistente responda preguntas y realice acciones usando las aplicaciones instaladas."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Tu teléfono envía esta información a tu Gateway, no a un servidor gestionado por OpenClaw. Tu Gateway puede incluirla en las solicitudes al proveedor de IA que elijas."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Aceptar y habilitar"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Ahora no"
@@ -2599,39 +2709,24 @@
       "translated": "Atrás"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Aprobación de comandos"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Enviando"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Permitir una vez"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Aprobación ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Permitiendo"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Siempre"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Guardando"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Denegar"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Denegando"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Descartar aviso de aprobación"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Buscar en configuración"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount listos"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Revisar disponibilidad"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Ninguna app puede compartir este mensaje"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Ir a lo más reciente"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Cargando sesión"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Aún no hay mensajes"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Preparando audio…"
@@ -3649,6 +3719,11 @@
       "translated": "Tú"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Reintentar"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Abrir vista previa de la imagen"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Cerrar vista previa de la imagen"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw está preparando una respuesta."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Descartar advertencia de imagen compartida"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Detener"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway sin conexión"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Cerrar selector de nivel de pensamiento"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Abrir selector de nivel de pensamiento"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Las solicitudes de Gateway aparecerán aquí."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 en espera"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) en espera"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Alta"
@@ -6544,14 +6654,9 @@
       "translated": "No hay acciones de Gateway esperando revisión."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Revisa la acción pendiente de Gateway."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 en espera"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Revisa las acciones pendientes del Gateway."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Abrir Notificaciones"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Permitir"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Aprobaciones pendientes"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Revisar aprobación de ejecución"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Revisando"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Permitir una vez"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "Permitir siempre"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Denegar"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Descartar"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Permitir siempre"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Descartar"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Denegar"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Sin conexión"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Aprobación"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Esta aprobación ya fue"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Aprobación configurada como Permitir siempre."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Esta aprobación ya estaba configurada como Permitir siempre."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Aprobación necesaria"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Abre el comando completo antes de que haya decisiones disponibles"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Cargando"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Cargando aprobación"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "No disponible"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Aprobación no cargada"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Revisar de nuevo"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Comando"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Comando a revisar"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Tú"
@@ -9314,24 +9499,24 @@
       "translated": "Aprobación"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Enviando decisión..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Revisar comando"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Aprobar"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Ejecución de comandos"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Permitir una vez"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Denegar"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw en GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "No se pudo instalar OpenClaw en Aplicaciones. Muévelo allí manualmente y luego abre esa copia."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "¿Instalar OpenClaw en Aplicaciones?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "¿Reemplazar la versión anterior de OpenClaw en Aplicaciones?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw se copiará en Aplicaciones y se reabrirá allí para que las actualizaciones y el inicio de sesión sigan siendo fiables."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Esta copia es más reciente que la app instalada. OpenClaw la reemplazará y se reabrirá desde Aplicaciones."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Instalar y reiniciar"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Reemplazar y reiniciar"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw está instalado en Aplicaciones, pero no se pudo reabrir automáticamente. Ábrelo allí manualmente."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Usa los inicios de sesión de tu navegador"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Copia las cookies de \\(browsers) en un perfil de agente aislado. Las contraseñas nunca se tocan."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Importando cookies del navegador…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "Copiando \\(profile.displayName) en «\\(target)». Puede que se requiera Touch ID."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Inicios de sesión del navegador importados"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) de \\(result.cookies.total) cookies copiadas en «\\(result.into)»: ahora es el perfil predeterminado para la navegación del agente."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Error al importar del navegador"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "tu navegador"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Importar"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Reintentar"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Descartar"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "La importación del navegador requiere el modo local"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Cambia esta app de Mac a un Gateway local antes de importar las cookies del navegador."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "No se encontró ningún perfil de Chrome, Brave, Edge o Chromium con cookies en este Mac."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "La importación del perfil del navegador del sistema está deshabilitada en la configuración del Gateway local."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "No hay inicio de sesión del navegador disponible"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Importación del navegador no disponible"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "Error al instalar la CLI"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "Instalación de la CLI finalizada"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Estable"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "sin entrega"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Reconectando el panel"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "El Gateway seleccionado ha cambiado."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Esperando una nueva conexión autenticada."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Panel no disponible"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Comprueba Configuración → Conexión o usa Depurar → Restablecer túnel remoto, luego inténtalo de nuevo."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "¿Finalizar \\(listener.command) (\\(listener.pid))?"
@@ -10704,6 +11069,16 @@
       "translated": "Solo patrones de ruta. Incluye '/', '~' o '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Esta entrada de la lista de permitidos es heredada. Edita el ámbito propietario y reinténtalo."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "No se pudieron guardar las aprobaciones de exec. Se muestran los últimos ajustes conocidos; reintenta el cambio."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Iniciar OpenClaw automáticamente después de iniciar sesión."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Mueve OpenClaw a Aplicaciones antes de habilitar el inicio al iniciar sesión."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Mostrar icono en el Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Permitir que las herramientas firmadas (p. ej., `peekaboo`) controlen la automatización de la interfaz de usuario mediante PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Navegador"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Inicio de sesión del navegador"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Copia las cookies de un perfil de la familia Chrome en un perfil gestionado aislado."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Importar…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Configuración..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Atrás"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Adelante"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Aprobaciones de ejecución"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Cargando aprobaciones de exec…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Reintentar aprobaciones de exec"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Uso"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource requiere un systemRunPlan coincidente"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "la aprobación explícita requiere un systemRunPlan coincidente"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Emparejamiento de nodo aprobado"
@@ -11729,137 +12159,272 @@
       "translated": "Siguiente"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
-      "source": "Looking for AI you already use…",
-      "translated": "Buscando IA que ya uses…"
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "La solicitud de configuración del Gateway falló."
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "La solicitud de configuración del Gateway falló. Muestra los detalles para inspeccionar o copiar el error."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) no pudo completar la prueba."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) no pudo completar la prueba. Muestra los detalles para inspeccionar o copiar el error."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Buscando IA que ya usas…"
+    },
+    {
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Esperando a que finalice la prueba de IA anterior…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "translated": "Comprobando Claude Code, Codex, Gemini y claves de API guardadas."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
-      "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "No se pudo comprobar este Mac en busca de cuentas de IA"
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw volverá a comprobar antes de cambiar cualquier ajuste de inferencia."
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "No se pudo comprobar si este Gateway tiene cuentas de IA"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
+      "source": "Couldn’t check this Mac for AI accounts",
+      "translated": "No se pudo comprobar si este Mac tiene cuentas de IA"
+    },
+    {
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "No se pudo cargar la lista completa de proveedores"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
-      "translated": "Intentar de nuevo"
+      "translated": "Inténtalo de nuevo"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Ninguna de las opciones encontradas funcionó"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "Los detalles se muestran en cada opción de arriba. Puedes corregir el inicio de sesión y reintentar, o conectarte con una clave de API o un token a continuación."
+      "translated": "Los detalles se muestran en cada opción de arriba. Puedes corregir el inicio de sesión y reintentar, o conectarte con una clave de API o token a continuación."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "¿Necesitas ayuda? Chatea con Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "Tu IA está lista"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Detalles de configuración"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Copiar detalles de configuración"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
       "translated": "No se encontraron cuentas de IA en este Mac"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "No hay problema: puedes conectar uno con una clave de API o un token. Si usas Claude Code, Codex o Gemini CLI en este Mac, inicia sesión allí primero y pulsa “Comprobar de nuevo”."
+      "translated": "No pasa nada: puedes conectar una con una clave de API o token. Si usas Claude Code, Codex o el Gemini CLI en este Mac, inicia sesión ahí primero y pulsa “Comprobar de nuevo”."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Recomendado"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
       "translated": "No hay proveedores basados en clave disponibles"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "Habilita o instala un complemento de proveedor de inferencia de texto en este Gateway y vuelve a comprobar."
+      "translated": "Activa o instala un plugin de proveedor de inferencia de texto en este Gateway y vuelve a comprobar."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Comprobar de nuevo"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "Conectar con una clave de API o un token en su lugar…"
+      "translated": "Conectar con una clave de API o token en su lugar…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Iniciar sesión con un proveedor"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Usa una suscripción o cuenta de proveedor existente. OpenClaw abre el propio flujo de inicio de sesión del proveedor y luego lo verifica con una respuesta real."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Más opciones de inicio de sesión"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Emparejar"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Iniciar sesión"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Las credenciales permanecen en este Gateway y solo se guardan tras superar la prueba en vivo."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Abrir página de inicio de sesión…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Iniciando sesión segura…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "El inicio de sesión no se completó"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Finaliza en tu navegador"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Copiar"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Caduca en \\(minutes) minutos"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Abrir página de inicio de sesión"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Opción"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Confirmar"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "He iniciado sesión"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Continuar"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Enviar"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
-      "translated": "Conectar con una clave de API o un token"
+      "translated": "Conéctate con una clave de API o un token"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Proveedor"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "Clave de API o token"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Conectar"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Esa clave no funcionó"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — asistente de configuración"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Listo"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Abrir ayuda…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Ocultar detalles"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Mostrar detalles"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Copiar error"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Intentar de nuevo"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Espacio de trabajo del agente"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw ejecuta el agente desde un espacio de trabajo dedicado para que pueda cargar `AGENTS.md` y escribir archivos allí sin mezclarlos con tus otros proyectos."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Gateway remoto detectado"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Crea el espacio de trabajo en el host remoto (entra primero por SSH). La app de macOS aún no puede escribir archivos en tu Gateway mediante SSH."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Copiado"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Copiar comando de configuración"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Carpeta del espacio de trabajo"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Crear espacio de trabajo"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Abrir carpeta"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Guardar en la configuración"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Consejo: edita AGENTS.md en esta carpeta para definir el comportamiento del asistente. Para tener una copia de seguridad, convierte el espacio de trabajo en un repositorio git privado para que la “memoria” de tu agente quede versionada."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Conoce a tu agente"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Tu agente se presenta, elige un nombre contigo y te ayuda a conectar WhatsApp, Telegram u otro canal — solo chatea."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "¡Todo listo!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Ahora no"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Rechazar todo"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Aprobar todo"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Controla cómo se aprueban los comandos de shell del agente en esta Mac."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Cargando ajustes…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Leyendo la política persistente."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Aprobaciones de ejecución no disponibles"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "No se pudieron leer los ajustes"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Reintentar"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway conectado"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -24,6 +24,71 @@
       "translated": "پیش‌فرض"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "تأیید اجازه داده شد و ذخیره شد."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "تأیید یک‌بار اجازه داده شد."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "پاسخ قبلی این فرمان را اجازه داده و انتخاب را ذخیره کرده است."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "پاسخ قبلی این فرمان را یک‌بار اجازه داده است."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway تأیید را ثبت و انتخاب را ذخیره کرد."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway تأیید را یک‌بار ثبت کرد."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "تأیید رد شد."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "پاسخ قبلی این تأیید را رد کرده است."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway یک رد را ثبت کرد."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "این تأیید پیش از حل شدن منقضی شد."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "این تأیید پیش از حل شدن لغو شد."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "پاسخ قبلی این تأیید را حل کرده است."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "درخواست فرمان"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "آماده"
@@ -94,6 +159,11 @@
       "translated": "${issue.providerLabel} را روی Gateway پیکربندی کنید"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "تعداد بسیار زیادی اشتراک در انتظار افزوده شدن است."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · میکروفون: در انتظار"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "نتیجه حل نامشخص است. اقدامات تا زمانی که سابقه Gateway تأیید شود غیرفعال می‌مانند."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway هنوز این تأیید را به‌عنوان در انتظار نمایش می‌دهد. پیش از تلاش مجدد آن را بررسی کنید."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "بارگیری جزئیات تأیید ممکن نشد. تازه‌سازی کنید و دوباره تلاش کنید."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "بارگیری تأییدها ممکن نشد."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "حل تأیید ممکن نشد. تازه‌سازی کنید و دوباره تلاش کنید."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount ارائه‌دهنده آماده است"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "در دسترس بودن ارائه‌دهنده نامشخص است"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "آمادگی ارائه‌دهنده\nو مدل‌های پیکربندی‌شده را بررسی کنید."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "ارائه‌دهندگان متصل"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "ارائه‌دهندگان و مدل‌های پیکربندی‌شده"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway آفلاین است"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "نیازمند توجه"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "آماده"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "مدل‌ها"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "نیاز دارد"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "نامشخص"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount مدل پیکربندی‌شده. برای بررسی مجدد در دسترس‌بودن، تازه‌سازی کنید."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "برای مشاهده آمادگی ارائه‌دهنده، Gateway خود را متصل کنید."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "برای بررسی دوباره آمادگی ارائه‌دهنده از Gateway خود، تازه‌سازی کنید."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "در حال تازه‌سازی"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} مدل"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} مدل پیکربندی‌شده"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "نشست‌ها"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "معکوس‌کردن ترتیب نشست‌ها"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "جستجوی نشست‌ها"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "جدیدترین"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "ابتدا جدیدترین"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "قدیمی‌ترین"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "ابتدا قدیمی‌ترین"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "باز کردن تنظیمات"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "اطلاعات برنامه‌های نصب‌شده به اشتراک گذاشته شود؟"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw نام‌ها، شناسه‌های بسته و وضعیت برنامه‌های قابل‌مشاهده روی این تلفن را هنگامی که Gateway جفت‌شدهٔ OpenClaw شما آن‌ها را درخواست کند، جمع‌آوری و ارسال می‌کند. این کار به دستیار شما امکان می‌دهد با استفاده از برنامه‌های نصب‌شده به پرسش‌ها پاسخ دهد و اقداماتی انجام دهد."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "تلفن شما این اطلاعات را به Gateway شما ارسال می‌کند، نه به سروری که توسط OpenClaw اجرا می‌شود. ممکن است Gateway شما آن را در درخواست‌ها به ارائه‌دهندهٔ هوش مصنوعی که انتخاب کرده‌اید بگنجاند."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "موافقت و فعال‌سازی"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "فعلاً نه"
@@ -2599,39 +2709,24 @@
       "translated": "بازگشت"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "تأیید فرمان"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "در حال ارسال"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "فقط یک‌بار مجاز باشد"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "تأیید ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "در حال مجاز کردن"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "همیشه"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "در حال ذخیره"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "رد کردن"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "در حال رد کردن"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "رد کردن اعلان تأیید"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "جستجوی تنظیمات"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount آماده"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "بررسی آمادگی"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "هیچ برنامه‌ای نمی‌تواند این پیام را به اشتراک بگذارد"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "پرش به آخرین مورد"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "در حال بارگذاری نشست"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "هنوز پیامی وجود ندارد"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "در حال آماده‌سازی صدا…"
@@ -3649,6 +3719,11 @@
       "translated": "شما"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "تلاش مجدد"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "باز کردن پیش‌نمایش تصویر"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "بستن پیش‌نمایش تصویر"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw در حال آماده‌سازی پاسخ است."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "رد کردن هشدار تصویر اشتراکی"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "توقف"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway آفلاین است"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "بستن انتخاب‌گر سطح تفکر"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "باز کردن انتخاب‌گر سطح تفکر"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "درخواست‌های Gateway اینجا نمایش داده می‌شوند."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "۱ در انتظار"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) در انتظار"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "بالا"
@@ -6544,14 +6654,9 @@
       "translated": "هیچ اقدام Gateway در انتظار بازبینی نیست."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "اقدام در انتظار Gateway را بازبینی کنید."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "۱ در انتظار"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "بررسی اقدامات در انتظار gateway."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,18 +6714,38 @@
       "translated": "باز کردن اعلان‌ها"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "مجاز کردن"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "تأییدیه‌های در انتظار"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
-      "translated": "همیشه مجاز باشد"
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "بررسی تأیید exec"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "در حال بررسی"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "یک‌بار اجازه بده"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
+      "translated": "همیشه اجازه بده"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
+      "translated": "رد کردن"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
       "translated": "رد کردن"
     },
     {
@@ -7504,6 +7629,11 @@
       "translated": "همیشه اجازه بده"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "رد کردن"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "رد کردن"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "آفلاین"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "تأیید"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "این تأیید قبلاً انجام شده بود"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "تأیید روی «همیشه اجازه بده» تنظیم شد."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "این تأیید قبلاً روی «همیشه اجازه بده» تنظیم شده بود."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "نیاز به تأیید"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "فرمان کامل را پیش از در دسترس بودن تصمیم‌ها باز می‌کند"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "در حال بارگذاری"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "در حال بارگذاری تأیید"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "در دسترس نیست"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "تأیید بارگذاری نشد"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "دوباره بررسی کنید"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "فرمان"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "فرمان برای بررسی"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "شما"
@@ -9314,24 +9499,24 @@
       "translated": "تأیید"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "در حال ارسال تصمیم..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "بازبینی فرمان"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "تأیید"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "اجرای فرمان"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "یک‌بار اجازه بده"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "رد کردن"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw در GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw نتوانست در Applications نصب شود. آن را به‌صورت دستی به آنجا منتقل کنید، سپس آن نسخه را باز کنید."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw در Applications نصب شود؟"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "نسخه قدیمی‌تر OpenClaw در Applications جایگزین شود؟"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw خود را در Applications کپی می‌کند و از آنجا دوباره باز می‌شود تا به‌روزرسانی‌ها و اجرا هنگام ورود قابل‌اعتماد بمانند."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "این نسخه جدیدتر از برنامه نصب‌شده است. OpenClaw آن را جایگزین می‌کند و از Applications دوباره باز می‌شود."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "نصب و راه‌اندازی مجدد"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "جایگزینی و راه‌اندازی مجدد"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw در Applications نصب شد، اما نتوانست به‌صورت خودکار دوباره باز شود. آن را به‌صورت دستی از آنجا باز کنید."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "از ورودهای مرورگر خود استفاده کنید"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "کوکی‌ها را از \\(browsers) در یک پروفایل ایزوله‌شده عامل کپی کنید. گذرواژه‌ها هرگز لمس نمی‌شوند."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "در حال وارد کردن کوکی‌های مرورگر…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "در حال کپی کردن \\(profile.displayName) در «\\(target)». ممکن است Touch ID لازم باشد."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "ورودهای مرورگر وارد شدند"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) از \\(result.cookies.total) کوکی در «\\(result.into)» کپی شد — اکنون پروفایل پیش‌فرض برای مرور عامل است."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "وارد کردن مرورگر ناموفق بود"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "مرورگر شما"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "درون‌ریزی"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "تلاش مجدد"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "رد کردن"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "درون‌ریزی مرورگر به حالت Local نیاز دارد"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "پیش از درون‌ریزی کوکی‌های مرورگر، این برنامه مک را به یک Gateway محلی تغییر دهید."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "هیچ نمایه Chrome، Brave، Edge یا Chromium دارای کوکی روی این مک یافت نشد."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "درون‌ریزی نمایه مرورگر سیستم در پیکربندی Gateway محلی غیرفعال است."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "ورود مرورگری در دسترس نیست"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "درون‌ریزی مرورگر در دسترس نیست"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "نصب CLI ناموفق بود"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "نصب CLI به پایان رسید"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "پایدار"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "بتا"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "بدون تحویل"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "در حال اتصال مجدد داشبورد"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Gateway انتخاب‌شده تغییر کرد."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "در انتظار یک اتصال احرازهویت‌شده تازه."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "داشبورد در دسترس نیست"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Settings → Connection را بررسی کنید یا از Debug → Reset Remote Tunnel استفاده کنید، سپس دوباره تلاش کنید."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "خاتمه دادن به \\(listener.command) (\\(listener.pid))؟"
@@ -10704,6 +11069,16 @@
       "translated": "فقط الگوهای مسیر. شامل '/', '~' یا '\\\\' باشد."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "این ورودی فهرست مجاز به‌ارث رسیده است. دامنه مالک آن را ویرایش کرده و دوباره تلاش کنید."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "ذخیره تأییدهای exec ممکن نشد. آخرین تنظیمات شناخته‌شده نمایش داده شده‌اند؛ تغییر را دوباره امتحان کنید."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "پس از ورود شما، OpenClaw به‌طور خودکار شروع شود."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "پیش از فعال‌سازی اجرا هنگام ورود، OpenClaw را به Applications منتقل کنید."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "نمایش آیکون Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "به ابزارهای امضاشده (مثلاً `peekaboo`) اجازه دهید از طریق PeekabooBridge اتوماسیون UI را هدایت کنند."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "مرورگر"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "ورود با مرورگر"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "کوکی‌ها را از یک نمایه خانواده Chrome به یک نمایه مدیریت‌شده جداشده کپی کنید."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "درون‌ریزی…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "تنظیمات..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "بازگشت"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "جلو"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "تأییدهای اجرا"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "در حال بارگذاری تأییدهای Exec…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "تلاش مجدد تأییدهای Exec"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "استفاده"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource به systemRunPlan منطبق نیاز دارد"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "تأیید صریح به systemRunPlan منطبق نیاز دارد"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "جفت‌سازی گره تأیید شد"
@@ -11729,137 +12159,272 @@
       "translated": "بعدی"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
-      "source": "Looking for AI you already use…",
-      "translated": "در حال جست‌وجوی هوش مصنوعی‌ای که از قبل استفاده می‌کنید…"
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "درخواست راه‌اندازی Gateway ناموفق بود."
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "درخواست راه‌اندازی Gateway ناموفق بود. برای بررسی یا کپی خطا جزئیات را نمایش دهید."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) نتوانست آزمایش را کامل کند."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) نتوانست آزمایش را کامل کند. برای بررسی یا کپی خطا جزئیات را نمایش دهید."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "در حال جستجوی هوش مصنوعی‌ای که پیش‌تر استفاده می‌کنید…"
+    },
+    {
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "در انتظار پایان آزمایش قبلی هوش مصنوعی…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "translated": "در حال بررسی Claude Code، Codex، Gemini و کلیدهای API ذخیره‌شده."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw پیش از تغییر هر تنظیم استنتاج دوباره بررسی می‌کند."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "بررسی این Gateway برای حساب‌های هوش مصنوعی ممکن نشد"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "امکان بررسی این Mac برای حساب‌های هوش مصنوعی وجود نداشت"
+      "translated": "بررسی این Mac برای حساب‌های هوش مصنوعی ممکن نشد"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
-      "translated": "بارگذاری فهرست کامل ارائه‌دهندگان ممکن نشد"
+      "translated": "بارگیری فهرست کامل ارائه‌دهندگان ممکن نشد"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
-      "translated": "دوباره تلاش کنید"
+      "translated": "تلاش دوباره"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
-      "translated": "هیچ‌یک از گزینه‌های پیدا‌شده کار نکرد"
+      "translated": "هیچ‌کدام از گزینه‌های یافت‌شده کار نکردند"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "جزئیات در هر گزینهٔ بالا فهرست شده است. می‌توانید ورود را اصلاح کرده و دوباره تلاش کنید، یا با یک کلید API یا توکن در پایین متصل شوید."
+      "translated": "جزئیات هر گزینه در بالا فهرست شده است. می‌توانید ورود را اصلاح کرده و دوباره تلاش کنید، یا با کلید API یا توکن در پایین متصل شوید."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "به کمک نیاز دارید؟ با Crestodian گفت‌وگو کنید"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "هوش مصنوعی شما آماده است"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
-      "source": "No AI accounts found on this Mac",
-      "translated": "هیچ حساب هوش مصنوعی‌ای در این Mac پیدا نشد"
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "جزئیات راه‌اندازی"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "کپی جزئیات راه‌اندازی"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
+      "source": "No AI accounts found on this Mac",
+      "translated": "هیچ حساب هوش مصنوعی روی این Mac یافت نشد"
+    },
+    {
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
       "translated": "اشکالی ندارد — می‌توانید یکی را با کلید API یا توکن متصل کنید. اگر از Claude Code، Codex یا Gemini CLI روی این Mac استفاده می‌کنید، ابتدا آنجا وارد شوید و روی «بررسی دوباره» بزنید."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "پیشنهادی"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "هیچ ارائه‌دهندهٔ مبتنی بر کلیدی در دسترس نیست"
+      "translated": "هیچ ارائه‌دهنده مبتنی بر کلید در دسترس نیست"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "یک افزونهٔ ارائه‌دهندهٔ استنتاج متنی را روی این Gateway فعال یا نصب کنید، سپس دوباره بررسی کنید."
+      "translated": "یک افزونه ارائه‌دهنده استنتاج متنی را روی این Gateway فعال یا نصب کنید، سپس دوباره بررسی کنید."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
-      "translated": "دوباره بررسی کنید"
+      "translated": "بررسی دوباره"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
       "translated": "در عوض با کلید API یا توکن متصل شوید…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "ورود با یک ارائه‌دهنده"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "از اشتراک یا حساب ارائه‌دهنده موجود استفاده کنید. OpenClaw جریان ورود خود ارائه‌دهنده را باز می‌کند، سپس آن را با یک پاسخ واقعی تأیید می‌کند."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "گزینه‌های بیشتر ورود"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "جفت‌سازی"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "ورود"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "اعتبارنامه‌ها روی همین Gateway باقی می‌مانند و تنها پس از موفقیت آزمایش زنده ذخیره می‌شوند."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "باز کردن صفحه ورود…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "در حال شروع ورود امن…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "ورود کامل نشد"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "لغو"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "در مرورگر خود تمام کنید"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "کپی"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "تا \\(minutes) دقیقه دیگر منقضی می‌شود"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "باز کردن صفحه ورود"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "گزینه"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "تأیید"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "وارد شده‌ام"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "ادامه"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "ارسال"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
       "translated": "اتصال با کلید API یا توکن"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "ارائه‌دهنده"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "کلید API یا توکن"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "اتصال"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "آن کلید کار نکرد"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
-      "translated": "Crestodian — راهنمای راه‌اندازی"
+      "translated": "Crestodian — دستیار راه‌اندازی"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "انجام شد"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "باز کردن راهنما…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "پنهان کردن جزئیات"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "نمایش جزئیات"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "کپی خطا"
     },
@@ -12209,71 +12774,6 @@
       "translated": "دوباره امتحان کنید"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "فضای کاری عامل"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw عامل را از یک فضای کاری اختصاصی اجرا می‌کند تا بتواند `AGENTS.md` را بارگذاری کند و بدون مخلوط شدن با پروژه‌های دیگر شما، فایل‌ها را آنجا بنویسد."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Gateway راه دور شناسایی شد"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "فضای کاری را روی میزبان راه دور ایجاد کنید (ابتدا با SSH وارد شوید). برنامه macOS هنوز نمی‌تواند از طریق SSH روی Gateway شما فایل بنویسد."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "کپی شد"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "کپی فرمان راه‌اندازی"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "پوشهٔ فضای کاری"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "ایجاد فضای کاری"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "باز کردن پوشه"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "ذخیره در config"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "نکته: برای شکل‌دهی به رفتار دستیار، AGENTS.md را در این پوشه ویرایش کنید. برای پشتیبان‌گیری، فضای کاری را به یک مخزن خصوصی git تبدیل کنید تا «حافظه» عامل شما نسخه‌بندی شود."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "با عامل خود آشنا شوید"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "عامل شما خودش را معرفی می‌کند، همراه با شما نامی انتخاب می‌کند و کمک می‌کند WhatsApp، Telegram یا کانال دیگری را وصل کنید — فقط چت کنید."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "همه چیز آماده است!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "اکنون نه"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "رد همه"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "تأیید همه"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "نحوهٔ تأیید فرمان‌های پوستهٔ عامل را در این Mac کنترل کنید."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "در حال بارگذاری تنظیمات…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "در حال خواندن سیاست ذخیره‌شده."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "تأییدهای اجرا در دسترس نیست"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "تنظیمات قابل خواندن نبود"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "تلاش دوباره"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway متصل شد"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -3539,6 +3539,11 @@
       "translated": "فعال کردن میکروفون"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "تازه‌سازی"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "فایل‌ها در دسترس نیستند"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "خطای چت"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "خاموش"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -24,6 +24,71 @@
       "translated": "Par défaut"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Approbation autorisée et enregistrée."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Approbation autorisée une fois."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Une réponse précédente a déjà autorisé cette commande et enregistré le choix."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Une réponse précédente a déjà autorisé cette commande une fois."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Le Gateway a enregistré l'approbation et le choix."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Le Gateway a enregistré l'approbation une fois."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Approbation refusée."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Une réponse précédente a déjà refusé cette approbation."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Le Gateway a enregistré un refus."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Cette approbation a expiré avant de pouvoir être résolue."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Cette approbation a été annulée avant de pouvoir être résolue."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Une réponse précédente a déjà résolu cette approbation."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Demande de commande"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Prêt"
@@ -94,6 +159,11 @@
       "translated": "Configurez ${issue.providerLabel} sur le Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Trop de partages attendent d'être ajoutés."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Micro : en attente"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Résultat de résolution inconnu. Les actions restent désactivées jusqu'à ce que l'enregistrement du Gateway soit vérifié."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Le Gateway affiche encore cette approbation comme en attente. Vérifiez-la avant de réessayer."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Impossible de charger les détails de l'approbation. Actualisez et réessayez."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Impossible de charger les approbations."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Impossible de résoudre l'approbation. Actualisez et réessayez."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount fournisseurs prêts"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Disponibilité du fournisseur inconnue"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Vérifiez la disponibilité des fournisseurs\net les modèles configurés."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Fournisseurs connectés"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Fournisseurs et modèles configurés"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway hors ligne"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Attention requise"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Prêt"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Modèles"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Requis"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Inconnu"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount modèles configurés. Actualisez pour revérifier la disponibilité."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Connectez votre Gateway pour voir la disponibilité des fournisseurs."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Actualisez pour revérifier la disponibilité des fournisseurs depuis votre Gateway."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Actualisation"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} modèles"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} modèles configurés"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sessions"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Inverser le tri des sessions"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Rechercher des sessions"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Le plus récent"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Plus récents d'abord"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Le plus ancien"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Plus anciens d'abord"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Ouvrir les réglages"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Partager les informations sur les applications installées ?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw collecte et envoie les noms, les identifiants de package et l'état des applications visibles sur ce téléphone lorsque votre Gateway OpenClaw associé les demande. Cela permet à votre assistant de répondre aux questions et d'effectuer des actions à l'aide des applications installées."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Votre téléphone envoie ces informations à votre Gateway, et non à un serveur exploité par OpenClaw. Votre Gateway peut les inclure dans les requêtes adressées au fournisseur d'IA que vous avez choisi."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Accepter et activer"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Pas maintenant"
@@ -2599,39 +2709,24 @@
       "translated": "Retour"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Approbation de commande"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Envoi"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Autoriser une fois"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Approbation ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Autorisation"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Toujours"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Enregistrement"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Refuser"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Refus"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Ignorer l'avis d'approbation"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Rechercher dans les paramètres"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount prêts"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Vérifier l’état de préparation"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Aucune app ne peut partager ce message"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Aller au plus récent"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Chargement de la session"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Aucun message pour le moment"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Préparation de l'audio…"
@@ -3649,6 +3719,11 @@
       "translated": "Vous"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Réessayer"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Ouvrir l'aperçu de l'image"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Fermer l'aperçu de l'image"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw prépare une réponse."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Ignorer l'avertissement d'image partagée"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Arrêter"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway hors ligne"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Fermer le sélecteur de niveau de réflexion"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Ouvrir le sélecteur de niveau de réflexion"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Les demandes du Gateway apparaîtront ici."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 en attente"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) en attente"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Élevé"
@@ -6544,14 +6654,9 @@
       "translated": "Aucune action de Gateway n’est en attente de révision."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Examinez l’action de Gateway en attente."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 en attente"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Examiner les actions du Gateway en attente."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Ouvrir les notifications"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Autoriser"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Approbations en attente"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Examiner l'approbation d'exécution"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Examen en cours"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Autoriser une fois"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "Toujours autoriser"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Refuser"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Ignorer"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Toujours autoriser"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Ignorer"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Refuser"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Hors ligne"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Approbation"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Cette approbation a déjà été"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Approbation définie sur Toujours autoriser."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Cette approbation était déjà définie sur Toujours autoriser."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Approbation requise"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Ouvre la commande complète avant que les décisions soient disponibles"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Chargement"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Chargement de l'approbation"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Indisponible"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Approbation non chargée"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Examiner à nouveau"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Commande"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Commande à examiner"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Vous"
@@ -9314,24 +9499,24 @@
       "translated": "Approbation"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Envoi de la décision..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Vérifier la commande"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Approuver"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Exécution de la commande"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Autoriser une fois"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Refuser"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw sur GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw n’a pas pu être installé dans Applications. Déplacez-le là manuellement, puis ouvrez cette copie."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Installer OpenClaw dans Applications ?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Remplacer l’ancienne version d’OpenClaw dans Applications ?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw va se copier dans Applications et se rouvrir depuis cet emplacement pour garantir la fiabilité des mises à jour et du lancement à l’ouverture de session."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Cette copie est plus récente que l’application installée. OpenClaw va la remplacer et se rouvrir depuis Applications."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Installer et relancer"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Remplacer et relancer"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw est installé dans Applications, mais n’a pas pu se rouvrir automatiquement. Ouvrez-le là manuellement."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Utiliser vos identifiants de navigateur"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Copiez les cookies de \\(browsers) dans un profil d’agent isolé. Les mots de passe ne sont jamais touchés."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Importation des cookies du navigateur…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "Copie de \\(profile.displayName) dans « \\(target) ». Touch ID peut être requis."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Identifiants du navigateur importés"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) cookies sur \\(result.cookies.total) copiés dans « \\(result.into) » — désormais le profil par défaut pour la navigation de l’agent."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Échec de l’importation du navigateur"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "votre navigateur"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Importer"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Réessayer"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Ignorer"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "L'importation depuis le navigateur nécessite le mode local"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Basculez cette application Mac vers un Gateway local avant d'importer les cookies du navigateur."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "Aucun profil Chrome, Brave, Edge ou Chromium contenant des cookies n'a été trouvé sur ce Mac."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "L'importation des profils du navigateur système est désactivée dans la configuration du Gateway local."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Aucune connexion via navigateur disponible"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Importation depuis le navigateur indisponible"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "Échec de l'installation de la CLI"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "Installation de la CLI terminée"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Stable"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Bêta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "pas de livraison"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Reconnexion du tableau de bord"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Le Gateway sélectionné a changé."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "En attente d'une nouvelle connexion authentifiée."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Tableau de bord indisponible"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Vérifiez Réglages → Connexion ou utilisez Débogage → Réinitialiser le tunnel distant, puis réessayez."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Arrêter \\(listener.command) (\\(listener.pid)) ?"
@@ -10704,6 +11069,16 @@
       "translated": "Motifs de chemin uniquement. Incluez '/', '~' ou '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Cette entrée de liste d'autorisation est héritée. Modifiez la portée à laquelle elle appartient, puis réessayez."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Impossible d'enregistrer les approbations exec. Les derniers paramètres connus sont affichés ; réessayez la modification."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Démarrer automatiquement OpenClaw après votre connexion."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Déplacez OpenClaw vers Applications avant d'activer le lancement à la connexion."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Afficher l’icône dans le Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Autoriser les outils signés (par ex. `peekaboo`) à piloter l’automatisation de l’interface utilisateur via PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Navigateur"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Connexion via le navigateur"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Copiez les cookies d'un profil de la famille Chrome dans un profil géré isolé."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Importer…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Réglages..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Retour"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Suivant"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Approbations d’exécution"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Chargement des approbations Exec…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Réessayer les approbations Exec"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Utilisation"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource nécessite un systemRunPlan correspondant"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "l'approbation explicite nécessite un systemRunPlan correspondant"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Appairage du nœud approuvé"
@@ -11729,139 +12159,274 @@
       "translated": "Suivant"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "La requête de configuration du Gateway a échoué."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "La requête de configuration du Gateway a échoué. Affichez les détails pour inspecter ou copier l'erreur."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) n'a pas pu terminer le test."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) n'a pas pu terminer le test. Affichez les détails pour inspecter ou copier l'erreur."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
-      "translated": "Recherche de l’IA que vous utilisez déjà…"
+      "translated": "Recherche d'une IA que vous utilisez déjà…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "En attente de la fin du test IA précédent…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Vérification de Claude Code, Codex, Gemini et des clés API enregistrées."
+      "translated": "Recherche de Claude Code, Codex, Gemini et des clés API enregistrées."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw vérifiera à nouveau avant de modifier les paramètres d'inférence."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Impossible de vérifier les comptes IA sur ce Gateway"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
       "translated": "Impossible de vérifier les comptes IA sur ce Mac"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "Impossible de charger la liste complète des fournisseurs"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "Réessayer"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Aucune des options trouvées n’a fonctionné"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
       "translated": "Les détails sont indiqués pour chaque option ci-dessus. Vous pouvez corriger la connexion et réessayer, ou vous connecter avec une clé API ou un jeton ci-dessous."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "Besoin d’aide ? Discutez avec Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "Votre IA est prête"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Détails de configuration"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Copier les détails de configuration"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
       "translated": "Aucun compte IA trouvé sur ce Mac"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Ce n’est pas un problème — vous pouvez en connecter un avec une clé API ou un jeton. Si vous utilisez Claude Code, Codex ou la CLI Gemini sur ce Mac, connectez-vous d’abord là-bas et cliquez sur « Vérifier à nouveau »."
+      "translated": "Ce n’est pas grave — vous pouvez en connecter un avec une clé API ou un jeton. Si vous utilisez Claude Code, Codex ou la Gemini CLI sur ce Mac, connectez-vous-y d’abord puis appuyez sur « Vérifier à nouveau »."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Recommandé"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
       "translated": "Aucun fournisseur basé sur une clé n’est disponible"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "translated": "Activez ou installez un plugin de fournisseur d’inférence de texte sur ce Gateway, puis vérifiez à nouveau."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Vérifier à nouveau"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "Se connecter avec une clé API ou un jeton à la place…"
+      "translated": "Se connecter plutôt avec une clé API ou un jeton…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Se connecter avec un fournisseur"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Utilisez un abonnement ou un compte fournisseur existant. OpenClaw ouvre le processus de connexion propre au fournisseur, puis le vérifie avec une réponse réelle."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Plus d’options de connexion"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Associer"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Se connecter"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Les identifiants restent sur ce Gateway et ne sont enregistrés qu'après la réussite du test en direct."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Ouvrir la page de connexion…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Démarrage de la connexion sécurisée…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "La connexion ne s'est pas terminée"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Annuler"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Terminez dans votre navigateur"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Copier"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Expire dans \\(minutes) minutes"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Ouvrir la page de connexion"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Option"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Confirmer"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Je me suis connecté"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Continuer"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Envoyer"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
       "translated": "Se connecter avec une clé API ou un jeton"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Fournisseur"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "Clé API ou jeton"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Connecter"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
-      "translated": "Cette clé n’a pas fonctionné"
+      "translated": "Cette clé n'a pas fonctionné"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — assistant de configuration"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Terminé"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
-      "translated": "Ouvrir l’aide…"
+      "translated": "Ouvrir l'aide…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Masquer les détails"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Afficher les détails"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
-      "translated": "Copier l’erreur"
+      "translated": "Copier l'erreur"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12209,71 +12774,6 @@
       "translated": "Réessayer"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Espace de travail de l’agent"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw exécute l’agent depuis un espace de travail dédié afin qu’il puisse charger `AGENTS.md` et y écrire des fichiers sans les mélanger à vos autres projets."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Gateway distante détectée"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Créez l’espace de travail sur l’hôte distant (connectez-vous d’abord en SSH). L’app macOS ne peut pas encore écrire de fichiers sur votre Gateway via SSH."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Copié"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Copier la commande de configuration"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Dossier de l’espace de travail"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Créer un espace de travail"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Ouvrir le dossier"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Enregistrer dans la configuration"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Astuce : modifiez AGENTS.md dans ce dossier pour façonner le comportement de l’assistant. Pour la sauvegarde, faites de l’espace de travail un dépôt git privé afin que la « mémoire » de votre agent soit versionnée."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Découvrez votre agent"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Votre agent se présente, choisit un nom avec vous et vous aide à connecter WhatsApp, Telegram ou un autre canal — il suffit de discuter."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Tout est prêt !"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Pas maintenant"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Tout rejeter"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Tout approuver"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Contrôlez la façon dont les commandes shell de l’agent sont approuvées sur ce Mac."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Chargement des paramètres…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Lecture de la politique persistante."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Approbations d'exécution indisponibles"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Impossible de lire les paramètres"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Réessayer"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway connecté"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -3539,6 +3539,11 @@
       "translated": "Activer le microphone"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Actualiser"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Fichiers indisponibles"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Erreur de discussion"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Désactivé"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -3539,6 +3539,11 @@
       "translated": "माइक्रोफ़ोन सक्षम करें"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "रीफ़्रेश करें"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "फ़ाइलें उपलब्ध नहीं हैं"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "चैट त्रुटि"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "बंद"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -24,6 +24,71 @@
       "translated": "डिफ़ॉल्ट"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "स्वीकृति की अनुमति दी गई और सहेजी गई।"
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "स्वीकृति एक बार अनुमति दी गई।"
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "पिछले उत्तर में इस कमांड की पहले ही अनुमति दी गई थी और चयन सहेजा गया था।"
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "पिछले उत्तर में इस कमांड की पहले ही एक बार अनुमति दी गई थी।"
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway ने स्वीकृति दर्ज की और चयन सहेजा।"
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway ने स्वीकृति एक बार दर्ज की।"
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "स्वीकृति अस्वीकृत की गई।"
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "पिछले उत्तर में इस स्वीकृति को पहले ही अस्वीकार कर दिया गया था।"
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway ने अस्वीकृति दर्ज की।"
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "यह स्वीकृति हल होने से पहले ही समाप्त हो गई।"
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "यह स्वीकृति हल होने से पहले ही रद्द कर दी गई।"
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "पिछले उत्तर में इस स्वीकृति को पहले ही हल कर दिया गया था।"
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "कमांड अनुरोध"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "तैयार"
@@ -94,6 +159,11 @@
       "translated": "Gateway पर ${issue.providerLabel} कॉन्फ़िगर करें"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "बहुत से शेयर जोड़े जाने की प्रतीक्षा कर रहे हैं।"
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · माइक: लंबित"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "समाधान का परिणाम अज्ञात है। Gateway रिकॉर्ड सत्यापित होने तक कार्रवाइयाँ अक्षम रहती हैं।"
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway अभी भी इस स्वीकृति को लंबित दिखा रहा है। फिर से प्रयास करने से पहले इसकी समीक्षा करें।"
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "स्वीकृति विवरण लोड नहीं हो सका। रिफ़्रेश करें और फिर से प्रयास करें।"
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "स्वीकृतियाँ लोड नहीं हो सकीं।"
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "स्वीकृति हल नहीं हो सकी। रिफ़्रेश करें और फिर से प्रयास करें।"
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount प्रोवाइडर तैयार"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "प्रदाता उपलब्धता अज्ञात"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "प्रदाता की तैयारी\nऔर कॉन्फ़िगर किए गए मॉडलों की समीक्षा करें।"
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "कनेक्टेड प्रदाता"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "प्रदाता और कॉन्फ़िगर किए गए मॉडल"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway ऑफ़लाइन"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "ध्यान देने की आवश्यकता है"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "तैयार"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "मॉडल"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "आवश्यक"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "अज्ञात"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount कॉन्फ़िगर किए गए मॉडल। उपलब्धता दोबारा जाँचने के लिए रीफ़्रेश करें।"
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "प्रदाता की तैयारी देखने के लिए अपने Gateway को कनेक्ट करें।"
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "अपने Gateway से प्रदाता की तैयारी फिर से जाँचने के लिए रिफ़्रेश करें।"
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "रिफ़्रेश हो रहा है"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} मॉडल"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} कॉन्फ़िगर किए गए मॉडल"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "सत्र"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "सत्र क्रम उलटें"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "सत्र खोजें"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "नवीनतम"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "सबसे नए पहले"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "सबसे पुराने"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "सबसे पुराने पहले"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "सेटिंग्स खोलें"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "इंस्टॉल किए गए ऐप की जानकारी साझा करें?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw इस फ़ोन पर दिखाई देने वाले ऐप्स के नाम, पैकेज ID और स्थिति एकत्र करके भेजता है जब आपका पेयर किया गया OpenClaw Gateway उन्हें माँगता है। इससे आपका असिस्टेंट इंस्टॉल किए गए ऐप्स का उपयोग करके प्रश्नों का उत्तर दे सकता है और कार्रवाइयाँ कर सकता है।"
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "आपका फ़ोन यह जानकारी आपके Gateway को भेजता है, न कि OpenClaw द्वारा चलाए जाने वाले किसी सर्वर को। आपका Gateway इसे आपके चुने हुए AI प्रदाता के अनुरोधों में शामिल कर सकता है।"
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "सहमत हों और सक्षम करें"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "अभी नहीं"
@@ -2599,39 +2709,24 @@
       "translated": "वापस"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "कमांड अनुमोदन"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "भेजा जा रहा है"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "एक बार अनुमति दें"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "अनुमोदन ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "अनुमति दी जा रही है"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "हमेशा"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "सहेजा जा रहा है"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "अस्वीकार करें"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "अस्वीकार किया जा रहा है"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "अनुमोदन सूचना खारिज करें"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "सेटिंग्स खोजें"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount तैयार"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "तैयारी की समीक्षा करें"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "कोई भी ऐप यह संदेश साझा नहीं कर सकता"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "नवीनतम पर जाएँ"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "सेशन लोड हो रहा है"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "अभी तक कोई संदेश नहीं"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "ऑडियो तैयार किया जा रहा है…"
@@ -3649,6 +3719,11 @@
       "translated": "आप"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "पुनः प्रयास करें"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "छवि पूर्वावलोकन खोलें"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "छवि पूर्वावलोकन बंद करें"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw जवाब तैयार कर रहा है।"
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "साझा-छवि चेतावनी खारिज करें"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "रोकें"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway ऑफ़लाइन"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "थिंकिंग स्तर चयनकर्ता बंद करें"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "थिंकिंग स्तर चयनकर्ता खोलें"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Gateway अनुरोध यहाँ दिखाई देंगे।"
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 प्रतीक्षारत"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) प्रतीक्षारत"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "उच्च"
@@ -6544,14 +6654,9 @@
       "translated": "समीक्षा के लिए कोई Gateway कार्रवाई प्रतीक्षा में नहीं है।"
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "लंबित Gateway कार्रवाई की समीक्षा करें।"
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 प्रतीक्षा में"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "लंबित gateway क्रियाओं की समीक्षा करें।"
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "सूचनाएँ खोलें"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "अनुमति दें"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "लंबित अनुमोदन"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "exec अनुमोदन की समीक्षा करें"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "समीक्षा हो रही है"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "एक बार अनुमति दें"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "हमेशा अनुमति दें"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "अस्वीकार करें"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "खारिज करें"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "हमेशा अनुमति दें"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "खारिज करें"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "अस्वीकार करें"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "ऑफ़लाइन"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "अनुमोदन"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "यह अनुमोदन पहले ही"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "अनुमोदन को हमेशा अनुमति दें पर सेट किया गया।"
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "यह अनुमोदन पहले ही हमेशा अनुमति दें पर सेट किया गया था।"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "अनुमोदन आवश्यक"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "निर्णय उपलब्ध होने से पहले पूरा कमांड खोलता है"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "लोड हो रहा है"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "अनुमोदन लोड हो रहा है"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "अनुपलब्ध"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "अनुमोदन लोड नहीं हुआ"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "फिर से समीक्षा करें"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "कमांड"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "समीक्षा करने के लिए कमांड"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "आप"
@@ -9314,24 +9499,24 @@
       "translated": "मंज़ूरी"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "निर्णय भेजा जा रहा है..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "कमांड की समीक्षा करें"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "मंज़ूर करें"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "कमांड निष्पादन"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "एक बार अनुमति दें"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "अस्वीकार करें"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "GitHub पर OpenClaw"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw को Applications में इंस्टॉल नहीं किया जा सका। इसे मैन्युअल रूप से वहां ले जाएं, फिर उस कॉपी को खोलें।"
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw को Applications में इंस्टॉल करें?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Applications में पुराने OpenClaw को बदलें?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw खुद को Applications में कॉपी करेगा और वहां से फिर से खुलेगा ताकि अपडेट और लॉगिन पर लॉन्च विश्वसनीय बने रहें।"
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "यह कॉपी इंस्टॉल किए गए ऐप से नई है। OpenClaw इसे बदल देगा और Applications से फिर से खुलेगा।"
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "इंस्टॉल करें और फिर से लॉन्च करें"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "बदलें और फिर से लॉन्च करें"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw Applications में इंस्टॉल है, लेकिन स्वचालित रूप से फिर से नहीं खुल सका। इसे वहां मैन्युअल रूप से खोलें।"
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "अपने ब्राउज़र लॉगिन का उपयोग करें"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "\\(browsers) से कुकीज़ को एक पृथक एजेंट प्रोफ़ाइल में कॉपी करें। पासवर्ड को कभी नहीं छुआ जाता।"
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "ब्राउज़र कुकीज़ आयात हो रही हैं…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "\\(profile.displayName) को “\\(target)” में कॉपी किया जा रहा है। Touch ID की आवश्यकता हो सकती है।"
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "ब्राउज़र लॉगिन आयात किए गए"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.total) में से \\(result.cookies.imported) कुकीज़ “\\(result.into)” में कॉपी की गईं — अब एजेंट ब्राउज़िंग के लिए डिफ़ॉल्ट प्रोफ़ाइल।"
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "ब्राउज़र आयात विफल"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "आपका ब्राउज़र"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "आयात करें"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "पुनः प्रयास करें"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "खारिज करें"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "ब्राउज़र आयात के लिए Local मोड आवश्यक है"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "ब्राउज़र कुकीज़ आयात करने से पहले इस Mac ऐप को लोकल Gateway पर स्विच करें।"
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "इस Mac पर कुकीज़ वाला कोई Chrome, Brave, Edge, या Chromium प्रोफ़ाइल नहीं मिला।"
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "लोकल Gateway कॉन्फ़िगरेशन में सिस्टम ब्राउज़र प्रोफ़ाइल आयात अक्षम है।"
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "कोई ब्राउज़र लॉगिन उपलब्ध नहीं"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "ब्राउज़र आयात अनुपलब्ध"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "CLI इंस्टॉल विफल रहा"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "CLI इंस्टॉल पूर्ण हुआ"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "स्टेबल"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "बीटा"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "डिलीवरी नहीं"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "डैशबोर्ड पुनः कनेक्ट हो रहा है"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "चयनित Gateway बदल गया।"
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "एक नए प्रमाणित कनेक्शन की प्रतीक्षा है।"
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "डैशबोर्ड अनुपलब्ध"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Settings → Connection जांचें या Debug → Reset Remote Tunnel का उपयोग करें, फिर पुनः प्रयास करें।"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) को समाप्त करें?"
@@ -10704,6 +11069,16 @@
       "translated": "केवल पाथ पैटर्न। '/', '~', या '\\\\' शामिल करें।"
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "यह allowlist प्रविष्टि इनहेरिट की गई है। इसके स्वामी स्कोप को संपादित करें और पुनः प्रयास करें।"
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Exec अनुमोदन सहेजे नहीं जा सके। अंतिम ज्ञात सेटिंग्स दिखाई गई हैं; परिवर्तन पुनः प्रयास करें।"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "आपके साइन इन करने के बाद OpenClaw को अपने आप शुरू करें।"
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "लॉगिन पर लॉन्च सक्षम करने से पहले OpenClaw को Applications में ले जाएँ।"
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Dock आइकन दिखाएँ"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "हस्ताक्षरित टूल (जैसे `peekaboo`) को PeekabooBridge के माध्यम से UI ऑटोमेशन चलाने की अनुमति दें।"
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Browser"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Browser लॉगिन"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "किसी Chrome-family प्रोफ़ाइल से कुकीज़ को एक पृथक प्रबंधित प्रोफ़ाइल में कॉपी करें।"
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "आयात करें…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "सेटिंग्स..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "वापस"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "आगे"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Exec अनुमोदन"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Exec Approvals लोड हो रहे हैं…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Exec Approvals पुनः प्रयास करें"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "उपयोग"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource के लिए मेल खाने वाले systemRunPlan की आवश्यकता है"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "explicit approval के लिए मेल खाने वाले systemRunPlan की आवश्यकता है"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Node pairing स्वीकृत"
@@ -11729,137 +12159,272 @@
       "translated": "अगला"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Gateway सेटअप अनुरोध विफल रहा।"
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Gateway सेटअप अनुरोध विफल रहा। त्रुटि का निरीक्षण या कॉपी करने के लिए विवरण दिखाएँ।"
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) परीक्षण पूरा नहीं कर सका।"
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) परीक्षण पूरा नहीं कर सका। त्रुटि का निरीक्षण या कॉपी करने के लिए विवरण दिखाएँ।"
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
-      "translated": "आपके द्वारा पहले से उपयोग किए जा रहे AI को खोजा जा रहा है…"
+      "translated": "आपके पहले से उपयोग किए जा रहे AI की खोज हो रही है…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "पिछले AI परीक्षण के समाप्त होने की प्रतीक्षा हो रही है…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Claude Code, Codex, Gemini, और सहेजी गई API keys की जाँच की जा रही है।"
+      "translated": "Claude Code, Codex, Gemini, और सहेजी गई API कुंजियों की जाँच हो रही है।"
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "किसी भी inference सेटिंग को बदलने से पहले OpenClaw फिर से जाँच करेगा।"
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "इस Gateway पर AI खातों की जाँच नहीं की जा सकी"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
       "translated": "इस Mac पर AI खातों की जाँच नहीं की जा सकी"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "पूरी प्रदाता सूची लोड नहीं हो सकी"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
-      "translated": "फिर से कोशिश करें"
+      "translated": "फिर से प्रयास करें"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
-      "translated": "मिले हुए विकल्पों में से कोई भी काम नहीं किया"
+      "translated": "मिले हुए विकल्पों में से कोई भी काम नहीं आया"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "विवरण ऊपर हर विकल्प पर सूचीबद्ध हैं। आप लॉगिन ठीक करके पुनः प्रयास कर सकते हैं, या नीचे API key या token से कनेक्ट कर सकते हैं।"
+      "translated": "विवरण ऊपर प्रत्येक विकल्प पर सूचीबद्ध हैं। आप लॉगिन ठीक करके फिर से प्रयास कर सकते हैं, या नीचे API key या token से कनेक्ट कर सकते हैं।"
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
-      "translated": "मदद चाहिए? Crestodian से चैट करें"
+      "translated": "मदद चाहिए? Crestodian के साथ चैट करें"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "आपका AI तैयार है"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "सेटअप विवरण"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "सेटअप विवरण कॉपी करें"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
       "translated": "इस Mac पर कोई AI खाता नहीं मिला"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "कोई बात नहीं — आप एक API key या token से कनेक्ट कर सकते हैं। यदि आप इस Mac पर Claude Code, Codex, या Gemini CLI का उपयोग करते हैं, तो पहले वहाँ साइन इन करें और “फिर से जाँचें” पर क्लिक करें।"
+      "translated": "कोई बात नहीं — आप इसे API key या token से कनेक्ट कर सकते हैं। यदि आप इस Mac पर Claude Code, Codex, या Gemini CLI का उपयोग करते हैं, तो पहले वहाँ साइन इन करें और “फिर से जाँचें” दबाएँ।"
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "अनुशंसित"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
       "translated": "कोई key-आधारित प्रदाता उपलब्ध नहीं है"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "इस Gateway पर एक text-inference प्रदाता प्लगइन सक्षम या इंस्टॉल करें, फिर से जाँचें।"
+      "translated": "इस Gateway पर एक text-inference प्रदाता प्लगइन सक्षम या इंस्टॉल करें, फिर फिर से जाँचें।"
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "फिर से जाँचें"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
       "translated": "इसके बजाय API key या token से कनेक्ट करें…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
-      "source": "Connect with an API key or token",
-      "translated": "API key या token से कनेक्ट करें"
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "किसी प्रदाता से साइन इन करें"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "किसी मौजूदा सदस्यता या प्रदाता खाते का उपयोग करें। OpenClaw प्रदाता के अपने साइन-इन फ़्लो को खोलता है, फिर एक वास्तविक उत्तर के साथ इसे सत्यापित करता है।"
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "अधिक साइन-इन विकल्प"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "पेयर करें"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "साइन इन करें"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "क्रेडेंशियल इस Gateway पर ही रहते हैं और लाइव टेस्ट सफल होने के बाद ही सहेजे जाते हैं।"
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "साइन-इन पेज खोलें…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "सुरक्षित साइन-इन शुरू हो रहा है…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "साइन-इन पूरा नहीं हुआ"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "रद्द करें"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "अपने ब्राउज़र में पूरा करें"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "कॉपी करें"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "\\(minutes) मिनट में समाप्त होगा"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "साइन-इन पेज खोलें"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "विकल्प"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "पुष्टि करें"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "मैंने साइन इन कर लिया है"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "जारी रखें"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "सबमिट करें"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
+      "source": "Connect with an API key or token",
+      "translated": "API कुंजी या टोकन से कनेक्ट करें"
+    },
+    {
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "प्रदाता"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
-      "translated": "API key या token"
+      "translated": "API कुंजी या टोकन"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "कनेक्ट करें"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
-      "translated": "वह key काम नहीं की"
+      "translated": "वह कुंजी काम नहीं आई"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — सेटअप सहायक"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
-      "translated": "हो गया"
+      "translated": "पूर्ण"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
-      "translated": "मदद खोलें…"
+      "translated": "सहायता खोलें…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "विवरण छिपाएँ"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "विवरण दिखाएँ"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "त्रुटि कॉपी करें"
     },
@@ -12209,71 +12774,6 @@
       "translated": "फिर से कोशिश करें"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "एजेंट वर्कस्पेस"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw एजेंट को एक समर्पित वर्कस्पेस से चलाता है ताकि यह `AGENTS.md` लोड कर सके और आपकी अन्य परियोजनाओं में मिलाए बिना वहाँ फ़ाइलें लिख सके।"
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "रिमोट Gateway मिला"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "रिमोट होस्ट पर वर्कस्पेस बनाएँ (पहले SSH इन करें)। macOS ऐप अभी SSH के ज़रिए आपके Gateway पर फ़ाइलें नहीं लिख सकता।"
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "कॉपी किया गया"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "सेटअप कमांड कॉपी करें"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "वर्कस्पेस फ़ोल्डर"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "वर्कस्पेस बनाएँ"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "फ़ोल्डर खोलें"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "config में सहेजें"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "सुझाव: सहायक के व्यवहार को आकार देने के लिए इस फ़ोल्डर में AGENTS.md संपादित करें। बैकअप के लिए, वर्कस्पेस को एक निजी git repo बनाएँ ताकि आपके एजेंट की “मेमोरी” वर्ज़न की गई हो।"
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "अपने एजेंट से मिलें"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "आपका agent अपना परिचय देता है, आपके साथ एक नाम चुनता है, और WhatsApp, Telegram या किसी अन्य channel से कनेक्ट करने में मदद करता है — बस chat करें।"
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "आप पूरी तरह तैयार हैं!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "अभी नहीं"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "सभी अस्वीकार करें"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "सभी स्वीकृत करें"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "नियंत्रित करें कि इस Mac पर agent shell commands को कैसे अनुमोदित किया जाता है।"
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "सेटिंग्स लोड हो रही हैं…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "संग्रहीत नीति पढ़ी जा रही है।"
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Exec अनुमोदन अनुपलब्ध"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "सेटिंग्स पढ़ी नहीं जा सकीं"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "पुनः प्रयास करें"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway कनेक्ट हो गया"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -24,6 +24,71 @@
       "translated": "Default"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Persetujuan diizinkan dan disimpan."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Persetujuan diizinkan sekali."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Respons sebelumnya sudah mengizinkan perintah ini dan menyimpan pilihan tersebut."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Respons sebelumnya sudah mengizinkan perintah ini sekali."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway mencatat persetujuan dan menyimpan pilihan tersebut."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway mencatat persetujuan sekali."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Persetujuan ditolak."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Respons sebelumnya sudah menolak persetujuan ini."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway mencatat penolakan."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Persetujuan ini kedaluwarsa sebelum dapat diselesaikan."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Persetujuan ini dibatalkan sebelum dapat diselesaikan."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Respons sebelumnya sudah menyelesaikan persetujuan ini."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Permintaan perintah"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Siap"
@@ -94,6 +159,11 @@
       "translated": "Konfigurasikan ${issue.providerLabel} di Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Terlalu banyak berbagi yang menunggu untuk ditambahkan."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Mikrofon: Tertunda"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Hasil penyelesaian tidak diketahui. Tindakan tetap dinonaktifkan hingga catatan Gateway diverifikasi."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway masih menampilkan persetujuan ini sebagai tertunda. Tinjau sebelum mencoba lagi."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Tidak dapat memuat detail persetujuan. Segarkan dan coba lagi."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Tidak dapat memuat persetujuan."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Tidak dapat menyelesaikan persetujuan. Segarkan dan coba lagi."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount penyedia siap"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Ketersediaan penyedia tidak diketahui"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Tinjau kesiapan penyedia\ndan model yang dikonfigurasi."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Penyedia terhubung"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Penyedia dan model yang dikonfigurasi"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway offline"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Perlu perhatian"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Siap"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Model"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Perlu"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Tidak diketahui"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount model yang dikonfigurasi. Segarkan untuk memeriksa ketersediaan."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Hubungkan Gateway Anda untuk melihat kesiapan penyedia."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Segarkan untuk memeriksa ulang kesiapan penyedia dari Gateway Anda."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Menyegarkan"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} model"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} model yang dikonfigurasi"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sesi"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Balik urutan sesi"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Cari sesi"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Terbaru"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Terbaru dahulu"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Terlama"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Terlama dahulu"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Buka Pengaturan"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Bagikan informasi aplikasi yang terpasang?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw mengumpulkan dan mengirim nama, ID paket, dan status aplikasi yang terlihat di ponsel ini saat OpenClaw Gateway yang dipasangkan memintanya. Ini memungkinkan asisten Anda menjawab pertanyaan dan mengambil tindakan menggunakan aplikasi yang terpasang."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Ponsel Anda mengirim informasi ini ke Gateway Anda, bukan ke server yang dijalankan oleh OpenClaw. Gateway Anda mungkin menyertakannya dalam permintaan ke penyedia AI yang Anda pilih."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Setuju dan Aktifkan"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Jangan Sekarang"
@@ -2599,39 +2709,24 @@
       "translated": "Kembali"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Persetujuan perintah"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Mengirim"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Izinkan Sekali"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Persetujuan ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Mengizinkan"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Selalu"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Menyimpan"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Tolak"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Menolak"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Tutup pemberitahuan persetujuan"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Cari pengaturan"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount siap"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Tinjau kesiapan"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Tidak ada aplikasi yang dapat membagikan pesan ini"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Lompat ke terbaru"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Memuat sesi"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Belum ada pesan"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Menyiapkan audio…"
@@ -3649,6 +3719,11 @@
       "translated": "Anda"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Coba lagi"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Buka pratinjau gambar"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Tutup pratinjau gambar"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw sedang menyiapkan respons."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Tutup peringatan gambar yang dibagikan"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Berhenti"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway offline"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Tutup pemilih tingkat berpikir"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Buka pemilih tingkat berpikir"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Permintaan Gateway akan muncul di sini."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 menunggu"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) menunggu"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Tinggi"
@@ -6544,14 +6654,9 @@
       "translated": "Tidak ada tindakan gateway yang menunggu ditinjau."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
       "translated": "Tinjau tindakan gateway yang tertunda."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 menunggu"
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Buka Notifikasi"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Izinkan"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Persetujuan tertunda"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Tinjau persetujuan exec"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Meninjau"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Izinkan Sekali"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "Selalu Izinkan"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Tolak"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Tutup"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Selalu Izinkan"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Tutup"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Tolak"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Offline"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Persetujuan"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Persetujuan ini sudah"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Persetujuan diatur ke Selalu Izinkan."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Persetujuan ini sudah diatur ke Selalu Izinkan."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Persetujuan diperlukan"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Membuka perintah lengkap sebelum keputusan tersedia"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Memuat"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Memuat persetujuan"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Tidak tersedia"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Persetujuan tidak dimuat"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Tinjau lagi"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Perintah"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Perintah untuk ditinjau"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Anda"
@@ -9314,24 +9499,24 @@
       "translated": "Persetujuan"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Mengirim keputusan..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Tinjau Perintah"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Setujui"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Eksekusi perintah"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Izinkan Sekali"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Tolak"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw di GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw tidak dapat diinstal di Applications. Pindahkan ke sana secara manual, lalu buka salinan tersebut."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Instal OpenClaw di Applications?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Ganti OpenClaw yang lebih lama di Applications?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw akan menyalin dirinya ke Applications dan membuka kembali di sana agar pembaruan dan peluncuran saat login tetap andal."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Salinan ini lebih baru daripada aplikasi yang terinstal. OpenClaw akan menggantinya dan membuka kembali dari Applications."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Instal dan Luncurkan Ulang"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Ganti dan Luncurkan Ulang"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw terinstal di Applications, tetapi tidak dapat membuka kembali secara otomatis. Buka di sana secara manual."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Gunakan login browser Anda"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Salin cookie dari \\(browsers) ke profil agen yang terisolasi. Kata sandi tidak pernah disentuh."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Mengimpor cookie browser…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "Menyalin \\(profile.displayName) ke “\\(target)”. Touch ID mungkin diperlukan."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Login browser diimpor"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) dari \\(result.cookies.total) cookie disalin ke “\\(result.into)” — sekarang menjadi profil default untuk penjelajahan agen."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Impor browser gagal"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "browser Anda"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Impor"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Coba Lagi"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Tutup"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "Impor browser memerlukan mode Local"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Alihkan aplikasi Mac ini ke Gateway lokal sebelum mengimpor cookie browser."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "Tidak ada profil Chrome, Brave, Edge, atau Chromium dengan cookie yang ditemukan di Mac ini."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "Impor profil browser sistem dinonaktifkan dalam konfigurasi Gateway lokal."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Tidak ada login browser tersedia"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Impor browser tidak tersedia"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "Pemasangan CLI gagal"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "Pemasangan CLI selesai"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Stabil"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "tidak ada pengiriman"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Menghubungkan kembali dashboard"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Gateway yang dipilih berubah."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Menunggu koneksi terautentikasi yang baru."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Dashboard tidak tersedia"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Periksa Settings → Connection atau gunakan Debug → Reset Remote Tunnel, lalu coba lagi."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Hentikan \\(listener.command) (\\(listener.pid))?"
@@ -10704,6 +11069,16 @@
       "translated": "Hanya pola path. Sertakan '/', '~', atau '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Entri allowlist ini diwarisi. Edit scope pemiliknya lalu coba lagi."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Tidak dapat menyimpan persetujuan exec. Pengaturan terakhir yang diketahui ditampilkan; coba lagi perubahannya."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Mulai OpenClaw secara otomatis setelah Anda masuk."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Pindahkan OpenClaw ke Applications sebelum mengaktifkan luncurkan saat login."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Tampilkan ikon Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Izinkan alat bertanda tangan (mis. `peekaboo`) menjalankan otomatisasi UI melalui PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Browser"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Login browser"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Salin cookie dari profil keluarga Chrome ke dalam profil terkelola yang terisolasi."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Impor…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Pengaturan..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Kembali"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Maju"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Persetujuan Eksekusi"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Memuat Persetujuan Exec…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Coba Lagi Persetujuan Exec"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Penggunaan"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource memerlukan systemRunPlan yang cocok"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "persetujuan eksplisit memerlukan systemRunPlan yang cocok"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Pemasangan node disetujui"
@@ -11729,137 +12159,272 @@
       "translated": "Berikutnya"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Permintaan penyiapan Gateway gagal."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Permintaan penyiapan Gateway gagal. Tampilkan detail untuk memeriksa atau menyalin kesalahannya."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) tidak dapat menyelesaikan pengujian."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) tidak dapat menyelesaikan pengujian. Tampilkan detail untuk memeriksa atau menyalin kesalahannya."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
       "translated": "Mencari AI yang sudah Anda gunakan…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Menunggu pengujian AI sebelumnya selesai…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "translated": "Memeriksa Claude Code, Codex, Gemini, dan kunci API yang tersimpan."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
-      "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "Tidak dapat memeriksa Mac ini untuk akun AI"
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw akan memeriksa lagi sebelum mengubah pengaturan inferensi apa pun."
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Tidak dapat memeriksa akun AI pada Gateway ini"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
+      "source": "Couldn’t check this Mac for AI accounts",
+      "translated": "Tidak dapat memeriksa akun AI pada Mac ini"
+    },
+    {
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "Tidak dapat memuat daftar penyedia lengkap"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "Coba lagi"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
-      "translated": "Tidak ada opsi yang ditemukan yang berhasil"
+      "translated": "Tidak ada opsi yang ditemukan yang berfungsi"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "Detailnya tercantum pada setiap opsi di atas. Anda dapat memperbaiki login dan mencoba lagi, atau terhubung dengan API key atau token di bawah."
+      "translated": "Detailnya tercantum pada setiap opsi di atas. Anda dapat memperbaiki login dan mencoba lagi, atau terhubung dengan kunci API atau token di bawah."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "Butuh bantuan? Mengobrol dengan Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "AI Anda siap"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Detail penyiapan"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Salin detail penyiapan"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "Tidak ada akun AI yang ditemukan di Mac ini"
+      "translated": "Tidak ada akun AI yang ditemukan pada Mac ini"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Tidak masalah — Anda dapat menghubungkan satu dengan API key atau token. Jika Anda menggunakan Claude Code, Codex, atau Gemini CLI di Mac ini, masuk di sana terlebih dahulu lalu tekan “Periksa lagi”."
+      "translated": "Tidak masalah — Anda dapat menghubungkannya dengan kunci API atau token. Jika Anda menggunakan Claude Code, Codex, atau Gemini CLI pada Mac ini, masuk di sana terlebih dahulu lalu tekan “Periksa lagi”."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Direkomendasikan"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "Tidak ada penyedia berbasis key yang tersedia"
+      "translated": "Tidak ada penyedia berbasis kunci yang tersedia"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "Aktifkan atau pasang plugin penyedia inferensi teks pada Gateway ini, lalu periksa lagi."
+      "translated": "Aktifkan atau pasang plugin penyedia text-inference pada Gateway ini, lalu periksa lagi."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Periksa lagi"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "Hubungkan dengan API key atau token saja…"
+      "translated": "Hubungkan dengan kunci API atau token saja…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Masuk dengan penyedia"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Gunakan langganan atau akun penyedia yang sudah ada. OpenClaw membuka alur masuk milik penyedia sendiri, lalu memverifikasinya dengan balasan sungguhan."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Opsi masuk lainnya"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Pasangkan"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Masuk"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Kredensial tetap berada di Gateway ini dan hanya disimpan setelah tes langsung berhasil."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Buka halaman masuk…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Memulai proses masuk yang aman…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "Proses masuk tidak selesai"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Batal"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Selesaikan di browser Anda"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Salin"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Kedaluwarsa dalam \\(minutes) menit"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Buka halaman masuk"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Opsi"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Konfirmasi"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Saya sudah masuk"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Lanjutkan"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Kirim"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
-      "translated": "Hubungkan dengan API key atau token"
+      "translated": "Hubungkan dengan kunci API atau token"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Penyedia"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
-      "translated": "API key atau token"
+      "translated": "Kunci API atau token"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Hubungkan"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Kunci itu tidak berfungsi"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
-      "translated": "Crestodian — pembantu penyiapan"
+      "translated": "Crestodian — asisten penyiapan"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Selesai"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Buka bantuan…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Sembunyikan detail"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Tampilkan detail"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Salin kesalahan"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Coba lagi"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Ruang kerja agen"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw menjalankan agen dari ruang kerja khusus agar dapat memuat `AGENTS.md` dan menulis file di sana tanpa bercampur dengan proyek Anda yang lain."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Gateway jarak jauh terdeteksi"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Buat ruang kerja di host jarak jauh (masuk melalui SSH terlebih dahulu). App macOS belum dapat menulis file di gateway Anda melalui SSH."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Disalin"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Salin perintah penyiapan"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Folder workspace"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Buat workspace"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Buka folder"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Simpan dalam config"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Tips: edit AGENTS.md di folder ini untuk membentuk perilaku asisten. Untuk pencadangan, jadikan workspace sebagai repo git pribadi agar “memori” agen Anda memiliki versi."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Kenali agen Anda"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Agen Anda memperkenalkan diri, memilih nama bersama Anda, dan membantu Anda menghubungkan WhatsApp, Telegram, atau kanal lain — cukup mengobrol."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Anda sudah siap!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Jangan Sekarang"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Tolak Semua"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Setujui Semua"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Kontrol cara perintah shell agen disetujui di Mac ini."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Memuat pengaturan…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Membaca kebijakan yang tersimpan."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Persetujuan Exec Tidak Tersedia"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Pengaturan tidak dapat dibaca"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Coba Lagi"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway terhubung"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -3539,6 +3539,11 @@
       "translated": "Aktifkan Mikrofon"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Segarkan"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "File tidak tersedia"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Kesalahan chat"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Mati"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -24,6 +24,71 @@
       "translated": "Predefinito"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Approvazione consentita e salvata."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Approvazione consentita una volta."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Una risposta precedente ha già consentito questo comando e salvato la scelta."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Una risposta precedente ha già consentito questo comando una volta."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Il Gateway ha registrato l'approvazione e salvato la scelta."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Il Gateway ha registrato l'approvazione una volta."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Approvazione negata."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Una risposta precedente ha già negato questa approvazione."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Il Gateway ha registrato un rifiuto."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Questa approvazione è scaduta prima di poter essere risolta."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Questa approvazione è stata annullata prima di poter essere risolta."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Una risposta precedente ha già risolto questa approvazione."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Richiesta comando"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Pronto"
@@ -94,6 +159,11 @@
       "translated": "Configura ${issue.providerLabel} sul Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Troppe condivisioni in attesa di essere aggiunte."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Microfono: in sospeso"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Esito della risoluzione sconosciuto. Le azioni restano disabilitate finché il record del Gateway non viene verificato."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Il Gateway mostra ancora questa approvazione come in sospeso. Verificala prima di riprovare."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Impossibile caricare i dettagli dell'approvazione. Aggiorna e riprova."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Impossibile caricare le approvazioni."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Impossibile risolvere l'approvazione. Aggiorna e riprova."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount provider pronti"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Disponibilità del provider sconosciuta"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Rivedi lo stato di preparazione dei provider\ne i modelli configurati."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Provider connessi"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Provider e modelli configurati"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway offline"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Richiede attenzione"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Pronto"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Modelli"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Richiede"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Sconosciuto"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount modelli configurati. Aggiorna per ricontrollare la disponibilità."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Connetti il tuo Gateway per visualizzare lo stato di preparazione dei provider."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Aggiorna per ricontrollare lo stato di preparazione dei provider dal tuo Gateway."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Aggiornamento"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} modelli"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} modelli configurati"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sessioni"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Inverti l'ordinamento delle sessioni"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Cerca sessioni"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Più recenti"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Prima i più recenti"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Meno recenti"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Prima i più vecchi"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Apri Impostazioni"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Condividere le informazioni sulle app installate?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw raccoglie e invia i nomi, gli ID pacchetto e lo stato delle app visibili su questo telefono quando il Gateway OpenClaw associato li richiede. Questo consente al tuo assistente di rispondere a domande ed eseguire azioni utilizzando le app installate."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Il tuo telefono invia queste informazioni al tuo Gateway, non a un server gestito da OpenClaw. Il tuo Gateway può includerle nelle richieste al provider AI che hai scelto."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Accetta e abilita"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Non ora"
@@ -2599,39 +2709,24 @@
       "translated": "Indietro"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Approvazione comando"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Invio in corso"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Consenti una volta"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Approvazione ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Autorizzazione in corso"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Sempre"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Salvataggio in corso"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Nega"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Negazione in corso"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Ignora avviso di approvazione"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Cerca nelle impostazioni"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount pronti"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Verifica disponibilità"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Nessuna app può condividere questo messaggio"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Vai all'ultimo"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Caricamento sessione"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Ancora nessun messaggio"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Preparazione audio…"
@@ -3649,6 +3719,11 @@
       "translated": "Tu"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Riprova"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Apri anteprima immagine"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Chiudi anteprima immagine"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw sta preparando una risposta."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Ignora avviso immagine condivisa"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Interrompi"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway offline"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Chiudi selettore livello di riflessione"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Apri selettore livello di riflessione"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Le richieste del Gateway appariranno qui."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 in attesa"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) in attesa"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Alta"
@@ -6544,14 +6654,9 @@
       "translated": "Nessuna azione del gateway è in attesa di revisione."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Rivedi l'azione del gateway in sospeso."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 in attesa"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Rivedi le azioni gateway in sospeso."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Apri Notifiche"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Consenti"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Approvazioni in sospeso"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Rivedi approvazione exec"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "In revisione"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Consenti una volta"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "Consenti sempre"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Nega"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Ignora"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Consenti sempre"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Ignora"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Nega"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Offline"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Approvazione"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Questa approvazione era già"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Approvazione impostata su Consenti sempre."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Questa approvazione era già impostata su Consenti sempre."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Approvazione necessaria"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Apre il comando completo prima che le decisioni siano disponibili"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Caricamento"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Caricamento approvazione"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Non disponibile"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Approvazione non caricata"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Rivedi di nuovo"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Comando"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Comando da rivedere"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Tu"
@@ -9314,24 +9499,24 @@
       "translated": "Approvazione"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Invio decisione..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Rivedi comando"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Approva"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Esecuzione comando"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Consenti una volta"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Rifiuta"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw su GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "Impossibile installare OpenClaw in Applicazioni. Spostalo lì manualmente, poi apri quella copia."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Installare OpenClaw in Applicazioni?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Sostituire la versione precedente di OpenClaw in Applicazioni?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw si copierà in Applicazioni e si riaprirà lì affinché gli aggiornamenti e l'avvio al login rimangano affidabili."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Questa copia è più recente dell'app installata. OpenClaw la sostituirà e si riaprirà da Applicazioni."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Installa e riavvia"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Sostituisci e riavvia"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw è installato in Applicazioni, ma non è stato possibile riaprirlo automaticamente. Aprilo lì manualmente."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Usa i login del tuo browser"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Copia i cookie da \\(browsers) in un profilo agente isolato. Le password non vengono mai toccate."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Importazione dei cookie del browser…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "Copia di \\(profile.displayName) in “\\(target)”. Potrebbe essere richiesto Touch ID."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Login del browser importati"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) di \\(result.cookies.total) cookie copiati in “\\(result.into)” — ora il profilo predefinito per la navigazione dell'agente."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Importazione del browser non riuscita"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "il tuo browser"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Importa"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Riprova"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Ignora"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "L'importazione dal browser richiede la modalità locale"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Passa questa app Mac a un Gateway locale prima di importare i cookie del browser."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "Nessun profilo di Chrome, Brave, Edge o Chromium con cookie è stato trovato su questo Mac."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "L'importazione del profilo del browser di sistema è disabilitata nella configurazione locale del Gateway."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Nessun accesso al browser disponibile"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Importazione dal browser non disponibile"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "Installazione CLI non riuscita"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "Installazione CLI completata"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Stabile"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "nessuna consegna"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Riconnessione della dashboard in corso"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Il Gateway selezionato è cambiato."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "In attesa di una nuova connessione autenticata."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Dashboard non disponibile"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Controlla Impostazioni → Connessione o usa Debug → Reimposta tunnel remoto, quindi riprova."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Terminare \\(listener.command) (\\(listener.pid))?"
@@ -10704,6 +11069,16 @@
       "translated": "Solo pattern di percorsi. Includi '/', '~' o '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Questa voce dell'elenco consentiti è ereditata. Modifica il suo scope proprietario e riprova."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Impossibile salvare le approvazioni exec. Sono mostrate le ultime impostazioni note; riprova la modifica."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Avvia automaticamente OpenClaw dopo l'accesso."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Sposta OpenClaw in Applicazioni prima di abilitare l'avvio al login."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Mostra icona nel Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Consenti agli strumenti firmati (ad es. `peekaboo`) di eseguire l'automazione dell'interfaccia utente tramite PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Browser"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Accesso al browser"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Copia i cookie da un profilo della famiglia Chrome in un profilo gestito isolato."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Importa…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Impostazioni..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Indietro"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Avanti"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Approvazioni esecuzione"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Caricamento approvazioni exec…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Riprova approvazioni exec"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Utilizzo"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource richiede un systemRunPlan corrispondente"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "l'approvazione esplicita richiede un systemRunPlan corrispondente"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Abbinamento del nodo approvato"
@@ -11729,137 +12159,272 @@
       "translated": "Avanti"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "La richiesta di configurazione del Gateway non è riuscita."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "La richiesta di configurazione del Gateway non è riuscita. Mostra i dettagli per ispezionare o copiare l'errore."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) non ha potuto completare il test."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) non ha potuto completare il test. Mostra i dettagli per ispezionare o copiare l'errore."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
-      "translated": "Ricerca dell'IA che usi già…"
+      "translated": "Ricerca di AI che usi già in corso…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "In attesa del completamento del test AI precedente…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Controllo di Claude Code, Codex, Gemini e delle chiavi API salvate."
+      "translated": "Verifica di Claude Code, Codex, Gemini e chiavi API salvate."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw verificherà di nuovo prima di modificare qualsiasi impostazione di inferenza."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Impossibile verificare la presenza di account AI su questo Gateway"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "Impossibile controllare questo Mac per gli account IA"
+      "translated": "Impossibile verificare la presenza di account AI su questo Mac"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "Impossibile caricare l'elenco completo dei provider"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "Riprova"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Nessuna delle opzioni trovate ha funzionato"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "I dettagli sono elencati in ciascuna opzione sopra. Puoi correggere l'accesso e riprovare, oppure connetterti con una chiave API o un token qui sotto."
+      "translated": "I dettagli sono elencati per ciascuna opzione qui sopra. Puoi correggere l'accesso e riprovare, oppure connetterti con una chiave API o un token qui sotto."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "Hai bisogno di aiuto? Chatta con Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
-      "translated": "La tua IA è pronta"
+      "translated": "La tua AI è pronta"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Dettagli di configurazione"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Copia i dettagli di configurazione"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "Nessun account IA trovato su questo Mac"
+      "translated": "Nessun account AI trovato su questo Mac"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Va bene — puoi connetterne uno con una chiave API o un token. Se usi Claude Code, Codex o la Gemini CLI su questo Mac, accedi prima lì e premi \"Controlla di nuovo\"."
+      "translated": "Nessun problema: puoi connetterne uno con una chiave API o un token. Se usi Claude Code, Codex o la Gemini CLI su questo Mac, accedi lì prima e premi “Controlla di nuovo”."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Consigliato"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "Nessun provider basato su chiave è disponibile"
+      "translated": "Nessun provider basato su chiave disponibile"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "translated": "Abilita o installa un plugin provider di inferenza testuale su questo Gateway, quindi controlla di nuovo."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Controlla di nuovo"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
       "translated": "Connetti invece con una chiave API o un token…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Accedi con un provider"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Usa un abbonamento o un account provider esistente. OpenClaw apre il flusso di accesso del provider stesso, quindi lo verifica con una risposta reale."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Altre opzioni di accesso"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Associa"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Accedi"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Le credenziali rimangono su questo Gateway e vengono salvate solo dopo che il test in tempo reale ha esito positivo."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Apri pagina di accesso…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Avvio accesso sicuro…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "Accesso non completato"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Annulla"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Completa nel browser"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Copia"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Scade tra \\(minutes) minuti"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Apri pagina di accesso"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Opzione"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Conferma"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Ho effettuato l'accesso"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Continua"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Invia"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
       "translated": "Connetti con una chiave API o un token"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Provider"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "Chiave API o token"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Connetti"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Quella chiave non ha funzionato"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
-      "translated": "Crestodian — assistente alla configurazione"
+      "translated": "Crestodian — assistente di configurazione"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Fine"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
-      "translated": "Apri la guida…"
+      "translated": "Apri aiuto…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Nascondi dettagli"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Mostra dettagli"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Copia errore"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Riprova"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Area di lavoro dell'agente"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw esegue l'agente da un'area di lavoro dedicata, così può caricare `AGENTS.md` e scrivere file lì senza mescolarli con gli altri tuoi progetti."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Gateway remoto rilevato"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Crea l'area di lavoro sull'host remoto (prima accedi tramite SSH). L'app macOS non può ancora scrivere file sul tuo gateway tramite SSH."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Copiato"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Copia comando di configurazione"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Cartella dell'area di lavoro"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Crea area di lavoro"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Apri cartella"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Salva nella configurazione"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Suggerimento: modifica AGENTS.md in questa cartella per definire il comportamento dell'assistente. Per il backup, rendi l'area di lavoro un repository git privato, così la “memoria” del tuo agente sarà versionata."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Incontra il tuo agente"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Il tuo agente si presenta, sceglie un nome insieme a te e ti aiuta a collegare WhatsApp, Telegram o un altro canale — basta chattare."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "È tutto pronto!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Non ora"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Rifiuta tutto"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Approva tutto"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Controlla come vengono approvati i comandi shell dell’agente su questo Mac."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Caricamento impostazioni…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Lettura del criterio persistente."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Approvazioni Exec non disponibili"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Impossibile leggere le impostazioni"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Riprova"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway connesso"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -3539,6 +3539,11 @@
       "translated": "Abilita microfono"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Aggiorna"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "File non disponibili"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Errore chat"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Disattivato"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -24,6 +24,71 @@
       "translated": "デフォルト"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "承認を許可して保存しました。"
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "承認を1回だけ許可しました。"
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "以前の応答でこのコマンドが既に許可され、選択が保存されています。"
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "以前の応答でこのコマンドが既に1回許可されています。"
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway が承認を記録し、選択を保存しました。"
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway が承認を1回記録しました。"
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "承認が拒否されました。"
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "以前の応答でこの承認は既に拒否されています。"
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway が拒否を記録しました。"
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "この承認は解決される前に有効期限が切れました。"
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "この承認は解決される前にキャンセルされました。"
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "以前の応答でこの承認は既に解決されています。"
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "コマンドリクエスト"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "準備完了"
@@ -94,6 +159,11 @@
       "translated": "Gateway で ${issue.providerLabel} を設定してください"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "追加待ちの共有が多すぎます。"
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · マイク: 保留中"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "解決結果が不明です。Gateway の記録が確認されるまで操作は無効のままです。"
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway ではこの承認がまだ保留中と表示されています。再試行する前に確認してください。"
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "承認の詳細を読み込めませんでした。更新してもう一度お試しください。"
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "承認を読み込めませんでした。"
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "承認を解決できませんでした。更新してもう一度お試しください。"
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount 件のプロバイダーが準備完了"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "プロバイダーの利用可否が不明です"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "プロバイダーの準備状況と\n設定済みモデルを確認します。"
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "接続済みプロバイダー"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "プロバイダーと設定済みモデル"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway オフライン"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "対応が必要です"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "準備完了"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "モデル"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "必要"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "不明"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount 個の設定済みモデル。更新して利用可否を再確認してください。"
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "プロバイダーの準備状況を表示するには、Gateway を接続してください。"
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Gateway からプロバイダーの準備状況を再確認するには更新してください。"
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "更新中"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} 個のモデル"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} 個の設定済みモデル"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "セッション"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "セッションの並び順を反転"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,13 +1869,13 @@
       "translated": "セッションを検索"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
       "translated": "新しい順"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
       "translated": "古い順"
     },
     {
@@ -2329,6 +2419,26 @@
       "translated": "設定を開く"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "インストール済みアプリの情報を共有しますか？"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw は、ペアリングされた OpenClaw Gateway が要求したときに、この端末に表示されているアプリの名前、パッケージ ID、ステータスを収集して送信します。これにより、アシスタントがインストール済みアプリを使って質問に答えたり操作を実行したりできます。"
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "この情報は、OpenClaw が運営するサーバーではなく、お使いの Gateway に送信されます。Gateway は、選択した AI プロバイダーへのリクエストにこの情報を含める場合があります。"
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "同意して有効化"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "今はしない"
@@ -2599,39 +2709,24 @@
       "translated": "戻る"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "コマンドの承認"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "送信中"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "一度だけ許可"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "承認 ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "許可中"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "常に許可"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "保存中"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "拒否"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "拒否中"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "承認通知を閉じる"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "設定を検索"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount 件準備完了"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "準備状況を確認"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "このメッセージを共有できるアプリがありません"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "最新に移動"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "セッションを読み込み中"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "まだメッセージはありません"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "音声を準備中…"
@@ -3649,6 +3719,11 @@
       "translated": "あなた"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "再試行"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "画像プレビューを開く"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "画像プレビューを閉じる"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw が応答を準備しています。"
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "共有画像の警告を閉じる"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "停止"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway オフライン"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "思考レベルセレクターを閉じる"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "思考レベルセレクターを開く"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Gateway のリクエストがここに表示されます。"
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 件待機中"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) 件待機中"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "高"
@@ -6544,14 +6654,9 @@
       "translated": "レビュー待ちのGatewayアクションはありません。"
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "保留中のGatewayアクションをレビューしてください。"
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1件待機中"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "保留中の Gateway アクションを確認します。"
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "通知を開く"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "許可"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "保留中の承認"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "実行承認を確認"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "確認中"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "1回のみ許可"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "常に許可"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "拒否"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "却下"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "常に許可"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "却下"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "拒否"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "オフライン"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "承認"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "この承認はすでに"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "承認を「常に許可」に設定しました。"
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "この承認はすでに「常に許可」に設定されています。"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "承認が必要です"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "決定が可能になる前に完全なコマンドを開きます"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "読み込み中"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "承認を読み込み中"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "利用不可"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "承認が読み込まれていません"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "もう一度確認"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "コマンド"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "確認するコマンド"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "あなた"
@@ -9314,24 +9499,24 @@
       "translated": "承認"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "決定を送信中..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "コマンドを確認"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "承認"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "コマンドの実行"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "1回だけ許可"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "拒否"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "GitHub 上の OpenClaw"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw を Applications にインストールできませんでした。手動で移動してから、そのコピーを開いてください。"
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw を Applications にインストールしますか？"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Applications にある古い OpenClaw を置き換えますか？"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw は自身を Applications にコピーし、そこで再起動します。これにより更新とログイン時の起動が確実に機能します。"
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "このコピーはインストール済みのアプリより新しいバージョンです。OpenClaw は置き換えて、Applications から再起動します。"
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "インストールして再起動"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "置き換えて再起動"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw は Applications にインストールされましたが、自動的に再起動できませんでした。手動でそこから開いてください。"
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "ブラウザのログインを使用"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "\\(browsers) の Cookie を分離されたエージェントプロファイルにコピーします。パスワードには一切触れません。"
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "ブラウザの Cookie をインポート中…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "\\(profile.displayName) を「\\(target)」にコピーしています。Touch ID が必要な場合があります。"
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "ブラウザのログインをインポートしました"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.total) 件中 \\(result.cookies.imported) 件の Cookie を「\\(result.into)」にコピーしました。これがエージェントのブラウジングの既定プロファイルになりました。"
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "ブラウザのインポートに失敗しました"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "お使いのブラウザ"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "インポート"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "再試行"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "閉じる"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "ブラウザインポートには Local モードが必要です"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "ブラウザの Cookie をインポートする前に、この Mac アプリをローカル Gateway に切り替えてください。"
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "この Mac では Cookie を含む Chrome、Brave、Edge、Chromium のプロファイルが見つかりませんでした。"
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "ローカル Gateway 設定でシステムブラウザプロファイルのインポートが無効になっています。"
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "利用可能なブラウザログインがありません"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "ブラウザインポートを利用できません"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "CLI のインストールに失敗しました"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "CLI のインストールが完了しました"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "安定版"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "ベータ版"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "開発版 (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "配信なし"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "ダッシュボードを再接続中"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "選択された Gateway が変更されました。"
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "新しい認証済み接続を待機しています。"
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "ダッシュボードを利用できません"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "設定 → 接続を確認するか、デバッグ → リモートトンネルをリセットしてから、もう一度お試しください。"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) を終了しますか？"
@@ -10704,6 +11069,16 @@
       "translated": "パスパターンのみ。'/'、'~'、または '\\\\' を含めてください。"
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "この許可リストエントリは継承されています。所有するスコープを編集して再試行してください。"
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "exec承認を保存できませんでした。最後に確認された設定を表示しています。変更をやり直してください。"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "サインイン後に OpenClaw を自動的に起動します。"
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "ログイン時の起動を有効にする前に、OpenClawをアプリケーションに移動してください。"
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Dock アイコンを表示"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "署名済みツール（例: `peekaboo`）が PeekabooBridge 経由で UI 自動化を実行できるようにします。"
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "ブラウザ"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "ブラウザログイン"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Chromeファミリーのプロファイルから、分離された管理プロファイルにCookieをコピーします。"
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "インポート…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "設定..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "戻る"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "進む"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "実行承認"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "exec承認を読み込み中…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "exec承認を再試行"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "使用状況"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSourceには一致するsystemRunPlanが必要です"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "明示的な承認には一致するsystemRunPlanが必要です"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "ノードのペアリングが承認されました"
@@ -11729,137 +12159,272 @@
       "translated": "次へ"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Gatewayのセットアップリクエストが失敗しました。"
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Gatewayのセットアップリクエストが失敗しました。詳細を表示してエラーを確認またはコピーしてください。"
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label)はテストを完了できませんでした。"
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label)はテストを完了できませんでした。詳細を表示してエラーを確認またはコピーしてください。"
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
-      "translated": "すでにお使いのAIを探しています…"
+      "translated": "すでに使用しているAIを探しています…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "前のAIテストの完了を待っています…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Claude Code、Codex、Gemini、保存済みのAPIキーを確認しています。"
+      "translated": "Claude Code、Codex、Gemini、および保存されたAPIキーを確認しています。"
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClawは推論設定を変更する前に再度確認します。"
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "この Gateway で AI アカウントを確認できませんでした"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "このMacのAIアカウントを確認できませんでした"
+      "translated": "この Mac で AI アカウントを確認できませんでした"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
-      "translated": "プロバイダーの完全な一覧を読み込めませんでした"
+      "translated": "プロバイダーの全リストを読み込めませんでした"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "再試行"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "見つかったオプションはいずれも機能しませんでした"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "詳細は上記の各オプションに記載されています。ログインを修正して再試行するか、以下のAPIキーまたはトークンで接続できます。"
+      "translated": "詳細は上記の各オプションに記載されています。ログインを修正して再試行するか、下記の API キーまたはトークンで接続できます。"
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
-      "translated": "お困りですか？Crestodianにチャットで相談"
+      "translated": "お困りですか？ Crestodian とチャット"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
-      "translated": "AIの準備ができました"
+      "translated": "AI の準備ができました"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "セットアップの詳細"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "セットアップの詳細をコピー"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "このMacでAIアカウントが見つかりませんでした"
+      "translated": "この Mac に AI アカウントが見つかりませんでした"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "問題ありません — APIキーまたはトークンで接続できます。このMacでClaude Code、Codex、またはGemini CLIを使用している場合は、まずそこでサインインして「再確認」を押してください。"
+      "translated": "問題ありません — API キーまたはトークンで接続できます。この Mac で Claude Code、Codex、または Gemini CLI を使用している場合は、まずそこでサインインし、「再確認」を押してください。"
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "推奨"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "キーベースのプロバイダーは利用できません"
+      "translated": "キーベースのプロバイダーがありません"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "このGatewayでテキスト推論プロバイダープラグインを有効化またはインストールしてから、再度確認してください。"
+      "translated": "この Gateway でテキスト推論プロバイダーのプラグインを有効化またはインストールしてから、再度確認してください。"
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
-      "translated": "もう一度確認"
+      "translated": "再確認"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "代わりにAPIキーまたはトークンで接続…"
+      "translated": "代わりに API キーまたはトークンで接続…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "プロバイダーでサインイン"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "既存のサブスクリプションまたはプロバイダーアカウントを使用します。OpenClaw はプロバイダー独自のサインインフローを開き、実際の応答で検証します。"
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "その他のサインインオプション"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "ペアリング"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "サインイン"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "認証情報はこの Gateway 上に留まり、ライブテストが成功した後にのみ保存されます。"
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "サインインページを開く…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "安全なサインインを開始しています…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "サインインが完了しませんでした"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "キャンセル"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "ブラウザで完了してください"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "コピー"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "\\(minutes) 分後に期限切れ"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "サインインページを開く"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "オプション"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "確認"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "サインインしました"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "続ける"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "送信"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
-      "translated": "APIキーまたはトークンで接続"
+      "translated": "API キーまたはトークンで接続"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "プロバイダー"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
-      "translated": "APIキーまたはトークン"
+      "translated": "API キーまたはトークン"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "接続"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
-      "translated": "そのキーは機能しませんでした"
+      "translated": "そのキーは使用できませんでした"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — セットアップヘルパー"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "完了"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "ヘルプを開く…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
-      "translated": "詳細を非表示"
+      "translated": "詳細を隠す"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "詳細を表示"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "エラーをコピー"
     },
@@ -12209,71 +12774,6 @@
       "translated": "もう一度試す"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "エージェントワークスペース"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw は専用ワークスペースからエージェントを実行するため、他のプロジェクトと混在させずに `AGENTS.md` を読み込み、そこにファイルを書き込むことができます。"
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "リモート Gateway を検出しました"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "リモートホスト上にワークスペースを作成してください (先に SSH で接続してください)。macOS アプリはまだ SSH 経由で Gateway 上にファイルを書き込めません。"
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "コピーしました"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "セットアップコマンドをコピー"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "ワークスペースフォルダ"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "ワークスペースを作成"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "フォルダを開く"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "config に保存"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "ヒント: アシスタントの動作を調整するには、このフォルダ内の AGENTS.md を編集してください。バックアップのために、ワークスペースをプライベートな git repo にして、エージェントの「メモリ」をバージョン管理できるようにしましょう。"
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "エージェントに会う"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "エージェントが自己紹介し、あなたと一緒に名前を決め、WhatsApp、Telegram、または別のチャネルへの接続を手伝います — チャットするだけです。"
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "すべて設定完了です！"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "後で"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "すべて拒否"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "すべて承認"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "この Mac でエージェントのシェルコマンドをどのように承認するかを制御します。"
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "設定を読み込み中…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "保存されたポリシーを読み込んでいます。"
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "実行の承認は利用できません"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "設定を読み込めませんでした"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "再試行"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway接続済み"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -3539,6 +3539,11 @@
       "translated": "マイクを有効にする"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "更新"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "ファイルを利用できません"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "チャット エラー"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "オフ"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -24,6 +24,71 @@
       "translated": "기본값"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "승인이 허용되고 저장되었습니다."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "한 번 승인이 허용되었습니다."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "이전 응답에서 이미 이 명령을 허용하고 선택을 저장했습니다."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "이전 응답에서 이미 이 명령을 한 번 허용했습니다."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway가 승인을 기록하고 선택을 저장했습니다."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway가 한 번 승인을 기록했습니다."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "승인이 거부되었습니다."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "이전 응답에서 이미 이 승인을 거부했습니다."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway가 거부를 기록했습니다."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "이 승인은 처리되기 전에 만료되었습니다."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "이 승인은 처리되기 전에 취소되었습니다."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "이전 응답에서 이미 이 승인을 처리했습니다."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "명령 요청"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "준비됨"
@@ -94,6 +159,11 @@
       "translated": "Gateway에서 ${issue.providerLabel} 구성"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "추가 대기 중인 공유가 너무 많습니다."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · 마이크: 대기 중"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "처리 결과를 알 수 없습니다. Gateway 기록이 확인될 때까지 작업이 비활성화됩니다."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway에서 이 승인이 여전히 대기 중으로 표시됩니다. 다시 시도하기 전에 검토하세요."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "승인 세부 정보를 불러오지 못했습니다. 새로 고침 후 다시 시도하세요."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "승인을 불러오지 못했습니다."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "승인을 처리하지 못했습니다. 새로 고침 후 다시 시도하세요."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount개 제공자 준비됨"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "제공자 가용성 알 수 없음"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "제공자 준비 상태와\n구성된 모델을 검토하세요."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "연결된 제공자"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "제공자 및 구성된 모델"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway 오프라인"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "주의 필요"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "준비됨"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "모델"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "필요"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "알 수 없음"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "구성된 모델 $modelCount개. 새로 고침하여 사용 가능 여부를 다시 확인하세요."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "제공자 준비 상태를 보려면 Gateway를 연결하세요."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Gateway에서 제공자 준비 상태를 다시 확인하려면 새로 고치세요."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "새로 고치는 중"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount}개 모델"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "구성된 모델 ${row.modelCount}개"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "세션"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "세션 정렬 반전"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,13 +1869,13 @@
       "translated": "세션 검색"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
       "translated": "최신순"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
       "translated": "오래된순"
     },
     {
@@ -2329,6 +2419,26 @@
       "translated": "설정 열기"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "설치된 앱 정보를 공유하시겠습니까?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw는 페어링된 OpenClaw Gateway가 요청할 때 이 휴대폰에 표시되는 앱의 이름, 패키지 ID, 상태를 수집하여 전송합니다. 이를 통해 어시스턴트가 설치된 앱을 사용하여 질문에 답하고 작업을 수행할 수 있습니다."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "휴대폰은 이 정보를 OpenClaw가 운영하는 서버가 아니라 사용자의 Gateway로 전송합니다. Gateway는 사용자가 선택한 AI 제공자에 대한 요청에 이 정보를 포함할 수 있습니다."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "동의하고 활성화"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "나중에"
@@ -2599,39 +2709,24 @@
       "translated": "뒤로"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "명령 승인"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "전송 중"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "한 번만 허용"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "승인 ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "허용 중"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "항상"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "저장 중"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "거부"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "거부 중"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "승인 알림 닫기"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "설정 검색"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount개 준비됨"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "준비 상태 검토"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "이 메시지를 공유할 수 있는 앱이 없습니다"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "최신 항목으로 이동"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "세션 로드 중"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "아직 메시지가 없습니다"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "오디오 준비 중…"
@@ -3649,6 +3719,11 @@
       "translated": "나"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "다시 시도"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "이미지 미리 보기 열기"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "이미지 미리 보기 닫기"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw가 응답을 준비하고 있습니다."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "공유 이미지 경고 닫기"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "중지"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway 오프라인"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "생각 수준 선택기 닫기"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "생각 수준 선택기 열기"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Gateway 요청이 여기에 표시됩니다."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1개 대기 중"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount)개 대기 중"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "높음"
@@ -6544,14 +6654,9 @@
       "translated": "검토를 기다리는 게이트웨이 작업이 없습니다."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "대기 중인 게이트웨이 작업을 검토하세요."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1개 대기 중"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "대기 중인 gateway 작업을 검토합니다."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "알림 열기"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "허용"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "대기 중인 승인"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "실행 승인 검토"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "검토 중"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "한 번만 허용"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "항상 허용"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "거부"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "닫기"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "항상 허용"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "닫기"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "거부"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "오프라인"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "승인"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "이 승인은 이미"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "승인이 항상 허용으로 설정되었습니다."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "이 승인은 이미 항상 허용으로 설정되어 있습니다."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "승인 필요"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "결정 항목이 표시되기 전에 전체 명령을 엽니다"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "불러오는 중"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "승인 불러오는 중"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "사용할 수 없음"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "승인이 로드되지 않음"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "다시 검토"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "명령"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "검토할 명령"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "나"
@@ -9314,24 +9499,24 @@
       "translated": "승인"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "결정 전송 중..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "명령 검토"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "승인"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "명령 실행"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "한 번 허용"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "거부"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "GitHub의 OpenClaw"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw를 응용 프로그램에 설치할 수 없습니다. 수동으로 이동한 다음 해당 복사본을 여세요."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw를 응용 프로그램에 설치하시겠어요?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "응용 프로그램의 이전 OpenClaw를 교체하시겠어요?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw가 자신을 응용 프로그램에 복사하고 그곳에서 다시 열어 업데이트와 로그인 시 실행이 안정적으로 유지됩니다."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "이 복사본은 설치된 앱보다 최신입니다. OpenClaw가 이를 교체하고 응용 프로그램에서 다시 엽니다."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "설치 후 다시 시작"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "교체 후 다시 시작"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw가 응용 프로그램에 설치되었지만 자동으로 다시 열 수 없습니다. 그곳에서 수동으로 여세요."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "브라우저 로그인 사용"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "\\(browsers)의 쿠키를 격리된 에이전트 프로필로 복사합니다. 비밀번호는 절대 건드리지 않습니다."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "브라우저 쿠키 가져오는 중…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "\\(profile.displayName)을(를) “\\(target)”(으)로 복사하는 중입니다. Touch ID가 필요할 수 있습니다."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "브라우저 로그인 가져옴"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "쿠키 \\(result.cookies.total)개 중 \\(result.cookies.imported)개를 “\\(result.into)”(으)로 복사했습니다 — 이제 에이전트 브라우징의 기본 프로필입니다."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "브라우저 가져오기 실패"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "브라우저"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "가져오기"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "다시 시도"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "닫기"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "브라우저 가져오기는 로컬 모드가 필요합니다"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "브라우저 쿠키를 가져오기 전에 이 Mac 앱을 로컬 Gateway로 전환하세요."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "이 Mac에서 쿠키가 있는 Chrome, Brave, Edge 또는 Chromium 프로필을 찾을 수 없습니다."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "로컬 Gateway 구성에서 시스템 브라우저 프로필 가져오기가 비활성화되어 있습니다."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "사용 가능한 브라우저 로그인이 없습니다"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "브라우저 가져오기를 사용할 수 없음"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "CLI 설치 실패"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "CLI 설치 완료"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "안정 버전"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "베타"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "개발 (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "전달 없음"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "대시보드 재연결 중"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "선택한 Gateway가 변경되었습니다."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "새 인증된 연결을 기다리는 중입니다."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "대시보드를 사용할 수 없음"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "설정 → 연결을 확인하거나 디버그 → 원격 터널 재설정을 사용한 후 다시 시도하세요."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) 종료?"
@@ -10704,6 +11069,16 @@
       "translated": "경로 패턴만 가능합니다. '/', '~' 또는 '\\\\'를 포함하세요."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "이 허용 목록 항목은 상속되었습니다. 소유 범위를 편집한 후 다시 시도하세요."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "실행 승인을 저장할 수 없습니다. 마지막으로 알려진 설정이 표시되어 있으니 변경을 다시 시도하세요."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "로그인하면 OpenClaw를 자동으로 시작합니다."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "로그인 시 실행을 활성화하기 전에 OpenClaw를 응용 프로그램 폴더로 옮기세요."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Dock 아이콘 표시"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "서명된 도구(예: `peekaboo`)가 PeekabooBridge를 통해 UI 자동화를 실행하도록 허용합니다."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "브라우저"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "브라우저 로그인"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Chrome 계열 프로필의 쿠키를 격리된 관리형 프로필로 복사합니다."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "가져오기…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "설정..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "뒤로"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "앞으로"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "실행 승인"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "실행 승인 로드 중…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "실행 승인 다시 시도"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "사용량"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource에는 일치하는 systemRunPlan이 필요합니다"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "명시적 승인에는 일치하는 systemRunPlan이 필요합니다"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Node 페어링이 승인되었습니다"
@@ -11729,137 +12159,272 @@
       "translated": "다음"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Gateway 설정 요청이 실패했습니다."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Gateway 설정 요청이 실패했습니다. 세부 정보를 표시하여 오류를 확인하거나 복사하세요."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label)이(가) 테스트를 완료하지 못했습니다."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label)이(가) 테스트를 완료하지 못했습니다. 세부 정보를 표시하여 오류를 확인하거나 복사하세요."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
       "translated": "이미 사용 중인 AI를 찾는 중…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "이전 AI 테스트가 완료되기를 기다리는 중…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "translated": "Claude Code, Codex, Gemini 및 저장된 API 키를 확인하는 중입니다."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw는 추론 설정을 변경하기 전에 다시 확인합니다."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "이 Gateway에서 AI 계정을 확인할 수 없습니다"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
       "translated": "이 Mac에서 AI 계정을 확인할 수 없습니다"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "전체 공급자 목록을 불러올 수 없습니다"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "다시 시도"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
-      "translated": "찾은 옵션 중 작동한 것이 없습니다"
+      "translated": "발견된 옵션 중 작동하는 것이 없습니다"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "세부 정보는 위의 각 옵션에 나열되어 있습니다. 로그인을 수정하고 다시 시도하거나, 아래에서 API 키 또는 토큰으로 연결할 수 있습니다."
+      "translated": "자세한 내용은 위 각 옵션에 표시되어 있습니다. 로그인을 수정한 후 다시 시도하거나, 아래에서 API 키 또는 토큰으로 연결할 수 있습니다."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "도움이 필요하신가요? Crestodian과 채팅하세요"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "AI가 준비되었습니다"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "설정 세부 정보"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "설정 세부 정보 복사"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
       "translated": "이 Mac에서 AI 계정을 찾을 수 없습니다"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "괜찮습니다 — API 키 또는 토큰으로 연결할 수 있습니다. 이 Mac에서 Claude Code, Codex 또는 Gemini CLI를 사용하는 경우 먼저 거기에 로그인한 다음 “다시 확인”을 누르세요."
+      "translated": "괜찮습니다 — API 키 또는 토큰으로 연결할 수 있습니다. 이 Mac에서 Claude Code, Codex 또는 Gemini CLI를 사용한다면 먼저 거기에서 로그인한 후 “다시 확인”을 누르세요."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "권장"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "사용 가능한 키 기반 공급자가 없습니다"
+      "translated": "키 기반 공급자를 사용할 수 없습니다"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "이 Gateway에서 텍스트 추론 공급자 플러그인을 활성화하거나 설치한 다음 다시 확인하세요."
+      "translated": "이 Gateway에서 텍스트 추론 공급자 플러그인을 활성화하거나 설치한 후 다시 확인하세요."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "다시 확인"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
       "translated": "대신 API 키 또는 토큰으로 연결…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "공급자로 로그인"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "기존 구독 또는 공급자 계정을 사용하세요. OpenClaw가 공급자의 자체 로그인 절차를 열고, 실제 응답으로 이를 확인합니다."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "추가 로그인 옵션"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "페어링"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "로그인"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "자격 증명은 이 Gateway에만 유지되며 라이브 테스트가 성공한 후에만 저장됩니다."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "로그인 페이지 열기…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "보안 로그인 시작 중…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "로그인이 완료되지 않았습니다"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "취소"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "브라우저에서 완료하세요"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "복사"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "\\(minutes)분 후 만료"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "로그인 페이지 열기"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "옵션"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "확인"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "로그인했습니다"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "계속"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "제출"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
       "translated": "API 키 또는 토큰으로 연결"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
-      "translated": "제공자"
+      "translated": "공급자"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "API 키 또는 토큰"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "연결"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "해당 키가 작동하지 않았습니다"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — 설정 도우미"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "완료"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "도움말 열기…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "세부 정보 숨기기"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "세부 정보 표시"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "오류 복사"
     },
@@ -12209,71 +12774,6 @@
       "translated": "다시 시도"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "에이전트 작업 공간"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw는 전용 작업 공간에서 에이전트를 실행하므로, 다른 프로젝트와 섞이지 않고 그곳에서 `AGENTS.md`를 로드하고 파일을 쓸 수 있습니다."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "원격 Gateway 감지됨"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "원격 호스트에 작업 공간을 생성하세요(먼저 SSH로 접속). macOS 앱은 아직 SSH를 통해 Gateway에 파일을 쓸 수 없습니다."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "복사됨"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "설정 명령 복사"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "작업 공간 폴더"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "작업 공간 만들기"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "폴더 열기"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "config에 저장"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "팁: 이 폴더의 AGENTS.md를 편집하여 assistant의 동작을 조정하세요. 백업을 위해 작업 공간을 비공개 git repo로 만들어 agent의 “memory”가 버전 관리되도록 하세요."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "agent를 만나보세요"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "에이전트가 자신을 소개하고, 함께 이름을 정한 뒤, WhatsApp, Telegram 또는 다른 채널을 연결하도록 도와줍니다 — 그냥 채팅하세요."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "모두 준비되었습니다!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "나중에"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "모두 거부"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "모두 승인"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "이 Mac에서 에이전트 셸 명령 승인 방식을 제어합니다."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "설정 로드 중…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "저장된 정책을 읽는 중입니다."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "실행 승인을 사용할 수 없음"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "설정을 읽을 수 없습니다"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "다시 시도"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway 연결됨"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -3539,6 +3539,11 @@
       "translated": "마이크 활성화"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "새로 고침"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "파일을 사용할 수 없음"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "채팅 오류"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "꺼짐"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -24,6 +24,71 @@
       "translated": "Standaard"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Goedkeuring toegestaan en opgeslagen."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Eenmalig goedgekeurd."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Een eerdere reactie heeft deze opdracht al toegestaan en de keuze opgeslagen."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Een eerdere reactie heeft deze opdracht al eenmalig toegestaan."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway heeft de goedkeuring vastgelegd en de keuze opgeslagen."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway heeft eenmalig goedkeuring vastgelegd."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Goedkeuring geweigerd."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Een eerdere reactie heeft deze goedkeuring al geweigerd."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway heeft een weigering vastgelegd."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Deze goedkeuring is verlopen voordat ze kon worden afgehandeld."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Deze goedkeuring is geannuleerd voordat ze kon worden afgehandeld."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Een eerdere reactie heeft deze goedkeuring al afgehandeld."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Opdrachtverzoek"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Gereed"
@@ -94,6 +159,11 @@
       "translated": "Configureer ${issue.providerLabel} op de Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Er wachten te veel shares om toegevoegd te worden."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Microfoon: In behandeling"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Uitkomst van de afhandeling onbekend. Acties blijven uitgeschakeld totdat het Gateway-record is geverifieerd."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "De Gateway toont deze goedkeuring nog steeds als in behandeling. Bekijk deze voordat je het opnieuw probeert."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Kan goedkeuringsdetails niet laden. Vernieuw en probeer het opnieuw."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Kan goedkeuringen niet laden."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Kan goedkeuring niet afhandelen. Vernieuw en probeer het opnieuw."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount providers gereed"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Beschikbaarheid van provider onbekend"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Controleer de gereedheid van providers\nen geconfigureerde modellen."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Verbonden providers"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Providers en geconfigureerde modellen"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway offline"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Aandacht vereist"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Gereed"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Modellen"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Vereist"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Onbekend"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount geconfigureerde modellen. Vernieuw om beschikbaarheid opnieuw te controleren."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Verbind je Gateway om de gereedheid van providers te bekijken."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Vernieuw om de gereedheid van providers opnieuw te controleren vanuit je Gateway."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Vernieuwen"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} modellen"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} geconfigureerde modellen"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sessies"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Sessiesortering omkeren"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Sessies zoeken"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Nieuwste"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Nieuwste eerst"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Oudste"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Oudste eerst"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Instellingen openen"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Informatie over geïnstalleerde apps delen?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw verzamelt en verzendt de namen, pakket-ID's en status van apps die zichtbaar zijn op deze telefoon wanneer je gekoppelde OpenClaw Gateway hierom vraagt. Zo kan je assistent vragen beantwoorden en acties uitvoeren met geïnstalleerde apps."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Je telefoon verzendt deze informatie naar je Gateway, niet naar een server die door OpenClaw wordt beheerd. Je Gateway kan deze opnemen in verzoeken aan de door jou gekozen AI-provider."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Akkoord en inschakelen"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Niet nu"
@@ -2599,39 +2709,24 @@
       "translated": "Terug"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Opdrachtgoedkeuring"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Verzenden"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Eén keer toestaan"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Goedkeuring ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Toestaan"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Altijd"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Opslaan"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Weigeren"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Weigeren"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Goedkeuringsmelding sluiten"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Instellingen zoeken"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount gereed"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Gereedheid controleren"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Geen enkele app kan dit bericht delen"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Naar nieuwste springen"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Sessie laden"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Nog geen berichten"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Audio voorbereiden…"
@@ -3649,6 +3719,11 @@
       "translated": "Jij"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Opnieuw proberen"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Afbeeldingsvoorbeeld openen"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Afbeeldingsvoorbeeld sluiten"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw bereidt een antwoord voor."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Waarschuwing gedeelde afbeelding sluiten"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Stoppen"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway offline"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Selector voor denkniveau sluiten"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Selector voor denkniveau openen"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Gateway-aanvragen verschijnen hier."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 wachtend"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) wachtend"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Hoog"
@@ -6544,14 +6654,9 @@
       "translated": "Er wachten geen Gateway-acties op beoordeling."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Beoordeel de wachtende Gateway-actie."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 wachtend"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Beoordeel openstaande gateway-acties."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Meldingen openen"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Toestaan"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Openstaande goedkeuringen"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Exec-goedkeuring beoordelen"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Beoordelen"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Eén keer toestaan"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "Altijd toestaan"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Weigeren"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Sluiten"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Altijd toestaan"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Sluiten"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Weigeren"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Offline"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Goedkeuring"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Deze goedkeuring was al"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Goedkeuring ingesteld op Altijd toestaan."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Deze goedkeuring was al ingesteld op Altijd toestaan."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Goedkeuring nodig"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Opent de volledige opdracht voordat beslissingen beschikbaar zijn"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Laden"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Goedkeuring laden"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Niet beschikbaar"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Goedkeuring niet geladen"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Opnieuw bekijken"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Opdracht"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Te beoordelen opdracht"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Jij"
@@ -9314,24 +9499,24 @@
       "translated": "Goedkeuring"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Beslissing verzenden..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Opdracht controleren"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Goedkeuren"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Opdrachtuitvoering"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Eén keer toestaan"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Weigeren"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw op GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw kon niet in Programma's worden geïnstalleerd. Verplaats het daar handmatig naartoe en open die kopie."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw in Programma's installeren?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "De oudere OpenClaw in Programma's vervangen?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw kopieert zichzelf naar Programma's en opent daar opnieuw, zodat updates en starten bij aanmelden betrouwbaar blijven."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Deze kopie is nieuwer dan de geïnstalleerde app. OpenClaw vervangt deze en opent opnieuw vanuit Programma's."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Installeren en opnieuw starten"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Vervangen en opnieuw starten"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw is geïnstalleerd in Programma's, maar kon niet automatisch opnieuw worden geopend. Open het daar handmatig."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Gebruik je browseraanmeldingen"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Kopieer cookies van \\(browsers) naar een geïsoleerd agentprofiel. Wachtwoorden worden nooit aangeraakt."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Browsercookies importeren…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "\\(profile.displayName) wordt gekopieerd naar “\\(target)”. Touch ID kan vereist zijn."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Browseraanmeldingen geïmporteerd"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) van \\(result.cookies.total) cookies gekopieerd naar “\\(result.into)” — nu het standaardprofiel voor agentbrowsen."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Browserimport mislukt"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "je browser"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Importeren"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Opnieuw proberen"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Sluiten"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "Browserimport vereist lokale modus"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Schakel deze Mac-app over naar een lokale Gateway voordat je browsercookies importeert."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "Er is geen Chrome-, Brave-, Edge- of Chromium-profiel met cookies gevonden op deze Mac."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "Import van systeembrowserprofielen is uitgeschakeld in de lokale Gateway-configuratie."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Geen browserlogin beschikbaar"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Browserimport niet beschikbaar"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "CLI-installatie mislukt"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "CLI-installatie voltooid"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Stabiel"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "geen aflevering"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Dashboard maakt opnieuw verbinding"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "De geselecteerde Gateway is gewijzigd."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Wachten op een nieuwe geverifieerde verbinding."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Dashboard niet beschikbaar"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Controleer Instellingen → Verbinding of gebruik Debug → Reset Remote Tunnel en probeer het opnieuw."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) beëindigen?"
@@ -10704,6 +11069,16 @@
       "translated": "Alleen padpatronen. Neem '/', '~' of '\\\\' op."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Dit toegangslijst-item is overgeërfd. Bewerk de bijbehorende scope en probeer het opnieuw."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Kan exec-goedkeuringen niet opslaan. De laatst bekende instellingen worden getoond; probeer de wijziging opnieuw."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "OpenClaw automatisch starten nadat je bent ingelogd."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Verplaats OpenClaw naar Programma's voordat je automatisch starten bij inloggen inschakelt."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Toon Dock-icoon"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Sta ondertekende tools (bijv. `peekaboo`) toe om UI-automatisering aan te sturen via PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Browser"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Browserlogin"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Kopieer cookies van een Chrome-profiel naar een geïsoleerd beheerd profiel."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Importeren…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Instellingen..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Terug"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Vooruit"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Uitvoeringsgoedkeuringen"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Exec-goedkeuringen laden…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Exec-goedkeuringen opnieuw proberen"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Gebruik"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource vereist een overeenkomend systemRunPlan"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "expliciete goedkeuring vereist een overeenkomend systemRunPlan"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Node-koppeling goedgekeurd"
@@ -11729,137 +12159,272 @@
       "translated": "Volgende"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Het verzoek voor Gateway-installatie is mislukt."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Het verzoek voor Gateway-installatie is mislukt. Toon details om de fout te bekijken of te kopiëren."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) kon de test niet voltooien."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) kon de test niet voltooien. Toon details om de fout te bekijken of te kopiëren."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
       "translated": "Zoeken naar AI die je al gebruikt…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Wachten tot de vorige AI-test is voltooid…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "translated": "Controleren op Claude Code, Codex, Gemini en opgeslagen API-sleutels."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw controleert opnieuw voordat er inferentie-instellingen worden gewijzigd."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Kan deze Gateway niet controleren op AI-accounts"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "Kon deze Mac niet controleren op AI-accounts"
+      "translated": "Kan deze Mac niet controleren op AI-accounts"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
-      "translated": "Kon de volledige providerlijst niet laden"
+      "translated": "Kan de volledige providerlijst niet laden"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "Opnieuw proberen"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Geen van de gevonden opties werkte"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "De details staan hierboven bij elke optie vermeld. Je kunt de aanmelding herstellen en opnieuw proberen, of hieronder verbinden met een API-sleutel of token."
+      "translated": "De details staan bij elke optie hierboven. Je kunt de login herstellen en opnieuw proberen, of hieronder verbinden met een API-sleutel of token."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "Hulp nodig? Chat met Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "Je AI is klaar"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Installatiedetails"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Installatiedetails kopiëren"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
       "translated": "Geen AI-accounts gevonden op deze Mac"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Dat is prima — je kunt er een verbinden met een API-sleutel of token. Als je Claude Code, Codex of de Gemini CLI op deze Mac gebruikt, meld je daar eerst aan en klik op “Opnieuw controleren”."
+      "translated": "Dat is prima — je kunt er een verbinden met een API-sleutel of token. Als je Claude Code, Codex of de Gemini CLI op deze Mac gebruikt, log daar dan eerst in en klik op “Opnieuw controleren”."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Aanbevolen"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "Er zijn geen sleutelgebaseerde providers beschikbaar"
+      "translated": "Er zijn geen op sleutels gebaseerde providers beschikbaar"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "Schakel een text-inference-providerplug-in in of installeer deze op deze Gateway en controleer opnieuw."
+      "translated": "Schakel een text-inference-providerplug-in in of installeer die op deze Gateway en controleer opnieuw."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Opnieuw controleren"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
       "translated": "In plaats daarvan verbinden met een API-sleutel of token…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Aanmelden met een provider"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Gebruik een bestaand abonnement of provideraccount. OpenClaw opent de eigen aanmeldflow van de provider en verifieert die vervolgens met een echt antwoord."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Meer aanmeldopties"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Koppelen"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Aanmelden"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Inloggegevens blijven op deze Gateway en worden pas opgeslagen nadat de live test is geslaagd."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Aanmeldpagina openen…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Beveiligde aanmelding starten…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "Aanmelding is niet voltooid"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Annuleren"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Voltooien in je browser"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Kopiëren"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Verloopt over \\(minutes) minuten"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Aanmeldpagina openen"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Optie"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Bevestigen"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Ik heb me aangemeld"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Doorgaan"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Verzenden"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
       "translated": "Verbinden met een API-sleutel of token"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Provider"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "API-sleutel of token"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Verbinden"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Die sleutel werkte niet"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — installatiehulp"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
-      "translated": "Gereed"
+      "translated": "Klaar"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Help openen…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Details verbergen"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Details tonen"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Fout kopiëren"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Opnieuw proberen"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Agentwerkruimte"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw voert de agent uit vanuit een speciale werkruimte, zodat deze `AGENTS.md` kan laden en daar bestanden kan schrijven zonder ze met je andere projecten te vermengen."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Externe gateway gedetecteerd"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Maak de werkruimte aan op de externe host (eerst inloggen via SSH). De macOS-app kan nog geen bestanden via SSH naar je gateway schrijven."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Gekopieerd"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Setupopdracht kopiëren"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Werkruimtemap"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Werkruimte aanmaken"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Map openen"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Opslaan in config"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Tip: bewerk AGENTS.md in deze map om het gedrag van de assistent vorm te geven. Maak de werkruimte voor een back-up een privé-git-repo, zodat het “geheugen” van je agent van versiebeheer is voorzien."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Maak kennis met je agent"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Je agent stelt zich voor, kiest samen met jou een naam en helpt je WhatsApp, Telegram of een ander kanaal te verbinden — gewoon via de chat."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Je bent helemaal klaar!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Niet nu"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Alles afwijzen"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Alles goedkeuren"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Bepaal hoe shell-opdrachten van agenten op deze Mac worden goedgekeurd."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Instellingen laden…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Het opgeslagen beleid wordt gelezen."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Exec-goedkeuringen niet beschikbaar"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Instellingen konden niet worden gelezen"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Opnieuw proberen"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway verbonden"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -3539,6 +3539,11 @@
       "translated": "Microfoon inschakelen"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Vernieuwen"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Bestanden niet beschikbaar"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Chatfout"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Uit"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -3539,6 +3539,11 @@
       "translated": "Włącz mikrofon"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Odśwież"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Pliki niedostępne"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Błąd czatu"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Wyłączone"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -24,6 +24,71 @@
       "translated": "Domyślne"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Zatwierdzenie dozwolone i zapisane."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Zatwierdzenie dozwolone jednorazowo."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Wcześniejsza odpowiedź już zezwoliła na to polecenie i zapisała wybór."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Wcześniejsza odpowiedź już zezwoliła na to polecenie jednorazowo."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway zarejestrował zatwierdzenie i zapisał wybór."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway zarejestrował zatwierdzenie jednorazowo."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Zatwierdzenie odrzucone."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Wcześniejsza odpowiedź już odrzuciła to zatwierdzenie."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway zarejestrował odrzucenie."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "To zatwierdzenie wygasło, zanim mogło zostać rozstrzygnięte."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "To zatwierdzenie zostało anulowane, zanim mogło zostać rozstrzygnięte."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Wcześniejsza odpowiedź już rozstrzygnęła to zatwierdzenie."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Żądanie polecenia"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Gotowe"
@@ -94,6 +159,11 @@
       "translated": "Skonfiguruj ${issue.providerLabel} na Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Zbyt wiele udostępnień oczekuje na dodanie."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Mikrofon: oczekuje"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Wynik rozstrzygnięcia nieznany. Akcje pozostają wyłączone do czasu zweryfikowania rekordu Gateway."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway nadal pokazuje to zatwierdzenie jako oczekujące. Sprawdź je przed ponowną próbą."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Nie udało się załadować szczegółów zatwierdzenia. Odśwież i spróbuj ponownie."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Nie udało się załadować zatwierdzeń."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Nie udało się rozstrzygnąć zatwierdzenia. Odśwież i spróbuj ponownie."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount dostawców gotowych"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Dostępność dostawcy nieznana"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Sprawdź gotowość dostawców\ni skonfigurowane modele."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Połączeni dostawcy"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Dostawcy i skonfigurowane modele"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway offline"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Wymaga uwagi"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Gotowe"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Modele"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Wymaga"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Nieznane"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "Skonfigurowanych modeli: $modelCount. Odśwież, aby ponownie sprawdzić dostępność."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Połącz Gateway, aby zobaczyć gotowość dostawców."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Odśwież, aby ponownie sprawdzić gotowość dostawców z Gateway."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Odświeżanie"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} modeli"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} skonfigurowanych modeli"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sesje"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Odwróć sortowanie sesji"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Szukaj sesji"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Najnowsze"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Najpierw najnowsze"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Najstarsze"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Najpierw najstarsze"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Otwórz ustawienia"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Udostępnić informacje o zainstalowanych aplikacjach?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw zbiera i wysyła nazwy, identyfikatory pakietów oraz status aplikacji widocznych na tym telefonie, gdy poprosi o to sparowany Gateway OpenClaw. Pozwala to asystentowi odpowiadać na pytania i wykonywać działania z użyciem zainstalowanych aplikacji."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Twój telefon wysyła te informacje do Twojego Gateway, a nie na serwer prowadzony przez OpenClaw. Twój Gateway może uwzględnić je w żądaniach do wybranego przez Ciebie dostawcy AI."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Zaakceptuj i włącz"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Nie teraz"
@@ -2599,39 +2709,24 @@
       "translated": "Wstecz"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Zatwierdzanie poleceń"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Wysyłanie"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Zezwól raz"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Zatwierdzenie ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Zezwalanie"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Zawsze"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Zapisywanie"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Odmów"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Odmawianie"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Odrzuć powiadomienie o zatwierdzeniu"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Szukaj w ustawieniach"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount gotowe"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Sprawdź gotowość"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Żadna aplikacja nie może udostępnić tej wiadomości"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Przejdź do najnowszych"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Ładowanie sesji"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Brak wiadomości"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Przygotowywanie dźwięku…"
@@ -3649,6 +3719,11 @@
       "translated": "Ty"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Ponów próbę"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Otwórz podgląd obrazu"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Zamknij podgląd obrazu"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw przygotowuje odpowiedź."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Odrzuć ostrzeżenie o udostępnionym obrazie"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Zatrzymaj"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway offline"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Zamknij selektor poziomu myślenia"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Otwórz selektor poziomu myślenia"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Żądania Gateway pojawią się tutaj."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 oczekujące"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) oczekujących"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Wysoki"
@@ -6544,14 +6654,9 @@
       "translated": "Żadne działania Gateway nie czekają na sprawdzenie."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Sprawdź oczekujące działanie Gateway."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 oczekujące"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Przejrzyj oczekujące akcje gateway."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Otwórz Powiadomienia"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Zezwól"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Oczekujące zatwierdzenia"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
-      "translated": "Zawsze zezwalaj"
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Przejrzyj zatwierdzenie exec"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Przeglądanie"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Zezwól raz"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
+      "translated": "Zezwól zawsze"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Odmów"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Odrzuć"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Zawsze zezwalaj"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Odrzuć"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Odmów"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Offline"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Zatwierdzenie"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "To zatwierdzenie zostało już"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Zatwierdzenie ustawione na Zawsze zezwalaj."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "To zatwierdzenie zostało już ustawione na Zawsze zezwalaj."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Wymagane zatwierdzenie"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Otwiera pełne polecenie przed udostępnieniem decyzji"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Ładowanie"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Ładowanie zatwierdzenia"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Niedostępne"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Zatwierdzenie nie zostało załadowane"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Sprawdź ponownie"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Polecenie"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Polecenie do przejrzenia"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Ty"
@@ -9314,24 +9499,24 @@
       "translated": "Zatwierdzenie"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Wysyłanie decyzji..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Przejrzyj polecenie"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Zatwierdź"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Wykonanie polecenia"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Zezwól raz"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Odmów"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw na GitHubie"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "Nie udało się zainstalować OpenClaw w folderze Aplikacje. Przenieś go tam ręcznie, a następnie otwórz tę kopię."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Zainstalować OpenClaw w folderze Aplikacje?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Zastąpić starszą wersję OpenClaw w folderze Aplikacje?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw skopiuje się do folderu Aplikacje i otworzy się ponownie stamtąd, aby aktualizacje i uruchamianie przy logowaniu działały niezawodnie."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Ta kopia jest nowsza niż zainstalowana aplikacja. OpenClaw ją zastąpi i otworzy się ponownie z folderu Aplikacje."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Zainstaluj i uruchom ponownie"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Zastąp i uruchom ponownie"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw jest zainstalowany w folderze Aplikacje, ale nie udało się go otworzyć ponownie automatycznie. Otwórz go tam ręcznie."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Użyj loginów z przeglądarki"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Skopiuj pliki cookie z \\(browsers) do izolowanego profilu agenta. Hasła nigdy nie są ruszane."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Importowanie plików cookie przeglądarki…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "Kopiowanie \\(profile.displayName) do „\\(target)”. Może być wymagany Touch ID."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Zaimportowano loginy z przeglądarki"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "Skopiowano \\(result.cookies.imported) z \\(result.cookies.total) plików cookie do „\\(result.into)” — teraz jest to domyślny profil przeglądania agenta."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Import z przeglądarki nie powiódł się"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "twoja przeglądarka"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Importuj"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Ponów"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Odrzuć"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "Import z przeglądarki wymaga trybu lokalnego"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Przełącz tę aplikację Mac na lokalny Gateway przed zaimportowaniem plików cookie przeglądarki."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "Na tym Macu nie znaleziono profilu Chrome, Brave, Edge ani Chromium z plikami cookie."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "Import profilu przeglądarki systemowej jest wyłączony w konfiguracji lokalnego Gateway."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Brak dostępnego logowania przez przeglądarkę"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Import z przeglądarki niedostępny"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "Instalacja CLI nie powiodła się"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "Instalacja CLI zakończona"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Stabilna"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "brak dostarczenia"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Ponowne łączenie panelu"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Wybrany Gateway uległ zmianie."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Oczekiwanie na nowe uwierzytelnione połączenie."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Panel niedostępny"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Sprawdź Ustawienia → Połączenie lub użyj Debug → Reset Remote Tunnel, a następnie spróbuj ponownie."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Zakończyć \\(listener.command) (\\(listener.pid))?"
@@ -10704,6 +11069,16 @@
       "translated": "Tylko wzorce ścieżek. Uwzględnij '/', '~' lub '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Ten wpis listy dozwolonych jest dziedziczony. Edytuj zakres, do którego należy, i spróbuj ponownie."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Nie udało się zapisać zatwierdzeń exec. Wyświetlono ostatnie znane ustawienia; ponów zmianę."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Automatycznie uruchamiaj OpenClaw po zalogowaniu."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Przenieś OpenClaw do folderu Aplikacje przed włączeniem uruchamiania przy logowaniu."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Pokaż ikonę w Docku"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Zezwalaj podpisanym narzędziom (np. `peekaboo`) na sterowanie automatyzacją interfejsu użytkownika za pomocą PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Przeglądarka"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Logowanie w przeglądarce"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Skopiuj pliki cookie z profilu z rodziny Chrome do izolowanego zarządzanego profilu."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Importuj…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Ustawienia..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Wstecz"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Dalej"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Zatwierdzenia wykonania"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Ładowanie zatwierdzeń exec…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Ponów zatwierdzenia exec"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Użycie"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource wymaga zgodnego systemRunPlan"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "jawne zatwierdzenie wymaga zgodnego systemRunPlan"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Parowanie węzła zatwierdzone"
@@ -11729,137 +12159,272 @@
       "translated": "Dalej"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Żądanie konfiguracji Gateway nie powiodło się."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Żądanie konfiguracji Gateway nie powiodło się. Pokaż szczegóły, aby sprawdzić lub skopiować błąd."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) nie mógł ukończyć testu."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) nie mógł ukończyć testu. Pokaż szczegóły, aby sprawdzić lub skopiować błąd."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
-      "translated": "Szukamy AI, z której już korzystasz…"
+      "translated": "Wyszukiwanie AI, którego już używasz…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Oczekiwanie na zakończenie poprzedniego testu AI…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Sprawdzamy Claude Code, Codex, Gemini i zapisane klucze API."
+      "translated": "Sprawdzanie Claude Code, Codex, Gemini oraz zapisanych kluczy API."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw sprawdzi ponownie przed zmianą jakichkolwiek ustawień wnioskowania."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Nie udało się sprawdzić kont AI na tym Gateway"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "Nie udało się sprawdzić tego Maca pod kątem kont AI"
+      "translated": "Nie udało się sprawdzić kont AI na tym Macu"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "Nie udało się załadować pełnej listy dostawców"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "Spróbuj ponownie"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Żadna ze znalezionych opcji nie zadziałała"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "Szczegóły są wymienione przy każdej z opcji powyżej. Możesz poprawić logowanie i spróbować ponownie lub połączyć się za pomocą klucza API albo tokenu poniżej."
+      "translated": "Szczegóły są wymienione przy każdej opcji powyżej. Możesz poprawić logowanie i spróbować ponownie lub połączyć się za pomocą klucza API albo tokena poniżej."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "Potrzebujesz pomocy? Porozmawiaj z Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "Twoja AI jest gotowa"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Szczegóły konfiguracji"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Kopiuj szczegóły konfiguracji"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "Na tym Macu nie znaleziono kont AI"
+      "translated": "Nie znaleziono kont AI na tym Macu"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "W porządku — możesz połączyć się za pomocą klucza API lub tokenu. Jeśli używasz Claude Code, Codex lub Gemini CLI na tym Macu, najpierw zaloguj się tam i kliknij „Sprawdź ponownie”."
+      "translated": "Nie szkodzi — możesz połączyć jedno za pomocą klucza API lub tokena. Jeśli korzystasz z Claude Code, Codex lub Gemini CLI na tym Macu, najpierw zaloguj się tam i naciśnij „Sprawdź ponownie”."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Zalecane"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "Brak dostępnych dostawców opartych na kluczu"
+      "translated": "Brak dostępnych dostawców opartych na kluczach"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "Włącz lub zainstaluj wtyczkę dostawcy inferencji tekstowej na tym Gateway, a następnie sprawdź ponownie."
+      "translated": "Włącz lub zainstaluj wtyczkę dostawcy wnioskowania tekstowego na tym Gateway, a następnie sprawdź ponownie."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Sprawdź ponownie"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "Połącz się zamiast tego za pomocą klucza API lub tokenu…"
+      "translated": "Połącz zamiast tego za pomocą klucza API lub tokena…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Zaloguj się u dostawcy"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Użyj istniejącej subskrypcji lub konta dostawcy. OpenClaw otwiera własny proces logowania dostawcy, a następnie weryfikuje go prawdziwą odpowiedzią."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Więcej opcji logowania"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Sparuj"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Zaloguj się"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Dane uwierzytelniające pozostają na tym Gateway i są zapisywane dopiero po pomyślnym teście na żywo."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Otwórz stronę logowania…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Rozpoczynanie bezpiecznego logowania…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "Logowanie nie zostało ukończone"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Anuluj"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Dokończ w przeglądarce"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Kopiuj"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Wygasa za \\(minutes) min"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Otwórz stronę logowania"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Opcja"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Potwierdź"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Zalogowano"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Kontynuuj"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Prześlij"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
-      "translated": "Połącz się za pomocą klucza API lub tokenu"
+      "translated": "Połącz przy użyciu klucza API lub tokenu"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Dostawca"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "Klucz API lub token"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Połącz"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Ten klucz nie zadziałał"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
-      "translated": "Crestodian — pomocnik konfiguracji"
+      "translated": "Crestodian — asystent konfiguracji"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Gotowe"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Otwórz pomoc…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Ukryj szczegóły"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Pokaż szczegóły"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Kopiuj błąd"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Spróbuj ponownie"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Obszar roboczy agenta"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw uruchamia agenta z dedykowanego obszaru roboczego, aby mógł ładować `AGENTS.md` i zapisywać tam pliki bez mieszania ich z innymi projektami."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Wykryto zdalny Gateway"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Utwórz obszar roboczy na hoście zdalnym (najpierw połącz się przez SSH). Aplikacja macOS nie może jeszcze zapisywać plików na Twoim Gateway przez SSH."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Skopiowano"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Kopiuj polecenie konfiguracji"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Folder obszaru roboczego"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Utwórz obszar roboczy"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Otwórz folder"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Zapisz w config"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Wskazówka: edytuj AGENTS.md w tym folderze, aby dostosować zachowanie asystenta. Aby mieć kopię zapasową, utwórz z obszaru roboczego prywatne repozytorium git, dzięki czemu „pamięć” agenta będzie wersjonowana."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Poznaj swojego agenta"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Twój agent przedstawia się, wybiera z Tobą imię i pomaga połączyć WhatsApp, Telegram lub inny kanał — po prostu czatuj."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Wszystko gotowe!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Nie teraz"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Odrzuć wszystko"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Zatwierdź wszystko"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Kontroluj, jak zatwierdzane są polecenia powłoki agenta na tym Macu."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Ładowanie ustawień…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Odczytywanie zapisanej polityki."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Zatwierdzenia Exec niedostępne"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Nie można odczytać ustawień"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Ponów"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway połączony"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -24,6 +24,71 @@
       "translated": "Padrão"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Aprovação permitida e salva."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Aprovação permitida uma vez."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Uma resposta anterior já permitiu este comando e salvou a escolha."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Uma resposta anterior já permitiu este comando uma vez."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "O Gateway registrou a aprovação e salvou a escolha."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "O Gateway registrou a aprovação uma vez."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Aprovação negada."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Uma resposta anterior já negou esta aprovação."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "O Gateway registrou uma negação."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Esta aprovação expirou antes de poder ser resolvida."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Esta aprovação foi cancelada antes de poder ser resolvida."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Uma resposta anterior já resolveu esta aprovação."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Solicitação de comando"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Pronto"
@@ -94,6 +159,11 @@
       "translated": "Configure ${issue.providerLabel} no Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Há compartilhamentos demais aguardando para serem adicionados."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Mic: Pendente"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Resultado da resolução desconhecido. As ações permanecem desativadas até que o registro do Gateway seja verificado."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "O Gateway ainda mostra esta aprovação como pendente. Revise antes de tentar novamente."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Não foi possível carregar os detalhes da aprovação. Atualize e tente novamente."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Não foi possível carregar as aprovações."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Não foi possível resolver a aprovação. Atualize e tente novamente."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount provedores prontos"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Disponibilidade do provedor desconhecida"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Revise a prontidão dos provedores\ne os modelos configurados."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Provedores conectados"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Provedores e modelos configurados"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway offline"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Requer atenção"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Pronto"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Modelos"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Necessários"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Desconhecido"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount modelos configurados. Atualize para verificar a disponibilidade novamente."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Conecte seu Gateway para ver a prontidão dos provedores."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Atualize para verificar novamente a prontidão dos provedores no seu Gateway."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Atualizando"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} modelos"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} modelos configurados"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sessões"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Inverter ordenação de sessões"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Pesquisar sessões"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Mais recentes"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Mais recentes primeiro"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Mais antigas"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Mais antigos primeiro"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Abrir Ajustes"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Compartilhar informações dos aplicativos instalados?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "O OpenClaw coleta e envia os nomes, IDs de pacote e status dos aplicativos visíveis neste telefone quando o seu Gateway do OpenClaw pareado os solicita. Isso permite que o seu assistente responda perguntas e execute ações usando aplicativos instalados."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Seu telefone envia essas informações para o seu Gateway, e não para um servidor operado pelo OpenClaw. Seu Gateway pode incluí-las em solicitações ao provedor de IA que você escolheu."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Concordar e ativar"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Agora não"
@@ -2599,39 +2709,24 @@
       "translated": "Voltar"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Aprovação de comando"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Enviando"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Permitir uma vez"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Aprovação ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Permitindo"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Sempre"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Salvando"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Negar"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Negando"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Dispensar aviso de aprovação"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Pesquisar configurações"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount prontos"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Revisar prontidão"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Nenhum app pode compartilhar esta mensagem"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Ir para a mais recente"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Carregando sessão"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Ainda não há mensagens"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Preparando áudio…"
@@ -3649,6 +3719,11 @@
       "translated": "Você"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Tentar novamente"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Abrir visualização da imagem"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Fechar visualização da imagem"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw está preparando uma resposta."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Dispensar aviso de imagem compartilhada"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Parar"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway offline"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Fechar seletor de nível de raciocínio"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Abrir seletor de nível de raciocínio"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "As solicitações do Gateway aparecerão aqui."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 aguardando"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) aguardando"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Alta"
@@ -6544,14 +6654,9 @@
       "translated": "Nenhuma ação do gateway está aguardando revisão."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Revise a ação pendente do gateway."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 aguardando"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Revise ações pendentes do Gateway."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Abrir Notificações"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Permitir"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Aprovações pendentes"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Revisar aprovação de exec"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Revisando"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Permitir uma vez"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "Permitir sempre"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Negar"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Ignorar"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Permitir sempre"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Ignorar"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Negar"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Offline"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Aprovação"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Esta aprovação já foi"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Aprovação definida como Permitir sempre."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Esta aprovação já estava definida como Permitir sempre."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Aprovação necessária"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Abre o comando completo antes de as decisões ficarem disponíveis"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Carregando"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Carregando aprovação"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Indisponível"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Aprovação não carregada"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Revisar novamente"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Comando"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Comando a revisar"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Você"
@@ -9314,24 +9499,24 @@
       "translated": "Aprovação"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Enviando decisão..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Revisar Comando"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Aprovar"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Execução de comando"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Permitir Uma Vez"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Negar"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw no GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "Não foi possível instalar o OpenClaw em Aplicativos. Mova-o para lá manualmente e abra essa cópia."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Instalar o OpenClaw em Aplicativos?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Substituir a versão mais antiga do OpenClaw em Aplicativos?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "O OpenClaw se copiará para Aplicativos e reabrirá de lá para que as atualizações e a inicialização no login permaneçam confiáveis."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Esta cópia é mais recente que o aplicativo instalado. O OpenClaw irá substituí-lo e reabrir a partir de Aplicativos."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Instalar e Reiniciar"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Substituir e Reiniciar"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "O OpenClaw está instalado em Aplicativos, mas não foi possível reabri-lo automaticamente. Abra-o lá manualmente."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Use seus logins de navegador"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Copie os cookies de \\(browsers) para um perfil de agente isolado. As senhas nunca são tocadas."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Importando cookies do navegador…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "Copiando \\(profile.displayName) para “\\(target)”. Pode ser necessário o Touch ID."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Logins do navegador importados"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) de \\(result.cookies.total) cookies copiados para “\\(result.into)” — agora o perfil padrão para navegação do agente."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Falha na importação do navegador"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "seu navegador"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Importar"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Tentar novamente"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Dispensar"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "A importação do navegador requer o modo Local"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Alterne este app do Mac para um Gateway local antes de importar os cookies do navegador."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "Nenhum perfil do Chrome, Brave, Edge ou Chromium com cookies foi encontrado neste Mac."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "A importação de perfil do navegador do sistema está desativada na configuração do Gateway local."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Nenhum login de navegador disponível"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Importação do navegador indisponível"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "Falha na instalação da CLI"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "Instalação da CLI concluída"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Estável"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "sem entrega"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Reconectando o painel"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "O Gateway selecionado foi alterado."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Aguardando uma nova conexão autenticada."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Painel indisponível"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Verifique Configurações → Conexão ou use Depuração → Redefinir Túnel Remoto e tente novamente."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Encerrar \\(listener.command) (\\(listener.pid))?"
@@ -10704,6 +11069,16 @@
       "translated": "Somente padrões de caminho. Inclua '/', '~' ou '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Esta entrada da lista de permissões é herdada. Edite o escopo proprietário e tente novamente."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Não foi possível salvar as aprovações de execução. As últimas configurações conhecidas são exibidas; tente a alteração novamente."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Iniciar o OpenClaw automaticamente após você entrar."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Mova o OpenClaw para Aplicativos antes de ativar a inicialização no login."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Mostrar ícone no Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Permitir que ferramentas assinadas (por exemplo, `peekaboo`) controlem a automação da UI via PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Navegador"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Login pelo navegador"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Copie cookies de um perfil da família Chrome para um perfil gerenciado isolado."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Importar…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Configurações..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Voltar"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Avançar"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Aprovações de execução"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Carregando aprovações de execução…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Tentar aprovações de execução novamente"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Uso"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource requer systemRunPlan correspondente"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "a aprovação explícita requer systemRunPlan correspondente"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Pareamento do nó aprovado"
@@ -11729,137 +12159,272 @@
       "translated": "Avançar"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "A solicitação de configuração do Gateway falhou."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "A solicitação de configuração do Gateway falhou. Mostre os detalhes para inspecionar ou copiar o erro."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) não conseguiu concluir o teste."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) não conseguiu concluir o teste. Mostre os detalhes para inspecionar ou copiar o erro."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
       "translated": "Procurando IA que você já usa…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Aguardando a conclusão do teste de IA anterior…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "translated": "Verificando Claude Code, Codex, Gemini e chaves de API salvas."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
-      "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "Não foi possível verificar este Mac em busca de contas de IA"
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "O OpenClaw verificará novamente antes de alterar qualquer configuração de inferência."
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Não foi possível verificar contas de IA neste Gateway"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
+      "source": "Couldn’t check this Mac for AI accounts",
+      "translated": "Não foi possível verificar contas de IA neste Mac"
+    },
+    {
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "Não foi possível carregar a lista completa de provedores"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "Tentar novamente"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Nenhuma das opções encontradas funcionou"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "Os detalhes estão listados em cada opção acima. Você pode corrigir o login e tentar novamente, ou conectar com uma chave de API ou token abaixo."
+      "translated": "Os detalhes estão listados em cada opção acima. Você pode corrigir o login e tentar de novo, ou conectar com uma chave de API ou token abaixo."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
-      "translated": "Precisa de ajuda? Converse com o Crestodian"
+      "translated": "Precisa de ajuda? Converse com a Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "Sua IA está pronta"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Detalhes da configuração"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Copiar detalhes da configuração"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
       "translated": "Nenhuma conta de IA encontrada neste Mac"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Tudo bem — você pode conectar um com uma chave de API ou token. Se você usa o Claude Code, Codex ou o Gemini CLI neste Mac, faça login lá primeiro e clique em “Verificar novamente”."
+      "translated": "Tudo bem — você pode conectar uma com uma chave de API ou token. Se você usa o Claude Code, o Codex ou o Gemini CLI neste Mac, faça login lá primeiro e toque em “Verificar novamente”."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Recomendado"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
       "translated": "Nenhum provedor baseado em chave está disponível"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "translated": "Ative ou instale um plugin de provedor de inferência de texto neste Gateway e verifique novamente."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Verificar novamente"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
       "translated": "Conectar com uma chave de API ou token…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
-      "source": "Connect with an API key or token",
-      "translated": "Conectar com uma chave de API ou token"
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Entrar com um provedor"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Use uma assinatura ou conta de provedor existente. O OpenClaw abre o próprio fluxo de login do provedor e depois o verifica com uma resposta real."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Mais opções de login"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Parear"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Entrar"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "As credenciais permanecem neste Gateway e são salvas apenas após o teste ao vivo ser bem-sucedido."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Abrir página de login…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Iniciando login seguro…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "O login não foi concluído"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Cancelar"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Conclua no seu navegador"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Copiar"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Expira em \\(minutes) minutos"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Abrir página de login"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Opção"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Confirmar"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Já fiz login"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Continuar"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Enviar"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
+      "source": "Connect with an API key or token",
+      "translated": "Conecte-se com uma chave de API ou token"
+    },
+    {
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Provedor"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "Chave de API ou token"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Conectar"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Essa chave não funcionou"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — assistente de configuração"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Concluído"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Abrir ajuda…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Ocultar detalhes"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Mostrar detalhes"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Copiar erro"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Tentar novamente"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Workspace do agente"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "O OpenClaw executa o agente a partir de um workspace dedicado para que ele possa carregar `AGENTS.md` e gravar arquivos lá sem se misturar aos seus outros projetos."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Gateway remoto detectado"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Crie o workspace no host remoto (acesse via SSH primeiro). O app para macOS ainda não consegue gravar arquivos no seu gateway por SSH."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Copiado"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Copiar comando de configuração"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Pasta do workspace"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Criar workspace"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Abrir pasta"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Salvar na configuração"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Dica: edite AGENTS.md nesta pasta para moldar o comportamento do assistente. Para backup, transforme o workspace em um repositório git privado para que a “memória” do seu agente seja versionada."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Conheça seu agente"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Seu agente se apresenta, escolhe um nome com você e ajuda você a conectar WhatsApp, Telegram ou outro canal — é só conversar."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Tudo pronto!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Agora Não"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Rejeitar tudo"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Aprovar tudo"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Controle como os comandos de shell do agente são aprovados neste Mac."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Carregando configurações…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Lendo a política persistida."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Aprovações de Exec indisponíveis"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Não foi possível ler as configurações"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Tentar novamente"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway conectado"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -3539,6 +3539,11 @@
       "translated": "Ativar microfone"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Atualizar"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Arquivos indisponíveis"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Erro no chat"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Desativado"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -24,6 +24,71 @@
       "translated": "По умолчанию"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Одобрение разрешено и сохранено."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Одобрение разрешено однократно."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Предыдущий ответ уже разрешил эту команду и сохранил выбор."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Предыдущий ответ уже разрешил эту команду однократно."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway зафиксировал одобрение и сохранил выбор."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway зафиксировал одобрение однократно."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Одобрение отклонено."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Предыдущий ответ уже отклонил это одобрение."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway зафиксировал отклонение."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Срок действия этого одобрения истёк до его разрешения."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Это одобрение было отменено до его разрешения."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Предыдущий ответ уже разрешил это одобрение."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Запрос команды"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Готово"
@@ -94,6 +159,11 @@
       "translated": "Настройте ${issue.providerLabel} на Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Слишком много общих ресурсов ожидают добавления."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Микрофон: ожидает"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Результат разрешения неизвестен. Действия остаются отключёнными, пока запись Gateway не будет проверена."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway по-прежнему показывает это одобрение как ожидающее. Проверьте его перед повторной попыткой."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Не удалось загрузить сведения об одобрении. Обновите и попробуйте снова."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Не удалось загрузить одобрения."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Не удалось разрешить одобрение. Обновите и попробуйте снова."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount провайдеров готово"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Доступность провайдера неизвестна"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Проверьте готовность провайдеров\nи настроенные модели."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Подключенные провайдеры"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Провайдеры и настроенные модели"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway офлайн"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Требует внимания"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Готово"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Модели"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Требуется"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Неизвестно"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount настроенных моделей. Обновите, чтобы повторно проверить доступность."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Подключите Gateway, чтобы просмотреть готовность провайдеров."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Обновите, чтобы повторно проверить готовность провайдеров из вашего Gateway."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Обновление"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} моделей"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} настроенных моделей"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Сессии"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Обратный порядок сортировки сессий"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,13 +1869,13 @@
       "translated": "Поиск сессий"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
       "translated": "Сначала новые"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
       "translated": "Сначала старые"
     },
     {
@@ -2329,6 +2419,26 @@
       "translated": "Открыть настройки"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Поделиться информацией об установленных приложениях?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw собирает и отправляет названия, идентификаторы пакетов и статус приложений, видимых на этом телефоне, когда сопряжённый OpenClaw Gateway запрашивает их. Это позволяет вашему ассистенту отвечать на вопросы и выполнять действия с помощью установленных приложений."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Ваш телефон отправляет эту информацию на ваш Gateway, а не на сервер, управляемый OpenClaw. Ваш Gateway может включать её в запросы к выбранному вами провайдеру ИИ."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Согласиться и включить"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Не сейчас"
@@ -2599,39 +2709,24 @@
       "translated": "Назад"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Подтверждение команды"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Отправка"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Разрешить один раз"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Подтверждение ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Разрешение"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Всегда"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Сохранение"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Запретить"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Запрет"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Закрыть уведомление о подтверждении"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Поиск в настройках"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount готово"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Проверить готовность"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Нет приложения, которое может поделиться этим сообщением"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Перейти к последнему"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Загрузка сеанса"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Пока нет сообщений"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Подготовка аудио…"
@@ -3649,6 +3719,11 @@
       "translated": "Вы"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Повторить"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Открыть предпросмотр изображения"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Закрыть предпросмотр изображения"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw готовит ответ."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Закрыть предупреждение об общем изображении"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Остановить"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway не в сети"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Закрыть выбор уровня размышления"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Открыть выбор уровня размышления"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Запросы Gateway будут отображаться здесь."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 в ожидании"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) в ожидании"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Высокий"
@@ -6544,14 +6654,9 @@
       "translated": "Нет действий Gateway, ожидающих проверки."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Проверьте ожидающее действие Gateway."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 ожидает"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Просмотрите ожидающие действия Gateway."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Открыть уведомления"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Разрешить"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Ожидающие подтверждения"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
-      "translated": "Всегда разрешать"
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Просмотреть подтверждение выполнения"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Проверка"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Разрешить один раз"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
+      "translated": "Разрешить всегда"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Запретить"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Отклонить"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Разрешать всегда"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Отклонить"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Запретить"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Не в сети"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Подтверждение"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Это подтверждение уже было"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Подтверждение установлено на «Разрешить всегда»."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Это подтверждение уже установлено на «Разрешить всегда»."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Требуется подтверждение"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Открывает полную команду до появления решений"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Загрузка"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Загрузка подтверждения"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Недоступно"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Подтверждение не загружено"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Проверить снова"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Команда"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Команда для проверки"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Вы"
@@ -9314,24 +9499,24 @@
       "translated": "Подтверждение"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Отправка решения..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Проверить команду"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Подтвердить"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Выполнение команды"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Разрешить один раз"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Отклонить"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw на GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "Не удалось установить OpenClaw в Applications. Переместите приложение туда вручную, затем откройте эту копию."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Установить OpenClaw в Applications?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Заменить более старый OpenClaw в Applications?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw скопирует себя в Applications и снова откроется оттуда, чтобы обновления и запуск при входе работали надёжно."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Эта копия новее установленного приложения. OpenClaw заменит его и снова откроется из Applications."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Установить и перезапустить"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Заменить и перезапустить"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw установлен в Applications, но не смог открыться автоматически. Откройте его там вручную."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Использовать логины из браузера"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Скопировать куки из \\(browsers) в изолированный профиль агента. Пароли не затрагиваются."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Импорт куки из браузера…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "Копирование \\(profile.displayName) в «\\(target)». Может потребоваться Touch ID."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Логины из браузера импортированы"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) из \\(result.cookies.total) куки скопировано в «\\(result.into)» — теперь это профиль по умолчанию для просмотра агентом."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Не удалось импортировать браузер"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "ваш браузер"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Импорт"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Повторить"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Закрыть"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "Импорт из браузера требует локального режима"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Переключите это приложение Mac на локальный Gateway перед импортом cookie браузера."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "На этом Mac не найдено профиля Chrome, Brave, Edge или Chromium с cookie."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "Импорт профиля системного браузера отключён в конфигурации локального Gateway."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Вход через браузер недоступен"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Импорт из браузера недоступен"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "Не удалось установить CLI"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "Установка CLI завершена"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Стабильная"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Бета"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "нет доставки"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Переподключение панели управления"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Выбранный Gateway изменился."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Ожидание нового аутентифицированного подключения."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Панель управления недоступна"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Проверьте Настройки → Подключение или используйте Отладка → Сбросить удалённый туннель, затем повторите попытку."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Завершить \\(listener.command) (\\(listener.pid))?"
@@ -10704,6 +11069,16 @@
       "translated": "Только шаблоны путей. Включите '/', '~' или '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Эта запись списка разрешений унаследована. Отредактируйте её область-владельца и повторите попытку."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Не удалось сохранить одобрения выполнения. Показаны последние известные настройки; повторите изменение."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Автоматически запускать OpenClaw после входа в систему."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Переместите OpenClaw в Applications перед включением запуска при входе."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Показывать значок в Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Разрешить подписанным инструментам (например, `peekaboo`) выполнять автоматизацию UI через PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Браузер"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Вход через браузер"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Скопируйте cookie из профиля семейства Chrome в изолированный управляемый профиль."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Импорт…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Настройки..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Назад"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Вперёд"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Подтверждения выполнения"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Загрузка одобрений выполнения…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Повторить одобрения выполнения"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Использование"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource требует соответствующего systemRunPlan"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "явное одобрение требует соответствующего systemRunPlan"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Сопряжение узла одобрено"
@@ -11729,137 +12159,272 @@
       "translated": "Далее"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Запрос настройки Gateway не выполнен."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Запрос настройки Gateway не выполнен. Покажите подробности, чтобы просмотреть или скопировать ошибку."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) не удалось завершить тест."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) не удалось завершить тест. Покажите подробности, чтобы просмотреть или скопировать ошибку."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
-      "translated": "Ищем ИИ, которым вы уже пользуетесь…"
+      "translated": "Поиск ИИ, которым вы уже пользуетесь…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Ожидание завершения предыдущего теста ИИ…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Проверяем Claude Code, Codex, Gemini и сохраненные API-ключи."
+      "translated": "Проверка Claude Code, Codex, Gemini и сохранённых ключей API."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw проверит снова перед изменением любых настроек вывода."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Не удалось проверить этот Gateway на наличие AI-аккаунтов"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "Не удалось проверить этот Mac на наличие аккаунтов ИИ"
+      "translated": "Не удалось проверить этот Mac на наличие AI-аккаунтов"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "Не удалось загрузить полный список провайдеров"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
-      "translated": "Повторить попытку"
+      "translated": "Повторить"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Ни один из найденных вариантов не сработал"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "Подробности указаны для каждого варианта выше. Вы можете исправить вход и повторить попытку или подключиться с помощью ключа API или токена ниже."
+      "translated": "Подробности указаны для каждого варианта выше. Вы можете исправить вход и повторить попытку или подключиться с помощью API-ключа или токена ниже."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
-      "translated": "Нужна помощь? Напишите в чат Crestodian"
+      "translated": "Нужна помощь? Напишите Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
-      "translated": "Ваш ИИ готов"
+      "translated": "Ваш AI готов"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Параметры настройки"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Скопировать параметры настройки"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "На этом Mac не найдено аккаунтов ИИ"
+      "translated": "На этом Mac не найдено AI-аккаунтов"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Это нормально — вы можете подключиться с помощью ключа API или токена. Если вы используете Claude Code, Codex или Gemini CLI на этом Mac, сначала войдите там и нажмите «Проверить снова»."
+      "translated": "Это нормально — вы можете подключить его с помощью API-ключа или токена. Если вы используете Claude Code, Codex или Gemini CLI на этом Mac, сначала войдите там и нажмите «Проверить снова»."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Рекомендуется"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "Нет доступных провайдеров на основе ключей"
+      "translated": "Нет доступных провайдеров с ключом"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "translated": "Включите или установите плагин провайдера текстового вывода на этом Gateway, затем проверьте снова."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
-      "translated": "Проверить еще раз"
+      "translated": "Проверить снова"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "Подключиться с помощью ключа API или токена…"
+      "translated": "Подключиться с помощью API-ключа или токена…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Войти через провайдера"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Используйте существующую подписку или аккаунт провайдера. OpenClaw откроет собственный процесс входа провайдера, затем проверит его реальным ответом."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Больше вариантов входа"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Связать"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Войти"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Учётные данные остаются на этом Gateway и сохраняются только после успешной проверки в реальном времени."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Открыть страницу входа…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Запуск безопасного входа…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "Вход не завершён"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Отмена"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Завершите в браузере"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Копировать"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Истекает через \\(minutes) мин."
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Открыть страницу входа"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Вариант"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Подтвердить"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Я вошёл"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Продолжить"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Отправить"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
-      "translated": "Подключиться с помощью ключа API или токена"
+      "translated": "Подключиться с помощью API-ключа или токена"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Провайдер"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
-      "translated": "Ключ API или токен"
+      "translated": "API-ключ или токен"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
-      "translated": "Подключиться"
+      "translated": "Подключить"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Этот ключ не сработал"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — помощник настройки"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Готово"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Открыть справку…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Скрыть подробности"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Показать подробности"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Скопировать ошибку"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Повторить попытку"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Рабочая область агента"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw запускает агента из выделенной рабочей области, чтобы он мог загружать `AGENTS.md` и записывать туда файлы, не смешивая их с другими вашими проектами."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Обнаружен удаленный Gateway"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Создайте рабочую область на удаленном хосте (сначала подключитесь по SSH). Приложение macOS пока не может записывать файлы на ваш Gateway через SSH."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Скопировано"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Скопировать команду настройки"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Папка рабочего пространства"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Создать рабочее пространство"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Открыть папку"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Сохранить в конфигурации"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Совет: отредактируйте AGENTS.md в этой папке, чтобы настроить поведение ассистента. Для резервного копирования сделайте рабочее пространство приватным git-репозиторием, чтобы «память» вашего агента сохранялась в версиях."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Познакомьтесь с вашим агентом"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Ваш агент представится, вместе с вами выберет имя и поможет подключить WhatsApp, Telegram или другой канал — просто общайтесь в чате."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Всё готово!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Не сейчас"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Отклонить все"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Одобрить все"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Управляйте тем, как на этом Mac подтверждаются команды оболочки агента."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Загрузка настроек…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Чтение сохранённой политики."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Одобрения выполнения недоступны"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Не удалось прочитать настройки"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Повторить"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway подключён"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -3539,6 +3539,11 @@
       "translated": "Включить микрофон"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Обновить"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Файлы недоступны"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Ошибка чата"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Выкл."
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -3539,6 +3539,11 @@
       "translated": "Aktivera mikrofon"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Uppdatera"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Filer är inte tillgängliga"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Chattfel"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Av"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -24,6 +24,71 @@
       "translated": "Standard"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Godkännande tillåtet och sparat."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Godkännande tillåtet en gång."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Ett tidigare svar tillät redan detta kommando och sparade valet."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Ett tidigare svar tillät redan detta kommando en gång."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway registrerade godkännandet och sparade valet."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway registrerade godkännandet en gång."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Godkännande nekat."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Ett tidigare svar nekade redan detta godkännande."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway registrerade ett nekande."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Detta godkännande upphörde att gälla innan det kunde behandlas."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Detta godkännande avbröts innan det kunde behandlas."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Ett tidigare svar behandlade redan detta godkännande."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Kommandobegäran"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Klar"
@@ -94,6 +159,11 @@
       "translated": "Konfigurera ${issue.providerLabel} på Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "För många delningar väntar på att läggas till."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Mikrofon: Väntar"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Behandlingsresultat okänt. Åtgärder förblir inaktiverade tills Gateway-posten är verifierad."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway visar fortfarande detta godkännande som väntande. Granska det innan du försöker igen."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Kunde inte läsa in godkännandedetaljer. Uppdatera och försök igen."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Kunde inte läsa in godkännanden."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Kunde inte behandla godkännandet. Uppdatera och försök igen."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount leverantörer redo"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Leverantörstillgänglighet okänd"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Granska leverantörernas beredskap\noch konfigurerade modeller."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Anslutna leverantörer"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Leverantörer och konfigurerade modeller"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway offline"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Kräver uppmärksamhet"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Klar"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Modeller"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Behöver"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Okänd"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount konfigurerade modeller. Uppdatera för att kontrollera tillgänglighet igen."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Anslut din Gateway för att visa leverantörernas beredskap."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Uppdatera för att kontrollera leverantörernas beredskap från din Gateway igen."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Uppdaterar"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} modeller"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} konfigurerade modeller"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sessioner"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Omvänd sessionssortering"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Sök sessioner"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Nyast"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Nyaste först"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Äldst"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Äldsta först"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Öppna inställningar"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Dela information om installerade appar?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw samlar in och skickar namn, paket-ID:n och status för appar som är synliga på den här telefonen när din parkopplade OpenClaw Gateway begär det. Detta gör att din assistent kan svara på frågor och utföra åtgärder med installerade appar."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Din telefon skickar denna information till din Gateway, inte till en server som drivs av OpenClaw. Din Gateway kan inkludera den i förfrågningar till den AI-leverantör du valt."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Godkänn och aktivera"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Inte nu"
@@ -2599,39 +2709,24 @@
       "translated": "Tillbaka"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Kommandogodkännande"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Skickar"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Tillåt en gång"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Godkännande ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Tillåter"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Alltid"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Sparar"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Neka"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Nekar"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Avfärda godkännandemeddelande"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Sök i inställningar"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount redo"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Granska beredskap"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Ingen app kan dela det här meddelandet"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Hoppa till senaste"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Läser in session"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Inga meddelanden än"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Förbereder ljud…"
@@ -3649,6 +3719,11 @@
       "translated": "Du"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Försök igen"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Öppna bildförhandsvisning"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Stäng bildförhandsvisning"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw förbereder ett svar."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Avfärda varning om delad bild"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Stoppa"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway offline"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Stäng väljaren för tänkenivå"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Öppna väljaren för tänkenivå"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Gateway-förfrågningar visas här."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 väntar"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) väntar"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Hög"
@@ -6544,14 +6654,9 @@
       "translated": "Inga gateway-åtgärder väntar på granskning."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Granska den väntande gateway-åtgärden."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 väntar"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Granska väntande gateway-åtgärder."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Öppna Notiser"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Tillåt"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Väntande godkännanden"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Granska exec-godkännande"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Granskar"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Tillåt en gång"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "Tillåt alltid"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Neka"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Avfärda"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Tillåt alltid"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Avfärda"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Neka"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Offline"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Godkännande"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Detta godkännande var redan"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Godkännande inställt på Tillåt alltid."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Detta godkännande var redan inställt på Tillåt alltid."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Godkännande krävs"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Öppnar hela kommandot innan beslut är tillgängliga"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Laddar"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Laddar godkännande"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Otillgänglig"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Godkännande inte laddat"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Granska igen"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Kommando"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Kommando att granska"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Du"
@@ -9314,24 +9499,24 @@
       "translated": "Godkännande"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Skickar beslut..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Granska kommando"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Godkänn"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Kommandokörning"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Tillåt en gång"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Neka"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw på GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw kunde inte installeras i Program. Flytta det dit manuellt och öppna sedan den kopian."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Installera OpenClaw i Program?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Ersätt den äldre OpenClaw i Program?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw kopierar sig själv till Program och öppnas där igen så att uppdateringar och start vid inloggning förblir pålitliga."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Den här kopian är nyare än den installerade appen. OpenClaw ersätter den och öppnas igen från Program."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Installera och starta om"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Ersätt och starta om"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw är installerat i Program, men kunde inte öppnas igen automatiskt. Öppna det där manuellt."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Använd dina webbläsarinloggningar"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Kopiera cookies från \\(browsers) till en isolerad agentprofil. Lösenord berörs aldrig."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Importerar webbläsarcookies…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "Kopierar \\(profile.displayName) till ”\\(target)”. Touch ID kan krävas."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Webbläsarinloggningar importerade"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) av \\(result.cookies.total) cookies kopierades till ”\\(result.into)” — nu standardprofilen för agentwebbläsning."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Webbläsarimport misslyckades"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "din webbläsare"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Importera"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Försök igen"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Avfärda"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "Webbläsarimport kräver lokalt läge"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Växla den här Mac-appen till en lokal Gateway innan du importerar webbläsarcookies."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "Ingen Chrome-, Brave-, Edge- eller Chromium-profil med cookies hittades på den här Mac-datorn."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "Import av systemets webbläsarprofil är inaktiverad i den lokala Gateway-konfigurationen."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Ingen webbläsarinloggning tillgänglig"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Webbläsarimport otillgänglig"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "CLI-installation misslyckades"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "CLI-installation slutförd"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Stabil"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "ingen leverans"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Instrumentpanelen återansluter"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Den valda Gateway ändrades."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Väntar på en ny autentiserad anslutning."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Instrumentpanelen otillgänglig"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Kontrollera Inställningar → Anslutning eller använd Felsökning → Återställ fjärrtunnel och försök sedan igen."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Avsluta \\(listener.command) (\\(listener.pid))?"
@@ -10704,6 +11069,16 @@
       "translated": "Endast sökvägsmönster. Inkludera '/', '~' eller '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Den här tillåtelselistposten är ärvd. Redigera dess ägande omfång och försök igen."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Det gick inte att spara exec-godkännanden. De senast kända inställningarna visas; försök att ändra igen."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Starta OpenClaw automatiskt efter att du har loggat in."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Flytta OpenClaw till Program innan du aktiverar start vid inloggning."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Visa Dock-symbol"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Tillåt signerade verktyg (t.ex. `peekaboo`) att styra UI-automatisering via PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Webbläsare"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Webbläsarinloggning"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Kopiera cookies från en profil i Chrome-familjen till en isolerad hanterad profil."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Importera…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Inställningar..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Bakåt"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Framåt"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Exec-godkännanden"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Läser in exec-godkännanden…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Försök igen med exec-godkännanden"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Användning"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource kräver matchande systemRunPlan"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "uttryckligt godkännande kräver matchande systemRunPlan"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Nodparkoppling godkänd"
@@ -11729,137 +12159,272 @@
       "translated": "Nästa"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Gateway-konfigurationsbegäran misslyckades."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Gateway-konfigurationsbegäran misslyckades. Visa detaljer för att granska eller kopiera felet."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) kunde inte slutföra testet."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) kunde inte slutföra testet. Visa detaljer för att granska eller kopiera felet."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
-      "translated": "Söker efter AI som du redan använder…"
+      "translated": "Letar efter AI du redan använder…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Väntar på att det tidigare AI-testet ska slutföras…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Kontrollerar Claude Code, Codex, Gemini och sparade API-nycklar."
+      "translated": "Söker efter Claude Code, Codex, Gemini och sparade API-nycklar."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw kontrollerar igen innan några inferensinställningar ändras."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Kunde inte kontrollera denna Gateway för AI-konton"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "Kunde inte kontrollera den här Macen efter AI-konton"
+      "translated": "Kunde inte kontrollera denna Mac för AI-konton"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
-      "translated": "Det gick inte att läsa in hela leverantörslistan"
+      "translated": "Kunde inte läsa in hela leverantörslistan"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "Försök igen"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Inget av de hittade alternativen fungerade"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
       "translated": "Detaljerna listas för varje alternativ ovan. Du kan åtgärda inloggningen och försöka igen, eller ansluta med en API-nyckel eller token nedan."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "Behöver du hjälp? Chatta med Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "Din AI är redo"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Konfigurationsdetaljer"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Kopiera konfigurationsdetaljer"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "Inga AI-konton hittades på den här Macen"
+      "translated": "Inga AI-konton hittades på denna Mac"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Det gör inget – du kan ansluta en med en API-nyckel eller token. Om du använder Claude Code, Codex eller Gemini CLI på den här Macen loggar du in där först och trycker på ”Kontrollera igen”."
+      "translated": "Det är okej – du kan ansluta ett med en API-nyckel eller token. Om du använder Claude Code, Codex eller Gemini CLI på denna Mac, logga in där först och tryck på ”Kontrollera igen”."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Rekommenderas"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
       "translated": "Inga nyckelbaserade leverantörer är tillgängliga"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "Aktivera eller installera en plugin för textinferensleverantör på den här Gateway och kontrollera sedan igen."
+      "translated": "Aktivera eller installera ett plugin för textinferensleverantör på denna Gateway och kontrollera sedan igen."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Kontrollera igen"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
       "translated": "Anslut med en API-nyckel eller token istället…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Logga in med en leverantör"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Använd en befintlig prenumeration eller ett leverantörskonto. OpenClaw öppnar leverantörens egen inloggningsflöde och verifierar det sedan med ett riktigt svar."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Fler inloggningsalternativ"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Para"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Logga in"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Autentiseringsuppgifterna stannar på denna Gateway och sparas endast efter att livetestet har lyckats."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Öppna inloggningssidan…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Startar säker inloggning…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "Inloggningen slutfördes inte"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Avbryt"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Slutför i din webbläsare"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Kopiera"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Upphör om \\(minutes) minuter"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Öppna inloggningssidan"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Alternativ"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Bekräfta"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Jag har loggat in"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Fortsätt"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Skicka"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
       "translated": "Anslut med en API-nyckel eller token"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Leverantör"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "API-nyckel eller token"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Anslut"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Den nyckeln fungerade inte"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
-      "translated": "Crestodian — konfigurationshjälp"
+      "translated": "Crestodian — installationshjälp"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
-      "translated": "Klart"
+      "translated": "Klar"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Öppna hjälp…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Dölj detaljer"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Visa detaljer"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Kopiera fel"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Försök igen"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Agentarbetsyta"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw kör agenten från en dedikerad arbetsyta så att den kan läsa in `AGENTS.md` och skriva filer där utan att blandas med dina andra projekt."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Fjärr-Gateway upptäckt"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Skapa arbetsytan på fjärrvärden (logga in med SSH först). macOS-appen kan inte skriva filer på din Gateway via SSH ännu."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Kopierat"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Kopiera konfigurationskommando"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Arbetsytemapp"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Skapa arbetsyta"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Öppna mapp"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Spara i config"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Tips: redigera AGENTS.md i den här mappen för att styra assistentens beteende. För säkerhetskopiering kan du göra arbetsytan till ett privat git-repo så att din agents ”minne” versionshanteras."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Träffa din agent"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Din agent presenterar sig, väljer ett namn tillsammans med dig och hjälper dig att ansluta WhatsApp, Telegram eller en annan kanal — bara chatta."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Allt är klart!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Inte nu"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Avvisa alla"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Godkänn alla"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Styr hur agentens skalkommandon godkänns på denna Mac."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Läser in inställningar…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Läser den sparade policyn."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Exec-godkännanden är inte tillgängliga"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Inställningarna kunde inte läsas"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Försök igen"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway ansluten"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -24,6 +24,71 @@
       "translated": "ค่าเริ่มต้น"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "อนุมัติและบันทึกแล้ว"
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "อนุมัติหนึ่งครั้ง"
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "การตอบกลับก่อนหน้านี้อนุญาตคำสั่งนี้และบันทึกตัวเลือกไว้แล้ว"
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "การตอบกลับก่อนหน้านี้อนุญาตคำสั่งนี้หนึ่งครั้งแล้ว"
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway บันทึกการอนุมัติและบันทึกตัวเลือกไว้แล้ว"
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway บันทึกการอนุมัติหนึ่งครั้ง"
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "ปฏิเสธการอนุมัติแล้ว"
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "การตอบกลับก่อนหน้านี้ปฏิเสธการอนุมัตินี้แล้ว"
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway บันทึกการปฏิเสธ"
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "การอนุมัตินี้หมดอายุก่อนที่จะสามารถดำเนินการได้"
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "การอนุมัตินี้ถูกยกเลิกก่อนที่จะสามารถดำเนินการได้"
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "การตอบกลับก่อนหน้านี้ดำเนินการอนุมัตินี้แล้ว"
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "คำขอคำสั่ง"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "พร้อม"
@@ -94,6 +159,11 @@
       "translated": "กำหนดค่า ${issue.providerLabel} บน Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "มีการแชร์รอเพิ่มมากเกินไป"
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · ไมค์: รอดำเนินการ"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "ไม่ทราบผลการดำเนินการ การดำเนินการจะยังคงถูกปิดใช้งานจนกว่าจะยืนยันบันทึกของ Gateway"
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway ยังคงแสดงการอนุมัตินี้เป็นรอดำเนินการ กรุณาตรวจสอบก่อนลองอีกครั้ง"
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "ไม่สามารถโหลดรายละเอียดการอนุมัติได้ รีเฟรชแล้วลองอีกครั้ง"
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "ไม่สามารถโหลดการอนุมัติได้"
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "ไม่สามารถดำเนินการอนุมัติได้ รีเฟรชแล้วลองอีกครั้ง"
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "ผู้ให้บริการ $readyProviderCount รายพร้อมใช้งาน"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "ไม่ทราบความพร้อมใช้งานของผู้ให้บริการ"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "ตรวจสอบความพร้อมของผู้ให้บริการ\nและโมเดลที่กำหนดค่าไว้"
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "ผู้ให้บริการที่เชื่อมต่อแล้ว"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "ผู้ให้บริการและโมเดลที่กำหนดค่าไว้"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway ออฟไลน์"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "ต้องตรวจสอบ"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "พร้อมใช้งาน"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "โมเดล"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "ต้องการ"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "ไม่ทราบ"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount โมเดลที่กำหนดค่าไว้ รีเฟรชเพื่อตรวจสอบความพร้อมใช้งานอีกครั้ง"
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "เชื่อมต่อ Gateway ของคุณเพื่อดูความพร้อมของผู้ให้บริการ"
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "รีเฟรชเพื่อตรวจสอบความพร้อมของผู้ให้บริการจาก Gateway ของคุณอีกครั้ง"
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "กำลังรีเฟรช"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} โมเดล"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} โมเดลที่กำหนดค่าไว้"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "เซสชัน"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "กลับลำดับการเรียงเซสชัน"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "ค้นหาเซสชัน"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "ใหม่ที่สุด"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "ใหม่สุดก่อน"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "เก่าที่สุด"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "เก่าสุดก่อน"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "เปิดการตั้งค่า"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "แชร์ข้อมูลแอปที่ติดตั้งไว้หรือไม่?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw จะรวบรวมและส่งชื่อ, รหัสแพ็กเกจ และสถานะของแอปที่มองเห็นได้บนโทรศัพท์เครื่องนี้เมื่อ OpenClaw Gateway ที่จับคู่ไว้ร้องขอ ซึ่งช่วยให้ผู้ช่วยของคุณตอบคำถามและดำเนินการโดยใช้แอปที่ติดตั้งไว้"
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "โทรศัพท์ของคุณจะส่งข้อมูลนี้ไปยัง Gateway ของคุณ ไม่ใช่ไปยังเซิร์ฟเวอร์ที่ดำเนินการโดย OpenClaw Gateway ของคุณอาจรวมข้อมูลนี้ในคำขอไปยังผู้ให้บริการ AI ที่คุณเลือก"
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "ยอมรับและเปิดใช้งาน"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "ไม่ใช่ตอนนี้"
@@ -2599,39 +2709,24 @@
       "translated": "ย้อนกลับ"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "การอนุมัติคำสั่ง"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "กำลังส่ง"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "อนุญาตครั้งเดียว"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "การอนุมัติ ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "กำลังอนุญาต"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "เสมอ"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "กำลังบันทึก"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "ปฏิเสธ"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "กำลังปฏิเสธ"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "ปิดการแจ้งเตือนการอนุมัติ"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "ค้นหาการตั้งค่า"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount พร้อม"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "ตรวจสอบความพร้อม"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "ไม่มีแอปที่สามารถแชร์ข้อความนี้ได้"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "ข้ามไปยังล่าสุด"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "กำลังโหลดเซสชัน"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "ยังไม่มีข้อความ"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "กำลังเตรียมเสียง…"
@@ -3649,6 +3719,11 @@
       "translated": "คุณ"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "ลองอีกครั้ง"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "เปิดตัวอย่างรูปภาพ"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "ปิดตัวอย่างรูปภาพ"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw กำลังเตรียมคำตอบ"
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "ปิดคำเตือนรูปภาพที่แชร์"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "หยุด"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway ออฟไลน์"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "ปิดตัวเลือกระดับการคิด"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "เปิดตัวเลือกระดับการคิด"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "คำขอจาก Gateway จะปรากฏที่นี่"
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "รออยู่ 1 รายการ"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) รอดำเนินการ"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "สูง"
@@ -6544,14 +6654,9 @@
       "translated": "ไม่มีการดำเนินการของ Gateway ที่รอการตรวจสอบ"
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "ตรวจสอบการดำเนินการของ Gateway ที่รอดำเนินการ"
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "รอ 1 รายการ"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "ตรวจสอบการดำเนินการ Gateway ที่รอดำเนินการ"
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "เปิดการแจ้งเตือน"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "อนุญาต"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "การอนุมัติที่รอดำเนินการ"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "ตรวจสอบการอนุมัติ exec"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "กำลังตรวจสอบ"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "อนุญาตครั้งเดียว"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "อนุญาตเสมอ"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "ปฏิเสธ"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "ปิด"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "อนุญาตเสมอ"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "ปิด"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "ปฏิเสธ"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "ออฟไลน์"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "การอนุมัติ"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "การอนุมัตินี้ถูกดำเนินการแล้ว"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "ตั้งค่าการอนุมัติเป็นอนุญาตเสมอ"
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "การอนุมัตินี้ถูกตั้งค่าเป็นอนุญาตเสมอแล้ว"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "ต้องการการอนุมัติ"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "เปิดคำสั่งเต็มก่อนที่จะมีการตัดสินใจ"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "กำลังโหลด"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "กำลังโหลดการอนุมัติ"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "ไม่พร้อมใช้งาน"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "ไม่ได้โหลดการอนุมัติ"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "ตรวจสอบอีกครั้ง"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "คำสั่ง"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "คำสั่งที่จะตรวจสอบ"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "คุณ"
@@ -9314,24 +9499,24 @@
       "translated": "การอนุมัติ"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "กำลังส่งการตัดสินใจ..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "ตรวจสอบคำสั่ง"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "อนุมัติ"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "การเรียกใช้คำสั่ง"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "อนุญาตครั้งเดียว"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "ปฏิเสธ"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw บน GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "ไม่สามารถติดตั้ง OpenClaw ใน Applications ได้ ย้ายไปที่นั่นด้วยตนเอง แล้วเปิดสำเนานั้น"
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "ติดตั้ง OpenClaw ใน Applications หรือไม่?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "แทนที่ OpenClaw เวอร์ชันเก่าใน Applications หรือไม่?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw จะคัดลอกตัวเองไปยัง Applications และเปิดใหม่ที่นั่น เพื่อให้การอัปเดตและการเปิดตอนเข้าสู่ระบบทำงานได้อย่างเสถียร"
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "สำเนานี้ใหม่กว่าแอปที่ติดตั้งไว้ OpenClaw จะแทนที่และเปิดใหม่จาก Applications"
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "ติดตั้งและเปิดใหม่"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "แทนที่และเปิดใหม่"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw ถูกติดตั้งใน Applications แล้ว แต่ไม่สามารถเปิดใหม่โดยอัตโนมัติได้ เปิดที่นั่นด้วยตนเอง"
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "ใช้การเข้าสู่ระบบเบราว์เซอร์ของคุณ"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "คัดลอกคุกกี้จาก \\(browsers) ไปยังโปรไฟล์เอเจนต์ที่แยกออกมา รหัสผ่านจะไม่ถูกแตะต้อง"
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "กำลังนำเข้าคุกกี้เบราว์เซอร์…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "กำลังคัดลอก \\(profile.displayName) ไปยัง “\\(target)” อาจต้องใช้ Touch ID"
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "นำเข้าการเข้าสู่ระบบเบราว์เซอร์แล้ว"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "คัดลอกคุกกี้ \\(result.cookies.imported) จาก \\(result.cookies.total) รายการไปยัง “\\(result.into)” แล้ว — ตอนนี้เป็นโปรไฟล์เริ่มต้นสำหรับการเรียกดูของเอเจนต์"
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "การนำเข้าเบราว์เซอร์ล้มเหลว"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "เบราว์เซอร์ของคุณ"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "นำเข้า"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "ลองใหม่"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "ปิด"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "การนำเข้าจากเบราว์เซอร์ต้องใช้โหมด Local"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "เปลี่ยนแอป Mac นี้เป็น Gateway ในเครื่องก่อนนำเข้าคุกกี้ของเบราว์เซอร์"
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "ไม่พบโปรไฟล์ Chrome, Brave, Edge หรือ Chromium ที่มีคุกกี้บน Mac นี้"
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "การนำเข้าโปรไฟล์เบราว์เซอร์ของระบบถูกปิดใช้งานในการกำหนดค่า Gateway ในเครื่อง"
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "ไม่มีการเข้าสู่ระบบผ่านเบราว์เซอร์"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "ไม่สามารถนำเข้าจากเบราว์เซอร์ได้"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "การติดตั้ง CLI ล้มเหลว"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "การติดตั้ง CLI เสร็จสิ้น"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "เสถียร"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "เบต้า"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "ไม่มีการส่ง"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "กำลังเชื่อมต่อแดชบอร์ดใหม่"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Gateway ที่เลือกมีการเปลี่ยนแปลง"
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "กำลังรอการเชื่อมต่อที่ยืนยันตัวตนใหม่"
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "แดชบอร์ดไม่พร้อมใช้งาน"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "ตรวจสอบที่ Settings → Connection หรือใช้ Debug → Reset Remote Tunnel แล้วลองอีกครั้ง"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "หยุด \\(listener.command) (\\(listener.pid))?"
@@ -10704,6 +11069,16 @@
       "translated": "เฉพาะรูปแบบพาธเท่านั้น ต้องมี '/', '~' หรือ '\\\\'"
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "รายการอนุญาตนี้ได้รับการสืบทอดมา แก้ไขขอบเขตที่เป็นเจ้าของแล้วลองอีกครั้ง"
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "ไม่สามารถบันทึกการอนุมัติ exec ได้ กำลังแสดงการตั้งค่าที่ทราบล่าสุด โปรดลองเปลี่ยนแปลงอีกครั้ง"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "เริ่ม OpenClaw โดยอัตโนมัติหลังจากคุณลงชื่อเข้าใช้"
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "ย้าย OpenClaw ไปยัง Applications ก่อนเปิดใช้งานการเริ่มทำงานเมื่อเข้าสู่ระบบ"
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "แสดงไอคอน Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "อนุญาตให้เครื่องมือที่ลงนามแล้ว (เช่น `peekaboo`) ขับเคลื่อนการทำงานอัตโนมัติของ UI ผ่าน PeekabooBridge"
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "เบราว์เซอร์"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "เข้าสู่ระบบด้วยเบราว์เซอร์"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "คัดลอกคุกกี้จากโปรไฟล์ตระกูล Chrome ไปยังโปรไฟล์ที่จัดการแบบแยกต่างหาก"
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "นำเข้า…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "การตั้งค่า..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "ย้อนกลับ"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "ไปข้างหน้า"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "การอนุมัติ Exec"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "กำลังโหลดการอนุมัติ Exec…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "ลองการอนุมัติ Exec อีกครั้ง"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "การใช้งาน"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource ต้องมี systemRunPlan ที่ตรงกัน"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "การอนุมัติแบบชัดแจ้งต้องมี systemRunPlan ที่ตรงกัน"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "อนุมัติการจับคู่โหนดแล้ว"
@@ -11729,137 +12159,272 @@
       "translated": "ถัดไป"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "คำขอตั้งค่า Gateway ล้มเหลว"
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "คำขอตั้งค่า Gateway ล้มเหลว แสดงรายละเอียดเพื่อตรวจสอบหรือคัดลอกข้อผิดพลาด"
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) ไม่สามารถทำการทดสอบให้เสร็จสมบูรณ์ได้"
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) ไม่สามารถทำการทดสอบให้เสร็จสมบูรณ์ได้ แสดงรายละเอียดเพื่อตรวจสอบหรือคัดลอกข้อผิดพลาด"
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
       "translated": "กำลังค้นหา AI ที่คุณใช้อยู่แล้ว…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "กำลังรอให้การทดสอบ AI ก่อนหน้านี้เสร็จสิ้น…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "translated": "กำลังตรวจสอบ Claude Code, Codex, Gemini และคีย์ API ที่บันทึกไว้"
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
-      "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "ไม่สามารถตรวจสอบบัญชี AI บน Mac เครื่องนี้ได้"
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw จะตรวจสอบอีกครั้งก่อนเปลี่ยนการตั้งค่าการอนุมานใดๆ"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "ไม่สามารถตรวจสอบบัญชี AI บน Gateway นี้ได้"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
+      "source": "Couldn’t check this Mac for AI accounts",
+      "translated": "ไม่สามารถตรวจสอบบัญชี AI บน Mac นี้ได้"
+    },
+    {
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "ไม่สามารถโหลดรายชื่อผู้ให้บริการทั้งหมดได้"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "ลองอีกครั้ง"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
-      "translated": "ตัวเลือกที่พบไม่มีตัวเลือกใดใช้งานได้"
+      "translated": "ไม่มีตัวเลือกที่พบตัวใดใช้งานได้"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "รายละเอียดแสดงอยู่ในแต่ละตัวเลือกด้านบน คุณสามารถแก้ไขการเข้าสู่ระบบแล้วลองใหม่ หรือเชื่อมต่อด้วย API key หรือ token ด้านล่างได้"
+      "translated": "รายละเอียดแสดงอยู่ในแต่ละตัวเลือกด้านบน คุณสามารถแก้ไขการเข้าสู่ระบบและลองใหม่ หรือเชื่อมต่อด้วย API key หรือโทเค็นด้านล่าง"
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "ต้องการความช่วยเหลือ? แชทกับ Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "AI ของคุณพร้อมแล้ว"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "รายละเอียดการตั้งค่า"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "คัดลอกรายละเอียดการตั้งค่า"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "ไม่พบบัญชี AI บน Mac เครื่องนี้"
+      "translated": "ไม่พบบัญชี AI บน Mac นี้"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "ไม่เป็นไร — คุณสามารถเชื่อมต่อด้วย API key หรือ token ได้ หากคุณใช้ Claude Code, Codex หรือ Gemini CLI บน Mac เครื่องนี้ ให้เข้าสู่ระบบที่นั่นก่อนแล้วกด “ตรวจสอบอีกครั้ง”"
+      "translated": "ไม่เป็นไร — คุณสามารถเชื่อมต่อได้ด้วย API key หรือโทเค็น หากคุณใช้ Claude Code, Codex หรือ Gemini CLI บน Mac นี้ ให้เข้าสู่ระบบที่นั่นก่อนแล้วกด “ตรวจสอบอีกครั้ง”"
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "แนะนำ"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "ไม่มีผู้ให้บริการแบบใช้คีย์ให้ใช้งาน"
+      "translated": "ไม่มีผู้ให้บริการแบบใช้ key ที่พร้อมใช้งาน"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "เปิดใช้งานหรือติดตั้งปลั๊กอินผู้ให้บริการการอนุมานข้อความบน Gateway นี้ แล้วตรวจสอบอีกครั้ง"
+      "translated": "เปิดใช้งานหรือติดตั้งปลั๊กอินผู้ให้บริการ text-inference บน Gateway นี้ แล้วตรวจสอบอีกครั้ง"
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "ตรวจสอบอีกครั้ง"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "เชื่อมต่อด้วย API key หรือ token แทน…"
+      "translated": "เชื่อมต่อด้วย API key หรือโทเค็นแทน…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "ลงชื่อเข้าใช้ด้วยผู้ให้บริการ"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "ใช้การสมัครสมาชิกหรือบัญชีผู้ให้บริการที่มีอยู่ OpenClaw จะเปิดขั้นตอนการลงชื่อเข้าใช้ของผู้ให้บริการเอง จากนั้นยืนยันด้วยการตอบกลับจริง"
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "ตัวเลือกการลงชื่อเข้าใช้เพิ่มเติม"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "จับคู่"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "ลงชื่อเข้าใช้"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "ข้อมูลรับรองจะอยู่บน Gateway นี้และจะถูกบันทึกก็ต่อเมื่อการทดสอบแบบสดสำเร็จเท่านั้น"
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "เปิดหน้าลงชื่อเข้าใช้…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "กำลังเริ่มการลงชื่อเข้าใช้แบบปลอดภัย…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "การลงชื่อเข้าใช้ยังไม่เสร็จสมบูรณ์"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "ยกเลิก"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "ดำเนินการให้เสร็จในเบราว์เซอร์ของคุณ"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "คัดลอก"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "หมดอายุใน \\(minutes) นาที"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "เปิดหน้าลงชื่อเข้าใช้"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "ตัวเลือก"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "ยืนยัน"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "ฉันลงชื่อเข้าใช้แล้ว"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "ดำเนินการต่อ"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "ส่ง"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
       "translated": "เชื่อมต่อด้วย API key หรือ token"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "ผู้ให้บริการ"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "API key หรือ token"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "เชื่อมต่อ"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
-      "translated": "คีย์นั้นใช้ไม่ได้"
+      "translated": "key นั้นใช้งานไม่ได้"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — ตัวช่วยตั้งค่า"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "เสร็จสิ้น"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
-      "translated": "เปิดวิธีใช้…"
+      "translated": "เปิดความช่วยเหลือ…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "ซ่อนรายละเอียด"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "แสดงรายละเอียด"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "คัดลอกข้อผิดพลาด"
     },
@@ -12209,71 +12774,6 @@
       "translated": "ลองอีกครั้ง"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "พื้นที่ทำงานของเอเจนต์"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw เรียกใช้เอเจนต์จากพื้นที่ทำงานเฉพาะ เพื่อให้สามารถโหลด `AGENTS.md` และเขียนไฟล์ที่นั่นได้โดยไม่ปะปนกับโปรเจกต์อื่นของคุณ"
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "ตรวจพบ Gateway ระยะไกล"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "สร้างพื้นที่ทำงานบนโฮสต์ระยะไกล (SSH เข้าไปก่อน) แอป macOS ยังไม่สามารถเขียนไฟล์บน Gateway ของคุณผ่าน SSH ได้"
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "คัดลอกแล้ว"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "คัดลอกคำสั่งตั้งค่า"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "โฟลเดอร์เวิร์กสเปซ"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "สร้างเวิร์กสเปซ"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "เปิดโฟลเดอร์"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "บันทึกในการกำหนดค่า"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "เคล็ดลับ: แก้ไข AGENTS.md ในโฟลเดอร์นี้เพื่อกำหนดพฤติกรรมของผู้ช่วย สำหรับการสำรองข้อมูล ให้ทำเวิร์กสเปซเป็น git repo ส่วนตัวเพื่อให้ “ความทรงจำ” ของเอเจนต์มีการจัดการเวอร์ชัน"
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "พบกับเอเจนต์ของคุณ"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "ตัวแทนของคุณจะแนะนำตัว เลือกชื่อร่วมกับคุณ และช่วยคุณเชื่อมต่อ WhatsApp, Telegram หรือช่องทางอื่น — แค่แชท"
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "ตั้งค่าเสร็จเรียบร้อยแล้ว!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "ไม่ใช่ตอนนี้"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "ปฏิเสธทั้งหมด"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "อนุมัติทั้งหมด"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "ควบคุมวิธีอนุมัติคำสั่งเชลล์ของเอเจนต์บน Mac เครื่องนี้"
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "กำลังโหลดการตั้งค่า…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "กำลังอ่านนโยบายที่บันทึกไว้"
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "การอนุมัติ Exec ไม่พร้อมใช้งาน"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "ไม่สามารถอ่านการตั้งค่าได้"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "ลองใหม่"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "เชื่อมต่อ Gateway แล้ว"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -3539,6 +3539,11 @@
       "translated": "เปิดใช้งานไมโครโฟน"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "รีเฟรช"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "ไฟล์ไม่พร้อมใช้งาน"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "ข้อผิดพลาดของแชท"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "ปิด"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -3539,6 +3539,11 @@
       "translated": "Mikrofonu Etkinleştir"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Yenile"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Dosyalar kullanılamıyor"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Sohbet hatası"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Kapalı"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -24,6 +24,71 @@
       "translated": "Varsayılan"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Onay verildi ve kaydedildi."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Onay bir kez verildi."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Önceki bir yanıt bu komuta zaten izin verdi ve seçimi kaydetti."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Önceki bir yanıt bu komuta zaten bir kez izin verdi."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway onayı kaydetti ve seçimi sakladı."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway onayı bir kez kaydetti."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Onay reddedildi."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Önceki bir yanıt bu onayı zaten reddetti."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway bir ret kaydetti."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Bu onay çözülemeden önce süresi doldu."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Bu onay çözülemeden önce iptal edildi."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Önceki bir yanıt bu onayı zaten çözdü."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Komut isteği"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Hazır"
@@ -94,6 +159,11 @@
       "translated": "Gateway üzerinde ${issue.providerLabel} yapılandırın"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Eklenmeyi bekleyen çok fazla paylaşım var."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Mikrofon: Beklemede"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Çözüm sonucu bilinmiyor. Gateway kaydı doğrulanana kadar işlemler devre dışı kalır."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway bu onayı hâlâ beklemede olarak gösteriyor. Tekrar denemeden önce inceleyin."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Onay ayrıntıları yüklenemedi. Yenileyip tekrar deneyin."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Onaylar yüklenemedi."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Onay çözülemedi. Yenileyip tekrar deneyin."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount sağlayıcı hazır"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Sağlayıcı erişilebilirliği bilinmiyor"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Sağlayıcı hazırlığını\nve yapılandırılmış modelleri inceleyin."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Bağlı sağlayıcılar"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Sağlayıcılar ve yapılandırılmış modeller"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway çevrimdışı"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Dikkat gerekiyor"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Hazır"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Modeller"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Gerekenler"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Bilinmiyor"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount yapılandırılmış model. Kullanılabilirliği yeniden kontrol etmek için yenileyin."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Sağlayıcı hazırlığını görüntülemek için Gateway’inizi bağlayın."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Gateway’inizden sağlayıcı hazırlığını yeniden kontrol etmek için yenileyin."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Yenileniyor"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} model"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} yapılandırılmış model"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Oturumlar"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Oturum sıralamasını tersine çevir"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Oturumlarda ara"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "En yeni"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Önce en yeni"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "En eski"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Önce en eski"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Ayarları Aç"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Yüklü uygulama bilgileri paylaşılsın mı?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw, eşleştirilmiş OpenClaw Gateway'iniz istediğinde bu telefonda görünen uygulamaların adlarını, paket kimliklerini ve durumunu toplar ve gönderir. Bu, asistanınızın yüklü uygulamaları kullanarak soruları yanıtlamasını ve işlemler yapmasını sağlar."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Telefonunuz bu bilgileri OpenClaw tarafından çalıştırılan bir sunucuya değil, Gateway'inize gönderir. Gateway'iniz bunu, seçtiğiniz AI sağlayıcısına yaptığı isteklere dahil edebilir."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Kabul Et ve Etkinleştir"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Şimdi Değil"
@@ -2599,39 +2709,24 @@
       "translated": "Geri"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Komut onayı"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Gönderiliyor"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Bir Kez İzin Ver"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Onay ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "İzin veriliyor"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Her Zaman"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Kaydediliyor"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Reddet"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Reddediliyor"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Onay bildirimini kapat"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Ayarlarda ara"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount hazır"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Hazırlığı gözden geçir"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Hiçbir uygulama bu mesajı paylaşamaz"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "En yeniye atla"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Oturum yükleniyor"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Henüz mesaj yok"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Ses hazırlanıyor…"
@@ -3649,6 +3719,11 @@
       "translated": "Siz"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Yeniden dene"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Görüntü önizlemesini aç"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Görüntü önizlemesini kapat"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw bir yanıt hazırlıyor."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Paylaşılan görüntü uyarısını kapat"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Durdur"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway çevrimdışı"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Düşünme düzeyi seçicisini kapat"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Düşünme düzeyi seçicisini aç"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Gateway istekleri burada görünecek."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 bekliyor"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) bekliyor"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Yüksek"
@@ -6544,14 +6654,9 @@
       "translated": "İnceleme bekleyen Gateway işlemi yok."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Bekleyen Gateway işlemini inceleyin."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 bekliyor"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Bekleyen gateway işlemlerini inceleyin."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Bildirimleri Aç"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "İzin Ver"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Bekleyen onaylar"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Exec onayını inceleyin"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "İnceleniyor"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Bir Kez İzin Ver"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "Her Zaman İzin Ver"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Reddet"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Kapat"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Her Zaman İzin Ver"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Kapat"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Reddet"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Çevrimdışı"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Onay"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Bu onay zaten"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Onay Her Zaman İzin Ver olarak ayarlandı."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Bu onay zaten Her Zaman İzin Ver olarak ayarlanmıştı."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Onay gerekiyor"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Kararlar mevcut olmadan önce tam komutu açar"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Yükleniyor"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Onay yükleniyor"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Kullanılamıyor"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Onay yüklenmedi"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Tekrar gözden geçir"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Komut"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "İncelenecek komut"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Siz"
@@ -9314,24 +9499,24 @@
       "translated": "Onay"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Karar gönderiliyor..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Komutu İncele"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Onayla"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Komut yürütme"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Bir Kez İzin Ver"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Reddet"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "GitHub'da OpenClaw"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw, Applications klasörüne yüklenemedi. Dosyayı manuel olarak oraya taşıyın, ardından o kopyayı açın."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw, Applications klasörüne yüklensin mi?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Applications içindeki eski OpenClaw değiştirilsin mi?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw kendini Applications klasörüne kopyalayacak ve orada yeniden açılacak, böylece güncellemeler ve oturum açıldığında başlatma güvenilir kalır."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Bu kopya yüklü uygulamadan daha yeni. OpenClaw onu değiştirecek ve Applications klasöründen yeniden açılacak."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Yükle ve Yeniden Başlat"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Değiştir ve Yeniden Başlat"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw, Applications klasörüne yüklendi ancak otomatik olarak yeniden açılamadı. Uygulamayı orada manuel olarak açın."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Tarayıcı oturumlarınızı kullanın"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "\\(browsers) tarayıcısındaki çerezleri izole bir agent profiline kopyalayın. Parolalara asla dokunulmaz."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Tarayıcı çerezleri içe aktarılıyor…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "\\(profile.displayName) “\\(target)” içine kopyalanıyor. Touch ID gerekebilir."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Tarayıcı oturumları içe aktarıldı"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.total) çerezden \\(result.cookies.imported) tanesi “\\(result.into)” içine kopyalandı — artık agent tarama için varsayılan profil."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Tarayıcı içe aktarma başarısız oldu"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "tarayıcınız"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "İçe Aktar"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Yeniden Dene"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Kapat"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "Tarayıcı içe aktarma için Local mod gerekir"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Tarayıcı çerezlerini içe aktarmadan önce bu Mac uygulamasını yerel bir Gateway'e geçirin."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "Bu Mac'te çerezleri olan Chrome, Brave, Edge veya Chromium profili bulunamadı."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "Sistem tarayıcısı profili içe aktarma yerel Gateway yapılandırmasında devre dışı."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Tarayıcı girişi mevcut değil"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Tarayıcı içe aktarma kullanılamıyor"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "CLI kurulumu başarısız oldu"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "CLI kurulumu tamamlandı"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Kararlı"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "teslimat yok"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Kontrol paneli yeniden bağlanıyor"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Seçili Gateway değişti."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Yeni bir kimliği doğrulanmış bağlantı bekleniyor."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Kontrol paneli kullanılamıyor"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Ayarlar → Bağlantı'yı kontrol edin veya Debug → Reset Remote Tunnel kullanın, ardından tekrar deneyin."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) sonlandırılsın mı?"
@@ -10704,6 +11069,16 @@
       "translated": "Yalnızca yol desenleri. '/', '~' veya '\\\\' içermelidir."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Bu izin listesi girişi devralınmıştır. Sahip olduğu kapsamı düzenleyip tekrar deneyin."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Exec onayları kaydedilemedi. Bilinen son ayarlar gösteriliyor; değişikliği tekrar deneyin."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Oturum açtıktan sonra OpenClaw'ı otomatik olarak başlat."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Girişte başlatmayı etkinleştirmeden önce OpenClaw'u Applications klasörüne taşıyın."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Dock simgesini göster"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "İmzalı araçların (örn. `peekaboo`) PeekabooBridge üzerinden UI otomasyonunu yönlendirmesine izin ver."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Tarayıcı"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Tarayıcı girişi"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Bir Chrome ailesi profilinden çerezleri izole edilmiş, yönetilen bir profile kopyalayın."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "İçe Aktar…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Ayarlar..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Geri"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "İleri"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Exec Onayları"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Exec Onayları yükleniyor…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Exec Onaylarını Yeniden Dene"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Kullanım"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource, eşleşen bir systemRunPlan gerektirir"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "açık onay, eşleşen bir systemRunPlan gerektirir"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Düğüm eşleştirmesi onaylandı"
@@ -11729,137 +12159,272 @@
       "translated": "İleri"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Gateway kurulum isteği başarısız oldu."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Gateway kurulum isteği başarısız oldu. Hatayı incelemek veya kopyalamak için ayrıntıları gösterin."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) testi tamamlayamadı."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) testi tamamlayamadı. Hatayı incelemek veya kopyalamak için ayrıntıları gösterin."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
       "translated": "Zaten kullandığınız AI aranıyor…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Önceki AI testinin bitmesi bekleniyor…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Claude Code, Codex, Gemini ve kayıtlı API anahtarları kontrol ediliyor."
+      "translated": "Claude Code, Codex, Gemini ve kayıtlı API anahtarları denetleniyor."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw, herhangi bir çıkarım ayarını değiştirmeden önce tekrar denetleyecek."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Bu Gateway'de AI hesapları kontrol edilemedi"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "Bu Mac’teki AI hesapları kontrol edilemedi"
+      "translated": "Bu Mac'te AI hesapları kontrol edilemedi"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "Tam sağlayıcı listesi yüklenemedi"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
-      "translated": "Tekrar deneyin"
+      "translated": "Tekrar dene"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
-      "translated": "Bulunan seçeneklerin hiçbiri çalışmadı"
+      "translated": "Bulunan seçeneklerin hiçbiri işe yaramadı"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "Ayrıntılar yukarıdaki her seçenekte listelenmiştir. Girişi düzeltip yeniden deneyebilir veya aşağıdan bir API anahtarı ya da belirteç ile bağlanabilirsiniz."
+      "translated": "Ayrıntılar yukarıdaki her seçenekte listeleniyor. Girişi düzeltip yeniden deneyebilir veya aşağıda bir API anahtarı ya da token ile bağlanabilirsiniz."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
-      "translated": "Yardıma mı ihtiyacınız var? Crestodian ile sohbet edin"
+      "translated": "Yardım mı lazım? Crestodian ile sohbet edin"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
-      "translated": "AI’nız hazır"
+      "translated": "AI'nız hazır"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Kurulum ayrıntıları"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Kurulum ayrıntılarını kopyala"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "Bu Mac’te AI hesabı bulunamadı"
+      "translated": "Bu Mac'te AI hesabı bulunamadı"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Sorun değil — bir API anahtarı veya belirteç ile bağlanabilirsiniz. Bu Mac'te Claude Code, Codex veya Gemini CLI kullanıyorsanız önce oraya giriş yapın ve “Tekrar kontrol et”e basın."
+      "translated": "Sorun değil — bir API anahtarı veya token ile bağlanabilirsiniz. Bu Mac'te Claude Code, Codex veya Gemini CLI kullanıyorsanız, önce oradan oturum açın ve “Tekrar kontrol et”e basın."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Önerilen"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
       "translated": "Anahtar tabanlı sağlayıcı yok"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "translated": "Bu Gateway'de bir metin çıkarım sağlayıcısı eklentisini etkinleştirin veya yükleyin, ardından tekrar kontrol edin."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Tekrar kontrol et"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "Bunun yerine bir API anahtarı veya belirteç ile bağlan…"
+      "translated": "Bunun yerine bir API anahtarı veya token ile bağlan…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Bir sağlayıcıyla oturum aç"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Mevcut bir abonelik veya sağlayıcı hesabı kullanın. OpenClaw, sağlayıcının kendi oturum açma akışını açar, ardından gerçek bir yanıtla doğrular."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Daha fazla oturum açma seçeneği"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Eşleştir"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Oturum aç"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Kimlik bilgileri bu Gateway'de kalır ve yalnızca canlı test başarılı olduktan sonra kaydedilir."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Oturum açma sayfasını aç…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Güvenli oturum açma başlatılıyor…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "Oturum açma tamamlanmadı"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "İptal"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Tarayıcınızda tamamlayın"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Kopyala"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "\\(minutes) dakika içinde sona erer"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Oturum açma sayfasını aç"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Seçenek"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Onayla"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Oturum açtım"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Devam et"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Gönder"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
-      "translated": "Bir API anahtarı veya belirteç ile bağlan"
+      "translated": "API anahtarı veya belirteci ile bağlan"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Sağlayıcı"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
-      "translated": "API anahtarı veya belirteç"
+      "translated": "API anahtarı veya belirteci"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Bağlan"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Bu anahtar işe yaramadı"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — kurulum yardımcısı"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Bitti"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Yardımı aç…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Ayrıntıları gizle"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Ayrıntıları göster"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Hatayı kopyala"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Tekrar deneyin"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Ajan çalışma alanı"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw, `AGENTS.md` dosyasını yükleyebilmesi ve diğer projelerinize karışmadan oraya dosya yazabilmesi için ajanı özel bir çalışma alanından çalıştırır."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Uzak Gateway algılandı"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Çalışma alanını uzak ana makinede oluşturun (önce SSH ile bağlanın). macOS uygulaması henüz Gateway’inize SSH üzerinden dosya yazamaz."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Kopyalandı"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Kurulum komutunu kopyala"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Çalışma alanı klasörü"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Çalışma alanı oluştur"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Klasör aç"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Config’e kaydet"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "İpucu: asistanın davranışını şekillendirmek için bu klasördeki AGENTS.md dosyasını düzenleyin. Yedekleme için çalışma alanını özel bir git deposu yapın; böylece aracınızın “belleği” sürümlendirilir."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Aracınızla tanışın"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Aracınız kendini tanıtır, sizinle birlikte bir ad seçer ve WhatsApp, Telegram veya başka bir kanalı bağlamanıza yardımcı olur — yalnızca sohbet edin."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Her şey hazır!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Şimdi Değil"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Tümünü Reddet"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Tümünü Onayla"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Bu Mac'te ajan kabuk komutlarının nasıl onaylanacağını kontrol edin."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Ayarlar yükleniyor…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Kalıcı politika okunuyor."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Exec Onayları Kullanılamıyor"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Ayarlar okunamadı"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Yeniden Dene"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway bağlandı"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -24,6 +24,71 @@
       "translated": "За замовчуванням"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Схвалення дозволено та збережено."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Схвалення дозволено один раз."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Попередня відповідь уже дозволила цю команду та зберегла вибір."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Попередня відповідь уже дозволила цю команду один раз."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway зафіксував схвалення та зберіг вибір."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway зафіксував схвалення один раз."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Схвалення відхилено."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Попередня відповідь уже відхилила це схвалення."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway зафіксував відхилення."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Термін дії цього схвалення закінчився до його вирішення."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Це схвалення було скасовано до його вирішення."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Попередня відповідь уже вирішила це схвалення."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Запит команди"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Готово"
@@ -94,6 +159,11 @@
       "translated": "Налаштуйте ${issue.providerLabel} на Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Забагато спільних ресурсів очікують на додавання."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Мікрофон: очікує"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Результат вирішення невідомий. Дії залишаються вимкненими, доки запис Gateway не буде перевірено."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway досі показує це схвалення як в очікуванні. Перегляньте його, перш ніж спробувати знову."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Не вдалося завантажити деталі схвалення. Оновіть і спробуйте знову."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Не вдалося завантажити схвалення."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Не вдалося вирішити схвалення. Оновіть і спробуйте знову."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount провайдерів готові"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Доступність постачальника невідома"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Перегляньте готовність постачальників\nі налаштовані моделі."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Підключені постачальники"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Провайдери та налаштовані моделі"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway офлайн"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Потребує уваги"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Готово"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Моделі"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Потрібно"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Невідомо"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount налаштованих моделей. Оновіть, щоб повторно перевірити доступність."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Підключіть ваш Gateway, щоб переглянути готовність постачальників."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Оновіть, щоб повторно перевірити готовність постачальників із вашого Gateway."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Оновлення"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} моделей"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} налаштованих моделей"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Сеанси"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Змінити порядок сортування сеансів на зворотний"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Пошук сеансів"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Найновіші"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Спочатку найновіші"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Найстаріші"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Спочатку найстаріші"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Відкрити налаштування"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Поділитися інформацією про встановлені застосунки?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw збирає та надсилає назви, ідентифікатори пакетів і статус застосунків, видимих на цьому телефоні, коли ваш підключений OpenClaw Gateway запитує їх. Це дозволяє вашому асистенту відповідати на запитання та виконувати дії за допомогою встановлених застосунків."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Ваш телефон надсилає цю інформацію на ваш Gateway, а не на сервер, керований OpenClaw. Ваш Gateway може включати її в запити до вибраного вами AI-провайдера."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Погодитися та ввімкнути"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Не зараз"
@@ -2599,39 +2709,24 @@
       "translated": "Назад"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Схвалення команди"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Надсилання"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Дозволити один раз"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Схвалення ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Надання дозволу"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Завжди"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Збереження"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Заборонити"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Заборона"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Закрити сповіщення про схвалення"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Пошук налаштувань"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount готово"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Перевірити готовність"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Немає застосунку, який може поділитися цим повідомленням"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Перейти до останнього"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Завантаження сеансу"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Повідомлень ще немає"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Підготовка аудіо…"
@@ -3649,6 +3719,11 @@
       "translated": "Ви"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Повторити"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Відкрити попередній перегляд зображення"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Закрити попередній перегляд зображення"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw готує відповідь."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Закрити попередження про спільне зображення"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Зупинити"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway офлайн"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Закрити вибір рівня мислення"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Відкрити вибір рівня мислення"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Запити Gateway з’являтимуться тут."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 очікує"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) очікує"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Високий"
@@ -6544,14 +6654,9 @@
       "translated": "Немає дій Gateway, що очікують на розгляд."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Перегляньте дію Gateway, що очікує."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 очікує"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Перегляньте незавершені дії Gateway."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,18 +6714,38 @@
       "translated": "Відкрити сповіщення"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Дозволити"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Незавершені підтвердження"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
-      "translated": "Завжди дозволяти"
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Перегляньте підтвердження виконання"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Перегляд"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Дозволити раз"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
+      "translated": "Дозволити завжди"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
+      "translated": "Відхилити"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
       "translated": "Відхилити"
     },
     {
@@ -7504,6 +7629,11 @@
       "translated": "Дозволяти завжди"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Відхилити"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Відхилити"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Офлайн"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Підтвердження"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Це підтвердження вже було"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Підтвердження встановлено на «Дозволити завжди»."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Це підтвердження вже було встановлено на «Дозволити завжди»."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Потрібне схвалення"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Відкриває повну команду до того, як стануть доступні рішення"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Завантаження"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Завантаження підтвердження"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Недоступно"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Підтвердження не завантажено"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Переглянути ще раз"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Команда"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Команда для перегляду"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Ви"
@@ -9314,24 +9499,24 @@
       "translated": "Схвалення"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Надсилання рішення..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Переглянути команду"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Схвалити"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Виконання команди"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Дозволити один раз"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Відхилити"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw на GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw не вдалося встановити в Applications. Перемістіть його туди вручну, потім відкрийте цю копію."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Встановити OpenClaw в Applications?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Замінити старішу версію OpenClaw в Applications?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw скопіює себе в Applications і повторно відкриється там, щоб оновлення та запуск при вході залишалися надійними."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Ця копія новіша за встановлений застосунок. OpenClaw замінить його і повторно відкриється з Applications."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Встановити та перезапустити"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Замінити та перезапустити"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw встановлено в Applications, але не вдалося повторно відкрити автоматично. Відкрийте його там вручну."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Використовуйте логіни вашого браузера"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Копіювати cookies з \\(browsers) в ізольований профіль агента. Паролі ніколи не зачіпаються."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Імпортування cookies браузера…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "Копіювання \\(profile.displayName) в «\\(target)». Може знадобитися Touch ID."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Логіни браузера імпортовано"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) з \\(result.cookies.total) cookies скопійовано в «\\(result.into)» — тепер це стандартний профіль для перегляду агентом."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Не вдалося імпортувати браузер"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "ваш браузер"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Імпорт"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Повторити"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Відхилити"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "Імпорт із браузера потребує локального режиму"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Перемкніть цей застосунок Mac на локальний Gateway перед імпортом файлів cookie браузера."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "На цьому Mac не знайдено профілю Chrome, Brave, Edge чи Chromium із файлами cookie."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "Імпорт профілю системного браузера вимкнено в конфігурації локального Gateway."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Вхід через браузер недоступний"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Імпорт із браузера недоступний"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "Не вдалося встановити CLI"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "Встановлення CLI завершено"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Стабільна"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Бета"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "немає доставки"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Повторне підключення панелі"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Вибраний Gateway змінився."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Очікування нового автентифікованого підключення."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Панель недоступна"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Перевірте Налаштування → Підключення або скористайтеся Налагодження → Скинути віддалений тунель, а потім повторіть спробу."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Завершити \\(listener.command) (\\(listener.pid))?"
@@ -10704,6 +11069,16 @@
       "translated": "Лише шаблони шляхів. Додайте '/', '~' або '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Цей запис списку дозволів успадковано. Відредагуйте область, якій він належить, і повторіть спробу."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Не вдалося зберегти дозволи на виконання. Показано останні відомі налаштування; повторіть зміну."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Автоматично запускати OpenClaw після входу."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Перемістіть OpenClaw до Applications, перш ніж вмикати запуск під час входу."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Показувати іконку в Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Дозволити підписаним інструментам (наприклад, `peekaboo`) виконувати автоматизацію UI через PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Браузер"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Вхід через браузер"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Скопіюйте файли cookie з профілю сімейства Chrome до ізольованого керованого профілю."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Імпортувати…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Налаштування..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Назад"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Вперед"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Підтвердження виконання"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Завантаження дозволів на виконання…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Повторити дозволи на виконання"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Використання"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource потребує відповідного systemRunPlan"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "явне схвалення потребує відповідного systemRunPlan"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Сполучення вузла схвалено"
@@ -11729,137 +12159,272 @@
       "translated": "Далі"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Запит на налаштування Gateway не вдався."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Запит на налаштування Gateway не вдався. Покажіть подробиці, щоб переглянути або скопіювати помилку."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) не вдалося завершити тест."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) не вдалося завершити тест. Покажіть подробиці, щоб переглянути або скопіювати помилку."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
-      "translated": "Шукаємо AI, яким ви вже користуєтеся…"
+      "translated": "Пошук ШІ, який ви вже використовуєте…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Очікування завершення попереднього тесту ШІ…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Перевіряємо Claude Code, Codex, Gemini та збережені ключі API."
+      "translated": "Перевірка наявності Claude Code, Codex, Gemini та збережених ключів API."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw перевірить ще раз перед зміною будь-яких налаштувань висновування."
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Не вдалося перевірити цей Gateway на наявність облікових записів ШІ"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "Не вдалося перевірити цей Mac на наявність облікових записів AI"
+      "translated": "Не вдалося перевірити цей Mac на наявність облікових записів ШІ"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
-      "translated": "Не вдалося завантажити повний список постачальників"
+      "translated": "Не вдалося завантажити повний список провайдерів"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "Спробувати ще раз"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Жоден зі знайдених варіантів не спрацював"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "Деталі перелічені для кожного варіанту вище. Ви можете виправити вхід і повторити спробу або підключитися за допомогою ключа API чи токена нижче."
+      "translated": "Деталі наведено для кожного варіанта вище. Ви можете виправити вхід і повторити спробу або підключитися за допомогою ключа API чи токена нижче."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
-      "translated": "Потрібна допомога? Поспілкуйтеся з Crestodian"
+      "translated": "Потрібна допомога? Напишіть у чат Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
-      "translated": "Ваш AI готовий"
+      "translated": "Ваш ШІ готовий"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Деталі налаштування"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Скопіювати деталі налаштування"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "На цьому Mac не знайдено облікових записів AI"
+      "translated": "На цьому Mac не знайдено облікових записів ШІ"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Нічого страшного — ви можете підключити його за допомогою ключа API чи токена. Якщо ви користуєтеся Claude Code, Codex або Gemini CLI на цьому Mac, спочатку увійдіть там і натисніть «Перевірити ще раз»."
+      "translated": "Це нормально — ви можете підключити його за допомогою ключа API чи токена. Якщо ви використовуєте Claude Code, Codex або Gemini CLI на цьому Mac, спершу увійдіть там і натисніть «Перевірити ще раз»."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Рекомендовано"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "Немає доступних постачальників на основі ключів"
+      "translated": "Немає доступних провайдерів на основі ключів"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "Увімкніть або встановіть плагін постачальника текстового висновку на цьому Gateway, потім перевірте ще раз."
+      "translated": "Увімкніть або встановіть плагін провайдера текстового висновку на цьому Gateway, а потім перевірте ще раз."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Перевірити ще раз"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
       "translated": "Підключитися за допомогою ключа API чи токена натомість…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Увійти через провайдера"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Використовуйте наявну підписку або обліковий запис провайдера. OpenClaw відкриває власний процес входу провайдера, а потім перевіряє його реальною відповіддю."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Більше варіантів входу"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Спарувати"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Увійти"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Облікові дані залишаються на цьому Gateway і зберігаються лише після успішного онлайн-тесту."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Відкрити сторінку входу…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Запуск безпечного входу…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "Вхід не завершено"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Скасувати"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Завершіть у браузері"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Копіювати"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Термін дії спливає за \\(minutes) хв"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Відкрити сторінку входу"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Параметр"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Підтвердити"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Я увійшов"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Продовжити"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Надіслати"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
-      "translated": "Підключитися за допомогою ключа API чи токена"
+      "translated": "Підключитися за допомогою ключа API або токена"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
-      "translated": "Постачальник"
+      "translated": "Провайдер"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
-      "translated": "Ключ API чи токен"
+      "translated": "Ключ API або токен"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Підключити"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Цей ключ не спрацював"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — помічник із налаштування"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Готово"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Відкрити довідку…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Приховати деталі"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Показати деталі"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Копіювати помилку"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Спробувати ще раз"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Робочий простір агента"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw запускає агента з окремого робочого простору, щоб він міг завантажувати `AGENTS.md` і записувати файли там, не змішуючи їх з іншими вашими проєктами."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Виявлено віддалений Gateway"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Створіть робочий простір на віддаленому хості (спочатку підключіться через SSH). Програма macOS ще не може записувати файли на ваш Gateway через SSH."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Скопійовано"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Копіювати команду налаштування"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Папка робочого простору"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Створити робочий простір"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Відкрити папку"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Зберегти в config"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Порада: відредагуйте AGENTS.md у цій папці, щоб налаштувати поведінку асистента. Для резервного копіювання зробіть робочий простір приватним git-репозиторієм, щоб «пам’ять» вашого агента зберігалася у версіях."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Знайомство з вашим агентом"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Ваш агент представиться, вибере ім’я разом із вами та допоможе підключити WhatsApp, Telegram або інший канал — просто спілкуйтеся в чаті."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Усе готово!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Не зараз"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Відхилити все"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Схвалити все"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Керуйте тим, як схвалюються команди оболонки агента на цьому Mac."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Завантаження налаштувань…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Читання збереженої політики."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Схвалення виконання недоступні"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Не вдалося прочитати налаштування"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Повторити"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway підключено"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -3539,6 +3539,11 @@
       "translated": "Увімкнути мікрофон"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Оновити"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Файли недоступні"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Помилка чату"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Вимкнено"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -24,6 +24,71 @@
       "translated": "Mặc định"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "Đã cho phép và lưu phê duyệt."
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "Đã cho phép phê duyệt một lần."
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "Một phản hồi trước đó đã cho phép lệnh này và lưu lựa chọn."
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "Một phản hồi trước đó đã cho phép lệnh này một lần."
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway đã ghi nhận phê duyệt và lưu lựa chọn."
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway đã ghi nhận phê duyệt một lần."
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "Đã từ chối phê duyệt."
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "Một phản hồi trước đó đã từ chối phê duyệt này."
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway đã ghi nhận việc từ chối."
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "Phê duyệt này đã hết hạn trước khi có thể được xử lý."
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "Phê duyệt này đã bị hủy trước khi có thể được xử lý."
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "Một phản hồi trước đó đã xử lý phê duyệt này."
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "Yêu cầu lệnh"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "Sẵn sàng"
@@ -94,6 +159,11 @@
       "translated": "Cấu hình ${issue.providerLabel} trên Gateway"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "Quá nhiều lượt chia sẻ đang chờ được thêm vào."
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · Mic: Đang chờ"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "Không rõ kết quả xử lý. Các thao tác vẫn bị vô hiệu hóa cho đến khi bản ghi Gateway được xác minh."
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway vẫn hiển thị phê duyệt này đang chờ xử lý. Hãy xem lại trước khi thử lại."
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "Không thể tải chi tiết phê duyệt. Hãy làm mới và thử lại."
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "Không thể tải các phê duyệt."
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "Không thể xử lý phê duyệt. Hãy làm mới và thử lại."
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount nhà cung cấp đã sẵn sàng"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "Không rõ tình trạng khả dụng của nhà cung cấp"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "Xem xét mức độ sẵn sàng của nhà cung cấp\nvà các mô hình đã cấu hình."
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "Nhà cung cấp đã kết nối"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "Nhà cung cấp và mô hình đã cấu hình"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway ngoại tuyến"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "Cần chú ý"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "Sẵn sàng"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "Mô hình"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "Cần"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "Không xác định"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount mô hình đã cấu hình. Làm mới để kiểm tra lại tính khả dụng."
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "Kết nối Gateway của bạn để xem mức độ sẵn sàng của nhà cung cấp."
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "Làm mới để kiểm tra lại mức độ sẵn sàng của nhà cung cấp từ Gateway của bạn."
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "Đang làm mới"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} mô hình"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} mô hình đã cấu hình"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Phiên"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "Đảo ngược thứ tự sắp xếp phiên"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "Tìm kiếm phiên"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "Mới nhất"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "Mới nhất trước"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "Cũ nhất"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "Cũ nhất trước"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "Mở Cài đặt"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "Chia sẻ thông tin ứng dụng đã cài đặt?"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "OpenClaw thu thập và gửi tên, ID gói và trạng thái của các ứng dụng hiển thị trên điện thoại này khi Gateway OpenClaw đã ghép nối của bạn yêu cầu. Điều này cho phép trợ lý của bạn trả lời câu hỏi và thực hiện hành động bằng các ứng dụng đã cài đặt."
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "Điện thoại của bạn gửi thông tin này đến Gateway của bạn, không phải đến máy chủ do OpenClaw vận hành. Gateway của bạn có thể đưa nó vào các yêu cầu gửi đến nhà cung cấp AI bạn đã chọn."
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "Đồng ý và Bật"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "Không phải bây giờ"
@@ -2599,39 +2709,24 @@
       "translated": "Quay lại"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "Phê duyệt lệnh"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "Đang gửi"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "Cho phép một lần"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "Phê duyệt ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "Đang cho phép"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "Luôn cho phép"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "Đang lưu"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "Từ chối"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "Đang từ chối"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "Bỏ qua thông báo phê duyệt"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "Tìm kiếm cài đặt"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount sẵn sàng"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "Xem lại trạng thái sẵn sàng"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "Không có ứng dụng nào có thể chia sẻ tin nhắn này"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "Chuyển đến mới nhất"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "Đang tải phiên"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "Chưa có tin nhắn"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "Đang chuẩn bị âm thanh…"
@@ -3649,6 +3719,11 @@
       "translated": "Bạn"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "Thử lại"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "Mở xem trước hình ảnh"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "Đóng xem trước hình ảnh"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw đang chuẩn bị phản hồi."
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "Bỏ qua cảnh báo hình ảnh được chia sẻ"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "Dừng"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway ngoại tuyến"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "Đóng bộ chọn mức độ suy nghĩ"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "Mở bộ chọn mức độ suy nghĩ"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Các yêu cầu Gateway sẽ xuất hiện tại đây."
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 đang chờ"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) đang chờ"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "Cao"
@@ -6544,14 +6654,9 @@
       "translated": "Không có hành động gateway nào đang chờ xem xét."
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "Xem xét hành động gateway đang chờ."
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 đang chờ"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "Xem lại các hành động gateway đang chờ."
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "Mở Thông báo"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "Cho phép"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "Phê duyệt đang chờ"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "Xem lại phê duyệt exec"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "Đang xem lại"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "Cho phép một lần"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "Luôn cho phép"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "Từ chối"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "Bỏ qua"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "Luôn cho phép"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "Bỏ qua"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "Từ chối"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "Ngoại tuyến"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "Phê duyệt"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "Phê duyệt này đã được"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "Phê duyệt được đặt thành Luôn cho phép."
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Phê duyệt này đã được đặt thành Luôn cho phép."
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "Cần phê duyệt"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "Mở lệnh đầy đủ trước khi có sẵn quyết định"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "Đang tải"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "Đang tải phê duyệt"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "Không khả dụng"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "Chưa tải phê duyệt"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "Xem lại lần nữa"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "Lệnh"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "Lệnh cần xem lại"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Bạn"
@@ -9314,24 +9499,24 @@
       "translated": "Phê duyệt"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "Đang gửi quyết định..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "Xem lại lệnh"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "Phê duyệt"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "Thực thi lệnh"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "Cho phép một lần"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Từ chối"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "OpenClaw trên GitHub"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "Không thể cài đặt OpenClaw trong Applications. Hãy chuyển nó vào đó thủ công, sau đó mở bản sao đó."
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Cài đặt OpenClaw trong Applications?"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "Thay thế OpenClaw cũ hơn trong Applications?"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw sẽ tự sao chép vào Applications và mở lại ở đó để việc cập nhật và khởi chạy khi đăng nhập luôn ổn định."
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "Bản sao này mới hơn ứng dụng đã cài. OpenClaw sẽ thay thế nó và mở lại từ Applications."
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "Cài đặt và khởi chạy lại"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "Thay thế và khởi chạy lại"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw đã được cài đặt trong Applications, nhưng không thể mở lại tự động. Hãy mở nó ở đó thủ công."
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "Dùng thông tin đăng nhập trình duyệt của bạn"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "Sao chép cookie từ \\(browsers) vào một hồ sơ agent riêng biệt. Mật khẩu không bao giờ bị đụng đến."
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "Đang nhập cookie trình duyệt…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "Đang sao chép \\(profile.displayName) vào “\\(target)”. Có thể cần Touch ID."
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "Đã nhập thông tin đăng nhập trình duyệt"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "\\(result.cookies.imported) trong số \\(result.cookies.total) cookie đã được sao chép vào “\\(result.into)” — hiện là hồ sơ mặc định cho việc duyệt web của agent."
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "Nhập trình duyệt thất bại"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "trình duyệt của bạn"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title). \\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "Nhập"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "Thử lại"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "Bỏ qua"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "Nhập từ trình duyệt yêu cầu chế độ Local"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "Chuyển ứng dụng Mac này sang Gateway cục bộ trước khi nhập cookie trình duyệt."
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "Không tìm thấy hồ sơ Chrome, Brave, Edge hoặc Chromium có cookie trên máy Mac này."
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "Nhập hồ sơ trình duyệt hệ thống bị tắt trong cấu hình Gateway cục bộ."
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "Không có đăng nhập trình duyệt khả dụng"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "Không thể nhập từ trình duyệt"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "Cài đặt CLI thất bại"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "Cài đặt CLI hoàn tất"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "Ổn định"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev (Git main)"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "không giao"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "Đang kết nối lại bảng điều khiển"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "Gateway đã chọn đã thay đổi."
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "Đang chờ kết nối xác thực mới."
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "Bảng điều khiển không khả dụng"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "Kiểm tra Cài đặt → Kết nối hoặc dùng Debug → Reset Remote Tunnel, rồi thử lại."
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Dừng \\(listener.command) (\\(listener.pid))?"
@@ -10704,6 +11069,16 @@
       "translated": "Chỉ mẫu đường dẫn. Bao gồm '/', '~' hoặc '\\\\'."
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "Mục danh sách cho phép này được kế thừa. Chỉnh sửa phạm vi sở hữu và thử lại."
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "Không thể lưu phê duyệt thực thi. Hiển thị các cài đặt đã biết gần nhất; hãy thử lại thay đổi."
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "Tự động khởi động OpenClaw sau khi bạn đăng nhập."
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "Di chuyển OpenClaw vào Applications trước khi bật khởi động khi đăng nhập."
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "Hiển thị biểu tượng Dock"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "Cho phép các công cụ đã ký (ví dụ: `peekaboo`) điều khiển tự động hóa UI qua PeekabooBridge."
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "Trình duyệt"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "Đăng nhập trình duyệt"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "Sao chép cookie từ hồ sơ thuộc dòng Chrome vào một hồ sơ được quản lý riêng biệt."
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "Nhập…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "Cài đặt..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "Quay lại"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "Tiến tới"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "Phê duyệt thực thi"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "Đang tải Phê duyệt Thực thi…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "Thử lại Phê duyệt Thực thi"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "Mức sử dụng"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource yêu cầu systemRunPlan khớp"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "phê duyệt tường minh yêu cầu systemRunPlan khớp"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "Đã phê duyệt ghép nối nút"
@@ -11729,137 +12159,272 @@
       "translated": "Tiếp theo"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Yêu cầu thiết lập Gateway đã thất bại."
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Yêu cầu thiết lập Gateway đã thất bại. Hiển thị chi tiết để kiểm tra hoặc sao chép lỗi."
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) không thể hoàn tất bài kiểm tra."
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) không thể hoàn tất bài kiểm tra. Hiển thị chi tiết để kiểm tra hoặc sao chép lỗi."
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
       "translated": "Đang tìm AI bạn đã sử dụng…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "Đang chờ bài kiểm tra AI trước đó hoàn tất…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "translated": "Đang kiểm tra Claude Code, Codex, Gemini và các khóa API đã lưu."
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
-      "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "Không thể kiểm tra máy Mac này để tìm tài khoản AI"
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw sẽ kiểm tra lại trước khi thay đổi bất kỳ cài đặt suy luận nào."
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "Không thể kiểm tra tài khoản AI trên Gateway này"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
+      "source": "Couldn’t check this Mac for AI accounts",
+      "translated": "Không thể kiểm tra tài khoản AI trên máy Mac này"
+    },
+    {
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "Không thể tải toàn bộ danh sách nhà cung cấp"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "Thử lại"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "Không có tùy chọn nào tìm thấy hoạt động"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "Chi tiết được liệt kê ở từng tùy chọn phía trên. Bạn có thể sửa thông tin đăng nhập rồi thử lại, hoặc kết nối bằng API key hoặc token bên dưới."
+      "translated": "Chi tiết được liệt kê ở mỗi tùy chọn phía trên. Bạn có thể sửa đăng nhập rồi thử lại, hoặc kết nối bằng khóa API hoặc token bên dưới."
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "Cần trợ giúp? Trò chuyện với Crestodian"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
       "translated": "AI của bạn đã sẵn sàng"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "Chi tiết thiết lập"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "Sao chép chi tiết thiết lập"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
       "translated": "Không tìm thấy tài khoản AI nào trên máy Mac này"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "Không sao — bạn có thể kết nối bằng API key hoặc token. Nếu bạn dùng Claude Code, Codex, hoặc Gemini CLI trên máy Mac này, hãy đăng nhập ở đó trước rồi nhấn “Kiểm tra lại”."
+      "translated": "Không sao — bạn có thể kết nối một tài khoản bằng khóa API hoặc token. Nếu bạn dùng Claude Code, Codex, hoặc Gemini CLI trên máy Mac này, hãy đăng nhập ở đó trước rồi nhấn “Kiểm tra lại”."
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "Được đề xuất"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "Không có nhà cung cấp dựa trên key nào khả dụng"
+      "translated": "Không có nhà cung cấp dựa trên khóa nào khả dụng"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "translated": "Bật hoặc cài đặt một plugin nhà cung cấp suy luận văn bản trên Gateway này, rồi kiểm tra lại."
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "Kiểm tra lại"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "Thay vào đó, kết nối bằng API key hoặc token…"
+      "translated": "Kết nối bằng khóa API hoặc token…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "Đăng nhập với một nhà cung cấp"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "Dùng gói đăng ký hoặc tài khoản nhà cung cấp hiện có. OpenClaw mở luồng đăng nhập riêng của nhà cung cấp, rồi xác minh bằng một phản hồi thực."
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "Thêm tùy chọn đăng nhập"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "Ghép nối"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "Đăng nhập"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "Thông tin đăng nhập được giữ trên Gateway này và chỉ được lưu sau khi kiểm tra trực tiếp thành công."
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "Mở trang đăng nhập…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "Đang bắt đầu đăng nhập an toàn…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "Đăng nhập chưa hoàn tất"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "Hủy"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "Hoàn tất trong trình duyệt của bạn"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "Sao chép"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "Hết hạn sau \\(minutes) phút"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "Mở trang đăng nhập"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "Tùy chọn"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "Xác nhận"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "Tôi đã đăng nhập"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "Tiếp tục"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "Gửi"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
-      "translated": "Kết nối bằng API key hoặc token"
+      "translated": "Kết nối bằng khóa API hoặc token"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "Nhà cung cấp"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
-      "translated": "API key hoặc token"
+      "translated": "Khóa API hoặc token"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "Kết nối"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
       "translated": "Khóa đó không hoạt động"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
-      "translated": "Crestodian — trình trợ giúp thiết lập"
+      "translated": "Crestodian — trợ lý thiết lập"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "Xong"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "Mở trợ giúp…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
       "translated": "Ẩn chi tiết"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
       "translated": "Hiện chi tiết"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Sao chép lỗi"
     },
@@ -12209,71 +12774,6 @@
       "translated": "Thử lại"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Không gian làm việc của agent"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw chạy agent từ một không gian làm việc chuyên dụng để có thể tải `AGENTS.md` và ghi tệp ở đó mà không lẫn vào các dự án khác của bạn."
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "Đã phát hiện gateway từ xa"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "Tạo không gian làm việc trên máy chủ từ xa (SSH vào trước). Ứng dụng macOS chưa thể ghi tệp trên gateway của bạn qua SSH."
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "Đã sao chép"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "Sao chép lệnh thiết lập"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "Thư mục workspace"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "Tạo workspace"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "Mở thư mục"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "Lưu trong config"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "Mẹo: chỉnh sửa AGENTS.md trong thư mục này để định hình hành vi của trợ lý. Để sao lưu, hãy đặt workspace thành một kho git riêng tư để “bộ nhớ” của agent được quản lý phiên bản."
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "Gặp agent của bạn"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "Agent của bạn sẽ tự giới thiệu, cùng bạn chọn tên và giúp bạn kết nối WhatsApp, Telegram hoặc một kênh khác — chỉ cần trò chuyện."
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "Bạn đã sẵn sàng!"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "Không phải bây giờ"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "Từ chối tất cả"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "Phê duyệt tất cả"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "Kiểm soát cách phê duyệt các lệnh shell của agent trên máy Mac này."
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "Đang tải cài đặt…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "Đang đọc chính sách đã lưu."
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "Không thể phê duyệt Exec"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "Không thể đọc cài đặt"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "Thử lại"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway đã kết nối"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -3539,6 +3539,11 @@
       "translated": "Bật micrô"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "Làm mới"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "Tệp không khả dụng"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "Lỗi trò chuyện"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "Tắt"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -24,6 +24,71 @@
       "translated": "默认"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "已批准并保存。"
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "已批准一次。"
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "先前的响应已批准此命令并保存了选择。"
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "先前的响应已批准此命令一次。"
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway 已记录批准并保存了选择。"
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway 已记录一次批准。"
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "已拒绝批准。"
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "先前的响应已拒绝此批准。"
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway 已记录一次拒绝。"
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "此批准在处理完成前已过期。"
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "此批准在处理完成前已取消。"
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "先前的响应已处理此批准。"
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "命令请求"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "就绪"
@@ -94,6 +159,11 @@
       "translated": "在 Gateway 上配置 ${issue.providerLabel}"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "等待添加的共享过多。"
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · 麦克风：待处理"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "处理结果未知。在验证 Gateway 记录之前，操作将保持禁用。"
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway 仍将此批准显示为待处理。请先查看再重试。"
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "无法加载批准详情。请刷新后重试。"
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "无法加载批准。"
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "无法处理批准。请刷新后重试。"
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount 个提供方已就绪"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "提供方可用性未知"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "查看提供商就绪状态\n和已配置的模型。"
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "已连接的提供商"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "提供商和已配置的模型"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway 离线"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "需要注意"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "就绪"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "模型"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "需要"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "未知"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount 个已配置的模型。刷新以重新检查可用性。"
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "连接您的 Gateway 以查看提供商就绪状态。"
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "刷新以从您的 Gateway 重新检查提供商就绪状态。"
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "正在刷新"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} 个模型"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} 个已配置的模型"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "会话"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "反转会话排序"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "搜索会话"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "最新"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "最新优先"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "最早"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "最早优先"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "打开设置"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "分享已安装应用的信息？"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "当配对的 OpenClaw Gateway 请求时，OpenClaw 会收集并发送此手机上可见应用的名称、包 ID 和状态。这可让您的助手使用已安装的应用回答问题和执行操作。"
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "您的手机会将此信息发送到您的 Gateway，而不是 OpenClaw 运营的服务器。您的 Gateway 可能会将其包含在向您选择的 AI 提供商发出的请求中。"
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "同意并启用"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "暂不"
@@ -2599,39 +2709,24 @@
       "translated": "返回"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "命令批准"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "正在发送"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "仅允许一次"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "批准 ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "正在允许"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "始终"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "正在保存"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "拒绝"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "正在拒绝"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "关闭批准通知"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "搜索设置"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount 个已就绪"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "检查就绪状态"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "没有应用可以分享此消息"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "跳转到最新"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "正在加载会话"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "暂无消息"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "正在准备音频…"
@@ -3649,6 +3719,11 @@
       "translated": "你"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "重试"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "打开图片预览"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "关闭图片预览"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw 正在准备回复。"
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "关闭共享图片警告"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "停止"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway 离线"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "关闭思考级别选择器"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "打开思考级别选择器"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Gateway 请求将显示在此处。"
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 个等待中"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) 个等待中"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "高"
@@ -6544,14 +6654,9 @@
       "translated": "没有 Gateway 操作等待审核。"
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "审核待处理的 Gateway 操作。"
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 个等待中"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "查看待处理的 gateway 操作。"
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "打开通知"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "允许"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "待处理审批"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "查看执行审批"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "审查中"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "允许一次"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "始终允许"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "拒绝"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "忽略"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "始终允许"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "忽略"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "拒绝"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "离线"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "审批"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "此审批已经"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "审批已设置为始终允许。"
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "此审批已设置为始终允许。"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "需要审批"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "在决策可用之前打开完整命令"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "加载中"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "正在加载审批"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "不可用"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "审批未加载"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "再次审核"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "命令"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "待审查的命令"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "你"
@@ -9314,24 +9499,24 @@
       "translated": "审批"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "正在发送决定..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "查看命令"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "批准"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "命令执行"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "允许一次"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "拒绝"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "GitHub 上的 OpenClaw"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw 无法安装到“应用程序”中。请手动将其移至该位置，然后打开那份副本。"
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "将 OpenClaw 安装到“应用程序”中？"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "替换“应用程序”中较旧的 OpenClaw？"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw 会将自身复制到“应用程序”并从那里重新打开，以确保更新和登录时启动保持可靠。"
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "此副本比已安装的应用更新。OpenClaw 将替换它并从“应用程序”重新打开。"
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "安装并重新启动"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "替换并重新启动"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw 已安装到“应用程序”中，但无法自动重新打开。请在那里手动打开它。"
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "使用你的浏览器登录信息"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "将 \\(browsers) 中的 cookie 复制到一个隔离的代理配置文件。密码绝不会被触及。"
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "正在导入浏览器 cookie…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "正在将 \\(profile.displayName) 复制到“\\(target)”。可能需要 Touch ID。"
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "已导入浏览器登录信息"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "已将 \\(result.cookies.total) 个 cookie 中的 \\(result.cookies.imported) 个复制到“\\(result.into)”——现在它是代理浏览的默认配置文件。"
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "浏览器导入失败"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "你的浏览器"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title)。\\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "导入"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "重试"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "关闭"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "浏览器导入需要本地模式"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "在导入浏览器 cookie 之前，请将此 Mac 应用切换到本地 Gateway。"
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "在此 Mac 上未找到包含 cookie 的 Chrome、Brave、Edge 或 Chromium 配置文件。"
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "本地 Gateway 配置中已禁用系统浏览器配置文件导入。"
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "无可用的浏览器登录"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "浏览器导入不可用"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "CLI 安装失败"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "CLI 安装完成"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "稳定版"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "Beta"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "Dev（Git main）"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "未送达"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "仪表盘正在重新连接"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "所选的 Gateway 已更改。"
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "正在等待新的已认证连接。"
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "仪表盘不可用"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "请检查“设置 → 连接”或使用“调试 → 重置远程隧道”，然后重试。"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "结束 \\(listener.command) (\\(listener.pid))？"
@@ -10704,6 +11069,16 @@
       "translated": "仅限路径模式。请包含“/”、“~”或“\\\\”。"
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "此允许列表条目为继承而来。请编辑其所属作用域并重试。"
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "无法保存执行审批。已显示最后已知的设置；请重试更改。"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "登录后自动启动 OpenClaw。"
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "在启用登录时启动之前，请将 OpenClaw 移至“应用程序”。"
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "显示 Dock 图标"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "允许已签名工具（例如 `peekaboo`）通过 PeekabooBridge 驱动 UI 自动化。"
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "浏览器"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "浏览器登录"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "将 Chrome 系列配置文件中的 Cookie 复制到隔离的托管配置文件中。"
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "导入…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "设置..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "返回"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "前进"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "执行审批"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "正在加载执行审批…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "重试执行审批"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "用量"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource requires matching systemRunPlan"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "explicit approval requires matching systemRunPlan"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "节点配对已批准"
@@ -11729,137 +12159,272 @@
       "translated": "下一步"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
-      "source": "Looking for AI you already use…",
-      "translated": "正在查找你已在使用的 AI…"
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Gateway 设置请求失败。"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Gateway 设置请求失败。显示详情以查看或复制错误。"
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) 无法完成测试。"
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) 无法完成测试。显示详情以查看或复制错误。"
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "正在查找您已在使用的 AI…"
+    },
+    {
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "正在等待上一个 AI 测试完成…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
       "translated": "正在检查 Claude Code、Codex、Gemini 和已保存的 API 密钥。"
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
-      "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "无法检查这台 Mac 上的 AI 账号"
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw 会在更改任何推理设置之前再次检查。"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "无法在此 Gateway 上检查 AI 账户"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
+      "source": "Couldn’t check this Mac for AI accounts",
+      "translated": "无法在此 Mac 上检查 AI 账户"
+    },
+    {
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "无法加载完整的提供商列表"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "重试"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
-      "translated": "找到的选项都无法使用"
+      "translated": "找到的选项均无效"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "详细信息已列在上方每个选项中。你可以修复登录并重试，或在下方使用 API 密钥或令牌连接。"
+      "translated": "详细信息列在上方每个选项中。你可以修正登录信息后重试，或在下方使用 API 密钥或令牌连接。"
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
-      "translated": "需要帮助？与 Crestodian 聊聊"
+      "translated": "需要帮助？与 Crestodian 聊天"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
-      "translated": "你的 AI 已准备就绪"
+      "translated": "你的 AI 已就绪"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "设置详情"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "复制设置详情"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "在这台 Mac 上未找到 AI 账号"
+      "translated": "在此 Mac 上未找到 AI 账户"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "没关系——你可以使用 API 密钥或令牌连接。如果你在这台 Mac 上使用 Claude Code、Codex 或 Gemini CLI，请先在那里登录，然后点击“再次检查”。"
+      "translated": "没关系——你可以使用 API 密钥或令牌连接一个。如果你在此 Mac 上使用 Claude Code、Codex 或 Gemini CLI，请先在那里登录，然后点击“再次检查”。"
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "推荐"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
       "translated": "没有可用的基于密钥的提供商"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
-      "translated": "请在此 Gateway 上启用或安装文本推理提供商插件，然后再次检查。"
+      "translated": "在此 Gateway 上启用或安装文本推理提供商插件，然后再次检查。"
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "再次检查"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "改为使用 API 密钥或令牌连接…"
+      "translated": "改用 API 密钥或令牌连接…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "使用提供商登录"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "使用现有的订阅或提供商账户。OpenClaw 会打开该提供商自己的登录流程，然后通过真实回复进行验证。"
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "更多登录选项"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "配对"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "登录"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "凭据仅保留在此 Gateway 上，且仅在实时测试成功后才会保存。"
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "打开登录页面…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "正在启动安全登录…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "登录未完成"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "在浏览器中完成"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "复制"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "将在 \\(minutes) 分钟后过期"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "打开登录页面"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "选项"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "确认"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "我已登录"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "继续"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "提交"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
       "translated": "使用 API 密钥或令牌连接"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
       "translated": "提供商"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
       "translated": "API 密钥或令牌"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "连接"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
-      "translated": "该 key 无法使用"
+      "translated": "该密钥无效"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
       "translated": "Crestodian — 设置助手"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "完成"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "打开帮助…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
-      "translated": "隐藏详细信息"
+      "translated": "隐藏详情"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
-      "translated": "显示详细信息"
+      "translated": "显示详情"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "复制错误"
     },
@@ -12209,71 +12774,6 @@
       "translated": "重试"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "Agent 工作区"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw 会从专用工作区运行 Agent，以便它可以加载 `AGENTS.md` 并在那里写入文件，而不会混入你的其他项目。"
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "检测到远程 Gateway"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "请在远程主机上创建工作区（先通过 SSH 登录）。macOS App 目前还无法通过 SSH 在你的 Gateway 上写入文件。"
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "已复制"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "复制设置命令"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "工作区文件夹"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "创建工作区"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "打开文件夹"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "保存到配置"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "提示：编辑此文件夹中的 AGENTS.md 以调整助手的行为。为便于备份，请将工作区设为私有 git 仓库，以便对你的智能体“记忆”进行版本管理。"
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "认识你的智能体"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "你的 agent 会自我介绍，与你一起取名，并帮助你连接 WhatsApp、Telegram 或其他频道 — 只需聊天即可。"
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "你已全部设置完成！"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "暂不"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "全部拒绝"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "全部批准"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "控制此 Mac 上代理 shell 命令的审批方式。"
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "正在加载设置…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "正在读取已保存的策略。"
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "无法使用执行批准"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "无法读取设置"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "重试"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway 已连接"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -3539,6 +3539,11 @@
       "translated": "启用麦克风"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "刷新"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "文件不可用"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "聊天错误"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "关闭"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -24,6 +24,71 @@
       "translated": "預設"
     },
     {
+      "id": "native.android.d00110fa302427ec",
+      "source": "Approval allowed and saved.",
+      "translated": "已允許核准並儲存。"
+    },
+    {
+      "id": "native.android.a2539552c0136bb6",
+      "source": "Approval allowed once.",
+      "translated": "已允許核准一次。"
+    },
+    {
+      "id": "native.android.5757ec300265ff2c",
+      "source": "A prior response already allowed this command and saved the choice.",
+      "translated": "先前的回應已允許此命令並儲存了選擇。"
+    },
+    {
+      "id": "native.android.3d2b0158e7e2a7ac",
+      "source": "A prior response already allowed this command once.",
+      "translated": "先前的回應已允許此命令一次。"
+    },
+    {
+      "id": "native.android.db50b9d7ab7d78cd",
+      "source": "Gateway recorded approval and saved the choice.",
+      "translated": "Gateway 已記錄核准並儲存了選擇。"
+    },
+    {
+      "id": "native.android.342387ec384c891e",
+      "source": "Gateway recorded approval once.",
+      "translated": "Gateway 已記錄核准一次。"
+    },
+    {
+      "id": "native.android.85992377452e4155",
+      "source": "Approval denied.",
+      "translated": "已拒絕核准。"
+    },
+    {
+      "id": "native.android.52f0f741fa2ea221",
+      "source": "A prior response already denied this approval.",
+      "translated": "先前的回應已拒絕此核准。"
+    },
+    {
+      "id": "native.android.67e7a7d8ef8b5ee3",
+      "source": "Gateway recorded a denial.",
+      "translated": "Gateway 已記錄拒絕。"
+    },
+    {
+      "id": "native.android.6c52ab373984e933",
+      "source": "This approval expired before it could be resolved.",
+      "translated": "此核准在解決前已過期。"
+    },
+    {
+      "id": "native.android.5aa316ff5982f079",
+      "source": "This approval was cancelled before it could be resolved.",
+      "translated": "此核准在解決前已被取消。"
+    },
+    {
+      "id": "native.android.616b338c2081cd07",
+      "source": "A prior response already resolved this approval.",
+      "translated": "先前的回應已解決此核准。"
+    },
+    {
+      "id": "native.android.b2505b999166dffe",
+      "source": "Command request",
+      "translated": "命令請求"
+    },
+    {
       "id": "native.android.805d35da3b3c9d18",
       "source": "Ready",
       "translated": "就緒"
@@ -94,6 +159,11 @@
       "translated": "在 Gateway 上設定 ${issue.providerLabel}"
     },
     {
+      "id": "native.android.21a3ed1199d96f1e",
+      "source": "Too many shares are waiting to be added.",
+      "translated": "等待新增的共享太多。"
+    },
+    {
       "id": "native.android.ff4c22906eac1e9e",
       "source": "OPENCLAW",
       "translated": "OPENCLAW"
@@ -132,6 +202,31 @@
       "id": "native.android.7521acb4a7bc9a75",
       "source": " · Mic: Pending",
       "translated": " · 麥克風：待處理"
+    },
+    {
+      "id": "native.android.41090d74a07fa3ba",
+      "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
+      "translated": "解決結果未知。在驗證 Gateway 記錄前，操作將維持停用。"
+    },
+    {
+      "id": "native.android.780d205fe49d942c",
+      "source": "The Gateway still shows this approval as pending. Review it before trying again.",
+      "translated": "Gateway 仍顯示此核准為待處理。請先檢視後再試一次。"
+    },
+    {
+      "id": "native.android.d76e21aac82dea76",
+      "source": "Could not load approval details. Refresh and try again.",
+      "translated": "無法載入核准詳細資訊。請重新整理後再試一次。"
+    },
+    {
+      "id": "native.android.2e982293714523e0",
+      "source": "Could not load approvals.",
+      "translated": "無法載入核准。"
+    },
+    {
+      "id": "native.android.25808ff4b760bf48",
+      "source": "Could not resolve approval. Refresh and try again.",
+      "translated": "無法解決核准。請重新整理後再試一次。"
     },
     {
       "id": "native.android.c65b61de70a063e7",
@@ -497,6 +592,11 @@
       "id": "native.android.cb4cc4336cf67145",
       "source": "$readyProviderCount providers ready",
       "translated": "$readyProviderCount 個提供者已就緒"
+    },
+    {
+      "id": "native.android.625b4d9f7e893047",
+      "source": "Provider availability unknown",
+      "translated": "供應商可用性未知"
     },
     {
       "id": "native.android.d5aca322cbdaad85",
@@ -1674,9 +1774,9 @@
       "translated": "檢閱提供者就緒狀態\n和已設定的模型。"
     },
     {
-      "id": "native.android.0a5b541f486e6760",
-      "source": "Connected providers",
-      "translated": "已連線的提供者"
+      "id": "native.android.ca79d0de89bfa25a",
+      "source": "Providers and configured models",
+      "translated": "供應商與已設定的模型"
     },
     {
       "id": "native.android.c76ebb6f80eaad93",
@@ -1687,11 +1787,6 @@
       "id": "native.android.bffaa0de604a6248",
       "source": "Gateway offline",
       "translated": "Gateway 離線"
-    },
-    {
-      "id": "native.android.b21d6b8b2a1bf1c2",
-      "source": "Needs attention",
-      "translated": "需要注意"
     },
     {
       "id": "native.android.cc7752fdd9d78d63",
@@ -1709,24 +1804,24 @@
       "translated": "就緒"
     },
     {
-      "id": "native.android.bbe270b421ba7ee0",
-      "source": "Models",
-      "translated": "模型"
-    },
-    {
       "id": "native.android.b36b0c2003a82b53",
       "source": "Needs",
       "translated": "需要"
     },
     {
+      "id": "native.android.35fbba1d22e775ac",
+      "source": "Unknown",
+      "translated": "未知"
+    },
+    {
+      "id": "native.android.62fdb673c946ccf0",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "translated": "$modelCount 個已設定的模型。重新整理以重新檢查可用性。"
+    },
+    {
       "id": "native.android.24fe64a90afae34e",
       "source": "Connect your Gateway to view provider readiness.",
       "translated": "連線您的 Gateway 以檢視提供者就緒狀態。"
-    },
-    {
-      "id": "native.android.0bf3fd4d988ecdd9",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "translated": "重新整理，以從您的 Gateway 重新檢查提供者就緒狀態。"
     },
     {
       "id": "native.android.7a7bcb60c83ed920",
@@ -1739,9 +1834,9 @@
       "translated": "重新整理中"
     },
     {
-      "id": "native.android.80393d587b549b8e",
-      "source": "${row.modelCount} models",
-      "translated": "${row.modelCount} 個模型"
+      "id": "native.android.c11f2727dd9a93f7",
+      "source": "${row.modelCount} configured models",
+      "translated": "${row.modelCount} 個已設定的模型"
     },
     {
       "id": "native.android.51228649f9d8627a",
@@ -1752,11 +1847,6 @@
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "工作階段"
-    },
-    {
-      "id": "native.android.2806eb5b11becd89",
-      "source": "Reverse session sort",
-      "translated": "反轉工作階段排序"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1779,14 +1869,14 @@
       "translated": "搜尋工作階段"
     },
     {
-      "id": "native.android.9d0765fc76c3fca5",
-      "source": "Newest",
-      "translated": "最新"
+      "id": "native.android.dc52c5f9d7b85ec8",
+      "source": "Newest first",
+      "translated": "最新優先"
     },
     {
-      "id": "native.android.7f0fea03a2e789d3",
-      "source": "Oldest",
-      "translated": "最舊"
+      "id": "native.android.78b9d0ab41446a1b",
+      "source": "Oldest first",
+      "translated": "最舊優先"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -2329,6 +2419,26 @@
       "translated": "開啟設定"
     },
     {
+      "id": "native.android.165ebcc998a9b275",
+      "source": "Share installed app information?",
+      "translated": "分享已安裝的應用程式資訊？"
+    },
+    {
+      "id": "native.android.c3a001bb0191892d",
+      "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
+      "translated": "當已配對的 OpenClaw Gateway 提出要求時，OpenClaw 會收集並傳送此手機上可見應用程式的名稱、套件 ID 及狀態。這讓您的助理能使用已安裝的應用程式回答問題並執行操作。"
+    },
+    {
+      "id": "native.android.b05f8909de072d71",
+      "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
+      "translated": "您的手機會將此資訊傳送至您的 Gateway，而非傳送至 OpenClaw 執行的伺服器。您的 Gateway 可能會將其包含在傳送給您所選 AI 供應商的請求中。"
+    },
+    {
+      "id": "native.android.95a3cc1b163c1edf",
+      "source": "Agree and Enable",
+      "translated": "同意並啟用"
+    },
+    {
       "id": "native.android.fd97640418602532",
       "source": "Not Now",
       "translated": "暫時不要"
@@ -2599,39 +2709,24 @@
       "translated": "返回"
     },
     {
+      "id": "native.android.8d8f3b067cf74034",
+      "source": "Command approval",
+      "translated": "指令核准"
+    },
+    {
       "id": "native.android.6bbeb853f2a32dba",
       "source": "Sending",
       "translated": "傳送中"
     },
     {
-      "id": "native.android.db394198a0c15dc6",
-      "source": "Allow Once",
-      "translated": "允許一次"
+      "id": "native.android.eaa50bee1f61e423",
+      "source": "Approval ${notice.approvalId}",
+      "translated": "核准 ${notice.approvalId}"
     },
     {
-      "id": "native.android.b67b2df8c644f96b",
-      "source": "Allowing",
-      "translated": "允許中"
-    },
-    {
-      "id": "native.android.09fc3fe9b711771c",
-      "source": "Always",
-      "translated": "一律允許"
-    },
-    {
-      "id": "native.android.4ced4ce2002b025d",
-      "source": "Saving",
-      "translated": "儲存中"
-    },
-    {
-      "id": "native.android.00907f438ed4228e",
-      "source": "Deny",
-      "translated": "拒絕"
-    },
-    {
-      "id": "native.android.403afe272ef0d19e",
-      "source": "Denying",
-      "translated": "拒絕中"
+      "id": "native.android.0fb6fd448e378900",
+      "source": "Dismiss approval notice",
+      "translated": "關閉核准通知"
     },
     {
       "id": "native.android.4d44e246d2cba408",
@@ -2912,16 +3007,6 @@
       "id": "native.android.74a2f842d14cdd25",
       "source": "Search settings",
       "translated": "搜尋設定"
-    },
-    {
-      "id": "native.android.07ee62163aebc378",
-      "source": "$readyProviderCount ready",
-      "translated": "$readyProviderCount 已就緒"
-    },
-    {
-      "id": "native.android.fc155dcf9db1d39c",
-      "source": "Review readiness",
-      "translated": "檢查就緒狀態"
     },
     {
       "id": "native.android.68c6f975e8448995",
@@ -3574,21 +3659,6 @@
       "translated": "沒有應用程式可分享此訊息"
     },
     {
-      "id": "native.android.97a0b44d89402809",
-      "source": "Jump to latest",
-      "translated": "跳至最新內容"
-    },
-    {
-      "id": "native.android.69239493702da212",
-      "source": "Loading session",
-      "translated": "正在載入工作階段"
-    },
-    {
-      "id": "native.android.a7d32e86ce4c0a17",
-      "source": "No messages yet",
-      "translated": "尚無訊息"
-    },
-    {
       "id": "native.android.9ab1dd78954fc3c2",
       "source": "Preparing audio…",
       "translated": "正在準備音訊…"
@@ -3649,6 +3719,11 @@
       "translated": "你"
     },
     {
+      "id": "native.android.10d8391dea9f334b",
+      "source": "📎 ${attachment.fileName}",
+      "translated": "📎 ${attachment.fileName}"
+    },
+    {
       "id": "native.android.9bd31c23ebdf7c7a",
       "source": "Retry",
       "translated": "重試"
@@ -3672,6 +3747,16 @@
       "id": "native.android.82e9fe45e93909b6",
       "source": "OpenClaw",
       "translated": "OpenClaw"
+    },
+    {
+      "id": "native.android.316927b46135a7ab",
+      "source": "Open image preview",
+      "translated": "開啟圖片預覽"
+    },
+    {
+      "id": "native.android.7f8cf7bee5cc491f",
+      "source": "Close image preview",
+      "translated": "關閉圖片預覽"
     },
     {
       "id": "native.android.09720189ba712747",
@@ -3774,6 +3859,11 @@
       "translated": "OpenClaw 正在準備回應。"
     },
     {
+      "id": "native.android.f3806d79e43f568f",
+      "source": "Dismiss shared-image warning",
+      "translated": "關閉分享圖片警告"
+    },
+    {
       "id": "native.android.76d574acfac94fee",
       "source": "Stop",
       "translated": "停止"
@@ -3802,6 +3892,16 @@
       "id": "native.android.8e3e367df24cae4b",
       "source": "Gateway offline",
       "translated": "Gateway 離線"
+    },
+    {
+      "id": "native.android.36ed01582459bc10",
+      "source": "Close thinking level selector",
+      "translated": "關閉思考層級選擇器"
+    },
+    {
+      "id": "native.android.82d6389036a1e211",
+      "source": "Open thinking level selector",
+      "translated": "開啟思考層級選擇器"
     },
     {
       "id": "native.android.623e434c83e3c020",
@@ -6414,6 +6514,16 @@
       "translated": "Gateway 請求會顯示在這裡。"
     },
     {
+      "id": "native.apple.ebd38d32acb5373c",
+      "source": "1 waiting",
+      "translated": "1 個等待中"
+    },
+    {
+      "id": "native.apple.651249e2a5fc8852",
+      "source": "\\(self.pendingApprovalCount) waiting",
+      "translated": "\\(self.pendingApprovalCount) 個等待中"
+    },
+    {
       "id": "native.apple.0194fd3744125fd1",
       "source": "High",
       "translated": "高"
@@ -6544,14 +6654,9 @@
       "translated": "沒有 Gateway 動作正在等待審核。"
     },
     {
-      "id": "native.apple.2f164497392d8357",
-      "source": "Review the pending gateway action.",
-      "translated": "審核待處理的 Gateway 動作。"
-    },
-    {
-      "id": "native.apple.6156b1e3a8cec56c",
-      "source": "1 waiting",
-      "translated": "1 個等待中"
+      "id": "native.apple.cd9730a7cb964be7",
+      "source": "Review pending gateway actions.",
+      "translated": "檢閱待處理的 gateway 動作。"
     },
     {
       "id": "native.apple.561d865ad24910d2",
@@ -6609,19 +6714,39 @@
       "translated": "開啟通知"
     },
     {
-      "id": "native.apple.34b198d5caa2f6de",
-      "source": "Allow",
-      "translated": "允許"
+      "id": "native.apple.8a6df64f48087b74",
+      "source": "Pending approvals",
+      "translated": "待處理的核准"
     },
     {
-      "id": "native.apple.53c2c08c522ceb97",
-      "source": "Always Allow",
+      "id": "native.apple.e70b7e1453061f75",
+      "source": "Review exec approval",
+      "translated": "檢閱執行核准"
+    },
+    {
+      "id": "native.apple.2bdc4dfaddf2236d",
+      "source": "Reviewing",
+      "translated": "檢閱中"
+    },
+    {
+      "id": "native.apple.77d924dde15c505e",
+      "source": "Allow Once",
+      "translated": "允許一次"
+    },
+    {
+      "id": "native.apple.d002a80c43148553",
+      "source": "Allow Always",
       "translated": "永遠允許"
     },
     {
       "id": "native.apple.47aa34a39a9e05e5",
       "source": "Deny",
       "translated": "拒絕"
+    },
+    {
+      "id": "native.apple.eb833f81b7901d39",
+      "source": "Dismiss",
+      "translated": "關閉"
     },
     {
       "id": "native.apple.9bc57eb179ada99d",
@@ -7504,6 +7629,11 @@
       "translated": "一律允許"
     },
     {
+      "id": "native.apple.528a2fce8714d569",
+      "source": "Dismiss",
+      "translated": "關閉"
+    },
+    {
       "id": "native.apple.ac88205cbb8a974d",
       "source": "Deny",
       "translated": "拒絕"
@@ -8032,6 +8162,26 @@
       "id": "native.apple.ae33908b61c6d70b",
       "source": "Offline",
       "translated": "離線"
+    },
+    {
+      "id": "native.apple.0b1eff808df04e2b",
+      "source": "Approval",
+      "translated": "核准"
+    },
+    {
+      "id": "native.apple.c74dccc1c5d71750",
+      "source": "This approval was already",
+      "translated": "此核准已"
+    },
+    {
+      "id": "native.apple.4864b3b8c6ed7158",
+      "source": "Approval set to Always Allow.",
+      "translated": "核准已設為永遠允許。"
+    },
+    {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "此核准已設為永遠允許。"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -9099,6 +9249,31 @@
       "translated": "需要核准"
     },
     {
+      "id": "native.apple.3472ab6e7b81a746",
+      "source": "Opens the full command before decisions are available",
+      "translated": "在可進行決策之前開啟完整指令"
+    },
+    {
+      "id": "native.apple.ceaf03f87100f512",
+      "source": "Loading",
+      "translated": "載入中"
+    },
+    {
+      "id": "native.apple.fb9ff1586850b8a9",
+      "source": "Loading approval",
+      "translated": "正在載入核准"
+    },
+    {
+      "id": "native.apple.7eadc6444e799223",
+      "source": "Unavailable",
+      "translated": "無法使用"
+    },
+    {
+      "id": "native.apple.6699bd5238af0897",
+      "source": "Approval not loaded",
+      "translated": "核准未載入"
+    },
+    {
       "id": "native.apple.373973b577f97d63",
       "source": "Review again",
       "translated": "再次檢視"
@@ -9264,6 +9439,16 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.apple.a4e70d96cf65b2b2",
+      "source": "Command",
+      "translated": "指令"
+    },
+    {
+      "id": "native.apple.5aeafce9c079fcb8",
+      "source": "Command to review",
+      "translated": "要檢閱的指令"
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "你"
@@ -9314,24 +9499,24 @@
       "translated": "核准"
     },
     {
-      "id": "native.apple.24aa28fc8c954704",
-      "source": "Sending decision...",
-      "translated": "正在傳送決定..."
+      "id": "native.apple.507b63347d559665",
+      "source": "Review Command",
+      "translated": "檢閱指令"
     },
     {
-      "id": "native.apple.b7b88bee2f79f10e",
-      "source": "Approve",
-      "translated": "核准"
+      "id": "native.apple.cd22b958c904f66f",
+      "source": "Command execution",
+      "translated": "指令執行"
+    },
+    {
+      "id": "native.apple.82ee6f7c58b18b55",
+      "source": "Allow Once",
+      "translated": "允許一次"
     },
     {
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "拒絕"
-    },
-    {
-      "id": "native.apple.6fdc607c6178ba31",
-      "source": "OpenClaw on GitHub",
-      "translated": "GitHub 上的 OpenClaw"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9447,6 +9632,161 @@
       "id": "native.apple.69b64bb81b900cc4",
       "source": "\\(user)@\\(host):\\(port)",
       "translated": "\\(user)@\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.edfef1f4b5cb081f",
+      "source": "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.",
+      "translated": "OpenClaw 無法安裝到「應用程式」中。請手動將其移至該處，然後開啟該副本。"
+    },
+    {
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "要將 OpenClaw 安裝到「應用程式」中嗎？"
+    },
+    {
+      "id": "native.apple.7f86f5acf3d32ec2",
+      "source": "Replace the older OpenClaw in Applications?",
+      "translated": "要取代「應用程式」中較舊的 OpenClaw 嗎？"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw 會將自身複製到「應用程式」並在該處重新開啟，以確保更新與登入時啟動維持穩定。"
+    },
+    {
+      "id": "native.apple.c8898d685457401f",
+      "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
+      "translated": "此副本比已安裝的應用程式更新。OpenClaw 會將其取代並從「應用程式」重新開啟。"
+    },
+    {
+      "id": "native.apple.22ebb7b228c8275a",
+      "source": "Install and Relaunch",
+      "translated": "安裝並重新啟動"
+    },
+    {
+      "id": "native.apple.184b1c0eda89e496",
+      "source": "Replace and Relaunch",
+      "translated": "取代並重新啟動"
+    },
+    {
+      "id": "native.apple.9ac444c15bd52f0e",
+      "source": "OpenClaw is installed in Applications, but couldn’t reopen automatically. Open it there manually.",
+      "translated": "OpenClaw 已安裝到「應用程式」中，但無法自動重新開啟。請在該處手動開啟。"
+    },
+    {
+      "id": "native.apple.d1faee12838b677f",
+      "source": "Use your browser logins",
+      "translated": "使用您的瀏覽器登入資訊"
+    },
+    {
+      "id": "native.apple.c5ff31546d6a679d",
+      "source": "Copy cookies from \\(browsers) into an isolated agent profile. Passwords are never touched.",
+      "translated": "將 \\(browsers) 的 cookie 複製到隔離的代理設定檔中。密碼絕不會被觸及。"
+    },
+    {
+      "id": "native.apple.8dc63b7646cb0bdb",
+      "source": "Importing browser cookies…",
+      "translated": "正在匯入瀏覽器 cookie…"
+    },
+    {
+      "id": "native.apple.726d99301dedf301",
+      "source": "Copying \\(profile.displayName) into “\\(target)”. Touch ID may be required.",
+      "translated": "正在將 \\(profile.displayName) 複製到「\\(target)」。可能需要 Touch ID。"
+    },
+    {
+      "id": "native.apple.afe729bf54ad5a20",
+      "source": "Browser logins imported",
+      "translated": "已匯入瀏覽器登入資訊"
+    },
+    {
+      "id": "native.apple.f2537efb54feeba4",
+      "source": "\\(result.cookies.imported) of \\(result.cookies.total) cookies copied into “\\(result.into)” — now the default profile for agent browsing.",
+      "translated": "已將 \\(result.cookies.total) 個 cookie 中的 \\(result.cookies.imported) 個複製到「\\(result.into)」——現在成為代理瀏覽的預設設定檔。"
+    },
+    {
+      "id": "native.apple.aaa27f92ea6143c3",
+      "source": "Browser import failed",
+      "translated": "瀏覽器匯入失敗"
+    },
+    {
+      "id": "native.apple.0a0426e216fde2a3",
+      "source": "your browser",
+      "translated": "您的瀏覽器"
+    },
+    {
+      "id": "native.apple.b75ef7dd2b515a59",
+      "source": "\\(content.title). \\(content.subtitle)",
+      "translated": "\\(content.title)。\\(content.subtitle)"
+    },
+    {
+      "id": "native.apple.cc06661a63fc0cad",
+      "source": "Import",
+      "translated": "匯入"
+    },
+    {
+      "id": "native.apple.a99a3c13a2a98ba3",
+      "source": "Retry",
+      "translated": "重試"
+    },
+    {
+      "id": "native.apple.792cfb2474ad0533",
+      "source": "Dismiss",
+      "translated": "關閉"
+    },
+    {
+      "id": "native.apple.ed83068f5cbb2b04",
+      "source": "Browser import requires Local mode",
+      "translated": "瀏覽器匯入需要本機模式"
+    },
+    {
+      "id": "native.apple.eb2383ae167c90fd",
+      "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
+      "translated": "匯入瀏覽器 cookie 前，請先將此 Mac 應用程式切換為本機 Gateway。"
+    },
+    {
+      "id": "native.apple.fdf0ffe662bd620f",
+      "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
+      "translated": "在此 Mac 上找不到含 cookie 的 Chrome、Brave、Edge 或 Chromium 設定檔。"
+    },
+    {
+      "id": "native.apple.eedf0eec72f6d287",
+      "source": "System browser profile import is disabled in the local Gateway configuration.",
+      "translated": "本機 Gateway 設定中已停用系統瀏覽器設定檔匯入。"
+    },
+    {
+      "id": "native.apple.a8164afad8e43408",
+      "source": "No browser login available",
+      "translated": "沒有可用的瀏覽器登入"
+    },
+    {
+      "id": "native.apple.52bd5967f06d4ea2",
+      "source": "Browser import unavailable",
+      "translated": "無法使用瀏覽器匯入"
+    },
+    {
+      "id": "native.apple.b9da2c873ad24b0f",
+      "source": "CLI install failed",
+      "translated": "CLI 安裝失敗"
+    },
+    {
+      "id": "native.apple.506cd570a8f8a80d",
+      "source": "CLI install finished",
+      "translated": "CLI 安裝完成"
+    },
+    {
+      "id": "native.apple.a952bff9aa7c7e9b",
+      "source": "Stable",
+      "translated": "穩定版"
+    },
+    {
+      "id": "native.apple.a80cbef551294895",
+      "source": "Beta",
+      "translated": "測試版"
+    },
+    {
+      "id": "native.apple.dac0bc4221a6e965",
+      "source": "Dev (Git main)",
+      "translated": "開發版（Git main）"
     },
     {
       "id": "native.apple.cfc2509b8bbcf1d7",
@@ -10239,6 +10579,31 @@
       "translated": "未送達"
     },
     {
+      "id": "native.apple.5eea57b14cab3876",
+      "source": "Dashboard reconnecting",
+      "translated": "儀表板正在重新連線"
+    },
+    {
+      "id": "native.apple.4a3bf4e766652536",
+      "source": "The selected Gateway changed.",
+      "translated": "所選的 Gateway 已變更。"
+    },
+    {
+      "id": "native.apple.2049ebe709019afb",
+      "source": "Waiting for a fresh authenticated connection.",
+      "translated": "正在等待新的已驗證連線。"
+    },
+    {
+      "id": "native.apple.d107ce2696f1259f",
+      "source": "Dashboard unavailable",
+      "translated": "無法使用儀表板"
+    },
+    {
+      "id": "native.apple.3ed077c15e06c140",
+      "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
+      "translated": "請檢查「設定」→「連線」，或使用「除錯」→「重設遠端通道」，然後再試一次。"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "要終止 \\(listener.command) (\\(listener.pid)) 嗎？"
@@ -10704,6 +11069,16 @@
       "translated": "僅限路徑模式。請包含 '/'、'~' 或 '\\\\'。"
     },
     {
+      "id": "native.apple.5b9878c76d9a0995",
+      "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
+      "translated": "此允許清單項目為繼承而來。請編輯其所屬範圍後再重試。"
+    },
+    {
+      "id": "native.apple.511333a8588db7e2",
+      "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
+      "translated": "無法儲存 exec 核准。顯示的是最後已知的設定；請重試變更。"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -10774,6 +11149,11 @@
       "translated": "登入後自動啟動 OpenClaw。"
     },
     {
+      "id": "native.apple.8b74758a60f78642",
+      "source": "Move OpenClaw to Applications before enabling launch at login.",
+      "translated": "啟用登入時啟動前，請先將 OpenClaw 移至「應用程式」。"
+    },
+    {
       "id": "native.apple.927819c087ca3520",
       "source": "Show Dock icon",
       "translated": "顯示 Dock 圖示"
@@ -10837,6 +11217,26 @@
       "id": "native.apple.82e287000e34b51e",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "translated": "允許已簽署工具（例如 `peekaboo`）透過 PeekabooBridge 驅動 UI 自動化。"
+    },
+    {
+      "id": "native.apple.72b24ed86295d6fa",
+      "source": "Browser",
+      "translated": "瀏覽器"
+    },
+    {
+      "id": "native.apple.439535b659ad69df",
+      "source": "Browser login",
+      "translated": "瀏覽器登入"
+    },
+    {
+      "id": "native.apple.de4f3832100c9a23",
+      "source": "Copy cookies from a Chrome-family profile into an isolated managed profile.",
+      "translated": "將 Chrome 系列設定檔中的 cookies 複製到獨立的受管理設定檔。"
+    },
+    {
+      "id": "native.apple.89dab98753cdc0c2",
+      "source": "Import…",
+      "translated": "匯入…"
     },
     {
       "id": "native.apple.476c2358c26250a7",
@@ -11354,6 +11754,16 @@
       "translated": "設定..."
     },
     {
+      "id": "native.apple.f6048387f9b99c8e",
+      "source": "Back",
+      "translated": "返回"
+    },
+    {
+      "id": "native.apple.c19b0989064c0020",
+      "source": "Forward",
+      "translated": "前進"
+    },
+    {
       "id": "native.apple.fae2cf18519da0d5",
       "source": "OpenClaw",
       "translated": "OpenClaw"
@@ -11407,6 +11817,16 @@
       "id": "native.apple.a7298f07a717f564",
       "source": "Exec Approvals",
       "translated": "執行核准"
+    },
+    {
+      "id": "native.apple.348d4adeb2afab25",
+      "source": "Loading Exec Approvals…",
+      "translated": "正在載入 Exec 核准…"
+    },
+    {
+      "id": "native.apple.b2f5f038c81a4a89",
+      "source": "Retry Exec Approvals",
+      "translated": "重試 Exec 核准"
     },
     {
       "id": "native.apple.fa9ee90b4a391979",
@@ -11704,6 +12124,16 @@
       "translated": "用量"
     },
     {
+      "id": "native.apple.386595fa18585dbb",
+      "source": "approvalSource requires matching systemRunPlan",
+      "translated": "approvalSource requires matching systemRunPlan"
+    },
+    {
+      "id": "native.apple.014ff905cecd753b",
+      "source": "explicit approval requires matching systemRunPlan",
+      "translated": "explicit approval requires matching systemRunPlan"
+    },
+    {
       "id": "native.apple.7eb0a88b8274ced8",
       "source": "Node pairing approved",
       "translated": "節點配對已核准"
@@ -11729,137 +12159,272 @@
       "translated": "下一步"
     },
     {
-      "id": "native.apple.0a6a895baa7f708e",
+      "id": "native.apple.0f3c1c6f0672bed7",
+      "source": "The Gateway setup request failed.",
+      "translated": "Gateway 設定請求失敗。"
+    },
+    {
+      "id": "native.apple.1d0e9fc5cec8e38e",
+      "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
+      "translated": "Gateway 設定請求失敗。顯示詳細資料以檢查或複製錯誤。"
+    },
+    {
+      "id": "native.apple.a93918d55c7a93e2",
+      "source": "\\(label) couldn’t complete the test.",
+      "translated": "\\(label) 無法完成測試。"
+    },
+    {
+      "id": "native.apple.e49b3d2d2cc77bd1",
+      "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
+      "translated": "\\(label) 無法完成測試。顯示詳細資料以檢查或複製錯誤。"
+    },
+    {
+      "id": "native.apple.f3f900bed1ccf58b",
       "source": "Looking for AI you already use…",
-      "translated": "正在尋找您已使用的 AI…"
+      "translated": "正在尋找您已在使用的 AI…"
     },
     {
-      "id": "native.apple.9d19cb7eb5fa6d79",
+      "id": "native.apple.87f0d2248ff12e38",
+      "source": "Waiting for the previous AI test to finish…",
+      "translated": "正在等待前一個 AI 測試完成…"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
       "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "正在檢查 Claude Code、Codex、Gemini 和已儲存的 API keys。"
+      "translated": "正在檢查 Claude Code、Codex、Gemini 及已儲存的 API 金鑰。"
     },
     {
-      "id": "native.apple.7e1e827f427bc317",
+      "id": "native.apple.e3e27d22fd2312a2",
+      "source": "OpenClaw will check again before changing any inference settings.",
+      "translated": "OpenClaw 會在變更任何推論設定前再次檢查。"
+    },
+    {
+      "id": "native.apple.0fd3e5267cdf8250",
+      "source": "Couldn’t check this Gateway for AI accounts",
+      "translated": "無法檢查此 Gateway 是否有 AI 帳戶"
+    },
+    {
+      "id": "native.apple.0af61b95d249c351",
       "source": "Couldn’t check this Mac for AI accounts",
-      "translated": "無法檢查這台 Mac 上的 AI 帳號"
+      "translated": "無法檢查此 Mac 是否有 AI 帳戶"
     },
     {
-      "id": "native.apple.3b56fbfb9200f050",
+      "id": "native.apple.ab05bb1569f89077",
       "source": "Couldn’t load the full provider list",
       "translated": "無法載入完整的供應商清單"
     },
     {
-      "id": "native.apple.87a3b9052eedd7eb",
+      "id": "native.apple.e8c5cb9022586a87",
       "source": "Try again",
       "translated": "再試一次"
     },
     {
-      "id": "native.apple.3a585b31d77507d8",
+      "id": "native.apple.d281e0ae214cc599",
       "source": "None of the found options worked",
       "translated": "找到的選項都無法使用"
     },
     {
-      "id": "native.apple.9947fd4c5e97875f",
+      "id": "native.apple.51a8291ef11e844d",
       "source": "The details are listed on each option above. You can fix the login and retry, or connect with an API key or token below.",
-      "translated": "詳細資訊列在上方每個選項中。您可以修正登入後重試，或使用下方的 API key 或 token 連接。"
+      "translated": "詳細資訊列在上方每個選項中。您可以修正登入資訊後重試，或使用下方的 API 金鑰或權杖連接。"
     },
     {
-      "id": "native.apple.dc51d7deab7b6c1e",
+      "id": "native.apple.11383227f922aaec",
       "source": "Need help? Chat with Crestodian",
       "translated": "需要協助嗎？與 Crestodian 聊聊"
     },
     {
-      "id": "native.apple.6bf2e2bdd950a97d",
+      "id": "native.apple.6526ced182e1fe50",
       "source": "Your AI is ready",
-      "translated": "您的 AI 已準備就緒"
+      "translated": "您的 AI 已就緒"
     },
     {
-      "id": "native.apple.c3ed46eded513a65",
+      "id": "native.apple.5d8998398be53d6f",
+      "source": "Setup details",
+      "translated": "設定詳細資訊"
+    },
+    {
+      "id": "native.apple.1967fcaeb9e74257",
+      "source": "Copy setup details",
+      "translated": "複製設定詳細資訊"
+    },
+    {
+      "id": "native.apple.f5a157404f7a0eff",
       "source": "No AI accounts found on this Mac",
-      "translated": "在這台 Mac 上找不到 AI 帳號"
+      "translated": "在此 Mac 上找不到 AI 帳戶"
     },
     {
-      "id": "native.apple.08d6423b6ed142a8",
+      "id": "native.apple.76072d0308a553ca",
       "source": "That’s fine — you can connect one with an API key or token. If you use Claude Code, Codex, or the Gemini CLI on this Mac, sign in there first and hit “Check again”.",
-      "translated": "沒問題 — 您可以使用 API key 或 token 連接一個。如果您在這台 Mac 上使用 Claude Code、Codex 或 Gemini CLI，請先在那裡登入，然後按「再次檢查」。"
+      "translated": "沒關係——您可以使用 API 金鑰或權杖連接。如果您在此 Mac 上使用 Claude Code、Codex 或 Gemini CLI，請先在那裡登入，然後點按「再次檢查」。"
     },
     {
-      "id": "native.apple.f51a11c7f56bdb29",
-      "source": "Recommended",
-      "translated": "建議"
-    },
-    {
-      "id": "native.apple.d13850075df8f0f3",
+      "id": "native.apple.5f28927fe23c11cb",
       "source": "No key-based providers are available",
-      "translated": "沒有可用的以金鑰為基礎的供應商"
+      "translated": "沒有可用的金鑰型供應商"
     },
     {
-      "id": "native.apple.0dd754dd6da55727",
+      "id": "native.apple.aa4be25696c3f5fc",
       "source": "Enable or install a text-inference provider plugin on this Gateway, then check again.",
       "translated": "在此 Gateway 上啟用或安裝文字推論供應商外掛，然後再次檢查。"
     },
     {
-      "id": "native.apple.ff87d5ec9e15e581",
+      "id": "native.apple.89790664bd5e0758",
       "source": "Check again",
       "translated": "再次檢查"
     },
     {
-      "id": "native.apple.459cc3789bc7128d",
+      "id": "native.apple.f179b0447a18bbf4",
       "source": "Connect with an API key or token instead…",
-      "translated": "改用 API key 或 token 連接…"
+      "translated": "改用 API 金鑰或權杖連接…"
     },
     {
-      "id": "native.apple.8347a2f698a63735",
+      "id": "native.apple.7fc409b6aaa6d3b9",
+      "source": "Sign in with a provider",
+      "translated": "使用供應商登入"
+    },
+    {
+      "id": "native.apple.4a1e5a5600b907f4",
+      "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
+      "translated": "使用現有的訂閱或供應商帳戶。OpenClaw 會開啟供應商本身的登入流程，然後以實際回覆驗證。"
+    },
+    {
+      "id": "native.apple.14b23c357d7a9eff",
+      "source": "More sign-in options",
+      "translated": "更多登入選項"
+    },
+    {
+      "id": "native.apple.10971b41012d4f36",
+      "source": "Pair",
+      "translated": "配對"
+    },
+    {
+      "id": "native.apple.f431c2a7838e89d7",
+      "source": "Sign in",
+      "translated": "登入"
+    },
+    {
+      "id": "native.apple.869fe436119bb8a6",
+      "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
+      "translated": "認證資訊會保留在此 Gateway 上，且僅在即時測試成功後才會儲存。"
+    },
+    {
+      "id": "native.apple.3d5ffc1c8a803630",
+      "source": "Open sign-in page…",
+      "translated": "開啟登入頁面…"
+    },
+    {
+      "id": "native.apple.bb3352787887c424",
+      "source": "Starting secure sign-in…",
+      "translated": "正在啟動安全登入…"
+    },
+    {
+      "id": "native.apple.d7519516740bfc93",
+      "source": "Sign-in didn’t complete",
+      "translated": "登入未完成"
+    },
+    {
+      "id": "native.apple.b72a34ae3707531f",
+      "source": "Cancel",
+      "translated": "取消"
+    },
+    {
+      "id": "native.apple.012f9f442abb9624",
+      "source": "Finish in your browser",
+      "translated": "在瀏覽器中完成"
+    },
+    {
+      "id": "native.apple.d9f2c3523534fd83",
+      "source": "Copy",
+      "translated": "複製"
+    },
+    {
+      "id": "native.apple.acb7041e820bfb87",
+      "source": "Expires in \\(minutes) minutes",
+      "translated": "將於 \\(minutes) 分鐘後過期"
+    },
+    {
+      "id": "native.apple.3e537aee648f41a5",
+      "source": "Open sign-in page",
+      "translated": "開啟登入頁面"
+    },
+    {
+      "id": "native.apple.b83aa2f66237a802",
+      "source": "Option",
+      "translated": "選項"
+    },
+    {
+      "id": "native.apple.675c1390266b5ccb",
+      "source": "Confirm",
+      "translated": "確認"
+    },
+    {
+      "id": "native.apple.707648a54749ed5b",
+      "source": "I've signed in",
+      "translated": "我已登入"
+    },
+    {
+      "id": "native.apple.b98630f560f6bada",
+      "source": "Continue",
+      "translated": "繼續"
+    },
+    {
+      "id": "native.apple.955e33c4ed4d5d3a",
+      "source": "Submit",
+      "translated": "提交"
+    },
+    {
+      "id": "native.apple.c3e8449bcdd9b054",
       "source": "Connect with an API key or token",
-      "translated": "使用 API key 或 token 連接"
+      "translated": "使用 API 金鑰或權杖連線"
     },
     {
-      "id": "native.apple.9da1d31635dca50b",
+      "id": "native.apple.a9c9e609d96ec001",
       "source": "Provider",
-      "translated": "提供者"
+      "translated": "供應商"
     },
     {
-      "id": "native.apple.cb3d8a8506943d3a",
+      "id": "native.apple.2fb28e8b6b9e3918",
       "source": "API key or token",
-      "translated": "API key 或 token"
+      "translated": "API 金鑰或權杖"
     },
     {
-      "id": "native.apple.41d117fdc784999f",
+      "id": "native.apple.6621d46d9ebfefa6",
       "source": "Connect",
       "translated": "連線"
     },
     {
-      "id": "native.apple.ce55144c35473419",
+      "id": "native.apple.953d477f3f3f2efa",
       "source": "That key didn’t work",
-      "translated": "該 key 無法使用"
+      "translated": "該金鑰無法使用"
     },
     {
-      "id": "native.apple.95ba6710c48389ae",
+      "id": "native.apple.18c6f84a21b9d92f",
       "source": "Crestodian — setup helper",
-      "translated": "Crestodian — 設定協助工具"
+      "translated": "Crestodian — 設定小幫手"
     },
     {
-      "id": "native.apple.06d9df11b5b462b4",
+      "id": "native.apple.bea852c8622c8214",
       "source": "Done",
       "translated": "完成"
     },
     {
-      "id": "native.apple.c3460290224a3ed3",
+      "id": "native.apple.f91347240d07008f",
       "source": "Open help…",
       "translated": "開啟說明…"
     },
     {
-      "id": "native.apple.cd74ba4ea185d89e",
+      "id": "native.apple.1af12c60f9a7c364",
       "source": "Hide details",
-      "translated": "隱藏詳細資訊"
+      "translated": "隱藏詳細資料"
     },
     {
-      "id": "native.apple.3a8d0f37b25ab92d",
+      "id": "native.apple.5e7e4e9dbc9a3980",
       "source": "Show details",
-      "translated": "顯示詳細資訊"
+      "translated": "顯示詳細資料"
     },
     {
-      "id": "native.apple.bdf53a219bdfbe0d",
+      "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "複製錯誤"
     },
@@ -12209,71 +12774,6 @@
       "translated": "再試一次"
     },
     {
-      "id": "native.apple.155fc8bc8b9f8c3f",
-      "source": "Agent workspace",
-      "translated": "代理程式工作區"
-    },
-    {
-      "id": "native.apple.d82e61ae0119bf7c",
-      "source": "OpenClaw runs the agent from a dedicated workspace so it can load `AGENTS.md` and write files there without mixing into your other projects.",
-      "translated": "OpenClaw 會從專用工作區執行代理程式，以便載入 `AGENTS.md` 並在其中寫入檔案，而不會混入你的其他專案。"
-    },
-    {
-      "id": "native.apple.5a32f8309c1faaee",
-      "source": "Remote gateway detected",
-      "translated": "偵測到遠端 Gateway"
-    },
-    {
-      "id": "native.apple.2156b2c0e9afe407",
-      "source": "Create the workspace on the remote host (SSH in first). The macOS app can’t write files on your gateway over SSH yet.",
-      "translated": "請在遠端主機上建立工作區（先透過 SSH 連入）。macOS App 目前尚無法透過 SSH 在你的 Gateway 上寫入檔案。"
-    },
-    {
-      "id": "native.apple.7285ab8a8c5a17a1",
-      "source": "Copied",
-      "translated": "已複製"
-    },
-    {
-      "id": "native.apple.d006e5220689679b",
-      "source": "Copy setup command",
-      "translated": "複製設定指令"
-    },
-    {
-      "id": "native.apple.e707cf5fab72f1f3",
-      "source": "Workspace folder",
-      "translated": "工作區資料夾"
-    },
-    {
-      "id": "native.apple.88d2a41a6763127a",
-      "source": "Create workspace",
-      "translated": "建立工作區"
-    },
-    {
-      "id": "native.apple.3c9e2e010d0a878f",
-      "source": "Open folder",
-      "translated": "開啟資料夾"
-    },
-    {
-      "id": "native.apple.0172a11ddaa58a58",
-      "source": "Save in config",
-      "translated": "儲存至設定"
-    },
-    {
-      "id": "native.apple.fc612f22fe551226",
-      "source": "Tip: edit AGENTS.md in this folder to shape the assistant’s behavior. For backup, make the workspace a private git repo so your agent’s “memory” is versioned.",
-      "translated": "提示：編輯此資料夾中的 AGENTS.md，以調整助理的行為。若要備份，請將工作區設為私有 git repo，讓代理的「記憶」具備版本管理。"
-    },
-    {
-      "id": "native.apple.803fffba25310a90",
-      "source": "Meet your agent",
-      "translated": "認識你的代理"
-    },
-    {
-      "id": "native.apple.6c35dc9becd6ca0f",
-      "source": "Your agent introduces itself, picks a name with you, and helps you connect WhatsApp, Telegram, or another channel — just chat.",
-      "translated": "你的代理會自我介紹，與你一起取個名字，並協助你連接 WhatsApp、Telegram 或其他管道 — 只要聊天即可。"
-    },
-    {
       "id": "native.apple.25e82538dc9e9aad",
       "source": "You’re all set!",
       "translated": "你已全部設定完成！"
@@ -12402,6 +12902,16 @@
       "id": "native.apple.048e9cc88fb7af55",
       "source": "Not Now",
       "translated": "暫時不要"
+    },
+    {
+      "id": "native.apple.4f271aca6df52a32",
+      "source": "Reject All",
+      "translated": "全部拒絕"
+    },
+    {
+      "id": "native.apple.bef7b0a91ca5c184",
+      "source": "Approve All",
+      "translated": "全部核准"
     },
     {
       "id": "native.apple.57e27a9a3ef63ac4",
@@ -13237,6 +13747,31 @@
       "id": "native.apple.e5198b803f0b5c9f",
       "source": "Control how agent shell commands are approved on this Mac.",
       "translated": "控制這台 Mac 上代理程式 Shell 命令的核准方式。"
+    },
+    {
+      "id": "native.apple.4ec0e98876dd4130",
+      "source": "Loading settings…",
+      "translated": "正在載入設定…"
+    },
+    {
+      "id": "native.apple.15112b7a64de6801",
+      "source": "Reading the persisted policy.",
+      "translated": "正在讀取已保存的原則。"
+    },
+    {
+      "id": "native.apple.10ccbcb69920d863",
+      "source": "Exec Approvals Unavailable",
+      "translated": "無法使用執行核准"
+    },
+    {
+      "id": "native.apple.f8de480303620970",
+      "source": "Settings could not be read",
+      "translated": "無法讀取設定"
+    },
+    {
+      "id": "native.apple.761db018bc2fc118",
+      "source": "Retry",
+      "translated": "重試"
     },
     {
       "id": "native.apple.4c894d7779471cda",
@@ -14507,6 +15042,11 @@
       "id": "native.apple.8d0606ab1a2c0f44",
       "source": "Gateway connected",
       "translated": "Gateway 已連線"
+    },
+    {
+      "id": "native.apple.f74d150ce05205dd",
+      "source": "z",
+      "translated": "z"
     },
     {
       "id": "native.apple.71e0219d1501de06",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -3539,6 +3539,11 @@
       "translated": "啟用麥克風"
     },
     {
+      "id": "native.android.066337249b9d9d30",
+      "source": "Refresh",
+      "translated": "重新整理"
+    },
+    {
       "id": "native.android.eb6ff96aba8f67b4",
       "source": "Files unavailable",
       "translated": "檔案無法使用"
@@ -4132,11 +4137,6 @@
       "id": "native.android.42af8acef7e61a34",
       "source": "Chat error",
       "translated": "聊天錯誤"
-    },
-    {
-      "id": "native.android.e368d73d1c767bed",
-      "source": "Off",
-      "translated": "關閉"
     },
     {
       "id": "native.android.f392ee2d50d6b7ce",


### PR DESCRIPTION
## What Problem This Solves

The checked-in native translation-memory artifacts had drifted behind the current source inventory. Every locale was missing current entries, which blocks exact artifact validation and the runtime localization work tracked in #103691.

## Why This Change Was Made

This preserves the latest translation refresh generated by the native locale workflow, then reconciles its one-entry source-inventory delta against current `main`.

The generated refresh remains a separate prerequisite so the runtime iOS, watchOS, and Android localization changes can be reviewed without 21 locale artifacts obscuring their code diff.

## User Impact

No runtime UI changes in this PR. Translators and follow-up localization generators receive complete, ordered artifacts for all supported native locales.

## Evidence

- Exact artifact validation: 21 locale files, 3,024 ordered entries each, 63,504 non-empty translation cells.
- Locale metadata, entry IDs, source text, ordering, and uniqueness match `apps/.i18n/native-source.json`.
- `git diff --check origin/main..HEAD`
- Structured autoreview was attempted but refused the 1.1 MB generated diff because it exceeds the review bundle limit.

Refs #103691
