### PR TITLE
fix(ci): restore Control UI i18n gate

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -4,8 +4,8 @@
   "locale": "ar",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -4,8 +4,8 @@
   "locale": "de",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -4,8 +4,8 @@
   "locale": "es",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -4,8 +4,8 @@
   "locale": "fa",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -4,8 +4,8 @@
   "locale": "fr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -4,8 +4,8 @@
   "locale": "hi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -4,8 +4,8 @@
   "locale": "id",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -4,8 +4,8 @@
   "locale": "it",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -4,8 +4,8 @@
   "locale": "ja-JP",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -4,8 +4,8 @@
   "locale": "ko",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -4,8 +4,8 @@
   "locale": "nl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -4,8 +4,8 @@
   "locale": "pl",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -4,8 +4,8 @@
   "locale": "pt-BR",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -689,6 +689,13 @@
     },
     {
       "count": 1,
+      "kind": "html-attribute",
+      "name": "title",
+      "path": "ui/src/components/mcp-app-view.ts",
+      "text": "MCP App"
+    },
+    {
+      "count": 1,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/components/settings-sidebar.ts",

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -4,8 +4,8 @@
   "locale": "ru",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -4,8 +4,8 @@
   "locale": "th",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -4,8 +4,8 @@
   "locale": "tr",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -4,8 +4,8 @@
   "locale": "uk",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -4,8 +4,8 @@
   "locale": "vi",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -4,8 +4,8 @@
   "locale": "zh-CN",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -4,8 +4,8 @@
   "locale": "zh-TW",
   "model": "gpt-5.6-sol",
   "provider": "openai",
-  "sourceHash": "6cb0eb00b85c6dc651213591e7f375bdd3f3b9ecb4575dd11147789a3af523f7",
-  "totalKeys": 2083,
-  "translatedKeys": 2083,
+  "sourceHash": "eaa448c55b09b18b7da491af2aa94ef1db396848efffeb8edef06c653868231d",
+  "totalKeys": 2119,
+  "translatedKeys": 2119,
   "workflow": 1
 }


### PR DESCRIPTION
Related: #104768
Related: #69039

## What Problem This Solves

Resolves the Control UI i18n gate failure that blocks `main` and unrelated pull requests, including #104814.

The originally reported `Interrupted` drift from #104768 was already absorbed by the later raw-copy refresh in #104834. Current `main` then acquired a new raw-copy delta from #69039 (`MCP App`) and still carried stale source hashes/key counts for the already-translated locale bundles.

## Why This Change Was Made

Refreshes the generated raw-copy baseline for the intentional MCP Apps product term and aligns all locale metadata with the existing 2,119 translated English keys. No locale text, runtime behavior, or fallback content changes.

Provenance: @steipete authored #104768; @sallyom authored #69039.

## User Impact

Restores the shared Control UI i18n CI gate so unrelated changes can land again. No user-visible copy changes.

## Evidence

- Before: `corepack pnpm ui:i18n:check` failed on current `main` with raw-copy drift for `ui/src/components/mcp-app-view.ts` title `MCP App`; after resolving that delta, it exposed stale metadata for all 20 locale bundles.
- After: Blacksmith Testbox through Crabbox `tbx_01kxac4mmd1rhgcnsss1fcq6bp` — `corepack pnpm ui:i18n:check` passed with 727 baseline entries, all 20 locales clean, and zero fallbacks.
- `git diff --check`
- JSON parse validation for every changed metadata/baseline file.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings.

AI-assisted: Codex implemented and verified this repair.
