### PR TITLE
fix(workspaces): reject raw file binding pointers

### DIFF
--- a/extensions/workspaces/src/data-read.test.ts
+++ b/extensions/workspaces/src/data-read.test.ts
@@ -43,7 +43,7 @@ describe("workspace data binding resolver", () => {
     }
   });
 
-  it("reads JSON pointers and raw markdown from the workspace data jail", async () => {
+  it("applies pointers to JSON and raw text files in the workspace data jail", async () => {
     await withTempStateDir(async (stateDir) => {
       await fs.mkdir(path.join(stateDir, "workspaces", "data", "metrics"), { recursive: true });
       await fs.writeFile(
@@ -51,6 +51,7 @@ describe("workspace data binding resolver", () => {
         JSON.stringify({ revenue: 42, nested: { "a/b": "escaped" } }),
       );
       await fs.writeFile(path.join(stateDir, "workspaces", "data", "notes.md"), "# Notes\n");
+      await fs.writeFile(path.join(stateDir, "workspaces", "data", "table.csv"), "name,value\n");
 
       await expect(
         resolveBinding(
@@ -61,6 +62,18 @@ describe("workspace data binding resolver", () => {
       await expect(
         resolveBinding({ source: "file", path: "notes.md" }, { stateDir }),
       ).resolves.toBe("# Notes\n");
+      await expect(
+        resolveBinding({ source: "file", path: "notes.md", pointer: "" }, { stateDir }),
+      ).resolves.toBe("# Notes\n");
+      await expect(
+        resolveBinding({ source: "file", path: "notes.md", pointer: "/missing" }, { stateDir }),
+      ).rejects.toMatchObject({ code: "binding_not_found" });
+      await expect(
+        resolveBinding({ source: "file", path: "table.csv", pointer: "/missing" }, { stateDir }),
+      ).rejects.toMatchObject({ code: "binding_not_found" });
+      await expect(
+        resolveBinding({ source: "file", path: "notes.md", pointer: "missing" }, { stateDir }),
+      ).rejects.toMatchObject({ code: "binding_invalid" });
     });
   });
 

--- a/extensions/workspaces/src/data-read.ts
+++ b/extensions/workspaces/src/data-read.ts
@@ -95,16 +95,6 @@ function applyJsonPointer(value: unknown, pointer: string | undefined): unknown 
   return current;
 }
 
-function applyRawTextPointer(value: string, pointer: string | undefined): string {
-  if (pointer === undefined || pointer === "") {
-    return value;
-  }
-  if (!pointer.startsWith("/")) {
-    throw new WorkspaceBindingResolutionError("binding_invalid", "JSON pointer is invalid");
-  }
-  throw new WorkspaceBindingResolutionError("binding_not_found", "JSON pointer not found");
-}
-
 async function resolveFileBinding(
   binding: Extract<WorkspaceBinding, { source: "file" }>,
   options: ResolveBindingOptions,
@@ -147,7 +137,7 @@ async function resolveFileBinding(
   }
   const extension = path.extname(logicalPath).toLowerCase();
   if (extension === ".md" || extension === ".csv") {
-    return applyRawTextPointer(content, binding.pointer);
+    return applyJsonPointer(content, binding.pointer);
   }
   try {
     return applyJsonPointer(JSON.parse(content), binding.pointer);

--- a/extensions/workspaces/src/data-read.ts
+++ b/extensions/workspaces/src/data-read.ts
@@ -95,6 +95,16 @@ function applyJsonPointer(value: unknown, pointer: string | undefined): unknown 
   return current;
 }
 
+function applyRawTextPointer(value: string, pointer: string | undefined): string {
+  if (pointer === undefined || pointer === "") {
+    return value;
+  }
+  if (!pointer.startsWith("/")) {
+    throw new WorkspaceBindingResolutionError("binding_invalid", "JSON pointer is invalid");
+  }
+  throw new WorkspaceBindingResolutionError("binding_not_found", "JSON pointer not found");
+}
+
 async function resolveFileBinding(
   binding: Extract<WorkspaceBinding, { source: "file" }>,
   options: ResolveBindingOptions,
@@ -137,7 +147,7 @@ async function resolveFileBinding(
   }
   const extension = path.extname(logicalPath).toLowerCase();
   if (extension === ".md" || extension === ".csv") {
-    return content;
+    return applyRawTextPointer(content, binding.pointer);
   }
   try {
     return applyJsonPointer(JSON.parse(content), binding.pointer);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading workspace Markdown or CSV file bindings with a JSON pointer could receive the full raw file even when the pointer selected a missing non-root value.

## Why This Change Was Made

The Workspaces file-binding resolver now applies the same pointer contract at the raw-text owner boundary: omitted or root pointers return the file content, malformed pointers raise the existing invalid-binding error, and syntactically valid non-root pointers raise the existing not-found error. This covers the `.md` and `.csv` raw-text micro-cluster without changing JSON pointer handling, configuration, schema, storage schema, or provider behavior.

## User Impact

Workspace data reads for `file:<path>#<pointer>` now give a clear binding error for unsupported raw-text member lookups instead of treating a missing Markdown or CSV pointer as a successful full-file read.

## Evidence

- Current refreshed head: `5a06cf651c68f7087ee27b3c3bacbcfa12eac5eb` after `gh pr update-branch --rebase`.
- Claim proved: Markdown and CSV workspace file bindings preserve full-file reads for omitted or root pointers and reject unsupported raw-text pointer lookups through binding errors.
- Exact-head GitHub `Real behavior proof` passed on the refreshed head.
- Exact-head checks are complete with no failed or pending checks after the refresh.