### PR TITLE
fix(sandbox): use Buffer.byteLength for env var value size limit

### DIFF
--- a/src/agents/sandbox/sanitize-env-vars.test.ts
+++ b/src/agents/sandbox/sanitize-env-vars.test.ts
@@ -1,7 +1,11 @@
 // Sandbox env sanitizer tests cover credential filtering for inherited and
 // explicitly configured sandbox environment variables.
 import { describe, expect, it } from "vitest";
-import { sanitizeEnvVars, sanitizeExplicitSandboxEnvVars } from "./sanitize-env-vars.js";
+import {
+  sanitizeEnvVars,
+  sanitizeExplicitSandboxEnvVars,
+  validateEnvVarValue,
+} from "./sanitize-env-vars.js";
 
 describe("sanitizeEnvVars", () => {
   it("keeps normal env vars and blocks obvious credentials", () => {
@@ -106,26 +110,11 @@ describe("sanitizeEnvVars", () => {
     expect(result.blocked).toStrictEqual(["NULL_SECRET"]);
   });
 
-  it("warns on multi-byte values whose UTF-8 byte length exceeds the limit", () => {
-    // Each CJK character is 3 UTF-8 bytes; 11000 chars × 3 bytes = 33000 bytes > 32768.
-    const multiByteValue = "值".repeat(11000);
-    expect(multiByteValue.length).toBe(11000); // UTF-16 length is below 32768
-    expect(Buffer.byteLength(multiByteValue, "utf8")).toBe(33000); // but UTF-8 exceeds limit
+  it("measures the value limit in UTF-8 bytes", () => {
+    const atLimit = "a!".repeat(16384);
 
-    const result = sanitizeEnvVars({ MULTIBYTE: multiByteValue });
-    expect(result.allowed).toEqual({ MULTIBYTE: multiByteValue });
-    expect(result.warnings).toContain("MULTIBYTE: Value exceeds maximum length");
-  });
-
-  it("allows ASCII values at the byte limit boundary", () => {
-    // Use characters outside the base64 charset to avoid triggering the
-    // base64-credential heuristic, which runs before the length check.
-    const atLimit = "a!b!".repeat(8192); // 8192*4 = 32768 bytes, contains !
-    const overLimit = atLimit + "x"; // 32769 bytes
-
-    expect(sanitizeEnvVars({ AT_LIMIT: atLimit }).warnings).toStrictEqual([]);
-    expect(sanitizeEnvVars({ OVER_LIMIT: overLimit }).warnings).toContain(
-      "OVER_LIMIT: Value exceeds maximum length",
-    );
+    expect(validateEnvVarValue(atLimit)).toBeUndefined();
+    expect(validateEnvVarValue(`${atLimit}x`)).toBe("Value exceeds maximum length");
+    expect(validateEnvVarValue("值".repeat(11000))).toBe("Value exceeds maximum length");
   });
 });

--- a/src/agents/sandbox/sanitize-env-vars.test.ts
+++ b/src/agents/sandbox/sanitize-env-vars.test.ts
@@ -105,4 +105,27 @@ describe("sanitizeEnvVars", () => {
     expect(result.allowed).toEqual({ SAFE_SECRET: "ok" });
     expect(result.blocked).toStrictEqual(["NULL_SECRET"]);
   });
+
+  it("warns on multi-byte values whose UTF-8 byte length exceeds the limit", () => {
+    // Each CJK character is 3 UTF-8 bytes; 11000 chars × 3 bytes = 33000 bytes > 32768.
+    const multiByteValue = "值".repeat(11000);
+    expect(multiByteValue.length).toBe(11000); // UTF-16 length is below 32768
+    expect(Buffer.byteLength(multiByteValue, "utf8")).toBe(33000); // but UTF-8 exceeds limit
+
+    const result = sanitizeEnvVars({ MULTIBYTE: multiByteValue });
+    expect(result.allowed).toEqual({ MULTIBYTE: multiByteValue });
+    expect(result.warnings).toContain("MULTIBYTE: Value exceeds maximum length");
+  });
+
+  it("allows ASCII values at the byte limit boundary", () => {
+    // Use characters outside the base64 charset to avoid triggering the
+    // base64-credential heuristic, which runs before the length check.
+    const atLimit = "a!b!".repeat(8192); // 8192*4 = 32768 bytes, contains !
+    const overLimit = atLimit + "x"; // 32769 bytes
+
+    expect(sanitizeEnvVars({ AT_LIMIT: atLimit }).warnings).toStrictEqual([]);
+    expect(sanitizeEnvVars({ OVER_LIMIT: overLimit }).warnings).toContain(
+      "OVER_LIMIT: Value exceeds maximum length",
+    );
+  });
 });

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -53,12 +53,14 @@ type EnvSanitizationOptions = {
   customAllowedPatterns?: ReadonlyArray<RegExp>;
 };
 
+const MAX_ENV_VAR_VALUE_BYTES = 32768;
+
 /** Returns a warning or block reason for environment values that look unsafe to forward. */
 export function validateEnvVarValue(value: string): string | undefined {
   if (value.includes("\0")) {
     return "Contains null bytes";
   }
-  if (value.length > 32768) {
+  if (Buffer.byteLength(value, "utf8") > MAX_ENV_VAR_VALUE_BYTES) {
     return "Value exceeds maximum length";
   }
   if (/^[A-Za-z0-9+/=]{80,}$/.test(value)) {


### PR DESCRIPTION
## What Problem This Solves

`validateEnvVarValue` in `sanitize-env-vars.ts` checked `value.length` (UTF-16 code units) against a 32 768-byte limit. Multi-byte CJK values like `"值".repeat(11000)` have `.length === 11000` but occupy 33 000 UTF-8 bytes, silently bypassing the OS limit. The env var would be forwarded to the sandbox without a warning, potentially causing the container/SSH session to fail at launch.

## Fix

Replace `value.length` with `Buffer.byteLength(value, "utf8")` to correctly measure UTF-8 byte size. Extract the limit into a named constant `MAX_ENV_VAR_VALUE_BYTES = 32768`.

## Evidence

### Before fix (main branch): CJK bypass

```
CJK value: .length = 11000, Buffer.byteLength = 33000
value.length > 32768? false → would NOT trigger warning (BUG)
Buffer.byteLength > 32768? true → SHOULD trigger warning
```

The 33 000-byte CJK value passes the `.length` check and is forwarded without a warning.

### After fix (this PR): Correct byte-length check

```
$ npx tsx -e 'import { validateEnvVarValue } from "./src/agents/sandbox/sanitize-env-vars.ts"; ...'

validateEnvVarValue(CJK 11000 chars): Value exceeds maximum length
validateEnvVarValue(ASCII 32768 chars): Value looks like base64-encoded credential data
validateEnvVarValue(ASCII 32769 chars): Value exceeds maximum length
```

- CJK 11 000 chars (33 000 bytes): now correctly warned as exceeding the limit
- ASCII 32 768 chars (32 768 bytes): at the boundary, no length warning (base64 heuristic still applies)
- ASCII 32 769 chars (32 769 bytes): correctly warned as exceeding the limit

### Vitest output (9/9 tests pass)

```
$ npx vitest run src/agents/sandbox/sanitize-env-vars.test.ts --reporter=verbose

 ✓ sanitizeEnvVars > keeps normal env vars and blocks obvious credentials
 ✓ sanitizeEnvVars > blocks credentials even when suffix pattern matches
 ✓ sanitizeEnvVars > adds warnings for suspicious values
 ✓ sanitizeEnvVars > supports strict mode with explicit allowlist
 ✓ sanitizeEnvVars > skips undefined values when sanitizing process-style env maps
 ✓ sanitizeEnvVars > allows explicit configured sandbox env names that look like credentials
 ✓ sanitizeEnvVars > still blocks invalid explicit configured sandbox env values
 ✓ sanitizeEnvVars > warns on multi-byte values whose UTF-8 byte length exceeds the limit
 ✓ sanitizeEnvVars > allows ASCII values at the byte limit boundary

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

## Test plan

- [x] New test: CJK 11 000 chars (33 000 bytes) triggers "Value exceeds maximum length"
- [x] New test: ASCII at exact 32 768-byte boundary passes length check
- [x] New test: ASCII at 32 769 bytes triggers "Value exceeds maximum length"
- [x] Existing 7 sanitizeEnvVars tests still pass