### PR TITLE
fix(process): report correct byte counts for Unicode input

### DIFF
--- a/src/agents/bash-tools.process-send-keys.ts
+++ b/src/agents/bash-tools.process-send-keys.ts
@@ -75,7 +75,7 @@ export async function handleProcessSendKeys(params: {
       {
         type: "text",
         text:
-          `Sent ${data.length} bytes to session ${params.sessionId}.` +
+          `Sent ${Buffer.byteLength(data, "utf8")} bytes to session ${params.sessionId}.` +
           (warnings.length ? `\nWarnings:\n- ${warnings.join("\n- ")}` : ""),
       },
     ],

--- a/src/agents/bash-tools.process.byte-count.test.ts
+++ b/src/agents/bash-tools.process.byte-count.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { addSession, resetProcessRegistryForTests } from "./bash-process-registry.js";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { createProcessTool } from "./bash-tools.process.js";
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+});
+
+const payload = "你好🙂";
+
+async function expectUtf8ByteCount(testCase: {
+  id: string;
+  args: { action: "write"; data: string } | { action: "send-keys"; literal: string };
+  verb: string;
+}) {
+  const write = vi.fn((data: string, callback?: (error?: Error | null) => void) => {
+    callback?.(null);
+  });
+  const session = createProcessSessionFixture({
+    id: testCase.id,
+    backgrounded: true,
+    cursorKeyMode: "normal",
+  });
+  session.stdin = { write, end: vi.fn(), destroyed: false };
+  addSession(session);
+
+  const result = await createProcessTool().execute("toolcall", {
+    ...testCase.args,
+    sessionId: testCase.id,
+  });
+
+  expect(write).toHaveBeenCalledWith(payload, expect.any(Function));
+  expect(result.content[0]).toMatchObject({
+    type: "text",
+    text: `${testCase.verb} 10 bytes to session ${testCase.id}.`,
+  });
+}
+
+test("process write reports UTF-8 byte counts", async () => {
+  expect(payload).toHaveLength(4);
+  expect(Buffer.byteLength(payload, "utf8")).toBe(10);
+
+  await expectUtf8ByteCount({
+    id: "write-unicode",
+    args: { action: "write", data: payload },
+    verb: "Wrote",
+  });
+});
+
+test("process send-keys reports UTF-8 byte counts", async () => {
+  await expectUtf8ByteCount({
+    id: "send-keys-unicode",
+    args: { action: "send-keys", literal: payload },
+    verb: "Sent",
+  });
+});

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -593,13 +593,14 @@ export function createProcessTool(
           if (!resolved.ok) {
             return resolved.result;
           }
-          await writeProcessStdin(resolved.stdin, params.data ?? "");
+          const data = params.data ?? "";
+          await writeProcessStdin(resolved.stdin, data);
           if (params.eof) {
             resolved.stdin.end();
           }
           return runningSessionResult(
             resolved.session,
-            `Wrote ${(params.data ?? "").length} bytes to session ${params.sessionId}${
+            `Wrote ${Buffer.byteLength(data, "utf8")} bytes to session ${params.sessionId}${
               params.eof ? " (stdin closed)" : ""
             }.`,
           );


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where agents sending Chinese, emoji, or other multibyte Unicode input to a running process would receive a success confirmation with an under-reported byte count. Both `process write` and `process send-keys` could say that four bytes were sent for input that actually occupied ten UTF-8 bytes.

## Why This Change Was Made

The two process input paths now count the final string passed to the live session stdin with UTF-8 byte semantics. For `send-keys`, the count is taken after key/literal/hex encoding; process schemas, accepted input, PTY transport, paste character reporting, and result shapes are unchanged.

## User Impact

Agents can trust the byte count reported after writing Unicode input to a background session. ASCII confirmations remain unchanged, while multibyte text now reports the actual bytes delivered to stdin.

## Evidence

- TDD red on the pre-fix task head: `你好🙂` is 4 JavaScript UTF-16 code units and 10 UTF-8 bytes; focused regressions observed `Wrote 4 bytes` and `Sent 4 bytes` before the production change.
- Real PTY behavior proof used production `runExecProcess`, the real process registry, and `createProcessTool`. Both raw-mode Node children observed the exact ten input bytes, and both fixed confirmations reported ten:

  ```text
  payload: 你好🙂
  expected_utf8_bytes: 10
  write receipt: Wrote 10 bytes to session <session>.
  write child: OBSERVED_BYTES:10
  send-keys receipt: Sent 10 bytes to session <session>.
  send-keys child: OBSERVED_BYTES:10
  observed hex: e4bda0e5a5bdf09f9982
  ```

- Focused regression: 1 file, 2 tests passed.
- Existing send-keys coverage: 1 file, 2 tests passed.
- Existing real PTY integration: 1 file, 1 test passed.
- Changed TypeScript surface passed oxlint and oxfmt check.
