### PR TITLE
fix(exa): forward abort signal when web search runs are canceled

### DIFF
--- a/extensions/exa/proof/abort-guarded-fetch-proof.test.ts
+++ b/extensions/exa/proof/abort-guarded-fetch-proof.test.ts
@@ -44,8 +44,8 @@ describe("exa abort signal proof", () => {
     }
 
     const startedAt = Date.now();
-    let errorType: string;
-    let errorMessage: string;
+    let errorType = "unknown";
+    let errorMessage = "unknown";
     try {
       await tool.execute({ query: "openclaw test" }, { signal: controller.signal });
       throw new Error("Expected execute() to reject with aborted signal");
@@ -98,8 +98,8 @@ describe("exa abort signal proof", () => {
     await expect(searchPromise).rejects.toThrow();
     const elapsed = Date.now() - startedAt;
 
-    let errorType: string;
-    let errorMessage: string;
+    let errorType = "unknown";
+    let errorMessage = "unknown";
     try {
       await searchPromise;
     } catch (err) {

--- a/extensions/exa/proof/abort-guarded-fetch-proof.test.ts
+++ b/extensions/exa/proof/abort-guarded-fetch-proof.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Real behavior proof: abort signal through the guarded-fetch stack used by Exa.
+ *
+ * Exa production code path:
+ *   executeExaWebSearchProviderTool (exa-web-search-provider.runtime.ts)
+ *   → runExaSearch({ signal })
+ *   → withTrustedWebSearchEndpoint({ signal }) (web-search-provider-common.ts)
+ *   → withTrustedWebToolsEndpoint (web-guarded-fetch.ts)
+ *   → fetchWithSsrFGuard (fetch-guard.ts)
+ *   → buildTimeoutAbortSignal → fetch()
+ *
+ * This proof uses withSelfHostedWebSearchEndpoint — the localhost-allowed
+ * sibling. Both share identical fetchWithSsrFGuard → buildTimeoutAbortSignal
+ * → fetch() code paths; only the SSRF policy object differs.
+ */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+
+describe("exa abort signal proof", () => {
+  it("propagates abort signal through the guarded-fetch stack used by Exa", async () => {
+    const { withSelfHostedWebSearchEndpoint } = await vi.importActual<
+      typeof import("openclaw/plugin-sdk/provider-web-search")
+    >("openclaw/plugin-sdk/provider-web-search");
+
+    const server = createServer((_req, res) => {
+      res.socket?.setTimeout(0);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+
+    const controller = new AbortController();
+    const startedAt = Date.now();
+
+    const searchPromise = withSelfHostedWebSearchEndpoint(
+      {
+        url: `http://127.0.0.1:${port}/stall`,
+        timeoutSeconds: 30,
+        init: { method: "GET" },
+        signal: controller.signal,
+      },
+      async () => ({ ok: true }),
+    );
+
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 100);
+    });
+    controller.abort("proof: cancellation");
+
+    await expect(searchPromise).rejects.toThrow();
+    const elapsed = Date.now() - startedAt;
+
+    let errorType = "unknown";
+    let errorMessage = "";
+    try {
+      await searchPromise;
+    } catch (err) {
+      errorType = err?.constructor?.name ?? "unknown";
+      errorMessage = err instanceof Error ? err.message : String(err);
+    }
+
+    console.log(
+      `[proof] Signal propagated in ${elapsed}ms through guarded-fetch stack ` +
+        `(withSelfHostedWebSearchEndpoint → fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch)`,
+    );
+    console.log(`[proof] stalled server: http://127.0.0.1:${port}/stall`);
+    console.log(`[proof] abort: controller.abort("proof: cancellation") @ ~100ms`);
+    console.log(`[proof] error: ${errorType}: ${errorMessage}`);
+
+    server.close();
+    expect(elapsed).toBeLessThan(5000);
+  }, 15000);
+});

--- a/extensions/exa/proof/abort-guarded-fetch-proof.test.ts
+++ b/extensions/exa/proof/abort-guarded-fetch-proof.test.ts
@@ -1,23 +1,65 @@
 /**
- * Real behavior proof: abort signal through the guarded-fetch stack used by Exa.
+ * Real behavior proof: abort signal through Exa's full provider→fetch chain.
  *
  * Exa production code path:
- *   executeExaWebSearchProviderTool (exa-web-search-provider.runtime.ts)
- *   → runExaSearch({ signal })
- *   → withTrustedWebSearchEndpoint({ signal }) (web-search-provider-common.ts)
- *   → withTrustedWebToolsEndpoint (web-guarded-fetch.ts)
- *   → fetchWithSsrFGuard (fetch-guard.ts)
- *   → buildTimeoutAbortSignal → fetch()
+ *   createExaWebSearchProvider().createTool(ctx).execute(args, context)
+ *   → executeExaWebSearchProviderTool(ctx, args, { signal: context?.signal })
+ *   → runExaSearch({ signal: opts?.signal })
+ *   → withTrustedWebSearchEndpoint({ signal: params.signal })
+ *   → withTrustedWebToolsEndpoint({ signal })
+ *   → fetchWithSsrFGuard({ signal })
+ *   → buildTimeoutAbortSignal({ signal })
+ *   → fetch()
  *
- * This proof uses withSelfHostedWebSearchEndpoint — the localhost-allowed
- * sibling. Both share identical fetchWithSsrFGuard → buildTimeoutAbortSignal
- * → fetch() code paths; only the SSRF policy object differs.
+ * Two-part proof:
+ * 1. Pre-aborted signal through provider path — proves signal flows from
+ *    provider.execute() through all intermediate layers to fetch().
+ *    buildTimeoutAbortSignal sees the already-aborted parent signal and
+ *    immediately aborts its controller, so no network I/O occurs.
+ * 2. Stalled-server proof through withSelfHostedWebSearchEndpoint — proves the
+ *    common guarded-fetch stack cancels real in-flight HTTP requests.
+ *    Self-hosted variant allows localhost; both variants share identical
+ *    fetchWithSsrFGuard → buildTimeoutAbortSignal → fetch() code paths.
  */
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { describe, expect, it, vi } from "vitest";
+import { createExaWebSearchProvider } from "../src/exa-web-search-provider.js";
 
 describe("exa abort signal proof", () => {
+  it("propagates pre-aborted signal from provider execute through full client path", async () => {
+    // Provide a fake API key so the provider passes the apiKey check
+    // and the signal reaches the fetch layer. With a pre-aborted signal,
+    // buildTimeoutAbortSignal immediately aborts its controller, and
+    // fetch() rejects before any network I/O — no real API call occurs.
+    vi.stubEnv("EXA_API_KEY", "proof-test-key");
+
+    const controller = new AbortController();
+    controller.abort(new Error("proof: pre-aborted signal"));
+
+    const provider = createExaWebSearchProvider();
+    const tool = provider.createTool({ config: {} as never });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const startedAt = Date.now();
+    let errorType: string;
+    let errorMessage: string;
+    try {
+      await tool.execute({ query: "openclaw test" }, { signal: controller.signal });
+      throw new Error("Expected execute() to reject with aborted signal");
+    } catch (err) {
+      errorType = err?.constructor?.name ?? "unknown";
+      errorMessage = err instanceof Error ? err.message : String(err);
+    }
+    const elapsed = Date.now() - startedAt;
+
+    console.log(`[proof] Pre-aborted signal propagated through Exa provider in ${elapsed}ms`);
+    console.log(`[proof] error: ${errorType}: ${errorMessage}`);
+    expect(elapsed).toBeLessThan(5000);
+  }, 15000);
+
   it("propagates abort signal through the guarded-fetch stack used by Exa", async () => {
     const { withSelfHostedWebSearchEndpoint } = await vi.importActual<
       typeof import("openclaw/plugin-sdk/provider-web-search")
@@ -27,7 +69,9 @@ describe("exa abort signal proof", () => {
       res.socket?.setTimeout(0);
     });
     await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", () => resolve());
+      server.listen(0, "127.0.0.1", () => {
+        resolve();
+      });
     });
     const { port } = server.address() as AddressInfo;
 
@@ -45,15 +89,17 @@ describe("exa abort signal proof", () => {
     );
 
     await new Promise<void>((resolve) => {
-      setTimeout(() => resolve(), 100);
+      setTimeout(() => {
+        resolve();
+      }, 100);
     });
     controller.abort("proof: cancellation");
 
     await expect(searchPromise).rejects.toThrow();
     const elapsed = Date.now() - startedAt;
 
-    let errorType = "unknown";
-    let errorMessage = "";
+    let errorType: string;
+    let errorMessage: string;
     try {
       await searchPromise;
     } catch (err) {

--- a/extensions/exa/src/exa-web-search-provider.runtime.ts
+++ b/extensions/exa/src/exa-web-search-provider.runtime.ts
@@ -392,6 +392,7 @@ async function runExaSearch(params: {
   type: ExaSearchType;
   contents?: ExaContentsArgs;
   timeoutSeconds: number;
+  signal?: AbortSignal;
 }): Promise<ExaSearchResult[]> {
   const body: Record<string, unknown> = {
     query: params.query,
@@ -413,6 +414,7 @@ async function runExaSearch(params: {
     {
       url: params.endpoint,
       timeoutSeconds: params.timeoutSeconds,
+      signal: params.signal,
       init: {
         method: "POST",
         headers: {
@@ -471,6 +473,7 @@ function buildExaCacheKey(params: {
 export async function executeExaWebSearchProviderTool(
   ctx: { config?: Record<string, unknown>; searchConfig?: SearchConfigRecord },
   args: Record<string, unknown>,
+  opts?: { signal?: AbortSignal },
 ): Promise<Record<string, unknown>> {
   const searchConfig = mergeScopedSearchConfig(
     ctx.searchConfig,
@@ -570,6 +573,7 @@ export async function executeExaWebSearchProviderTool(
     type,
     contents,
     timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
+    signal: opts?.signal,
   });
 
   const payload = {

--- a/extensions/exa/src/exa-web-search-provider.ts
+++ b/extensions/exa/src/exa-web-search-provider.ts
@@ -67,9 +67,11 @@ export function createExaWebSearchProvider(): WebSearchProviderPlugin {
       description:
         "Search the web using Exa AI. Supports neural or keyword search, publication date filters, and optional highlights or text extraction.",
       parameters: ExaSearchSchema,
-      execute: async (args) => {
+      execute: async (args, context) => {
         const { executeExaWebSearchProviderTool } = await loadExaWebSearchRuntime();
-        return await executeExaWebSearchProviderTool(ctx, args);
+        return await executeExaWebSearchProviderTool(ctx, args, {
+          signal: context?.signal,
+        });
       },
     }),
   };

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -266,6 +266,49 @@ describe("web search runtime", () => {
     );
   });
 
+  it("does not fall back to another provider after parent cancellation", async () => {
+    const controller = new AbortController();
+    const firstExecute = vi.fn(
+      async (_args: Record<string, unknown>, _context?: { signal?: AbortSignal }) => {
+        controller.abort();
+        throw controller.signal.reason;
+      },
+    );
+    const fallbackExecute = vi.fn(async () => ({ ok: true }));
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
+      createCustomSearchProvider({
+        credentialPath: "",
+        createTool: () => ({
+          description: "first",
+          parameters: {},
+          execute: firstExecute,
+        }),
+      }),
+      createCustomSearchProvider({
+        pluginId: "fallback-search",
+        id: "fallback",
+        credentialPath: "",
+        autoDetectOrder: 2,
+        getConfiguredCredentialValue: () => "configured",
+        createTool: () => ({
+          description: "fallback",
+          parameters: {},
+          execute: fallbackExecute,
+        }),
+      }),
+    ]);
+
+    await expect(
+      runWebSearch({
+        config: createCustomSearchConfig("custom-config-key"),
+        args: { query: "abort fallback" },
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(firstExecute).toHaveBeenCalledOnce();
+    expect(fallbackExecute).not.toHaveBeenCalled();
+  });
+
   it("auto-detects a provider from canonical plugin-owned credentials", async () => {
     const provider = createCustomSearchProvider();
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -472,6 +472,7 @@ export async function runWebSearch(params: RunWebSearchParams): Promise<RunWebSe
   let sawUnavailableProvider = false;
 
   for (const candidate of candidates) {
+    params.signal?.throwIfAborted();
     try {
       const definition = candidate.createTool({
         config,
@@ -499,7 +500,7 @@ export async function runWebSearch(params: RunWebSearchParams): Promise<RunWebSe
       };
     } catch (error) {
       lastError = error;
-      if (!allowFallback) {
+      if (params.signal?.aborted || !allowFallback) {
         throw error;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Exa web searches continue running after the agent run is canceled. The web search runtime already threads the caller's `AbortSignal` into `execute(args, { signal })`, but the Exa provider discarded it — so aborted runs still consumed network resources.

## Why This Change Was Made

**Exa signal forwarding** (provider + runtime): Forward `context?.signal` through the Exa provider and search runtime to `withTrustedWebSearchEndpoint` (which already supports `signal?: AbortSignal`). The pattern matches searxng #104216, duckduckgo #104899, and tavily #104965 — one provider per PR.

**Shared runtime abort guard** (`src/web-search/runtime.ts`): Add `throwIfAborted()` at top of provider loop + `signal?.aborted` in catch block so a canceled request does not trigger unintended fallback.

## Evidence

### Real behavior proof — abort through the guarded-fetch stack

Stalled HTTP server exercises the same `fetchWithSsrFGuard` → `buildTimeoutAbortSignal` → `fetch()` code path that Exa's `withTrustedWebSearchEndpoint` uses:

```
[proof] Signal propagated in 119ms through guarded-fetch stack
[proof] abort: controller.abort("proof: cancellation") @ ~100ms
[proof] error: DOMException: This operation was aborted
```

Proof: `extensions/exa/proof/abort-guarded-fetch-proof.test.ts`

### Signal chain

| Layer | File | Line | Mechanism |
|---|---|---|---|
| Web search runtime | `src/web-search/runtime.ts` | 475 | `params.signal?.throwIfAborted()` (new) |
| Web search runtime | `src/web-search/runtime.ts` | 503 | `params.signal?.aborted \|\| !allowFallback` (new) |
| Exa provider | `extensions/exa/src/exa-web-search-provider.ts` | 70 | `execute: async (args, context)` → `signal: context?.signal` (new) |
| Exa search runtime | `extensions/exa/src/exa-web-search-provider.runtime.ts` | 474 | `opts?.signal` (new) |
| Exa HTTP layer | `extensions/exa/src/exa-web-search-provider.runtime.ts` | 415 | `signal: params.signal` → `withTrustedWebSearchEndpoint` (new) |
| Trusted endpoint | `src/agents/tools/web-search-provider-common.ts` | 105 | Native support |

### Test suite

```
$ node scripts/run-vitest.mjs run extensions/exa/ src/web-search/runtime.test.ts
 ✓ exa: 17/17 passed
 ✓ runtime: 31/31 passed (includes "does not fall back after parent cancellation")
```

### Landing order

The `src/web-search/runtime.ts` abort guard is included for standalone typecheck. #104216, #104899, and #104965 carry the same guard — whichever lands first, others rebase.
