### PR TITLE
refactor(apps): reuse Watch approval transport models

### DIFF
--- a/apps/ios/Sources/Services/ExactOpaqueIdentifier.swift
+++ b/apps/ios/Sources/Services/ExactOpaqueIdentifier.swift
@@ -29,7 +29,7 @@ struct ExactOpaqueIdentifierKey: Hashable, Sendable {
                 [0x25, hexDigits[Int(byte >> 4)], hexDigits[Int(byte & 0x0F)]]
             }
         }
-        return String(decoding: encoded, as: UTF8.self)
+        return String(encoded.map { Character(UnicodeScalar($0)) })
     }
 }
 

--- a/apps/ios/Sources/Services/ExactOpaqueIdentifier.swift
+++ b/apps/ios/Sources/Services/ExactOpaqueIdentifier.swift
@@ -16,6 +16,21 @@ struct ExactOpaqueIdentifierKey: Hashable, Sendable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(self.bytes)
     }
+
+    var notificationComponent: String {
+        let hexDigits = Array("0123456789ABCDEF".utf8)
+        // Keep dots encoded so gateway and approval components cannot collapse into
+        // the same notification identifier when their separator moves.
+        let encoded = self.bytes.flatMap { byte -> [UInt8] in
+            switch byte {
+            case 0x30...0x39, 0x41...0x5A, 0x61...0x7A, 0x2D, 0x5F, 0x7E:
+                [byte]
+            default:
+                [0x25, hexDigits[Int(byte >> 4)], hexDigits[Int(byte & 0x0F)]]
+            }
+        }
+        return String(decoding: encoded, as: UTF8.self)
+    }
 }
 
 enum ExactOpaqueIdentifier {

--- a/apps/ios/Tests/WatchApprovalTransportSourceGuardTests.swift
+++ b/apps/ios/Tests/WatchApprovalTransportSourceGuardTests.swift
@@ -1,15 +1,6 @@
 import Foundation
 import Testing
-
-private struct TestSnapshotCorrelation: Hashable {
-    let requestID: [UInt8]
-    let gatewayID: [UInt8]
-
-    init(requestID: String, gatewayID: String) {
-        self.requestID = Array(requestID.utf8)
-        self.gatewayID = Array(gatewayID.utf8)
-    }
-}
+@testable import OpenClaw
 
 struct WatchApprovalTransportSourceGuardTests {
     @Test func `watch approval loading and screenshot proof are visible`() throws {
@@ -122,17 +113,6 @@ struct WatchApprovalTransportSourceGuardTests {
             "WatchGatewayID.key(snapshot.gatewayStableID) == WatchGatewayID.key(token.gatewayStableID)"))
     }
 
-    @Test func `lost requested snapshot ignores unrelated accepted snapshots`() {
-        let requested = TestSnapshotCorrelation(requestID: "request-a", gatewayID: "gateway-a")
-        let unrelatedRequest = TestSnapshotCorrelation(requestID: "request-b", gatewayID: "gateway-a")
-        let unrelatedOwner = TestSnapshotCorrelation(requestID: "request-a", gatewayID: "gateway-b")
-        var accepted: Set<TestSnapshotCorrelation> = [unrelatedRequest, unrelatedOwner]
-
-        #expect(accepted.remove(requested) == nil)
-        accepted.insert(requested)
-        #expect(accepted.remove(requested) == requested)
-    }
-
     @Test func `watch applies retry reset only to its exact active attempt`() throws {
         let storeSource = try Self.readWatchSource("WatchInboxStore.swift")
         let promptConsume = try Self.extract(
@@ -176,10 +156,11 @@ struct WatchApprovalTransportSourceGuardTests {
         #expect(!parser.contains("?? []"))
     }
 
-    @Test func `watch approval ids remain exact opaque values`() throws {
+    @Test func `watch reuses exact compound identifier policy`() throws {
         let receiverSource = try Self.readWatchSource("WatchConnectivityReceiver.swift")
         let storeSource = try Self.readWatchSource("WatchInboxStore.swift")
         let messagesSource = try Self.readWatchSource("WatchInboxMessages.swift")
+        let viewSource = try Self.readWatchSource("WatchInboxView.swift")
         let parser = try Self.extract(
             receiverSource,
             from: "private static func parseExecApprovalItem(",
@@ -196,20 +177,13 @@ struct WatchApprovalTransportSourceGuardTests {
             storeSource,
             from: "private func restorePersistedState()",
             to: "private func persistState()")
-        // The identity validators live in WatchInboxMessages.swift since the
-        // message/model types were split out of WatchInboxStore.swift.
-        let approvalValidator = try Self.extract(
-            messagesSource,
-            from: "enum WatchApprovalID {",
-            to: "enum WatchGatewayID {")
-        let gatewayValidator = try Self.extract(
-            messagesSource,
-            from: "enum WatchGatewayID {",
-            to: "struct WatchExecApprovalIdentityKey:")
-
         let prefixed = "\u{001C}approval"
-        #expect(prefixed != "approval")
-        #expect(Array(prefixed.utf8) != Array("approval".utf8))
+        #expect(ExecApprovalIdentifier.exact(prefixed) == prefixed)
+        #expect(ExecApprovalIdentifier.exact(" approval ") == " approval ")
+        #expect(ExecApprovalIdentifier.exact(".") == nil)
+        #expect(GatewayStableIdentifier.exact(" gateway ") == " gateway ")
+        #expect(messagesSource.contains("typealias WatchApprovalID = ExecApprovalIdentifier"))
+        #expect(messagesSource.contains("typealias WatchGatewayID = GatewayStableIdentifier"))
         #expect(parser.contains("WatchApprovalID.exact(payload[\"id\"] as? String)"))
         #expect(!parser.contains("id = (payload[\"id\"] as? String)?.trimmingCharacters"))
         #expect(ownerKey.contains("WatchApprovalID.key(approvalId)"))
@@ -218,26 +192,10 @@ struct WatchApprovalTransportSourceGuardTests {
         #expect(snapshotConsume.contains("let hasCanonicalRequestCorrelation ="))
         #expect(snapshotConsume.contains("guard hasCanonicalRequestCorrelation else { return true }"))
         #expect(restore.contains("WatchApprovalID.exact(record.approvalID) != nil"))
-        #expect(approvalValidator.contains("!value.isEmpty"))
-        #expect(approvalValidator.contains("value != \".\","))
-        #expect(approvalValidator.contains("value != \"..\""))
-        #expect(!approvalValidator.contains("trimmingCharacters"))
-        #expect(!approvalValidator.contains("isECMAScriptTrimScalar"))
-        #expect(gatewayValidator.contains("guard let value, !value.isEmpty"))
-        #expect(!gatewayValidator.contains("WatchApprovalID.exact"))
-        #expect(!gatewayValidator.contains("value != \".\""))
-        #expect(!gatewayValidator.contains("trimmingCharacters"))
-        #expect(Array(" approval ".utf8) != Array("approval".utf8))
-    }
-
-    @Test func `watch canonical-equivalent approval IDs remain independently targetable`() throws {
-        let storeSource = try Self.readWatchSource("WatchInboxStore.swift")
-        let messagesSource = try Self.readWatchSource("WatchInboxMessages.swift")
-        let viewSource = try Self.readWatchSource("WatchInboxView.swift")
         let composedID = "approval-\u{00E9}"
         let decomposedID = "approval-e\u{0301}"
-        let composedKey = Data(composedID.utf8)
-        let decomposedKey = Data(decomposedID.utf8)
+        let composedKey = ExactOpaqueIdentifierKey(composedID)
+        let decomposedKey = ExactOpaqueIdentifierKey(decomposedID)
         #expect(composedID == decomposedID)
         #expect(composedKey != decomposedKey)
 
@@ -246,16 +204,19 @@ struct WatchApprovalTransportSourceGuardTests {
         let remainingID = try #require(pending[decomposedKey])
         #expect(Array(remainingID.utf8) == Array(decomposedID.utf8))
 
-        // Byte-exact identity types live in WatchInboxMessages.swift after the split.
-        #expect(messagesSource.contains("self.bytes = Array(rawValue.utf8)"))
+        #expect(messagesSource.contains("typealias WatchOpaqueUTF8Key = ExactOpaqueIdentifierKey"))
         #expect(messagesSource.contains("var id: WatchExecApprovalIdentityKey"))
         #expect(messagesSource.contains("var approvalID: WatchApprovalID.Key"))
         #expect(messagesSource.contains("var gatewayID: WatchGatewayID.Key"))
         #expect(storeSource.contains("WatchApprovalID.key(tombstone.approvalId) == key.approvalID"))
+        #expect(storeSource.contains("WatchGatewayID.key(tombstone.gatewayStableID) == key.gatewayID"))
         #expect(storeSource.contains("approvalKey.notificationComponent"))
+        #expect(storeSource.contains("gatewayKey.notificationComponent"))
         #expect(!storeSource.contains("record.id == approval.id"))
         #expect(!messagesSource.contains("record.id == approval.id"))
         #expect(!storeSource.contains("tombstone.approvalId == key.approvalId"))
+        #expect(receiverSource.contains("WatchGatewayID.exact(payload[\"gatewayStableID\"] as? String)"))
+        #expect(!receiverSource.contains("gatewayStableID?.trimmingCharacters"))
         #expect(viewSource.contains("record.approvalID"))
         #expect(viewSource.contains("$0.id == self.record.id"))
     }
@@ -316,32 +277,10 @@ struct WatchApprovalTransportSourceGuardTests {
         #expect(detailScroll.contains("self.content"))
     }
 
-    @Test func `watch compounds exact owner and approval identity`() throws {
-        let storeSource = try Self.readWatchSource("WatchInboxStore.swift")
-        let messagesSource = try Self.readWatchSource("WatchInboxMessages.swift")
-        let receiverSource = try Self.readWatchSource("WatchConnectivityReceiver.swift")
-        let sameApprovalID = Data("approval-same".utf8)
-        let composedOwner = Data("gateway-\u{00E9}".utf8)
-        let decomposedOwner = Data("gateway-e\u{0301}".utf8)
-        #expect(composedOwner != decomposedOwner)
-        #expect(Set([[composedOwner, sameApprovalID], [decomposedOwner, sameApprovalID]]).count == 2)
-
-        // The compound identity key type lives in WatchInboxMessages.swift after the split.
-        #expect(messagesSource.contains("struct WatchExecApprovalIdentityKey: Hashable"))
-        #expect(storeSource.contains("selectedExecApprovalGatewayStableID"))
-        #expect(storeSource.contains("gatewayKey.notificationComponent"))
-        #expect(storeSource.contains("WatchGatewayID.key(tombstone.gatewayStableID) == key.gatewayID"))
-        #expect(storeSource.contains("\"watch.execApproval.\\(record.approvalID)\""))
-        #expect(receiverSource.contains("WatchGatewayID.exact(payload[\"gatewayStableID\"] as? String)"))
-        #expect(!receiverSource.contains("gatewayStableID?.trimmingCharacters"))
-        #expect(!storeSource.contains("isECMAScriptTrimScalar"))
-        #expect(!messagesSource.contains("isECMAScriptTrimScalar"))
-        #expect(Array("\u{0085}gateway".utf8) != Array("gateway".utf8))
-    }
-
     @Test func `watch notification identity frames dotted components`() throws {
         let storeSource = try Self.readWatchSource("WatchInboxStore.swift")
         let messagesSource = try Self.readWatchSource("WatchInboxMessages.swift")
+        let identifierSource = try Self.readIOSServiceSource("ExactOpaqueIdentifier.swift")
         let promptConsume = try Self.extract(
             storeSource,
             from: "func consume(\n        execApprovalPrompt",
@@ -350,12 +289,14 @@ struct WatchApprovalTransportSourceGuardTests {
         let rawRight = "a" + "." + "b.c"
         #expect(rawLeft == rawRight)
 
-        let framedLeft = Self.notificationComponent("a.b") + "." + Self.notificationComponent("c")
-        let framedRight = Self.notificationComponent("a") + "." + Self.notificationComponent("b.c")
+        let framedLeft = ExactOpaqueIdentifierKey("a.b").notificationComponent + "."
+            + ExactOpaqueIdentifierKey("c").notificationComponent
+        let framedRight = ExactOpaqueIdentifierKey("a").notificationComponent + "."
+            + ExactOpaqueIdentifierKey("b.c").notificationComponent
         #expect(framedLeft != framedRight)
-        // The notification-component percent encoder lives in WatchInboxMessages.swift.
-        #expect(messagesSource.contains("0x2D, 0x5F, 0x7E"))
-        #expect(!messagesSource.contains("0x2D, 0x2E, 0x5F, 0x7E"))
+        #expect(messagesSource.contains("typealias WatchOpaqueUTF8Key = ExactOpaqueIdentifierKey"))
+        #expect(identifierSource.contains("0x2D, 0x5F, 0x7E"))
+        #expect(!identifierSource.contains("0x2D, 0x2E, 0x5F, 0x7E"))
         #expect(!storeSource.contains("0x2D, 0x2E, 0x5F, 0x7E"))
         #expect(storeSource.contains("gatewayKey.notificationComponent).\\(approvalKey.notificationComponent"))
         #expect(storeSource.contains("legacyExecApprovalNotificationIdentifier"))
@@ -412,27 +353,20 @@ struct WatchApprovalTransportSourceGuardTests {
             "Self.gatewayIDsMatch(approval.gatewayStableID, snapshotGatewayID)"))
     }
 
-    private static func notificationComponent(_ rawValue: String) -> String {
-        let hexDigits = Array("0123456789ABCDEF".utf8)
-        var encoded: [UInt8] = []
-        for byte in rawValue.utf8 {
-            switch byte {
-            case 0x30...0x39, 0x41...0x5A, 0x61...0x7A, 0x2D, 0x5F, 0x7E:
-                encoded.append(byte)
-            default:
-                encoded.append(0x25)
-                encoded.append(hexDigits[Int(byte >> 4)])
-                encoded.append(hexDigits[Int(byte & 0x0F)])
-            }
-        }
-        return String(decoding: encoded, as: UTF8.self)
-    }
-
     private static func readWatchSource(_ filename: String) throws -> String {
         let url = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("WatchApp/Sources")
+            .appendingPathComponent(filename)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func readIOSServiceSource(_ filename: String) throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Services")
             .appendingPathComponent(filename)
         return try String(contentsOf: url, encoding: .utf8)
     }

--- a/apps/ios/WatchApp/Sources/WatchInboxMessages.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxMessages.swift
@@ -1,131 +1,22 @@
 import Foundation
+import OpenClawKit
 
-enum WatchPayloadType: String, Codable, Equatable {
-    case notify = "watch.notify"
-    case directNodeSetup = "watch.node.setup"
-    case reply = "watch.reply"
-    case appSnapshot = "watch.app.snapshot"
-    case appSnapshotRequest = "watch.app.snapshotRequest"
-    case appCommand = "watch.app.command"
-    case chatCompletion = "watch.chat.completion"
-    case execApprovalPrompt = "watch.execApproval.prompt"
-    case execApprovalResolve = "watch.execApproval.resolve"
-    case execApprovalResolved = "watch.execApproval.resolved"
-    case execApprovalExpired = "watch.execApproval.expired"
-    case execApprovalSnapshot = "watch.execApproval.snapshot"
-    case execApprovalSnapshotRequest = "watch.execApproval.snapshotRequest"
-}
-
-enum WatchRiskLevel: String, Codable, Equatable {
-    case low
-    case medium
-    case high
-}
-
-enum WatchExecApprovalDecision: String, Codable, Equatable {
-    case allowOnce = "allow-once"
-    case deny
-}
-
-enum WatchExecApprovalCloseReason: String, Codable, Equatable {
-    case expired
-    case notFound = "not-found"
-    case unavailable
-    case replaced
-    case resolved
-}
-
-struct WatchOpaqueUTF8Key: Hashable, Sendable {
-    fileprivate let bytes: [UInt8]
-
-    init(_ rawValue: String) {
-        self.bytes = Array(rawValue.utf8)
-    }
-
-    var notificationComponent: String {
-        let hexDigits = Array("0123456789ABCDEF".utf8)
-        var encoded: [UInt8] = []
-        encoded.reserveCapacity(self.bytes.count)
-        for byte in self.bytes {
-            switch byte {
-            case 0x30...0x39, 0x41...0x5A, 0x61...0x7A, 0x2D, 0x5F, 0x7E:
-                encoded.append(byte)
-            default:
-                encoded.append(0x25)
-                encoded.append(hexDigits[Int(byte >> 4)])
-                encoded.append(hexDigits[Int(byte & 0x0F)])
-            }
-        }
-        guard let component = String(bytes: encoded, encoding: .utf8) else {
-            preconditionFailure("Percent-encoded approval ID must be UTF-8")
-        }
-        return component
-    }
-}
-
-enum WatchApprovalID {
-    typealias Key = WatchOpaqueUTF8Key
-
-    /// Approval IDs are opaque protocol values. Validate without trimming or normalization.
-    static func exact(_ value: String?) -> String? {
-        guard let value,
-              !value.isEmpty,
-              value != ".",
-              value != ".."
-        else { return nil }
-        let codeUnits = Array(value.utf16)
-        var index = 0
-        while index < codeUnits.count {
-            let codeUnit = codeUnits[index]
-            if (0xD800...0xDBFF).contains(codeUnit) {
-                guard index + 1 < codeUnits.count,
-                      (0xDC00...0xDFFF).contains(codeUnits[index + 1])
-                else { return nil }
-                index += 2
-                continue
-            }
-            guard !(0xDC00...0xDFFF).contains(codeUnit) else { return nil }
-            index += 1
-        }
-        return value
-    }
-
-    static func key(_ value: String?) -> Key? {
-        self.exact(value).map(Key.init)
-    }
-}
-
-enum WatchGatewayID {
-    typealias Key = WatchOpaqueUTF8Key
-
-    static func exact(_ value: String?) -> String? {
-        guard let value, !value.isEmpty else { return nil }
-        return value
-    }
-
-    static func key(_ value: String?) -> Key? {
-        self.exact(value).map(Key.init)
-    }
-}
+// Canonical transport leaf models live in OpenClawKit. The local envelope types
+// below retain the existing Watch inbox persistence shape without `type`.
+typealias WatchPayloadType = OpenClawWatchPayloadType
+typealias WatchRiskLevel = OpenClawWatchRisk
+typealias WatchExecApprovalDecision = OpenClawWatchExecApprovalDecision
+typealias WatchExecApprovalCloseReason = OpenClawWatchExecApprovalCloseReason
+typealias WatchOpaqueUTF8Key = ExactOpaqueIdentifierKey
+typealias WatchApprovalID = ExecApprovalIdentifier
+typealias WatchGatewayID = GatewayStableIdentifier
 
 struct WatchExecApprovalIdentityKey: Hashable, Sendable {
     var gatewayID: WatchGatewayID.Key
     var approvalID: WatchApprovalID.Key
 }
 
-struct WatchExecApprovalItem: Codable, Equatable {
-    var id: String
-    var gatewayStableID: String?
-    var commandText: String
-    var commandPreview: String?
-    var warningText: String?
-    var host: String?
-    var nodeId: String?
-    var agentId: String?
-    var expiresAtMs: Int64?
-    var allowedDecisions: [WatchExecApprovalDecision]
-    var risk: WatchRiskLevel?
-}
+typealias WatchExecApprovalItem = OpenClawWatchExecApprovalItem
 
 struct WatchExecApprovalPromptMessage: Codable, Equatable {
     var approval: WatchExecApprovalItem
@@ -174,37 +65,9 @@ struct WatchExecApprovalSnapshotMessage: Codable, Equatable {
     }
 }
 
-struct WatchExecApprovalSnapshotRequestMessage: Codable, Equatable, Sendable {
-    var requestId: String
-    var sentAtMs: Int64?
-    var gatewayStableID: String?
-    var heldApprovals: [WatchExecApprovalSnapshotRequestItem]
-
-    init(
-        requestId: String,
-        sentAtMs: Int64? = nil,
-        gatewayStableID: String? = nil,
-        heldApprovals: [WatchExecApprovalSnapshotRequestItem] = [])
-    {
-        self.requestId = requestId
-        self.sentAtMs = sentAtMs
-        self.gatewayStableID = gatewayStableID
-        self.heldApprovals = heldApprovals
-    }
-}
-
-struct WatchExecApprovalSnapshotRequestItem: Codable, Equatable, Sendable {
-    var approvalId: String
-    var activeResolutionAttemptId: String?
-}
-
-struct WatchExecApprovalResolveMessage: Codable, Equatable {
-    var approvalId: String
-    var gatewayStableID: String?
-    var decision: WatchExecApprovalDecision
-    var replyId: String
-    var sentAtMs: Int64?
-}
+typealias WatchExecApprovalSnapshotRequestMessage = OpenClawWatchExecApprovalSnapshotRequestMessage
+typealias WatchExecApprovalSnapshotRequestItem = OpenClawWatchExecApprovalSnapshotRequestItem
+typealias WatchExecApprovalResolveMessage = OpenClawWatchExecApprovalResolveMessage
 
 struct WatchAppSnapshotMessage: Codable, Equatable {
     var gatewayStatusText: String
@@ -225,46 +88,12 @@ struct WatchAppSnapshotMessage: Codable, Equatable {
     var snapshotId: String?
 }
 
-struct WatchChatCompletionMessage: Codable, Equatable {
-    var commandId: String
-    var replyText: String
-    var sentAtMs: Int64?
-}
-
-struct WatchChatItem: Codable, Equatable, Identifiable {
-    var id: String
-    var role: String
-    var text: String
-    var timestampMs: Int64?
-}
-
-struct WatchAppSnapshotRequestMessage: Codable, Equatable {
-    var requestId: String
-    var sentAtMs: Int64?
-}
-
-enum WatchAppCommand: String, Codable, Equatable {
-    case refresh
-    case openChat = "open-chat"
-    case sendChat = "send-chat"
-    case startTalk = "start-talk"
-    case stopTalk = "stop-talk"
-}
-
-struct WatchAppCommandMessage: Codable, Equatable {
-    var command: WatchAppCommand
-    var commandId: String
-    var sessionKey: String?
-    var gatewayStableID: String?
-    var text: String?
-    var sentAtMs: Int64?
-}
-
-struct WatchPromptAction: Codable, Equatable, Identifiable {
-    var id: String
-    var label: String
-    var style: String?
-}
+typealias WatchChatCompletionMessage = OpenClawWatchChatCompletionMessage
+typealias WatchChatItem = OpenClawWatchChatItem
+typealias WatchAppSnapshotRequestMessage = OpenClawWatchAppSnapshotRequestMessage
+typealias WatchAppCommand = OpenClawWatchAppCommand
+typealias WatchAppCommandMessage = OpenClawWatchAppCommandMessage
+typealias WatchPromptAction = OpenClawWatchAction
 
 struct WatchNotifyMessage: Codable {
     var id: String?

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -309,7 +309,9 @@ targets:
           - Info.plist
       - path: Sources/Services/WatchSessionActivationGate.swift
         group: Sources/Services
-      # Universal talk waveform, compiled directly since the watch links no packages.
+      - path: Sources/Services/ExactOpaqueIdentifier.swift
+        group: Sources/Services
+      # Universal talk waveform, compiled directly to keep the watch styling local.
       - path: ../shared/OpenClawKit/Sources/OpenClawChatUI/TalkWaveformView.swift
         group: Shared
       - path: Sources/Fonts
@@ -318,6 +320,7 @@ targets:
         buildPhase: resources
     dependencies:
       - package: OpenClawKit
+        product: OpenClawKit
       - sdk: AppIntents.framework
       - sdk: AVFAudio.framework
       - sdk: WatchConnectivity.framework

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/WatchCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/WatchCommands.swift
@@ -40,7 +40,7 @@ public enum OpenClawWatchExecApprovalCloseReason: String, Codable, Sendable, Equ
     case resolved
 }
 
-public struct OpenClawWatchAction: Codable, Sendable, Equatable {
+public struct OpenClawWatchAction: Codable, Sendable, Equatable, Identifiable {
     public var id: String
     public var label: String
     public var style: String?


### PR DESCRIPTION
Related: #103912

## What Problem This Solves

The native approval client feature is valuable, but the Watch target carried local copies of transport enums, commands, approval items, identifiers, and leaf DTOs that already existed in `OpenClawKit`. That duplication made the approval stack larger and allowed equivalent phone/Watch protocol models to drift.

## Why This Change Was Made

This refactor makes `OpenClawKit` the canonical owner for reusable Watch transport leaf models while retaining local Watch envelope structs where their Codable shape is part of the existing persisted inbox state. It also compiles the phone's exact opaque-identifier implementation into the Watch target, moves notification-component framing onto that shared byte-exact key, and gives the canonical Watch action model the `Identifiable` conformance required by SwiftUI.

The focused test cleanup removes source guards that reimplemented generic `Set` and UTF-8 behavior, while keeping guards for transport ordering, canonical readback, compound ownership, accessibility, notification framing, and snapshot acceptance.

## User Impact

No feature or behavior change. Android, iPhone, and Apple Watch approval review retain the same decisions, exact identifiers, persistence envelopes, WatchConnectivity payloads, retry/readback behavior, notification identity, and UI. The maintained diff is 219 net lines smaller, including 153 fewer production lines.

## Evidence

- `git diff --check`
- SwiftFormat 0.62.1 lint on all changed Swift files: clean
- `swiftc -parse` on all changed Swift sources/tests: clean
- XcodeGen 2.45.4 generation from `apps/ios/project.yml`: clean
- Blacksmith Testbox through Crabbox `tbx_01kxac3r9grcjsypes0vr72czx`: `pnpm check:changed` passed with app-surface guards and 5 routed Vitest shards (174 passed, 37 skipped)
- Final structured autoreview (`gpt-5.6-sol`, xhigh): no accepted/actionable findings
- Net diff: 74 additions, 293 deletions across 5 files

Remaining platform gate: macOS CI owns SwiftLint and the authoritative iPhone/Watch compile because the delegated Testbox is Linux.
