### PR TITLE
refactor(acp): share runtime option action handling

### DIFF
--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -35,6 +35,7 @@ const hoisted = vi.hoisted(() => {
   const getStatusMock = vi.fn();
   const setModeMock = vi.fn();
   const setConfigOptionMock = vi.fn();
+  const updateSessionRuntimeOptionsMock = vi.fn();
   const doctorMock = vi.fn();
   return {
     callGatewayMock,
@@ -58,6 +59,7 @@ const hoisted = vi.hoisted(() => {
     getStatusMock,
     setModeMock,
     setConfigOptionMock,
+    updateSessionRuntimeOptionsMock,
     doctorMock,
   };
 });
@@ -961,6 +963,7 @@ describe("/acp command", () => {
     });
     hoisted.setModeMock.mockReset().mockResolvedValue(undefined);
     hoisted.setConfigOptionMock.mockReset().mockResolvedValue(undefined);
+    hoisted.updateSessionRuntimeOptionsMock.mockReset().mockResolvedValue(undefined);
     hoisted.doctorMock.mockReset().mockResolvedValue({
       ok: true,
       message: "acpx command available",
@@ -1108,10 +1111,13 @@ describe("/acp command", () => {
         return { mode: input.runtimeMode };
       },
       setSessionConfigOption: async (input: { key: string; value: string }) => {
-        await hoisted.setConfigOptionMock(input);
-        return { [input.key]: input.value };
+        const options = await hoisted.setConfigOptionMock(input);
+        return options ?? { [input.key]: input.value };
       },
-      updateSessionRuntimeOptions: async (input: { patch: Record<string, unknown> }) => input.patch,
+      updateSessionRuntimeOptions: async (input: { patch: Record<string, unknown> }) => {
+        const options = await hoisted.updateSessionRuntimeOptionsMock(input);
+        return options ?? input.patch;
+      },
       closeSession: async (input: { clearMeta?: boolean; sessionKey: string }) => {
         await hoisted.closeMock(input);
         if (input.clearMeta === true) {
@@ -2096,6 +2102,68 @@ describe("/acp command", () => {
     const setCwd = await runThreadAcpCommand("/acp set cwd /tmp/worktree", baseCfg);
     expect(hoisted.setConfigOptionMock).not.toHaveBeenCalled();
     expect(setCwd?.reply?.text).toContain("Updated ACP cwd");
+  });
+
+  it.each([
+    {
+      action: "cwd",
+      command: "/acp cwd /tmp/worktree",
+      effectiveOptions: { cwd: "/tmp/worktree" },
+      managerMock: hoisted.updateSessionRuntimeOptionsMock,
+      managerInput: { patch: { cwd: "/tmp/worktree" } },
+      expectedText: `✅ Updated ACP cwd for ${defaultAcpSessionKey}: /tmp/worktree. Effective options: cwd=/tmp/worktree`,
+    },
+    {
+      action: "permissions",
+      command: "/acp permissions approve-all",
+      effectiveOptions: { permissionProfile: "approve-all" },
+      managerMock: hoisted.setConfigOptionMock,
+      managerInput: { key: "approval_policy", value: "approve-all" },
+      expectedText: `✅ Updated ACP permissions profile for ${defaultAcpSessionKey}: approve-all. Effective options: permissionProfile=approve-all`,
+    },
+    {
+      action: "timeout",
+      command: "/acp timeout 120",
+      effectiveOptions: { timeoutSeconds: 120 },
+      managerMock: hoisted.setConfigOptionMock,
+      managerInput: { key: "timeout", value: "120" },
+      expectedText: `✅ Updated ACP timeout for ${defaultAcpSessionKey}: 120s. Effective options: timeoutSeconds=120`,
+    },
+    {
+      action: "model",
+      command: "/acp model openai/gpt-5.5",
+      effectiveOptions: { model: "openai/gpt-5.5" },
+      managerMock: hoisted.setConfigOptionMock,
+      managerInput: { key: "model", value: "openai/gpt-5.5" },
+      expectedText: `✅ Updated ACP model for ${defaultAcpSessionKey}: openai/gpt-5.5. Effective options: model=openai/gpt-5.5`,
+    },
+  ])("updates ACP $action through the dedicated runtime-option action", async (testCase) => {
+    mockBoundThreadSession();
+    testCase.managerMock.mockResolvedValueOnce(testCase.effectiveOptions);
+
+    const result = await runThreadAcpCommand(testCase.command, baseCfg);
+
+    expect(result?.reply?.text).toBe(testCase.expectedText);
+    expectMockCallFields(testCase.managerMock, {
+      cfg: baseCfg,
+      sessionKey: defaultAcpSessionKey,
+      ...testCase.managerInput,
+    });
+    expect(
+      hoisted.setConfigOptionMock.mock.calls.length +
+        hoisted.updateSessionRuntimeOptionsMock.mock.calls.length,
+    ).toBe(1);
+  });
+
+  it("preserves the dedicated runtime-option failure boundary", async () => {
+    mockBoundThreadSession();
+    hoisted.setConfigOptionMock.mockRejectedValueOnce("backend failure");
+
+    const result = await runThreadAcpCommand("/acp model openai/gpt-5.5", baseCfg);
+
+    expect(result?.reply?.text).toBe(
+      "ACP error (ACP_TURN_FAILED): Could not update ACP model.\nnext: Retry, or use `/acp cancel` and send the message again.",
+    );
   });
 
   it("rejects non-absolute cwd values via ACP runtime option validation", async () => {

--- a/src/auto-reply/reply/commands-acp/runtime-options.ts
+++ b/src/auto-reply/reply/commands-acp/runtime-options.ts
@@ -11,6 +11,7 @@ import {
   validateRuntimeModelInput,
   validateRuntimePermissionProfileInput,
 } from "../../../acp/control-plane/runtime-options.js";
+import type { AcpSessionRuntimeOptions } from "../../../config/sessions/types.js";
 import { findLatestTaskForRelatedSessionKeyForOwner } from "../../../tasks/task-owner-access.js";
 import { sanitizeTaskStatusText } from "../../../tasks/task-status.js";
 import type { CommandHandlerResult, HandleCommandsParams } from "../commands-types.js";
@@ -103,6 +104,40 @@ async function withSingleTargetValue<T>(params: {
     return resolved;
   }
   return await params.run(resolved);
+}
+
+async function handleSingleRuntimeOptionAction<T>(
+  commandParams: HandleCommandsParams,
+  restTokens: string[],
+  action: {
+    usage: string;
+    optionLabel: string;
+    parseValue: (value: string) => T;
+    formatValue?: (value: T) => string;
+    update: (targetSessionKey: string, value: T) => Promise<AcpSessionRuntimeOptions>;
+  },
+): Promise<CommandHandlerResult> {
+  return await withSingleTargetValue({
+    commandParams,
+    restTokens,
+    usage: action.usage,
+    run: async ({ targetSessionKey, value }) =>
+      await withAcpCommandErrorBoundary({
+        run: async () => {
+          const parsedValue = action.parseValue(value);
+          const options = await action.update(targetSessionKey, parsedValue);
+          return { parsedValue, options };
+        },
+        fallbackCode: "ACP_TURN_FAILED",
+        fallbackMessage: `Could not update ACP ${action.optionLabel}.`,
+        onSuccess: ({ parsedValue, options }) => {
+          const valueText = action.formatValue?.(parsedValue) ?? String(parsedValue);
+          return stopWithText(
+            `✅ Updated ACP ${action.optionLabel} for ${targetSessionKey}: ${valueText}. Effective options: ${formatRuntimeOptionsText(options)}`,
+          );
+        },
+      }),
+  });
 }
 
 export async function handleAcpStatusAction(
@@ -269,30 +304,15 @@ export async function handleAcpCwdAction(
   params: HandleCommandsParams,
   restTokens: string[],
 ): Promise<CommandHandlerResult> {
-  return await withSingleTargetValue({
-    commandParams: params,
-    restTokens,
+  return await handleSingleRuntimeOptionAction(params, restTokens, {
     usage: ACP_CWD_USAGE,
-    run: async ({ targetSessionKey, value }) =>
-      await withAcpCommandErrorBoundary({
-        run: async () => {
-          const cwd = validateRuntimeCwdInput(value);
-          const options = await getAcpSessionManager().updateSessionRuntimeOptions({
-            cfg: params.cfg,
-            sessionKey: targetSessionKey,
-            patch: { cwd },
-          });
-          return {
-            cwd,
-            options,
-          };
-        },
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP cwd.",
-        onSuccess: ({ cwd, options }) =>
-          stopWithText(
-            `✅ Updated ACP cwd for ${targetSessionKey}: ${cwd}. Effective options: ${formatRuntimeOptionsText(options)}`,
-          ),
+    optionLabel: "cwd",
+    parseValue: validateRuntimeCwdInput,
+    update: async (targetSessionKey, value) =>
+      await getAcpSessionManager().updateSessionRuntimeOptions({
+        cfg: params.cfg,
+        sessionKey: targetSessionKey,
+        patch: { cwd: value },
       }),
   });
 }
@@ -301,31 +321,16 @@ export async function handleAcpPermissionsAction(
   params: HandleCommandsParams,
   restTokens: string[],
 ): Promise<CommandHandlerResult> {
-  return await withSingleTargetValue({
-    commandParams: params,
-    restTokens,
+  return await handleSingleRuntimeOptionAction(params, restTokens, {
     usage: ACP_PERMISSIONS_USAGE,
-    run: async ({ targetSessionKey, value }) =>
-      await withAcpCommandErrorBoundary({
-        run: async () => {
-          const permissionProfile = validateRuntimePermissionProfileInput(value);
-          const options = await getAcpSessionManager().setSessionConfigOption({
-            cfg: params.cfg,
-            sessionKey: targetSessionKey,
-            key: "approval_policy",
-            value: permissionProfile,
-          });
-          return {
-            permissionProfile,
-            options,
-          };
-        },
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP permissions profile.",
-        onSuccess: ({ permissionProfile, options }) =>
-          stopWithText(
-            `✅ Updated ACP permissions profile for ${targetSessionKey}: ${permissionProfile}. Effective options: ${formatRuntimeOptionsText(options)}`,
-          ),
+    optionLabel: "permissions profile",
+    parseValue: validateRuntimePermissionProfileInput,
+    update: async (targetSessionKey, value) =>
+      await getAcpSessionManager().setSessionConfigOption({
+        cfg: params.cfg,
+        sessionKey: targetSessionKey,
+        key: "approval_policy",
+        value,
       }),
   });
 }
@@ -334,31 +339,17 @@ export async function handleAcpTimeoutAction(
   params: HandleCommandsParams,
   restTokens: string[],
 ): Promise<CommandHandlerResult> {
-  return await withSingleTargetValue({
-    commandParams: params,
-    restTokens,
+  return await handleSingleRuntimeOptionAction(params, restTokens, {
     usage: ACP_TIMEOUT_USAGE,
-    run: async ({ targetSessionKey, value }) =>
-      await withAcpCommandErrorBoundary({
-        run: async () => {
-          const timeoutSeconds = parseRuntimeTimeoutSecondsInput(value);
-          const options = await getAcpSessionManager().setSessionConfigOption({
-            cfg: params.cfg,
-            sessionKey: targetSessionKey,
-            key: "timeout",
-            value: String(timeoutSeconds),
-          });
-          return {
-            timeoutSeconds,
-            options,
-          };
-        },
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP timeout.",
-        onSuccess: ({ timeoutSeconds, options }) =>
-          stopWithText(
-            `✅ Updated ACP timeout for ${targetSessionKey}: ${timeoutSeconds}s. Effective options: ${formatRuntimeOptionsText(options)}`,
-          ),
+    optionLabel: "timeout",
+    parseValue: parseRuntimeTimeoutSecondsInput,
+    formatValue: (value) => `${value}s`,
+    update: async (targetSessionKey, value) =>
+      await getAcpSessionManager().setSessionConfigOption({
+        cfg: params.cfg,
+        sessionKey: targetSessionKey,
+        key: "timeout",
+        value: String(value),
       }),
   });
 }
@@ -367,31 +358,16 @@ export async function handleAcpModelAction(
   params: HandleCommandsParams,
   restTokens: string[],
 ): Promise<CommandHandlerResult> {
-  return await withSingleTargetValue({
-    commandParams: params,
-    restTokens,
+  return await handleSingleRuntimeOptionAction(params, restTokens, {
     usage: ACP_MODEL_USAGE,
-    run: async ({ targetSessionKey, value }) =>
-      await withAcpCommandErrorBoundary({
-        run: async () => {
-          const model = validateRuntimeModelInput(value);
-          const options = await getAcpSessionManager().setSessionConfigOption({
-            cfg: params.cfg,
-            sessionKey: targetSessionKey,
-            key: "model",
-            value: model,
-          });
-          return {
-            model,
-            options,
-          };
-        },
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP model.",
-        onSuccess: ({ model, options }) =>
-          stopWithText(
-            `✅ Updated ACP model for ${targetSessionKey}: ${model}. Effective options: ${formatRuntimeOptionsText(options)}`,
-          ),
+    optionLabel: "model",
+    parseValue: validateRuntimeModelInput,
+    update: async (targetSessionKey, value) =>
+      await getAcpSessionManager().setSessionConfigOption({
+        cfg: params.cfg,
+        sessionKey: targetSessionKey,
+        key: "model",
+        value,
       }),
   });
 }


### PR DESCRIPTION
## What Problem This Solves

The dedicated ACP cwd, permissions, timeout, and model commands repeated the same target resolution, value parsing, error boundary, manager update, and success response plumbing. That duplication made response and failure behavior harder to audit consistently.

Related: #104982

## Why This Change Was Made

- Centralize the common single-value ACP runtime-option action lifecycle.
- Keep each command's validator and manager update explicit at its call site.
- Preserve every exported handler, command usage string, response, validation rule, and error code.
- Add table-driven proof for all four manager calls, effective-option responses, and the shared failure boundary.

## User Impact

No intended behavior change. ACP runtime-option commands keep the same inputs, updates, errors, and response text with 24 fewer production lines.

## Evidence

- `corepack pnpm test:serial src/auto-reply/reply/commands-acp.test.ts` on Blacksmith Testbox `tbx_01kxaaxxz7xgh30r4bmva194en`: 66 tests passed.
- `corepack pnpm check:changed -- src/auto-reply/reply/commands-acp/runtime-options.ts src/auto-reply/reply/commands-acp.test.ts` on the same Testbox: passed.
- Fresh local autoreview: clean, no accepted/actionable findings.
- `git diff --check`: passed.
