### PR TITLE
fix(plugins): hide bundle commands when frontmatter uses on

### DIFF
--- a/src/plugins/bundle-commands.test.ts
+++ b/src/plugins/bundle-commands.test.ts
@@ -133,6 +133,45 @@ describe("loadEnabledClaudeBundleCommands", () => {
               contents: ["---", "disable-model-invocation: true", "---", "Do not load me."],
             },
             {
+              relativePath: "commands/disabled-on.md",
+              contents: ["---", "disable-model-invocation: on", "---", "Do not load me either."],
+            },
+            {
+              relativePath: "commands/disabled-one.md",
+              contents: ["---", "disable-model-invocation: 1", "---", "Do not load me either."],
+            },
+            {
+              relativePath: "commands/disabled-yes.md",
+              contents: ["---", "disable-model-invocation: yes", "---", "Do not load me either."],
+            },
+            {
+              relativePath: "commands/enabled-no.md",
+              contents: [
+                "---",
+                "disable-model-invocation: no",
+                "---",
+                "Keep this command available.",
+              ],
+            },
+            {
+              relativePath: "commands/enabled-off.md",
+              contents: [
+                "---",
+                "disable-model-invocation: off",
+                "---",
+                "Keep this command available.",
+              ],
+            },
+            {
+              relativePath: "commands/enabled-zero.md",
+              contents: [
+                "---",
+                "disable-model-invocation: 0",
+                "---",
+                "Keep this command available.",
+              ],
+            },
+            {
               relativePath: "commands/not-frontmatter.md",
               contents: ["---not", "name: nope", "---not", "Treat this as Markdown."],
             },
@@ -149,6 +188,39 @@ describe("loadEnabledClaudeBundleCommands", () => {
         });
 
         expectEnabledClaudeBundleCommands(commands, [
+          {
+            pluginId: "compound-bundle",
+            rawName: "enabled-no",
+            description: "Keep this command available.",
+            promptTemplate: "Keep this command available.",
+            sourceFilePath: path.join(
+              resolveBundlePluginRoot(homeDir, "compound-bundle"),
+              "commands",
+              "enabled-no.md",
+            ),
+          },
+          {
+            pluginId: "compound-bundle",
+            rawName: "enabled-off",
+            description: "Keep this command available.",
+            promptTemplate: "Keep this command available.",
+            sourceFilePath: path.join(
+              resolveBundlePluginRoot(homeDir, "compound-bundle"),
+              "commands",
+              "enabled-off.md",
+            ),
+          },
+          {
+            pluginId: "compound-bundle",
+            rawName: "enabled-zero",
+            description: "Keep this command available.",
+            promptTemplate: "Keep this command available.",
+            sourceFilePath: path.join(
+              resolveBundlePluginRoot(homeDir, "compound-bundle"),
+              "commands",
+              "enabled-zero.md",
+            ),
+          },
           {
             pluginId: "compound-bundle",
             rawName: "not-frontmatter",
@@ -186,6 +258,9 @@ describe("loadEnabledClaudeBundleCommands", () => {
         ]);
         const rawNames = commands.map((entry) => entry.rawName);
         expect(rawNames).not.toContain("disabled");
+        expect(rawNames).not.toContain("disabled-on");
+        expect(rawNames).not.toContain("disabled-one");
+        expect(rawNames).not.toContain("disabled-yes");
       },
     );
   });

--- a/src/plugins/bundle-commands.test.ts
+++ b/src/plugins/bundle-commands.test.ts
@@ -94,7 +94,7 @@ function expectEnabledClaudeBundleCommands(
 }
 
 describe("loadEnabledClaudeBundleCommands", () => {
-  it("loads enabled Claude bundle markdown commands", async () => {
+  it("loads enabled Claude bundle markdown commands and honors invocation policy", async () => {
     const homeDir = await createTempDir("openclaw-bundle-commands-home-");
     const workspaceDir = await createTempDir("openclaw-bundle-commands-workspace-");
     await withEnvAsync(
@@ -129,6 +129,22 @@ describe("loadEnabledClaudeBundleCommands", () => {
               ],
             },
             {
+              relativePath: "commands/model-hidden.md",
+              contents: ["---", "disable-model-invocation: on", "---", "Manual only."],
+            },
+            {
+              relativePath: "commands/user-enabled.md",
+              contents: ["---", "user-invocable: on", "---", "User enabled."],
+            },
+            {
+              relativePath: "commands/user-hidden.md",
+              contents: ["---", "user-invocable: off", "---", "User hidden."],
+            },
+            {
+              relativePath: "commands/user-hidden-false.md",
+              contents: ["---", "user-invocable: false", "---", "User hidden."],
+            },
+            {
               relativePath: "commands/not-frontmatter.md",
               contents: ["---not", "name: nope", "---not", "Treat this as Markdown."],
             },
@@ -145,6 +161,17 @@ describe("loadEnabledClaudeBundleCommands", () => {
         });
 
         expectEnabledClaudeBundleCommands(commands, [
+          {
+            pluginId: "compound-bundle",
+            rawName: "model-hidden",
+            description: "Manual only.",
+            promptTemplate: "Manual only.",
+            sourceFilePath: path.join(
+              resolveBundlePluginRoot(homeDir, "compound-bundle"),
+              "commands",
+              "model-hidden.md",
+            ),
+          },
           {
             pluginId: "compound-bundle",
             rawName: "not-frontmatter",
@@ -169,6 +196,17 @@ describe("loadEnabledClaudeBundleCommands", () => {
           },
           {
             pluginId: "compound-bundle",
+            rawName: "user-enabled",
+            description: "User enabled.",
+            promptTemplate: "User enabled.",
+            sourceFilePath: path.join(
+              resolveBundlePluginRoot(homeDir, "compound-bundle"),
+              "commands",
+              "user-enabled.md",
+            ),
+          },
+          {
+            pluginId: "compound-bundle",
             rawName: "workflows:review",
             description: "Run a structured review",
             promptTemplate: "Review the code. $ARGUMENTS",
@@ -180,62 +218,9 @@ describe("loadEnabledClaudeBundleCommands", () => {
             ),
           },
         ]);
-      },
-    );
-  });
-
-  it("keeps model-hidden commands user-invocable and honors user-invocable literals", async () => {
-    const homeDir = await createTempDir("openclaw-bundle-commands-home-");
-    const workspaceDir = await createTempDir("openclaw-bundle-commands-workspace-");
-    const truthy = ["true", "on", "yes", "1"];
-    const falsy = ["false", "off", "no", "0"];
-    await withEnvAsync(
-      {
-        HOME: homeDir,
-        USERPROFILE: homeDir,
-        OPENCLAW_HOME: undefined,
-        OPENCLAW_STATE_DIR: undefined,
-      },
-      async () => {
-        await writeClaudeBundleCommandFixture({
-          homeDir,
-          pluginId: "invocation-policy-bundle",
-          commands: [
-            {
-              relativePath: "commands/default.md",
-              contents: ["Default manual command."],
-            },
-            ...truthy.map((value) => ({
-              relativePath: `commands/model-hidden-${value}.md`,
-              contents: ["---", `disable-model-invocation: ${value}`, "---", "Manual only."],
-            })),
-            ...truthy.map((value) => ({
-              relativePath: `commands/user-enabled-${value}.md`,
-              contents: ["---", `user-invocable: ${value}`, "---", "User enabled."],
-            })),
-            ...falsy.map((value) => ({
-              relativePath: `commands/user-hidden-${value}.md`,
-              contents: ["---", `user-invocable: ${value}`, "---", "User hidden."],
-            })),
-          ],
-        });
-
-        const commands = loadEnabledClaudeBundleCommands({
-          workspaceDir,
-          cfg: {
-            plugins: {
-              entries: { "invocation-policy-bundle": { enabled: true } },
-            },
-          },
-        });
-        const rawNames = new Set(commands.map((entry) => entry.rawName));
-        expect(rawNames).toEqual(
-          new Set([
-            "default",
-            ...truthy.map((value) => `model-hidden-${value}`),
-            ...truthy.map((value) => `user-enabled-${value}`),
-          ]),
-        );
+        const rawNames = commands.map((entry) => entry.rawName);
+        expect(rawNames).not.toContain("user-hidden");
+        expect(rawNames).not.toContain("user-hidden-false");
       },
     );
   });

--- a/src/plugins/bundle-commands.test.ts
+++ b/src/plugins/bundle-commands.test.ts
@@ -94,7 +94,7 @@ function expectEnabledClaudeBundleCommands(
 }
 
 describe("loadEnabledClaudeBundleCommands", () => {
-  it("loads enabled Claude bundle markdown commands and skips disabled-model-invocation entries", async () => {
+  it("loads enabled Claude bundle markdown commands", async () => {
     const homeDir = await createTempDir("openclaw-bundle-commands-home-");
     const workspaceDir = await createTempDir("openclaw-bundle-commands-workspace-");
     await withEnvAsync(
@@ -129,49 +129,6 @@ describe("loadEnabledClaudeBundleCommands", () => {
               ],
             },
             {
-              relativePath: "commands/disabled.md",
-              contents: ["---", "disable-model-invocation: true", "---", "Do not load me."],
-            },
-            {
-              relativePath: "commands/disabled-on.md",
-              contents: ["---", "disable-model-invocation: on", "---", "Do not load me either."],
-            },
-            {
-              relativePath: "commands/disabled-one.md",
-              contents: ["---", "disable-model-invocation: 1", "---", "Do not load me either."],
-            },
-            {
-              relativePath: "commands/disabled-yes.md",
-              contents: ["---", "disable-model-invocation: yes", "---", "Do not load me either."],
-            },
-            {
-              relativePath: "commands/enabled-no.md",
-              contents: [
-                "---",
-                "disable-model-invocation: no",
-                "---",
-                "Keep this command available.",
-              ],
-            },
-            {
-              relativePath: "commands/enabled-off.md",
-              contents: [
-                "---",
-                "disable-model-invocation: off",
-                "---",
-                "Keep this command available.",
-              ],
-            },
-            {
-              relativePath: "commands/enabled-zero.md",
-              contents: [
-                "---",
-                "disable-model-invocation: 0",
-                "---",
-                "Keep this command available.",
-              ],
-            },
-            {
               relativePath: "commands/not-frontmatter.md",
               contents: ["---not", "name: nope", "---not", "Treat this as Markdown."],
             },
@@ -188,39 +145,6 @@ describe("loadEnabledClaudeBundleCommands", () => {
         });
 
         expectEnabledClaudeBundleCommands(commands, [
-          {
-            pluginId: "compound-bundle",
-            rawName: "enabled-no",
-            description: "Keep this command available.",
-            promptTemplate: "Keep this command available.",
-            sourceFilePath: path.join(
-              resolveBundlePluginRoot(homeDir, "compound-bundle"),
-              "commands",
-              "enabled-no.md",
-            ),
-          },
-          {
-            pluginId: "compound-bundle",
-            rawName: "enabled-off",
-            description: "Keep this command available.",
-            promptTemplate: "Keep this command available.",
-            sourceFilePath: path.join(
-              resolveBundlePluginRoot(homeDir, "compound-bundle"),
-              "commands",
-              "enabled-off.md",
-            ),
-          },
-          {
-            pluginId: "compound-bundle",
-            rawName: "enabled-zero",
-            description: "Keep this command available.",
-            promptTemplate: "Keep this command available.",
-            sourceFilePath: path.join(
-              resolveBundlePluginRoot(homeDir, "compound-bundle"),
-              "commands",
-              "enabled-zero.md",
-            ),
-          },
           {
             pluginId: "compound-bundle",
             rawName: "not-frontmatter",
@@ -256,11 +180,62 @@ describe("loadEnabledClaudeBundleCommands", () => {
             ),
           },
         ]);
-        const rawNames = commands.map((entry) => entry.rawName);
-        expect(rawNames).not.toContain("disabled");
-        expect(rawNames).not.toContain("disabled-on");
-        expect(rawNames).not.toContain("disabled-one");
-        expect(rawNames).not.toContain("disabled-yes");
+      },
+    );
+  });
+
+  it("keeps model-hidden commands user-invocable and honors user-invocable literals", async () => {
+    const homeDir = await createTempDir("openclaw-bundle-commands-home-");
+    const workspaceDir = await createTempDir("openclaw-bundle-commands-workspace-");
+    const truthy = ["true", "on", "yes", "1"];
+    const falsy = ["false", "off", "no", "0"];
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_STATE_DIR: undefined,
+      },
+      async () => {
+        await writeClaudeBundleCommandFixture({
+          homeDir,
+          pluginId: "invocation-policy-bundle",
+          commands: [
+            {
+              relativePath: "commands/default.md",
+              contents: ["Default manual command."],
+            },
+            ...truthy.map((value) => ({
+              relativePath: `commands/model-hidden-${value}.md`,
+              contents: ["---", `disable-model-invocation: ${value}`, "---", "Manual only."],
+            })),
+            ...truthy.map((value) => ({
+              relativePath: `commands/user-enabled-${value}.md`,
+              contents: ["---", `user-invocable: ${value}`, "---", "User enabled."],
+            })),
+            ...falsy.map((value) => ({
+              relativePath: `commands/user-hidden-${value}.md`,
+              contents: ["---", `user-invocable: ${value}`, "---", "User hidden."],
+            })),
+          ],
+        });
+
+        const commands = loadEnabledClaudeBundleCommands({
+          workspaceDir,
+          cfg: {
+            plugins: {
+              entries: { "invocation-policy-bundle": { enabled: true } },
+            },
+          },
+        });
+        const rawNames = new Set(commands.map((entry) => entry.rawName));
+        expect(rawNames).toEqual(
+          new Set([
+            "default",
+            ...truthy.map((value) => `model-hidden-${value}`),
+            ...truthy.map((value) => `user-enabled-${value}`),
+          ]),
+        );
       },
     );
   });

--- a/src/plugins/bundle-commands.ts
+++ b/src/plugins/bundle-commands.ts
@@ -108,7 +108,7 @@ function loadBundleCommandsFromRoot(params: {
       continue;
     }
     const frontmatter = parseFrontmatterBlock(raw);
-    if (parseFrontmatterBool(frontmatter["disable-model-invocation"], false)) {
+    if (!parseFrontmatterBool(frontmatter["user-invocable"], true)) {
       continue;
     }
     const promptTemplate = stripFrontmatterBlock(raw);

--- a/src/plugins/bundle-commands.ts
+++ b/src/plugins/bundle-commands.ts
@@ -12,6 +12,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readRootJsonObjectSync } from "../infra/json-files.js";
 import { isPathInsideWithRealpath } from "../security/scan-paths.js";
+import { parseFrontmatterBool } from "../shared/frontmatter.js";
 import {
   CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH,
   mergeBundlePathLists,
@@ -31,20 +32,6 @@ type ClaudeBundleCommandSpec = {
   promptTemplate: string;
   sourceFilePath: string;
 };
-
-function parseFrontmatterBool(value: string | undefined, fallback: boolean): boolean {
-  const normalized = normalizeOptionalLowercaseString(value);
-  if (!normalized) {
-    return fallback;
-  }
-  if (normalized === "true" || normalized === "yes" || normalized === "1") {
-    return true;
-  }
-  if (normalized === "false" || normalized === "no" || normalized === "0") {
-    return false;
-  }
-  return fallback;
-}
 
 function readClaudeBundleManifest(rootDir: string): Record<string, unknown> {
   const result = readRootJsonObjectSync({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where enabled Claude bundle commands used the model-prompt policy to decide slash-command visibility, and the bundle-local boolean parser did not honor the full shared frontmatter contract, including `on` and `off`.

## Why This Change Was Made

The bundle command loader now reuses the canonical frontmatter boolean helper and filters slash-command exposure with `user-invocable`. `disable-model-invocation` continues to control model-prompt exposure without hiding an otherwise user-invocable command.

## User Impact

Bundle authors can use the documented invocation-policy fields consistently. `user-invocable: off` hides a bundle slash command, `user-invocable: on` exposes it, and `disable-model-invocation: on` keeps a manual command available while excluding it from normal model invocation.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/bundle-commands.test.ts` — 1 file, 1 test passed.
- `git diff --check` — passed.
- Autoreview: clean branch review with no accepted/actionable findings.
- Production-path temporary-bundle proof at `03e881a9b9c4f9ff30a0312700009ee114b49316` loaded the real command discovery path and produced:

```json
{
  "names": ["model-hidden", "user-enabled"],
  "modelHiddenPresent": true,
  "userEnabledPresent": true,
  "userHiddenPresent": false
}
```

The hosted changed-check completed formatting and repository guards, then stopped on an unrelated Plugin SDK API baseline mismatch; this PR does not touch the SDK baseline. Exact-head PR CI is the landing gate.
