### PR TITLE
fix(channels): add idempotency guard to nack() (#104903)

### DIFF
--- a/scripts/proof-issue-104903.ts
+++ b/scripts/proof-issue-104903.ts
@@ -1,0 +1,84 @@
+/**
+ * Proof script for issue #104903 fix.
+ *
+ * Demonstrates that nack() is now idempotent — duplicate calls
+ * are no-ops and onNack fires only once.
+ *
+ * Usage: npx tsx scripts/proof-issue-104903.ts
+ */
+import { createMessageReceiveContext } from "../src/channels/message/receive.js";
+
+const divider = "=".repeat(64);
+let exitCode = 0;
+
+function check(cond: boolean, label: string): void {
+  console.log(`  ${cond ? "✓" : "✗"} ${label}`);
+  if (!cond) {
+    exitCode = 1;
+  }
+}
+
+console.log(divider);
+console.log("PROOF: nack() idempotency guard — issue #104903");
+console.log(divider);
+
+// ── Test: duplicate nack calls ──────────────────────────────────────
+console.log("\n--- Duplicate nack calls ---\n");
+
+let nackCount = 0;
+const ctx = createMessageReceiveContext({
+  id: "test",
+  channel: "test",
+  message: {},
+  onNack: () => {
+    nackCount++;
+  },
+});
+
+await ctx.nack(new Error("first error"));
+console.log("  First nack:  onNack called");
+await ctx.nack(new Error("second error - should be ignored"));
+console.log("  Second nack: no-op (guard prevented onNack)");
+
+console.log();
+check(nackCount === 1, `onNack called exactly once (${nackCount})`);
+check(ctx.ackState === "nacked", `ackState is "nacked"`);
+check(ctx.nackErrorMessage?.includes("first error") ?? false, "first error message preserved");
+
+// ── BEFORE/AFTER ───────────────────────────────────────────────────
+console.log("\n" + divider);
+console.log("BEFORE/AFTER");
+console.log(divider);
+console.log(`
+BEFORE FIX:
+  nack: async (error) => {
+    await params.onNack?.(error);    // Fires every call
+    ctx.ackState = "nacked";
+    ctx.nackErrorMessage = normalizeAckErrorMessage(error);
+  },
+  → Duplicate calls re-fire onNack and overwrite nackErrorMessage
+
+AFTER FIX:
+  nack: async (error) => {
+    if (ctx.ackState !== "pending") { return; }  // Idempotent guard
+    await params.onNack?.(error);
+    ctx.ackState = "nacked";
+    ctx.nackErrorMessage = normalizeAckErrorMessage(error);
+  },
+  → Duplicate calls are no-ops, matching ack() behavior
+`);
+
+console.log(divider);
+console.log("RESULT");
+console.log(divider);
+if (exitCode === 0) {
+  console.log("  ALL CHECKS PASSED ✓");
+} else {
+  console.log("  SOME CHECKS FAILED ✗");
+}
+console.log();
+console.log("Fix:  src/channels/message/receive.ts (+4 lines)");
+console.log("Test: src/channels/message/receive.test.ts (5 tests)");
+console.log("Verified on: " + new Date().toISOString());
+console.log(divider);
+process.exit(exitCode);

--- a/src/channels/message/receive.test.ts
+++ b/src/channels/message/receive.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for createMessageReceiveContext with ack/nack idempotency.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createMessageReceiveContext } from "./receive.js";
+
+describe("createMessageReceiveContext ack/nack", () => {
+  it("nack ignores duplicate calls (idempotent guard) (#104903)", async () => {
+    const onNack = vi.fn();
+    const ctx = createMessageReceiveContext({
+      id: "test",
+      channel: "test",
+      message: {},
+      onNack,
+    });
+
+    await ctx.nack(new Error("first"));
+    await ctx.nack(new Error("second"));
+
+    // onNack must only fire once — duplicate calls are no-ops.
+    expect(onNack).toHaveBeenCalledTimes(1);
+  });
+
+  it("nack preserves the first error message on duplicate calls", async () => {
+    const ctx = createMessageReceiveContext({
+      id: "test",
+      channel: "test",
+      message: {},
+    });
+
+    await ctx.nack(new Error("first error"));
+
+    // Second call must not overwrite the first nack error.
+    await ctx.nack(new Error("duplicate error"));
+
+    expect(ctx.nackErrorMessage).toContain("first error");
+    expect(ctx.nackErrorMessage).not.toContain("duplicate error");
+  });
+
+  it("ack remains idempotent (regression guard)", async () => {
+    const onAck = vi.fn();
+    const ctx = createMessageReceiveContext({
+      id: "test",
+      channel: "test",
+      message: {},
+      onAck,
+    });
+
+    await ctx.ack();
+    await ctx.ack();
+
+    expect(onAck).toHaveBeenCalledTimes(1);
+  });
+
+  it("nack after ack is a no-op", async () => {
+    const onAck = vi.fn();
+    const onNack = vi.fn();
+    const ctx = createMessageReceiveContext({
+      id: "test",
+      channel: "test",
+      message: {},
+      onAck,
+      onNack,
+    });
+
+    await ctx.ack();
+    await ctx.nack(new Error("after ack"));
+
+    expect(onAck).toHaveBeenCalledTimes(1);
+    expect(onNack).not.toHaveBeenCalled();
+  });
+
+  it("nack sets ackState correctly", async () => {
+    const ctx = createMessageReceiveContext({
+      id: "test",
+      channel: "test",
+      message: {},
+    });
+    expect(ctx.ackState).toBe("pending");
+
+    await ctx.nack(new Error("test"));
+    expect(ctx.ackState).toBe("nacked");
+  });
+});

--- a/src/channels/message/receive.ts
+++ b/src/channels/message/receive.ts
@@ -88,6 +88,12 @@ export function createMessageReceiveContext<TMessage>(params: {
       delete ctx.nackErrorMessage;
     },
     nack: async (error) => {
+      // Nack callbacks must be idempotent because receive pipelines may
+      // revisit completed stages — same reason as ack() above.
+      // See: https://github.com/openclaw/openclaw/issues/104903
+      if (ctx.ackState !== "pending") {
+        return;
+      }
       await params.onNack?.(error);
       ctx.ackState = "nacked";
       ctx.nackErrorMessage = normalizeAckErrorMessage(error);


### PR DESCRIPTION
## What Problem This Solves

Fixes P2 issue #104903: `nack()` in `createMessageReceiveContext` lacks the idempotency guard that `ack()` already has. In receive pipelines that revisit completed stages, duplicate `nack()` calls re-fire the `onNack` callback and overwrite `nackErrorMessage` — leading to repeated error handling, cleanup, or logging.

**Root cause**: `nack()` unconditionally fires `onNack()` while `ack()` correctly guards with `if (ctx.ackState === "acked") { return; }`. The two methods are used in the same pipeline context and should have symmetric protection.

## Why This Change Was Made

Added `if (ctx.ackState !== "pending") { return; }` at the top of `nack()`, matching the existing guard in `ack()`. The fix is 4 lines of code in `src/channels/message/receive.ts`.

## Evidence

### Real behavior proof (`npx tsx scripts/proof-issue-104903.ts`)

```
================================================================
PROOF: nack() idempotency guard — issue #104903
================================================================

--- Duplicate nack calls ---

  First nack:  onNack called
  Second nack: no-op (guard prevented onNack)

  ✓ onNack called exactly once (1)
  ✓ ackState is "nacked"
  ✓ first error message preserved

================================================================
BEFORE/AFTER
================================================================

BEFORE FIX:
  nack: async (error) => {
    await params.onNack?.(error);    // Fires every call
    ctx.ackState = "nacked";
    ctx.nackErrorMessage = normalizeAckErrorMessage(error);
  },
  → Duplicate calls re-fire onNack and overwrite nackErrorMessage

AFTER FIX:
  nack: async (error) => {
    if (ctx.ackState !== "pending") { return; }  // Idempotent guard
    await params.onNack?.(error);
    ctx.ackState = "nacked";
    ctx.nackErrorMessage = normalizeAckErrorMessage(error);
  },
  → Duplicate calls are no-ops, matching ack() behavior
================================================================
ALL CHECKS PASSED ✓
```

### Test results

`src/channels/message/receive.test.ts` — 5 regression tests:
- nack ignores duplicate calls
- nack preserves first error on duplicate calls
- ack remains idempotent (regression guard)
- nack after ack is a no-op
- nack sets ackState correctly

### Changed files (3 files, +174/-0)

- `src/channels/message/receive.ts` — +4 lines (idempotency guard)
- `src/channels/message/receive.test.ts` — 5 regression tests (new file)
- `scripts/proof-issue-104903.ts` — proof script (new file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)