### PR TITLE
fix(tests): relocate provider auth-literal parity test outside core source

### DIFF
--- a/test/plugins/bundled-provider-auth-literal-parity.test.ts
+++ b/test/plugins/bundled-provider-auth-literal-parity.test.ts
@@ -3,15 +3,15 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { createNonExitingRuntime } from "../runtime.js";
-import { createCapturedPluginRegistration } from "../test-utils/plugin-registration.js";
-import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
-import type { PluginManifestProviderAuthChoice } from "./manifest.js";
+import { listBundledPluginMetadata } from "../../src/plugins/bundled-plugin-metadata.js";
+import type { PluginManifestProviderAuthChoice } from "../../src/plugins/manifest.js";
 import type {
   ProviderAuthMethod,
   ProviderPlugin,
   ProviderResolveNonInteractiveApiKeyParams,
-} from "./types.js";
+} from "../../src/plugins/types.js";
+import { createNonExitingRuntime } from "../../src/runtime.js";
+import { createCapturedPluginRegistration } from "../../src/test-utils/plugin-registration.js";
 
 const PARITY_TIMEOUT_MS = 120_000;
 const SENTINEL_API_KEY = "parity-sentinel-api-key";
@@ -74,7 +74,7 @@ async function loadPluginRegister(
   // plugin dists pulls large module graphs into the shared worker cache and
   // breaks co-resident vi.mock-based unit tests (observed with memory-host-sdk).
   const { loadBundledPluginPublicSurface, resolveBundledPluginPublicModulePath } =
-    await import("../test-utils/bundled-plugin-public-surface.js");
+    await import("../../src/test-utils/bundled-plugin-public-surface.js");
   // Resolve first so unknown plugin ids fail with a clear path error before import.
   resolveBundledPluginPublicModulePath({
     pluginId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where every PR whose changed-file set triggers the `build-artifacts` CI shard fails: `test/extension-test-boundary.test.ts > keeps bundled plugin public-surface imports out of core source` flags `src/plugins/bundled-provider-auth-literal-parity.test.ts` (landed in `33186b0f54b`/`fe9af7dfc7a`), which dynamically imports the test-only `src/test-utils/bundled-plugin-public-surface.js` helper from inside `src/**`. Reproduced identically on clean `origin/main`.

## Why This Change Was Made

Relocates the parity test to `test/plugins/` (the boundary walk covers `src/**` only) with import paths adjusted; the dynamic import that keeps built-plugin dists out of the unit-fast worker cache is preserved as-is.

## User Impact

Unblocks CI for all in-flight PRs; no runtime or test-behavior change.

## Evidence

- `test/extension-test-boundary.test.ts` fails on clean main, passes with this change.
- Relocated parity suite passes (72 tests), `test-projects` and `ci-node-test-plan` routing tests pass (282 total), root test lane typechecks clean.
