### PR TITLE
refactor(acpx): remove redundant probe plumbing

### DIFF
--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -49,10 +49,6 @@
         "type": "number",
         "minimum": 0
       },
-      "probeAgent": {
-        "type": "string",
-        "minLength": 1
-      },
       "mcpServers": {
         "type": "object",
         "additionalProperties": {

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -29,6 +29,7 @@ describe("embedded acpx plugin config", () => {
     expect(resolved.permissionMode).toBe("approve-reads");
     expect(resolved.nonInteractivePermissions).toBe("fail");
     expect(resolved.timeoutSeconds).toBe(120);
+    expect(resolved.probeAgent).toBeUndefined();
     expect(resolved.agents).toStrictEqual({});
   });
 
@@ -41,17 +42,6 @@ describe("embedded acpx plugin config", () => {
     });
 
     expect(resolved.timeoutSeconds).toBe(300);
-  });
-
-  it("keeps explicit probeAgent config", () => {
-    const resolved = resolveAcpxPluginConfig({
-      rawConfig: {
-        probeAgent: "claude",
-      },
-      workspaceDir: "/tmp/openclaw-acpx",
-    });
-
-    expect(resolved.probeAgent).toBe("claude");
   });
 
   it("accepts agent command overrides", () => {
@@ -127,16 +117,7 @@ describe("embedded acpx plugin config", () => {
     });
   });
 
-  it("leaves probeAgent undefined by default so the runtime picks its built-in probe agent", () => {
-    const resolved = resolveAcpxPluginConfig({
-      rawConfig: undefined,
-      workspaceDir: "/tmp/openclaw-acpx",
-    });
-
-    expect(resolved.probeAgent).toBeUndefined();
-  });
-
-  it("carries an explicit probeAgent through to the resolved plugin config, trimmed and lowercased", () => {
+  it("carries an explicit probeAgent through to the resolved plugin config, trimmed", () => {
     const resolved = resolveAcpxPluginConfig({
       rawConfig: {
         probeAgent: "  OpenCode  ",
@@ -144,7 +125,7 @@ describe("embedded acpx plugin config", () => {
       workspaceDir: "/tmp/openclaw-acpx",
     });
 
-    expect(resolved.probeAgent).toBe("opencode");
+    expect(resolved.probeAgent).toBe("OpenCode");
   });
 
   it("rejects an empty probeAgent string", () => {

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -261,16 +261,10 @@ export function resolveAcpxPluginConfig(params: {
     }),
   );
 
-  // Lowercase probeAgent so lookups match the registry keys built above, which
-  // also go through normalizeLowercaseStringOrEmpty. Without this, a user who
-  // writes `probeAgent: "OpenCode"` would silently miss the stored "opencode"
-  // key.
-  const probeAgent = normalizeLowercaseStringOrEmpty(normalized.probeAgent) || undefined;
-
   return {
     cwd,
     stateDir,
-    probeAgent,
+    probeAgent: normalized.probeAgent,
     permissionMode: normalized.permissionMode ?? DEFAULT_PERMISSION_MODE,
     nonInteractivePermissions:
       normalized.nonInteractivePermissions ?? DEFAULT_NON_INTERACTIVE_POLICY,

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -2211,7 +2211,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
 
     const { runtime, delegate, bridgeSafeDelegate } = makeRuntime(baseStore, {
       mcpServers: [{ name: "tools", command: "mcp-tools" }] as never,
-      probeAgent: "openclaw",
+      probeAgent: "  OpenClaw  ",
       agentRegistry: {
         resolve: (agentName: string) =>
           agentName === "openclaw" ? DOCUMENTED_OPENCLAW_BRIDGE_COMMAND : agentName,

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -667,18 +667,6 @@ function resolveAgentCommand(params: {
   return typeof resolvedCommand === "string" ? resolvedCommand.trim() || undefined : undefined;
 }
 
-function resolveProbeAgentName(options: AcpRuntimeOptions): string {
-  const { probeAgent } = options as { probeAgent?: unknown };
-  return normalizeAgentName(typeof probeAgent === "string" ? probeAgent : undefined) ?? "codex";
-}
-
-function resolveAgentCommandForName(params: {
-  agentName: string | undefined;
-  agentRegistry: AcpAgentRegistry;
-}): string | undefined {
-  return resolveAgentCommand(params);
-}
-
 function shouldUseBridgeSafeDelegateForCommand(command: string | undefined): boolean {
   return isOpenClawBridgeCommand(command);
 }
@@ -773,21 +761,13 @@ export class AcpxRuntime implements AcpRuntime {
           this.delegateTestOptions,
         )
       : this.delegate;
-    this.probeDelegate = this.openclawToolsMcpBridgeEnabled
-      ? this.bridgeSafeDelegate
-      : this.resolveDelegateForAgent(resolveProbeAgentName(options));
-  }
-
-  private resolveDelegateForAgent(agentName: string | undefined): BaseAcpxRuntime {
-    const command = resolveAgentCommandForName({
-      agentName,
+    const probeCommand = resolveAgentCommand({
+      agentName: normalizeAgentName(options.probeAgent) ?? "codex",
       agentRegistry: this.agentRegistry,
     });
-    return this.resolveDelegateForCommand(command);
-  }
-
-  private resolveDelegateForCommand(command: string | undefined): BaseAcpxRuntime {
-    return shouldUseBridgeSafeDelegateForCommand(command) ? this.bridgeSafeDelegate : this.delegate;
+    const useBridgeSafeProbe =
+      this.openclawToolsMcpBridgeEnabled || shouldUseBridgeSafeDelegateForCommand(probeCommand);
+    this.probeDelegate = useBridgeSafeProbe ? this.bridgeSafeDelegate : this.delegate;
   }
 
   private resolveDelegateForSession(params: {
@@ -858,7 +838,7 @@ export class AcpxRuntime implements AcpRuntime {
       });
     }
     const agentName = readAgentFromHandle(handle);
-    const command = resolveAgentCommandForName({
+    const command = resolveAgentCommand({
       agentName,
       agentRegistry: this.agentRegistry,
     });
@@ -871,7 +851,7 @@ export class AcpxRuntime implements AcpRuntime {
     if (recordCommand) {
       return recordCommand;
     }
-    return resolveAgentCommandForName({
+    return resolveAgentCommand({
       agentName: readAgentFromHandle(handle),
       agentRegistry: this.agentRegistry,
     });
@@ -1040,7 +1020,7 @@ export class AcpxRuntime implements AcpRuntime {
 
     const rootCommand =
       readAgentCommandFromRecord(record) ??
-      resolveAgentCommandForName({
+      resolveAgentCommand({
         agentName: readAgentFromHandle(handle),
         agentRegistry: this.agentRegistry,
       });
@@ -1074,7 +1054,7 @@ export class AcpxRuntime implements AcpRuntime {
     input: Parameters<AcpRuntime["ensureSession"]>[0],
   ): Promise<AcpRuntimeHandle> {
     assertSupportedRuntimeSessionMode(input.mode);
-    const command = resolveAgentCommandForName({
+    const command = resolveAgentCommand({
       agentName: input.agent,
       agentRegistry: this.agentRegistry,
     });

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -714,31 +714,6 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
-  it("forwards a configured probeAgent to the runtime factory so the probe does not hardcode the default", async () => {
-    const workspaceDir = await makeTempDir();
-    const ctx = createServiceContext(workspaceDir);
-    const runtime = {
-      ensureSession: vi.fn(),
-      runTurn: vi.fn(),
-      cancel: vi.fn(),
-      close: vi.fn(),
-      probeAvailability: vi.fn(async () => {}),
-      isHealthy: vi.fn(() => true),
-      doctor: vi.fn(async () => ({ ok: true, message: "ok" })),
-    };
-    const runtimeFactory = vi.fn(() => runtime as never);
-    const service = createAcpxRuntimeService(ctx, {
-      pluginConfig: { probeAgent: "opencode" },
-      runtimeFactory,
-    });
-
-    await service.start(ctx);
-
-    expect(readFirstRuntimeFactoryInput(runtimeFactory).pluginConfig.probeAgent).toBe("opencode");
-
-    await service.stop?.(ctx);
-  });
-
   it("uses the first allowed ACP agent as the default probe agent", async () => {
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -13,6 +13,7 @@ import type {
   OpenKeyedStoreOptions,
   PluginStateKeyedStore,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
   AcpRuntime,
   OpenClawPluginService,
@@ -179,14 +180,9 @@ function formatDoctorFailureMessage(report: { message: string; details?: unknown
   return detailText ? `${report.message} (${detailText})` : report.message;
 }
 
-function normalizeProbeAgent(value: string | undefined): string | undefined {
-  const normalized = value?.trim().toLowerCase();
-  return normalized ? normalized : undefined;
-}
-
 function resolveAllowedAgentsProbeAgent(ctx: OpenClawPluginServiceContext): string | undefined {
   for (const agent of ctx.config.acp?.allowedAgents ?? []) {
-    const normalized = normalizeProbeAgent(agent);
+    const normalized = normalizeLowercaseStringOrEmpty(agent);
     if (normalized) {
       return normalized;
     }

--- a/src/gateway/gateway-acp-spawn-defaults.live.test.ts
+++ b/src/gateway/gateway-acp-spawn-defaults.live.test.ts
@@ -254,7 +254,6 @@ function createConfig(params: {
         acpx: {
           enabled: true,
           config: {
-            probeAgent: params.acpAgentId,
             permissionMode: "approve-all",
             nonInteractivePermissions: "deny",
             agents: {


### PR DESCRIPTION
## What Problem This Solves

Resolves ACPX probe setup duplication that spread one invariant across the plugin manifest, config resolver, service, runtime helpers, and overlapping tests. The duplication made the probe path harder to audit and easier for equivalent normalization and routing logic to drift.

## Why This Change Was Made

Keep probe-agent validation and trimming in config, normalize names at the runtime lookup boundary, and use the shared string normalizer for allowed-agent fallback. Remove the duplicate manifest property, pass-through runtime helpers, redundant assertions, and an unnecessary live-test override while preserving the canonical `probeAgent` schema entry and bridge-safe probe selection.

## User Impact

No intended user-visible behavior change. Existing `probeAgent` configuration remains supported; the runtime continues to normalize mixed-case names and choose the same probe delegate.

## Evidence

- Blacksmith Testbox `tbx_01kxacmzr38br0cpbd48qyeb4n` (`pearl-prawn`)
- Focused ACPX proof: 3 files, 87 tests passed
- `pnpm check:changed`: passed on the exact patch against current `main`
- Patch ID remained `fd609946c3593fedd3ff7b218d38774d7da3fd4e` after the final rebase
- `gpt-5.6-sol` medium autoreview: initial review clean at 0.96 confidence; final branch review raised one rejected false positive claiming `probeAgent` was removed, while the canonical schema entry remains in `extensions/acpx/openclaw.plugin.json`
- GitHub Actions Testbox run: https://github.com/openclaw/openclaw/actions/runs/29181169588

AI-assisted: yes. Session transcript intentionally not attached.
