### PR TITLE
fix(shared): keep tool-call-shaped text scan truncation UTF-16 safe

### DIFF
--- a/src/shared/text/tool-call-shaped-text.test.ts
+++ b/src/shared/text/tool-call-shaped-text.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, it } from "vitest";
 import { detectToolCallShapedText } from "./tool-call-shaped-text.js";
 
+const MAX_SCAN_CHARS = 20_000;
+
 describe("detectToolCallShapedText", () => {
   it("detects standalone OpenAI-style function-call JSON", () => {
     expect(detectToolCallShapedText('{"name":"read","arguments":{"path":"README.md"}}')).toEqual({
@@ -36,6 +38,19 @@ describe("detectToolCallShapedText", () => {
         '[TOOL_CALL]{tool => "web_search", args => {"query":"NET stock price"}}[/TOOL_CALL]',
       ),
     ).toEqual({ kind: "bracketed_tool_call", toolName: "web_search" });
+  });
+
+  it("keeps the scan boundary UTF-16 safe when an emoji straddles MAX_SCAN_CHARS", () => {
+    // Place a supplementary character (\u{1F642}) so its high surrogate
+    // lands at MAX_SCAN_CHARS - 1. Before the fix, raw .slice(0, 20000)
+    // left a lone high surrogate at the boundary.
+    const pad = "x".repeat(MAX_SCAN_CHARS - 1);
+    const emoji = String.fromCodePoint(0x1f642);
+    const payload = `${pad}${emoji}`;
+    // payload.length == 20001; .slice(0, 20000) keeps lone high surrogate.
+    // truncateUtf16Safe drops both halves so the scan sees clean content.
+    const result = detectToolCallShapedText(payload);
+    expect(result).toBeNull();
   });
 
   it("ignores normal JSON and prose mentions", () => {

--- a/src/shared/text/tool-call-shaped-text.ts
+++ b/src/shared/text/tool-call-shaped-text.ts
@@ -1,6 +1,7 @@
 // Tool-call shaped text helpers detect malformed text that resembles tool calls.
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as readTrimmedString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 type ToolCallShapedTextDetection = {
   kind: "json_tool_call" | "xml_tool_call" | "bracketed_tool_call" | "react_action";
@@ -220,7 +221,7 @@ function detectReactAction(text: string): ToolCallShapedTextDetection | null {
 
 /** Detects assistant-visible text that looks like an unexecuted tool call instead of prose. */
 export function detectToolCallShapedText(text: string): ToolCallShapedTextDetection | null {
-  const trimmed = text.slice(0, MAX_SCAN_CHARS).trim();
+  const trimmed = truncateUtf16Safe(text, MAX_SCAN_CHARS).trim();
   if (!trimmed || !TOOL_TEXT_PREFILTER_RE.test(trimmed)) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `detectToolCallShapedText` could produce a corrupted intermediate string when a supplementary Unicode character (emoji, CJK extension, etc.) landed exactly on the 20,000-char scan cap. The raw `text.slice(0, MAX_SCAN_CHARS)` call splits UTF-16 surrogate pairs, leaving a lone high surrogate at the boundary. Downstream regex matching and tool-name extraction on the corrupted string could produce garbled results.

## Why This Change Was Made

Replace `text.slice(0, MAX_SCAN_CHARS)` with the existing shared `truncateUtf16Safe` helper from `@openclaw/normalization-core/utf16-slice`. The helper detects surrogate pairs at the cut point and adjusts the boundary to keep them together. This is a single-site fix — no schema, config, or API changes.

## User Impact

No visible behavioral change for valid input. When an emoji or other supplementary character falls at the exact scan boundary, the function now returns correct results instead of potentially producing garbled tool-name classifications.

## Evidence

### Test suite

```
$ node scripts/run-vitest.mjs run src/shared/text/tool-call-shaped-text.test.ts --reporter=verbose
 ✓ 6/6 passed (including new UTF-16 boundary regression test)
```

The new test places a supplementary character (`U+1F642`) so its high surrogate lands at `MAX_SCAN_CHARS - 1`, then verifies the scan returns null (clean, no crash).

### Lint

```
$ node scripts/run-oxlint.mjs src/shared/text/tool-call-shaped-text.ts
✓ clean
```
