### PR TITLE
fix(agents): use UTF-16 safe truncation for compaction reason details

### DIFF
--- a/src/agents/embedded-agent-runner/compact-reasons.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.ts
@@ -2,6 +2,7 @@
  * Normalizes and classifies compaction failure reasons for diagnostics.
  */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 
 const MAX_COMPACTION_REASON_DETAIL_CHARS = 100;
@@ -86,5 +87,5 @@ export function formatUnknownCompactionReasonDetail(reason?: string): string | u
   if (!sanitized) {
     return undefined;
   }
-  return sanitized.slice(0, MAX_COMPACTION_REASON_DETAIL_CHARS);
+  return truncateUtf16Safe(sanitized, MAX_COMPACTION_REASON_DETAIL_CHARS);
 }


### PR DESCRIPTION
## What Problem This Solves

`formatUnknownCompactionReasonDetail` in `src/agents/embedded-agent-runner/compact-reasons.ts` truncates sanitized compaction reasons with `String.prototype.slice(0, MAX_COMPACTION_REASON_DETAIL_CHARS)`, which can split surrogate pairs in reason strings containing emoji or other multi-byte characters.

## Why This Change Was Made

Replaces `sanitized.slice(0, MAX_COMPACTION_REASON_DETAIL_CHARS)` with `truncateUtf16Safe()` from `@openclaw/normalization-core/utf16-slice`, matching the pattern established by 10+ merged UTF-16 safety PRs across the codebase.

## User Impact

- Compaction failure reason details containing emoji/Unicode are now truncated without corrupting surrogate pairs
- No change to truncation behavior for ASCII strings
- Same `MAX_COMPACTION_REASON_DETAIL_CHARS = 100` limit preserved

## Evidence

```
$ npx vitest run src/agents/embedded-agent-runner/compact-reasons.test.ts --reporter=verbose

 ✓  unit-fast  compact-reasons.test.ts > resolveCompactionFailureReason > replaces generic compaction cancellation
 ✓  unit-fast  compact-reasons.test.ts > resolveCompactionFailureReason > preserves non-generic compaction failures
 ✓  unit-fast  compact-reasons.test.ts > classifyCompactionReason > classifies "nothing to compact"
 ✓  unit-fast  compact-reasons.test.ts > classifyCompactionReason > classifies "already under target"
 ✓  unit-fast  compact-reasons.test.ts > classifyCompactionReason > classifies deferred background maintenance
 ✓  unit-fast  compact-reasons.test.ts > classifyCompactionReason > classifies safeguard messages as guard-blocked
 ✓  unit-fast  compact-reasons.test.ts > classifyCompactionReason > keeps unclassified provider errors in unknown bucket
 ✓  unit-fast  compact-reasons.test.ts > formatUnknownCompactionReasonDetail > formats unknown reasons as single-token
 ✓  unit-fast  compact-reasons.test.ts > formatUnknownCompactionReasonDetail > strips terminal escapes and log separators
 ✓  unit-fast  compact-reasons.test.ts > formatUnknownCompactionReasonDetail > omits empty unknown reason detail
 ✓  unit-fast  compact-reasons.test.ts > formatUnknownCompactionReasonDetail > limits unknown reason detail length

 Test Files  1 passed (1)
      Tests  11 passed (11)
```