### PR TITLE
fix: hide external files from the session workspace rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI session files:** omit transcript-touched paths outside the active workspace from the workspace rail while preserving missing-file status for paths inside the workspace. Fixes #95685. Refs #96660. Thanks @shawnsaxis1971-arch and @mmhzlrj.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI session files:** omit transcript-touched paths outside the active workspace from the workspace rail while preserving missing-file status for paths inside the workspace. Fixes #95685. Refs #96660. Thanks @shawnsaxis1971-arch and @mmhzlrj.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.

--- a/src/gateway/server-methods/sessions-files.test.ts
+++ b/src/gateway/server-methods/sessions-files.test.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sessionsFilesHandlers } from "./sessions-files.js";
 import { updateWorkspaceFile } from "./workspace-fs.js";
@@ -498,6 +499,49 @@ describe("sessions.files RPC handlers", () => {
           type: "session_file_not_found",
         });
       }
+    } finally {
+      fs.rmSync(outsidePath, { force: true });
+    }
+  });
+
+  it("omits transcript paths outside the workspace without hiding missing workspace files", async () => {
+    const outsidePath = path.join(os.tmpdir(), `openclaw-outside-list-${Date.now()}.txt`);
+    fs.writeFileSync(outsidePath, "outside\n", "utf8");
+    hoisted.visitSessionMessagesAsync.mockImplementation(async (_scope, visit) => {
+      [
+        outsidePath,
+        "../outside.txt",
+        "~/.openclaw-external.txt",
+        pathToFileURL(outsidePath).href,
+        `@${outsidePath}`,
+        "..cache/missing.txt",
+        "missing.txt",
+        "src/readme.md",
+      ].forEach((filePath, index) =>
+        visit(assistantToolCall("read", { path: filePath }), index + 1),
+      );
+      return 8;
+    });
+
+    try {
+      const payload = expectOkPayload(
+        await invokeSessionFilesHandler("sessions.files.list", {
+          sessionKey: "agent:main:main",
+        }),
+      );
+
+      expect(payload.files).toHaveLength(3);
+      expect(payload.files).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: "..cache/missing.txt", missing: true }),
+          expect.objectContaining({ path: "missing.txt", missing: true }),
+          expect.objectContaining({
+            path: "src/readme.md",
+            missing: false,
+            workspacePath: "src/readme.md",
+          }),
+        ]),
+      );
     } finally {
       fs.rmSync(outsidePath, { force: true });
     }

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -16,6 +16,7 @@ import {
   validateSessionsFilesSetParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveToCwd as resolveSessionToolPathToCwd } from "../../agents/sessions/tools/path-utils.js";
 import { FsSafeError } from "../../infra/fs-safe.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { visitSessionMessagesAsync } from "../session-transcript-readers.js";
@@ -189,7 +190,10 @@ function toDisplayPath(root: string, resolved: string): string {
 
 function isInsideRoot(root: string, candidate: string): boolean {
   const relative = path.relative(root, candidate);
-  return !relative.startsWith("..") && !path.isAbsolute(relative);
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
 }
 
 function resolveTouchedFilePath(params: {
@@ -201,9 +205,7 @@ function resolveTouchedFilePath(params: {
     return undefined;
   }
   const base = params.fileRoot ?? params.root;
-  const resolved = path.isAbsolute(params.filePath)
-    ? path.resolve(params.filePath)
-    : path.resolve(base, params.filePath);
+  const resolved = resolveSessionToolPathToCwd(params.filePath, base);
   if (!isInsideRoot(params.root, resolved)) {
     return undefined;
   }
@@ -547,18 +549,24 @@ async function buildListResult(params: {
   search?: string;
 }): Promise<{ root?: string; files: SessionFileEntry[]; browser?: SessionFileBrowserResult }> {
   const loaded = await loadSessionFiles(params);
+  const root = loaded.root;
+  const workspaceFiles = root
+    ? loaded.files.filter((file) =>
+        Boolean(resolveTouchedFilePath({ root, fileRoot: loaded.fileRoot, filePath: file.path })),
+      )
+    : loaded.files;
   const files = await Promise.all(
-    loaded.files.map((file) => toSessionFileEntry(file, loaded.root, loaded.fileRoot)),
+    workspaceFiles.map((file) => toSessionFileEntry(file, loaded.root, loaded.fileRoot)),
   );
   const browser = await buildBrowserResult({
-    root: loaded.root,
+    root,
     fileRoot: loaded.fileRoot,
     path: params.path,
     search: params.search,
-    files: loaded.files,
+    files: workspaceFiles,
   });
   return {
-    ...(loaded.root ? { root: loaded.root } : {}),
+    ...(root ? { root } : {}),
     files,
     ...(browser ? { browser } : {}),
   };


### PR DESCRIPTION
## What Problem This Solves

The Control UI workspace rail treated every file path mentioned by session read tools as a workspace file. Absolute paths, parent-relative paths, home-relative paths, file URLs, and `@`-prefixed paths outside the active workspace therefore appeared as red `Missing` entries. Closes #95685. Refs #96660.

## Why This Change Was Made

Filter transcript-touched paths at the `sessions.files.list` owner boundary using the same canonical path resolver as session read tools. This keeps external paths out of both rail entries and browser relevance calculation while preserving legitimate missing paths inside the workspace, including names such as `..cache`.

The containment check remains lexical; existing `fs-safe` handling continues to enforce symlink containment for file access. This avoids exposing external existence, size, or modification metadata.

## User Impact

The workspace rail now lists only paths that belong to the active workspace. Missing workspace files remain visible and accurately marked.

Thanks @shawnsaxis1971-arch and @mmhzlrj for reporting the affected paths and UI symptoms. Release-note context is kept here because the root changelog is release-owned.

## Evidence

- Focused Testbox: `corepack pnpm test src/gateway/server-methods/sessions-files.test.ts` — 60 tests passed.
- Changed gate: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed.
- Regression contract covers absolute, parent-relative, home-relative, file URL, and `@`-prefixed external paths plus existing and missing in-workspace paths.
- Fresh autoreview: no accepted/actionable findings; patch correct (0.94 confidence).

AI-assisted implementation and review; maintainer-directed scope and validation.
