### PR TITLE
fix(gateway): prevent broken emoji in WebSocket log IDs

### DIFF
--- a/src/gateway/ws-log.test.ts
+++ b/src/gateway/ws-log.test.ts
@@ -7,6 +7,29 @@ import { formatForLog, summarizeAgentEventForWsLog } from "./ws-log.js";
 describe("gateway ws log helpers", () => {
   test.each([
     {
+      name: "run ID prefix boundary",
+      payload: { runId: `${"a".repeat(11)}🚀${"b".repeat(20)}` },
+      field: "run",
+      expected: `${"a".repeat(11)}…bbbb`,
+    },
+    {
+      name: "tool-call ID suffix boundary",
+      payload: {
+        stream: "tool",
+        data: { toolCallId: `${"a".repeat(25)}🚀bbb` },
+      },
+      field: "call",
+      expected: `${"a".repeat(12)}…bbb`,
+    },
+  ])("summarizeAgentEventForWsLog keeps the $name UTF-16 safe", ({ payload, field, expected }) => {
+    const value = summarizeAgentEventForWsLog(payload)[field];
+
+    expect(value).toBe(expected);
+    expect(value).not.toMatch(/[\uD800-\uDFFF]/);
+  });
+
+  test.each([
+    {
       name: "formats Error instances",
       input: Object.assign(new Error("boom"), { name: "TestError" }),
       expected: "TestError: boom",

--- a/src/gateway/ws-log.ts
+++ b/src/gateway/ws-log.ts
@@ -1,7 +1,7 @@
 // Gateway WebSocket log formatting.
 // Redacts and compacts request/response/event metadata for console diagnostics.
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import chalk from "chalk";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { isVerbose } from "../globals.js";
@@ -104,12 +104,12 @@ export function shouldLogWs(): boolean {
 function shortId(value: string): string {
   const s = value.trim();
   if (UUID_RE.test(s)) {
-    return `${s.slice(0, 8)}…${s.slice(-4)}`;
+    return `${sliceUtf16Safe(s, 0, 8)}…${sliceUtf16Safe(s, -4)}`;
   }
   if (s.length <= 24) {
     return s;
   }
-  return `${s.slice(0, 12)}…${s.slice(-4)}`;
+  return `${sliceUtf16Safe(s, 0, 12)}…${sliceUtf16Safe(s, -4)}`;
 }
 
 /** Formats and redacts arbitrary values before they are written to gateway logs. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators inspecting gateway WebSocket logs could see a broken replacement glyph in compact request, response, connection, run, or tool-call identifiers when a long Unicode ID crossed the retained prefix or suffix boundary.

The protocol frame still carried the original ID, but the operator-visible log could render `�`, making correlation output malformed and harder to search reliably.

## Why This Change Was Made

All gateway WebSocket log styles already converge on the same private `shortId` owner. This change uses the shared UTF-16-safe slice helper for both retained edges and drives regression coverage through the public agent-event summarizer.

The existing length budgets and ASCII/UUID output stay unchanged. This does not change WebSocket payloads, request IDs, auth, config, persistence, or logging policy.

## User Impact

Gateway logs now keep compact Unicode identifiers well-formed, so operators can read and correlate request and agent-event activity without replacement characters caused by truncation.

There is no behavior change for ordinary ASCII IDs or UUIDs, and no ID is modified on the wire.

## Evidence

- Gateway-core regression suite: 1 file passed, 15 tests passed. Coverage exercises run-ID prefix and tool-call-ID suffix surrogate boundaries through `summarizeAgentEventForWsLog`, with exact output and no-surrogate assertions.
- Focused current-head proof: Blacksmith Testbox through Crabbox `tbx_01kxfz1tx0jhy9rrm9nw8qn8ht`; [Actions run 29321586284](https://github.com/openclaw/openclaw/actions/runs/29321586284).
- Direct touched-surface proof: core production types, core test types, and exact two-file lint passed with zero warnings or errors on Testbox `tbx_01kxfz7a2e6p6p3mha4ey59ann`; [Actions run 29321767410](https://github.com/openclaw/openclaw/actions/runs/29321767410).
- Controlled real `logWs` capture on the byte-identical patch:

  ```text
  [ws] → event probe conn=aaaaaaaaaaa…bbbb id=aaaaaaaaaaaa…bbb
  hasSurrogate=false
  ```

- Changed-surface conflict, LOC, attribution, export, duplicate, dependency, and formatter guards passed. The broad gate then hit an unrelated current-main Plugin SDK API baseline drift before its type/lint phases; the direct touched-surface lanes above cover this PR.
- Codex `gpt-5.6-sol` xhigh-reasoning autoreview reported no actionable findings (confidence 0.98).
- Owner-chain sweep covered inbound request IDs, response IDs, connection IDs, and agent-event run/tool-call IDs across full, compact, and optimized log styles. No public or wire contract changed.

Thanks @zhangguiping-xydt for the fix.
