### PR TITLE
fix(i18n): keep native locale artifacts exact

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -227,7 +227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 122,
+      "line": 123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway did not identify the active ${issue.target.title} provider",
       "surface": "android",
@@ -235,7 +235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 124,
+      "line": 125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Choose a supported ${issue.target.title} provider on the Gateway",
       "surface": "android",
@@ -304,6 +304,14 @@
       "source": "Talk mode active",
       "surface": "android",
       "id": "native.android.3e0889d921c92cab"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 337,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
+      "source": " · Location: Always",
+      "surface": "android",
+      "id": "native.android.de9c39aaec621319"
     },
     {
       "kind": "conditional-branch",
@@ -403,7 +411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3246,
+      "line": 3247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -411,7 +419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3248,
+      "line": 3249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -419,11 +427,27 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3250,
+      "line": 3251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
       "id": "native.android.84ce52ae1375fded"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 4025,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
+      "source": "Update your Gateway to view provider model config.",
+      "surface": "android",
+      "id": "native.android.b76bb2741d8344d0"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 4027,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
+      "source": "Could not load provider model config.",
+      "surface": "android",
+      "id": "native.android.711a08905cf3719e"
     },
     {
       "kind": "ui-dialog",
@@ -624,6 +648,22 @@
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "surface": "android",
       "id": "native.android.5b17d331b254e403"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 209,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/tools/ToolDisplay.kt",
+      "source": "${firstLine.take(157)}…",
+      "surface": "android",
+      "id": "native.android.f7a4f3bbcb0b2090"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 220,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/tools/ToolDisplay.kt",
+      "source": "$preview…",
+      "surface": "android",
+      "id": "native.android.356609f717b92350"
     },
     {
       "kind": "conditional-branch",
@@ -1002,6 +1042,22 @@
       "id": "native.android.362073d4e1e4624d"
     },
     {
+      "kind": "conditional-branch",
+      "line": 121,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "surface": "android",
+      "id": "native.android.a3fcfa20dc395b87"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 123,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "surface": "android",
+      "id": "native.android.db9f08d611b4c508"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
@@ -1010,12 +1066,12 @@
       "id": "native.android.212889821e40127e"
     },
     {
-      "kind": "ui-named-argument",
-      "line": 177,
+      "kind": "ui-named-argument-concatenated",
+      "line": 178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
       "surface": "android",
-      "id": "native.android.954671d2e72ae79c"
+      "id": "native.android.9f359445f7fb935e"
     },
     {
       "kind": "conditional-branch",
@@ -1370,6 +1426,22 @@
       "id": "native.android.e45a470156b0f564"
     },
     {
+      "kind": "conditional-branch",
+      "line": 527,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
+      "source": "Command working directory",
+      "surface": "android",
+      "id": "native.android.da748b7868da4ea7"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 529,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
+      "source": "Command working directory · cannot clear",
+      "surface": "android",
+      "id": "native.android.99955291fac0d844"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 535,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
@@ -1595,7 +1667,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 306,
+      "line": 243,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "surface": "android",
+      "id": "native.android.ff5abe2418979715"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 245,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "surface": "android",
+      "id": "native.android.28e58e1bd98e08ab"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 307,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code points to an insecure remote gateway. $remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
@@ -1603,7 +1691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 308,
+      "line": 309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code points to an insecure remote gateway. $remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
@@ -1611,7 +1699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 310,
+      "line": 311,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "$remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
@@ -1619,7 +1707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 315,
+      "line": 316,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code uses an IPv6 zone ID. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
@@ -1627,7 +1715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 317,
+      "line": 318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code uses an IPv6 zone ID. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
@@ -1635,7 +1723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 319,
+      "line": 320,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "IPv6 zone IDs are not supported. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
@@ -2112,6 +2200,14 @@
       "source": "Online",
       "surface": "android",
       "id": "native.android.0bbe0d733b1328fd"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 276,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "surface": "android",
+      "id": "native.android.13024ff403917bfe"
     },
     {
       "kind": "ui-call",
@@ -2707,6 +2803,22 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 2623,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "surface": "android",
+      "id": "native.android.bdd063b9f766050b"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2627,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Gateway paired. Checking node capability approval.",
+      "surface": "android",
+      "id": "native.android.d0c1dcc8236a1ab9"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 2639,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The code may have expired or been generated for another Gateway.",
@@ -2739,7 +2851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2647,
+      "line": 2648,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -2771,11 +2883,35 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2670,
+      "line": 2705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
-      "source": "$summary $it",
+      "source": "openclaw devices approve $requestId",
       "surface": "android",
-      "id": "native.android.e9fa7abb92b3cc99"
+      "id": "native.android.ee7dad03cd78babe"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2707,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "openclaw devices list",
+      "surface": "android",
+      "id": "native.android.3792801e2951bb11"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2714,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "openclaw nodes approve $requestId",
+      "surface": "android",
+      "id": "native.android.8fe20d8f8090064d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2716,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "surface": "android",
+      "id": "native.android.2961a521c1b6837f"
     },
     {
       "kind": "ui-toast",
@@ -2946,6 +3082,14 @@
       "id": "native.android.51228649f9d8627a"
     },
     {
+      "kind": "conditional-branch",
+      "line": 388,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
+      "source": "${tokens / 1_000}k",
+      "surface": "android",
+      "id": "native.android.4832c0d0e9774283"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
@@ -3016,6 +3160,14 @@
       "source": "Oldest first",
       "surface": "android",
       "id": "native.android.78b9d0ab41446a1b"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 231,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "surface": "android",
+      "id": "native.android.d7e09574a17f9ccd"
     },
     {
       "kind": "ui-named-argument",
@@ -3202,6 +3354,38 @@
       "id": "native.android.b5e4ae7f8c9eca2d"
     },
     {
+      "kind": "ui-call",
+      "line": 628,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Unarchive",
+      "surface": "android",
+      "id": "native.android.f46b06f8550516e4"
+    },
+    {
+      "kind": "ui-call",
+      "line": 632,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Delete…",
+      "surface": "android",
+      "id": "native.android.a157cb1bddfc3b79"
+    },
+    {
+      "kind": "ui-call",
+      "line": 637,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "← Back",
+      "surface": "android",
+      "id": "native.android.283c9264772e2024"
+    },
+    {
+      "kind": "ui-call",
+      "line": 651,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Remove from group",
+      "surface": "android",
+      "id": "native.android.fff8fad5db365fa6"
+    },
+    {
       "kind": "conditional-branch",
       "line": 658,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
@@ -3232,6 +3416,62 @@
       "source": "Mark as unread",
       "surface": "android",
       "id": "native.android.a9619e8ed4fd6aa2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 666,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Rename…",
+      "surface": "android",
+      "id": "native.android.c2dcfd6ce61bb9a7"
+    },
+    {
+      "kind": "ui-call",
+      "line": 670,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Fork",
+      "surface": "android",
+      "id": "native.android.7e4fef64a05f84f4"
+    },
+    {
+      "kind": "ui-call",
+      "line": 674,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Move to group",
+      "surface": "android",
+      "id": "native.android.442655ac5b85b24d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 675,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Archive",
+      "surface": "android",
+      "id": "native.android.e78c3cf125b5a40c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 709,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Rename group…",
+      "surface": "android",
+      "id": "native.android.11e20947d40764fb"
+    },
+    {
+      "kind": "ui-call",
+      "line": 713,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "New group…",
+      "surface": "android",
+      "id": "native.android.f9b342d9485114cf"
+    },
+    {
+      "kind": "ui-call",
+      "line": 717,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Delete group…",
+      "surface": "android",
+      "id": "native.android.ecfbc9a95c3ca671"
     },
     {
       "kind": "conditional-branch",
@@ -3722,6 +3962,22 @@
       "id": "native.android.5a077bf9cf4f47c8"
     },
     {
+      "kind": "ui-call",
+      "line": 837,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Forward Notifications",
+      "surface": "android",
+      "id": "native.android.f0397533c269b90c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 838,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Quiet Hours",
+      "surface": "android",
+      "id": "native.android.a04ee29c0a3b68f5"
+    },
+    {
       "kind": "conditional-branch",
       "line": 849,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
@@ -3842,6 +4098,30 @@
       "id": "native.android.13c46f9ddf516110"
     },
     {
+      "kind": "ui-call",
+      "line": 1198,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Camera",
+      "surface": "android",
+      "id": "native.android.2d1dd1a2e9dae8e9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1199,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Precise Location",
+      "surface": "android",
+      "id": "native.android.3104a266665b9e19"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1201,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Photos",
+      "surface": "android",
+      "id": "native.android.c38c2616e6b13dd4"
+    },
+    {
       "kind": "conditional-branch",
       "line": 1203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
@@ -3858,6 +4138,14 @@
       "id": "native.android.8424669e7840699a"
     },
     {
+      "kind": "ui-call",
+      "line": 1211,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Installed Apps",
+      "surface": "android",
+      "id": "native.android.74fb102d11305307"
+    },
+    {
       "kind": "conditional-branch",
       "line": 1213,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
@@ -3872,6 +4160,22 @@
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
       "id": "native.android.bdafaceb7af93f5a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1218,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Keep Awake",
+      "surface": "android",
+      "id": "native.android.be89d5601904322a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1219,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Canvas Status",
+      "surface": "android",
+      "id": "native.android.66e7775ab738ed4f"
     },
     {
       "kind": "ui-named-argument",
@@ -3898,12 +4202,12 @@
       "id": "native.android.d5a8d7f97a7971b1"
     },
     {
-      "kind": "ui-call",
+      "kind": "ui-call-concatenated",
       "line": 1269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
       "surface": "android",
-      "id": "native.android.9d149d1ad66e42f9"
+      "id": "native.android.031d3ed6fb8a6559"
     },
     {
       "kind": "ui-call",
@@ -3976,6 +4280,14 @@
       "source": "Forget gateway?",
       "surface": "android",
       "id": "native.android.66aad1078731e6a3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1398,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "surface": "android",
+      "id": "native.android.fc2b37bf96ebd49d"
     },
     {
       "kind": "ui-call",
@@ -4363,11 +4675,35 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 1884,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "surface": "android",
+      "id": "native.android.d66786c625242bbf"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 1902,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
       "id": "native.android.cfffa5b838a65ca4"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1909,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "surface": "android",
+      "id": "native.android.5a540761383fa474"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1911,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "surface": "android",
+      "id": "native.android.3a3bea53e6a6ada7"
     },
     {
       "kind": "ui-named-argument",
@@ -4531,14 +4867,6 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2431,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "No limits reported",
-      "surface": "android",
-      "id": "native.android.28ecef67eb7d30b2"
-    },
-    {
-      "kind": "conditional-branch",
       "line": 2462,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
@@ -4576,6 +4904,38 @@
       "source": "Payload Text",
       "surface": "android",
       "id": "native.android.f36439e78187c554"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2516,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "surface": "android",
+      "id": "native.android.d89f6d465e3e4725"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2518,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "surface": "android",
+      "id": "native.android.f38672bd0713cb8b"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2522,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "surface": "android",
+      "id": "native.android.eeabea3c662af708"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2524,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "surface": "android",
+      "id": "native.android.8db7e536cf5ffaf4"
     },
     {
       "kind": "ui-named-argument",
@@ -4640,6 +5000,14 @@
       "source": "ACTIVE AGENT",
       "surface": "android",
       "id": "native.android.586490ecd89b15cc"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 655,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "$agentName is working",
+      "surface": "android",
+      "id": "native.android.5fb62fa35b740ba6"
     },
     {
       "kind": "ui-named-argument",
@@ -4779,6 +5147,14 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 1055,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "surface": "android",
+      "id": "native.android.70c2bdc593d2259b"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 1082,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
@@ -4906,6 +5282,22 @@
       "id": "native.android.a6179e3618d40108"
     },
     {
+      "kind": "ui-call",
+      "line": 1641,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "Account",
+      "surface": "android",
+      "id": "native.android.bbf9d9dc946efe85"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1652,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "Licenses",
+      "surface": "android",
+      "id": "native.android.13edbcfbe3598233"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 1667,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
@@ -4952,22 +5344,6 @@
       "source": "$count providers",
       "surface": "android",
       "id": "native.android.22d0e2dfa67399d3"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1710,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "$ready/${skills.size} ready",
-      "surface": "android",
-      "id": "native.android.5905ff41489004c6"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1710,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "No skills",
-      "surface": "android",
-      "id": "native.android.087c72ddfc807c5c"
     },
     {
       "kind": "conditional-branch",
@@ -5099,7 +5475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 268,
+      "line": 269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "This will ${action.action.label.lowercase()} \"${action.title}\" and refresh Skill Workshop state from the gateway.",
       "surface": "android",
@@ -5538,6 +5914,30 @@
       "id": "native.android.3d5d539d6adde13c"
     },
     {
+      "kind": "conditional-branch",
+      "line": 467,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
+      "source": "OpenClaw speaking",
+      "surface": "android",
+      "id": "native.android.9d977253fdcda216"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 469,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
+      "source": "Realtime voice",
+      "surface": "android",
+      "id": "native.android.1babfd757bbcfeb4"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 471,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
+      "source": "Connected",
+      "surface": "android",
+      "id": "native.android.4a273a765eedc369"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
@@ -5794,6 +6194,14 @@
       "id": "native.android.f57b231996a10d14"
     },
     {
+      "kind": "conditional-branch",
+      "line": 47,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatCommandControls.kt",
+      "source": "$text ",
+      "surface": "android",
+      "id": "native.android.6384b9802cfdacfe"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 326,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
@@ -5994,6 +6402,14 @@
       "id": "native.android.29021f925bf290c7"
     },
     {
+      "kind": "ui-call",
+      "line": 446,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "user",
+      "surface": "android",
+      "id": "native.android.552a4d6f5110e6a3"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
@@ -6024,6 +6440,14 @@
       "source": "Delete",
       "surface": "android",
       "id": "native.android.b728b15914267f57"
+    },
+    {
+      "kind": "ui-call",
+      "line": 506,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "assistant",
+      "surface": "android",
+      "id": "native.android.5d4f893886312f82"
     },
     {
       "kind": "ui-named-argument",
@@ -6072,6 +6496,14 @@
       "source": "Unsupported attachment",
       "surface": "android",
       "id": "native.android.09720189ba712747"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 311,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Some shared images were omitted or could not be added.",
+      "surface": "android",
+      "id": "native.android.794796c2c771a75b"
     },
     {
       "kind": "ui-named-argument",
@@ -6152,6 +6584,30 @@
       "source": "Ready when you are",
       "surface": "android",
       "id": "native.android.9df2c9d68bad169f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 894,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Start with a prompt, or use voice.",
+      "surface": "android",
+      "id": "native.android.569efec44d3ac9f8"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 896,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Use the recovery options below to reconnect.",
+      "surface": "android",
+      "id": "native.android.28238225371cf3c3"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 898,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Chat is checking Gateway health.",
+      "surface": "android",
+      "id": "native.android.55bd10b5ca2368db"
     },
     {
       "kind": "ui-named-argument",
@@ -6554,6 +7010,22 @@
       "id": "native.android.3457b4ee28d964ee"
     },
     {
+      "kind": "ui-call",
+      "line": 94,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/image/SafeRemoteImage.kt",
+      "source": "Accept",
+      "surface": "android",
+      "id": "native.android.7a6a37643fcfb2d9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 104,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/image/SafeRemoteImage.kt",
+      "source": "Location",
+      "surface": "android",
+      "id": "native.android.969f267b28a69e16"
+    },
+    {
       "kind": "conditional-branch",
       "line": 228,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
@@ -6608,6 +7080,14 @@
       "source": "Sending queued voice",
       "surface": "android",
       "id": "native.android.01ac388cd8ae0732"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 583,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
+      "source": "Voice reply timed out; retrying queued turn",
+      "surface": "android",
+      "id": "native.android.a4cd123d7ec88d53"
     },
     {
       "kind": "conditional-branch",
@@ -6883,6 +7363,14 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 233,
+      "path": "apps/ios/ShareExtension/ShareViewController.swift",
+      "source": "Just received your iOS share + request, working on it.",
+      "surface": "apple",
+      "id": "native.apple.382fd936eaf238f7"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 189,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Camera",
@@ -6901,9 +7389,9 @@
       "kind": "conditional-branch",
       "line": 356,
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
-      "source": "\\\"\\(trimmed)\\\"",
+      "source": "\"\\(trimmed)\"",
       "surface": "apple",
-      "id": "native.apple.28740d4b2df6637c"
+      "id": "native.apple.5ec8cdd5af7c54a7"
     },
     {
       "kind": "conditional-branch",
@@ -7117,17 +7605,17 @@
       "kind": "conditional-branch",
       "line": 256,
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "surface": "apple",
-      "id": "native.apple.a6a454a28f1db7df"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 256,
-      "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "\\(diary.path) exists but has no readable content.",
       "surface": "apple",
       "id": "native.apple.bb7c4a8dbc801a19"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 257,
+      "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "surface": "apple",
+      "id": "native.apple.a6a454a28f1db7df"
     },
     {
       "kind": "conditional-branch",
@@ -7141,17 +7629,17 @@
       "kind": "conditional-branch",
       "line": 265,
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
-      "source": "Connect a gateway to read dream diary entries.",
-      "surface": "apple",
-      "id": "native.apple.e9772e2a1bbfb483"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 265,
-      "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The gateway did not return dream diary content.",
       "surface": "apple",
       "id": "native.apple.6f80c38b0b83c057"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 266,
+      "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
+      "source": "Connect a gateway to read dream diary entries.",
+      "surface": "apple",
+      "id": "native.apple.e9772e2a1bbfb483"
     },
     {
       "kind": "ui-modifier",
@@ -7205,17 +7693,17 @@
       "kind": "conditional-branch",
       "line": 404,
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
-      "source": "Connect a gateway to load dreaming phases.",
-      "surface": "apple",
-      "id": "native.apple.3ce988bd2b2215b2"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 404,
-      "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The gateway did not return dreaming phase details.",
       "surface": "apple",
       "id": "native.apple.128c6782a7b1d919"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 405,
+      "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
+      "source": "Connect a gateway to load dreaming phases.",
+      "surface": "apple",
+      "id": "native.apple.3ce988bd2b2215b2"
     },
     {
       "kind": "conditional-branch",
@@ -7232,6 +7720,22 @@
       "source": "no repair needed",
       "surface": "apple",
       "id": "native.apple.da9b0546b320aa00"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 631,
+      "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
+      "source": "\\(index)",
+      "surface": "apple",
+      "id": "native.apple.43258a1742cabdb6"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 633,
+      "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
+      "source": "No diary prose for this day.",
+      "surface": "apple",
+      "id": "native.apple.2cb500a4a64c9a05"
     },
     {
       "kind": "ui-named-argument",
@@ -7301,17 +7805,17 @@
       "kind": "conditional-branch",
       "line": 101,
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
-      "source": "Connect a gateway to inspect connected instances.",
-      "surface": "apple",
-      "id": "native.apple.36618248cdaccc84"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 101,
-      "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "The gateway did not report any system presence entries.",
       "surface": "apple",
       "id": "native.apple.26327e8fdd0a869b"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 102,
+      "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
+      "source": "Connect a gateway to inspect connected instances.",
+      "surface": "apple",
+      "id": "native.apple.36618248cdaccc84"
     },
     {
       "kind": "ui-call",
@@ -7410,6 +7914,22 @@
       "id": "native.apple.e9c4662a91a0188e"
     },
     {
+      "kind": "conditional-branch",
+      "line": 326,
+      "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
+      "source": "\\(scopesCount) scopes",
+      "surface": "apple",
+      "id": "native.apple.41526676f6d4d2cf"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 327,
+      "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
+      "source": "\\(rolesCount) roles",
+      "surface": "apple",
+      "id": "native.apple.58bcd0a6ffe9de8a"
+    },
+    {
       "kind": "ui-call",
       "line": 10,
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
@@ -7504,6 +8024,14 @@
       "source": "Usage",
       "surface": "apple",
       "id": "native.apple.4bee0220d011ab53"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 33,
+      "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
+      "source": "Default",
+      "surface": "apple",
+      "id": "native.apple.49160020f0318366"
     },
     {
       "kind": "conditional-branch",
@@ -7717,17 +8245,17 @@
       "kind": "conditional-branch",
       "line": 459,
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
-      "source": "Connect a gateway to load scheduled work.",
-      "surface": "apple",
-      "id": "native.apple.ae4aa2339b285164"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 459,
-      "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "The gateway has no visible cron jobs.",
       "surface": "apple",
       "id": "native.apple.0cd04bacdbcd8fa5"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 460,
+      "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
+      "source": "Connect a gateway to load scheduled work.",
+      "surface": "apple",
+      "id": "native.apple.ae4aa2339b285164"
     },
     {
       "kind": "conditional-branch",
@@ -7941,17 +8469,17 @@
       "kind": "conditional-branch",
       "line": 199,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
-      "source": "Connect a gateway to load workspace skills.",
-      "surface": "apple",
-      "id": "native.apple.37c0e98e8a49fe44"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 199,
-      "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Try a different search or refresh from the gateway.",
       "surface": "apple",
       "id": "native.apple.698f37c66a7d9436"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 200,
+      "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
+      "source": "Connect a gateway to load workspace skills.",
+      "surface": "apple",
+      "id": "native.apple.37c0e98e8a49fe44"
     },
     {
       "kind": "ui-call",
@@ -8139,7 +8667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 700,
+      "line": 701,
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "API key saved.",
       "surface": "apple",
@@ -8571,7 +9099,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 194,
+      "line": 195,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Delete Session?",
       "surface": "apple",
@@ -8747,7 +9275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 310,
+      "line": 311,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Online",
       "surface": "apple",
@@ -8755,7 +9283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 312,
+      "line": 313,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -8763,7 +9291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 314,
+      "line": 315,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Attention",
       "surface": "apple",
@@ -8771,7 +9299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 316,
+      "line": 317,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Offline",
       "surface": "apple",
@@ -8803,7 +9331,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 758,
+      "line": 759,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Delete Group?",
       "surface": "apple",
@@ -8867,7 +9395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 833,
+      "line": 834,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -8962,6 +9490,14 @@
       "id": "native.apple.1b727fbf231de39f"
     },
     {
+      "kind": "conditional-branch",
+      "line": 1160,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Try again after the gateway reconnects.",
+      "surface": "apple",
+      "id": "native.apple.a87991de580598a9"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 30,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
@@ -9000,6 +9536,14 @@
       "source": "Recent activity",
       "surface": "apple",
       "id": "native.apple.4813254a14ae910f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 72,
+      "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
+      "source": "Loading",
+      "surface": "apple",
+      "id": "native.apple.18b4b1d1291e8402"
     },
     {
       "kind": "ui-named-argument",
@@ -9077,17 +9621,25 @@
       "kind": "conditional-branch",
       "line": 136,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
+      "source": "Start a chat and it will appear here.",
+      "surface": "apple",
+      "id": "native.apple.e3586d8a603f67e0"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 137,
+      "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Connect to the gateway to load recent chat activity.",
       "surface": "apple",
       "id": "native.apple.f47ceff451b1cce8"
     },
     {
       "kind": "conditional-branch",
-      "line": 136,
+      "line": 140,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
-      "source": "Start a chat and it will appear here.",
+      "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.e3586d8a603f67e0"
+      "id": "native.apple.9094f48f7ebd28c5"
     },
     {
       "kind": "ui-named-argument",
@@ -9099,7 +9651,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 11,
+      "line": 177,
+      "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
+      "source": "Offline",
+      "surface": "apple",
+      "id": "native.apple.c61170392d1aa557"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 227,
+      "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
+      "source": "Try again after the gateway reconnects.",
+      "surface": "apple",
+      "id": "native.apple.225dcb2dfdcaa76f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 12,
       "path": "apps/ios/Sources/Design/IPadSidebarFeatureScreens.swift",
       "source": "Gateway offline.",
       "surface": "apple",
@@ -9107,7 +9675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 13,
+      "line": 14,
       "path": "apps/ios/Sources/Design/IPadSidebarFeatureScreens.swift",
       "source": "Could not encode request.",
       "surface": "apple",
@@ -9237,17 +9805,17 @@
       "kind": "conditional-branch",
       "line": 288,
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "surface": "apple",
-      "id": "native.apple.bacbe7d1ade39252"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 288,
-      "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "New proposals will appear here when agents draft skills.",
       "surface": "apple",
       "id": "native.apple.401016421351cd1d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 289,
+      "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "surface": "apple",
+      "id": "native.apple.bacbe7d1ade39252"
     },
     {
       "kind": "ui-named-argument",
@@ -9525,17 +10093,17 @@
       "kind": "conditional-branch",
       "line": 477,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
-      "source": "Connect from Settings to load workboard cards.",
-      "surface": "apple",
-      "id": "native.apple.60483b8876b7f59f"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 477,
-      "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Create a card or change the filter.",
       "surface": "apple",
       "id": "native.apple.d150c79eaa14ec76"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 478,
+      "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
+      "source": "Connect from Settings to load workboard cards.",
+      "surface": "apple",
+      "id": "native.apple.60483b8876b7f59f"
     },
     {
       "kind": "ui-call",
@@ -9635,7 +10203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1256,
+      "line": 1257,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Default agent",
       "surface": "apple",
@@ -9843,7 +10411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 635,
+      "line": 636,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Online",
       "surface": "apple",
@@ -9851,7 +10419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 637,
+      "line": 638,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -9859,7 +10427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 639,
+      "line": 640,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Attention",
       "surface": "apple",
@@ -9867,7 +10435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 641,
+      "line": 642,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Offline",
       "surface": "apple",
@@ -10059,7 +10627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 555,
+      "line": 556,
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Could not encode channel request.",
       "surface": "apple",
@@ -10227,7 +10795,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 298,
+      "line": 299,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -10243,7 +10811,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 315,
+      "line": 316,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Access Level",
       "surface": "apple",
@@ -10272,6 +10840,14 @@
       "source": "Choose when OpenClaw may share this iPhone's location with gateway tools.",
       "surface": "apple",
       "id": "native.apple.756ff21ca904b2d8"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 341,
+      "path": "apps/ios/Sources/Design/SettingsProTab.swift",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "surface": "apple",
+      "id": "native.apple.d5eb77296d18a08b"
     },
     {
       "kind": "ui-call",
@@ -10403,6 +10979,14 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 161,
+      "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
+      "source": "\\(endpoint) • TLS",
+      "surface": "apple",
+      "id": "native.apple.27942ed8539c84c6"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 163,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Discovered",
@@ -10421,17 +11005,17 @@
       "kind": "conditional-branch",
       "line": 922,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "surface": "apple",
-      "id": "native.apple.a9a778465dfe1198"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 922,
-      "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "surface": "apple",
       "id": "native.apple.3503aca018f04865"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 923,
+      "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "surface": "apple",
+      "id": "native.apple.a9a778465dfe1198"
     },
     {
       "kind": "conditional-branch",
@@ -10448,6 +11032,14 @@
       "source": "Not configured",
       "surface": "apple",
       "id": "native.apple.ad28c6e82fda63b0"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1117,
+      "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
+      "source": "Connected",
+      "surface": "apple",
+      "id": "native.apple.3ba1d988ea9c9a21"
     },
     {
       "kind": "conditional-branch",
@@ -10683,6 +11275,14 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 356,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "surface": "apple",
+      "id": "native.apple.ca97c3ccc7e33122"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 357,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateway actions are waiting for review.",
@@ -10691,11 +11291,19 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 357,
+      "line": 358,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Review pending gateway actions.",
       "surface": "apple",
       "id": "native.apple.cd9730a7cb964be7"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 360,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Alerts Off",
+      "surface": "apple",
+      "id": "native.apple.32a85f247d3bc0af"
     },
     {
       "kind": "ui-named-argument",
@@ -10709,17 +11317,17 @@
       "kind": "conditional-branch",
       "line": 380,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "surface": "apple",
-      "id": "native.apple.1bd0f0b41f4d4750"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 380,
-      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Relay remains available; direct mode adds an independent Gateway node.",
       "surface": "apple",
       "id": "native.apple.df05bfb397806b0d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 381,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "surface": "apple",
+      "id": "native.apple.1bd0f0b41f4d4750"
     },
     {
       "kind": "conditional-branch",
@@ -10728,6 +11336,14 @@
       "source": "Installed",
       "surface": "apple",
       "id": "native.apple.cfa1c0be2d607257"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 382,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Reachable",
+      "surface": "apple",
+      "id": "native.apple.3710cda9cb13870f"
     },
     {
       "kind": "conditional-branch",
@@ -10746,7 +11362,7 @@
       "id": "native.apple.0177670438314602"
     },
     {
-      "kind": "ui-call-multiline",
+      "kind": "ui-call",
       "line": 405,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "The watch receives a one-time pairing code and stores its own device token. A reachable secure Gateway URL is required away from the iPhone.",
@@ -11643,7 +12259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 294,
+      "line": 295,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking iOS notification permission.",
       "surface": "apple",
@@ -11651,7 +12267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 296,
+      "line": 297,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw can show approval prompts and event alerts when the app is not active.",
       "surface": "apple",
@@ -11659,7 +12275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 298,
+      "line": 299,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw notifications are off.",
       "surface": "apple",
@@ -11667,7 +12283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 300,
+      "line": 301,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Finish notification setup to receive alerts when the app is not active.",
       "surface": "apple",
@@ -11675,7 +12291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 302,
+      "line": 303,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Notifications have been denied. Enable them in iOS Settings.",
       "surface": "apple",
@@ -11683,7 +12299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 304,
+      "line": 305,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Enable notifications to receive approval prompts and event alerts outside the app.",
       "surface": "apple",
@@ -11691,7 +12307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 306,
+      "line": 307,
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw cannot determine the current notification permission state.",
       "surface": "apple",
@@ -12003,7 +12619,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 368,
+      "line": 233,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Not loaded",
+      "surface": "apple",
+      "id": "native.apple.877fb5c1abfaafa1"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 369,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Gateway permission required",
       "surface": "apple",
@@ -12011,7 +12635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 370,
+      "line": 371,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Requesting approval",
       "surface": "apple",
@@ -12019,7 +12643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 372,
+      "line": 373,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Approval requested",
       "surface": "apple",
@@ -12027,7 +12651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 374,
+      "line": 375,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice API key missing",
       "surface": "apple",
@@ -12035,7 +12659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 376,
+      "line": 377,
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice config failed",
       "surface": "apple",
@@ -12154,7 +12778,7 @@
       "id": "native.apple.c218ef5194d0ee56"
     },
     {
-      "kind": "ui-call-multiline",
+      "kind": "ui-call",
       "line": 19,
       "path": "apps/ios/Sources/Gateway/DeepLinkAgentPromptAlert.swift",
       "source": "Message:\n\\(prompt.messagePreview)\n\nURL:\n\\(prompt.urlPreview)",
@@ -12387,7 +13011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 63,
+      "line": 64,
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Fix on gateway",
       "surface": "apple",
@@ -12395,7 +13019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 65,
+      "line": 66,
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Fix on this device",
       "surface": "apple",
@@ -12403,7 +13027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 67,
+      "line": 68,
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Check both",
       "surface": "apple",
@@ -12411,7 +13035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 69,
+      "line": 70,
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Check network",
       "surface": "apple",
@@ -12419,7 +13043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 71,
+      "line": 72,
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -12650,8 +13274,24 @@
       "id": "native.apple.72083d0b7fc77a6d"
     },
     {
+      "kind": "conditional-branch",
+      "line": 649,
+      "path": "apps/ios/Sources/Gateway/GatewaySettingsStore.swift",
+      "source": "\\(host):\\(port)",
+      "surface": "apple",
+      "id": "native.apple.1c9a058b7bb966b6"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 712,
+      "path": "apps/ios/Sources/Gateway/GatewaySettingsStore.swift",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "surface": "apple",
+      "id": "native.apple.47d9865a941033d5"
+    },
+    {
       "kind": "ui-modifier",
-      "line": 8,
+      "line": 9,
       "path": "apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift",
       "source": "Trust this gateway?",
       "surface": "apple",
@@ -12682,7 +13322,7 @@
       "id": "native.apple.381baa85bbbd0f31"
     },
     {
-      "kind": "ui-call-multiline",
+      "kind": "ui-call",
       "line": 54,
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Exec approvals can only be reviewed while OpenClaw is open and connected.\n\nEnable Notifications to receive approval notifications while OpenClaw is not open.",
@@ -12811,7 +13451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 42,
+      "line": 43,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Off",
       "surface": "apple",
@@ -12819,7 +13459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 44,
+      "line": 45,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "While Using",
       "surface": "apple",
@@ -12827,7 +13467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 46,
+      "line": 47,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always",
       "surface": "apple",
@@ -12835,7 +13475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 58,
+      "line": 59,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. Location Services are off in iOS Settings.",
       "surface": "apple",
@@ -12843,7 +13483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 60,
+      "line": 61,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. iOS currently allows Always.",
       "surface": "apple",
@@ -12851,7 +13491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 62,
+      "line": 63,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. iOS currently allows While Using.",
       "surface": "apple",
@@ -12859,7 +13499,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 64,
+      "line": 65,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled.",
       "surface": "apple",
@@ -12867,7 +13507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 66,
+      "line": 67,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location Services are off in iOS Settings.",
       "surface": "apple",
@@ -12875,7 +13515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 70,
+      "line": 71,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed. Precise Location is on.",
       "surface": "apple",
@@ -12883,7 +13523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 74,
+      "line": 75,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed. Precise Location is off.",
       "surface": "apple",
@@ -12891,7 +13531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 78,
+      "line": 79,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed.",
       "surface": "apple",
@@ -12899,7 +13539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 80,
+      "line": 81,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed. Precise Location is on.",
       "surface": "apple",
@@ -12907,7 +13547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 82,
+      "line": 83,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed. Precise Location is off.",
       "surface": "apple",
@@ -12915,7 +13555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 84,
+      "line": 85,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed.",
       "surface": "apple",
@@ -12923,7 +13563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 86,
+      "line": 87,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app. Precise Location is on.",
       "surface": "apple",
@@ -12931,7 +13571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 88,
+      "line": 89,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app. Precise Location is off.",
       "surface": "apple",
@@ -12939,7 +13579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 90,
+      "line": 91,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app.",
       "surface": "apple",
@@ -12947,7 +13587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 92,
+      "line": 93,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location permission is denied in iOS Settings.",
       "surface": "apple",
@@ -12955,7 +13595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 94,
+      "line": 95,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location permission is restricted on this device.",
       "surface": "apple",
@@ -12963,7 +13603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 96,
+      "line": 97,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Choose a location mode to request iOS permission.",
       "surface": "apple",
@@ -12971,7 +13611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 98,
+      "line": 99,
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "OpenClaw cannot determine the current iOS location permission.",
       "surface": "apple",
@@ -13107,6 +13747,14 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 5859,
+      "path": "apps/ios/Sources/Model/NodeAppModel.swift",
+      "source": "No chat messages yet",
+      "surface": "apple",
+      "id": "native.apple.4a98b3a346be2662"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 8216,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
@@ -13125,21 +13773,29 @@
       "kind": "conditional-branch",
       "line": 8222,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
-      "source": "Approval set to Always Allow.",
-      "surface": "apple",
-      "id": "native.apple.4864b3b8c6ed7158"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 8222,
-      "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
       "id": "native.apple.4e3a9dc13016600b"
     },
     {
       "kind": "conditional-branch",
-      "line": 10,
+      "line": 8223,
+      "path": "apps/ios/Sources/Model/NodeAppModel.swift",
+      "source": "Approval set to Always Allow.",
+      "surface": "apple",
+      "id": "native.apple.4864b3b8c6ed7158"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 9527,
+      "path": "apps/ios/Sources/Model/NodeAppModel.swift",
+      "source": "\\(urlText.prefix(500))…",
+      "surface": "apple",
+      "id": "native.apple.1a8232361f3d72fb"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 11,
       "path": "apps/ios/Sources/Onboarding/OnboardingStateStore.swift",
       "source": "Home Network",
       "surface": "apple",
@@ -13147,7 +13803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 12,
+      "line": 13,
       "path": "apps/ios/Sources/Onboarding/OnboardingStateStore.swift",
       "source": "Remote Domain",
       "surface": "apple",
@@ -13155,7 +13811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 14,
+      "line": 15,
       "path": "apps/ios/Sources/Onboarding/OnboardingStateStore.swift",
       "source": "Same Machine (Dev)",
       "surface": "apple",
@@ -13250,6 +13906,14 @@
       "id": "native.apple.9e208d090ce2e84f"
     },
     {
+      "kind": "conditional-branch",
+      "line": 145,
+      "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
+      "source": "Retry",
+      "surface": "apple",
+      "id": "native.apple.7f671f0202cb1d9b"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 148,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
@@ -13325,17 +13989,17 @@
       "kind": "conditional-branch",
       "line": 195,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "surface": "apple",
-      "id": "native.apple.6bfb611862fb1687"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 195,
-      "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "surface": "apple",
       "id": "native.apple.3329c7f367f10c78"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 197,
+      "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "surface": "apple",
+      "id": "native.apple.6bfb611862fb1687"
     },
     {
       "kind": "ui-call",
@@ -13400,6 +14064,14 @@
       "source": "Copy setup code command",
       "surface": "apple",
       "id": "native.apple.eae3bd9e4e9112a0"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 207,
+      "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
+      "source": "Copied",
+      "surface": "apple",
+      "id": "native.apple.88792f11a553bab7"
     },
     {
       "kind": "ui-named-argument",
@@ -13515,7 +14187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 107,
+      "line": 108,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway auth token is missing.",
       "surface": "apple",
@@ -13523,7 +14195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 109,
+      "line": 110,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials.",
       "surface": "apple",
@@ -13531,7 +14203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 113,
+      "line": 114,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Could not reach the gateway.",
       "surface": "apple",
@@ -13842,6 +14514,22 @@
       "id": "native.apple.ab58b30ddda7aeb0"
     },
     {
+      "kind": "conditional-branch",
+      "line": 523,
+      "path": "apps/ios/Sources/OpenClawApp.swift",
+      "source": "OpenClaw",
+      "surface": "apple",
+      "id": "native.apple.5b46de1ccb06852b"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 490,
+      "path": "apps/ios/Sources/Push/PushRelayClient.swift",
+      "source": "unknown relay error",
+      "surface": "apple",
+      "id": "native.apple.e5f6435b9cb5a2d8"
+    },
+    {
       "kind": "ui-call",
       "line": 179,
       "path": "apps/ios/Sources/RootTabs.swift",
@@ -13891,7 +14579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 348,
+      "line": 349,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Online",
       "surface": "apple",
@@ -13899,7 +14587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 350,
+      "line": 351,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -13907,7 +14595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 352,
+      "line": 353,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -13915,7 +14603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 354,
+      "line": 355,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Offline",
       "surface": "apple",
@@ -14032,6 +14720,14 @@
       "source": "Gateway default",
       "surface": "apple",
       "id": "native.apple.e91893761485b9e8"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1073,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Routed on this phone",
+      "surface": "apple",
+      "id": "native.apple.e5c9d5012c42a604"
     },
     {
       "kind": "conditional-branch",
@@ -14315,7 +15011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 142,
+      "line": 143,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Limited",
       "surface": "apple",
@@ -14331,7 +15027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 155,
+      "line": 156,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read recent photos for the assistant.",
       "surface": "apple",
@@ -14339,7 +15035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 302,
+      "line": 303,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Allowed",
       "surface": "apple",
@@ -14347,7 +15043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 304,
+      "line": 305,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add-Only",
       "surface": "apple",
@@ -14355,7 +15051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 306,
+      "line": 307,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Set",
       "surface": "apple",
@@ -14363,7 +15059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 308,
+      "line": 309,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Allowed",
       "surface": "apple",
@@ -14371,7 +15067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 310,
+      "line": 311,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Unknown",
       "surface": "apple",
@@ -14467,7 +15163,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 13,
+      "line": 183,
+      "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
+      "source": "[\\(host)]",
+      "surface": "apple",
+      "id": "native.apple.f90c1fb8880c70c0"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 14,
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Not checked",
       "surface": "apple",
@@ -14475,7 +15179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 15,
+      "line": 16,
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Ready",
       "surface": "apple",
@@ -14483,7 +15187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 17,
+      "line": 18,
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Missing \\(scope)",
       "surface": "apple",
@@ -14491,7 +15195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 19,
+      "line": 20,
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Requesting approval",
       "surface": "apple",
@@ -14499,7 +15203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 21,
+      "line": 22,
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Approval requested",
       "surface": "apple",
@@ -14507,7 +15211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 23,
+      "line": 24,
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Request failed",
       "surface": "apple",
@@ -14515,7 +15219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 25,
+      "line": 26,
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "API key missing",
       "surface": "apple",
@@ -14523,7 +15227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 27,
+      "line": 28,
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Load failed",
       "surface": "apple",
@@ -14531,7 +15235,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 210,
+      "line": 135,
+      "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
+      "source": "Realtime Voice",
+      "surface": "apple",
+      "id": "native.apple.f2be0b00a9d003fe"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 139,
+      "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
+      "source": "Talk Voice",
+      "surface": "apple",
+      "id": "native.apple.571d17c55ce80675"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 211,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -14539,7 +15259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 212,
+      "line": 213,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "ElevenLabs",
       "surface": "apple",
@@ -14547,7 +15267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 214,
+      "line": 215,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Realtime-2 (OpenAI)",
       "surface": "apple",
@@ -14605,6 +15325,14 @@
       "kind": "conditional-branch",
       "line": 3850,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Gateway Relay",
+      "surface": "apple",
+      "id": "native.apple.465b84d5ff3f3717"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 3850,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native",
       "surface": "apple",
       "id": "native.apple.c48dc51b49089432"
@@ -14643,7 +15371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 137,
+      "line": 138,
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Sending approval request",
       "surface": "apple",
@@ -14651,7 +15379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 139,
+      "line": 140,
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Approval sent",
       "surface": "apple",
@@ -14659,7 +15387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 141,
+      "line": 142,
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Could not request approval",
       "surface": "apple",
@@ -14667,7 +15395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 143,
+      "line": 144,
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Enable Talk",
       "surface": "apple",
@@ -14675,7 +15403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 150,
+      "line": 151,
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Sending a new pairing request to your gateway...",
       "surface": "apple",
@@ -14683,7 +15411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 152,
+      "line": 153,
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Approve this request on your gateway. Talk will start automatically when approval lands.",
       "surface": "apple",
@@ -14691,11 +15419,11 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 154,
+      "line": 155,
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
       "surface": "apple",
-      "id": "native.apple.bd7d6f4323b9c3c2"
+      "id": "native.apple.80faa829f543c03c"
     },
     {
       "kind": "conditional-branch",
@@ -14755,6 +15483,38 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 567,
+      "path": "apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift",
+      "source": "Unknown",
+      "surface": "apple",
+      "id": "native.apple.f01783596898f5d6"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 569,
+      "path": "apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift",
+      "source": "Main",
+      "surface": "apple",
+      "id": "native.apple.7d8e032476dee789"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 574,
+      "path": "apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift",
+      "source": "Off",
+      "surface": "apple",
+      "id": "native.apple.c7d56c96499accff"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 62,
+      "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "surface": "apple",
+      "id": "native.apple.9df4056896cf6c02"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 115,
       "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
       "source": "Ready to connect",
@@ -14771,11 +15531,35 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 187,
+      "line": 188,
       "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
       "source": "Use iPhone Settings to enable direct connection.",
       "surface": "apple",
       "id": "native.apple.0e0763442f318e2f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 258,
+      "path": "apps/ios/WatchApp/Sources/WatchInboxStore.swift",
+      "source": "Connected",
+      "surface": "apple",
+      "id": "native.apple.f3cc640d74e3b4b5"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 270,
+      "path": "apps/ios/WatchApp/Sources/WatchInboxStore.swift",
+      "source": "Ready",
+      "surface": "apple",
+      "id": "native.apple.9486a204b499e24a"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 312,
+      "path": "apps/ios/WatchApp/Sources/WatchInboxStore.swift",
+      "source": "OpenClaw",
+      "surface": "apple",
+      "id": "native.apple.ca02fd2965efe74e"
     },
     {
       "kind": "ui-named-argument",
@@ -14933,17 +15717,17 @@
       "kind": "conditional-branch",
       "line": 321,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
-      "source": "Open iPhone Settings → Apple Watch",
-      "surface": "apple",
-      "id": "native.apple.08583448d9b2455e"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 321,
-      "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "surface": "apple",
       "id": "native.apple.c7d87356e6cdb374"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 322,
+      "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
+      "source": "Open iPhone Settings → Apple Watch",
+      "surface": "apple",
+      "id": "native.apple.08583448d9b2455e"
     },
     {
       "kind": "conditional-branch",
@@ -15163,7 +15947,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1112,
+      "line": 1061,
+      "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
+      "source": "Sending decision...",
+      "surface": "apple",
+      "id": "native.apple.a4fc6006c24b42df"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1113,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "You",
       "surface": "apple",
@@ -15171,7 +15963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1114,
+      "line": 1115,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "System",
       "surface": "apple",
@@ -15242,6 +16034,14 @@
       "id": "native.apple.ef3ff87537a32741"
     },
     {
+      "kind": "conditional-branch",
+      "line": 1465,
+      "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
+      "source": "Pending review",
+      "surface": "apple",
+      "id": "native.apple.2cf742a80121a8ea"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 1484,
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
@@ -15272,6 +16072,14 @@
       "source": "Deny",
       "surface": "apple",
       "id": "native.apple.096fb24013ac5455"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1560,
+      "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
+      "source": "Review command below",
+      "surface": "apple",
+      "id": "native.apple.f84adc6a026a3aaf"
     },
     {
       "kind": "ui-call",
@@ -15469,25 +16277,17 @@
       "kind": "conditional-branch",
       "line": 282,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
-      "source": "Install OpenClaw in Applications?",
-      "surface": "apple",
-      "id": "native.apple.088b39cc34b44e54"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 282,
-      "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
       "source": "Replace the older OpenClaw in Applications?",
       "surface": "apple",
       "id": "native.apple.7f86f5acf3d32ec2"
     },
     {
       "kind": "conditional-branch",
-      "line": 285,
+      "line": 283,
       "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "source": "Install OpenClaw in Applications?",
       "surface": "apple",
-      "id": "native.apple.a77a46d0ca32551f"
+      "id": "native.apple.088b39cc34b44e54"
     },
     {
       "kind": "conditional-branch",
@@ -15496,6 +16296,14 @@
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "surface": "apple",
       "id": "native.apple.c8898d685457401f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 286,
+      "path": "apps/macos/Sources/OpenClaw/ApplicationRelocator.swift",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "surface": "apple",
+      "id": "native.apple.a77a46d0ca32551f"
     },
     {
       "kind": "conditional-branch",
@@ -15627,7 +16435,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 140,
+      "line": 141,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "Switch this Mac app to a local Gateway before importing browser cookies.",
       "surface": "apple",
@@ -15635,7 +16443,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 160,
+      "line": 161,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "No Chrome, Brave, Edge, or Chromium profile with cookies was found on this Mac.",
       "surface": "apple",
@@ -15643,7 +16451,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 162,
+      "line": 163,
       "path": "apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift",
       "source": "System browser profile import is disabled in the local Gateway configuration.",
       "surface": "apple",
@@ -15707,7 +16515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 105,
+      "line": 106,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "OpenClaw Gateway \\(version) is ready.",
       "surface": "apple",
@@ -15715,7 +16523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 107,
+      "line": 108,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "OpenClaw Gateway is not installed yet.",
       "surface": "apple",
@@ -15723,7 +16531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 109,
+      "line": 110,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "The OpenClaw Gateway could not be verified. Setup will repair it.",
       "surface": "apple",
@@ -15731,7 +16539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 111,
+      "line": 112,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "Gateway \\(found) does not match app \\(required). Setup will update it.",
       "surface": "apple",
@@ -15752,6 +16560,14 @@
       "source": "Microphone",
       "surface": "apple",
       "id": "native.apple.40d3846b9b907a73"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 223,
+      "path": "apps/macos/Sources/OpenClaw/CanvasManager.swift",
+      "source": "Degraded",
+      "surface": "apple",
+      "id": "native.apple.533965afb8350ace"
     },
     {
       "kind": "ui-call",
@@ -15971,6 +16787,14 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 114,
+      "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "surface": "apple",
+      "id": "native.apple.60f2b09010a7809b"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 148,
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "Logged out and cleared credentials.",
@@ -15979,7 +16803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 148,
+      "line": 149,
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "No WhatsApp session found.",
       "surface": "apple",
@@ -15989,17 +16813,17 @@
       "kind": "conditional-branch",
       "line": 173,
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
-      "source": "No Telegram token configured.",
-      "surface": "apple",
-      "id": "native.apple.53f4d1e63fb7d589"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 173,
-      "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "Telegram token cleared.",
       "surface": "apple",
       "id": "native.apple.de729686d8ba05d6"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 174,
+      "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
+      "source": "No Telegram token configured.",
+      "surface": "apple",
+      "id": "native.apple.53f4d1e63fb7d589"
     },
     {
       "kind": "ui-call",
@@ -16037,17 +16861,17 @@
       "kind": "conditional-branch",
       "line": 168,
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "surface": "apple",
-      "id": "native.apple.8103e662c0e40760"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 168,
-      "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "surface": "apple",
       "id": "native.apple.e7afd1797978a4fd"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 169,
+      "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "surface": "apple",
+      "id": "native.apple.8103e662c0e40760"
     },
     {
       "kind": "ui-call",
@@ -16162,6 +16986,14 @@
       "id": "native.apple.dac4643a71326e9b"
     },
     {
+      "kind": "conditional-branch",
+      "line": 344,
+      "path": "apps/macos/Sources/OpenClaw/ControlChannel.swift",
+      "source": "unknown gateway error",
+      "surface": "apple",
+      "id": "native.apple.d0c8044293c26723"
+    },
+    {
       "kind": "ui-call",
       "line": 27,
       "path": "apps/macos/Sources/OpenClaw/CostUsageMenuView.swift",
@@ -16194,12 +17026,12 @@
       "id": "native.apple.84f1d9ae4965cfe0"
     },
     {
-      "kind": "ui-named-argument",
+      "kind": "ui-named-argument-concatenated",
       "line": 23,
       "path": "apps/macos/Sources/OpenClaw/CrestodianSettings.swift",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
       "surface": "apple",
-      "id": "native.apple.2a00563ee9d35dd3"
+      "id": "native.apple.4398066b42292ca3"
     },
     {
       "kind": "ui-call",
@@ -16600,6 +17432,14 @@
       "source": "Do not fail the job if announce fails",
       "surface": "apple",
       "id": "native.apple.75ea8e8d38238dfd"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 373,
+      "path": "apps/macos/Sources/OpenClaw/CronModels.swift",
+      "source": "Untitled job",
+      "surface": "apple",
+      "id": "native.apple.ecf3f166f2b6a13e"
     },
     {
       "kind": "ui-modifier",
@@ -17010,6 +17850,14 @@
       "id": "native.apple.3ed077c15e06c140"
     },
     {
+      "kind": "conditional-branch",
+      "line": 720,
+      "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
+      "source": "[\\(host)]",
+      "surface": "apple",
+      "id": "native.apple.226341f8c8b5d459"
+    },
+    {
       "kind": "ui-call",
       "line": 68,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
@@ -17250,12 +18098,12 @@
       "id": "native.apple.badf38ad13935f27"
     },
     {
-      "kind": "ui-modifier",
-      "line": 289,
+      "kind": "ui-modifier-concatenated",
+      "line": 290,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
       "surface": "apple",
-      "id": "native.apple.78ca12c226ea35ef"
+      "id": "native.apple.5437c7d545b749ca"
     },
     {
       "kind": "ui-call",
@@ -17426,7 +18274,7 @@
       "id": "native.apple.12fbaf28bf105c23"
     },
     {
-      "kind": "ui-call-multiline",
+      "kind": "ui-call",
       "line": 488,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Uses the Voice Wake path: forwards over SSH when configured,\notherwise runs locally via rpc.",
@@ -17674,6 +18522,14 @@
       "id": "native.apple.333dcda29354b1d0"
     },
     {
+      "kind": "conditional-branch",
+      "line": 104,
+      "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
+      "source": "\\(urlText.prefix(500))…",
+      "surface": "apple",
+      "id": "native.apple.f65276f4e789db3c"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 107,
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
@@ -17739,7 +18595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 118,
+      "line": 119,
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Pattern cannot be empty.",
       "surface": "apple",
@@ -17747,15 +18603,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 120,
+      "line": 121,
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
       "surface": "apple",
-      "id": "native.apple.7b81869cd37132d0"
+      "id": "native.apple.e69fc6a151dd8879"
     },
     {
       "kind": "conditional-branch",
-      "line": 282,
+      "line": 283,
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
       "surface": "apple",
@@ -17763,11 +18619,19 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 284,
+      "line": 285,
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
       "surface": "apple",
       "id": "native.apple.511333a8588db7e2"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1235,
+      "path": "apps/macos/Sources/OpenClaw/ExecApprovalsStore.swift",
+      "source": "missing:\\(hash)",
+      "surface": "apple",
+      "id": "native.apple.1b8ba1cf6f9dfdc9"
     },
     {
       "kind": "conditional-branch",
@@ -17789,17 +18653,17 @@
       "kind": "conditional-branch",
       "line": 72,
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "surface": "apple",
-      "id": "native.apple.2a5e0e9e073b8db1"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 72,
-      "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "surface": "apple",
       "id": "native.apple.08a145c293ac0695"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 73,
+      "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "surface": "apple",
+      "id": "native.apple.2a5e0e9e073b8db1"
     },
     {
       "kind": "ui-modifier",
@@ -17808,6 +18672,22 @@
       "source": "Discover OpenClaw gateways on your LAN",
       "surface": "apple",
       "id": "native.apple.66ad783199ef9729"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 195,
+      "path": "apps/macos/Sources/OpenClaw/GatewayEnvironment.swift",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "surface": "apple",
+      "id": "native.apple.110f6e64e25dcd2e"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 199,
+      "path": "apps/macos/Sources/OpenClaw/GatewayEnvironment.swift",
+      "source": "(\\(gatewayLabel))",
+      "surface": "apple",
+      "id": "native.apple.e1c93fb7ef1b6cb8"
     },
     {
       "kind": "conditional-branch",
@@ -17840,6 +18720,14 @@
       "source": "not linked",
       "surface": "apple",
       "id": "native.apple.151e5b5ab7d08a2a"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 270,
+      "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
+      "source": "unknown error",
+      "surface": "apple",
+      "id": "native.apple.4bd8ea604f3c21fa"
     },
     {
       "kind": "ui-named-argument",
@@ -17883,7 +18771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 78,
+      "line": 79,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Move OpenClaw to Applications before enabling launch at login.",
       "surface": "apple",
@@ -18091,7 +18979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 216,
+      "line": 217,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Processing messages through the local Gateway on this Mac.",
       "surface": "apple",
@@ -18099,7 +18987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 218,
+      "line": 219,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Connected to a remote Gateway configuration.",
       "surface": "apple",
@@ -18107,7 +18995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 220,
+      "line": 221,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Ready to run after you choose a Gateway connection.",
       "surface": "apple",
@@ -18171,7 +19059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 328,
+      "line": 329,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw starts and monitors the Gateway on this Mac.",
       "surface": "apple",
@@ -18179,7 +19067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 337,
+      "line": 338,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Choose local or remote before the app can attach to a Gateway.",
       "surface": "apple",
@@ -18309,17 +19197,17 @@
       "kind": "conditional-branch",
       "line": 479,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "surface": "apple",
-      "id": "native.apple.ff5020c25b825be3"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 479,
-      "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "surface": "apple",
       "id": "native.apple.5eebc911fb011a34"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 480,
+      "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "surface": "apple",
+      "id": "native.apple.ff5020c25b825be3"
     },
     {
       "kind": "ui-call",
@@ -18869,17 +19757,17 @@
       "kind": "conditional-branch",
       "line": 138,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
-      "source": "OpenClaw",
-      "surface": "apple",
-      "id": "native.apple.fae2cf18519da0d5"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 138,
-      "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw - Voice Wake live meter active",
       "surface": "apple",
       "id": "native.apple.13a7356f48278757"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 139,
+      "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
+      "source": "OpenClaw",
+      "surface": "apple",
+      "id": "native.apple.fae2cf18519da0d5"
     },
     {
       "kind": "conditional-branch",
@@ -19067,7 +19955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 197,
+      "line": 198,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "OpenClaw Not Configured",
       "surface": "apple",
@@ -19075,7 +19963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 199,
+      "line": 200,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Remote OpenClaw Active",
       "surface": "apple",
@@ -19083,7 +19971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 201,
+      "line": 202,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "OpenClaw Active",
       "surface": "apple",
@@ -19149,17 +20037,17 @@
       "kind": "conditional-branch",
       "line": 276,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
-      "source": "Verbose Logging (Main): Off",
-      "surface": "apple",
-      "id": "native.apple.a03ddd3d711b5a36"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 276,
-      "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): On",
       "surface": "apple",
       "id": "native.apple.e9868e7cdc856b06"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 277,
+      "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
+      "source": "Verbose Logging (Main): Off",
+      "surface": "apple",
+      "id": "native.apple.a03ddd3d711b5a36"
     },
     {
       "kind": "ui-call",
@@ -19173,17 +20061,17 @@
       "kind": "conditional-branch",
       "line": 289,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
-      "source": "File Logging: Off",
-      "surface": "apple",
-      "id": "native.apple.b0785f8c2ae712ff"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 289,
-      "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: On",
       "surface": "apple",
       "id": "native.apple.4f577b502efb658c"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 290,
+      "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
+      "source": "File Logging: Off",
+      "surface": "apple",
+      "id": "native.apple.b0785f8c2ae712ff"
     },
     {
       "kind": "ui-call",
@@ -19304,6 +20192,14 @@
       "source": "Disconnected (using System default)",
       "surface": "apple",
       "id": "native.apple.3e248379359c7593"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 134,
+      "path": "apps/macos/Sources/OpenClaw/MenuContextCardInjector.swift",
+      "source": "\\(firstLine.prefix(87))…",
+      "surface": "apple",
+      "id": "native.apple.0c726ae72b63e9dc"
     },
     {
       "kind": "ui-named-argument",
@@ -19451,7 +20347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 985,
+      "line": 986,
       "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
       "source": "explicit approval requires matching systemRunPlan",
       "surface": "apple",
@@ -19507,7 +20403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 80,
+      "line": 81,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "The Gateway setup request failed. Show details to inspect or copy the error.",
       "surface": "apple",
@@ -19523,19 +20419,11 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 165,
+      "line": 166,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift",
       "source": "\\(label) couldn’t complete the test. Show details to inspect or copy the error.",
       "surface": "apple",
       "id": "native.apple.e49b3d2d2cc77bd1"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 107,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
-      "source": "Looking for AI you already use…",
-      "surface": "apple",
-      "id": "native.apple.f3f900bed1ccf58b"
     },
     {
       "kind": "conditional-branch",
@@ -19547,11 +20435,11 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 111,
+      "line": 108,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "source": "Looking for AI you already use…",
       "surface": "apple",
-      "id": "native.apple.c7a02803addf11fa"
+      "id": "native.apple.f3f900bed1ccf58b"
     },
     {
       "kind": "conditional-branch",
@@ -19563,6 +20451,14 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 112,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "surface": "apple",
+      "id": "native.apple.c7a02803addf11fa"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 143,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Couldn’t check this Gateway for AI accounts",
@@ -19571,7 +20467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 143,
+      "line": 144,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Couldn’t check this Mac for AI accounts",
       "surface": "apple",
@@ -19931,6 +20827,14 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 119,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
+      "source": "<redacted secret>",
+      "surface": "apple",
+      "id": "native.apple.6f51ff950befb37a"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 218,
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Crestodian was interrupted. Restart to try again.",
@@ -19939,7 +20843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 218,
+      "line": 219,
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "The Gateway connection changed. Restart Crestodian to reconnect.",
       "surface": "apple",
@@ -20139,7 +21043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 179,
+      "line": 180,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Port \\(probe.port) already in use",
       "surface": "apple",
@@ -20163,7 +21067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 189,
+      "line": 190,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "\\(count) gateways found on your network — click to choose one.",
       "surface": "apple",
@@ -20309,17 +21213,17 @@
       "kind": "conditional-branch",
       "line": 328,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "surface": "apple",
-      "id": "native.apple.ab88df30f426b434"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 328,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "surface": "apple",
       "id": "native.apple.56e9b0831ec1eded"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 329,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "surface": "apple",
+      "id": "native.apple.ab88df30f426b434"
     },
     {
       "kind": "ui-call",
@@ -20594,12 +21498,12 @@
       "id": "native.apple.349252c2bd1d7b9d"
     },
     {
-      "kind": "ui-named-argument",
+      "kind": "ui-named-argument-concatenated",
       "line": 922,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
       "surface": "apple",
-      "id": "native.apple.b0c3df725bfafbec"
+      "id": "native.apple.774cf9fe7e3e289e"
     },
     {
       "kind": "ui-named-argument",
@@ -20757,17 +21661,17 @@
       "kind": "conditional-branch",
       "line": 295,
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
-      "source": "A device wants to connect to OpenClaw.",
-      "surface": "apple",
-      "id": "native.apple.2e9d9d1f5d4346d4"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 295,
-      "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "A node wants to connect to OpenClaw.",
       "surface": "apple",
       "id": "native.apple.11b1b5e9dd510766"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 296,
+      "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
+      "source": "A device wants to connect to OpenClaw.",
+      "surface": "apple",
+      "id": "native.apple.2e9d9d1f5d4346d4"
     },
     {
       "kind": "conditional-branch",
@@ -20784,6 +21688,22 @@
       "source": "OpenClaw Mac app",
       "surface": "apple",
       "id": "native.apple.a09a61f4efe1e63e"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 323,
+      "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
+      "source": "Operator",
+      "surface": "apple",
+      "id": "native.apple.6b29ec65de666dab"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 523,
+      "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
+      "source": "Mac",
+      "surface": "apple",
+      "id": "native.apple.7a62dc7bc8d3fab9"
     },
     {
       "kind": "ui-named-argument",
@@ -21059,7 +21979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 341,
+      "line": 342,
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Control other apps (e.g. Terminal) for automation actions",
       "surface": "apple",
@@ -21123,7 +22043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 46,
+      "line": 47,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway requires an auth token",
       "surface": "apple",
@@ -21131,7 +22051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 48,
+      "line": 49,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "That token did not match the gateway",
       "surface": "apple",
@@ -21139,7 +22059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 50,
+      "line": 51,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway host needs token setup",
       "surface": "apple",
@@ -21147,7 +22067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 52,
+      "line": 53,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This setup code is no longer valid",
       "surface": "apple",
@@ -21155,7 +22075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 54,
+      "line": 55,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway is using unsupported auth",
       "surface": "apple",
@@ -21163,7 +22083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 56,
+      "line": 57,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This device needs pairing approval",
       "surface": "apple",
@@ -21171,15 +22091,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 63,
+      "line": 64,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
-      "source": "Paste the token configured on the gateway host. ",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
       "surface": "apple",
-      "id": "native.apple.59ca961e52333852"
+      "id": "native.apple.b52cb4aae7ca6573"
     },
     {
       "kind": "conditional-branch",
-      "line": 67,
+      "line": 68,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Check `gateway.auth.token` or `OPENCLAW_GATEWAY_TOKEN` on the gateway host and try again.",
       "surface": "apple",
@@ -21187,15 +22107,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 69,
+      "line": 70,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
       "surface": "apple",
-      "id": "native.apple.d517136ce6599ed7"
+      "id": "native.apple.c26f61d639591f81"
     },
     {
       "kind": "conditional-branch",
-      "line": 73,
+      "line": 74,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Scan or paste a fresh setup code from an already-paired OpenClaw client, then try again.",
       "surface": "apple",
@@ -21203,23 +22123,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 75,
+      "line": 76,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
-      "source": "This onboarding flow does not support password auth yet. ",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
       "surface": "apple",
-      "id": "native.apple.4230f873600b819e"
+      "id": "native.apple.a8bf4f7ab4a35dc0"
     },
     {
       "kind": "conditional-branch",
-      "line": 78,
+      "line": 79,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
       "surface": "apple",
-      "id": "native.apple.5123702739aace5f"
+      "id": "native.apple.52c0f97f0b3bb792"
     },
     {
       "kind": "conditional-branch",
-      "line": 101,
+      "line": 102,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway requires an auth token from the gateway host.",
       "surface": "apple",
@@ -21227,7 +22147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 103,
+      "line": 104,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Gateway token mismatch. Check gateway.auth.token or OPENCLAW_GATEWAY_TOKEN on the gateway host.",
       "surface": "apple",
@@ -21235,7 +22155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 105,
+      "line": 106,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway has token auth enabled, but no gateway.auth.token is configured on the host.",
       "surface": "apple",
@@ -21243,7 +22163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 107,
+      "line": 108,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Setup code expired or already used. Scan a fresh setup code, then try again.",
       "surface": "apple",
@@ -21251,7 +22171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 109,
+      "line": 110,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet.",
       "surface": "apple",
@@ -21259,15 +22179,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 111,
+      "line": 112,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
       "surface": "apple",
-      "id": "native.apple.37d1f4842869452a"
+      "id": "native.apple.3e5a2b2a24f73418"
     },
     {
       "kind": "conditional-branch",
-      "line": 129,
+      "line": 130,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected via paired device",
       "surface": "apple",
@@ -21275,7 +22195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 131,
+      "line": 132,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with setup code",
       "surface": "apple",
@@ -21283,7 +22203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 133,
+      "line": 134,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with gateway token",
       "surface": "apple",
@@ -21291,7 +22211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 135,
+      "line": 136,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with password",
       "surface": "apple",
@@ -21299,7 +22219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 137,
+      "line": 138,
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Remote gateway ready",
       "surface": "apple",
@@ -21794,6 +22714,14 @@
       "id": "native.apple.8f5459c837515766"
     },
     {
+      "kind": "conditional-branch",
+      "line": 135,
+      "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
+      "source": "Reading the Gateway skill catalog.",
+      "surface": "apple",
+      "id": "native.apple.84c069138aa2c31d"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 170,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
@@ -21811,7 +22739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 221,
+      "line": 222,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "All",
       "surface": "apple",
@@ -21819,7 +22747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 223,
+      "line": 224,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Ready",
       "surface": "apple",
@@ -21827,7 +22755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 225,
+      "line": 226,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Needs Setup",
       "surface": "apple",
@@ -21835,7 +22763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 227,
+      "line": 228,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Disabled",
       "surface": "apple",
@@ -21867,7 +22795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 350,
+      "line": 351,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Managed",
       "surface": "apple",
@@ -21875,7 +22803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 352,
+      "line": 353,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Workspace",
       "surface": "apple",
@@ -21883,7 +22811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 354,
+      "line": 355,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Extra",
       "surface": "apple",
@@ -21891,7 +22819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 356,
+      "line": 357,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Plugin",
       "surface": "apple",
@@ -22411,7 +23339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 22,
+      "line": 23,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "No automatic Tailscale configuration.",
       "surface": "apple",
@@ -22419,7 +23347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 24,
+      "line": 25,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Tailnet-only HTTPS via Tailscale Serve.",
       "surface": "apple",
@@ -22427,7 +23355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 26,
+      "line": 27,
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Public HTTPS via Tailscale Funnel (requires auth).",
       "surface": "apple",
@@ -22603,11 +23531,19 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 19,
+      "line": 20,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeChime.swift",
       "source": "No Sound",
       "surface": "apple",
       "id": "native.apple.16e9766e8b59af53"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 16,
+      "path": "apps/macos/Sources/OpenClaw/VoiceWakeForwarder.swift",
+      "source": "this Mac",
+      "surface": "apple",
+      "id": "native.apple.458f94aded551547"
     },
     {
       "kind": "ui-call",
@@ -22874,6 +23810,14 @@
       "id": "native.apple.061460a0ef5d6017"
     },
     {
+      "kind": "conditional-branch",
+      "line": 546,
+      "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
+      "source": "Unavailable",
+      "surface": "apple",
+      "id": "native.apple.a8fb74eafee3d446"
+    },
+    {
       "kind": "ui-call",
       "line": 557,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
@@ -23019,7 +23963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 73,
+      "line": 74,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Press start, say a trigger word, and wait for detection.",
       "surface": "apple",
@@ -23027,7 +23971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 76,
+      "line": 77,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Requesting mic & speech permission…",
       "surface": "apple",
@@ -23035,7 +23979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 79,
+      "line": 80,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Listening… say your trigger word.",
       "surface": "apple",
@@ -23043,7 +23987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 82,
+      "line": 83,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Heard: \\(text)",
       "surface": "apple",
@@ -23051,7 +23995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 85,
+      "line": 86,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Finalizing…",
       "surface": "apple",
@@ -23059,7 +24003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 88,
+      "line": 89,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Voice wake detected!",
       "surface": "apple",
@@ -23072,6 +24016,14 @@
       "source": " (local filtered)",
       "surface": "apple",
       "id": "native.apple.c5d8bca2d78e1b9b"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 141,
+      "path": "apps/macos/Sources/OpenClawMacCLI/DiscoverCommand.swift",
+      "source": "(none)",
+      "surface": "apple",
+      "id": "native.apple.a0a9d0973963de42"
     },
     {
       "kind": "conditional-branch",
@@ -23112,6 +24064,14 @@
       "source": " — \\(option.hint!)",
       "surface": "apple",
       "id": "native.apple.9e54815f3eca97bf"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 509,
+      "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "surface": "apple",
+      "id": "native.apple.e70b56cadc8fbac3"
     },
     {
       "kind": "conditional-branch",
@@ -23338,6 +24298,14 @@
       "id": "native.apple.898849eb2bcb0b53"
     },
     {
+      "kind": "conditional-branch",
+      "line": 1191,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Message…",
+      "surface": "apple",
+      "id": "native.apple.b6adfcd17a6e73d7"
+    },
+    {
       "kind": "ui-localized-call",
       "line": 122,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
@@ -23426,6 +24394,14 @@
       "id": "native.apple.a902d7f653b46010"
     },
     {
+      "kind": "conditional-branch",
+      "line": 547,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift",
+      "source": "Image",
+      "surface": "apple",
+      "id": "native.apple.769b7dcea4708c40"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 337,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
@@ -23440,6 +24416,14 @@
       "source": "Message usage",
       "surface": "apple",
       "id": "native.apple.6426e369511b043c"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 513,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Voice note",
+      "surface": "apple",
+      "id": "native.apple.3c8c3679fd99c074"
     },
     {
       "kind": "conditional-branch",
@@ -23491,7 +24475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 696,
+      "line": 697,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
@@ -23499,7 +24483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 720,
+      "line": 721,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Queued",
       "surface": "apple",
@@ -23507,7 +24491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 722,
+      "line": 723,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sending…",
       "surface": "apple",
@@ -23515,7 +24499,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 724,
+      "line": 725,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Confirming…",
       "surface": "apple",
@@ -23523,7 +24507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 726,
+      "line": 727,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Delivery unknown",
       "surface": "apple",
@@ -23531,7 +24515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 728,
+      "line": 729,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Not sent",
       "surface": "apple",
@@ -23539,7 +24523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 750,
+      "line": 751,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Queued, sends when reconnected",
       "surface": "apple",
@@ -23547,7 +24531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 752,
+      "line": 753,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sending",
       "surface": "apple",
@@ -23555,7 +24539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 754,
+      "line": 755,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sent, waiting for chat history confirmation",
       "surface": "apple",
@@ -23563,7 +24547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 756,
+      "line": 757,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Delivery unconfirmed, touch and hold to retry or delete",
       "surface": "apple",
@@ -23571,7 +24555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 758,
+      "line": 759,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Not sent, touch and hold to retry or delete",
       "surface": "apple",
@@ -23643,7 +24627,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 102,
+      "line": 103,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Rename Session",
       "surface": "apple",
@@ -23728,6 +24712,46 @@
       "source": "Unarchive",
       "surface": "apple",
       "id": "native.apple.34b910911a05110e"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1347,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "surface": "apple",
+      "id": "native.apple.c4e808a2ec8d49f5"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1352,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "surface": "apple",
+      "id": "native.apple.4e7e29be3f05b828"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 80,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptExporter.swift",
+      "source": "Chat transcript",
+      "surface": "apple",
+      "id": "native.apple.e743b1178c2fdec8"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 102,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptExporter.swift",
+      "source": "Attachment",
+      "surface": "apple",
+      "id": "native.apple.9add620a81268972"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 125,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptExporter.swift",
+      "source": "Message",
+      "surface": "apple",
+      "id": "native.apple.0149100bb5c8b985"
     },
     {
       "kind": "ui-call",
@@ -23835,6 +24859,22 @@
     },
     {
       "kind": "conditional-branch",
+      "line": 43,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
+      "source": "\\(invocation) ",
+      "surface": "apple",
+      "id": "native.apple.61b7d1ecf7fdae3e"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 293,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
+      "source": "See attached.",
+      "surface": "apple",
+      "id": "native.apple.788a4fe0a4885066"
+    },
+    {
+      "kind": "conditional-branch",
       "line": 671,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "delivery unconfirmed",
@@ -23851,7 +24891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1181,
+      "line": 1182,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -23859,7 +24899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1237,
+      "line": 1238,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",
@@ -23867,7 +24907,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 39,
+      "line": 40,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Clear this session's history?",
       "surface": "apple",
@@ -24219,7 +25259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 682,
+      "line": 683,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift",
       "source": " This device could not verify the new certificate.",
       "surface": "apple",
@@ -24240,6 +25280,30 @@
       "source": "Setup",
       "surface": "apple",
       "id": "native.apple.0cb1206714c2bf4d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 87,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift",
+      "source": "gateway connect failed",
+      "surface": "apple",
+      "id": "native.apple.081a07c7306b223e"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 52,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/InstanceIdentity.swift",
+      "source": "Apple Watch",
+      "surface": "apple",
+      "id": "native.apple.2f45f005d2a7c3c2"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 198,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/ToolDisplay.swift",
+      "source": "\\(preview)…",
+      "surface": "apple",
+      "id": "native.apple.e97067187c9a359d"
     }
   ]
 }

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -194,6 +194,11 @@
       "translated": "وضع التحدث نشط"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · الميكروفون: يستمع"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "فشل: تعذر الوصول إلى نقطة نهاية البوابة الآمنة لهذا المضيف."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "يؤدي هذا إلى إزالة المهمة المجدولة نهائيًا من الـ Gateway."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "مطلوب وصول المسؤول"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "تتطلب تغييرات Cron صلاحية operator.admin. لا تمنح رموز الإعداد هذه الصلاحية عمدًا. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "مسار اختياري"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "يمكن للـ Gateway تغيير هذا المسار لكن لا يمكنه مسح مسار موجود."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "ي"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "متصل"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "الأذونات"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "ربما انتهت صلاحية الرمز أو تم إنشاؤه لـ Gateway آخر."
@@ -1734,9 +1804,24 @@
       "translated": "تحتاج مصادقة Gateway إلى مراجعة. تحقق من إعدادات Gateway، ثم أعد المحاولة."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "لا توجد نماذج مكوّنة"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "الجلسات"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "البحث في الجلسات"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "الأحدث أولاً"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "الأقدم أولاً"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "التخطيط: مفصّل"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "تثبيت"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "تعليم كغير مقروء"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "يمكن لـ OpenClaw تلقي التنبيهات المحددة."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "ممنوح"
@@ -2374,6 +2564,21 @@
       "translated": "إمكانات الهاتف"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "السماح بالوصول إلى مكتبة الصور."
@@ -2384,6 +2589,11 @@
       "translated": "تم منح الوصول إلى الصور المحددة أو الوصول الكامل إلى الصور."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "تبقى قائمة التطبيقات على هذا الهاتف."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "يمكن لـ OpenClaw عرض قائمة التطبيقات الظاهرة في المشغّل."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "السماح بالموقع في الخلفية؟"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "يتحقق OpenClaw من الموقع فقط عندما يطلب Gateway المقترن ذلك. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "هل تريد نسيان Gateway؟"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "فتح ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "تحقق"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "لم يتم الإبلاغ عن أي حدود"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "إيقاف"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "نص الحمولة"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "الوكيل النشط"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "لا شيء"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "المحادثات الحديثة"
@@ -3039,6 +3304,16 @@
       "translated": "مقفل"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count مزوّدين"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} جاهز"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "لا توجد Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "التحدث في الوقت الفعلي"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "إعدادات التحدث"
@@ -3594,6 +3874,11 @@
       "translated": "تعذر فك ترميز هذه الصورة."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} أخرى"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "أنت"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "حذف"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "مرفق غير مدعوم"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "جاهز عندما تكون جاهزًا"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "سيعرض OpenClaw الموافقات والمهام الفاشلة ومشكلات القنوات هنا."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "يتحدث · بانتظار الرد"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "جارٍ إرسال الصوت في قائمة الانتظار"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "الكاميرا"
@@ -4284,9 +4619,9 @@
       "translated": "الميكروفون"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "لا توجد يوميات أحلام بعد"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "لم تعثر البوابة على DREAMS.md أو dreams.md في مساحة عمل الوكيل النشطة."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) موجود لكنه لا يحتوي على محتوى قابل للقراءة."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "لم تعثر البوابة على DREAMS.md أو dreams.md في مساحة عمل الوكيل النشطة."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "اليوميات غير متاحة"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "اتصل ببوابة لقراءة إدخالات يوميات الأحلام."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "لم تُرجع البوابة محتوى يوميات الأحلام."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "اتصل ببوابة لقراءة إدخالات يوميات الأحلام."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "لا توجد حالة للمرحلة"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "وصّل Gateway لتحميل مراحل الحلم."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "لم يُرجع Gateway تفاصيل مراحل الحلم."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "وصّل Gateway لتحميل مراحل الحلم."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "لا حاجة إلى إصلاح"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "لا توجد مثيلات متصلة"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "وصّل Gateway لفحص المثيلات المتصلة."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "لم يبلّغ Gateway عن أي إدخالات حضور للنظام."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "وصّل Gateway لفحص المثيلات المتصلة."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "لم يتم الإبلاغ عن أي شيء."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "المجدول"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "الاستخدام"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "لا توجد مهام مجدولة"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "وصّل Gateway لتحميل العمل المجدول."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "لا يحتوي Gateway على مهام cron مرئية."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "وصّل Gateway لتحميل العمل المجدول."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills غير متوفرة"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "وصّل Gateway لتحميل Skills الخاصة بمساحة العمل."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "جرّب بحثًا مختلفًا أو حدّث من Gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "وصّل Gateway لتحميل Skills الخاصة بمساحة العمل."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "إعادة تسمية المجموعة"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "النشاط"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "النشاط الأخير"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "نشاط الجلسة غير متصل"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "اتصل بـ Gateway لتحميل نشاط الدردشة الأخير."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "ابدأ دردشة وستظهر هنا."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "اتصل بـ Gateway لتحميل نشاط الدردشة الأخير."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "فتح"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "لم يتم تحميل أي مقترحات"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "اتصل من الإعدادات لتحميل مقترحات Skill Workshop."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "ستظهر المقترحات الجديدة هنا عندما تقوم الوكلاء بصياغة المهارات."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "اتصل من الإعدادات لتحميل مقترحات Skill Workshop."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "لم يتم تحميل أي بطاقات"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "اتصل من الإعدادات لتحميل بطاقات Workboard."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "أنشئ بطاقة أو غيّر عامل التصفية."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "اتصل من الإعدادات لتحميل بطاقات Workboard."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "اختر متى يمكن لـ OpenClaw مشاركة موقع هذا الـ iPhone مع أدوات Gateway."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "نسيان Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "التنبيه الصوتي"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "تم الاكتشاف"
@@ -6484,14 +6879,14 @@
       "translated": "تم الاكتشاف • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "تم وضع الإعداد في قائمة الانتظار للساعة. افتح OpenClaw قبل انتهاء صلاحية الرمز."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "تم إرسال الإعداد. افتح OpenClaw على الساعة للاتصال."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "تم وضع الإعداد في قائمة الانتظار للساعة. افتح OpenClaw قبل انتهاء صلاحية الرمز."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "غير مُهيأ"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "الموافقات"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "لا توجد إجراءات Gateway بانتظار المراجعة."
@@ -6659,14 +7064,14 @@
       "translated": "مراجعة إجراءات Gateway المعلّقة."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "ثبّت تطبيق OpenClaw للساعة قبل تمكين الوضع المباشر."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "يبقى التتابع متاحًا؛ يضيف الوضع المباشر عقدة Gateway مستقلة."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "ثبّت تطبيق OpenClaw للساعة قبل تمكين الوضع المباشر."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "مثبّت"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "إعدادات الصوت والتحدث"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "إذن Gateway مطلوب"
@@ -7879,6 +8299,16 @@
       "translated": "افتح الإعدادات إذا كنت بحاجة إلى مضيف يدوي."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "هل تثق بهذا Gateway؟"
@@ -8164,6 +8594,11 @@
       "translated": "غير متصل"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "الموافقة"
@@ -8174,14 +8609,19 @@
       "translated": "تمت هذه الموافقة بالفعل"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "تم ضبط هذه الموافقة بالفعل على السماح دائمًا."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "تم ضبط الموافقة على السماح دائمًا."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "تم ضبط هذه الموافقة بالفعل على السماح دائمًا."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "يحتاج إلى انتباه"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "جاهز للاتصال"
@@ -8299,14 +8744,14 @@
       "translated": "رابط الإعداد"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "قد يكشف النص العادي بيانات الاعتماد. تابع فقط إذا كنت تثق بهذه الشبكة المحلية وهذا المضيف."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "راجع نقطة النهاية هذه. لا تُطبَّق بيانات الاعتماد إلا بعد النقر على اتصال."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "قد يكشف النص العادي بيانات الاعتماد. تابع فقط إذا كنت تثق بهذه الشبكة المحلية وهذا المضيف."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "نسخ أمر رمز الإعداد"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "اتصال"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "تحدّث"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway الافتراضي"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "فتح إعدادات Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "لم يتم التحقق"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "فشل التحميل"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "خطأ في الدردشة"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "وافق على هذا الطلب على gateway الخاص بك. سيبدأ Talk تلقائيًا عند وصول الموافقة."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "يحتاج هذا الجهاز إلى موافقة gateway قبل أن يتمكن Talk من استخدام الصوت في الوقت الفعلي. سينتقل الصوت مباشرةً من "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "يربط OpenClaw ساعة Apple Watch هذه مباشرةً بـ Gateway الخاص بك على الشبكات المحلية الموثوقة."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "جاهز للاتصال"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "استخدم إعدادات iPhone لتفعيل الاتصال المباشر."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "الإعداد"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "افتح إعدادات iPhone ← Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "يستخدم Wi-Fi أو الشبكة الخلوية أثناء نشاط OpenClaw"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "افتح إعدادات iPhone ← Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "الأمر المراد مراجعته"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "أنت"
@@ -9499,6 +10024,11 @@
       "translated": "الموافقة"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "مراجعة الأمر"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "رفض"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "تعذّر تثبيت OpenClaw في التطبيقات. انقله إلى هناك يدويًا، ثم افتح تلك النسخة."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "تثبيت OpenClaw في التطبيقات؟"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "استبدال النسخة الأقدم من OpenClaw في التطبيقات؟"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "سيقوم OpenClaw بنسخ نفسه إلى التطبيقات وإعادة الفتح هناك للحفاظ على موثوقية التحديثات والتشغيل عند تسجيل الدخول."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "تثبيت OpenClaw في التطبيقات؟"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "هذه النسخة أحدث من التطبيق المثبَّت. سيستبدلها OpenClaw ويعيد الفتح من التطبيقات."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "سيقوم OpenClaw بنسخ نفسه إلى التطبيقات وإعادة الفتح هناك للحفاظ على موثوقية التحديثات والتشغيل عند تسجيل الدخول."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "الميكروفون"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "مفعّل"
@@ -9954,6 +10494,11 @@
       "translated": "خطأ"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "تم تسجيل الخروج ومسح بيانات الاعتماد."
@@ -9964,14 +10509,14 @@
       "translated": "لم يتم العثور على جلسة WhatsApp."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "لم يتم تكوين رمز Telegram."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "تم مسح رمز Telegram."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "لم يتم تكوين رمز Telegram."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "التكوين"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "حرّر ~/.openclaw/openclaw.json باستخدام النموذج المستند إلى المخطط."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "علامة التبويب هذه للقراءة فقط في وضع Nix. حرّر التكوين عبر Nix وأعد البناء."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "حرّر ~/.openclaw/openclaw.json باستخدام النموذج المستند إلى المخطط."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "متدهور: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "اليوم"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "مساعد الإعداد المدعوم بالذكاء الاصطناعي. يمكنه التحقق من الحالة وإصلاح التهيئة، "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "لا تُفشل المهمة إذا فشل الإعلان"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "تحقق من الإعدادات ← الاتصال أو استخدم تصحيح الأخطاء ← إعادة تعيين النفق البعيد، ثم حاول مرة أخرى."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "إنهاء \\(listener.command) (\\(listener.pid))؟"
@@ -10754,9 +11314,9 @@
       "translated": "كتابة سجل تشخيصات متداول (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "يكتب سجلًا متناوبًا ومحليًا فقط ضمن ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "تم حظر الرابط العميق"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "تشغيل وكيل OpenClaw؟"
@@ -11064,9 +11629,9 @@
       "translated": "لا يمكن أن يكون النمط فارغًا."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "أنماط المسارات فقط. ضمّن '/' أو '~' أو '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "تعذّر حفظ موافقات التنفيذ. تُعرض آخر الإعدادات المعروفة؛ أعد محاولة التغيير."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "لم يتم العثور على أي gateways بعد."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "انقر على gateway مكتشف لملء هدف SSH."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "انقر على gateway مكتشف لملء عنوان URL الخاص بالـ gateway."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "انقر على gateway مكتشف لملء هدف SSH."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "اكتشف gateways الخاصة بـ OpenClaw على شبكة LAN لديك"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "غير مرتبط"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "الإعداد الموصى به"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "استخدم Tailscale Serve ليحصل Gateway على شهادة HTTPS صالحة."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "استخدم Tailscale بالإضافة إلى نفق SSH للوصول الخاص المستقر."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "استخدم Tailscale Serve ليحصل Gateway على شهادة HTTPS صالحة."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "تقديم"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - عدّاد التنبيه الصوتي المباشر نشط"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "إعادة تعيين النفق البعيد"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "التسجيل المطوّل (الرئيسي): إيقاف"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "التسجيل المطوّل (الرئيسي): تشغيل"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "التسجيل المطوّل (الرئيسي): إيقاف"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "مستوى التفصيل"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "تسجيل الملفات: إيقاف"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "تسجيل الملفات: تشغيل"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "تسجيل الملفات: إيقاف"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "غير متصل (يستخدم الإعداد الافتراضي للنظام)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "تعذّر على \\(label) إكمال الاختبار. اعرض التفاصيل لفحص الخطأ أو نسخه."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "جارٍ البحث عن أدوات ذكاء اصطناعي تستخدمها بالفعل…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "في انتظار انتهاء اختبار الذكاء الاصطناعي السابق…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "جارٍ التحقق من Claude Code وCodex وGemini ومفاتيح API المحفوظة."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "جارٍ البحث عن أدوات ذكاء اصطناعي تستخدمها بالفعل…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "سيتحقق OpenClaw مرة أخرى قبل تغيير أي من إعدادات الاستدلال."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "جارٍ التحقق من Claude Code وCodex وGemini ومفاتيح API المحفوظة."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "نسخ الخطأ"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "تلميح: أبقِ Tailscale مفعّلًا حتى يظل gateway لديك قابلاً للوصول."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "تلميح: استخدم Tailscale Serve حتى يحصل gateway على شهادة HTTPS صالحة."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "تلميح: أبقِ Tailscale مفعّلًا حتى يظل gateway لديك قابلاً للوصول."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "استخدم اللوحة + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "افتح لوحة شريط القوائم للدردشة السريعة؛ يمكن للوكيل عرض معاينات "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "رفض"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "جهاز يريد الاتصال بـ OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "عقدة تريد الاتصال بـ OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "جهاز يريد الاتصال بـ OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "تطبيق OpenClaw لنظام Mac"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "يحتاج هذا الجهاز إلى موافقة الاقتران"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "الصق الرمز الذي تم تكوينه على مضيف Gateway. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "تحقق من `gateway.auth.token` أو `OPENCLAW_GATEWAY_TOKEN` على مضيف Gateway ثم حاول مرة أخرى."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "تم ضبط هذا Gateway على مصادقة الرمز، لكن لم يتم تكوين `gateway.auth.token` على مضيف Gateway. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "امسح ضوئيًا أو الصق رمز إعداد جديدًا من عميل OpenClaw مقترن بالفعل، ثم حاول مرة أخرى."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "لا يدعم مسار الإعداد هذا مصادقة كلمة المرور بعد. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "وافق على هذا الجهاز من عميل OpenClaw مقترن بالفعل. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "يستخدم هذا Gateway مصادقة كلمة المرور. لا يمكن للإعداد عن بُعد على macOS جمع كلمات مرور Gateway بعد."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "الإقران مطلوب. في عميل OpenClaw مقترن مسبقًا، "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "لم يتم الإبلاغ عن أي Skills بعد"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "بدون صوت"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "تتطلب ميزة Voice Wake نظام macOS 26 أو أحدث"
@@ -14269,6 +14884,11 @@
       "translated": "الإعداد الافتراضي للنظام"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "غير متصل (يستخدم الإعداد الافتراضي للنظام)"
@@ -14394,6 +15014,11 @@
       "translated": " (مفلتر محليًا)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "عنوان URL غير صالح: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "تم اتصال Gateway"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "رموز الإدخال: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "استخدام السياق"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "استخدام الرسائل"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "إلغاء الأرشفة"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "إعادة الإرسال"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "الإعداد"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -194,6 +194,11 @@
       "translated": "Sprechmodus aktiv"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Mikrofon: Hört zu"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Fehlgeschlagen: Der sichere Gateway-Endpunkt für diesen Host konnte nicht erreicht werden."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Dadurch wird der geplante Job dauerhaft vom Gateway entfernt."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Administratorzugriff erforderlich"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Cron-Änderungen erfordern operator.admin. Setup-Codes gewähren dies absichtlich nicht. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Optionaler Pfad"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Das Gateway kann diesen Pfad ändern, aber einen vorhandenen Pfad nicht löschen."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "T"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Online"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Berechtigungen"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Der Code ist möglicherweise abgelaufen oder wurde für ein anderes Gateway generiert."
@@ -1734,9 +1804,24 @@
       "translated": "Gateway-Authentifizierung muss überprüft werden. Prüfen Sie die Gateway-Einstellungen und versuchen Sie es erneut."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Keine konfigurierten Modelle"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sitzungen"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Sitzungen suchen"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Neueste zuerst"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Älteste zuerst"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Layout: Detailliert"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Anheften"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Als ungelesen markieren"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw kann ausgewählte Hinweise empfangen."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Gewährt"
@@ -2374,6 +2564,21 @@
       "translated": "Telefonfunktionen"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Zugriff auf die Fotomediathek erlauben."
@@ -2384,6 +2589,11 @@
       "translated": "Ausgewählter oder vollständiger Fotozugriff gewährt."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "App-Liste bleibt auf diesem Telefon."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw kann im Launcher sichtbare Apps auflisten."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Hintergrundstandort zulassen?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw prüft den Standort nur, wenn Ihre gekoppelte Gateway dies anfordert. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Gateway vergessen?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "${license.title} öffnen"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Prüfen"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Keine Limits gemeldet"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Aus"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Payload-Text"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "AKTIVER AGENT"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Keine"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Aktuelle Unterhaltungen"
@@ -3039,6 +3304,16 @@
       "translated": "Gesperrt"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count Anbieter"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} bereit"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Keine Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Echtzeitgespräch"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Gesprächseinstellungen"
@@ -3594,6 +3874,11 @@
       "translated": "Dieses Bild konnte nicht decodiert werden."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} weitere"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Du"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Löschen"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Nicht unterstützter Anhang"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Bereit, wenn du es bist"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw zeigt hier Genehmigungen, fehlgeschlagene Aufträge und Kanalprobleme an."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Spricht · wartet auf Antwort"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Sendet Sprachnachricht in Warteschlange"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Kamera"
@@ -4284,9 +4619,9 @@
       "translated": "Mikrofon"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Noch kein Traumtagebuch"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Das Gateway hat DREAMS.md oder dreams.md im aktiven Agent-Arbeitsbereich nicht gefunden."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) ist vorhanden, hat aber keinen lesbaren Inhalt."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Das Gateway hat DREAMS.md oder dreams.md im aktiven Agent-Arbeitsbereich nicht gefunden."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Tagebuch nicht verfügbar"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Verbinden Sie ein Gateway, um Traumtagebuch-Einträge zu lesen."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Das Gateway hat keinen Traumtagebuch-Inhalt zurückgegeben."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Verbinden Sie ein Gateway, um Traumtagebuch-Einträge zu lesen."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Kein Phasenstatus"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Verbinden Sie eine Gateway, um Dreaming-Phasen zu laden."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Die Gateway hat keine Details zu Dreaming-Phasen zurückgegeben."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Verbinden Sie eine Gateway, um Dreaming-Phasen zu laden."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "keine Reparatur erforderlich"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Keine Instanzen verbunden"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Verbinden Sie eine Gateway, um verbundene Instanzen zu prüfen."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Die Gateway hat keine Systempräsenz-Einträge gemeldet."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Verbinden Sie eine Gateway, um verbundene Instanzen zu prüfen."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Keine gemeldet."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Scheduler"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Nutzung"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Keine geplanten Aufträge"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Verbinden Sie ein Gateway, um geplante Arbeiten zu laden."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Das Gateway hat keine sichtbaren Cron-Aufträge."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Verbinden Sie ein Gateway, um geplante Arbeiten zu laden."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills nicht verfügbar"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Verbinden Sie eine Gateway, um Arbeitsbereich-Skills zu laden."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Versuchen Sie eine andere Suche oder aktualisieren Sie über die Gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Verbinden Sie eine Gateway, um Arbeitsbereich-Skills zu laden."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Gruppe umbenennen"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Aktivität"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Letzte Aktivität"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Sitzungsaktivität offline"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Verbinden Sie sich mit dem Gateway, um die letzte Chat-Aktivität zu laden."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Starten Sie einen Chat, dann wird er hier angezeigt."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Verbinden Sie sich mit dem Gateway, um die letzte Chat-Aktivität zu laden."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Öffnen"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Keine Vorschläge geladen"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "In den Einstellungen verbinden, um Skill Workshop-Vorschläge zu laden."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Neue Vorschläge werden hier angezeigt, wenn Agenten Skills entwerfen."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "In den Einstellungen verbinden, um Skill Workshop-Vorschläge zu laden."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Keine Karten geladen"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Über die Einstellungen verbinden, um Workboard-Karten zu laden."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Erstellen Sie eine Karte oder ändern Sie den Filter."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Über die Einstellungen verbinden, um Workboard-Karten zu laden."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Wähle, wann OpenClaw den Standort dieses iPhones mit Gateway-Tools teilen darf."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Gateway entfernen"
@@ -6474,6 +6864,11 @@
       "translated": "Sprachaktivierung"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Erkannt"
@@ -6484,14 +6879,14 @@
       "translated": "Erkannt • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Einrichtung für die Uhr in Warteschlange. Öffne OpenClaw, bevor der Code abläuft."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Einrichtung gesendet. Öffne OpenClaw auf der Uhr, um die Verbindung herzustellen."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Einrichtung für die Uhr in Warteschlange. Öffne OpenClaw, bevor der Code abläuft."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Nicht konfiguriert"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Genehmigungen"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Keine Gateway-Aktionen warten auf Überprüfung."
@@ -6659,14 +7064,14 @@
       "translated": "Ausstehende Gateway-Aktionen prüfen."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Installiere die OpenClaw-Watch-App, bevor du den Direktmodus aktivierst."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Relay bleibt verfügbar; der Direktmodus fügt einen unabhängigen Gateway-Knoten hinzu."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Installiere die OpenClaw-Watch-App, bevor du den Direktmodus aktivierst."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Installiert"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Einstellungen für Stimme & Sprechen"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Gateway-Berechtigung erforderlich"
@@ -7879,6 +8299,16 @@
       "translated": "Öffnen Sie die Einstellungen, wenn Sie einen manuellen Host benötigen."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Dieser Gateway vertrauen?"
@@ -8164,6 +8594,11 @@
       "translated": "Offline"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Genehmigung"
@@ -8174,14 +8609,19 @@
       "translated": "Diese Genehmigung wurde bereits"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Diese Genehmigung wurde bereits auf „Immer zulassen“ gesetzt."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Genehmigung auf „Immer zulassen“ gesetzt."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Diese Genehmigung wurde bereits auf „Immer zulassen“ gesetzt."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Erfordert Aufmerksamkeit"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Bereit zum Verbinden"
@@ -8299,14 +8744,14 @@
       "translated": "Einrichtungslink"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Klartext kann Zugangsdaten offenlegen. Fahren Sie nur fort, wenn Sie diesem lokalen Netzwerk und Host vertrauen."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Prüfen Sie diesen Endpunkt. Zugangsdaten werden erst angewendet, nachdem Sie auf „Verbinden“ tippen."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Klartext kann Zugangsdaten offenlegen. Fahren Sie nur fort, wenn Sie diesem lokalen Netzwerk und Host vertrauen."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Befehl für Einrichtungscode kopieren"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Verbinden"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Sprechen"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway-Standard"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Gateway-Einstellungen öffnen"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Nicht geprüft"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Laden fehlgeschlagen"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Chatfehler"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Genehmige diese Anfrage auf deiner Gateway. Talk startet automatisch, sobald die Genehmigung eintrifft."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Dieses Gerät benötigt eine Genehmigung durch die Gateway, bevor Talk Echtzeit-Sprache verwenden kann. Audio wird direkt übertragen von "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw verbindet diese Apple Watch in vertrauenswürdigen lokalen Netzwerken direkt mit Ihrem Gateway."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Bereit zum Verbinden"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Verwenden Sie die iPhone-Einstellungen, um die Direktverbindung zu aktivieren."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Einrichtung"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "iPhone-Einstellungen öffnen → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Verwendet WLAN oder Mobilfunk, während OpenClaw aktiv ist"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "iPhone-Einstellungen öffnen → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Zu prüfender Befehl"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Du"
@@ -9499,6 +10024,11 @@
       "translated": "Genehmigung"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Befehl überprüfen"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Ablehnen"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw konnte nicht im Ordner „Programme“ installiert werden. Verschiebe es manuell dorthin und öffne dann diese Kopie."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "OpenClaw im Ordner „Programme“ installieren?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Das ältere OpenClaw im Ordner „Programme“ ersetzen?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw kopiert sich selbst in den Ordner „Programme“ und öffnet sich dort erneut, damit Updates und der Start beim Anmelden zuverlässig funktionieren."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw im Ordner „Programme“ installieren?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Diese Kopie ist neuer als die installierte App. OpenClaw ersetzt sie und öffnet sich erneut aus dem Ordner „Programme“."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw kopiert sich selbst in den Ordner „Programme“ und öffnet sich dort erneut, damit Updates und der Start beim Anmelden zuverlässig funktionieren."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Mikrofon"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Aktiviert"
@@ -9954,6 +10494,11 @@
       "translated": "Fehler"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Abgemeldet und Zugangsdaten gelöscht."
@@ -9964,14 +10509,14 @@
       "translated": "Keine WhatsApp-Sitzung gefunden."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Kein Telegram-Token konfiguriert."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Telegram-Token gelöscht."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Kein Telegram-Token konfiguriert."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Konfiguration"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Bearbeiten Sie ~/.openclaw/openclaw.json mithilfe des schemagesteuerten Formulars."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Dieser Tab ist im Nix-Modus schreibgeschützt. Bearbeiten Sie die Konfiguration über Nix und erstellen Sie sie neu."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Bearbeiten Sie ~/.openclaw/openclaw.json mithilfe des schemagesteuerten Formulars."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "eingeschränkt: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Heute"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Dein KI-gestützter Einrichtungshelfer. Er kann den Status prüfen, die Konfiguration korrigieren, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Job nicht fehlschlagen lassen, wenn die Ankündigung fehlschlägt"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Prüfen Sie Einstellungen → Verbindung oder verwenden Sie Debug → Remote-Tunnel zurücksetzen und versuchen Sie es erneut."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) beenden?"
@@ -10754,9 +11314,9 @@
       "translated": "Rollierendes Diagnoseprotokoll schreiben (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Schreibt ein rotierendes, nur lokales Protokoll unter ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Deep Link blockiert"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "OpenClaw-Agent ausführen?"
@@ -11064,9 +11629,9 @@
       "translated": "Muster darf nicht leer sein."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Nur Pfadmuster. „/“, „~“ oder „\\\\“ einschließen."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Exec-Genehmigungen konnten nicht gespeichert werden. Die zuletzt bekannten Einstellungen werden angezeigt; wiederholen Sie die Änderung."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Noch keine Gateways gefunden."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Klicken Sie auf ein gefundenes Gateway, um das SSH-Ziel auszufüllen."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Klicken Sie auf ein gefundenes Gateway, um die Gateway-URL auszufüllen."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Klicken Sie auf ein gefundenes Gateway, um das SSH-Ziel auszufüllen."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "OpenClaw-Gateways in Ihrem LAN entdecken"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "nicht verknüpft"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Empfohlene Einrichtung"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Verwenden Sie Tailscale Serve, damit das Gateway ein gültiges HTTPS-Zertifikat hat."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Verwenden Sie Tailscale plus einen SSH-Tunnel für stabilen privaten Zugriff."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Verwenden Sie Tailscale Serve, damit das Gateway ein gültiges HTTPS-Zertifikat hat."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Vorwärts"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw – Voice Wake-Live-Anzeige aktiv"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Remote-Tunnel zurücksetzen"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Ausführliche Protokollierung (Main): Aus"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Ausführliche Protokollierung (Main): Ein"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Ausführliche Protokollierung (Main): Aus"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Ausführlichkeit"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Dateiprotokollierung: Aus"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Dateiprotokollierung: Ein"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Dateiprotokollierung: Aus"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Getrennt (Systemstandard wird verwendet)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) konnte den Test nicht abschließen. Zeigen Sie die Details an, um den Fehler zu prüfen oder zu kopieren."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Es wird nach bereits von Ihnen genutzter KI gesucht…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Warten auf den Abschluss des vorherigen KI-Tests…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Es wird nach Claude Code, Codex, Gemini und gespeicherten API-Schlüsseln gesucht."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Es wird nach bereits von Ihnen genutzter KI gesucht…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw prüft erneut, bevor Inferenzeinstellungen geändert werden."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Es wird nach Claude Code, Codex, Gemini und gespeicherten API-Schlüsseln gesucht."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Fehler kopieren"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Tipp: Lassen Sie Tailscale aktiviert, damit Ihre Gateway erreichbar bleibt."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Tipp: Verwenden Sie Tailscale Serve, damit das Gateway ein gültiges HTTPS-Zertifikat hat."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Tipp: Lassen Sie Tailscale aktiviert, damit Ihre Gateway erreichbar bleibt."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Panel + Canvas verwenden"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Öffne das Menüleisten-Panel für den Schnell-Chat; der Agent kann Vorschauen anzeigen "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Ablehnen"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Ein Gerät möchte sich mit OpenClaw verbinden."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Ein Knoten möchte sich mit OpenClaw verbinden."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Ein Gerät möchte sich mit OpenClaw verbinden."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "OpenClaw Mac App"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Dieses Gerät benötigt eine Kopplungsgenehmigung"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Füge das auf dem Gateway-Host konfigurierte Token ein. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Prüfe `gateway.auth.token` oder `OPENCLAW_GATEWAY_TOKEN` auf dem Gateway-Host und versuche es erneut."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Diese Gateway ist auf Token-Authentifizierung eingestellt, aber auf dem Gateway-Host ist kein `gateway.auth.token` konfiguriert. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Scanne oder füge einen neuen Einrichtungscode von einem bereits gekoppelten OpenClaw-Client ein und versuche es dann erneut."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Dieser Onboarding-Ablauf unterstützt die Passwortauthentifizierung noch nicht. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Genehmige dieses Gerät über einen bereits gekoppelten OpenClaw-Client. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Diese Gateway verwendet Passwortauthentifizierung. Remote-Onboarding unter macOS kann Gateway-Passwörter noch nicht erfassen."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Kopplung erforderlich. In einem bereits gekoppelten OpenClaw-Client, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Noch keine Skills gemeldet"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Kein Ton"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake erfordert macOS 26 oder neuer"
@@ -14269,6 +14884,11 @@
       "translated": "Systemstandard"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Getrennt (Systemstandard wird verwendet)"
@@ -14394,6 +15014,11 @@
       "translated": " (lokal gefiltert)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "Ungültige URL: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway verbunden"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Eingabe-Tokens: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Kontextnutzung"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Nachrichtennutzung"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Aus Archiv holen"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Erneut senden"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Einrichtung"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -194,6 +194,11 @@
       "translated": "Modo de conversación activo"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Micrófono: escuchando"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Error: no se pudo alcanzar el endpoint seguro del gateway para este host."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Esto elimina permanentemente la tarea programada del Gateway."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Se requiere acceso de administrador"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Los cambios de cron requieren operator.admin. Los códigos de configuración no lo otorgan intencionadamente. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Ruta opcional"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "El gateway puede cambiar esta ruta pero no puede borrar una ruta existente."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "En línea"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Permisos"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Es posible que el código haya caducado o que se haya generado para otro Gateway."
@@ -1734,9 +1804,24 @@
       "translated": "La autenticación de Gateway necesita revisión. Comprueba la configuración de Gateway y vuelve a intentarlo."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "No hay modelos configurados"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sesiones"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Buscar sesiones"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Más recientes primero"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Más antiguos primero"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Diseño: Detallado"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Fijar"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Marcar como no leído"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw puede recibir alertas seleccionadas."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Concedido"
@@ -2374,6 +2564,21 @@
       "translated": "Capacidades del teléfono"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Permitir acceso a la fototeca."
@@ -2384,6 +2589,11 @@
       "translated": "Acceso seleccionado o completo a fotos concedido."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "La lista de apps permanece en este teléfono."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw puede listar las apps visibles en el lanzador."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "¿Permitir ubicación en segundo plano?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw solo comprueba la ubicación cuando tu Gateway emparejado lo solicita. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "¿Olvidar gateway?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "Abrir ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Comprobar"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "No se informaron límites"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Desactivado"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Texto de carga útil"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "AGENTE ACTIVO"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Ninguna"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Conversaciones recientes"
@@ -3039,6 +3304,16 @@
       "translated": "Bloqueado"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count proveedores"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} listos"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Sin Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Conversación en tiempo real"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Configuración de conversación"
@@ -3594,6 +3874,11 @@
       "translated": "No se pudo decodificar esta imagen."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} más"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Tú"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Eliminar"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Adjunto no compatible"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Listo cuando quieras"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw mostrará aquí las aprobaciones, los trabajos fallidos y los problemas de canales."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Hablando · esperando respuesta"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Enviando voz en cola"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Cámara"
@@ -4284,9 +4619,9 @@
       "translated": "Micrófono"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Aún no hay diario de sueños"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "El Gateway no encontró DREAMS.md ni dreams.md en el espacio de trabajo del agente activo."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) existe, pero no tiene contenido legible."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "El Gateway no encontró DREAMS.md ni dreams.md en el espacio de trabajo del agente activo."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Diario no disponible"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Conecta un Gateway para leer las entradas del diario de sueños."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "El Gateway no devolvió contenido del diario de sueños."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Conecta un Gateway para leer las entradas del diario de sueños."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Sin estado de fase"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Conecta un Gateway para cargar las fases de dreaming."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "El Gateway no devolvió detalles de la fase de dreaming."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Conecta un Gateway para cargar las fases de dreaming."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "no se necesita reparación"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "No hay instancias conectadas"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Conecta un Gateway para inspeccionar las instancias conectadas."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "El Gateway no informó ninguna entrada de presencia del sistema."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Conecta un Gateway para inspeccionar las instancias conectadas."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "No se informó de nada."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Programador"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Uso"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "No hay trabajos programados"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Conecta un Gateway para cargar el trabajo programado."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "El Gateway no tiene trabajos de cron visibles."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Conecta un Gateway para cargar el trabajo programado."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills no disponibles"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Conecta un Gateway para cargar las Skills del espacio de trabajo."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Prueba con otra búsqueda o actualiza desde el Gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Conecta un Gateway para cargar las Skills del espacio de trabajo."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Renombrar grupo"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Actividad"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Actividad reciente"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Actividad de sesión sin conexión"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Conéctate al gateway para cargar la actividad reciente del chat."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Inicia un chat y aparecerá aquí."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Conéctate al gateway para cargar la actividad reciente del chat."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Abrir"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "No se cargaron propuestas"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Conéctate desde Ajustes para cargar las propuestas de Skill Workshop."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Las nuevas propuestas aparecerán aquí cuando los agentes redacten skills."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Conéctate desde Ajustes para cargar las propuestas de Skill Workshop."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "No se cargaron tarjetas"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Conéctate desde Configuración para cargar las tarjetas del workboard."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Crea una tarjeta o cambia el filtro."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Conéctate desde Configuración para cargar las tarjetas del workboard."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Elige cuándo OpenClaw puede compartir la ubicación de este iPhone con las herramientas del Gateway."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Olvidar Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "Activación por voz"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Descubierto"
@@ -6484,14 +6879,14 @@
       "translated": "Descubierto • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Configuración en cola para el reloj. Abre OpenClaw antes de que caduque el código."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Configuración enviada. Abre OpenClaw en el reloj para conectar."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Configuración en cola para el reloj. Abre OpenClaw antes de que caduque el código."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "No configurado"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Aprobaciones"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "No hay acciones de Gateway esperando revisión."
@@ -6659,14 +7064,14 @@
       "translated": "Revisa las acciones pendientes del Gateway."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Instala la app de OpenClaw para el reloj antes de habilitar el modo directo."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "El relé sigue disponible; el modo directo añade un nodo de Gateway independiente."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Instala la app de OpenClaw para el reloj antes de habilitar el modo directo."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Instalado"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Configuración de voz y conversación"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Se requiere permiso del Gateway"
@@ -7879,6 +8299,16 @@
       "translated": "Abre Configuración si necesitas un host manual."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "¿Confiar en este gateway?"
@@ -8164,6 +8594,11 @@
       "translated": "Sin conexión"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Aprobación"
@@ -8174,14 +8609,19 @@
       "translated": "Esta aprobación ya fue"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Esta aprobación ya estaba configurada como Permitir siempre."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Aprobación configurada como Permitir siempre."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Esta aprobación ya estaba configurada como Permitir siempre."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Necesita atención"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Listo para conectar"
@@ -8299,14 +8744,14 @@
       "translated": "Enlace de configuración"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "El texto sin formato puede exponer las credenciales. Continúa solo si confías en esta red local y en el host."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Revisa este endpoint. Las credenciales se aplican solo después de que toques Conectar."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "El texto sin formato puede exponer las credenciales. Continúa solo si confías en esta red local y en el host."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Copiar comando de código de configuración"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Conectar"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Hablar"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Predeterminado de Gateway"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Abrir configuración de Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "No comprobado"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Error al cargar"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Error de chat"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Aprueba esta solicitud en tu gateway. Talk se iniciará automáticamente cuando llegue la aprobación."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Este dispositivo necesita la aprobación del gateway antes de que Talk pueda usar voz en tiempo real. El audio irá directamente desde "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw conecta este Apple Watch directamente a tu Gateway en redes locales de confianza."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Listo para conectar"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Usa los Ajustes del iPhone para activar la conexión directa."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Configuración"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Abre los Ajustes del iPhone → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Usa Wi-Fi o datos móviles mientras OpenClaw está activo"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Abre los Ajustes del iPhone → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Comando a revisar"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Tú"
@@ -9499,6 +10024,11 @@
       "translated": "Aprobación"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Revisar comando"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Denegar"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "No se pudo instalar OpenClaw en Aplicaciones. Muévelo allí manualmente y luego abre esa copia."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "¿Instalar OpenClaw en Aplicaciones?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "¿Reemplazar la versión anterior de OpenClaw en Aplicaciones?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw se copiará en Aplicaciones y se reabrirá allí para que las actualizaciones y el inicio de sesión sigan siendo fiables."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "¿Instalar OpenClaw en Aplicaciones?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Esta copia es más reciente que la app instalada. OpenClaw la reemplazará y se reabrirá desde Aplicaciones."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw se copiará en Aplicaciones y se reabrirá allí para que las actualizaciones y el inicio de sesión sigan siendo fiables."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Micrófono"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Activado"
@@ -9954,6 +10494,11 @@
       "translated": "Error"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Sesión cerrada y credenciales borradas."
@@ -9964,14 +10509,14 @@
       "translated": "No se encontró ninguna sesión de WhatsApp."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "No hay ningún token de Telegram configurado."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Token de Telegram borrado."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "No hay ningún token de Telegram configurado."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Configuración"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Edita ~/.openclaw/openclaw.json usando el formulario basado en el esquema."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Esta pestaña es de solo lectura en modo Nix. Edita la configuración mediante Nix y recompila."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Edita ~/.openclaw/openclaw.json usando el formulario basado en el esquema."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "degradado: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Hoy"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Tu asistente de configuración con IA. Puede comprobar el estado, corregir la configuración, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "No fallar el trabajo si el anuncio falla"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Comprueba Configuración → Conexión o usa Depurar → Restablecer túnel remoto, luego inténtalo de nuevo."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "¿Finalizar \\(listener.command) (\\(listener.pid))?"
@@ -10754,9 +11314,9 @@
       "translated": "Escribir registro de diagnóstico rotativo (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Escribe un registro rotativo, solo local, en ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Enlace profundo bloqueado"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "¿Ejecutar el agente de OpenClaw?"
@@ -11064,9 +11629,9 @@
       "translated": "El patrón no puede estar vacío."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Solo patrones de ruta. Incluye '/', '~' o '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "No se pudieron guardar las aprobaciones de exec. Se muestran los últimos ajustes conocidos; reintenta el cambio."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Aún no se encontraron gateways."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Haz clic en un gateway descubierto para completar el destino SSH."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Haz clic en un gateway descubierto para completar la URL del gateway."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Haz clic en un gateway descubierto para completar el destino SSH."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "Detectar gateways de OpenClaw en tu LAN"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "no vinculado"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Configuración recomendada"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Usa Tailscale Serve para que el gateway tenga un certificado HTTPS válido."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Usa Tailscale y un túnel SSH para un acceso privado estable."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Usa Tailscale Serve para que el gateway tenga un certificado HTTPS válido."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Adelante"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - medidor en vivo de activación por voz activo"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Restablecer túnel remoto"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Registro detallado (principal): desactivado"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Registro detallado (principal): activado"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Registro detallado (principal): desactivado"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Nivel de detalle"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Registro en archivo: desactivado"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Registro en archivo: activado"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Registro en archivo: desactivado"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Desconectado (usando el valor predeterminado del sistema)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) no pudo completar la prueba. Muestra los detalles para inspeccionar o copiar el error."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Buscando IA que ya usas…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Esperando a que finalice la prueba de IA anterior…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Comprobando Claude Code, Codex, Gemini y claves de API guardadas."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Buscando IA que ya usas…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw volverá a comprobar antes de cambiar cualquier ajuste de inferencia."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Comprobando Claude Code, Codex, Gemini y claves de API guardadas."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Copiar error"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Consejo: mantén Tailscale activado para que tu gateway siga siendo accesible."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Consejo: usa Tailscale Serve para que el gateway tenga un certificado HTTPS válido."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Consejo: mantén Tailscale activado para que tu gateway siga siendo accesible."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Usa el panel + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Abre el panel de la barra de menús para chatear rápidamente; el agente puede mostrar vistas previas "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Rechazar"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Un dispositivo quiere conectarse a OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Un nodo quiere conectarse a OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Un dispositivo quiere conectarse a OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "Aplicación de OpenClaw para Mac"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Este dispositivo necesita aprobación de emparejamiento"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Pega el token configurado en el host del gateway. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Revisa `gateway.auth.token` u `OPENCLAW_GATEWAY_TOKEN` en el host del gateway e inténtalo de nuevo."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Este gateway está configurado con autenticación por token, pero no se ha configurado ningún `gateway.auth.token` en el host del gateway. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Escanea o pega un código de configuración nuevo desde un cliente de OpenClaw ya emparejado y vuelve a intentarlo."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Este flujo de incorporación aún no admite autenticación con contraseña. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Aprueba este dispositivo desde un cliente de OpenClaw ya emparejado. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Este gateway usa autenticación con contraseña. La incorporación remota en macOS aún no puede recopilar contraseñas de gateway."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Se requiere emparejamiento. En un cliente de OpenClaw ya emparejado, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Aún no se han informado Skills"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Sin sonido"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake requiere macOS 26 o posterior"
@@ -14269,6 +14884,11 @@
       "translated": "Predeterminado del sistema"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Desconectado (usando el predeterminado del sistema)"
@@ -14394,6 +15014,11 @@
       "translated": " (filtrado local)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "URL no válida: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway conectado"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Tokens de entrada: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Uso de contexto"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Uso de mensajes"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Desarchivar"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Reintentar envío"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Configuración"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -194,6 +194,11 @@
       "translated": "حالت گفت‌وگو فعال است"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · میکروفون: در حال گوش دادن"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "ناموفق: امکان دسترسی به نقطه پایانی امن Gateway برای این میزبان وجود نداشت."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "این کار زمان‌بندی‌شده را برای همیشه از gateway حذف می‌کند."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "دسترسی مدیر لازم است"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "تغییرات cron به operator.admin نیاز دارد. کدهای راه‌اندازی عمداً آن را اعطا نمی‌کنند. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "مسیر اختیاری"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "gateway می‌تواند این مسیر را تغییر دهد اما نمی‌تواند مسیر موجود را پاک کند."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "آنلاین"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "مجوزها"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "ممکن است کد منقضی شده باشد یا برای Gateway دیگری تولید شده باشد."
@@ -1734,9 +1804,24 @@
       "translated": "احراز هویت Gateway نیاز به بازبینی دارد. تنظیمات Gateway را بررسی کنید، سپس دوباره تلاش کنید."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "هیچ مدلی پیکربندی نشده است"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "نشست‌ها"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "جستجوی نشست‌ها"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "ابتدا جدیدترین"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "ابتدا قدیمی‌ترین"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "چیدمان: با جزئیات"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "سنجاق کردن"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "علامت‌گذاری به‌عنوان خوانده‌نشده"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw می‌تواند هشدارهای انتخاب‌شده را دریافت کند."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "اعطا شده"
@@ -2374,6 +2564,21 @@
       "translated": "قابلیت‌های تلفن"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "اجازه دسترسی به کتابخانه عکس را بدهید."
@@ -2384,6 +2589,11 @@
       "translated": "دسترسی انتخابی یا کامل به عکس‌ها اعطا شده است."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "فهرست برنامه‌ها روی این تلفن باقی می‌ماند."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw می‌تواند برنامه‌های قابل‌نمایش در لانچر را فهرست کند."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "اجازه دادن به موقعیت مکانی در پس‌زمینه؟"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw فقط زمانی موقعیت مکانی را بررسی می‌کند که Gateway جفت‌شده شما آن را درخواست کند. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Gateway فراموش شود؟"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "باز کردن ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "بررسی"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "هیچ محدودیتی گزارش نشده است"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "خاموش"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "متن Payload"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "عامل فعال"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "هیچ‌کدام"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "گفتگوهای اخیر"
@@ -3039,6 +3304,16 @@
       "translated": "قفل‌شده"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count ارائه‌دهنده"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} آماده"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "بدون Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "گفت‌وگوی بلادرنگ"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "تنظیمات گفت‌وگو"
@@ -3594,6 +3874,11 @@
       "translated": "این تصویر قابل رمزگشایی نبود."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} مورد دیگر"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "شما"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "حذف"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "پیوست پشتیبانی‌نشده"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "هر وقت آماده باشید، آماده‌ام"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw تأییدها، کارهای ناموفق و مشکلات کانال را اینجا نمایش خواهد داد."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "در حال صحبت · در انتظار پاسخ"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "در حال ارسال صدای در صف"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "اشتراک‌گذاری OpenClaw"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "دوربین"
@@ -4284,9 +4619,9 @@
       "translated": "میکروفون"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "هنوز دفترچه رؤیایی وجود ندارد"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "gateway فایل DREAMS.md یا dreams.md را در فضای کاری عامل فعال پیدا نکرد."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) وجود دارد اما محتوای قابل‌خواندن ندارد."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "gateway فایل DREAMS.md یا dreams.md را در فضای کاری عامل فعال پیدا نکرد."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "دفترچه در دسترس نیست"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "برای خواندن ورودی‌های دفترچه رؤیا، یک gateway متصل کنید."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "gateway محتوای دفترچه رؤیا را برنگرداند."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "برای خواندن ورودی‌های دفترچه رؤیا، یک gateway متصل کنید."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "بدون وضعیت فاز"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "برای بارگیری فازهای dreaming، یک gateway متصل کنید."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "gateway جزئیات فاز dreaming را برنگرداند."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "برای بارگیری فازهای dreaming، یک gateway متصل کنید."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "نیازی به تعمیر نیست"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "هیچ نمونه‌ای متصل نیست"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "برای بررسی نمونه‌های متصل، یک gateway متصل کنید."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "gateway هیچ ورودی حضور سیستم را گزارش نکرد."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "برای بررسی نمونه‌های متصل، یک gateway متصل کنید."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "موردی گزارش نشده است."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "زمان‌بند"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "استفاده"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "هیچ کار زمان‌بندی‌شده‌ای وجود ندارد"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "برای بارگیری کارهای زمان‌بندی‌شده، یک gateway متصل کنید."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "این gateway هیچ کار cron قابل مشاهده‌ای ندارد."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "برای بارگیری کارهای زمان‌بندی‌شده، یک gateway متصل کنید."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills در دسترس نیست"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "برای بارگیری Skills فضای کاری، یک Gateway متصل کنید."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "جستجوی دیگری را امتحان کنید یا از Gateway تازه‌سازی کنید."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "برای بارگیری Skills فضای کاری، یک Gateway متصل کنید."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "تغییر نام گروه"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "فعالیت"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "فعالیت اخیر"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "فعالیت نشست آفلاین است"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "برای بارگذاری فعالیت اخیر گفتگو، به Gateway متصل شوید."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "گفتگویی را شروع کنید تا اینجا نمایش داده شود."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "برای بارگذاری فعالیت اخیر گفتگو، به Gateway متصل شوید."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "باز کردن"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "هیچ پیشنهادی بارگذاری نشده است"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "برای بارگذاری پیشنهادهای Skill Workshop از تنظیمات متصل شوید."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "وقتی عامل‌ها مهارت‌ها را پیش‌نویس کنند، پیشنهادهای جدید اینجا ظاهر می‌شوند."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "برای بارگذاری پیشنهادهای Skill Workshop از تنظیمات متصل شوید."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "هیچ کارتی بارگذاری نشده است"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "برای بارگذاری کارت‌های workboard از Settings متصل شوید."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "یک کارت ایجاد کنید یا فیلتر را تغییر دهید."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "برای بارگذاری کارت‌های workboard از Settings متصل شوید."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "انتخاب کنید که چه زمانی OpenClaw می‌تواند موقعیت مکانی این iPhone را با ابزارهای Gateway به اشتراک بگذارد."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "فراموش کردن Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "بیدارباش صوتی"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "کشف‌شده"
@@ -6484,14 +6879,14 @@
       "translated": "کشف‌شده • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "راه‌اندازی برای ساعت در صف قرار گرفت. پیش از انقضای کد، OpenClaw را باز کنید."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "راه‌اندازی ارسال شد. برای اتصال، OpenClaw را روی ساعت باز کنید."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "راه‌اندازی برای ساعت در صف قرار گرفت. پیش از انقضای کد، OpenClaw را باز کنید."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "پیکربندی نشده"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "تأییدها"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "هیچ اقدام Gateway در انتظار بازبینی نیست."
@@ -6659,14 +7064,14 @@
       "translated": "بررسی اقدامات در انتظار gateway."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "پیش از فعال‌سازی حالت مستقیم، برنامه ساعت OpenClaw را نصب کنید."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "رله همچنان در دسترس است؛ حالت مستقیم یک گره Gateway مستقل اضافه می‌کند."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "پیش از فعال‌سازی حالت مستقیم، برنامه ساعت OpenClaw را نصب کنید."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "نصب‌شده"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "تنظیمات صدا و گفت‌وگو"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "مجوز Gateway لازم است"
@@ -7879,6 +8299,16 @@
       "translated": "اگر به میزبان دستی نیاز دارید، Settings را باز کنید."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "به این gateway اعتماد می‌کنید؟"
@@ -8164,6 +8594,11 @@
       "translated": "آفلاین"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "تأیید"
@@ -8174,14 +8609,19 @@
       "translated": "این تأیید قبلاً انجام شده بود"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "این تأیید قبلاً روی «همیشه اجازه بده» تنظیم شده بود."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "تأیید روی «همیشه اجازه بده» تنظیم شد."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "این تأیید قبلاً روی «همیشه اجازه بده» تنظیم شده بود."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "نیازمند توجه"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "آماده اتصال"
@@ -8299,14 +8744,14 @@
       "translated": "پیوند راه‌اندازی"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "متن ساده ممکن است اطلاعات ورود را افشا کند. فقط در صورتی ادامه دهید که به این شبکهٔ محلی و میزبان اعتماد دارید."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "این نقطهٔ پایانی را بازبینی کنید. اطلاعات ورود فقط پس از لمس «اتصال» اعمال می‌شوند."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "متن ساده ممکن است اطلاعات ورود را افشا کند. فقط در صورتی ادامه دهید که به این شبکهٔ محلی و میزبان اعتماد دارید."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "کپی کردن فرمان کد راه‌اندازی"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "اتصال"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "گفتگو"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway پیش‌فرض"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "باز کردن تنظیمات Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "بررسی نشده"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "بارگذاری ناموفق بود"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "خطای گپ"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "این درخواست را در gateway خود تأیید کنید. پس از رسیدن تأیید، Talk به‌طور خودکار شروع می‌شود."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "این دستگاه پیش از اینکه Talk بتواند از صدای بلادرنگ استفاده کند، به تأیید gateway نیاز دارد. صدا مستقیماً از "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw این Apple Watch را در شبکه‌های محلی مورد اعتماد مستقیماً به Gateway شما متصل می‌کند."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "آماده برای اتصال"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "برای فعال کردن اتصال مستقیم از تنظیمات iPhone استفاده کنید."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "راه‌اندازی"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "باز کردن تنظیمات iPhone ← Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "هنگام فعال بودن OpenClaw از Wi-Fi یا شبکه سلولی استفاده می‌کند"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "باز کردن تنظیمات iPhone ← Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "فرمان برای بررسی"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "شما"
@@ -9499,6 +10024,11 @@
       "translated": "تأیید"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "بازبینی فرمان"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "رد کردن"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw نتوانست در Applications نصب شود. آن را به‌صورت دستی به آنجا منتقل کنید، سپس آن نسخه را باز کنید."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "OpenClaw در Applications نصب شود؟"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "نسخه قدیمی‌تر OpenClaw در Applications جایگزین شود؟"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw خود را در Applications کپی می‌کند و از آنجا دوباره باز می‌شود تا به‌روزرسانی‌ها و اجرا هنگام ورود قابل‌اعتماد بمانند."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw در Applications نصب شود؟"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "این نسخه جدیدتر از برنامه نصب‌شده است. OpenClaw آن را جایگزین می‌کند و از Applications دوباره باز می‌شود."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw خود را در Applications کپی می‌کند و از آنجا دوباره باز می‌شود تا به‌روزرسانی‌ها و اجرا هنگام ورود قابل‌اعتماد بمانند."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "میکروفون"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "فعال"
@@ -9954,6 +10494,11 @@
       "translated": "خطا"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "از سیستم خارج شدید و اعتبارنامه‌ها پاک شدند."
@@ -9964,14 +10509,14 @@
       "translated": "هیچ نشست WhatsApp یافت نشد."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "هیچ توکن Telegram پیکربندی نشده است."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "توکن Telegram پاک شد."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "هیچ توکن Telegram پیکربندی نشده است."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "پیکربندی"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "با استفاده از فرم مبتنی بر schema، فایل ~/.openclaw/openclaw.json را ویرایش کنید."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "این زبانه در حالت Nix فقط‌خواندنی است. پیکربندی را از طریق Nix ویرایش کنید و دوباره بسازید."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "با استفاده از فرم مبتنی بر schema، فایل ~/.openclaw/openclaw.json را ویرایش کنید."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "افت کیفیت: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "امروز"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "دستیار راه‌اندازی مبتنی بر هوش مصنوعی شما. می‌تواند وضعیت را بررسی کند، پیکربندی را اصلاح کند، "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "اگر اعلام ناموفق بود، کار را ناموفق نکنید"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Settings → Connection را بررسی کنید یا از Debug → Reset Remote Tunnel استفاده کنید، سپس دوباره تلاش کنید."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "خاتمه دادن به \\(listener.command) (\\(listener.pid))؟"
@@ -10754,9 +11314,9 @@
       "translated": "نوشتن گزارش عیب‌یابی چرخشی (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "یک گزارش چرخشی و فقط محلی را در مسیر ~/Library/Logs/OpenClaw/ می‌نویسد. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "پیوند عمیق مسدود شد"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "عامل OpenClaw اجرا شود؟"
@@ -11064,9 +11629,9 @@
       "translated": "الگو نمی‌تواند خالی باشد."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "فقط الگوهای مسیر. شامل '/', '~' یا '\\\\' باشد."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "ذخیره تأییدهای exec ممکن نشد. آخرین تنظیمات شناخته‌شده نمایش داده شده‌اند؛ تغییر را دوباره امتحان کنید."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "هنوز هیچ gatewayای پیدا نشده است."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "برای پر کردن هدف SSH، روی یک gateway کشف‌شده کلیک کنید."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "برای پر کردن URL gateway، روی یک gateway کشف‌شده کلیک کنید."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "برای پر کردن هدف SSH، روی یک gateway کشف‌شده کلیک کنید."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "کشف gatewayهای OpenClaw در LAN شما"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "پیوند نشده"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "راه‌اندازی پیشنهادی"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "از Tailscale Serve استفاده کنید تا Gateway یک گواهی HTTPS معتبر داشته باشد."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "برای دسترسی خصوصی پایدار، از Tailscale به‌همراه یک تونل SSH استفاده کنید."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "از Tailscale Serve استفاده کنید تا Gateway یک گواهی HTTPS معتبر داشته باشد."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "جلو"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - سنجهٔ زندهٔ بیدارباش صوتی فعال است"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "بازنشانی تونل راه‌دور"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "ثبت گزارش مفصل (اصلی): خاموش"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "ثبت گزارش مفصل (اصلی): روشن"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "ثبت گزارش مفصل (اصلی): خاموش"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "سطح تفصیل"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "ثبت گزارش در فایل: خاموش"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "ثبت گزارش در فایل: روشن"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "ثبت گزارش در فایل: خاموش"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "قطع شده (با استفاده از پیش‌فرض سیستم)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) نتوانست آزمایش را کامل کند. برای بررسی یا کپی خطا جزئیات را نمایش دهید."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "در حال جستجوی هوش مصنوعی‌ای که پیش‌تر استفاده می‌کنید…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "در انتظار پایان آزمایش قبلی هوش مصنوعی…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "در حال بررسی Claude Code، Codex، Gemini و کلیدهای API ذخیره‌شده."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "در حال جستجوی هوش مصنوعی‌ای که پیش‌تر استفاده می‌کنید…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw پیش از تغییر هر تنظیم استنتاج دوباره بررسی می‌کند."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "در حال بررسی Claude Code، Codex، Gemini و کلیدهای API ذخیره‌شده."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "کپی خطا"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "نکته: Tailscale را فعال نگه دارید تا gateway شما در دسترس بماند."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "نکته: از Tailscale Serve استفاده کنید تا gateway گواهی HTTPS معتبر داشته باشد."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "نکته: Tailscale را فعال نگه دارید تا gateway شما در دسترس بماند."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "از پنل + Canvas استفاده کنید"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "پنل نوار منو را برای چت سریع باز کنید؛ عامل می‌تواند پیش‌نمایش‌ها را نشان دهد "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "رد کردن"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "دستگاهی می‌خواهد به OpenClaw متصل شود."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "گره‌ای می‌خواهد به OpenClaw متصل شود."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "دستگاهی می‌خواهد به OpenClaw متصل شود."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "برنامه Mac OpenClaw"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "این دستگاه به تأیید جفت‌سازی نیاز دارد"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "توکن پیکربندی‌شده روی میزبان Gateway را جای‌گذاری کنید. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "`gateway.auth.token` یا `OPENCLAW_GATEWAY_TOKEN` را روی میزبان Gateway بررسی کنید و دوباره تلاش کنید."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "این Gateway روی احراز هویت با توکن تنظیم شده است، اما هیچ `gateway.auth.token` روی میزبان Gateway پیکربندی نشده است. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "یک کد راه‌اندازی تازه را از یک سرویس‌گیرنده OpenClaw که از قبل جفت‌سازی شده است اسکن یا جای‌گذاری کنید، سپس دوباره تلاش کنید."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "این جریان راه‌اندازی اولیه هنوز از احراز هویت با گذرواژه پشتیبانی نمی‌کند. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "این دستگاه را از یک سرویس‌گیرنده OpenClaw که از قبل جفت‌سازی شده است تأیید کنید. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "این Gateway از احراز هویت با گذرواژه استفاده می‌کند. راه‌اندازی اولیه از راه دور در macOS هنوز نمی‌تواند گذرواژه‌های Gateway را دریافت کند."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "جفت‌سازی لازم است. در یک کلاینت OpenClaw که از قبل جفت‌سازی شده است، "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "هنوز هیچ skillی گزارش نشده است"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "بدون صدا"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake به macOS 26 یا جدیدتر نیاز دارد"
@@ -14269,6 +14884,11 @@
       "translated": "پیش‌فرض سیستم"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "قطع شده (در حال استفاده از پیش‌فرض سیستم)"
@@ -14394,6 +15014,11 @@
       "translated": " (فیلترشده محلی)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "URL نامعتبر: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway متصل شد"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "توکن‌های ورودی: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "مصرف کانتکست"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "مصرف پیام"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "خروج از بایگانی"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "ارسال دوباره"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "راه‌اندازی"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -194,6 +194,11 @@
       "translated": "Mode conversation actif"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Micro : écoute"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Échec : impossible d’atteindre le point de terminaison sécurisé de la gateway pour cet hôte."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Cela supprime définitivement la tâche planifiée du Gateway."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Accès administrateur requis"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Les modifications cron nécessitent operator.admin. Les codes de configuration ne l'accordent volontairement pas. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Chemin facultatif"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Le gateway peut modifier ce chemin mais ne peut pas effacer un chemin existant."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "J"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "En ligne"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Autorisations"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Le code a peut-être expiré ou a été généré pour un autre Gateway."
@@ -1734,9 +1804,24 @@
       "translated": "L’authentification du Gateway doit être vérifiée. Vérifiez les paramètres du Gateway, puis réessayez."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Aucun modèle configuré"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sessions"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Rechercher des sessions"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Plus récents d'abord"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Plus anciens d'abord"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Disposition : détaillée"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Épingler"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Marquer comme non lu"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw peut recevoir les alertes sélectionnées."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Accordé"
@@ -2374,6 +2564,21 @@
       "translated": "Fonctionnalités du téléphone"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Autoriser l’accès à la photothèque."
@@ -2384,6 +2589,11 @@
       "translated": "Accès sélectionné ou complet aux photos accordé."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "La liste des applications reste sur ce téléphone."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw peut répertorier les applications visibles dans le lanceur."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Autoriser la localisation en arrière-plan ?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw vérifie la localisation uniquement lorsque votre Gateway appairée le demande. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Oublier le Gateway ?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "Ouvrir ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Vérifier"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Aucune limite signalée"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Désactivé"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Texte de la charge utile"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "AGENT ACTIF"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Aucun"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Conversations récentes"
@@ -3039,6 +3304,16 @@
       "translated": "Verrouillé"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count fournisseurs"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} prêts"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Aucune skill"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Conversation en temps réel"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Paramètres de conversation"
@@ -3594,6 +3874,11 @@
       "translated": "Cette image n’a pas pu être décodée."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} de plus"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Vous"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Supprimer"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Pièce jointe non prise en charge"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Prêt quand vous l’êtes"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw affichera ici les approbations, les tâches échouées et les problèmes de canaux."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Parle · en attente de réponse"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Envoi de la voix en file d’attente"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "Partage OpenClaw"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Appareil photo"
@@ -4284,9 +4619,9 @@
       "translated": "Microphone"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Pas encore de journal des rêves"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Le gateway n’a pas trouvé DREAMS.md ni dreams.md dans l’espace de travail de l’agent actif."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) existe, mais ne contient aucun contenu lisible."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Le gateway n’a pas trouvé DREAMS.md ni dreams.md dans l’espace de travail de l’agent actif."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Journal indisponible"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Connectez un gateway pour lire les entrées du journal des rêves."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Le gateway n’a pas renvoyé le contenu du journal des rêves."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Connectez un gateway pour lire les entrées du journal des rêves."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Aucun état de phase"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Connectez une Gateway pour charger les phases de rêve."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "La Gateway n’a pas renvoyé les détails des phases de rêve."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Connectez une Gateway pour charger les phases de rêve."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "aucune réparation nécessaire"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Aucune instance connectée"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Connectez une Gateway pour inspecter les instances connectées."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "La Gateway n’a signalé aucune entrée de présence système."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Connectez une Gateway pour inspecter les instances connectées."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Aucun signalement."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Planificateur"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Utilisation"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Aucune tâche planifiée"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Connectez un Gateway pour charger le travail planifié."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Le Gateway n’a aucune tâche cron visible."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Connectez un Gateway pour charger le travail planifié."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills indisponibles"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Connectez un gateway pour charger les Skills de l’espace de travail."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Essayez une autre recherche ou actualisez depuis le gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Connectez un gateway pour charger les Skills de l’espace de travail."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Renommer le groupe"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Activité"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Activité récente"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Activité de session hors ligne"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Connectez-vous au Gateway pour charger l’activité récente des chats."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Démarrez un chat et il apparaîtra ici."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Connectez-vous au Gateway pour charger l’activité récente des chats."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Ouvrir"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Aucune proposition chargée"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Connectez-vous depuis Réglages pour charger les propositions de Skill Workshop."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Les nouvelles propositions apparaîtront ici lorsque les agents rédigeront des skills."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Connectez-vous depuis Réglages pour charger les propositions de Skill Workshop."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Aucune carte chargée"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Connectez-vous depuis Réglages pour charger les cartes du workboard."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Créez une carte ou modifiez le filtre."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Connectez-vous depuis Réglages pour charger les cartes du workboard."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Choisissez quand OpenClaw peut partager la position de cet iPhone avec les outils du Gateway."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Oublier le Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "Réveil vocal"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Découvert"
@@ -6484,14 +6879,14 @@
       "translated": "Découvert • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Configuration mise en file d'attente pour la montre. Ouvrez OpenClaw avant l'expiration du code."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Configuration envoyée. Ouvrez OpenClaw sur la montre pour vous connecter."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Configuration mise en file d'attente pour la montre. Ouvrez OpenClaw avant l'expiration du code."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Non configuré"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Approbations"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Aucune action de Gateway n’est en attente de révision."
@@ -6659,14 +7064,14 @@
       "translated": "Examiner les actions du Gateway en attente."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Installez l'app OpenClaw pour la montre avant d'activer le mode direct."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Le relais reste disponible ; le mode direct ajoute un nœud Gateway indépendant."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Installez l'app OpenClaw pour la montre avant d'activer le mode direct."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Installé"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Paramètres de voix et de conversation"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Autorisation de Gateway requise"
@@ -7879,6 +8299,16 @@
       "translated": "Ouvrez les réglages si vous avez besoin d’un hôte manuel."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Faire confiance à cette Gateway ?"
@@ -8164,6 +8594,11 @@
       "translated": "Hors ligne"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Approbation"
@@ -8174,14 +8609,19 @@
       "translated": "Cette approbation a déjà été"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Cette approbation était déjà définie sur Toujours autoriser."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Approbation définie sur Toujours autoriser."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Cette approbation était déjà définie sur Toujours autoriser."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Nécessite votre attention"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Prêt à se connecter"
@@ -8299,14 +8744,14 @@
       "translated": "Lien de configuration"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Le texte en clair peut exposer les identifiants. Continuez uniquement si vous faites confiance à ce réseau local et à cet hôte."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Vérifiez ce point de terminaison. Les identifiants ne sont appliqués qu’après avoir touché Connecter."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Le texte en clair peut exposer les identifiants. Continuez uniquement si vous faites confiance à ce réseau local et à cet hôte."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Copier la commande du code de configuration"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Se connecter"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Parler"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway par défaut"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Ouvrir les paramètres du Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Non vérifié"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Échec du chargement"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Erreur de chat"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Approuvez cette demande sur votre gateway. Talk démarrera automatiquement une fois l’approbation reçue."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Cet appareil doit être approuvé par la gateway avant que Talk puisse utiliser la voix en temps réel. L’audio passera directement de "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw connecte cette Apple Watch directement à votre Gateway sur les réseaux locaux de confiance."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Prêt à se connecter"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Utilisez les réglages de l'iPhone pour activer la connexion directe."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Configuration"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Ouvrir les réglages de l'iPhone → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Utilise le Wi-Fi ou le réseau cellulaire lorsque OpenClaw est actif"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Ouvrir les réglages de l'iPhone → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Commande à examiner"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Vous"
@@ -9499,6 +10024,11 @@
       "translated": "Approbation"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Vérifier la commande"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Refuser"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw n’a pas pu être installé dans Applications. Déplacez-le là manuellement, puis ouvrez cette copie."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "Installer OpenClaw dans Applications ?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Remplacer l’ancienne version d’OpenClaw dans Applications ?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw va se copier dans Applications et se rouvrir depuis cet emplacement pour garantir la fiabilité des mises à jour et du lancement à l’ouverture de session."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Installer OpenClaw dans Applications ?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Cette copie est plus récente que l’application installée. OpenClaw va la remplacer et se rouvrir depuis Applications."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw va se copier dans Applications et se rouvrir depuis cet emplacement pour garantir la fiabilité des mises à jour et du lancement à l’ouverture de session."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Microphone"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Activé"
@@ -9954,6 +10494,11 @@
       "translated": "Erreur"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Déconnecté et identifiants effacés."
@@ -9964,14 +10509,14 @@
       "translated": "Aucune session WhatsApp trouvée."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Aucun jeton Telegram configuré."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Jeton Telegram effacé."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Aucun jeton Telegram configuré."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Configuration"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Modifiez ~/.openclaw/openclaw.json à l’aide du formulaire basé sur le schéma."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Cet onglet est en lecture seule en mode Nix. Modifiez la configuration via Nix et recompilez."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Modifiez ~/.openclaw/openclaw.json à l’aide du formulaire basé sur le schéma."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "dégradé : \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Aujourd’hui"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Votre assistant de configuration alimenté par l'IA. Il peut vérifier le statut, corriger la config, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Ne pas faire échouer la tâche si l’annonce échoue"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Vérifiez Réglages → Connexion ou utilisez Débogage → Réinitialiser le tunnel distant, puis réessayez."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Arrêter \\(listener.command) (\\(listener.pid)) ?"
@@ -10754,9 +11314,9 @@
       "translated": "Écrire un journal de diagnostic rotatif (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Écrit un journal rotatif, local uniquement, sous ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Lien profond bloqué"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "Exécuter l’agent OpenClaw ?"
@@ -11064,9 +11629,9 @@
       "translated": "Le motif ne peut pas être vide."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Motifs de chemin uniquement. Incluez '/', '~' ou '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Impossible d'enregistrer les approbations exec. Les derniers paramètres connus sont affichés ; réessayez la modification."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Aucun Gateway trouvé pour le moment."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Cliquez sur un Gateway détecté pour renseigner la cible SSH."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Cliquez sur un Gateway détecté pour renseigner l’URL du Gateway."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Cliquez sur un Gateway détecté pour renseigner la cible SSH."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "Découvrir les gateways OpenClaw sur votre LAN"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "non lié"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Configuration recommandée"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Utilisez Tailscale Serve afin que le Gateway dispose d’un certificat HTTPS valide."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Utilisez Tailscale avec un tunnel SSH pour un accès privé stable."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Utilisez Tailscale Serve afin que le Gateway dispose d’un certificat HTTPS valide."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Suivant"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - indicateur en direct de Voice Wake actif"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Réinitialiser le tunnel distant"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Journalisation détaillée (Main) : désactivée"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Journalisation détaillée (Main) : activée"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Journalisation détaillée (Main) : désactivée"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Niveau de détail"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Journalisation dans un fichier : désactivée"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Journalisation dans un fichier : activée"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Journalisation dans un fichier : désactivée"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Déconnecté (utilisation de la valeur par défaut du système)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) n'a pas pu terminer le test. Affichez les détails pour inspecter ou copier l'erreur."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Recherche d'une IA que vous utilisez déjà…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "En attente de la fin du test IA précédent…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Recherche de Claude Code, Codex, Gemini et des clés API enregistrées."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Recherche d'une IA que vous utilisez déjà…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw vérifiera à nouveau avant de modifier les paramètres d'inférence."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Recherche de Claude Code, Codex, Gemini et des clés API enregistrées."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Copier l'erreur"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Conseil : gardez Tailscale activé afin que votre gateway reste joignable."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Conseil : utilisez Tailscale Serve afin que la gateway dispose d’un certificat HTTPS valide."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Conseil : gardez Tailscale activé afin que votre gateway reste joignable."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Utiliser le panneau + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Ouvrez le panneau de la barre de menus pour discuter rapidement ; l’agent peut afficher des aperçus "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Rejeter"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Un appareil souhaite se connecter à OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Un nœud souhaite se connecter à OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Un appareil souhaite se connecter à OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "Application OpenClaw pour Mac"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Cet appareil nécessite une approbation d’appairage"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Collez le jeton configuré sur l’hôte Gateway. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Vérifiez `gateway.auth.token` ou `OPENCLAW_GATEWAY_TOKEN` sur l’hôte Gateway, puis réessayez."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Ce Gateway est configuré pour l’authentification par jeton, mais aucun `gateway.auth.token` n’est configuré sur l’hôte Gateway. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Scannez ou collez un nouveau code de configuration depuis un client OpenClaw déjà appairé, puis réessayez."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Ce parcours d’intégration ne prend pas encore en charge l’authentification par mot de passe. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Approuvez cet appareil depuis un client OpenClaw déjà appairé. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Ce Gateway utilise l’authentification par mot de passe. L’intégration à distance sur macOS ne peut pas encore collecter les mots de passe du Gateway."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Appairage requis. Dans un client OpenClaw déjà appairé, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Aucun skill signalé pour le moment"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Aucun son"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake nécessite macOS 26 ou une version plus récente"
@@ -14269,6 +14884,11 @@
       "translated": "Valeur par défaut du système"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Déconnecté (utilisation de la valeur par défaut du système)"
@@ -14394,6 +15014,11 @@
       "translated": " (filtré localement)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "URL invalide : \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway connecté"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Jetons d’entrée : \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Utilisation du contexte"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Utilisation des messages"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Désarchiver"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Réessayer l’envoi"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Configuration"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -194,6 +194,11 @@
       "translated": "टॉक मोड सक्रिय"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · माइक: सुन रहा है"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "विफल: इस होस्ट के लिए सुरक्षित gateway endpoint तक नहीं पहुँचा जा सका।"
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "यह अनुसूचित job को gateway से स्थायी रूप से हटा देता है।"
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Admin एक्सेस आवश्यक"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Cron परिवर्तनों के लिए operator.admin आवश्यक है। Setup codes जानबूझकर इसे प्रदान नहीं करते। "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "वैकल्पिक पथ"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "गेटवे इस पथ को बदल सकता है लेकिन मौजूदा पथ को हटा नहीं सकता।"
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "ऑनलाइन"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "अनुमतियाँ"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "कोड की समय-सीमा समाप्त हो गई हो सकती है या यह किसी अन्य Gateway के लिए जनरेट किया गया हो सकता है।"
@@ -1734,9 +1804,24 @@
       "translated": "Gateway प्रमाणीकरण की समीक्षा आवश्यक है। gateway सेटिंग्स जाँचें, फिर पुनः प्रयास करें।"
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "कोई कॉन्फ़िगर किए गए मॉडल नहीं"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "सत्र"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "सत्र खोजें"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "सबसे नए पहले"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "सबसे पुराने पहले"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "लेआउट: विस्तृत"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "पिन करें"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "अपठित चिह्नित करें"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw चयनित अलर्ट प्राप्त कर सकता है।"
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "अनुमति दी गई"
@@ -2374,6 +2564,21 @@
       "translated": "फ़ोन क्षमताएँ"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "फ़ोटो लाइब्रेरी एक्सेस की अनुमति दें।"
@@ -2384,6 +2589,11 @@
       "translated": "चयनित या पूर्ण फ़ोटो एक्सेस दी गई।"
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "ऐप सूची इसी फ़ोन पर रहती है।"
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw लॉन्चर में दिखाई देने वाले ऐप्स की सूची बना सकता है।"
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "बैकग्राउंड स्थान की अनुमति दें?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw केवल तब स्थान जांचता है जब आपका पेयर किया गया Gateway इसका अनुरोध करता है। "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Gateway भूलें?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "${license.title} खोलें"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "जाँचें"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "कोई सीमा रिपोर्ट नहीं की गई"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "बंद"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "पेलोड टेक्स्ट"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "सक्रिय एजेंट"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "कोई नहीं"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "हाल की बातचीत"
@@ -3039,6 +3304,16 @@
       "translated": "लॉक किया गया"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count प्रदाता"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} तैयार"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "कोई Skills नहीं"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "रीयलटाइम टॉक"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "टॉक सेटिंग्स"
@@ -3594,6 +3874,11 @@
       "translated": "इस इमेज को डिकोड नहीं किया जा सका."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} और"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "आप"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "हटाएँ"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "असमर्थित अटैचमेंट"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "जब आप तैयार हों"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw अनुमोदन, विफल जॉब्स और चैनल समस्याएँ यहाँ दिखाएगा।"
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "बोल रहा है · जवाब का इंतज़ार है"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "कतार में लगी आवाज़ भेजी जा रही है"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "कैमरा"
@@ -4284,9 +4619,9 @@
       "translated": "माइक्रोफ़ोन"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "अभी तक कोई ड्रीम डायरी नहीं"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "gateway को सक्रिय एजेंट वर्कस्पेस में DREAMS.md या dreams.md नहीं मिला।"
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) मौजूद है लेकिन उसमें पढ़ने योग्य सामग्री नहीं है।"
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "gateway को सक्रिय एजेंट वर्कस्पेस में DREAMS.md या dreams.md नहीं मिला।"
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "डायरी उपलब्ध नहीं है"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "ड्रीम डायरी प्रविष्टियाँ पढ़ने के लिए gateway कनेक्ट करें।"
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "gateway ने ड्रीम डायरी सामग्री नहीं लौटाई।"
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "ड्रीम डायरी प्रविष्टियाँ पढ़ने के लिए gateway कनेक्ट करें।"
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "कोई चरण स्थिति नहीं"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "ड्रीमिंग चरण लोड करने के लिए Gateway कनेक्ट करें।"
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway ने ड्रीमिंग चरण विवरण वापस नहीं किया।"
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "ड्रीमिंग चरण लोड करने के लिए Gateway कनेक्ट करें।"
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "सुधार की आवश्यकता नहीं"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "कोई इंस्टेंस कनेक्टेड नहीं"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "कनेक्टेड इंस्टेंस का निरीक्षण करने के लिए Gateway कनेक्ट करें।"
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway ने कोई सिस्टम उपस्थिति प्रविष्टि रिपोर्ट नहीं की।"
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "कनेक्टेड इंस्टेंस का निरीक्षण करने के लिए Gateway कनेक्ट करें।"
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "कुछ रिपोर्ट नहीं किया गया।"
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "शेड्यूलर"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "उपयोग"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "कोई शेड्यूल किए गए जॉब नहीं"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "शेड्यूल किया गया काम लोड करने के लिए Gateway कनेक्ट करें।"
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Gateway में कोई दृश्यमान cron जॉब नहीं है।"
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "शेड्यूल किया गया काम लोड करने के लिए Gateway कनेक्ट करें।"
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills उपलब्ध नहीं हैं"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "workspace skills लोड करने के लिए gateway कनेक्ट करें।"
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "कोई अलग खोज आज़माएँ या gateway से रीफ़्रेश करें।"
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "workspace skills लोड करने के लिए gateway कनेक्ट करें।"
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "समूह का नाम बदलें"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "गतिविधि"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "हाल की गतिविधि"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "सत्र गतिविधि ऑफ़लाइन है"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "हाल की चैट गतिविधि लोड करने के लिए Gateway से कनेक्ट करें।"
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "चैट शुरू करें और वह यहाँ दिखाई देगी।"
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "हाल की चैट गतिविधि लोड करने के लिए Gateway से कनेक्ट करें।"
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "खोलें"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "कोई प्रस्ताव लोड नहीं हुआ"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Skill Workshop प्रस्ताव लोड करने के लिए Settings से कनेक्ट करें."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "जब एजेंट Skills का ड्राफ़्ट बनाएंगे, तो नए प्रस्ताव यहाँ दिखाई देंगे."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Skill Workshop प्रस्ताव लोड करने के लिए Settings से कनेक्ट करें."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "कोई कार्ड लोड नहीं हुआ"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "वर्कबोर्ड कार्ड लोड करने के लिए Settings से कनेक्ट करें।"
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "कार्ड बनाएं या फ़िल्टर बदलें।"
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "वर्कबोर्ड कार्ड लोड करने के लिए Settings से कनेक्ट करें।"
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "चुनें कि OpenClaw कब इस iPhone का स्थान gateway टूल के साथ साझा कर सकता है।"
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Gateway भूल जाएँ"
@@ -6474,6 +6864,11 @@
       "translated": "वॉइस वेक"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "खोजा गया"
@@ -6484,14 +6879,14 @@
       "translated": "खोजा गया • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "watch के लिए सेटअप कतारबद्ध है। कोड समाप्त होने से पहले OpenClaw खोलें।"
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "सेटअप भेजा गया। कनेक्ट करने के लिए watch पर OpenClaw खोलें।"
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "watch के लिए सेटअप कतारबद्ध है। कोड समाप्त होने से पहले OpenClaw खोलें।"
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "कॉन्फ़िगर नहीं किया गया"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "अनुमोदन"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "समीक्षा के लिए कोई Gateway कार्रवाई प्रतीक्षा में नहीं है।"
@@ -6659,14 +7064,14 @@
       "translated": "लंबित gateway क्रियाओं की समीक्षा करें।"
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "डायरेक्ट मोड सक्षम करने से पहले OpenClaw watch ऐप इंस्टॉल करें।"
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "रिले उपलब्ध रहता है; डायरेक्ट मोड एक स्वतंत्र Gateway नोड जोड़ता है।"
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "डायरेक्ट मोड सक्षम करने से पहले OpenClaw watch ऐप इंस्टॉल करें।"
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "इंस्टॉल किया गया"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "वॉइस और बातचीत सेटिंग्स"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Gateway अनुमति आवश्यक है"
@@ -7879,6 +8299,16 @@
       "translated": "यदि आपको मैन्युअल होस्ट चाहिए, तो Settings खोलें।"
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "इस gateway पर भरोसा करें?"
@@ -8164,6 +8594,11 @@
       "translated": "ऑफ़लाइन"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "अनुमोदन"
@@ -8174,14 +8609,19 @@
       "translated": "यह अनुमोदन पहले ही"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "यह अनुमोदन पहले ही हमेशा अनुमति दें पर सेट किया गया था।"
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "अनुमोदन को हमेशा अनुमति दें पर सेट किया गया।"
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "यह अनुमोदन पहले ही हमेशा अनुमति दें पर सेट किया गया था।"
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "ध्यान देने की आवश्यकता है"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "कनेक्ट करने के लिए तैयार"
@@ -8299,14 +8744,14 @@
       "translated": "सेटअप लिंक"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "सादा टेक्स्ट क्रेडेंशियल्स को उजागर कर सकता है। केवल तभी जारी रखें जब आप इस स्थानीय नेटवर्क और होस्ट पर भरोसा करते हों।"
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "इस एंडपॉइंट की समीक्षा करें। क्रेडेंशियल्स केवल तब लागू होते हैं जब आप Connect पर टैप करते हैं।"
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "सादा टेक्स्ट क्रेडेंशियल्स को उजागर कर सकता है। केवल तभी जारी रखें जब आप इस स्थानीय नेटवर्क और होस्ट पर भरोसा करते हों।"
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "सेटअप कोड कमांड कॉपी करें"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "कनेक्ट करें"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "बात करें"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway डिफ़ॉल्ट"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Gateway सेटिंग्स खोलें"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "जाँचा नहीं गया"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "लोड विफल"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "चैट त्रुटि"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "अपने gateway पर इस अनुरोध को स्वीकृत करें। स्वीकृति मिलते ही Talk अपने-आप शुरू हो जाएगा।"
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Talk द्वारा realtime voice का उपयोग करने से पहले इस device को gateway स्वीकृति चाहिए। Audio सीधे जाएगा "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw इस Apple Watch को विश्वसनीय लोकल नेटवर्क पर सीधे आपके Gateway से कनेक्ट करता है।"
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "कनेक्ट करने के लिए तैयार"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "सीधा कनेक्शन सक्षम करने के लिए iPhone सेटिंग्स का उपयोग करें।"
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "सेटअप"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "iPhone सेटिंग्स → Apple Watch खोलें"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "OpenClaw सक्रिय होने पर Wi-Fi या सेल्युलर का उपयोग करता है"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "iPhone सेटिंग्स → Apple Watch खोलें"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "समीक्षा करने के लिए कमांड"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "आप"
@@ -9499,6 +10024,11 @@
       "translated": "मंज़ूरी"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "कमांड की समीक्षा करें"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "अस्वीकार करें"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw को Applications में इंस्टॉल नहीं किया जा सका। इसे मैन्युअल रूप से वहां ले जाएं, फिर उस कॉपी को खोलें।"
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "OpenClaw को Applications में इंस्टॉल करें?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Applications में पुराने OpenClaw को बदलें?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw खुद को Applications में कॉपी करेगा और वहां से फिर से खुलेगा ताकि अपडेट और लॉगिन पर लॉन्च विश्वसनीय बने रहें।"
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw को Applications में इंस्टॉल करें?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "यह कॉपी इंस्टॉल किए गए ऐप से नई है। OpenClaw इसे बदल देगा और Applications से फिर से खुलेगा।"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw खुद को Applications में कॉपी करेगा और वहां से फिर से खुलेगा ताकि अपडेट और लॉगिन पर लॉन्च विश्वसनीय बने रहें।"
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "माइक्रोफ़ोन"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "सक्षम"
@@ -9954,6 +10494,11 @@
       "translated": "त्रुटि"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "लॉग आउट किया गया और क्रेडेंशियल साफ़ कर दिए गए।"
@@ -9964,14 +10509,14 @@
       "translated": "कोई WhatsApp सत्र नहीं मिला।"
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "कोई Telegram टोकन कॉन्फ़िगर नहीं किया गया है।"
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Telegram टोकन साफ़ कर दिया गया।"
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "कोई Telegram टोकन कॉन्फ़िगर नहीं किया गया है।"
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "कॉन्फ़िग"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "schema-driven फ़ॉर्म का उपयोग करके ~/.openclaw/openclaw.json संपादित करें।"
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "यह टैब Nix मोड में केवल-पढ़ने योग्य है। Nix के माध्यम से कॉन्फ़िग संपादित करें और फिर से बिल्ड करें।"
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "schema-driven फ़ॉर्म का उपयोग करके ~/.openclaw/openclaw.json संपादित करें।"
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "क्षीण: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "आज"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "आपका AI-संचालित सेटअप सहायक। यह स्थिति जांच सकता है, config ठीक कर सकता है, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "यदि घोषणा विफल हो जाए तो जॉब को विफल न करें"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Settings → Connection जांचें या Debug → Reset Remote Tunnel का उपयोग करें, फिर पुनः प्रयास करें।"
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) को समाप्त करें?"
@@ -10754,9 +11314,9 @@
       "translated": "रोलिंग डायग्नोस्टिक्स लॉग (JSONL) लिखें"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "~/Library/Logs/OpenClaw/ के अंतर्गत एक रोटेटिंग, केवल-लोकल लॉग लिखता है. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "डीप लिंक अवरुद्ध किया गया"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "OpenClaw एजेंट चलाएँ?"
@@ -11064,9 +11629,9 @@
       "translated": "पैटर्न खाली नहीं हो सकता।"
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "केवल पाथ पैटर्न। '/', '~', या '\\\\' शामिल करें।"
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Exec अनुमोदन सहेजे नहीं जा सके। अंतिम ज्ञात सेटिंग्स दिखाई गई हैं; परिवर्तन पुनः प्रयास करें।"
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "अभी तक कोई gateways नहीं मिले।"
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "SSH target भरने के लिए किसी खोजे गए gateway पर क्लिक करें।"
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "gateway URL भरने के लिए किसी खोजे गए gateway पर क्लिक करें।"
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "SSH target भरने के लिए किसी खोजे गए gateway पर क्लिक करें।"
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "अपने LAN पर OpenClaw gateways खोजें"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "लिंक नहीं किया गया"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "अनुशंसित सेटअप"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Tailscale Serve का उपयोग करें ताकि gateway के पास एक मान्य HTTPS प्रमाणपत्र हो।"
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "स्थिर निजी पहुँच के लिए Tailscale और SSH tunnel का उपयोग करें।"
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Tailscale Serve का उपयोग करें ताकि gateway के पास एक मान्य HTTPS प्रमाणपत्र हो।"
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "आगे"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - Voice Wake लाइव मीटर सक्रिय"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "रिमोट टनल रीसेट करें"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Verbose Logging (Main): बंद"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Verbose Logging (Main): चालू"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Verbose Logging (Main): बंद"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "वर्बोसिटी"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "फ़ाइल लॉगिंग: बंद"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "फ़ाइल लॉगिंग: चालू"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "फ़ाइल लॉगिंग: बंद"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "डिस्कनेक्टेड (System default का उपयोग कर रहा है)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) परीक्षण पूरा नहीं कर सका। त्रुटि का निरीक्षण या कॉपी करने के लिए विवरण दिखाएँ।"
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "आपके पहले से उपयोग किए जा रहे AI की खोज हो रही है…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "पिछले AI परीक्षण के समाप्त होने की प्रतीक्षा हो रही है…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Claude Code, Codex, Gemini, और सहेजी गई API कुंजियों की जाँच हो रही है।"
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "आपके पहले से उपयोग किए जा रहे AI की खोज हो रही है…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "किसी भी inference सेटिंग को बदलने से पहले OpenClaw फिर से जाँच करेगा।"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Claude Code, Codex, Gemini, और सहेजी गई API कुंजियों की जाँच हो रही है।"
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "त्रुटि कॉपी करें"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "सुझाव: Tailscale सक्षम रखें ताकि आपका gateway पहुँच योग्य बना रहे."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "सुझाव: Tailscale Serve का उपयोग करें ताकि gateway के पास मान्य HTTPS cert हो."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "सुझाव: Tailscale सक्षम रखें ताकि आपका gateway पहुँच योग्य बना रहे."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "पैनल + Canvas का उपयोग करें"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "त्वरित चैट के लिए मेनू बार पैनल खोलें; एजेंट पूर्वावलोकन दिखा सकता है "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "अस्वीकार करें"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "एक डिवाइस OpenClaw से कनेक्ट करना चाहता है।"
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "एक नोड OpenClaw से कनेक्ट करना चाहता है।"
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "एक डिवाइस OpenClaw से कनेक्ट करना चाहता है।"
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "OpenClaw Mac ऐप"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "इस device को pairing approval की आवश्यकता है"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "gateway host पर कॉन्फ़िगर किया गया token पेस्ट करें। "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "gateway host पर `gateway.auth.token` या `OPENCLAW_GATEWAY_TOKEN` जाँचें और फिर से प्रयास करें।"
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "यह gateway token auth पर सेट है, लेकिन gateway host पर कोई `gateway.auth.token` कॉन्फ़िगर नहीं है। "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "पहले से paired OpenClaw client से एक नया setup code स्कैन या पेस्ट करें, फिर दोबारा प्रयास करें।"
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "यह onboarding flow अभी password auth का समर्थन नहीं करता। "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "पहले से paired OpenClaw client से इस device को approve करें। "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "यह gateway password auth का उपयोग करता है। macOS पर remote onboarding अभी gateway passwords collect नहीं कर सकता।"
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "पेयरिंग आवश्यक है। पहले से पेयर किए गए OpenClaw क्लाइंट में, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "अभी तक कोई Skills रिपोर्ट नहीं हुई हैं"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "कोई ध्वनि नहीं"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake के लिए macOS 26 या उससे नया आवश्यक है"
@@ -14269,6 +14884,11 @@
       "translated": "सिस्टम डिफ़ॉल्ट"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "डिस्कनेक्टेड (सिस्टम डिफ़ॉल्ट का उपयोग कर रहा है)"
@@ -14394,6 +15014,11 @@
       "translated": " (स्थानीय फ़िल्टर किया गया)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "अमान्य URL: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway कनेक्ट हो गया"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "इनपुट टोकन: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Context उपयोग"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "संदेश उपयोग"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "संग्रह से हटाएं"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "फिर से भेजें"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "सेटअप"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -194,6 +194,11 @@
       "translated": "Mode bicara aktif"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Mikrofon: Mendengarkan"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Gagal: tidak dapat menjangkau endpoint gateway aman untuk host ini."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Ini menghapus job terjadwal secara permanen dari gateway."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Akses admin diperlukan"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Perubahan cron memerlukan operator.admin. Kode penyiapan sengaja tidak memberikannya. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Jalur opsional"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Gateway dapat mengubah jalur ini tetapi tidak dapat menghapus jalur yang sudah ada."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Online"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Izin"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Kode mungkin telah kedaluwarsa atau dibuat untuk Gateway lain."
@@ -1734,9 +1804,24 @@
       "translated": "Autentikasi Gateway perlu ditinjau. Periksa setelan gateway, lalu coba lagi."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Tidak ada model yang dikonfigurasi"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sesi"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Cari sesi"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Terbaru dahulu"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Terlama dahulu"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Tata letak: Terperinci"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Sematkan"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Tandai sebagai belum dibaca"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw dapat menerima peringatan yang dipilih."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Diberikan"
@@ -2374,6 +2564,21 @@
       "translated": "Kemampuan Ponsel"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Izinkan akses pustaka foto."
@@ -2384,6 +2589,11 @@
       "translated": "Akses foto yang dipilih atau penuh telah diberikan."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "Daftar aplikasi tetap berada di ponsel ini."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw dapat menampilkan daftar aplikasi yang terlihat di launcher."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Izinkan lokasi latar belakang?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw hanya memeriksa lokasi saat Gateway yang dipasangkan meminta hal tersebut. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Lupakan gateway?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "Buka ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Periksa"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Tidak ada batas yang dilaporkan"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Nonaktif"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Teks Payload"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "AGEN AKTIF"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Tidak ada"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Percakapan terbaru"
@@ -3039,6 +3304,16 @@
       "translated": "Terkunci"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count provider"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} siap"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Tidak ada Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Bicara Realtime"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Pengaturan bicara"
@@ -3594,6 +3874,11 @@
       "translated": "Gambar ini tidak dapat didekode."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} lagi"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Anda"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Hapus"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Lampiran tidak didukung"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Siap saat Anda siap"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw akan menampilkan persetujuan, pekerjaan yang gagal, dan masalah saluran di sini."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Berbicara · menunggu balasan"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Mengirim suara dalam antrean"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Kamera"
@@ -4284,9 +4619,9 @@
       "translated": "Mikrofon"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Belum ada dream diary"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Gateway tidak menemukan DREAMS.md atau dreams.md di workspace agen aktif."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) ada tetapi tidak memiliki konten yang dapat dibaca."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Gateway tidak menemukan DREAMS.md atau dreams.md di workspace agen aktif."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Diary tidak tersedia"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Hubungkan gateway untuk membaca entri dream diary."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Gateway tidak mengembalikan konten dream diary."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Hubungkan gateway untuk membaca entri dream diary."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Tidak ada status fase"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Hubungkan Gateway untuk memuat fase dreaming."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway tidak mengembalikan detail fase dreaming."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Hubungkan Gateway untuk memuat fase dreaming."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "tidak perlu perbaikan"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Tidak ada instans yang terhubung"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Hubungkan Gateway untuk memeriksa instans yang terhubung."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway tidak melaporkan entri kehadiran sistem apa pun."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Hubungkan Gateway untuk memeriksa instans yang terhubung."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Tidak ada yang dilaporkan."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Penjadwal"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Penggunaan"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Tidak ada pekerjaan terjadwal"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Hubungkan gateway untuk memuat pekerjaan terjadwal."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Gateway tidak memiliki cron job yang terlihat."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Hubungkan gateway untuk memuat pekerjaan terjadwal."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills tidak tersedia"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Hubungkan gateway untuk memuat skills workspace."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Coba pencarian lain atau segarkan dari gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Hubungkan gateway untuk memuat skills workspace."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Ganti Nama Grup"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Aktivitas"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Aktivitas terbaru"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Aktivitas sesi offline"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Hubungkan ke gateway untuk memuat aktivitas chat terbaru."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Mulai chat dan akan muncul di sini."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Hubungkan ke gateway untuk memuat aktivitas chat terbaru."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Buka"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Belum ada proposal yang dimuat"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Hubungkan dari Settings untuk memuat proposal Skill Workshop."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Proposal baru akan muncul di sini saat agen menyusun skill."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Hubungkan dari Settings untuk memuat proposal Skill Workshop."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Tidak ada kartu yang dimuat"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Hubungkan dari Pengaturan untuk memuat kartu workboard."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Buat kartu atau ubah filter."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Hubungkan dari Pengaturan untuk memuat kartu workboard."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Pilih kapan OpenClaw boleh membagikan lokasi iPhone ini dengan alat gateway."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Lupakan Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "Bangun dengan Suara"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Ditemukan"
@@ -6484,14 +6879,14 @@
       "translated": "Ditemukan • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Penyiapan diantrekan untuk jam tangan. Buka OpenClaw sebelum kode kedaluwarsa."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Penyiapan terkirim. Buka OpenClaw di jam tangan untuk terhubung."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Penyiapan diantrekan untuk jam tangan. Buka OpenClaw sebelum kode kedaluwarsa."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Belum dikonfigurasi"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Persetujuan"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Tidak ada tindakan gateway yang menunggu ditinjau."
@@ -6659,14 +7064,14 @@
       "translated": "Tinjau tindakan gateway yang tertunda."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Instal aplikasi jam tangan OpenClaw sebelum mengaktifkan mode langsung."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Relay tetap tersedia; mode langsung menambahkan node Gateway independen."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Instal aplikasi jam tangan OpenClaw sebelum mengaktifkan mode langsung."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Terpasang"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Pengaturan Suara & Bicara"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Izin Gateway diperlukan"
@@ -7879,6 +8299,16 @@
       "translated": "Buka Pengaturan jika Anda memerlukan host manual."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Percayai gateway ini?"
@@ -8164,6 +8594,11 @@
       "translated": "Offline"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Persetujuan"
@@ -8174,14 +8609,19 @@
       "translated": "Persetujuan ini sudah"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Persetujuan ini sudah diatur ke Selalu Izinkan."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Persetujuan diatur ke Selalu Izinkan."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Persetujuan ini sudah diatur ke Selalu Izinkan."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Perlu perhatian"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Siap Terhubung"
@@ -8299,14 +8744,14 @@
       "translated": "Tautan Pengaturan"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Teks biasa dapat mengekspos kredensial. Lanjutkan hanya jika Anda memercayai jaringan lokal dan host ini."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Tinjau endpoint ini. Kredensial hanya diterapkan setelah Anda mengetuk Hubungkan."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Teks biasa dapat mengekspos kredensial. Lanjutkan hanya jika Anda memercayai jaringan lokal dan host ini."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Salin perintah kode penyiapan"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Hubungkan"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Bicara"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Default Gateway"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Buka Pengaturan Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Belum diperiksa"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Gagal memuat"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Kesalahan chat"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Setujui permintaan ini di gateway Anda. Talk akan dimulai otomatis saat persetujuan diterima."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Perangkat ini memerlukan persetujuan gateway sebelum Talk dapat menggunakan suara real-time. Audio akan langsung dikirim dari "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw menyambungkan Apple Watch ini langsung ke Gateway Anda di jaringan lokal tepercaya."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Siap disambungkan"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Gunakan Pengaturan iPhone untuk mengaktifkan koneksi langsung."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Penyiapan"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Buka Pengaturan iPhone → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Menggunakan Wi-Fi atau seluler saat OpenClaw aktif"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Buka Pengaturan iPhone → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Perintah untuk ditinjau"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Anda"
@@ -9499,6 +10024,11 @@
       "translated": "Persetujuan"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Tinjau Perintah"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Tolak"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw tidak dapat diinstal di Applications. Pindahkan ke sana secara manual, lalu buka salinan tersebut."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "Instal OpenClaw di Applications?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Ganti OpenClaw yang lebih lama di Applications?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw akan menyalin dirinya ke Applications dan membuka kembali di sana agar pembaruan dan peluncuran saat login tetap andal."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Instal OpenClaw di Applications?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Salinan ini lebih baru daripada aplikasi yang terinstal. OpenClaw akan menggantinya dan membuka kembali dari Applications."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw akan menyalin dirinya ke Applications dan membuka kembali di sana agar pembaruan dan peluncuran saat login tetap andal."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Mikrofon"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Diaktifkan"
@@ -9954,6 +10494,11 @@
       "translated": "Kesalahan"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Telah keluar dan kredensial dihapus."
@@ -9964,14 +10509,14 @@
       "translated": "Tidak ada sesi WhatsApp yang ditemukan."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Tidak ada token Telegram yang dikonfigurasi."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Token Telegram dihapus."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Tidak ada token Telegram yang dikonfigurasi."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Config"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Edit ~/.openclaw/openclaw.json menggunakan formulir berbasis skema."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Tab ini hanya-baca dalam mode Nix. Edit config melalui Nix dan bangun ulang."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Edit ~/.openclaw/openclaw.json menggunakan formulir berbasis skema."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "menurun: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Hari ini"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Asisten penyiapan bertenaga AI Anda. Dapat memeriksa status, memperbaiki konfigurasi, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Jangan gagalkan tugas jika pengumuman gagal"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Periksa Settings → Connection atau gunakan Debug → Reset Remote Tunnel, lalu coba lagi."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Hentikan \\(listener.command) (\\(listener.pid))?"
@@ -10754,9 +11314,9 @@
       "translated": "Tulis log diagnostik bergulir (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Menulis log berotasi, hanya lokal, di bawah ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Deep link diblokir"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "Jalankan agen OpenClaw?"
@@ -11064,9 +11629,9 @@
       "translated": "Pola tidak boleh kosong."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Hanya pola path. Sertakan '/', '~', atau '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Tidak dapat menyimpan persetujuan exec. Pengaturan terakhir yang diketahui ditampilkan; coba lagi perubahannya."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Belum ada gateway yang ditemukan."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Klik gateway yang ditemukan untuk mengisi target SSH."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Klik gateway yang ditemukan untuk mengisi URL gateway."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Klik gateway yang ditemukan untuk mengisi target SSH."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "Temukan gateway OpenClaw di LAN Anda"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "belum ditautkan"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Pengaturan yang disarankan"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Gunakan Tailscale Serve agar gateway memiliki sertifikat HTTPS yang valid."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Gunakan Tailscale plus tunnel SSH untuk akses privat yang stabil."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Gunakan Tailscale Serve agar gateway memiliki sertifikat HTTPS yang valid."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Maju"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - meter langsung Voice Wake aktif"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Atur Ulang Tunnel Jarak Jauh"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Logging Verbose (Utama): Nonaktif"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Logging Verbose (Utama): Aktif"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Logging Verbose (Utama): Nonaktif"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Verbosity"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Logging File: Nonaktif"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Logging File: Aktif"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Logging File: Nonaktif"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Terputus (menggunakan default Sistem)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) tidak dapat menyelesaikan pengujian. Tampilkan detail untuk memeriksa atau menyalin kesalahannya."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Mencari AI yang sudah Anda gunakan…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Menunggu pengujian AI sebelumnya selesai…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Memeriksa Claude Code, Codex, Gemini, dan kunci API yang tersimpan."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Mencari AI yang sudah Anda gunakan…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw akan memeriksa lagi sebelum mengubah pengaturan inferensi apa pun."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Memeriksa Claude Code, Codex, Gemini, dan kunci API yang tersimpan."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Salin kesalahan"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Tips: tetap aktifkan Tailscale agar gateway Anda tetap dapat dijangkau."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Tips: gunakan Tailscale Serve agar gateway memiliki sertifikat HTTPS yang valid."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Tips: tetap aktifkan Tailscale agar gateway Anda tetap dapat dijangkau."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Gunakan panel + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Buka panel bilah menu untuk chat cepat; agen dapat menampilkan pratinjau "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Tolak"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Perangkat ingin terhubung ke OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Node ingin terhubung ke OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Perangkat ingin terhubung ke OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "Aplikasi Mac OpenClaw"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Perangkat ini memerlukan persetujuan pemasangan"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Tempel token yang dikonfigurasi di host gateway. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Periksa `gateway.auth.token` atau `OPENCLAW_GATEWAY_TOKEN` di host gateway lalu coba lagi."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Gateway ini diatur ke autentikasi token, tetapi tidak ada `gateway.auth.token` yang dikonfigurasi di host gateway. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Pindai atau tempel kode penyiapan baru dari klien OpenClaw yang sudah dipasangkan, lalu coba lagi."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Alur onboarding ini belum mendukung autentikasi kata sandi. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Setujui perangkat ini dari klien OpenClaw yang sudah dipasangkan. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Gateway ini menggunakan autentikasi kata sandi. Onboarding jarak jauh di macOS belum dapat mengumpulkan kata sandi gateway."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Diperlukan pemasangan. Di klien OpenClaw yang sudah dipasangkan, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Belum ada skills yang dilaporkan"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Tanpa Suara"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake memerlukan macOS 26 atau yang lebih baru"
@@ -14269,6 +14884,11 @@
       "translated": "Default sistem"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Terputus (menggunakan Default sistem)"
@@ -14394,6 +15014,11 @@
       "translated": " (lokal difilter)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "URL tidak valid: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway terhubung"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Token input: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Penggunaan konteks"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Penggunaan pesan"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Batalkan Pengarsipan"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Coba Kirim Lagi"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Penyiapan"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -194,6 +194,11 @@
       "translated": "Modalità conversazione attiva"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Microfono: in ascolto"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Operazione non riuscita: impossibile raggiungere l'endpoint gateway sicuro per questo host."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Questo rimuove definitivamente il processo pianificato dal gateway."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Accesso amministratore richiesto"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Le modifiche cron richiedono operator.admin. I codici di configurazione intenzionalmente non lo concedono. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Percorso opzionale"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Il gateway può modificare questo percorso ma non può cancellare un percorso esistente."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Online"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Autorizzazioni"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Il codice potrebbe essere scaduto o essere stato generato per un altro Gateway."
@@ -1734,9 +1804,24 @@
       "translated": "L'autenticazione del Gateway richiede una verifica. Controlla le impostazioni del gateway, quindi riprova."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Nessun modello configurato"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sessioni"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Cerca sessioni"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Prima i più recenti"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Prima i più vecchi"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Layout: dettagliato"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Fissa"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Segna come non letto"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw può ricevere gli avvisi selezionati."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Concesso"
@@ -2374,6 +2564,21 @@
       "translated": "Funzionalità del telefono"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Consenti l'accesso alla libreria foto."
@@ -2384,6 +2589,11 @@
       "translated": "Accesso selezionato o completo alle foto concesso."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "L'elenco delle app resta su questo telefono."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw può elencare le app visibili nel launcher."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Consentire la posizione in background?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw controlla la posizione solo quando il Gateway associato lo richiede. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Dimenticare il gateway?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "Apri ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Controlla"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Nessun limite segnalato"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Disattivato"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Testo del payload"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "AGENTE ATTIVO"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Nessuna"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Conversazioni recenti"
@@ -3039,6 +3304,16 @@
       "translated": "Bloccato"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count provider"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} pronti"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Nessuna Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Conversazione in tempo reale"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Impostazioni conversazione"
@@ -3594,6 +3874,11 @@
       "translated": "Impossibile decodificare questa immagine."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} altri"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Tu"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Elimina"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Allegato non supportato"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Pronto quando vuoi"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw mostrerà qui approvazioni, processi non riusciti e problemi dei canali."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Parla · in attesa di risposta"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Invio della voce in coda"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Fotocamera"
@@ -4284,9 +4619,9 @@
       "translated": "Microfono"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Nessun diario dei sogni per ora"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Il Gateway non ha trovato DREAMS.md o dreams.md nell'area di lavoro dell'agente attivo."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) esiste ma non ha contenuti leggibili."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Il Gateway non ha trovato DREAMS.md o dreams.md nell'area di lavoro dell'agente attivo."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Diario non disponibile"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Connetti un Gateway per leggere le voci del diario dei sogni."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Il Gateway non ha restituito contenuti del diario dei sogni."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Connetti un Gateway per leggere le voci del diario dei sogni."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Nessuno stato della fase"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Connetti un gateway per caricare le fasi di dreaming."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Il gateway non ha restituito i dettagli delle fasi di dreaming."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Connetti un gateway per caricare le fasi di dreaming."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "nessuna riparazione necessaria"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Nessuna istanza connessa"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Connetti un gateway per esaminare le istanze connesse."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Il gateway non ha segnalato alcuna voce di presenza di sistema."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Connetti un gateway per esaminare le istanze connesse."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Nessuna segnalazione."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Pianificatore"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Utilizzo"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Nessun job pianificato"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Connetti un gateway per caricare il lavoro pianificato."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Il gateway non ha job cron visibili."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Connetti un gateway per caricare il lavoro pianificato."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills non disponibili"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Connetti un gateway per caricare le skill del workspace."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Prova una ricerca diversa o aggiorna dal gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Connetti un gateway per caricare le skill del workspace."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Rinomina gruppo"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Attività"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Attività recente"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Attività della sessione offline"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Connettiti al gateway per caricare l'attività recente della chat."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Avvia una chat e apparirà qui."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Connettiti al gateway per caricare l'attività recente della chat."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Apri"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Nessuna proposta caricata"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Connettiti dalle Impostazioni per caricare le proposte di Skill Workshop."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Le nuove proposte appariranno qui quando gli agenti creeranno bozze di skill."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Connettiti dalle Impostazioni per caricare le proposte di Skill Workshop."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Nessuna scheda caricata"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Connettiti dalle Impostazioni per caricare le schede workboard."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Crea una scheda o modifica il filtro."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Connettiti dalle Impostazioni per caricare le schede workboard."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Scegli quando OpenClaw può condividere la posizione di questo iPhone con gli strumenti del gateway."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Dimentica Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "Risveglio vocale"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Rilevato"
@@ -6484,14 +6879,14 @@
       "translated": "Rilevato • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Configurazione in coda per l'orologio. Apri OpenClaw prima che il codice scada."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Configurazione inviata. Apri OpenClaw sull'orologio per connetterti."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Configurazione in coda per l'orologio. Apri OpenClaw prima che il codice scada."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Non configurato"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Approvazioni"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Nessuna azione del gateway è in attesa di revisione."
@@ -6659,14 +7064,14 @@
       "translated": "Rivedi le azioni gateway in sospeso."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Installa l'app OpenClaw per l'orologio prima di abilitare la modalità diretta."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Il relay resta disponibile; la modalità diretta aggiunge un nodo Gateway indipendente."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Installa l'app OpenClaw per l'orologio prima di abilitare la modalità diretta."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Installato"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Impostazioni Voce e conversazione"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Autorizzazione del Gateway richiesta"
@@ -7879,6 +8299,16 @@
       "translated": "Apri Impostazioni se devi inserire manualmente un host."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Considerare attendibile questo gateway?"
@@ -8164,6 +8594,11 @@
       "translated": "Offline"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Approvazione"
@@ -8174,14 +8609,19 @@
       "translated": "Questa approvazione era già"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Questa approvazione era già impostata su Consenti sempre."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Approvazione impostata su Consenti sempre."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Questa approvazione era già impostata su Consenti sempre."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Richiede attenzione"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Pronto per la connessione"
@@ -8299,14 +8744,14 @@
       "translated": "Link di configurazione"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Il testo in chiaro può esporre le credenziali. Continua solo se consideri attendibili questa rete locale e questo host."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Controlla questo endpoint. Le credenziali vengono applicate solo dopo aver toccato Connetti."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Il testo in chiaro può esporre le credenziali. Continua solo se consideri attendibili questa rete locale e questo host."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Copia comando del codice di configurazione"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Connetti"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Parla"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway predefinito"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Apri impostazioni Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Non verificato"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Caricamento non riuscito"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Errore della chat"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Approva questa richiesta sul tuo gateway. Talk si avvierà automaticamente quando l'approvazione sarà ricevuta."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Questo dispositivo richiede l'approvazione del gateway prima che Talk possa usare la voce in tempo reale. L'audio andrà direttamente da "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw connette questo Apple Watch direttamente al tuo Gateway su reti locali attendibili."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Pronto per la connessione"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Usa le Impostazioni di iPhone per abilitare la connessione diretta."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Configurazione"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Apri Impostazioni iPhone → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Usa Wi-Fi o cellulare mentre OpenClaw è attivo"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Apri Impostazioni iPhone → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Comando da rivedere"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Tu"
@@ -9499,6 +10024,11 @@
       "translated": "Approvazione"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Rivedi comando"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Rifiuta"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "Impossibile installare OpenClaw in Applicazioni. Spostalo lì manualmente, poi apri quella copia."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "Installare OpenClaw in Applicazioni?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Sostituire la versione precedente di OpenClaw in Applicazioni?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw si copierà in Applicazioni e si riaprirà lì affinché gli aggiornamenti e l'avvio al login rimangano affidabili."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Installare OpenClaw in Applicazioni?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Questa copia è più recente dell'app installata. OpenClaw la sostituirà e si riaprirà da Applicazioni."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw si copierà in Applicazioni e si riaprirà lì affinché gli aggiornamenti e l'avvio al login rimangano affidabili."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Microfono"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Abilitato"
@@ -9954,6 +10494,11 @@
       "translated": "Errore"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Disconnessione effettuata e credenziali cancellate."
@@ -9964,14 +10509,14 @@
       "translated": "Nessuna sessione WhatsApp trovata."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Nessun token Telegram configurato."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Token Telegram cancellato."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Nessun token Telegram configurato."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Configurazione"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Modifica ~/.openclaw/openclaw.json usando il modulo basato sullo schema."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Questa scheda è di sola lettura in modalità Nix. Modifica la configurazione tramite Nix e ricompila."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Modifica ~/.openclaw/openclaw.json usando il modulo basato sullo schema."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "degradato: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Oggi"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "L'assistente di configurazione basato su IA. Può controllare lo stato, correggere la config, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Non far fallire il job se l'annuncio non riesce"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Controlla Impostazioni → Connessione o usa Debug → Reimposta tunnel remoto, quindi riprova."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Terminare \\(listener.command) (\\(listener.pid))?"
@@ -10754,9 +11314,9 @@
       "translated": "Scrivi log diagnostico a rotazione (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Scrive un log a rotazione, solo locale, in ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Deep link bloccato"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "Eseguire l'agente OpenClaw?"
@@ -11064,9 +11629,9 @@
       "translated": "Il pattern non può essere vuoto."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Solo pattern di percorsi. Includi '/', '~' o '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Impossibile salvare le approvazioni exec. Sono mostrate le ultime impostazioni note; riprova la modifica."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Nessun gateway trovato al momento."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Fai clic su un gateway rilevato per compilare la destinazione SSH."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Fai clic su un gateway rilevato per compilare l'URL del gateway."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Fai clic su un gateway rilevato per compilare la destinazione SSH."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "Rileva i gateway OpenClaw nella tua LAN"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "non collegato"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Configurazione consigliata"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Usa Tailscale Serve in modo che il gateway abbia un certificato HTTPS valido."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Usa Tailscale più un tunnel SSH per un accesso privato stabile."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Usa Tailscale Serve in modo che il gateway abbia un certificato HTTPS valido."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Avanti"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - Indicatore live di Voice Wake attivo"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Reimposta tunnel remoto"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Logging dettagliato (principale): disattivato"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Logging dettagliato (principale): attivato"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Logging dettagliato (principale): disattivato"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Livello di dettaglio"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Logging su file: disattivato"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Logging su file: attivato"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Logging su file: disattivato"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Disconnesso (uso predefinito del sistema)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) non ha potuto completare il test. Mostra i dettagli per ispezionare o copiare l'errore."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Ricerca di AI che usi già in corso…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "In attesa del completamento del test AI precedente…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Verifica di Claude Code, Codex, Gemini e chiavi API salvate."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Ricerca di AI che usi già in corso…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw verificherà di nuovo prima di modificare qualsiasi impostazione di inferenza."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Verifica di Claude Code, Codex, Gemini e chiavi API salvate."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Copia errore"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Suggerimento: tieni Tailscale abilitato affinché il tuo gateway rimanga raggiungibile."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Suggerimento: usa Tailscale Serve affinché il gateway abbia un certificato HTTPS valido."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Suggerimento: tieni Tailscale abilitato affinché il tuo gateway rimanga raggiungibile."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Usa il pannello + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Apri il pannello della barra dei menu per una chat rapida; l’agente può mostrare anteprime "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Rifiuta"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Un dispositivo vuole connettersi a OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Un nodo vuole connettersi a OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Un dispositivo vuole connettersi a OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "App OpenClaw per Mac"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Questo dispositivo richiede l'approvazione dell'abbinamento"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Incolla il token configurato sull'host gateway. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Controlla `gateway.auth.token` o `OPENCLAW_GATEWAY_TOKEN` sull'host gateway e riprova."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Questo gateway è impostato sull'autenticazione tramite token, ma nessun `gateway.auth.token` è configurato sull'host gateway. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Scansiona o incolla un nuovo codice di configurazione da un client OpenClaw già abbinato, quindi riprova."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Questo flusso di onboarding non supporta ancora l'autenticazione tramite password. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Approva questo dispositivo da un client OpenClaw già abbinato. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Questo gateway usa l'autenticazione tramite password. L'onboarding remoto su macOS non può ancora raccogliere le password del gateway."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Abbinamento richiesto. In un client OpenClaw già abbinato, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Nessuna skill segnalata ancora"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Nessun suono"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake richiede macOS 26 o versioni successive"
@@ -14269,6 +14884,11 @@
       "translated": "Predefinito di sistema"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Disconnesso (uso del predefinito di sistema)"
@@ -14394,6 +15014,11 @@
       "translated": " (filtrato locale)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "URL non valido: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway connesso"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Token di input: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Utilizzo del contesto"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Utilizzo messaggi"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Rimuovi dall'archivio"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Riprova invio"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Configurazione"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -194,6 +194,11 @@
       "translated": "トークモードが有効です"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · マイク: リスニング中"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "失敗: このホストのセキュア Gateway エンドポイントに到達できませんでした。"
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "これにより、スケジュールされたジョブがgatewayから完全に削除されます。"
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "管理者アクセスが必要です"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Cronの変更にはoperator.adminが必要です。セットアップコードは意図的にこれを付与しません。 "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "オプションのパス"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "gatewayはこのパスを変更できますが、既存のパスを消去することはできません。"
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "オンライン"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "権限"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "コードの有効期限が切れているか、別の Gateway 用に生成された可能性があります。"
@@ -1734,9 +1804,24 @@
       "translated": "Gateway 認証の確認が必要です。Gateway 設定を確認してから、再試行してください。"
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "設定済みのモデルはありません"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "セッション"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "セッションを検索"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "新しい順"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "古い順"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "レイアウト: 詳細"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "ピン留め"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "未読にする"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw は選択したアラートを受信できます。"
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "許可済み"
@@ -2374,6 +2564,21 @@
       "translated": "電話の機能"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "写真ライブラリへのアクセスを許可してください。"
@@ -2384,6 +2589,11 @@
       "translated": "選択した写真またはすべての写真へのアクセスが許可されています。"
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "アプリ一覧はこのスマートフォンに保持されます。"
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw はランチャーに表示されるアプリを一覧表示できます。"
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "バックグラウンドでの位置情報を許可しますか？"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw は、ペアリング済みの Gateway が要求した場合にのみ位置情報を確認します。 "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Gatewayを削除しますか？"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "${license.title} を開く"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "確認"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "制限は報告されていません"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "オフ"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "ペイロードテキスト"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "アクティブなエージェント"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "なし"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "最近の会話"
@@ -3039,6 +3304,16 @@
       "translated": "ロック中"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count 件のプロバイダー"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} 準備完了"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Skillsなし"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "リアルタイムトーク"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "トーク設定"
@@ -3594,6 +3874,11 @@
       "translated": "この画像をデコードできませんでした。"
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} 件追加"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "あなた"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "削除"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "サポートされていない添付ファイル"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "準備ができています"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw は承認、失敗したジョブ、チャネルの問題をここに表示します。"
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "発話中 · 返信を待機中"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "キュー内の音声を送信中"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "カメラ"
@@ -4284,9 +4619,9 @@
       "translated": "マイク"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "夢日記はまだありません"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Gateway はアクティブなエージェントワークスペース内で DREAMS.md または dreams.md を見つけられませんでした。"
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) は存在しますが、読み取り可能な内容がありません。"
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Gateway はアクティブなエージェントワークスペース内で DREAMS.md または dreams.md を見つけられませんでした。"
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "ダイアリーを利用できません"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "夢日記エントリを読み取るには Gateway に接続してください。"
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Gateway は夢日記の内容を返しませんでした。"
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "夢日記エントリを読み取るには Gateway に接続してください。"
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "フェーズステータスなし"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Gateway を接続して dreaming フェーズを読み込んでください。"
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway から dreaming フェーズの詳細が返されませんでした。"
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Gateway を接続して dreaming フェーズを読み込んでください。"
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "修復は不要です"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "接続されているインスタンスはありません"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Gateway を接続して、接続済みインスタンスを確認してください。"
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway からシステムプレゼンスのエントリが報告されませんでした。"
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Gateway を接続して、接続済みインスタンスを確認してください。"
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "報告はありません。"
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "スケジューラー"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "使用状況"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "スケジュール済みジョブはありません"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "スケジュール済みの作業を読み込むには、gateway に接続してください。"
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "gateway に表示可能な cron ジョブはありません。"
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "スケジュール済みの作業を読み込むには、gateway に接続してください。"
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skillsは利用できません"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Gatewayに接続してワークスペースのSkillsを読み込みます。"
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "別の検索を試すか、Gatewayから更新してください。"
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Gatewayに接続してワークスペースのSkillsを読み込みます。"
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "グループ名を変更"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "アクティビティ"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "最近のアクティビティ"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "セッションアクティビティはオフラインです"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Gatewayに接続して、最近のチャットアクティビティを読み込んでください。"
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "チャットを開始すると、ここに表示されます。"
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Gatewayに接続して、最近のチャットアクティビティを読み込んでください。"
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "開く"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "提案が読み込まれていません"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Skill Workshop の提案を読み込むには、設定から接続してください。"
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "エージェントが Skills を下書きすると、新しい提案がここに表示されます。"
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Skill Workshop の提案を読み込むには、設定から接続してください。"
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "カードが読み込まれていません"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "workboard カードを読み込むには、設定から接続してください。"
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "カードを作成するか、フィルターを変更してください。"
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "workboard カードを読み込むには、設定から接続してください。"
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "OpenClaw がこの iPhone の位置情報を Gateway ツールと共有できるタイミングを選択します。"
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Gateway を削除"
@@ -6474,6 +6864,11 @@
       "translated": "音声ウェイク"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "検出済み"
@@ -6484,14 +6879,14 @@
       "translated": "検出済み • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "ウォッチのセットアップがキューに入りました。コードの有効期限が切れる前に OpenClaw を開いてください。"
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "セットアップを送信しました。ウォッチで OpenClaw を開いて接続してください。"
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "ウォッチのセットアップがキューに入りました。コードの有効期限が切れる前に OpenClaw を開いてください。"
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "未設定"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "承認"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "レビュー待ちのGatewayアクションはありません。"
@@ -6659,14 +7064,14 @@
       "translated": "保留中の Gateway アクションを確認します。"
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "ダイレクトモードを有効にする前に OpenClaw ウォッチアプリをインストールしてください。"
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "リレーは引き続き利用可能です。ダイレクトモードは独立した Gateway ノードを追加します。"
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "ダイレクトモードを有効にする前に OpenClaw ウォッチアプリをインストールしてください。"
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "インストール済み"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "音声と会話の設定"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Gatewayの権限が必要です"
@@ -7879,6 +8299,16 @@
       "translated": "手動でホストを指定する必要がある場合は、設定を開いてください。"
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "このGatewayを信頼しますか？"
@@ -8164,6 +8594,11 @@
       "translated": "オフライン"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "承認"
@@ -8174,14 +8609,19 @@
       "translated": "この承認はすでに"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "この承認はすでに「常に許可」に設定されています。"
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "承認を「常に許可」に設定しました。"
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "この承認はすでに「常に許可」に設定されています。"
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "対応が必要です"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "接続の準備完了"
@@ -8299,14 +8744,14 @@
       "translated": "セットアップリンク"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "プレーンテキストでは認証情報が公開される可能性があります。このローカルネットワークとホストを信頼できる場合にのみ続行してください。"
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "このエンドポイントを確認してください。認証情報は「接続」をタップした後にのみ適用されます。"
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "プレーンテキストでは認証情報が公開される可能性があります。このローカルネットワークとホストを信頼できる場合にのみ続行してください。"
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "セットアップコードコマンドをコピー"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "接続"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "会話"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway デフォルト"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Gateway 設定を開く"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "未確認"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "読み込みに失敗しました"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "チャットエラー"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Gateway でこのリクエストを承認してください。承認されると Talk が自動的に開始します。"
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Talk がリアルタイム音声を使用する前に、このデバイスは Gateway の承認が必要です。音声は次から直接送信されます: "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw は信頼できるローカルネットワーク上で、この Apple Watch を Gateway に直接接続します。"
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "接続の準備ができました"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "iPhone の設定で直接接続を有効にしてください。"
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "セットアップ"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "iPhone の設定 → Apple Watch を開く"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "OpenClaw が有効な間は Wi-Fi またはセルラーを使用します"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "iPhone の設定 → Apple Watch を開く"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "確認するコマンド"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "あなた"
@@ -9499,6 +10024,11 @@
       "translated": "承認"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "コマンドを確認"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "拒否"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw を Applications にインストールできませんでした。手動で移動してから、そのコピーを開いてください。"
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "OpenClaw を Applications にインストールしますか？"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Applications にある古い OpenClaw を置き換えますか？"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw は自身を Applications にコピーし、そこで再起動します。これにより更新とログイン時の起動が確実に機能します。"
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw を Applications にインストールしますか？"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "このコピーはインストール済みのアプリより新しいバージョンです。OpenClaw は置き換えて、Applications から再起動します。"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw は自身を Applications にコピーし、そこで再起動します。これにより更新とログイン時の起動が確実に機能します。"
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "マイク"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "有効"
@@ -9954,6 +10494,11 @@
       "translated": "エラー"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "ログアウトし、認証情報を消去しました。"
@@ -9964,14 +10509,14 @@
       "translated": "WhatsApp セッションが見つかりません。"
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Telegram トークンが設定されていません。"
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Telegram トークンを消去しました。"
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Telegram トークンが設定されていません。"
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "設定"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "スキーマ駆動フォームを使用して ~/.openclaw/openclaw.json を編集します。"
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "このタブは Nix モードでは読み取り専用です。Nix で設定を編集し、再ビルドしてください。"
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "スキーマ駆動フォームを使用して ~/.openclaw/openclaw.json を編集します。"
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "低下: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "今日"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "AI 搭載のセットアップヘルパーです。ステータスの確認、設定の修正が可能です。"
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "announce が失敗してもジョブを失敗にしない"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "設定 → 接続を確認するか、デバッグ → リモートトンネルをリセットしてから、もう一度お試しください。"
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) を終了しますか？"
@@ -10754,9 +11314,9 @@
       "translated": "ローリング診断ログ（JSONL）を書き込む"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "~/Library/Logs/OpenClaw/ にローテーションされるローカル専用ログを書き込みます。 "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "ディープリンクがブロックされました"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "OpenClaw エージェントを実行しますか？"
@@ -11064,9 +11629,9 @@
       "translated": "パターンは空にできません。"
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "パスパターンのみ。'/'、'~'、または '\\\\' を含めてください。"
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "exec承認を保存できませんでした。最後に確認された設定を表示しています。変更をやり直してください。"
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Gateway はまだ見つかっていません。"
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "検出された Gateway をクリックして SSH ターゲットを入力します。"
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "検出された Gateway をクリックして Gateway URL を入力します。"
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "検出された Gateway をクリックして SSH ターゲットを入力します。"
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "LAN 上の OpenClaw Gateway を検出"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "リンクされていません"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "推奨セットアップ"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "gateway が有効な HTTPS 証明書を持つように Tailscale Serve を使用します。"
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "安定したプライベートアクセスには、Tailscale と SSH トンネルを使用します。"
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "gateway が有効な HTTPS 証明書を持つように Tailscale Serve を使用します。"
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "進む"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - Voice Wake ライブメーターがアクティブ"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "リモートトンネルをリセット"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "詳細ログ（メイン）：オフ"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "詳細ログ（メイン）：オン"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "詳細ログ（メイン）：オフ"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "詳細度"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "ファイルログ：オフ"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "ファイルログ：オン"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "ファイルログ：オフ"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "切断済み（システムデフォルトを使用）"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label)はテストを完了できませんでした。詳細を表示してエラーを確認またはコピーしてください。"
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "すでに使用しているAIを探しています…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "前のAIテストの完了を待っています…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Claude Code、Codex、Gemini、および保存されたAPIキーを確認しています。"
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "すでに使用しているAIを探しています…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClawは推論設定を変更する前に再度確認します。"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Claude Code、Codex、Gemini、および保存されたAPIキーを確認しています。"
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "エラーをコピー"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "ヒント: Gateway に到達できる状態を保つため、Tailscale を有効にしておいてください。"
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "ヒント: Gateway が有効な HTTPS 証明書を持つように、Tailscale Serve を使用してください。"
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "ヒント: Gateway に到達できる状態を保つため、Tailscale を有効にしておいてください。"
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "パネル + Canvas を使用"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "クイックチャット用にメニューバーパネルを開きます。エージェントはプレビューを表示できます "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "拒否"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "デバイスが OpenClaw への接続を要求しています。"
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "ノードが OpenClaw への接続を要求しています。"
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "デバイスが OpenClaw への接続を要求しています。"
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "OpenClaw Mac アプリ"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "このデバイスにはペアリングの承認が必要です"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Gateway ホストで設定されているトークンを貼り付けてください。 "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Gateway ホストで `gateway.auth.token` または `OPENCLAW_GATEWAY_TOKEN` を確認して、もう一度お試しください。"
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "この Gateway はトークン認証に設定されていますが、Gateway ホストで `gateway.auth.token` が設定されていません。 "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "すでにペアリング済みの OpenClaw クライアントから新しいセットアップコードをスキャンまたは貼り付けてから、もう一度お試しください。"
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "このオンボーディングフローは、まだパスワード認証をサポートしていません。 "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "すでにペアリング済みの OpenClaw クライアントからこのデバイスを承認してください。 "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "このGatewayはパスワード認証を使用しています。macOSでのリモートオンボーディングでは、まだGatewayのパスワードを収集できません。"
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "ペアリングが必要です。すでにペアリング済みのOpenClawクライアントで、"
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "報告されたSkillsはまだありません"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "サウンドなし"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice WakeにはmacOS 26以降が必要です"
@@ -14269,6 +14884,11 @@
       "translated": "システムデフォルト"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "接続解除（システムデフォルトを使用）"
@@ -14394,6 +15014,11 @@
       "translated": " (ローカルでフィルタ済み)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "無効なURL: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway に接続しました"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "入力トークン: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "コンテキスト使用量"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "メッセージ使用量"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "アーカイブ解除"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "送信を再試行"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "設定"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -194,6 +194,11 @@
       "translated": "대화 모드 활성화됨"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · 마이크: 듣는 중"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "실패: 이 호스트의 보안 gateway 엔드포인트에 도달할 수 없습니다."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "예약된 작업이 gateway에서 영구적으로 제거됩니다."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "관리자 권한 필요"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Cron 변경에는 operator.admin이 필요합니다. 설정 코드는 의도적으로 이를 부여하지 않습니다. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "선택적 경로"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "gateway는 이 경로를 변경할 수 있지만 기존 경로를 지울 수는 없습니다."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "온라인"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "권한"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "코드가 만료되었거나 다른 Gateway용으로 생성되었을 수 있습니다."
@@ -1734,9 +1804,24 @@
       "translated": "Gateway 인증을 검토해야 합니다. gateway 설정을 확인한 다음 다시 시도하세요."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "구성된 모델 없음"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "세션"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "세션 검색"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "최신순"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "오래된순"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "레이아웃: 자세히"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "고정"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "읽지 않음으로 표시"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw에서 선택한 알림을 받을 수 있습니다."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "허용됨"
@@ -2374,6 +2564,21 @@
       "translated": "휴대폰 기능"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "사진 보관함 접근을 허용하세요."
@@ -2384,6 +2589,11 @@
       "translated": "선택한 사진 또는 전체 사진 접근 권한이 허용되었습니다."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "앱 목록은 이 휴대폰에 유지됩니다."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw는 런처에 표시되는 앱을 나열할 수 있습니다."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "백그라운드 위치를 허용하시겠어요?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw는 페어링된 Gateway가 요청할 때만 위치를 확인합니다. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Gateway를 잊어버리시겠습니까?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "${license.title} 열기"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "확인"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "보고된 제한 없음"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "꺼짐"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "페이로드 텍스트"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "활성 에이전트"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "없음"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "최근 대화"
@@ -3039,6 +3304,16 @@
       "translated": "잠김"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "공급자 $count개"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size}개 준비됨"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "스킬 없음"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "실시간 대화"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "대화 설정"
@@ -3594,6 +3874,11 @@
       "translated": "이 이미지를 디코딩할 수 없습니다."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6}개 더"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "나"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "삭제"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "지원되지 않는 첨부 파일"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "준비되면 시작하세요"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw은 승인, 실패한 작업 및 채널 문제를 여기에 표시합니다."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "말하는 중 · 응답 대기 중"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "대기 중인 음성 보내는 중"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "카메라"
@@ -4284,9 +4619,9 @@
       "translated": "마이크"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "아직 꿈 다이어리가 없음"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Gateway가 활성 에이전트 작업 공간에서 DREAMS.md 또는 dreams.md를 찾지 못했습니다."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path)이(가) 존재하지만 읽을 수 있는 콘텐츠가 없습니다."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Gateway가 활성 에이전트 작업 공간에서 DREAMS.md 또는 dreams.md를 찾지 못했습니다."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "다이어리를 사용할 수 없음"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "꿈 다이어리 항목을 읽으려면 Gateway를 연결하세요."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Gateway가 꿈 다이어리 콘텐츠를 반환하지 않았습니다."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "꿈 다이어리 항목을 읽으려면 Gateway를 연결하세요."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "단계 상태 없음"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "드리밍 단계를 불러오려면 Gateway를 연결하세요."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway가 드리밍 단계 세부 정보를 반환하지 않았습니다."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "드리밍 단계를 불러오려면 Gateway를 연결하세요."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "복구 필요 없음"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "연결된 인스턴스 없음"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "연결된 인스턴스를 검사하려면 Gateway를 연결하세요."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway가 시스템 프레즌스 항목을 보고하지 않았습니다."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "연결된 인스턴스를 검사하려면 Gateway를 연결하세요."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "보고된 항목이 없습니다."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "스케줄러"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "사용량"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "예약된 작업 없음"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "예약된 작업을 불러오려면 Gateway를 연결하세요."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Gateway에 표시할 수 있는 cron 작업이 없습니다."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "예약된 작업을 불러오려면 Gateway를 연결하세요."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills를 사용할 수 없음"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "워크스페이스 Skills를 불러오려면 Gateway에 연결하세요."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "다른 검색어를 시도하거나 Gateway에서 새로 고치세요."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "워크스페이스 Skills를 불러오려면 Gateway에 연결하세요."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "그룹 이름 변경"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "활동"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "최근 활동"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "세션 활동 오프라인"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "최근 채팅 활동을 불러오려면 Gateway에 연결하세요."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "채팅을 시작하면 여기에 표시됩니다."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "최근 채팅 활동을 불러오려면 Gateway에 연결하세요."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "열기"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "로드된 제안 없음"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Skill Workshop 제안을 로드하려면 설정에서 연결하세요."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "에이전트가 스킬 초안을 작성하면 새 제안이 여기에 표시됩니다."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Skill Workshop 제안을 로드하려면 설정에서 연결하세요."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "로드된 카드 없음"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "workboard 카드를 로드하려면 Settings에서 연결하세요."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "카드를 만들거나 필터를 변경하세요."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "workboard 카드를 로드하려면 Settings에서 연결하세요."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "OpenClaw가 이 iPhone의 위치를 Gateway 도구와 공유할 시점을 선택하세요."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Gateway 삭제"
@@ -6474,6 +6864,11 @@
       "translated": "음성 깨우기"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "발견됨"
@@ -6484,14 +6879,14 @@
       "translated": "발견됨 • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "워치에 설정이 대기 중입니다. 코드가 만료되기 전에 OpenClaw를 여세요."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "설정을 보냈습니다. 워치에서 OpenClaw를 열어 연결하세요."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "워치에 설정이 대기 중입니다. 코드가 만료되기 전에 OpenClaw를 여세요."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "구성되지 않음"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "승인"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "검토를 기다리는 게이트웨이 작업이 없습니다."
@@ -6659,14 +7064,14 @@
       "translated": "대기 중인 gateway 작업을 검토합니다."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "직접 모드를 사용하기 전에 OpenClaw 워치 앱을 설치하세요."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "릴레이는 계속 사용할 수 있으며, 직접 모드는 독립적인 Gateway 노드를 추가합니다."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "직접 모드를 사용하기 전에 OpenClaw 워치 앱을 설치하세요."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "설치됨"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "음성 및 대화 설정"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Gateway 권한 필요"
@@ -7879,6 +8299,16 @@
       "translated": "수동 호스트가 필요하면 설정을 여세요."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "이 Gateway를 신뢰하시겠습니까?"
@@ -8164,6 +8594,11 @@
       "translated": "오프라인"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "승인"
@@ -8174,14 +8609,19 @@
       "translated": "이 승인은 이미"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "이 승인은 이미 항상 허용으로 설정되어 있습니다."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "승인이 항상 허용으로 설정되었습니다."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "이 승인은 이미 항상 허용으로 설정되어 있습니다."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "주의 필요"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "연결 준비 완료"
@@ -8299,14 +8744,14 @@
       "translated": "설정 링크"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "일반 텍스트는 자격 증명을 노출할 수 있습니다. 이 로컬 네트워크와 호스트를 신뢰하는 경우에만 계속하세요."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "이 엔드포인트를 검토하세요. 자격 증명은 연결을 탭한 후에만 적용됩니다."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "일반 텍스트는 자격 증명을 노출할 수 있습니다. 이 로컬 네트워크와 호스트를 신뢰하는 경우에만 계속하세요."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "설정 코드 명령 복사"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "연결"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "대화"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway 기본값"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Gateway 설정 열기"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "확인되지 않음"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "로드 실패"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "채팅 오류"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Gateway에서 이 요청을 승인하세요. 승인이 완료되면 Talk가 자동으로 시작됩니다."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Talk에서 실시간 음성을 사용하려면 이 기기에 Gateway 승인이 필요합니다. 오디오는 다음에서 직접 전송됩니다: "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw는 신뢰할 수 있는 로컬 네트워크에서 이 Apple Watch를 Gateway에 직접 연결합니다."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "연결 준비 완료"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "iPhone 설정에서 직접 연결을 활성화하세요."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "설정"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "iPhone 설정 → Apple Watch 열기"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "OpenClaw가 활성화된 동안 Wi-Fi 또는 셀룰러 사용"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "iPhone 설정 → Apple Watch 열기"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "검토할 명령"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "나"
@@ -9499,6 +10024,11 @@
       "translated": "승인"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "명령 검토"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "거부"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw를 응용 프로그램에 설치할 수 없습니다. 수동으로 이동한 다음 해당 복사본을 여세요."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "OpenClaw를 응용 프로그램에 설치하시겠어요?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "응용 프로그램의 이전 OpenClaw를 교체하시겠어요?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw가 자신을 응용 프로그램에 복사하고 그곳에서 다시 열어 업데이트와 로그인 시 실행이 안정적으로 유지됩니다."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw를 응용 프로그램에 설치하시겠어요?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "이 복사본은 설치된 앱보다 최신입니다. OpenClaw가 이를 교체하고 응용 프로그램에서 다시 엽니다."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw가 자신을 응용 프로그램에 복사하고 그곳에서 다시 열어 업데이트와 로그인 시 실행이 안정적으로 유지됩니다."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "마이크"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "활성화됨"
@@ -9954,6 +10494,11 @@
       "translated": "오류"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "로그아웃하고 자격 증명을 지웠습니다."
@@ -9964,14 +10509,14 @@
       "translated": "WhatsApp 세션을 찾을 수 없습니다."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "구성된 Telegram 토큰이 없습니다."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Telegram 토큰을 지웠습니다."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "구성된 Telegram 토큰이 없습니다."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "구성"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "스키마 기반 양식을 사용하여 ~/.openclaw/openclaw.json을 편집하세요."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "이 탭은 Nix 모드에서 읽기 전용입니다. Nix를 통해 구성을 편집하고 다시 빌드하세요."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "스키마 기반 양식을 사용하여 ~/.openclaw/openclaw.json을 편집하세요."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "저하됨: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "오늘"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "AI 기반 설정 도우미입니다. 상태를 확인하고 구성을 수정할 수 있습니다. "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "알림에 실패해도 작업을 실패로 처리하지 않음"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "설정 → 연결을 확인하거나 디버그 → 원격 터널 재설정을 사용한 후 다시 시도하세요."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) 종료?"
@@ -10754,9 +11314,9 @@
       "translated": "롤링 진단 로그 쓰기(JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "~/Library/Logs/OpenClaw/ 아래에 로컬 전용 순환 로그를 씁니다. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "딥 링크가 차단됨"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "OpenClaw 에이전트를 실행할까요?"
@@ -11064,9 +11629,9 @@
       "translated": "패턴은 비워 둘 수 없습니다."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "경로 패턴만 가능합니다. '/', '~' 또는 '\\\\'를 포함하세요."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "실행 승인을 저장할 수 없습니다. 마지막으로 알려진 설정이 표시되어 있으니 변경을 다시 시도하세요."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "아직 발견된 Gateway가 없습니다."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "검색된 Gateway를 클릭하여 SSH 대상을 채우세요."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "검색된 Gateway를 클릭하여 Gateway URL을 채우세요."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "검색된 Gateway를 클릭하여 SSH 대상을 채우세요."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "LAN에서 OpenClaw Gateway 검색"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "연결되지 않음"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "권장 설정"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Gateway에 유효한 HTTPS 인증서가 있도록 Tailscale Serve를 사용하세요."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "안정적인 비공개 액세스를 위해 Tailscale과 SSH 터널을 함께 사용하세요."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Gateway에 유효한 HTTPS 인증서가 있도록 Tailscale Serve를 사용하세요."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "앞으로"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - 음성 깨우기 라이브 미터 활성"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "원격 터널 재설정"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "자세한 로깅(메인): 꺼짐"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "자세한 로깅(메인): 켜짐"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "자세한 로깅(메인): 꺼짐"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "상세 수준"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "파일 로깅: 꺼짐"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "파일 로깅: 켜짐"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "파일 로깅: 꺼짐"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "연결 해제됨(시스템 기본값 사용)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label)이(가) 테스트를 완료하지 못했습니다. 세부 정보를 표시하여 오류를 확인하거나 복사하세요."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "이미 사용 중인 AI를 찾는 중…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "이전 AI 테스트가 완료되기를 기다리는 중…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Claude Code, Codex, Gemini 및 저장된 API 키를 확인하는 중입니다."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "이미 사용 중인 AI를 찾는 중…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw는 추론 설정을 변경하기 전에 다시 확인합니다."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Claude Code, Codex, Gemini 및 저장된 API 키를 확인하는 중입니다."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "오류 복사"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "팁: Gateway에 계속 접근할 수 있도록 Tailscale을 활성화해 두세요."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "팁: Gateway에 유효한 HTTPS 인증서가 있도록 Tailscale Serve를 사용하세요."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "팁: Gateway에 계속 접근할 수 있도록 Tailscale을 활성화해 두세요."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "패널 + Canvas 사용"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "빠른 채팅을 위해 메뉴 막대 패널을 여세요. 에이전트가 미리보기를 표시할 수 있습니다 "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "거부"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "장치가 OpenClaw에 연결하려고 합니다."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "노드가 OpenClaw에 연결하려고 합니다."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "장치가 OpenClaw에 연결하려고 합니다."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "OpenClaw Mac 앱"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "이 기기는 페어링 승인이 필요합니다"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Gateway 호스트에 구성된 토큰을 붙여넣으세요. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Gateway 호스트에서 `gateway.auth.token` 또는 `OPENCLAW_GATEWAY_TOKEN`을 확인하고 다시 시도하세요."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "이 Gateway는 토큰 인증으로 설정되어 있지만 Gateway 호스트에 `gateway.auth.token`이 구성되어 있지 않습니다. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "이미 페어링된 OpenClaw 클라이언트에서 새 설정 코드를 스캔하거나 붙여넣은 다음 다시 시도하세요."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "이 온보딩 흐름은 아직 비밀번호 인증을 지원하지 않습니다. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "이미 페어링된 OpenClaw 클라이언트에서 이 기기를 승인하세요. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "이 Gateway는 비밀번호 인증을 사용합니다. macOS의 원격 온보딩은 아직 Gateway 비밀번호를 수집할 수 없습니다."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "페어링이 필요합니다. 이미 페어링된 OpenClaw 클라이언트에서 "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "아직 보고된 Skills가 없습니다"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "소리 없음"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake에는 macOS 26 이상이 필요합니다"
@@ -14269,6 +14884,11 @@
       "translated": "시스템 기본값"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "연결 해제됨(시스템 기본값 사용 중)"
@@ -14394,6 +15014,11 @@
       "translated": " (로컬 필터링됨)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "잘못된 URL: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway 연결됨"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "입력 토큰: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "컨텍스트 사용량"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "메시지 사용량"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "보관 해제"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "전송 다시 시도"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "설정"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -194,6 +194,11 @@
       "translated": "Praatmodus actief"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Microfoon: Luistert"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Mislukt: kon het beveiligde gateway-eindpunt voor deze host niet bereiken."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Hiermee wordt de geplande taak definitief van de gateway verwijderd."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Beheerderstoegang vereist"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Cron-wijzigingen vereisen operator.admin. Instelcodes verlenen dit bewust niet. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Optioneel pad"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "De gateway kan dit pad wijzigen maar kan een bestaand pad niet wissen."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Online"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Machtigingen"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "De code is mogelijk verlopen of gegenereerd voor een andere Gateway."
@@ -1734,9 +1804,24 @@
       "translated": "Gateway-authenticatie moet worden gecontroleerd. Controleer de gateway-instellingen en probeer het opnieuw."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Geen geconfigureerde modellen"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sessies"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Sessies zoeken"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Nieuwste eerst"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Oudste eerst"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Lay-out: Gedetailleerd"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Vastmaken"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Markeren als ongelezen"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw kan geselecteerde waarschuwingen ontvangen."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Toegestaan"
@@ -2374,6 +2564,21 @@
       "translated": "Telefoonmogelijkheden"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Toegang tot fotobibliotheek toestaan."
@@ -2384,6 +2589,11 @@
       "translated": "Geselecteerde of volledige fototoegang toegestaan."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "App-lijst blijft op deze telefoon."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw kan apps weergeven die zichtbaar zijn in de launcher."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Locatie op de achtergrond toestaan?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw controleert de locatie alleen wanneer je gekoppelde Gateway daarom vraagt. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Gateway vergeten?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "${license.title} openen"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Controleren"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Geen limieten gemeld"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Uit"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Payloadtekst"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "ACTIEVE AGENT"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Geen"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Recente gesprekken"
@@ -3039,6 +3304,16 @@
       "translated": "Vergrendeld"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count providers"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} gereed"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Geen Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Realtime praten"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Praatinstellingen"
@@ -3594,6 +3874,11 @@
       "translated": "Deze afbeelding kan niet worden gedecodeerd."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} meer"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Jij"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Verwijderen"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Niet-ondersteunde bijlage"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Klaar wanneer jij dat bent"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw toont hier goedkeuringen, mislukte taken en kanaalproblemen."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Spreekt · wacht op antwoord"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Spraak in wachtrij verzenden"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Camera"
@@ -4284,9 +4619,9 @@
       "translated": "Microfoon"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Nog geen droomdagboek"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "De gateway heeft DREAMS.md of dreams.md niet gevonden in de werkruimte van de actieve agent."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) bestaat, maar heeft geen leesbare inhoud."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "De gateway heeft DREAMS.md of dreams.md niet gevonden in de werkruimte van de actieve agent."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Dagboek niet beschikbaar"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Verbind een gateway om droomdagboekvermeldingen te lezen."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "De gateway heeft geen droomdagboekinhoud geretourneerd."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Verbind een gateway om droomdagboekvermeldingen te lezen."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Geen fasestatus"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Verbind een gateway om droomfasen te laden."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "De gateway heeft geen details over droomfasen geretourneerd."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Verbind een gateway om droomfasen te laden."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "geen reparatie nodig"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Geen instanties verbonden"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Verbind een gateway om verbonden instanties te inspecteren."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "De gateway heeft geen systeemaanwezigheidsitems gerapporteerd."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Verbind een gateway om verbonden instanties te inspecteren."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Geen gemeld."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Planner"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Gebruik"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Geen geplande taken"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Verbind een Gateway om gepland werk te laden."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "De Gateway heeft geen zichtbare cron-taken."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Verbind een Gateway om gepland werk te laden."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills niet beschikbaar"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Verbind een gateway om workspace-Skills te laden."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Probeer een andere zoekopdracht of vernieuw vanuit de gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Verbind een gateway om workspace-Skills te laden."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Groep hernoemen"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Activiteit"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Recente activiteit"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Sessieactiviteit offline"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Maak verbinding met de gateway om recente chatactiviteit te laden."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Start een chat en deze verschijnt hier."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Maak verbinding met de gateway om recente chatactiviteit te laden."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Openen"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Geen voorstellen geladen"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Maak verbinding via Instellingen om Skill Workshop-voorstellen te laden."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Nieuwe voorstellen verschijnen hier wanneer agents skills opstellen."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Maak verbinding via Instellingen om Skill Workshop-voorstellen te laden."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Geen kaarten geladen"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Maak verbinding via Instellingen om werkbordkaarten te laden."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Maak een kaart aan of wijzig het filter."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Maak verbinding via Instellingen om werkbordkaarten te laden."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Kies wanneer OpenClaw de locatie van deze iPhone mag delen met gatewaytools."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Gateway vergeten"
@@ -6474,6 +6864,11 @@
       "translated": "Stemactivering"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Ontdekt"
@@ -6484,14 +6879,14 @@
       "translated": "Ontdekt • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Installatie in wachtrij voor de watch. Open OpenClaw voordat de code verloopt."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Installatie verzonden. Open OpenClaw op de watch om verbinding te maken."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Installatie in wachtrij voor de watch. Open OpenClaw voordat de code verloopt."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Niet geconfigureerd"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Goedkeuringen"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Er wachten geen Gateway-acties op beoordeling."
@@ -6659,14 +7064,14 @@
       "translated": "Beoordeel openstaande gateway-acties."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Installeer de OpenClaw watch-app voordat je directe modus inschakelt."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Relay blijft beschikbaar; directe modus voegt een onafhankelijke Gateway-node toe."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Installeer de OpenClaw watch-app voordat je directe modus inschakelt."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Geïnstalleerd"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Instellingen voor spraak en praten"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Gateway-toestemming vereist"
@@ -7879,6 +8299,16 @@
       "translated": "Open Instellingen als je een handmatige host nodig hebt."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Deze gateway vertrouwen?"
@@ -8164,6 +8594,11 @@
       "translated": "Offline"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Goedkeuring"
@@ -8174,14 +8609,19 @@
       "translated": "Deze goedkeuring was al"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Deze goedkeuring was al ingesteld op Altijd toestaan."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Goedkeuring ingesteld op Altijd toestaan."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Deze goedkeuring was al ingesteld op Altijd toestaan."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Vereist aandacht"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Klaar om te verbinden"
@@ -8299,14 +8744,14 @@
       "translated": "Configuratielink"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Platte tekst kan inloggegevens blootstellen. Ga alleen verder als je dit lokale netwerk en deze host vertrouwt."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Controleer dit eindpunt. Inloggegevens worden pas toegepast nadat je op Verbind tikt."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Platte tekst kan inloggegevens blootstellen. Ga alleen verder als je dit lokale netwerk en deze host vertrouwt."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Configuratiecodeopdracht kopiëren"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Verbinden"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Praten"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway standaard"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Gateway-instellingen openen"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Niet gecontroleerd"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Laden mislukt"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Chatfout"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Keur dit verzoek goed op je gateway. Talk start automatisch zodra de goedkeuring binnenkomt."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Dit apparaat heeft goedkeuring van de gateway nodig voordat Talk realtime spraak kan gebruiken. Audio gaat rechtstreeks vanaf "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw verbindt deze Apple Watch rechtstreeks met je Gateway op vertrouwde lokale netwerken."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Klaar om te verbinden"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Gebruik iPhone-instellingen om directe verbinding in te schakelen."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Instellen"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Open iPhone-instellingen → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Gebruikt wifi of mobiel netwerk terwijl OpenClaw actief is"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Open iPhone-instellingen → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Te beoordelen opdracht"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Jij"
@@ -9499,6 +10024,11 @@
       "translated": "Goedkeuring"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Opdracht controleren"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Weigeren"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw kon niet in Programma's worden geïnstalleerd. Verplaats het daar handmatig naartoe en open die kopie."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "OpenClaw in Programma's installeren?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "De oudere OpenClaw in Programma's vervangen?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw kopieert zichzelf naar Programma's en opent daar opnieuw, zodat updates en starten bij aanmelden betrouwbaar blijven."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw in Programma's installeren?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Deze kopie is nieuwer dan de geïnstalleerde app. OpenClaw vervangt deze en opent opnieuw vanuit Programma's."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw kopieert zichzelf naar Programma's en opent daar opnieuw, zodat updates en starten bij aanmelden betrouwbaar blijven."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Microfoon"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Ingeschakeld"
@@ -9954,6 +10494,11 @@
       "translated": "Fout"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Uitgelogd en inloggegevens gewist."
@@ -9964,14 +10509,14 @@
       "translated": "Geen WhatsApp-sessie gevonden."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Geen Telegram-token geconfigureerd."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Telegram-token gewist."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Geen Telegram-token geconfigureerd."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Configuratie"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Bewerk ~/.openclaw/openclaw.json met het schemagestuurde formulier."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Dit tabblad is alleen-lezen in Nix-modus. Bewerk de configuratie via Nix en bouw opnieuw."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Bewerk ~/.openclaw/openclaw.json met het schemagestuurde formulier."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "gedegradeerd: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Vandaag"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Je AI-aangedreven installatiehulp. Deze kan de status controleren, config repareren, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Laat de taak niet mislukken als aankondigen mislukt"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Controleer Instellingen → Verbinding of gebruik Debug → Reset Remote Tunnel en probeer het opnieuw."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) beëindigen?"
@@ -10754,9 +11314,9 @@
       "translated": "Doorlopend diagnostisch log schrijven (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Schrijft een roterend, alleen lokaal log onder ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Deep link geblokkeerd"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "OpenClaw-agent uitvoeren?"
@@ -11064,9 +11629,9 @@
       "translated": "Patroon mag niet leeg zijn."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Alleen padpatronen. Neem '/', '~' of '\\\\' op."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Kan exec-goedkeuringen niet opslaan. De laatst bekende instellingen worden getoond; probeer de wijziging opnieuw."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Nog geen gateways gevonden."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Klik op een gevonden gateway om het SSH-doel in te vullen."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Klik op een gevonden gateway om de gateway-URL in te vullen."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Klik op een gevonden gateway om het SSH-doel in te vullen."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "OpenClaw-gateways op je LAN ontdekken"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "niet gekoppeld"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Aanbevolen configuratie"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Gebruik Tailscale Serve zodat de Gateway een geldig HTTPS-certificaat heeft."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Gebruik Tailscale plus een SSH-tunnel voor stabiele privétoegang."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Gebruik Tailscale Serve zodat de Gateway een geldig HTTPS-certificaat heeft."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Vooruit"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - livemeter voor Voice Wake actief"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Externe tunnel resetten"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Uitgebreide logging (hoofd): uit"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Uitgebreide logging (hoofd): aan"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Uitgebreide logging (hoofd): uit"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Detailniveau"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Bestandslogging: uit"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Bestandslogging: aan"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Bestandslogging: uit"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Verbroken (systeemstandaard wordt gebruikt)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) kon de test niet voltooien. Toon details om de fout te bekijken of te kopiëren."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Zoeken naar AI die je al gebruikt…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Wachten tot de vorige AI-test is voltooid…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Controleren op Claude Code, Codex, Gemini en opgeslagen API-sleutels."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Zoeken naar AI die je al gebruikt…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw controleert opnieuw voordat er inferentie-instellingen worden gewijzigd."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Controleren op Claude Code, Codex, Gemini en opgeslagen API-sleutels."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Fout kopiëren"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Tip: houd Tailscale ingeschakeld zodat je gateway bereikbaar blijft."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Tip: gebruik Tailscale Serve zodat de gateway een geldig HTTPS-certificaat heeft."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Tip: houd Tailscale ingeschakeld zodat je gateway bereikbaar blijft."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Gebruik het paneel + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Open het menubalkpaneel voor snelle chat; de agent kan voorbeelden tonen "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Afwijzen"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Een apparaat wil verbinding maken met OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Een node wil verbinding maken met OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Een apparaat wil verbinding maken met OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "OpenClaw Mac-app"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Dit apparaat heeft koppelingsgoedkeuring nodig"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Plak het token dat op de gatewayhost is geconfigureerd. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Controleer `gateway.auth.token` of `OPENCLAW_GATEWAY_TOKEN` op de gatewayhost en probeer het opnieuw."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Deze gateway is ingesteld op token-auth, maar er is geen `gateway.auth.token` geconfigureerd op de gatewayhost. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Scan of plak een nieuwe instelcode van een al gekoppelde OpenClaw-client en probeer het opnieuw."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Deze onboardingflow ondersteunt wachtwoord-auth nog niet. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Keur dit apparaat goed vanuit een al gekoppelde OpenClaw-client. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Deze gateway gebruikt wachtwoord-auth. Remote onboarding op macOS kan nog geen gatewaywachtwoorden verzamelen."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Koppeling vereist. In een al gekoppelde OpenClaw-client, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Nog geen skills gerapporteerd"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Geen geluid"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake vereist macOS 26 of nieuwer"
@@ -14269,6 +14884,11 @@
       "translated": "Systeemstandaard"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Niet verbonden (systeemstandaard wordt gebruikt)"
@@ -14394,6 +15014,11 @@
       "translated": " (lokaal gefilterd)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "Ongeldige URL: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway verbonden"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Invoertokens: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Contextgebruik"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Berichtgebruik"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Dearchiveren"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Opnieuw verzenden"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Instellen"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -194,6 +194,11 @@
       "translated": "Tryb rozmowy aktywny"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Mikrofon: nasłuchuje"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Niepowodzenie: nie udało się połączyć z bezpiecznym punktem końcowym bramy dla tego hosta."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "To trwale usuwa zaplanowane zadanie z Gateway."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Wymagany dostęp administratora"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Zmiany cron wymagają operator.admin. Kody konfiguracyjne celowo go nie przyznają. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Opcjonalna ścieżka"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Gateway może zmienić tę ścieżkę, ale nie może usunąć istniejącej ścieżki."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Online"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Uprawnienia"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Kod mógł wygasnąć lub zostać wygenerowany dla innego Gateway."
@@ -1734,9 +1804,24 @@
       "translated": "Uwierzytelnianie Gateway wymaga sprawdzenia. Sprawdź ustawienia Gateway, a następnie spróbuj ponownie."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Brak skonfigurowanych modeli"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sesje"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Szukaj sesji"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Najpierw najnowsze"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Najpierw najstarsze"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Układ: szczegółowy"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Przypnij"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Oznacz jako nieprzeczytane"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw może odbierać wybrane alerty."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Przyznano"
@@ -2374,6 +2564,21 @@
       "translated": "Możliwości telefonu"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Zezwól na dostęp do biblioteki zdjęć."
@@ -2384,6 +2589,11 @@
       "translated": "Przyznano dostęp do wybranych zdjęć lub pełny dostęp do zdjęć."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "Lista aplikacji pozostaje na tym telefonie."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw może wyświetlać listę aplikacji widocznych w launcherze."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Zezwolić na lokalizację w tle?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw sprawdza lokalizację tylko wtedy, gdy zażąda tego sparowany Gateway. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Zapomnieć Gateway?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "Otwórz ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Sprawdź"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Nie zgłoszono limitów"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Wyłączone"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Tekst ładunku"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "AKTYWNY AGENT"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Brak"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Ostatnie rozmowy"
@@ -3039,6 +3304,16 @@
       "translated": "Zablokowane"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count dostawców"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} gotowe"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Brak Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Rozmowa w czasie rzeczywistym"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Ustawienia rozmowy"
@@ -3594,6 +3874,11 @@
       "translated": "Nie udało się zdekodować tego obrazu."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} więcej"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Ty"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Usuń"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Nieobsługiwany załącznik"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Gotowe, gdy Ty będziesz"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw będzie pokazywać tutaj zatwierdzenia, nieudane zadania i problemy z kanałami."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Mówienie · oczekiwanie na odpowiedź"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Wysyłanie głosu z kolejki"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Kamera"
@@ -4284,9 +4619,9 @@
       "translated": "Mikrofon"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Nie ma jeszcze dziennika snów"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Gateway nie znalazł pliku DREAMS.md ani dreams.md w aktywnym obszarze roboczym agenta."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) istnieje, ale nie ma czytelnej zawartości."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Gateway nie znalazł pliku DREAMS.md ani dreams.md w aktywnym obszarze roboczym agenta."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Dziennik niedostępny"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Połącz gateway, aby odczytać wpisy dziennika snów."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Gateway nie zwrócił zawartości dziennika snów."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Połącz gateway, aby odczytać wpisy dziennika snów."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Brak statusu fazy"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Połącz Gateway, aby wczytać fazy śnienia."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway nie zwrócił szczegółów fazy śnienia."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Połącz Gateway, aby wczytać fazy śnienia."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "naprawa nie była potrzebna"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Brak połączonych instancji"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Połącz Gateway, aby sprawdzić połączone instancje."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway nie zgłosił żadnych wpisów obecności systemu."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Połącz Gateway, aby sprawdzić połączone instancje."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Nie zgłoszono żadnych."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Harmonogram"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Użycie"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Brak zaplanowanych zadań"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Połącz Gateway, aby załadować zaplanowane zadania."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Gateway nie ma widocznych zadań cron."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Połącz Gateway, aby załadować zaplanowane zadania."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills niedostępne"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Połącz Gateway, aby wczytać Skills obszaru roboczego."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Spróbuj innego wyszukiwania lub odśwież z Gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Połącz Gateway, aby wczytać Skills obszaru roboczego."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Zmień nazwę grupy"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Aktywność"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Ostatnia aktywność"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Aktywność sesji offline"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Połącz się z gateway, aby załadować ostatnią aktywność czatu."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Rozpocznij czat, a pojawi się tutaj."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Połącz się z gateway, aby załadować ostatnią aktywność czatu."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Otwórz"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Nie wczytano propozycji"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Połącz w Ustawieniach, aby wczytać propozycje Skill Workshop."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Nowe propozycje pojawią się tutaj, gdy agenci opracują skills."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Połącz w Ustawieniach, aby wczytać propozycje Skill Workshop."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Nie wczytano kart"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Połącz w Ustawieniach, aby wczytać karty workboard."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Utwórz kartę lub zmień filtr."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Połącz w Ustawieniach, aby wczytać karty workboard."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Wybierz, kiedy OpenClaw może udostępniać lokalizację tego iPhone'a narzędziom Gateway."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Zapomnij Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "Wybudzanie głosem"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Wykryto"
@@ -6484,14 +6879,14 @@
       "translated": "Wykryto • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Konfiguracja zakolejkowana dla zegarka. Otwórz OpenClaw, zanim kod wygaśnie."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Konfiguracja wysłana. Otwórz OpenClaw na zegarku, aby się połączyć."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Konfiguracja zakolejkowana dla zegarka. Otwórz OpenClaw, zanim kod wygaśnie."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Nie skonfigurowano"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Zatwierdzenia"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Żadne działania Gateway nie czekają na sprawdzenie."
@@ -6659,14 +7064,14 @@
       "translated": "Przejrzyj oczekujące akcje gateway."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Zainstaluj aplikację OpenClaw na zegarku przed włączeniem trybu bezpośredniego."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Przekaźnik pozostaje dostępny; tryb bezpośredni dodaje niezależny węzeł Gateway."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Zainstaluj aplikację OpenClaw na zegarku przed włączeniem trybu bezpośredniego."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Zainstalowano"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Ustawienia głosu i rozmowy"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Wymagane uprawnienie Gateway"
@@ -7879,6 +8299,16 @@
       "translated": "Otwórz Ustawienia, jeśli potrzebujesz ręcznego hosta."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Zaufać temu Gateway?"
@@ -8164,6 +8594,11 @@
       "translated": "Offline"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Zatwierdzenie"
@@ -8174,14 +8609,19 @@
       "translated": "To zatwierdzenie zostało już"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "To zatwierdzenie zostało już ustawione na Zawsze zezwalaj."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Zatwierdzenie ustawione na Zawsze zezwalaj."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "To zatwierdzenie zostało już ustawione na Zawsze zezwalaj."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Wymaga uwagi"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Gotowe do połączenia"
@@ -8299,14 +8744,14 @@
       "translated": "Link konfiguracji"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Tekst jawny może ujawnić dane uwierzytelniające. Kontynuuj tylko wtedy, gdy ufasz tej sieci lokalnej i hostowi."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Sprawdź ten punkt końcowy. Dane uwierzytelniające zostaną zastosowane dopiero po stuknięciu Połącz."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Tekst jawny może ujawnić dane uwierzytelniające. Kontynuuj tylko wtedy, gdy ufasz tej sieci lokalnej i hostowi."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Kopiuj polecenie kodu konfiguracji"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Połącz"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Rozmawiaj"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Domyślna Gateway"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Otwórz ustawienia Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Nie sprawdzono"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Ładowanie nie powiodło się"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Błąd czatu"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Zatwierdź tę prośbę na swoim gateway. Talk uruchomi się automatycznie po otrzymaniu zatwierdzenia."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "To urządzenie wymaga zatwierdzenia przez gateway, zanim Talk będzie mógł używać głosu w czasie rzeczywistym. Dźwięk będzie przesyłany bezpośrednio z "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw łączy ten Apple Watch bezpośrednio z Twoim Gateway w zaufanych sieciach lokalnych."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Gotowe do połączenia"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Użyj Ustawień iPhone'a, aby włączyć połączenie bezpośrednie."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Konfiguracja"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Otwórz Ustawienia iPhone'a → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Używa Wi-Fi lub sieci komórkowej, gdy OpenClaw jest aktywny"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Otwórz Ustawienia iPhone'a → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Polecenie do przejrzenia"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Ty"
@@ -9499,6 +10024,11 @@
       "translated": "Zatwierdzenie"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Przejrzyj polecenie"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Odmów"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "Nie udało się zainstalować OpenClaw w folderze Aplikacje. Przenieś go tam ręcznie, a następnie otwórz tę kopię."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "Zainstalować OpenClaw w folderze Aplikacje?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Zastąpić starszą wersję OpenClaw w folderze Aplikacje?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw skopiuje się do folderu Aplikacje i otworzy się ponownie stamtąd, aby aktualizacje i uruchamianie przy logowaniu działały niezawodnie."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Zainstalować OpenClaw w folderze Aplikacje?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Ta kopia jest nowsza niż zainstalowana aplikacja. OpenClaw ją zastąpi i otworzy się ponownie z folderu Aplikacje."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw skopiuje się do folderu Aplikacje i otworzy się ponownie stamtąd, aby aktualizacje i uruchamianie przy logowaniu działały niezawodnie."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Mikrofon"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Włączone"
@@ -9954,6 +10494,11 @@
       "translated": "Błąd"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Wylogowano i wyczyszczono dane logowania."
@@ -9964,14 +10509,14 @@
       "translated": "Nie znaleziono sesji WhatsApp."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Nie skonfigurowano tokena Telegram."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Token Telegram wyczyszczony."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Nie skonfigurowano tokena Telegram."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Konfiguracja"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Edytuj ~/.openclaw/openclaw.json za pomocą formularza opartego na schemacie."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Ta karta jest tylko do odczytu w trybie Nix. Edytuj konfigurację przez Nix i przebuduj."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Edytuj ~/.openclaw/openclaw.json za pomocą formularza opartego na schemacie."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "pogorszony: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Dzisiaj"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Twój asystent konfiguracji oparty na AI. Może sprawdzać status, naprawiać konfigurację, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Nie oznaczaj zadania jako nieudanego, jeśli ogłoszenie się nie powiedzie"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Sprawdź Ustawienia → Połączenie lub użyj Debug → Reset Remote Tunnel, a następnie spróbuj ponownie."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Zakończyć \\(listener.command) (\\(listener.pid))?"
@@ -10754,9 +11314,9 @@
       "translated": "Zapisuj rotacyjny dziennik diagnostyczny (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Zapisuje rotacyjny, wyłącznie lokalny dziennik w ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Link głęboki zablokowany"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "Uruchomić agenta OpenClaw?"
@@ -11064,9 +11629,9 @@
       "translated": "Wzorzec nie może być pusty."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Tylko wzorce ścieżek. Uwzględnij '/', '~' lub '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Nie udało się zapisać zatwierdzeń exec. Wyświetlono ostatnie znane ustawienia; ponów zmianę."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Nie znaleziono jeszcze żadnych Gateway."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Kliknij wykryty Gateway, aby wypełnić cel SSH."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Kliknij wykryty Gateway, aby wypełnić adres URL Gateway."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Kliknij wykryty Gateway, aby wypełnić cel SSH."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "Wykrywaj Gateway OpenClaw w swojej sieci LAN"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "niepołączono"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Zalecana konfiguracja"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Użyj Tailscale Serve, aby gateway miał prawidłowy certyfikat HTTPS."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Użyj Tailscale oraz tunelu SSH, aby uzyskać stabilny prywatny dostęp."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Użyj Tailscale Serve, aby gateway miał prawidłowy certyfikat HTTPS."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Dalej"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw – aktywny miernik na żywo Voice Wake"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Resetuj tunel zdalny"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Szczegółowe logowanie (Main): Wyłączone"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Szczegółowe logowanie (Main): Włączone"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Szczegółowe logowanie (Main): Wyłączone"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Poziom szczegółowości"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Logowanie do pliku: Wyłączone"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Logowanie do pliku: Włączone"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Logowanie do pliku: Wyłączone"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Rozłączono (używanie domyślnego ustawienia systemowego)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) nie mógł ukończyć testu. Pokaż szczegóły, aby sprawdzić lub skopiować błąd."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Wyszukiwanie AI, którego już używasz…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Oczekiwanie na zakończenie poprzedniego testu AI…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Sprawdzanie Claude Code, Codex, Gemini oraz zapisanych kluczy API."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Wyszukiwanie AI, którego już używasz…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw sprawdzi ponownie przed zmianą jakichkolwiek ustawień wnioskowania."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Sprawdzanie Claude Code, Codex, Gemini oraz zapisanych kluczy API."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Kopiuj błąd"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Wskazówka: pozostaw Tailscale włączone, aby gateway był dostępny."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Wskazówka: użyj Tailscale Serve, aby gateway miał prawidłowy certyfikat HTTPS."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Wskazówka: pozostaw Tailscale włączone, aby gateway był dostępny."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Użyj panelu + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Otwórz panel paska menu, aby szybko rozmawiać; agent może pokazywać podglądy "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Odrzuć"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Urządzenie chce połączyć się z OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Węzeł chce połączyć się z OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Urządzenie chce połączyć się z OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "Aplikacja OpenClaw na Maca"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "To urządzenie wymaga zatwierdzenia parowania"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Wklej token skonfigurowany na hoście gateway. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Sprawdź `gateway.auth.token` lub `OPENCLAW_GATEWAY_TOKEN` na hoście gateway i spróbuj ponownie."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Ten gateway jest ustawiony na uwierzytelnianie tokenem, ale na hoście gateway nie skonfigurowano `gateway.auth.token`. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Zeskanuj lub wklej nowy kod konfiguracji z już sparowanego klienta OpenClaw, a następnie spróbuj ponownie."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Ten proces wdrażania nie obsługuje jeszcze uwierzytelniania hasłem. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Zatwierdź to urządzenie z już sparowanego klienta OpenClaw. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Ten gateway używa uwierzytelniania hasłem. Zdalne wdrażanie na macOS nie może jeszcze zbierać haseł gateway."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Wymagane parowanie. W już sparowanym kliencie OpenClaw, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Nie zgłoszono jeszcze żadnych skills"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Brak dźwięku"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake wymaga systemu macOS 26 lub nowszego"
@@ -14269,6 +14884,11 @@
       "translated": "Domyślne systemowe"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Odłączono (używane domyślne systemowe)"
@@ -14394,6 +15014,11 @@
       "translated": " (filtrowane lokalnie)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "Nieprawidłowy URL: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway połączony"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Tokeny wejściowe: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Wykorzystanie kontekstu"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Wykorzystanie wiadomości"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Przywróć z archiwum"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Ponów wysyłanie"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Konfiguracja"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -194,6 +194,11 @@
       "translated": "Modo de conversa ativo"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Mic: Ouvindo"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Falha: não foi possível acessar o endpoint seguro do gateway para este host."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Isso remove permanentemente a tarefa agendada do gateway."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Acesso de administrador necessário"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Alterações no cron exigem operator.admin. Os códigos de configuração intencionalmente não o concedem. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Caminho opcional"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "O gateway pode alterar este caminho, mas não pode limpar um caminho existente."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Online"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Permissões"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "O código pode ter expirado ou ter sido gerado para outro Gateway."
@@ -1734,9 +1804,24 @@
       "translated": "A autenticação do Gateway precisa ser revisada. Verifique as configurações do gateway e tente novamente."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Nenhum modelo configurado"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sessões"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Pesquisar sessões"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Mais recentes primeiro"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Mais antigos primeiro"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Layout: Detalhado"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Fixar"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Marcar como não lida"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "O OpenClaw pode receber alertas selecionados."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Concedido"
@@ -2374,6 +2564,21 @@
       "translated": "Recursos do telefone"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Permita acesso à biblioteca de fotos."
@@ -2384,6 +2589,11 @@
       "translated": "Acesso selecionado ou completo às fotos concedido."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "A lista de apps permanece neste telefone."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "O OpenClaw pode listar apps visíveis no launcher."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Permitir localização em segundo plano?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "O OpenClaw só verifica a localização quando o Gateway pareado solicita. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Esquecer Gateway?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "Abrir ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Verificar"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Nenhum limite informado"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Desativado"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Texto do payload"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "AGENTE ATIVO"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Nenhum"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Conversas recentes"
@@ -3039,6 +3304,16 @@
       "translated": "Bloqueado"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count provedores"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} prontos"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Nenhuma skill"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Conversa em tempo real"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Configurações da conversa"
@@ -3594,6 +3874,11 @@
       "translated": "Não foi possível decodificar esta imagem."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} mais"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Você"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Excluir"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Anexo não compatível"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Pronto quando você estiver"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "O OpenClaw exibirá aprovações, trabalhos com falha e problemas de canais aqui."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Falando · aguardando resposta"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Enviando voz na fila"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Câmera"
@@ -4284,9 +4619,9 @@
       "translated": "Microfone"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Ainda não há diário de sonhos"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "O gateway não encontrou DREAMS.md ou dreams.md no workspace do agente ativo."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) existe, mas não tem conteúdo legível."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "O gateway não encontrou DREAMS.md ou dreams.md no workspace do agente ativo."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Diário indisponível"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Conecte um gateway para ler entradas do diário de sonhos."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "O gateway não retornou conteúdo do diário de sonhos."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Conecte um gateway para ler entradas do diário de sonhos."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Sem status da fase"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Conecte um gateway para carregar as fases de sonho."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "O gateway não retornou detalhes das fases de sonho."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Conecte um gateway para carregar as fases de sonho."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "nenhum reparo necessário"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Nenhuma instância conectada"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Conecte um gateway para inspecionar as instâncias conectadas."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "O gateway não relatou nenhuma entrada de presença do sistema."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Conecte um gateway para inspecionar as instâncias conectadas."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Nada relatado."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Agendador"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Uso"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Nenhum trabalho agendado"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Conecte um gateway para carregar trabalhos agendados."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "O gateway não tem trabalhos cron visíveis."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Conecte um gateway para carregar trabalhos agendados."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills indisponíveis"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Conecte um Gateway para carregar as Skills do workspace."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Tente uma pesquisa diferente ou atualize pelo Gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Conecte um Gateway para carregar as Skills do workspace."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Renomear grupo"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Atividade"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Atividade recente"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Atividade da sessão offline"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Conecte-se ao gateway para carregar a atividade recente de chat."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Inicie um chat e ele aparecerá aqui."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Conecte-se ao gateway para carregar a atividade recente de chat."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Abrir"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Nenhuma proposta carregada"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Conecte-se em Ajustes para carregar propostas do Skill Workshop."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Novas propostas aparecerão aqui quando os agentes criarem rascunhos de skills."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Conecte-se em Ajustes para carregar propostas do Skill Workshop."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Nenhum cartão carregado"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Conecte em Ajustes para carregar cartões do quadro de trabalho."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Crie um cartão ou altere o filtro."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Conecte em Ajustes para carregar cartões do quadro de trabalho."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Escolha quando o OpenClaw pode compartilhar a localização deste iPhone com as ferramentas do gateway."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Esquecer Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "Ativação por voz"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Descoberto"
@@ -6484,14 +6879,14 @@
       "translated": "Descoberto • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Configuração na fila para o relógio. Abra o OpenClaw antes que o código expire."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Configuração enviada. Abra o OpenClaw no relógio para conectar."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Configuração na fila para o relógio. Abra o OpenClaw antes que o código expire."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Não configurado"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Aprovações"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Nenhuma ação do gateway está aguardando revisão."
@@ -6659,14 +7064,14 @@
       "translated": "Revise ações pendentes do Gateway."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Instale o app do OpenClaw para o relógio antes de ativar o modo direto."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "O relay permanece disponível; o modo direto adiciona um nó independente do Gateway."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Instale o app do OpenClaw para o relógio antes de ativar o modo direto."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Instalado"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Configurações de voz e fala"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Permissão do Gateway necessária"
@@ -7879,6 +8299,16 @@
       "translated": "Abra os Ajustes se precisar de um host manual."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Confiar neste Gateway?"
@@ -8164,6 +8594,11 @@
       "translated": "Offline"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Aprovação"
@@ -8174,14 +8609,19 @@
       "translated": "Esta aprovação já foi"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Esta aprovação já estava definida como Permitir sempre."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Aprovação definida como Permitir sempre."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Esta aprovação já estava definida como Permitir sempre."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Requer atenção"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Pronto para Conectar"
@@ -8299,14 +8744,14 @@
       "translated": "Link de configuração"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Texto simples pode expor credenciais. Continue apenas se você confia nesta rede local e neste host."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Revise este endpoint. As credenciais são aplicadas somente depois que você tocar em Conectar."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Texto simples pode expor credenciais. Continue apenas se você confia nesta rede local e neste host."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Copiar comando do código de configuração"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Conectar"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Conversar"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Padrão do Gateway"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Abrir configurações do Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Não verificado"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Falha ao carregar"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Erro no chat"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Aprove esta solicitação no seu gateway. O Talk será iniciado automaticamente quando a aprovação chegar."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Este dispositivo precisa da aprovação do gateway antes que o Talk possa usar voz em tempo real. O áudio irá diretamente de "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "O OpenClaw conecta este Apple Watch diretamente ao seu Gateway em redes locais confiáveis."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Pronto para conectar"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Use os Ajustes do iPhone para ativar a conexão direta."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Configuração"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Abra Ajustes do iPhone → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Usa Wi-Fi ou rede celular enquanto o OpenClaw está ativo"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Abra Ajustes do iPhone → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Comando a revisar"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Você"
@@ -9499,6 +10024,11 @@
       "translated": "Aprovação"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Revisar Comando"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Negar"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "Não foi possível instalar o OpenClaw em Aplicativos. Mova-o para lá manualmente e abra essa cópia."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "Instalar o OpenClaw em Aplicativos?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Substituir a versão mais antiga do OpenClaw em Aplicativos?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "O OpenClaw se copiará para Aplicativos e reabrirá de lá para que as atualizações e a inicialização no login permaneçam confiáveis."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Instalar o OpenClaw em Aplicativos?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Esta cópia é mais recente que o aplicativo instalado. O OpenClaw irá substituí-lo e reabrir a partir de Aplicativos."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "O OpenClaw se copiará para Aplicativos e reabrirá de lá para que as atualizações e a inicialização no login permaneçam confiáveis."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Microfone"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Ativado"
@@ -9954,6 +10494,11 @@
       "translated": "Erro"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Desconectado e credenciais apagadas."
@@ -9964,14 +10509,14 @@
       "translated": "Nenhuma sessão do WhatsApp encontrada."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Nenhum token do Telegram configurado."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Token do Telegram apagado."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Nenhum token do Telegram configurado."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Configuração"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Edite ~/.openclaw/openclaw.json usando o formulário orientado por esquema."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Esta aba é somente leitura no modo Nix. Edite a configuração via Nix e recompile."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Edite ~/.openclaw/openclaw.json usando o formulário orientado por esquema."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "degradado: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Hoje"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Seu assistente de configuração com IA. Ele pode verificar o status, corrigir configurações, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Não falhar a tarefa se o anúncio falhar"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Verifique Configurações → Conexão ou use Depuração → Redefinir Túnel Remoto e tente novamente."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Encerrar \\(listener.command) (\\(listener.pid))?"
@@ -10754,9 +11314,9 @@
       "translated": "Gravar log de diagnósticos rotativo (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Grava um log rotativo, apenas local, em ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Deep link bloqueado"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "Executar agente do OpenClaw?"
@@ -11064,9 +11629,9 @@
       "translated": "O padrão não pode estar vazio."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Somente padrões de caminho. Inclua '/', '~' ou '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Não foi possível salvar as aprovações de execução. As últimas configurações conhecidas são exibidas; tente a alteração novamente."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Nenhum gateway encontrado ainda."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Clique em um gateway descoberto para preencher o destino SSH."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Clique em um gateway descoberto para preencher a URL do gateway."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Clique em um gateway descoberto para preencher o destino SSH."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "Descobrir gateways OpenClaw na sua LAN"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "não vinculado"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Configuração recomendada"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Use Tailscale Serve para que o Gateway tenha um certificado HTTPS válido."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Use Tailscale com um túnel SSH para acesso privado estável."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Use Tailscale Serve para que o Gateway tenha um certificado HTTPS válido."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Avançar"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - medidor ao vivo de Voice Wake ativo"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Redefinir túnel remoto"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Registro detalhado (principal): desativado"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Registro detalhado (principal): ativado"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Registro detalhado (principal): desativado"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Nível de detalhamento"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Registro em arquivo: desativado"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Registro em arquivo: ativado"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Registro em arquivo: desativado"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Desconectado (usando o padrão do sistema)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) não conseguiu concluir o teste. Mostre os detalhes para inspecionar ou copiar o erro."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Procurando IA que você já usa…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Aguardando a conclusão do teste de IA anterior…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Verificando Claude Code, Codex, Gemini e chaves de API salvas."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Procurando IA que você já usa…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "O OpenClaw verificará novamente antes de alterar qualquer configuração de inferência."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Verificando Claude Code, Codex, Gemini e chaves de API salvas."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Copiar erro"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Dica: mantenha o Tailscale ativado para que seu gateway permaneça acessível."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Dica: use o Tailscale Serve para que o gateway tenha um certificado HTTPS válido."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Dica: mantenha o Tailscale ativado para que seu gateway permaneça acessível."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Usar o painel + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Abra o painel da barra de menus para um chat rápido; o agente pode mostrar prévias "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Rejeitar"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Um dispositivo quer se conectar ao OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Um nó quer se conectar ao OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Um dispositivo quer se conectar ao OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "Aplicativo OpenClaw para Mac"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Este dispositivo precisa de aprovação de pareamento"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Cole o token configurado no host do gateway. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Verifique `gateway.auth.token` ou `OPENCLAW_GATEWAY_TOKEN` no host do gateway e tente novamente."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Este gateway está configurado para autenticação por token, mas nenhum `gateway.auth.token` está configurado no host do gateway. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Escaneie ou cole um novo código de configuração de um cliente OpenClaw já pareado e tente novamente."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Este fluxo de integração ainda não é compatível com autenticação por senha. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Aprove este dispositivo a partir de um cliente OpenClaw já pareado. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Este gateway usa autenticação por senha. A integração remota no macOS ainda não consegue coletar senhas do gateway."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Pareamento necessário. Em um cliente OpenClaw já pareado, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Nenhuma skill informada ainda"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Sem som"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake requer macOS 26 ou mais recente"
@@ -14269,6 +14884,11 @@
       "translated": "Padrão do sistema"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Desconectado (usando o padrão do sistema)"
@@ -14394,6 +15014,11 @@
       "translated": " (filtrado local)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "URL inválida: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway conectado"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Tokens de entrada: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Uso de contexto"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Uso de mensagens"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Desarquivar"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Tentar enviar novamente"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Configuração"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -194,6 +194,11 @@
       "translated": "Режим разговора активен"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Микрофон: слушает"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Ошибка: не удалось подключиться к защищенному эндпоинту Gateway для этого хоста."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Это навсегда удалит запланированное задание из Gateway."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Требуется доступ администратора"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Изменения cron требуют operator.admin. Коды настройки намеренно не предоставляют его. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Необязательный путь"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Gateway может изменить этот путь, но не может удалить существующий путь."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Онлайн"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Разрешения"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Возможно, срок действия кода истек или он был создан для другого Gateway."
@@ -1734,9 +1804,24 @@
       "translated": "Аутентификация Gateway требует проверки. Проверьте настройки gateway, затем повторите попытку."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Нет настроенных моделей"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Сессии"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Поиск сессий"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Сначала новые"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Сначала старые"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Макет: подробный"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Закрепить"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Отметить как непрочитанное"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw может получать выбранные оповещения."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Предоставлено"
@@ -2374,6 +2564,21 @@
       "translated": "Возможности телефона"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Разрешите доступ к медиатеке."
@@ -2384,6 +2589,11 @@
       "translated": "Предоставлен доступ к выбранным фотографиям или ко всей медиатеке."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "Список приложений остается на этом телефоне."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw может показывать список приложений, видимых в лаунчере."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Разрешить фоновое определение местоположения?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw проверяет местоположение только по запросу вашего связанного Gateway. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Забыть gateway?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "Открыть ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Проверить"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Ограничения не указаны"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Выкл."
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Текст полезной нагрузки"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "АКТИВНЫЙ АГЕНТ"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Нет"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Недавние разговоры"
@@ -3039,6 +3304,16 @@
       "translated": "Заблокировано"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count провайдеров"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} готово"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Нет Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Разговор в реальном времени"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Настройки разговора"
@@ -3594,6 +3874,11 @@
       "translated": "Не удалось декодировать это изображение."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} еще"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Вы"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Удалить"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Неподдерживаемое вложение"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Готовы, когда будете готовы"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw будет показывать здесь подтверждения, неудачные задания и проблемы с каналами."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Говорит · ожидание ответа"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Отправка голоса из очереди"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Камера"
@@ -4284,9 +4619,9 @@
       "translated": "Микрофон"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Дневника сновидений пока нет"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Gateway не нашел DREAMS.md или dreams.md в активной рабочей области агента."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) существует, но не содержит читаемого содержимого."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Gateway не нашел DREAMS.md или dreams.md в активной рабочей области агента."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Дневник недоступен"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Подключите Gateway, чтобы читать записи дневника сновидений."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Gateway не вернул содержимое дневника сновидений."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Подключите Gateway, чтобы читать записи дневника сновидений."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Нет статуса фазы"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Подключите Gateway, чтобы загрузить фазы сновидения."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway не вернул сведения о фазах сновидения."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Подключите Gateway, чтобы загрузить фазы сновидения."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "восстановление не требуется"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Нет подключенных экземпляров"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Подключите Gateway, чтобы просмотреть подключенные экземпляры."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway не сообщил ни одной записи о присутствии в системе."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Подключите Gateway, чтобы просмотреть подключенные экземпляры."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Нет данных."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Планировщик"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Использование"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Нет запланированных заданий"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Подключите Gateway, чтобы загрузить запланированную работу."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "В Gateway нет видимых заданий cron."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Подключите Gateway, чтобы загрузить запланированную работу."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills недоступны"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Подключите Gateway, чтобы загрузить Skills рабочего пространства."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Попробуйте другой поисковый запрос или обновите данные через Gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Подключите Gateway, чтобы загрузить Skills рабочего пространства."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Переименовать группу"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Активность"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Недавняя активность"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Активность сеансов офлайн"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Подключитесь к Gateway, чтобы загрузить недавнюю активность чатов."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Начните чат, и он появится здесь."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Подключитесь к Gateway, чтобы загрузить недавнюю активность чатов."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Открыть"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Предложения не загружены"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Подключитесь в Settings, чтобы загрузить предложения Skill Workshop."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Новые предложения появятся здесь, когда агенты подготовят Skills."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Подключитесь в Settings, чтобы загрузить предложения Skill Workshop."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Карточки не загружены"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Подключитесь в Settings, чтобы загрузить карточки Workboard."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Создайте карточку или измените фильтр."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Подключитесь в Settings, чтобы загрузить карточки Workboard."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Выберите, когда OpenClaw может передавать местоположение этого iPhone инструментам Gateway."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Забыть Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "Голосовая активация"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Обнаружен"
@@ -6484,14 +6879,14 @@
       "translated": "Обнаружен • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Настройка поставлена в очередь для часов. Откройте OpenClaw до истечения срока действия кода."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Настройка отправлена. Откройте OpenClaw на часах, чтобы подключиться."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Настройка поставлена в очередь для часов. Откройте OpenClaw до истечения срока действия кода."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Не настроено"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Одобрения"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Нет действий Gateway, ожидающих проверки."
@@ -6659,14 +7064,14 @@
       "translated": "Просмотрите ожидающие действия Gateway."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Установите приложение OpenClaw для часов перед включением прямого режима."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Реле остаётся доступным; прямой режим добавляет независимый узел Gateway."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Установите приложение OpenClaw для часов перед включением прямого режима."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Установлено"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Настройки голоса и разговора"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Требуется разрешение Gateway"
@@ -7879,6 +8299,16 @@
       "translated": "Откройте настройки, если нужно указать хост вручную."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Доверять этому Gateway?"
@@ -8164,6 +8594,11 @@
       "translated": "Не в сети"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Подтверждение"
@@ -8174,14 +8609,19 @@
       "translated": "Это подтверждение уже было"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Это подтверждение уже установлено на «Разрешить всегда»."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Подтверждение установлено на «Разрешить всегда»."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Это подтверждение уже установлено на «Разрешить всегда»."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Требует внимания"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Готово к подключению"
@@ -8299,14 +8744,14 @@
       "translated": "Ссылка для настройки"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Открытый текст может раскрыть учетные данные. Продолжайте, только если вы доверяете этой локальной сети и хосту."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Проверьте эту конечную точку. Учетные данные будут применены только после нажатия Connect."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Открытый текст может раскрыть учетные данные. Продолжайте, только если вы доверяете этой локальной сети и хосту."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Скопировать команду с кодом настройки"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Подключиться"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Говорить"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway по умолчанию"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Открыть настройки Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Не проверено"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Не удалось загрузить"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Ошибка чата"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Подтвердите этот запрос на вашем gateway. Talk запустится автоматически, когда будет получено подтверждение."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Этому устройству требуется подтверждение gateway, прежде чем Talk сможет использовать голос в реальном времени. Аудио будет передаваться напрямую из "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw подключает эти Apple Watch напрямую к вашему Gateway в доверенных локальных сетях."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Готово к подключению"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Включите прямое подключение в настройках iPhone."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Настройка"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Откройте «Настройки iPhone» → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Использует Wi-Fi или сотовую сеть, пока OpenClaw активен"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Откройте «Настройки iPhone» → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Команда для проверки"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Вы"
@@ -9499,6 +10024,11 @@
       "translated": "Подтверждение"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Проверить команду"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Отклонить"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "Не удалось установить OpenClaw в Applications. Переместите приложение туда вручную, затем откройте эту копию."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "Установить OpenClaw в Applications?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Заменить более старый OpenClaw в Applications?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw скопирует себя в Applications и снова откроется оттуда, чтобы обновления и запуск при входе работали надёжно."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Установить OpenClaw в Applications?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Эта копия новее установленного приложения. OpenClaw заменит его и снова откроется из Applications."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw скопирует себя в Applications и снова откроется оттуда, чтобы обновления и запуск при входе работали надёжно."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Микрофон"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Включено"
@@ -9954,6 +10494,11 @@
       "translated": "Ошибка"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Выход выполнен, учетные данные удалены."
@@ -9964,14 +10509,14 @@
       "translated": "Сеанс WhatsApp не найден."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Токен Telegram не настроен."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Токен Telegram удален."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Токен Telegram не настроен."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Конфигурация"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Редактируйте ~/.openclaw/openclaw.json с помощью формы на основе схемы."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Эта вкладка доступна только для чтения в режиме Nix. Измените конфигурацию через Nix и выполните пересборку."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Редактируйте ~/.openclaw/openclaw.json с помощью формы на основе схемы."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "ухудшено: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Сегодня"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Ваш помощник по настройке на базе ИИ. Он может проверять статус, исправлять конфигурацию, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Не завершать задачу с ошибкой, если оповещение не удалось"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Проверьте Настройки → Подключение или используйте Отладка → Сбросить удалённый туннель, затем повторите попытку."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Завершить \\(listener.command) (\\(listener.pid))?"
@@ -10754,9 +11314,9 @@
       "translated": "Записывать циклический журнал диагностики (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Записывает локальный ротируемый журнал в ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Deep link заблокирован"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "Запустить агента OpenClaw?"
@@ -11064,9 +11629,9 @@
       "translated": "Шаблон не может быть пустым."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Только шаблоны путей. Включите '/', '~' или '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Не удалось сохранить одобрения выполнения. Показаны последние известные настройки; повторите изменение."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Шлюзы пока не найдены."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Нажмите на обнаруженный шлюз, чтобы заполнить цель SSH."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Нажмите на обнаруженный шлюз, чтобы заполнить URL шлюза."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Нажмите на обнаруженный шлюз, чтобы заполнить цель SSH."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "Обнаруживать шлюзы OpenClaw в вашей локальной сети"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "не связано"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Рекомендуемая настройка"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Используйте Tailscale Serve, чтобы у Gateway был действительный сертификат HTTPS."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Используйте Tailscale и SSH-туннель для стабильного приватного доступа."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Используйте Tailscale Serve, чтобы у Gateway был действительный сертификат HTTPS."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Вперёд"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - активен индикатор Voice Wake в реальном времени"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Сбросить удаленный туннель"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Подробное логирование (Main): выкл."
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Подробное логирование (Main): вкл."
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Подробное логирование (Main): выкл."
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Подробность"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Логирование в файл: выкл."
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Логирование в файл: вкл."
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Логирование в файл: выкл."
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Отключено (используется системное значение по умолчанию)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) не удалось завершить тест. Покажите подробности, чтобы просмотреть или скопировать ошибку."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Поиск ИИ, которым вы уже пользуетесь…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Ожидание завершения предыдущего теста ИИ…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Проверка Claude Code, Codex, Gemini и сохранённых ключей API."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Поиск ИИ, которым вы уже пользуетесь…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw проверит снова перед изменением любых настроек вывода."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Проверка Claude Code, Codex, Gemini и сохранённых ключей API."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Скопировать ошибку"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Совет: держите Tailscale включенным, чтобы ваш gateway оставался доступен."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Совет: используйте Tailscale Serve, чтобы у gateway был действительный HTTPS-сертификат."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Совет: держите Tailscale включенным, чтобы ваш gateway оставался доступен."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Используйте панель + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Откройте панель в строке меню для быстрого чата; агент может показывать предпросмотры "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Отклонить"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Устройство пытается подключиться к OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Узел пытается подключиться к OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Устройство пытается подключиться к OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "Приложение OpenClaw для Mac"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Для этого устройства требуется подтверждение сопряжения"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Вставьте токен, настроенный на хосте gateway. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Проверьте `gateway.auth.token` или `OPENCLAW_GATEWAY_TOKEN` на хосте gateway и повторите попытку."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Для этого gateway задана аутентификация по токену, но на хосте gateway не настроен `gateway.auth.token`. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Отсканируйте или вставьте новый код настройки из уже сопряженного клиента OpenClaw, затем повторите попытку."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Этот сценарий первичной настройки пока не поддерживает аутентификацию по паролю. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Подтвердите это устройство из уже сопряженного клиента OpenClaw. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Этот gateway использует аутентификацию по паролю. Удаленная первичная настройка в macOS пока не может получать пароли gateway."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Требуется сопряжение. В уже сопряженном клиенте OpenClaw, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Skills пока не обнаружены"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Без звука"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake требует macOS 26 или новее"
@@ -14269,6 +14884,11 @@
       "translated": "По умолчанию в системе"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Отключено (используется системное значение по умолчанию)"
@@ -14394,6 +15014,11 @@
       "translated": " (локально отфильтровано)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "Недопустимый URL: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway подключен"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Входные токены: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Использование контекста"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Использование сообщений"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Разархивировать"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Повторить отправку"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Настройка"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -194,6 +194,11 @@
       "translated": "Pratläge aktivt"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Mikrofon: Lyssnar"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Misslyckades: kunde inte nå den säkra Gateway-slutpunkten för den här värden."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Detta tar permanent bort det schemalagda jobbet från gatewayen."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Administratörsåtkomst krävs"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Cron-ändringar kräver operator.admin. Installationskoder ger avsiktligt inte det. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Valfri sökväg"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Gatewayen kan ändra denna sökväg men kan inte rensa en befintlig sökväg."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Online"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Behörigheter"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Koden kan ha gått ut eller genererats för en annan Gateway."
@@ -1734,9 +1804,24 @@
       "translated": "Gateway-autentisering behöver granskas. Kontrollera Gateway-inställningarna och försök igen."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Inga konfigurerade modeller"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Sessioner"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Sök sessioner"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Nyaste först"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Äldsta först"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Layout: Detaljerad"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Fäst"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Markera som oläst"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw kan ta emot valda varningar."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Beviljad"
@@ -2374,6 +2564,21 @@
       "translated": "Telefonfunktioner"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Tillåt åtkomst till fotobiblioteket."
@@ -2384,6 +2589,11 @@
       "translated": "Vald eller fullständig fotoåtkomst har beviljats."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "Applistan stannar på den här telefonen."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw kan lista appar som visas i startprogrammet."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Tillåt platsåtkomst i bakgrunden?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw kontrollerar endast platsen när din parkopplade Gateway begär det. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Glöm Gateway?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "Öppna ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Kontrollera"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Inga gränser rapporterade"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Av"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Nyttolasttext"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "AKTIV AGENT"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Ingen"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Senaste konversationer"
@@ -3039,6 +3304,16 @@
       "translated": "Låst"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count providers"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} redo"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Inga Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Realtidssamtal"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Samtalsinställningar"
@@ -3594,6 +3874,11 @@
       "translated": "Den här bilden kunde inte avkodas."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} till"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Du"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Radera"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Bilaga stöds inte"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Redo när du är det"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw kommer att visa godkännanden, misslyckade jobb och kanalproblem här."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Talar · väntar på svar"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Skickar köad röst"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Kamera"
@@ -4284,9 +4619,9 @@
       "translated": "Mikrofon"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Ingen drömdagbok ännu"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Gateway hittade inte DREAMS.md eller dreams.md i den aktiva agentarbetsytan."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) finns men har inget läsbart innehåll."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Gateway hittade inte DREAMS.md eller dreams.md i den aktiva agentarbetsytan."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Dagbok inte tillgänglig"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Anslut en gateway för att läsa drömdagboksanteckningar."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Gateway returnerade inget drömdagboksinnehåll."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Anslut en gateway för att läsa drömdagboksanteckningar."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Ingen fasstatus"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Anslut en gateway för att läsa in drömningsfaser."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gatewayen returnerade inga detaljer om drömningsfas."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Anslut en gateway för att läsa in drömningsfaser."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "ingen reparation behövs"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Inga instanser anslutna"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Anslut en gateway för att granska anslutna instanser."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gatewayen rapporterade inga poster om systemnärvaro."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Anslut en gateway för att granska anslutna instanser."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Inget rapporterat."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Schemaläggare"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Användning"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Inga schemalagda jobb"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Anslut en gateway för att läsa in schemalagt arbete."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Gateway har inga synliga cron-jobb."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Anslut en gateway för att läsa in schemalagt arbete."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills är inte tillgängliga"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Anslut en Gateway för att läsa in arbetsytans Skills."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Prova en annan sökning eller uppdatera från Gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Anslut en Gateway för att läsa in arbetsytans Skills."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Byt namn på grupp"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Aktivitet"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Senaste aktivitet"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Sessionsaktivitet offline"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Anslut till gatewayen för att läsa in senaste chattaktivitet."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Starta en chatt så visas den här."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Anslut till gatewayen för att läsa in senaste chattaktivitet."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Öppna"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Inga förslag inlästa"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Anslut från Inställningar för att läsa in Skill Workshop-förslag."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Nya förslag visas här när agenter utformar skills."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Anslut från Inställningar för att läsa in Skill Workshop-förslag."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Inga kort inlästa"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Anslut från Inställningar för att läsa in workboard-kort."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Skapa ett kort eller ändra filtret."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Anslut från Inställningar för att läsa in workboard-kort."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Välj när OpenClaw får dela den här iPhonens plats med gateway-verktyg."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Glöm Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "Röstväckning"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Upptäckt"
@@ -6484,14 +6879,14 @@
       "translated": "Upptäckt • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Konfiguration köad för klockan. Öppna OpenClaw innan koden går ut."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Konfiguration skickad. Öppna OpenClaw på klockan för att ansluta."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Konfiguration köad för klockan. Öppna OpenClaw innan koden går ut."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Inte konfigurerad"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Godkännanden"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Inga gateway-åtgärder väntar på granskning."
@@ -6659,14 +7064,14 @@
       "translated": "Granska väntande gateway-åtgärder."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Installera OpenClaw-klockappen innan du aktiverar direktläge."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Relä förblir tillgängligt; direktläge lägger till en oberoende Gateway-nod."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Installera OpenClaw-klockappen innan du aktiverar direktläge."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Installerad"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Inställningar för röst och samtal"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Gateway-behörighet krävs"
@@ -7879,6 +8299,16 @@
       "translated": "Öppna Inställningar om du behöver ange en värd manuellt."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Lita på denna Gateway?"
@@ -8164,6 +8594,11 @@
       "translated": "Offline"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Godkännande"
@@ -8174,14 +8609,19 @@
       "translated": "Detta godkännande var redan"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Detta godkännande var redan inställt på Tillåt alltid."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Godkännande inställt på Tillåt alltid."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Detta godkännande var redan inställt på Tillåt alltid."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Kräver åtgärd"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Redo att ansluta"
@@ -8299,14 +8744,14 @@
       "translated": "Konfigurationslänk"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Klartext kan exponera inloggningsuppgifter. Fortsätt endast om du litar på det här lokala nätverket och värden."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Granska den här ändpunkten. Inloggningsuppgifter tillämpas först efter att du trycker på Anslut."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Klartext kan exponera inloggningsuppgifter. Fortsätt endast om du litar på det här lokala nätverket och värden."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Kopiera kommando för konfigurationskod"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Anslut"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Prata"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway-standard"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Öppna Gateway-inställningar"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Inte kontrollerad"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Inläsning misslyckades"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Chattfel"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Godkänn den här förfrågan på din gateway. Talk startar automatiskt när godkännandet tas emot."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Den här enheten behöver gateway-godkännande innan Talk kan använda röst i realtid. Ljudet går direkt från "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw ansluter denna Apple Watch direkt till din Gateway på betrodda lokala nätverk."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Redo att ansluta"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Använd iPhone-inställningarna för att aktivera direktanslutning."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Konfiguration"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Öppna iPhone-inställningar → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Använder Wi-Fi eller mobilnät när OpenClaw är aktivt"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Öppna iPhone-inställningar → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Kommando att granska"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Du"
@@ -9499,6 +10024,11 @@
       "translated": "Godkännande"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Granska kommando"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Neka"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw kunde inte installeras i Program. Flytta det dit manuellt och öppna sedan den kopian."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "Installera OpenClaw i Program?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Ersätt den äldre OpenClaw i Program?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw kopierar sig själv till Program och öppnas där igen så att uppdateringar och start vid inloggning förblir pålitliga."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Installera OpenClaw i Program?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Den här kopian är nyare än den installerade appen. OpenClaw ersätter den och öppnas igen från Program."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw kopierar sig själv till Program och öppnas där igen så att uppdateringar och start vid inloggning förblir pålitliga."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Mikrofon"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Aktiverad"
@@ -9954,6 +10494,11 @@
       "translated": "Fel"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Utloggad och autentiseringsuppgifter rensade."
@@ -9964,14 +10509,14 @@
       "translated": "Ingen WhatsApp-session hittades."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Ingen Telegram-token har konfigurerats."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Telegram-token rensad."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Ingen Telegram-token har konfigurerats."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Konfiguration"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Redigera ~/.openclaw/openclaw.json med det schemastyrda formuläret."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Den här fliken är skrivskyddad i Nix-läge. Redigera konfigurationen via Nix och bygg om."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Redigera ~/.openclaw/openclaw.json med det schemastyrda formuläret."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "försämrad: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Idag"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Din AI-drivna installationshjälp. Den kan kontrollera status, åtgärda konfiguration, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Låt inte jobbet misslyckas om aviseringen misslyckas"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Kontrollera Inställningar → Anslutning eller använd Felsökning → Återställ fjärrtunnel och försök sedan igen."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Avsluta \\(listener.command) (\\(listener.pid))?"
@@ -10754,9 +11314,9 @@
       "translated": "Skriv rullande diagnostiklogg (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Skriver en roterande, endast lokal logg under ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Djuplänk blockerad"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "Köra OpenClaw-agent?"
@@ -11064,9 +11629,9 @@
       "translated": "Mönstret får inte vara tomt."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Endast sökvägsmönster. Inkludera '/', '~' eller '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Det gick inte att spara exec-godkännanden. De senast kända inställningarna visas; försök att ändra igen."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Inga gateways hittades ännu."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Klicka på en upptäckt gateway för att fylla i SSH-målet."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Klicka på en upptäckt gateway för att fylla i gateway-URL:en."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Klicka på en upptäckt gateway för att fylla i SSH-målet."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "Upptäck OpenClaw-gateways i ditt LAN"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "inte länkad"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Rekommenderad konfiguration"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Använd Tailscale Serve så att gatewayen har ett giltigt HTTPS-certifikat."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Använd Tailscale plus en SSH-tunnel för stabil privat åtkomst."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Använd Tailscale Serve så att gatewayen har ett giltigt HTTPS-certifikat."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Framåt"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - live-mätare för röstväckning aktiv"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Återställ fjärrtunnel"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Utförlig loggning (Main): Av"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Utförlig loggning (Main): På"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Utförlig loggning (Main): Av"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Utförlighetsnivå"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Filloggning: Av"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Filloggning: På"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Filloggning: Av"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Frånkopplad (använder systemstandard)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) kunde inte slutföra testet. Visa detaljer för att granska eller kopiera felet."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Letar efter AI du redan använder…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Väntar på att det tidigare AI-testet ska slutföras…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Söker efter Claude Code, Codex, Gemini och sparade API-nycklar."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Letar efter AI du redan använder…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw kontrollerar igen innan några inferensinställningar ändras."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Söker efter Claude Code, Codex, Gemini och sparade API-nycklar."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Kopiera fel"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Tips: håll Tailscale aktiverat så att din gateway förblir nåbar."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Tips: använd Tailscale Serve så att gatewayen har ett giltigt HTTPS-certifikat."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Tips: håll Tailscale aktiverat så att din gateway förblir nåbar."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Använd panelen + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Öppna menyradspanelen för snabbchatt; agenten kan visa förhandsvisningar "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Avvisa"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "En enhet vill ansluta till OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "En nod vill ansluta till OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "En enhet vill ansluta till OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "OpenClaw Mac-app"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Den här enheten behöver parkopplingsgodkännande"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Klistra in den token som är konfigurerad på Gateway-värden. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Kontrollera `gateway.auth.token` eller `OPENCLAW_GATEWAY_TOKEN` på Gateway-värden och försök igen."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Denna Gateway är inställd på tokenautentisering, men ingen `gateway.auth.token` är konfigurerad på Gateway-värden. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Skanna eller klistra in en ny konfigurationskod från en redan parkopplad OpenClaw-klient och försök sedan igen."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Det här introduktionsflödet stöder inte lösenordsautentisering ännu. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Godkänn den här enheten från en redan parkopplad OpenClaw-klient. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Denna Gateway använder lösenordsautentisering. Fjärrintroduktion på macOS kan ännu inte samla in Gateway-lösenord."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Parkoppling krävs. I en redan parkopplad OpenClaw-klient, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Inga Skills har rapporterats ännu"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Inget ljud"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake kräver macOS 26 eller senare"
@@ -14269,6 +14884,11 @@
       "translated": "Systemstandard"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Frånkopplad (använder systemstandard)"
@@ -14394,6 +15014,11 @@
       "translated": " (lokalt filtrerad)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "Ogiltig URL: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway ansluten"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Indatatokens: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Kontextanvändning"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Meddelandeanvändning"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Avarkivera"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Försök skicka igen"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Konfiguration"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -194,6 +194,11 @@
       "translated": "โหมดพูดคุยทำงานอยู่"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · ไมค์: กำลังฟัง"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "ล้มเหลว: ไม่สามารถเข้าถึงปลายทาง gateway ที่ปลอดภัยสำหรับโฮสต์นี้ได้"
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "การกระทำนี้จะลบงานที่กำหนดเวลาไว้ออกจาก gateway อย่างถาวร"
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "ต้องมีสิทธิ์ผู้ดูแลระบบ"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "การเปลี่ยนแปลง cron ต้องใช้ operator.admin โค้ดการตั้งค่าจะไม่ให้สิทธิ์นี้โดยตั้งใจ "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "เส้นทาง (ไม่บังคับ)"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "gateway สามารถเปลี่ยนเส้นทางนี้ได้ แต่ไม่สามารถล้างเส้นทางที่มีอยู่ได้"
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "ออนไลน์"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "สิทธิ์"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "รหัสอาจหมดอายุแล้วหรือถูกสร้างขึ้นสำหรับ Gateway อื่น"
@@ -1734,9 +1804,24 @@
       "translated": "การยืนยันตัวตน Gateway ต้องได้รับการตรวจสอบ ตรวจสอบการตั้งค่า Gateway แล้วลองอีกครั้ง"
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "ไม่มีโมเดลที่กำหนดค่าไว้"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "เซสชัน"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "ค้นหาเซสชัน"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "ใหม่สุดก่อน"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "เก่าสุดก่อน"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "เลย์เอาต์: รายละเอียด"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "ปักหมุด"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "ทำเครื่องหมายว่ายังไม่ได้อ่าน"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw สามารถรับการเตือนที่เลือกได้"
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "อนุญาตแล้ว"
@@ -2374,6 +2564,21 @@
       "translated": "ความสามารถของโทรศัพท์"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "อนุญาตการเข้าถึงคลังรูปภาพ"
@@ -2384,6 +2589,11 @@
       "translated": "อนุญาตการเข้าถึงรูปภาพที่เลือกหรือทั้งหมดแล้ว"
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "รายการแอปจะอยู่บนโทรศัพท์เครื่องนี้"
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw สามารถแสดงรายการแอปที่มองเห็นได้ใน Launcher"
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "อนุญาตตำแหน่งเบื้องหลังหรือไม่?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw จะตรวจสอบตำแหน่งเฉพาะเมื่อ Gateway ที่จับคู่ของคุณร้องขอเท่านั้น "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "ลืม Gateway หรือไม่?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "เปิด ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "ตรวจสอบ"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "ไม่มีการรายงานขีดจำกัด"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "ปิด"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "ข้อความ Payload"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "เอเจนต์ที่ใช้งานอยู่"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "ไม่มี"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "การสนทนาล่าสุด"
@@ -3039,6 +3304,16 @@
       "translated": "ล็อกแล้ว"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "ผู้ให้บริการ $count ราย"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} พร้อม"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "ไม่มี Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "คุยแบบเรียลไทม์"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "การตั้งค่าการคุย"
@@ -3594,6 +3874,11 @@
       "translated": "ไม่สามารถถอดรหัสรูปภาพนี้ได้"
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} เพิ่มเติม"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "คุณ"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "ลบ"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "ไฟล์แนบที่ไม่รองรับ"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "พร้อมเมื่อคุณพร้อม"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw จะแสดงการอนุมัติ งานที่ล้มเหลว และปัญหาของช่องทางไว้ที่นี่"
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "กำลังพูด · กำลังรอการตอบกลับ"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "กำลังส่งเสียงที่อยู่ในคิว"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "กล้อง"
@@ -4284,9 +4619,9 @@
       "translated": "ไมโครโฟน"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "ยังไม่มีไดอารีความฝัน"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "gateway ไม่พบ DREAMS.md หรือ dreams.md ในเวิร์กสเปซของเอเจนต์ที่ใช้งานอยู่"
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) มีอยู่แต่ไม่มีเนื้อหาที่อ่านได้"
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "gateway ไม่พบ DREAMS.md หรือ dreams.md ในเวิร์กสเปซของเอเจนต์ที่ใช้งานอยู่"
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "ไดอารีไม่พร้อมใช้งาน"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "เชื่อมต่อ gateway เพื่ออ่านรายการไดอารีความฝัน"
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "gateway ไม่ได้ส่งคืนเนื้อหาไดอารีความฝัน"
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "เชื่อมต่อ gateway เพื่ออ่านรายการไดอารีความฝัน"
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "ไม่มีสถานะเฟส"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "เชื่อมต่อ Gateway เพื่อโหลดเฟสการฝัน"
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway ไม่ได้ส่งคืนรายละเอียดเฟสการฝัน"
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "เชื่อมต่อ Gateway เพื่อโหลดเฟสการฝัน"
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "ไม่จำเป็นต้องซ่อมแซม"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "ไม่มีอินสแตนซ์ที่เชื่อมต่อ"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "เชื่อมต่อ Gateway เพื่อตรวจสอบอินสแตนซ์ที่เชื่อมต่อ"
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway ไม่ได้รายงานรายการสถานะการปรากฏของระบบใด ๆ"
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "เชื่อมต่อ Gateway เพื่อตรวจสอบอินสแตนซ์ที่เชื่อมต่อ"
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "ไม่มีรายงาน"
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "ตัวจัดกำหนดการ"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "การใช้งาน"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "ไม่มีงานที่กำหนดเวลาไว้"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "เชื่อมต่อ Gateway เพื่อโหลดงานที่กำหนดเวลาไว้"
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Gateway ไม่มีงาน cron ที่มองเห็นได้"
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "เชื่อมต่อ Gateway เพื่อโหลดงานที่กำหนดเวลาไว้"
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills ไม่พร้อมใช้งาน"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "เชื่อมต่อ Gateway เพื่อโหลด Skills ของ workspace"
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "ลองค้นหาด้วยคำอื่นหรือรีเฟรชจาก Gateway"
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "เชื่อมต่อ Gateway เพื่อโหลด Skills ของ workspace"
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "เปลี่ยนชื่อกลุ่ม"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "กิจกรรม"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "กิจกรรมล่าสุด"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "กิจกรรมเซสชันออฟไลน์"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "เชื่อมต่อกับ Gateway เพื่อโหลดกิจกรรมแชทล่าสุด"
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "เริ่มแชท แล้วแชทจะแสดงที่นี่"
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "เชื่อมต่อกับ Gateway เพื่อโหลดกิจกรรมแชทล่าสุด"
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "เปิด"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "ยังไม่ได้โหลดข้อเสนอ"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "เชื่อมต่อจากการตั้งค่าเพื่อโหลดข้อเสนอ Skill Workshop"
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "ข้อเสนอใหม่จะแสดงที่นี่เมื่อ Agent ร่าง Skills"
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "เชื่อมต่อจากการตั้งค่าเพื่อโหลดข้อเสนอ Skill Workshop"
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "ยังไม่ได้โหลดการ์ด"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "เชื่อมต่อจาก Settings เพื่อโหลดการ์ด workboard"
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "สร้างการ์ดหรือเปลี่ยนตัวกรอง"
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "เชื่อมต่อจาก Settings เพื่อโหลดการ์ด workboard"
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "เลือกว่าเมื่อใดที่ OpenClaw สามารถแชร์ตำแหน่งของ iPhone เครื่องนี้กับเครื่องมือของ Gateway"
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "ลืม Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "การปลุกด้วยเสียง"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "ค้นพบแล้ว"
@@ -6484,14 +6879,14 @@
       "translated": "ค้นพบแล้ว • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "จัดคิวการตั้งค่าสำหรับนาฬิกาแล้ว เปิด OpenClaw ก่อนที่รหัสจะหมดอายุ"
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "ส่งการตั้งค่าแล้ว เปิด OpenClaw บนนาฬิกาเพื่อเชื่อมต่อ"
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "จัดคิวการตั้งค่าสำหรับนาฬิกาแล้ว เปิด OpenClaw ก่อนที่รหัสจะหมดอายุ"
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "ยังไม่ได้กำหนดค่า"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "การอนุมัติ"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "ไม่มีการดำเนินการของ Gateway ที่รอการตรวจสอบ"
@@ -6659,14 +7064,14 @@
       "translated": "ตรวจสอบการดำเนินการ Gateway ที่รอดำเนินการ"
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "ติดตั้งแอป OpenClaw บนนาฬิกาก่อนเปิดใช้งานโหมดตรง"
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "รีเลย์ยังคงใช้งานได้ โหมดตรงจะเพิ่มโหนด Gateway อิสระ"
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "ติดตั้งแอป OpenClaw บนนาฬิกาก่อนเปิดใช้งานโหมดตรง"
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "ติดตั้งแล้ว"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "การตั้งค่าเสียงและการพูด"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "ต้องได้รับอนุญาตจาก Gateway"
@@ -7879,6 +8299,16 @@
       "translated": "เปิดการตั้งค่าหากคุณต้องระบุโฮสต์ด้วยตนเอง"
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "เชื่อถือ gateway นี้หรือไม่?"
@@ -8164,6 +8594,11 @@
       "translated": "ออฟไลน์"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "การอนุมัติ"
@@ -8174,14 +8609,19 @@
       "translated": "การอนุมัตินี้ถูกดำเนินการแล้ว"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "การอนุมัตินี้ถูกตั้งค่าเป็นอนุญาตเสมอแล้ว"
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "ตั้งค่าการอนุมัติเป็นอนุญาตเสมอ"
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "การอนุมัตินี้ถูกตั้งค่าเป็นอนุญาตเสมอแล้ว"
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "ต้องการความสนใจ"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "พร้อมเชื่อมต่อ"
@@ -8299,14 +8744,14 @@
       "translated": "ลิงก์การตั้งค่า"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "ข้อความธรรมดาอาจเปิดเผยข้อมูลประจำตัวได้ ดำเนินการต่อเฉพาะเมื่อคุณเชื่อถือเครือข่ายภายในและโฮสต์นี้เท่านั้น"
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "ตรวจสอบเอ็นด์พอยต์นี้ ข้อมูลประจำตัวจะถูกนำไปใช้หลังจากที่คุณแตะเชื่อมต่อเท่านั้น"
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "ข้อความธรรมดาอาจเปิดเผยข้อมูลประจำตัวได้ ดำเนินการต่อเฉพาะเมื่อคุณเชื่อถือเครือข่ายภายในและโฮสต์นี้เท่านั้น"
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "คัดลอกคำสั่งรหัสตั้งค่า"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "เชื่อมต่อ"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "พูดคุย"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway เริ่มต้น"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "เปิดการตั้งค่า Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "ยังไม่ได้ตรวจสอบ"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "โหลดไม่สำเร็จ"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "ข้อผิดพลาดของแชท"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "อนุมัติคำขอนี้บน gateway ของคุณ Talk จะเริ่มโดยอัตโนมัติเมื่อได้รับการอนุมัติ"
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "อุปกรณ์นี้ต้องได้รับการอนุมัติจาก gateway ก่อนที่ Talk จะใช้เสียงแบบเรียลไทม์ได้ เสียงจะส่งโดยตรงจาก "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw เชื่อมต่อ Apple Watch นี้เข้ากับ Gateway ของคุณโดยตรงบนเครือข่ายในพื้นที่ที่เชื่อถือได้"
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "พร้อมเชื่อมต่อ"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "ใช้การตั้งค่า iPhone เพื่อเปิดใช้งานการเชื่อมต่อโดยตรง"
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "ตั้งค่า"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "เปิดการตั้งค่า iPhone → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "ใช้ Wi-Fi หรือเซลลูลาร์ขณะที่ OpenClaw ทำงานอยู่"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "เปิดการตั้งค่า iPhone → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "คำสั่งที่จะตรวจสอบ"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "คุณ"
@@ -9499,6 +10024,11 @@
       "translated": "การอนุมัติ"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "ตรวจสอบคำสั่ง"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "ปฏิเสธ"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "ไม่สามารถติดตั้ง OpenClaw ใน Applications ได้ ย้ายไปที่นั่นด้วยตนเอง แล้วเปิดสำเนานั้น"
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "ติดตั้ง OpenClaw ใน Applications หรือไม่?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "แทนที่ OpenClaw เวอร์ชันเก่าใน Applications หรือไม่?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw จะคัดลอกตัวเองไปยัง Applications และเปิดใหม่ที่นั่น เพื่อให้การอัปเดตและการเปิดตอนเข้าสู่ระบบทำงานได้อย่างเสถียร"
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "ติดตั้ง OpenClaw ใน Applications หรือไม่?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "สำเนานี้ใหม่กว่าแอปที่ติดตั้งไว้ OpenClaw จะแทนที่และเปิดใหม่จาก Applications"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw จะคัดลอกตัวเองไปยัง Applications และเปิดใหม่ที่นั่น เพื่อให้การอัปเดตและการเปิดตอนเข้าสู่ระบบทำงานได้อย่างเสถียร"
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "ไมโครโฟน"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "เปิดใช้งานแล้ว"
@@ -9954,6 +10494,11 @@
       "translated": "ข้อผิดพลาด"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "ออกจากระบบและล้างข้อมูลรับรองแล้ว"
@@ -9964,14 +10509,14 @@
       "translated": "ไม่พบเซสชัน WhatsApp"
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "ไม่ได้กำหนดค่าโทเค็น Telegram"
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "ล้างโทเค็น Telegram แล้ว"
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "ไม่ได้กำหนดค่าโทเค็น Telegram"
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "การกำหนดค่า"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "แก้ไข ~/.openclaw/openclaw.json โดยใช้แบบฟอร์มที่ขับเคลื่อนด้วยสคีมา"
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "แท็บนี้เป็นแบบอ่านอย่างเดียวในโหมด Nix แก้ไขการกำหนดค่าผ่าน Nix แล้วสร้างใหม่"
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "แก้ไข ~/.openclaw/openclaw.json โดยใช้แบบฟอร์มที่ขับเคลื่อนด้วยสคีมา"
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "ลดประสิทธิภาพ: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "วันนี้"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "ผู้ช่วยตั้งค่าที่ขับเคลื่อนด้วย AI สามารถตรวจสอบสถานะ แก้ไขการตั้งค่า "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "อย่าทำให้งานล้มเหลวหากการประกาศล้มเหลว"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "ตรวจสอบที่ Settings → Connection หรือใช้ Debug → Reset Remote Tunnel แล้วลองอีกครั้ง"
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "หยุด \\(listener.command) (\\(listener.pid))?"
@@ -10754,9 +11314,9 @@
       "translated": "เขียนบันทึกการวินิจฉัยแบบหมุนเวียน (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "เขียนบันทึกแบบหมุนเวียนเฉพาะในเครื่องภายใต้ ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Deep link ถูกบล็อก"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "เรียกใช้ agent ของ OpenClaw หรือไม่"
@@ -11064,9 +11629,9 @@
       "translated": "รูปแบบต้องไม่ว่างเปล่า"
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "เฉพาะรูปแบบพาธเท่านั้น ต้องมี '/', '~' หรือ '\\\\'"
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "ไม่สามารถบันทึกการอนุมัติ exec ได้ กำลังแสดงการตั้งค่าที่ทราบล่าสุด โปรดลองเปลี่ยนแปลงอีกครั้ง"
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "ยังไม่พบ Gateway"
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "คลิก Gateway ที่ค้นพบเพื่อกรอกเป้าหมาย SSH"
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "คลิก Gateway ที่ค้นพบเพื่อกรอก URL ของ Gateway"
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "คลิก Gateway ที่ค้นพบเพื่อกรอกเป้าหมาย SSH"
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "ค้นหา Gateway ของ OpenClaw บน LAN ของคุณ"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "ยังไม่ได้ลิงก์"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "การตั้งค่าที่แนะนำ"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "ใช้ Tailscale Serve เพื่อให้ gateway มีใบรับรอง HTTPS ที่ถูกต้อง"
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "ใช้ Tailscale ร่วมกับอุโมงค์ SSH เพื่อการเข้าถึงแบบส่วนตัวที่เสถียร"
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "ใช้ Tailscale Serve เพื่อให้ gateway มีใบรับรอง HTTPS ที่ถูกต้อง"
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "ไปข้างหน้า"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - มาตรวัดสดสำหรับการปลุกด้วยเสียงเปิดใช้งานอยู่"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "รีเซ็ตอุโมงค์ระยะไกล"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "การบันทึกแบบละเอียด (หลัก): ปิด"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "การบันทึกแบบละเอียด (หลัก): เปิด"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "การบันทึกแบบละเอียด (หลัก): ปิด"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "ระดับความละเอียด"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "การบันทึกไฟล์: ปิด"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "การบันทึกไฟล์: เปิด"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "การบันทึกไฟล์: ปิด"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "ตัดการเชื่อมต่อแล้ว (ใช้ค่าเริ่มต้นของระบบ)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) ไม่สามารถทำการทดสอบให้เสร็จสมบูรณ์ได้ แสดงรายละเอียดเพื่อตรวจสอบหรือคัดลอกข้อผิดพลาด"
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "กำลังค้นหา AI ที่คุณใช้อยู่แล้ว…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "กำลังรอให้การทดสอบ AI ก่อนหน้านี้เสร็จสิ้น…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "กำลังตรวจสอบ Claude Code, Codex, Gemini และคีย์ API ที่บันทึกไว้"
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "กำลังค้นหา AI ที่คุณใช้อยู่แล้ว…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw จะตรวจสอบอีกครั้งก่อนเปลี่ยนการตั้งค่าการอนุมานใดๆ"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "กำลังตรวจสอบ Claude Code, Codex, Gemini และคีย์ API ที่บันทึกไว้"
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "คัดลอกข้อผิดพลาด"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "เคล็ดลับ: เปิดใช้งาน Tailscale ไว้เสมอเพื่อให้ gateway ของคุณเข้าถึงได้"
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "เคล็ดลับ: ใช้ Tailscale Serve เพื่อให้ gateway มีใบรับรอง HTTPS ที่ถูกต้อง"
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "เคล็ดลับ: เปิดใช้งาน Tailscale ไว้เสมอเพื่อให้ gateway ของคุณเข้าถึงได้"
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "ใช้แผง + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "เปิดแผงแถบเมนูเพื่อแชทอย่างรวดเร็ว; เอเจนต์สามารถแสดงตัวอย่างได้ "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "ปฏิเสธ"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "อุปกรณ์ต้องการเชื่อมต่อกับ OpenClaw"
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "โหนดต้องการเชื่อมต่อกับ OpenClaw"
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "อุปกรณ์ต้องการเชื่อมต่อกับ OpenClaw"
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "แอป OpenClaw Mac"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "อุปกรณ์นี้ต้องได้รับการอนุมัติการจับคู่"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "วางโทเค็นที่กำหนดค่าไว้บนโฮสต์ Gateway "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "ตรวจสอบ `gateway.auth.token` หรือ `OPENCLAW_GATEWAY_TOKEN` บนโฮสต์ Gateway แล้วลองอีกครั้ง"
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Gateway นี้ตั้งค่าให้ใช้การยืนยันตัวตนด้วยโทเค็น แต่ไม่ได้กำหนดค่า `gateway.auth.token` บนโฮสต์ Gateway "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "สแกนหรือวางรหัสตั้งค่าใหม่จากไคลเอนต์ OpenClaw ที่จับคู่แล้ว จากนั้นลองอีกครั้ง"
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "ขั้นตอนเริ่มต้นใช้งานนี้ยังไม่รองรับการยืนยันตัวตนด้วยรหัสผ่าน "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "อนุมัติอุปกรณ์นี้จากไคลเอนต์ OpenClaw ที่จับคู่แล้ว "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Gateway นี้ใช้การยืนยันตัวตนด้วยรหัสผ่าน การเริ่มต้นใช้งานระยะไกลบน macOS ยังไม่สามารถรวบรวมรหัสผ่านของ Gateway ได้"
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "จำเป็นต้องจับคู่ ในไคลเอนต์ OpenClaw ที่จับคู่แล้ว "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "ยังไม่มี Skills รายงาน"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "ไม่มีเสียง"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake ต้องใช้ macOS 26 หรือใหม่กว่า"
@@ -14269,6 +14884,11 @@
       "translated": "ค่าเริ่มต้นของระบบ"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "ไม่ได้เชื่อมต่อ (ใช้ค่าเริ่มต้นของระบบ)"
@@ -14394,6 +15014,11 @@
       "translated": " (กรองภายในเครื่อง)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "URL ไม่ถูกต้อง: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "เชื่อมต่อ Gateway แล้ว"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "โทเค็นอินพุต: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "การใช้บริบท"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "การใช้ข้อความ"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "เลิกเก็บถาวร"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "ลองส่งอีกครั้ง"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "ตั้งค่า"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -194,6 +194,11 @@
       "translated": "Konuşma modu etkin"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Mikrofon: Dinliyor"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Başarısız: Bu ana makine için güvenli gateway uç noktasına ulaşılamadı."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Bu, zamanlanmış işi gateway'den kalıcı olarak kaldırır."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Yönetici erişimi gerekli"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Cron değişiklikleri operator.admin gerektirir. Kurulum kodları bunu kasıtlı olarak sağlamaz. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "İsteğe bağlı yol"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Gateway bu yolu değiştirebilir ancak mevcut bir yolu temizleyemez."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Çevrimiçi"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "İzinler"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Kodun süresi dolmuş veya başka bir Gateway için oluşturulmuş olabilir."
@@ -1734,9 +1804,24 @@
       "translated": "Gateway kimlik doğrulamasının gözden geçirilmesi gerekiyor. Gateway ayarlarını kontrol edin, ardından tekrar deneyin."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Yapılandırılmış model yok"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Oturumlar"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Oturumlarda ara"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Önce en yeni"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Önce en eski"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Düzen: Ayrıntılı"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Sabitle"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Okunmadı olarak işaretle"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw seçilen uyarıları alabilir."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "İzin verildi"
@@ -2374,6 +2564,21 @@
       "translated": "Telefon Özellikleri"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Fotoğraf arşivine erişime izin verin."
@@ -2384,6 +2589,11 @@
       "translated": "Seçili veya tam fotoğraf erişimi verildi."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "Uygulama listesi bu telefonda kalır."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw, başlatıcıda görünen uygulamaları listeleyebilir."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Arka planda konuma izin verilsin mi?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw konumu yalnızca eşleştirilmiş Gateway’iniz istediğinde kontrol eder. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Gateway unutulsun mu?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "${license.title} öğesini aç"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Kontrol et"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Limit bildirilmedi"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Kapalı"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Yük Metni"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "AKTİF ARACI"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Yok"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Son konuşmalar"
@@ -3039,6 +3304,16 @@
       "translated": "Kilitli"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count sağlayıcı"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} hazır"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Skills yok"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Gerçek Zamanlı Konuşma"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Konuşma ayarları"
@@ -3594,6 +3874,11 @@
       "translated": "Bu görüntünün kodu çözülemedi."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} daha"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Siz"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Sil"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Desteklenmeyen ek"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Hazır olduğunuzda hazırım"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw onayları, başarısız işleri ve kanal sorunlarını burada gösterecek."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Konuşuyor · yanıt bekliyor"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Sıradaki ses gönderiliyor"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Kamera"
@@ -4284,9 +4619,9 @@
       "translated": "Mikrofon"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Henüz rüya günlüğü yok"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Gateway, etkin ajan çalışma alanında DREAMS.md veya dreams.md bulamadı."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) mevcut ancak okunabilir içerik yok."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Gateway, etkin ajan çalışma alanında DREAMS.md veya dreams.md bulamadı."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Günlük kullanılamıyor"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Rüya günlüğü girdilerini okumak için bir Gateway bağlayın."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Gateway, rüya günlüğü içeriği döndürmedi."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Rüya günlüğü girdilerini okumak için bir Gateway bağlayın."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Aşama durumu yok"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Dreaming aşamalarını yüklemek için bir gateway bağlayın."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway, dreaming aşaması ayrıntılarını döndürmedi."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Dreaming aşamalarını yüklemek için bir gateway bağlayın."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "onarım gerekmiyor"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Bağlı örnek yok"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Bağlı örnekleri incelemek için bir gateway bağlayın."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway herhangi bir sistem varlığı girdisi bildirmedi."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Bağlı örnekleri incelemek için bir gateway bağlayın."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Hiçbiri bildirilmedi."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Zamanlayıcı"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Kullanım"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Zamanlanmış iş yok"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Zamanlanmış işleri yüklemek için bir gateway bağlayın."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Gateway üzerinde görünür cron işi yok."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Zamanlanmış işleri yüklemek için bir gateway bağlayın."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills kullanılamıyor"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Çalışma alanı skills öğelerini yüklemek için bir gateway bağlayın."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Farklı bir arama deneyin veya gateway'den yenileyin."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Çalışma alanı skills öğelerini yüklemek için bir gateway bağlayın."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Grubu Yeniden Adlandır"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Etkinlik"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Son etkinlik"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Oturum etkinliği çevrimdışı"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Son sohbet etkinliğini yüklemek için Gateway'e bağlanın."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Bir sohbet başlatın; burada görünecek."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Son sohbet etkinliğini yüklemek için Gateway'e bağlanın."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Aç"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Yüklenmiş teklif yok"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Skill Workshop tekliflerini yüklemek için Ayarlar'dan bağlanın."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Aracılar skill taslakları oluşturduğunda yeni teklifler burada görünür."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Skill Workshop tekliflerini yüklemek için Ayarlar'dan bağlanın."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Kart yüklenmedi"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Workboard kartlarını yüklemek için Ayarlar'dan bağlanın."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Bir kart oluşturun veya filtreyi değiştirin."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Workboard kartlarını yüklemek için Ayarlar'dan bağlanın."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "OpenClaw'ın bu iPhone'un konumunu gateway araçlarıyla ne zaman paylaşabileceğini seçin."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Gateway'i Unut"
@@ -6474,6 +6864,11 @@
       "translated": "Sesle Uyandırma"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Bulundu"
@@ -6484,14 +6879,14 @@
       "translated": "Bulundu • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Kurulum saat için sıraya alındı. Kod süresi dolmadan OpenClaw'ı açın."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Kurulum gönderildi. Bağlanmak için saatte OpenClaw'ı açın."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Kurulum saat için sıraya alındı. Kod süresi dolmadan OpenClaw'ı açın."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Yapılandırılmadı"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Onaylar"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "İnceleme bekleyen Gateway işlemi yok."
@@ -6659,14 +7064,14 @@
       "translated": "Bekleyen gateway işlemlerini inceleyin."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Doğrudan modu etkinleştirmeden önce OpenClaw saat uygulamasını yükleyin."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Aktarma kullanılabilir kalır; doğrudan mod bağımsız bir Gateway düğümü ekler."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Doğrudan modu etkinleştirmeden önce OpenClaw saat uygulamasını yükleyin."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Yüklendi"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Ses ve Konuşma Ayarları"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Gateway izni gerekli"
@@ -7879,6 +8299,16 @@
       "translated": "Manuel ana bilgisayar gerekiyorsa Ayarlar’ı açın."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Bu gateway'e güvenilsin mi?"
@@ -8164,6 +8594,11 @@
       "translated": "Çevrimdışı"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Onay"
@@ -8174,14 +8609,19 @@
       "translated": "Bu onay zaten"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Bu onay zaten Her Zaman İzin Ver olarak ayarlanmıştı."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Onay Her Zaman İzin Ver olarak ayarlandı."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Bu onay zaten Her Zaman İzin Ver olarak ayarlanmıştı."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Dikkat gerektiriyor"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Bağlanmaya Hazır"
@@ -8299,14 +8744,14 @@
       "translated": "Kurulum Bağlantısı"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Düz metin kimlik bilgilerini açığa çıkarabilir. Yalnızca bu yerel ağa ve ana makineye güveniyorsanız devam edin."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Bu uç noktayı gözden geçirin. Kimlik bilgileri yalnızca Bağlan’a dokunduktan sonra uygulanır."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Düz metin kimlik bilgilerini açığa çıkarabilir. Yalnızca bu yerel ağa ve ana makineye güveniyorsanız devam edin."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Kurulum kodu komutunu kopyala"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Bağlan"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Konuş"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway varsayılanı"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Gateway Ayarlarını Aç"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Kontrol edilmedi"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Yükleme başarısız oldu"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Sohbet hatası"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Bu isteği gateway’inizde onaylayın. Onay geldiğinde Talk otomatik olarak başlayacak."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Talk’ın gerçek zamanlı sesi kullanabilmesi için bu cihazın gateway onayına ihtiyacı var. Ses doğrudan şuradan gidecek: "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw, bu Apple Watch'u güvenilir yerel ağlarda doğrudan Gateway'inize bağlar."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Bağlanmaya hazır"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Doğrudan bağlantıyı etkinleştirmek için iPhone Ayarları'nı kullanın."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Kurulum"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "iPhone Ayarları → Apple Watch'u açın"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "OpenClaw etkinken Wi-Fi veya hücresel bağlantı kullanır"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "iPhone Ayarları → Apple Watch'u açın"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "İncelenecek komut"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Siz"
@@ -9499,6 +10024,11 @@
       "translated": "Onay"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Komutu İncele"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Reddet"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw, Applications klasörüne yüklenemedi. Dosyayı manuel olarak oraya taşıyın, ardından o kopyayı açın."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "OpenClaw, Applications klasörüne yüklensin mi?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Applications içindeki eski OpenClaw değiştirilsin mi?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw kendini Applications klasörüne kopyalayacak ve orada yeniden açılacak, böylece güncellemeler ve oturum açıldığında başlatma güvenilir kalır."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "OpenClaw, Applications klasörüne yüklensin mi?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Bu kopya yüklü uygulamadan daha yeni. OpenClaw onu değiştirecek ve Applications klasöründen yeniden açılacak."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw kendini Applications klasörüne kopyalayacak ve orada yeniden açılacak, böylece güncellemeler ve oturum açıldığında başlatma güvenilir kalır."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Mikrofon"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Etkin"
@@ -9954,6 +10494,11 @@
       "translated": "Hata"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Oturum kapatıldı ve kimlik bilgileri temizlendi."
@@ -9964,14 +10509,14 @@
       "translated": "WhatsApp oturumu bulunamadı."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Telegram token'ı yapılandırılmamış."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Telegram token'ı temizlendi."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Telegram token'ı yapılandırılmamış."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Config"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Şema odaklı formu kullanarak ~/.openclaw/openclaw.json dosyasını düzenleyin."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Bu sekme Nix modunda salt okunurdur. Config'i Nix üzerinden düzenleyin ve yeniden derleyin."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Şema odaklı formu kullanarak ~/.openclaw/openclaw.json dosyasını düzenleyin."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "düşük performans: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Bugün"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Yapay zeka destekli kurulum yardımcınız. Durumu kontrol edebilir, yapılandırmayı düzeltebilir, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Duyuru başarısız olursa işi başarısız sayma"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Ayarlar → Bağlantı'yı kontrol edin veya Debug → Reset Remote Tunnel kullanın, ardından tekrar deneyin."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "\\(listener.command) (\\(listener.pid)) sonlandırılsın mı?"
@@ -10754,9 +11314,9 @@
       "translated": "Dönen tanılama günlüğü yaz (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "~/Library/Logs/OpenClaw/ altında dönen, yalnızca yerel bir günlük yazar. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Derin bağlantı engellendi"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "OpenClaw ajanı çalıştırılsın mı?"
@@ -11064,9 +11629,9 @@
       "translated": "Desen boş olamaz."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Yalnızca yol desenleri. '/', '~' veya '\\\\' içermelidir."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Exec onayları kaydedilemedi. Bilinen son ayarlar gösteriliyor; değişikliği tekrar deneyin."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Henüz gateway bulunamadı."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "SSH hedefini doldurmak için bulunan bir gateway'e tıklayın."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Gateway URL'sini doldurmak için bulunan bir gateway'e tıklayın."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "SSH hedefini doldurmak için bulunan bir gateway'e tıklayın."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "LAN'inizde OpenClaw gateway'lerini keşfedin"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "bağlı değil"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Önerilen kurulum"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Gateway'in geçerli bir HTTPS sertifikasına sahip olması için Tailscale Serve kullanın."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Kararlı özel erişim için Tailscale ve bir SSH tüneli kullanın."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Gateway'in geçerli bir HTTPS sertifikasına sahip olması için Tailscale Serve kullanın."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "İleri"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - Sesle Uyandırma canlı göstergesi etkin"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Uzak Tüneli Sıfırla"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Ayrıntılı Günlük Kaydı (Ana): Kapalı"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Ayrıntılı Günlük Kaydı (Ana): Açık"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Ayrıntılı Günlük Kaydı (Ana): Kapalı"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Ayrıntı Düzeyi"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Dosya Günlüğü: Kapalı"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Dosya Günlüğü: Açık"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Dosya Günlüğü: Kapalı"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Bağlantı kesildi (Sistem varsayılanı kullanılıyor)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) testi tamamlayamadı. Hatayı incelemek veya kopyalamak için ayrıntıları gösterin."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Zaten kullandığınız AI aranıyor…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Önceki AI testinin bitmesi bekleniyor…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Claude Code, Codex, Gemini ve kayıtlı API anahtarları denetleniyor."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Zaten kullandığınız AI aranıyor…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw, herhangi bir çıkarım ayarını değiştirmeden önce tekrar denetleyecek."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Claude Code, Codex, Gemini ve kayıtlı API anahtarları denetleniyor."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Hatayı kopyala"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "İpucu: Gateway'inizin erişilebilir kalması için Tailscale'i etkin tutun."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "İpucu: Gateway'in geçerli bir HTTPS sertifikasına sahip olması için Tailscale Serve kullanın."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "İpucu: Gateway'inizin erişilebilir kalması için Tailscale'i etkin tutun."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Panel + Canvas’ı kullanın"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Hızlı sohbet için menü çubuğu panelini açın; aracı önizlemeleri gösterebilir "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Reddet"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Bir cihaz OpenClaw'a bağlanmak istiyor."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Bir düğüm OpenClaw'a bağlanmak istiyor."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Bir cihaz OpenClaw'a bağlanmak istiyor."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "OpenClaw Mac uygulaması"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Bu cihazın eşleştirme onayına ihtiyacı var"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Gateway ana makinesinde yapılandırılan token'ı yapıştırın. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Gateway ana makinesinde `gateway.auth.token` veya `OPENCLAW_GATEWAY_TOKEN` değerini kontrol edip tekrar deneyin."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Bu gateway token kimlik doğrulamasına ayarlı, ancak gateway ana makinesinde `gateway.auth.token` yapılandırılmamış. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Zaten eşleştirilmiş bir OpenClaw istemcisinden yeni bir kurulum kodu tarayın veya yapıştırın, ardından tekrar deneyin."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Bu başlangıç akışı henüz parola kimlik doğrulamasını desteklemiyor. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Bu cihazı zaten eşleştirilmiş bir OpenClaw istemcisinden onaylayın. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Bu gateway parola kimlik doğrulaması kullanıyor. macOS'te uzaktan başlangıç henüz gateway parolalarını alamaz."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Eşleştirme gerekli. Zaten eşleştirilmiş bir OpenClaw istemcisinde, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Henüz bildirilen skill yok"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Ses Yok"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake, macOS 26 veya daha yenisini gerektirir"
@@ -14269,6 +14884,11 @@
       "translated": "Sistem varsayılanı"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Bağlantı kesildi (Sistem varsayılanı kullanılıyor)"
@@ -14394,6 +15014,11 @@
       "translated": " (yerel filtrelenmiş)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "Geçersiz URL: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway bağlı"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Girdi belirteçleri: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Bağlam kullanımı"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Mesaj kullanımı"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Arşivden Çıkar"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Göndermeyi Yeniden Dene"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Kurulum"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -194,6 +194,11 @@
       "translated": "Режим розмови активний"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Мікрофон: слухає"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Помилка: не вдалося досягти захищеної кінцевої точки Gateway для цього хоста."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Це назавжди видалить заплановане завдання з gateway."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Потрібен доступ адміністратора"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Зміни cron потребують operator.admin. Коди налаштування навмисно його не надають. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Необов'язковий шлях"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Gateway може змінити цей шлях, але не може очистити наявний шлях."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Онлайн"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Дозволи"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Можливо, код застарів або був згенерований для іншого Gateway."
@@ -1734,9 +1804,24 @@
       "translated": "Автентифікація Gateway потребує перевірки. Перевірте налаштування Gateway, а потім повторіть спробу."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Немає налаштованих моделей"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Сеанси"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Пошук сеансів"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Спочатку найновіші"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Спочатку найстаріші"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Макет: докладний"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Закріпити"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Позначити як непрочитане"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw може отримувати вибрані оповіщення."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Надано"
@@ -2374,6 +2564,21 @@
       "translated": "Можливості телефону"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Дозвольте доступ до фототеки."
@@ -2384,6 +2589,11 @@
       "translated": "Надано вибраний або повний доступ до фото."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "Список застосунків залишається на цьому телефоні."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw може показувати застосунки, видимі в лаунчері."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Дозволити фонове визначення місцезнаходження?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw перевіряє місцезнаходження лише тоді, коли це запитує ваш спарений Gateway. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Забути gateway?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "Відкрити ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Перевірити"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Обмежень не повідомлено"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Вимкнено"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Текст payload"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "АКТИВНИЙ АГЕНТ"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Немає"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Нещодавні розмови"
@@ -3039,6 +3304,16 @@
       "translated": "Заблоковано"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count провайдерів"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} готово"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Немає Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Розмова в реальному часі"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Налаштування розмови"
@@ -3594,6 +3874,11 @@
       "translated": "Не вдалося декодувати це зображення."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} ще"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Ви"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Видалити"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Непідтримуване вкладення"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Готово, коли будете готові"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw показуватиме тут схвалення, невдалі завдання та проблеми з каналами."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Говорить · очікування відповіді"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Надсилання голосу з черги"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Камера"
@@ -4284,9 +4619,9 @@
       "translated": "Мікрофон"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Щоденника сновидінь ще немає"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Gateway не знайшов DREAMS.md або dreams.md в активному робочому просторі агента."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) існує, але не має читабельного вмісту."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Gateway не знайшов DREAMS.md або dreams.md в активному робочому просторі агента."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Щоденник недоступний"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Підключіть Gateway, щоб читати записи щоденника сновидінь."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Gateway не повернув вміст щоденника сновидінь."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Підключіть Gateway, щоб читати записи щоденника сновидінь."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Немає статусу фази"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Підключіть Gateway, щоб завантажити фази сновидіння."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway не повернув відомості про фази сновидіння."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Підключіть Gateway, щоб завантажити фази сновидіння."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "відновлення не потрібне"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Немає підключених екземплярів"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Підключіть Gateway, щоб переглянути підключені екземпляри."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway не повідомив про жодні записи присутності в системі."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Підключіть Gateway, щоб переглянути підключені екземпляри."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Нічого не повідомлено."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Планувальник"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Використання"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Немає запланованих завдань"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Підключіть gateway, щоб завантажити заплановану роботу."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Gateway не має видимих cron-завдань."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Підключіть gateway, щоб завантажити заплановану роботу."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills недоступні"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Підключіть Gateway, щоб завантажити навички робочого простору."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Спробуйте інший пошук або оновіть із Gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Підключіть Gateway, щоб завантажити навички робочого простору."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Перейменувати групу"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Активність"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Нещодавня активність"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Активність сеансів офлайн"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Підключіться до Gateway, щоб завантажити нещодавню активність чатів."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Почніть чат, і він з’явиться тут."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Підключіться до Gateway, щоб завантажити нещодавню активність чатів."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Відкрити"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Пропозиції не завантажено"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Підключіться в налаштуваннях, щоб завантажити пропозиції Skill Workshop."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Нові пропозиції з’являться тут, коли агенти створять чернетки Skills."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Підключіться в налаштуваннях, щоб завантажити пропозиції Skill Workshop."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Картки не завантажено"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Підключіться в Settings, щоб завантажити картки робочої дошки."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Створіть картку або змініть фільтр."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Підключіться в Settings, щоб завантажити картки робочої дошки."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Оберіть, коли OpenClaw може ділитися розташуванням цього iPhone з інструментами Gateway."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Забути Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "Голосова активація"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Виявлено"
@@ -6484,14 +6879,14 @@
       "translated": "Виявлено • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Налаштування поставлено в чергу для годинника. Відкрийте OpenClaw до завершення терміну дії коду."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Налаштування надіслано. Відкрийте OpenClaw на годиннику, щоб підключитися."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Налаштування поставлено в чергу для годинника. Відкрийте OpenClaw до завершення терміну дії коду."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Не налаштовано"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Схвалення"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Немає дій Gateway, що очікують на розгляд."
@@ -6659,14 +7064,14 @@
       "translated": "Перегляньте незавершені дії Gateway."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Встановіть застосунок OpenClaw для годинника, перш ніж вмикати прямий режим."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Ретрансляція залишається доступною; прямий режим додає незалежний вузол Gateway."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Встановіть застосунок OpenClaw для годинника, перш ніж вмикати прямий режим."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Встановлено"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Налаштування голосу й розмови"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Потрібен дозвіл Gateway"
@@ -7879,6 +8299,16 @@
       "translated": "Відкрийте Налаштування, якщо потрібно вказати хост вручну."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Довіряти цьому Gateway?"
@@ -8164,6 +8594,11 @@
       "translated": "Офлайн"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Підтвердження"
@@ -8174,14 +8609,19 @@
       "translated": "Це підтвердження вже було"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Це підтвердження вже було встановлено на «Дозволити завжди»."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Підтвердження встановлено на «Дозволити завжди»."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Це підтвердження вже було встановлено на «Дозволити завжди»."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Потребує уваги"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Готово до з'єднання"
@@ -8299,14 +8744,14 @@
       "translated": "Посилання для налаштування"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Відкритий текст може розкрити облікові дані. Продовжуйте лише якщо ви довіряєте цій локальній мережі та хосту."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Перевірте цей кінцевий вузол. Облікові дані застосовуються лише після того, як ви торкнетеся «Підключити»."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Відкритий текст може розкрити облікові дані. Продовжуйте лише якщо ви довіряєте цій локальній мережі та хосту."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Копіювати команду коду налаштування"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Підключитися"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Говорити"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway за замовчуванням"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Відкрити налаштування Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Не перевірено"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Не вдалося завантажити"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Помилка чату"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Схваліть цей запит на вашому Gateway. Talk запуститься автоматично після отримання схвалення."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Цей пристрій потребує схвалення Gateway, перш ніж Talk зможе використовувати голос у реальному часі. Аудіо передаватиметься безпосередньо з "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw підключає цей Apple Watch безпосередньо до вашого Gateway в довірених локальних мережах."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Готово до підключення"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Скористайтеся Налаштуваннями iPhone, щоб увімкнути пряме з’єднання."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Налаштування"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Відкрийте Налаштування iPhone → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Використовує Wi-Fi або мобільну мережу, поки OpenClaw активний"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Відкрийте Налаштування iPhone → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Команда для перегляду"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Ви"
@@ -9499,6 +10024,11 @@
       "translated": "Схвалення"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Переглянути команду"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Відхилити"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw не вдалося встановити в Applications. Перемістіть його туди вручну, потім відкрийте цю копію."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "Встановити OpenClaw в Applications?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Замінити старішу версію OpenClaw в Applications?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw скопіює себе в Applications і повторно відкриється там, щоб оновлення та запуск при вході залишалися надійними."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Встановити OpenClaw в Applications?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Ця копія новіша за встановлений застосунок. OpenClaw замінить його і повторно відкриється з Applications."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw скопіює себе в Applications і повторно відкриється там, щоб оновлення та запуск при вході залишалися надійними."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Мікрофон"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Увімкнено"
@@ -9954,6 +10494,11 @@
       "translated": "Помилка"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Виконано вихід і очищено облікові дані."
@@ -9964,14 +10509,14 @@
       "translated": "Сеанс WhatsApp не знайдено."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Токен Telegram не налаштовано."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Токен Telegram очищено."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Токен Telegram не налаштовано."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Конфігурація"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Редагуйте ~/.openclaw/openclaw.json за допомогою форми на основі схеми."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Ця вкладка доступна лише для читання в режимі Nix. Редагуйте конфігурацію через Nix і перебудуйте."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Редагуйте ~/.openclaw/openclaw.json за допомогою форми на основі схеми."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "погіршено: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Сьогодні"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Ваш помічник із налаштування на основі AI. Він може перевіряти стан, виправляти конфігурацію, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Не завершувати завдання помилкою, якщо оголошення не вдасться"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Перевірте Налаштування → Підключення або скористайтеся Налагодження → Скинути віддалений тунель, а потім повторіть спробу."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Завершити \\(listener.command) (\\(listener.pid))?"
@@ -10754,9 +11314,9 @@
       "translated": "Записувати циклічний журнал діагностики (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Записує ротаційний локальний журнал у ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Deep link заблоковано"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "Запустити агента OpenClaw?"
@@ -11064,9 +11629,9 @@
       "translated": "Шаблон не може бути порожнім."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Лише шаблони шляхів. Додайте '/', '~' або '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Не вдалося зберегти дозволи на виконання. Показано останні відомі налаштування; повторіть зміну."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Шлюзи ще не знайдено."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Натисніть знайдений шлюз, щоб заповнити SSH target."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Натисніть знайдений шлюз, щоб заповнити URL-адресу шлюзу."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Натисніть знайдений шлюз, щоб заповнити SSH target."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "Виявляти шлюзи OpenClaw у вашій LAN"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "не пов’язано"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Рекомендоване налаштування"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Використовуйте Tailscale Serve, щоб Gateway мав дійсний сертифікат HTTPS."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Використовуйте Tailscale і тунель SSH для стабільного приватного доступу."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Використовуйте Tailscale Serve, щоб Gateway мав дійсний сертифікат HTTPS."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Вперед"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw — активний індикатор Voice Wake наживо"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Скинути віддалений тунель"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Детальне журналювання (Main): вимкнено"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Детальне журналювання (Main): увімкнено"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Детальне журналювання (Main): вимкнено"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Рівень деталізації"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Журналювання у файл: вимкнено"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Журналювання у файл: увімкнено"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Журналювання у файл: вимкнено"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Від’єднано (використовується системне значення за замовчуванням)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) не вдалося завершити тест. Покажіть подробиці, щоб переглянути або скопіювати помилку."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Пошук ШІ, який ви вже використовуєте…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Очікування завершення попереднього тесту ШІ…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Перевірка наявності Claude Code, Codex, Gemini та збережених ключів API."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Пошук ШІ, який ви вже використовуєте…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw перевірить ще раз перед зміною будь-яких налаштувань висновування."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Перевірка наявності Claude Code, Codex, Gemini та збережених ключів API."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Копіювати помилку"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Порада: тримайте Tailscale увімкненим, щоб ваш gateway залишався доступним."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Порада: використовуйте Tailscale Serve, щоб gateway мав дійсний HTTPS-сертифікат."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Порада: тримайте Tailscale увімкненим, щоб ваш gateway залишався доступним."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Використовуйте панель + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Відкрийте панель у рядку меню для швидкого чату; агент може показувати попередні перегляди "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Відхилити"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Пристрій хоче підключитися до OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Вузол хоче підключитися до OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Пристрій хоче підключитися до OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "Застосунок OpenClaw для Mac"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Цей пристрій потребує схвалення сполучення"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Вставте токен, налаштований на хості gateway. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Перевірте `gateway.auth.token` або `OPENCLAW_GATEWAY_TOKEN` на хості gateway і повторіть спробу."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Для цього gateway встановлено автентифікацію за токеном, але на хості gateway не налаштовано `gateway.auth.token`. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Відскануйте або вставте новий код налаштування з уже спареного клієнта OpenClaw, а потім повторіть спробу."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Цей процес онбордингу поки не підтримує автентифікацію за паролем. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Схваліть цей пристрій з уже спареного клієнта OpenClaw. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Цей gateway використовує автентифікацію за паролем. Віддалений онбординг у macOS поки не може отримувати паролі gateway."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Потрібне сполучення. У вже сполученому клієнті OpenClaw, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Поки що немає повідомлених skills"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Без звуку"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake потребує macOS 26 або новішої версії"
@@ -14269,6 +14884,11 @@
       "translated": "Типовий системний"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Від’єднано (використовується типовий системний)"
@@ -14394,6 +15014,11 @@
       "translated": " (локально відфільтровано)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "Недійсна URL-адреса: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway підключено"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Вхідні токени: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Використання контексту"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Використання повідомлень"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Розархівувати"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Повторити надсилання"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Налаштування"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -194,6 +194,11 @@
       "translated": "Chế độ nói đang hoạt động"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · Mic: Đang nghe"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "Không thành công: không thể truy cập điểm cuối gateway bảo mật cho máy chủ này."
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "Thao tác này sẽ xóa vĩnh viễn tác vụ đã lên lịch khỏi gateway."
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "Cần quyền quản trị"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Các thay đổi cron yêu cầu operator.admin. Mã cài đặt cố ý không cấp quyền này. "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "Đường dẫn tùy chọn"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Gateway có thể thay đổi đường dẫn này nhưng không thể xóa đường dẫn hiện có."
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "Trực tuyến"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "Quyền"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "Mã có thể đã hết hạn hoặc được tạo cho một Gateway khác."
@@ -1734,9 +1804,24 @@
       "translated": "Cần xem xét lại xác thực Gateway. Kiểm tra cài đặt gateway, rồi thử lại."
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "Chưa có mô hình nào được cấu hình"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "Phiên"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "Tìm kiếm phiên"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "Mới nhất trước"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "Cũ nhất trước"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "Bố cục: Chi tiết"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "Ghim"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "Đánh dấu là chưa đọc"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw có thể nhận các cảnh báo đã chọn."
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "Đã cấp"
@@ -2374,6 +2564,21 @@
       "translated": "Khả năng của điện thoại"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "Cho phép truy cập thư viện ảnh."
@@ -2384,6 +2589,11 @@
       "translated": "Đã cấp quyền truy cập ảnh đã chọn hoặc toàn bộ."
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "Danh sách ứng dụng vẫn ở trên điện thoại này."
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw có thể liệt kê các ứng dụng hiển thị trong launcher."
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "Cho phép vị trí nền?"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw chỉ kiểm tra vị trí khi Gateway đã ghép đôi của bạn yêu cầu. "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "Quên Gateway?"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "Mở ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "Kiểm tra"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "Không có giới hạn nào được báo cáo"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "Tắt"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "Văn bản payload"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "TÁC NHÂN ĐANG HOẠT ĐỘNG"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "Không có"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "Cuộc trò chuyện gần đây"
@@ -3039,6 +3304,16 @@
       "translated": "Đã khóa"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count nhà cung cấp"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} sẵn sàng"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "Không có Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "Trò chuyện thời gian thực"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "Cài đặt trò chuyện"
@@ -3594,6 +3874,11 @@
       "translated": "Không thể giải mã hình ảnh này."
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} nữa"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "Bạn"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "Xóa"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "Tệp đính kèm không được hỗ trợ"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "Sẵn sàng khi bạn cần"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw sẽ hiển thị các phê duyệt, tác vụ thất bại và sự cố kênh tại đây."
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "Đang nói · đang chờ phản hồi"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "Đang gửi giọng nói trong hàng đợi"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "Camera"
@@ -4284,9 +4619,9 @@
       "translated": "Micrô"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "Chưa có nhật ký dream"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Gateway không tìm thấy DREAMS.md hoặc dreams.md trong workspace tác tử đang hoạt động."
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) tồn tại nhưng không có nội dung có thể đọc."
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Gateway không tìm thấy DREAMS.md hoặc dreams.md trong workspace tác tử đang hoạt động."
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "Nhật ký không khả dụng"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "Kết nối Gateway để đọc các mục nhật ký dream."
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Gateway không trả về nội dung nhật ký dream."
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "Kết nối Gateway để đọc các mục nhật ký dream."
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "Không có trạng thái pha"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "Kết nối Gateway để tải các pha dreaming."
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway không trả về chi tiết pha dreaming."
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "Kết nối Gateway để tải các pha dreaming."
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "không cần sửa chữa"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "Không có phiên bản nào được kết nối"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "Kết nối Gateway để kiểm tra các phiên bản đã kết nối."
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway không báo cáo mục hiện diện hệ thống nào."
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "Kết nối Gateway để kiểm tra các phiên bản đã kết nối."
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "Không có báo cáo."
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "Bộ lập lịch"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "Mức sử dụng"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "Không có tác vụ đã lên lịch"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "Kết nối một gateway để tải công việc đã lên lịch."
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Gateway không có cron job hiển thị."
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "Kết nối một gateway để tải công việc đã lên lịch."
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills không khả dụng"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "Kết nối một gateway để tải Skills của workspace."
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "Thử tìm kiếm khác hoặc làm mới từ gateway."
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "Kết nối một gateway để tải Skills của workspace."
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "Đổi tên nhóm"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "Hoạt động"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "Hoạt động gần đây"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "Hoạt động phiên ngoại tuyến"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "Kết nối với gateway để tải hoạt động trò chuyện gần đây."
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "Bắt đầu một cuộc trò chuyện và nó sẽ xuất hiện ở đây."
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "Kết nối với gateway để tải hoạt động trò chuyện gần đây."
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "Mở"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "Chưa tải đề xuất nào"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "Kết nối từ Cài đặt để tải các đề xuất Skill Workshop."
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "Các đề xuất mới sẽ xuất hiện tại đây khi tác nhân soạn thảo kỹ năng."
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "Kết nối từ Cài đặt để tải các đề xuất Skill Workshop."
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "Chưa tải thẻ nào"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "Kết nối từ Cài đặt để tải thẻ workboard."
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "Tạo thẻ hoặc thay đổi bộ lọc."
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "Kết nối từ Cài đặt để tải thẻ workboard."
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "Chọn khi nào OpenClaw có thể chia sẻ vị trí của iPhone này với các công cụ gateway."
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "Quên Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "Đánh thức bằng giọng nói"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "Đã phát hiện"
@@ -6484,14 +6879,14 @@
       "translated": "Đã phát hiện • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "Đã xếp hàng thiết lập cho đồng hồ. Mở OpenClaw trước khi mã hết hạn."
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "Đã gửi thiết lập. Mở OpenClaw trên đồng hồ để kết nối."
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "Đã xếp hàng thiết lập cho đồng hồ. Mở OpenClaw trước khi mã hết hạn."
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "Chưa cấu hình"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "Phê duyệt"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "Không có hành động gateway nào đang chờ xem xét."
@@ -6659,14 +7064,14 @@
       "translated": "Xem lại các hành động gateway đang chờ."
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "Cài đặt ứng dụng OpenClaw cho đồng hồ trước khi bật chế độ trực tiếp."
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "Relay vẫn khả dụng; chế độ trực tiếp bổ sung một nút Gateway độc lập."
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "Cài đặt ứng dụng OpenClaw cho đồng hồ trước khi bật chế độ trực tiếp."
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "Đã cài đặt"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "Cài đặt Giọng nói & Trò chuyện"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "Cần quyền Gateway"
@@ -7879,6 +8299,16 @@
       "translated": "Mở Cài đặt nếu bạn cần nhập máy chủ thủ công."
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "Tin cậy gateway này?"
@@ -8164,6 +8594,11 @@
       "translated": "Ngoại tuyến"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "Phê duyệt"
@@ -8174,14 +8609,19 @@
       "translated": "Phê duyệt này đã được"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "Phê duyệt này đã được đặt thành Luôn cho phép."
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "Phê duyệt được đặt thành Luôn cho phép."
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "Phê duyệt này đã được đặt thành Luôn cho phép."
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "Cần chú ý"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "Sẵn sàng kết nối"
@@ -8299,14 +8744,14 @@
       "translated": "Liên kết thiết lập"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "Văn bản thuần có thể làm lộ thông tin đăng nhập. Chỉ tiếp tục nếu bạn tin tưởng mạng cục bộ và máy chủ này."
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "Xem lại điểm cuối này. Thông tin đăng nhập chỉ được áp dụng sau khi bạn nhấn Kết nối."
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "Văn bản thuần có thể làm lộ thông tin đăng nhập. Chỉ tiếp tục nếu bạn tin tưởng mạng cục bộ và máy chủ này."
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "Sao chép lệnh mã thiết lập"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "Kết nối"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "Trò chuyện"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway mặc định"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "Mở Cài đặt Gateway"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "Chưa kiểm tra"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "Tải không thành công"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "Lỗi trò chuyện"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "Phê duyệt yêu cầu này trên gateway của bạn. Talk sẽ tự động bắt đầu khi phê duyệt đến."
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "Thiết bị này cần được gateway phê duyệt trước khi Talk có thể dùng giọng nói thời gian thực. Âm thanh sẽ đi trực tiếp từ "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw kết nối Apple Watch này trực tiếp với Gateway của bạn trên các mạng cục bộ đáng tin cậy."
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "Sẵn sàng kết nối"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "Dùng Cài đặt iPhone để bật kết nối trực tiếp."
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "Thiết lập"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "Mở Cài đặt iPhone → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "Sử dụng Wi-Fi hoặc di động khi OpenClaw đang hoạt động"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "Mở Cài đặt iPhone → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "Lệnh cần xem lại"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "Bạn"
@@ -9499,6 +10024,11 @@
       "translated": "Phê duyệt"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "Xem lại lệnh"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "Từ chối"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "Không thể cài đặt OpenClaw trong Applications. Hãy chuyển nó vào đó thủ công, sau đó mở bản sao đó."
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "Cài đặt OpenClaw trong Applications?"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "Thay thế OpenClaw cũ hơn trong Applications?"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw sẽ tự sao chép vào Applications và mở lại ở đó để việc cập nhật và khởi chạy khi đăng nhập luôn ổn định."
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "Cài đặt OpenClaw trong Applications?"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "Bản sao này mới hơn ứng dụng đã cài. OpenClaw sẽ thay thế nó và mở lại từ Applications."
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw sẽ tự sao chép vào Applications và mở lại ở đó để việc cập nhật và khởi chạy khi đăng nhập luôn ổn định."
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "Micrô"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "Đã bật"
@@ -9954,6 +10494,11 @@
       "translated": "Lỗi"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "Đã đăng xuất và xóa thông tin xác thực."
@@ -9964,14 +10509,14 @@
       "translated": "Không tìm thấy phiên WhatsApp nào."
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "Chưa cấu hình token Telegram."
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Đã xóa token Telegram."
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "Chưa cấu hình token Telegram."
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Cấu hình"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "Chỉnh sửa ~/.openclaw/openclaw.json bằng biểu mẫu dựa trên schema."
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "Tab này ở chế độ chỉ đọc trong chế độ Nix. Chỉnh sửa cấu hình qua Nix và build lại."
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "Chỉnh sửa ~/.openclaw/openclaw.json bằng biểu mẫu dựa trên schema."
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "suy giảm: \\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "Hôm nay"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "Trợ lý thiết lập được hỗ trợ bởi AI. Nó có thể kiểm tra trạng thái, sửa cấu hình, "
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "Không làm tác vụ thất bại nếu thông báo thất bại"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "Kiểm tra Cài đặt → Kết nối hoặc dùng Debug → Reset Remote Tunnel, rồi thử lại."
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "Dừng \\(listener.command) (\\(listener.pid))?"
@@ -10754,9 +11314,9 @@
       "translated": "Ghi nhật ký chẩn đoán luân phiên (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "Ghi một nhật ký xoay vòng, chỉ lưu cục bộ trong ~/Library/Logs/OpenClaw/. "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "Deep link bị chặn"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "Chạy agent OpenClaw?"
@@ -11064,9 +11629,9 @@
       "translated": "Mẫu không được để trống."
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "Chỉ mẫu đường dẫn. Bao gồm '/', '~' hoặc '\\\\'."
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "Không thể lưu phê duyệt thực thi. Hiển thị các cài đặt đã biết gần nhất; hãy thử lại thay đổi."
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "Chưa tìm thấy gateway nào."
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "Nhấp vào một gateway đã phát hiện để điền đích SSH."
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "Nhấp vào một gateway đã phát hiện để điền URL gateway."
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "Nhấp vào một gateway đã phát hiện để điền đích SSH."
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "Khám phá các gateway OpenClaw trên mạng LAN của bạn"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "chưa liên kết"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "Thiết lập được đề xuất"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "Sử dụng Tailscale Serve để gateway có chứng chỉ HTTPS hợp lệ."
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "Sử dụng Tailscale cùng với đường hầm SSH để truy cập riêng tư ổn định."
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "Sử dụng Tailscale Serve để gateway có chứng chỉ HTTPS hợp lệ."
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "Tiến tới"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - đồng hồ đo trực tiếp Đánh thức bằng giọng nói đang hoạt động"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "Đặt lại đường hầm từ xa"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "Ghi nhật ký chi tiết (Chính): Tắt"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "Ghi nhật ký chi tiết (Chính): Bật"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "Ghi nhật ký chi tiết (Chính): Tắt"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "Mức độ chi tiết"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "Ghi nhật ký vào tệp: Tắt"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "Ghi nhật ký vào tệp: Bật"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "Ghi nhật ký vào tệp: Tắt"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "Đã ngắt kết nối (đang dùng mặc định của hệ thống)"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) không thể hoàn tất bài kiểm tra. Hiển thị chi tiết để kiểm tra hoặc sao chép lỗi."
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "Đang tìm AI bạn đã sử dụng…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "Đang chờ bài kiểm tra AI trước đó hoàn tất…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "Đang kiểm tra Claude Code, Codex, Gemini và các khóa API đã lưu."
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "Đang tìm AI bạn đã sử dụng…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw sẽ kiểm tra lại trước khi thay đổi bất kỳ cài đặt suy luận nào."
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "Đang kiểm tra Claude Code, Codex, Gemini và các khóa API đã lưu."
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "Sao chép lỗi"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "Mẹo: luôn bật Tailscale để gateway của bạn vẫn có thể truy cập được."
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "Mẹo: sử dụng Tailscale Serve để gateway có chứng chỉ HTTPS hợp lệ."
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "Mẹo: luôn bật Tailscale để gateway của bạn vẫn có thể truy cập được."
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "Dùng bảng điều khiển + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "Mở bảng thanh menu để trò chuyện nhanh; tác nhân có thể hiển thị bản xem trước "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "Từ chối"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "Một thiết bị muốn kết nối với OpenClaw."
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "Một node muốn kết nối với OpenClaw."
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "Một thiết bị muốn kết nối với OpenClaw."
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "Ứng dụng OpenClaw Mac"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "Thiết bị này cần được phê duyệt ghép đôi"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "Dán mã được cấu hình trên máy chủ Gateway. "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "Kiểm tra `gateway.auth.token` hoặc `OPENCLAW_GATEWAY_TOKEN` trên máy chủ Gateway rồi thử lại."
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "Gateway này được đặt dùng xác thực bằng mã, nhưng chưa có `gateway.auth.token` nào được cấu hình trên máy chủ Gateway. "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "Quét hoặc dán mã thiết lập mới từ một ứng dụng khách OpenClaw đã ghép đôi, rồi thử lại."
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "Luồng giới thiệu này chưa hỗ trợ xác thực bằng mật khẩu. "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "Phê duyệt thiết bị này từ một ứng dụng khách OpenClaw đã ghép đôi. "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "Gateway này dùng xác thực bằng mật khẩu. Quy trình giới thiệu từ xa trên macOS chưa thể thu thập mật khẩu Gateway."
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "Yêu cầu ghép nối. Trong một ứng dụng khách OpenClaw đã được ghép nối, "
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "Chưa có skill nào được báo cáo"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "Không có âm thanh"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake yêu cầu macOS 26 trở lên"
@@ -14269,6 +14884,11 @@
       "translated": "Mặc định hệ thống"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "Đã ngắt kết nối (đang dùng Mặc định hệ thống)"
@@ -14394,6 +15014,11 @@
       "translated": " (đã lọc cục bộ)"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "URL không hợp lệ: \\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway đã kết nối"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "Token đầu vào: \\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "Mức dùng ngữ cảnh"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "Mức dùng tin nhắn"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "Bỏ lưu trữ"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "Gửi lại"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "Thiết lập"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -194,6 +194,11 @@
       "translated": "通话模式已启用"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · 麦克风：正在聆听"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "失败：无法访问此主机的安全 gateway 端点。"
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "这将从 gateway 中永久移除该计划作业。"
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "需要管理员访问权限"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Cron 更改需要 operator.admin 权限。设置码有意不授予该权限。 "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "可选路径"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "Gateway 可以更改此路径，但无法清除现有路径。"
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "在线"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "权限"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "该代码可能已过期，或是为另一个 Gateway 生成的。"
@@ -1734,9 +1804,24 @@
       "translated": "Gateway 认证需要检查。请检查 Gateway 设置，然后重试。"
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "没有已配置的模型"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "会话"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "搜索会话"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "最新优先"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "最早优先"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "布局：详细"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "置顶"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "标记为未读"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw 可以接收选定的提醒。"
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "已授予"
@@ -2374,6 +2564,21 @@
       "translated": "手机功能"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "允许访问照片图库。"
@@ -2384,6 +2589,11 @@
       "translated": "已授予选定或完整照片访问权限。"
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "应用列表会保留在这部手机上。"
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw 可以列出启动器可见的应用。"
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "允许后台定位？"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw 仅在你配对的 Gateway 请求时检查位置。"
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "忘记 Gateway？"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "打开 ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "检查"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "未报告限制"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "关闭"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "负载文本"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "活跃代理"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "无"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "最近对话"
@@ -3039,6 +3304,16 @@
       "translated": "已锁定"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count 个提供商"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} 已就绪"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "无 Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "实时对话"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "对话设置"
@@ -3594,6 +3874,11 @@
       "translated": "无法解码此图像。"
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} 个更多"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "你"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "删除"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "不支持的附件"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "准备好了，随时开始"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw 将在此显示审批、失败的任务和频道问题。"
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "正在说话 · 等待回复"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "正在发送排队语音"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw 共享"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "相机"
@@ -4284,9 +4619,9 @@
       "translated": "麦克风"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "尚无梦境日记"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "gateway 未在活动代理工作区中找到 DREAMS.md 或 dreams.md。"
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) 存在，但没有可读取的内容。"
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "gateway 未在活动代理工作区中找到 DREAMS.md 或 dreams.md。"
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "日记不可用"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "连接 gateway 以读取梦境日记条目。"
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "gateway 未返回梦境日记内容。"
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "连接 gateway 以读取梦境日记条目。"
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "无阶段状态"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "连接 Gateway 以加载 dreaming 阶段。"
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway 未返回 dreaming 阶段详细信息。"
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "连接 Gateway 以加载 dreaming 阶段。"
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "无需修复"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "未连接实例"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "连接 Gateway 以检查已连接的实例。"
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway 未报告任何系统在线状态条目。"
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "连接 Gateway 以检查已连接的实例。"
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "未报告。"
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "调度器"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "用量"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "无计划任务"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "连接 Gateway 以加载计划工作。"
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "该 Gateway 没有可见的 cron 任务。"
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "连接 Gateway 以加载计划工作。"
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills 不可用"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "连接 Gateway 以加载工作区 Skills。"
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "尝试其他搜索或从 Gateway 刷新。"
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "连接 Gateway 以加载工作区 Skills。"
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "重命名群组"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "活动"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "最近活动"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "会话活动离线"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "连接到 Gateway 以加载最近的聊天活动。"
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "开始聊天后，它会显示在这里。"
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "连接到 Gateway 以加载最近的聊天活动。"
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "打开"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "未加载提案"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "从设置连接以加载 Skill Workshop 提案。"
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "当 Agent 草拟 Skills 时，新提案将显示在此处。"
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "从设置连接以加载 Skill Workshop 提案。"
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "未加载卡片"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "从“设置”连接以加载 workboard 卡片。"
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "创建卡片或更改筛选条件。"
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "从“设置”连接以加载 workboard 卡片。"
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "选择 OpenClaw 何时可以与 gateway 工具共享此 iPhone 的位置。"
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "忘记 Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "语音唤醒"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "已发现"
@@ -6484,14 +6879,14 @@
       "translated": "已发现 • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "已为手表排队设置。请在验证码过期前打开 OpenClaw。"
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "设置已发送。在手表上打开 OpenClaw 以连接。"
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "已为手表排队设置。请在验证码过期前打开 OpenClaw。"
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "未配置"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "审批"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "没有 Gateway 操作等待审核。"
@@ -6659,14 +7064,14 @@
       "translated": "查看待处理的 gateway 操作。"
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "在启用直连模式前，请安装 OpenClaw 手表应用。"
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "中继仍然可用；直连模式会添加一个独立的 Gateway 节点。"
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "在启用直连模式前，请安装 OpenClaw 手表应用。"
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "已安装"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "语音和通话设置"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "需要 Gateway 权限"
@@ -7879,6 +8299,16 @@
       "translated": "如果需要手动指定主机，请打开“设置”。"
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "信任此 Gateway？"
@@ -8164,6 +8594,11 @@
       "translated": "离线"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "审批"
@@ -8174,14 +8609,19 @@
       "translated": "此审批已经"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "此审批已设置为始终允许。"
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "审批已设置为始终允许。"
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "此审批已设置为始终允许。"
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "需要注意"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "准备连接"
@@ -8299,14 +8744,14 @@
       "translated": "设置链接"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "明文可能会暴露凭据。仅在你信任此本地网络和主机时继续。"
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "请检查此端点。凭据仅在你轻点“连接”后应用。"
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "明文可能会暴露凭据。仅在你信任此本地网络和主机时继续。"
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "复制设置代码命令"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "连接"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "对话"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway 默认值"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "打开 Gateway 设置"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "未检查"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "加载失败"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "聊天错误"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "请在您的 gateway 上批准此请求。审批完成后，Talk 将自动启动。"
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "此设备需要 gateway 审批后，Talk 才能使用实时语音。音频将直接来自 "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "在受信任的本地网络上，OpenClaw 将此 Apple Watch 直接连接到您的 Gateway。"
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "准备连接"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "使用 iPhone 设置启用直接连接。"
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "设置"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "打开 iPhone 设置 → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "OpenClaw 活动时使用 Wi-Fi 或蜂窝网络"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "打开 iPhone 设置 → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "待审查的命令"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "你"
@@ -9499,6 +10024,11 @@
       "translated": "审批"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "查看命令"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "拒绝"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw 无法安装到“应用程序”中。请手动将其移至该位置，然后打开那份副本。"
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "将 OpenClaw 安装到“应用程序”中？"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "替换“应用程序”中较旧的 OpenClaw？"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw 会将自身复制到“应用程序”并从那里重新打开，以确保更新和登录时启动保持可靠。"
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "将 OpenClaw 安装到“应用程序”中？"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "此副本比已安装的应用更新。OpenClaw 将替换它并从“应用程序”重新打开。"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw 会将自身复制到“应用程序”并从那里重新打开，以确保更新和登录时启动保持可靠。"
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "麦克风"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "已启用"
@@ -9954,6 +10494,11 @@
       "translated": "错误"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "已登出并清除凭据。"
@@ -9964,14 +10509,14 @@
       "translated": "未找到 WhatsApp 会话。"
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "未配置 Telegram 令牌。"
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "Telegram 令牌已清除。"
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "未配置 Telegram 令牌。"
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "配置"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "使用基于架构的表单编辑 ~/.openclaw/openclaw.json。"
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "此标签页在 Nix 模式下为只读。请通过 Nix 编辑配置并重新构建。"
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "使用基于架构的表单编辑 ~/.openclaw/openclaw.json。"
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "已降级：\\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "今天"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "你的 AI 驱动设置助手。它可以检查状态、修复配置，"
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "如果播报失败，不要使任务失败"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "请检查“设置 → 连接”或使用“调试 → 重置远程隧道”，然后重试。"
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "结束 \\(listener.command) (\\(listener.pid))？"
@@ -10754,9 +11314,9 @@
       "translated": "写入滚动诊断日志（JSONL）"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "在 ~/Library/Logs/OpenClaw/ 下写入轮转的仅本地日志。 "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "深度链接已被阻止"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "运行 OpenClaw 代理？"
@@ -11064,9 +11629,9 @@
       "translated": "模式不能为空。"
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "仅限路径模式。请包含“/”、“~”或“\\\\”。"
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "无法保存执行审批。已显示最后已知的设置；请重试更改。"
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "尚未找到 Gateway。"
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "点击发现的 Gateway 以填充 SSH 目标。"
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "点击发现的 Gateway 以填充 Gateway URL。"
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "点击发现的 Gateway 以填充 SSH 目标。"
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "在你的局域网上发现 OpenClaw Gateway"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "未链接"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "推荐设置"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "使用 Tailscale Serve，让网关拥有有效的 HTTPS 证书。"
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "使用 Tailscale 加 SSH 隧道，以获得稳定的私有访问。"
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "使用 Tailscale Serve，让网关拥有有效的 HTTPS 证书。"
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "前进"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - 语音唤醒实时计量器已启用"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "重置远程隧道"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "详细日志（主）：关闭"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "详细日志（主）：开启"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "详细日志（主）：关闭"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "详细程度"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "文件日志：关闭"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "文件日志：开启"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "文件日志：关闭"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "已断开连接（使用系统默认）"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) 无法完成测试。显示详情以查看或复制错误。"
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "正在查找您已在使用的 AI…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "正在等待上一个 AI 测试完成…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "正在检查 Claude Code、Codex、Gemini 和已保存的 API 密钥。"
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "正在查找您已在使用的 AI…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw 会在更改任何推理设置之前再次检查。"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "正在检查 Claude Code、Codex、Gemini 和已保存的 API 密钥。"
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "复制错误"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "提示：保持 Tailscale 启用，以便你的 gateway 保持可访问。"
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "提示：使用 Tailscale Serve，让 gateway 拥有有效的 HTTPS 证书。"
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "提示：保持 Tailscale 启用，以便你的 gateway 保持可访问。"
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "使用面板 + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "打开菜单栏面板以快速聊天；代理可以显示预览 "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "拒绝"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "有设备想要连接到 OpenClaw。"
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "有节点想要连接到 OpenClaw。"
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "有设备想要连接到 OpenClaw。"
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "OpenClaw Mac 应用"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "此设备需要配对批准"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "粘贴在 Gateway 主机上配置的令牌。 "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "检查 Gateway 主机上的 `gateway.auth.token` 或 `OPENCLAW_GATEWAY_TOKEN`，然后重试。"
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "此 Gateway 设置为令牌身份验证，但 Gateway 主机上未配置 `gateway.auth.token`。 "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "从已配对的 OpenClaw 客户端扫描或粘贴新的设置代码，然后重试。"
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "此引导流程尚不支持密码身份验证。 "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "请从已配对的 OpenClaw 客户端批准此设备。 "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "此 Gateway 使用密码认证。macOS 上的远程引导目前还无法收集 Gateway 密码。"
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "需要配对。在已配对的 OpenClaw 客户端中，"
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "尚未报告任何 skill"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "无声音"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake 需要 macOS 26 或更高版本"
@@ -14269,6 +14884,11 @@
       "translated": "系统默认"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "已断开连接（使用系统默认）"
@@ -14394,6 +15014,11 @@
       "translated": "（本地已过滤）"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "无效 URL：\\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway 已连接"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "输入 token：\\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "上下文使用量"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "消息使用量"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "取消归档"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "重试发送"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "设置"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -194,6 +194,11 @@
       "translated": "通話模式已啟用"
     },
     {
+      "id": "native.android.de9c39aaec621319",
+      "source": " · Location: Always",
+      "translated": " · Location: Always"
+    },
+    {
       "id": "native.android.ae88801e6a1b3343",
       "source": " · Mic: Listening",
       "translated": " · 麥克風：正在聆聽"
@@ -267,6 +272,16 @@
       "id": "native.android.84ce52ae1375fded",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "translated": "失敗：無法連到此主機的安全 gateway 端點。"
+    },
+    {
+      "id": "native.android.b76bb2741d8344d0",
+      "source": "Update your Gateway to view provider model config.",
+      "translated": "Update your Gateway to view provider model config."
+    },
+    {
+      "id": "native.android.711a08905cf3719e",
+      "source": "Could not load provider model config.",
+      "translated": "Could not load provider model config."
     },
     {
       "id": "native.android.c28c08aed378b051",
@@ -392,6 +407,16 @@
       "id": "native.android.5b17d331b254e403",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "translated": "Android $release (SDK ${Build.VERSION.SDK_INT})"
+    },
+    {
+      "id": "native.android.f7a4f3bbcb0b2090",
+      "source": "${firstLine.take(157)}…",
+      "translated": "${firstLine.take(157)}…"
+    },
+    {
+      "id": "native.android.356609f717b92350",
+      "source": "$preview…",
+      "translated": "$preview…"
     },
     {
       "id": "native.android.cc8d2e1456629a59",
@@ -629,14 +654,24 @@
       "translated": "這會從 gateway 永久移除已排程的工作。"
     },
     {
+      "id": "native.android.a3fcfa20dc395b87",
+      "source": "This job changed while you were editing. Revert to the latest gateway version before saving.",
+      "translated": "This job changed while you were editing. Revert to the latest gateway version before saving."
+    },
+    {
+      "id": "native.android.db9f08d611b4c508",
+      "source": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job.",
+      "translated": "Save or revert your edits before running, enabling, disabling, deleting, or refreshing this job."
+    },
+    {
       "id": "native.android.212889821e40127e",
       "source": "Admin access required",
       "translated": "需要管理員存取權"
     },
     {
-      "id": "native.android.954671d2e72ae79c",
-      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
-      "translated": "Cron 變更需要 operator.admin。設定代碼刻意不會授予此權限。 "
+      "id": "native.android.9f359445f7fb935e",
+      "source": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      "translated": "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client."
     },
     {
       "id": "native.android.f5ed7396dc317625",
@@ -859,6 +894,16 @@
       "translated": "選用路徑"
     },
     {
+      "id": "native.android.da748b7868da4ea7",
+      "source": "Command working directory",
+      "translated": "Command working directory"
+    },
+    {
+      "id": "native.android.99955291fac0d844",
+      "source": "Command working directory · cannot clear",
+      "translated": "Command working directory · cannot clear"
+    },
+    {
       "id": "native.android.00a27842963455a7",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "translated": "gateway 可以變更此路徑，但無法清除現有路徑。"
@@ -997,6 +1042,16 @@
       "id": "native.android.a45b15d8549e9539",
       "source": "D",
       "translated": "D"
+    },
+    {
+      "id": "native.android.ff5abe2418979715",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost"
+    },
+    {
+      "id": "native.android.28e58e1bd98e08ab",
+      "source": "${if (tls) \"https\" else \"http\"}://$displayHost:$port",
+      "translated": "${if (tls) \"https\" else \"http\"}://$displayHost:$port"
     },
     {
       "id": "native.android.458f8fd9ad7485a7",
@@ -1322,6 +1377,11 @@
       "id": "native.android.0bbe0d733b1328fd",
       "source": "Online",
       "translated": "線上"
+    },
+    {
+      "id": "native.android.13024ff403917bfe",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "translated": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>."
     },
     {
       "id": "native.android.9ac2d4498b17d478",
@@ -1694,6 +1754,16 @@
       "translated": "權限"
     },
     {
+      "id": "native.android.bdd063b9f766050b",
+      "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
+      "translated": "Gateway approval is in progress. OpenClaw will retry automatically."
+    },
+    {
+      "id": "native.android.d0c1dcc8236a1ab9",
+      "source": "Gateway paired. Checking node capability approval.",
+      "translated": "Gateway paired. Checking node capability approval."
+    },
+    {
       "id": "native.android.29732759e050c874",
       "source": "The code may have expired or been generated for another Gateway.",
       "translated": "代碼可能已過期，或是為另一個 Gateway 產生。"
@@ -1734,9 +1804,24 @@
       "translated": "Gateway 驗證需要檢查。請檢查 gateway 設定，然後重試。"
     },
     {
-      "id": "native.android.e9fa7abb92b3cc99",
-      "source": "$summary $it",
-      "translated": "$summary $it"
+      "id": "native.android.ee7dad03cd78babe",
+      "source": "openclaw devices approve $requestId",
+      "translated": "openclaw devices approve $requestId"
+    },
+    {
+      "id": "native.android.3792801e2951bb11",
+      "source": "openclaw devices list",
+      "translated": "openclaw devices list"
+    },
+    {
+      "id": "native.android.8fe20d8f8090064d",
+      "source": "openclaw nodes approve $requestId",
+      "translated": "openclaw nodes approve $requestId"
+    },
+    {
+      "id": "native.android.2961a521c1b6837f",
+      "source": "openclaw nodes approve REQUEST_ID",
+      "translated": "openclaw nodes approve REQUEST_ID"
     },
     {
       "id": "native.android.a7933196a18ec924",
@@ -1844,9 +1929,19 @@
       "translated": "沒有已設定的模型"
     },
     {
+      "id": "native.android.4832c0d0e9774283",
+      "source": "${tokens / 1_000}k",
+      "translated": "${tokens / 1_000}k"
+    },
+    {
       "id": "native.android.0e3157c15c56944f",
       "source": "Sessions",
       "translated": "工作階段"
+    },
+    {
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focus session search"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -1869,6 +1964,11 @@
       "translated": "搜尋工作階段"
     },
     {
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Clear session search"
+    },
+    {
       "id": "native.android.dc52c5f9d7b85ec8",
       "source": "Newest first",
       "translated": "最新優先"
@@ -1877,6 +1977,11 @@
       "id": "native.android.78b9d0ab41446a1b",
       "source": "Oldest first",
       "translated": "最舊優先"
+    },
+    {
+      "id": "native.android.d7e09574a17f9ccd",
+      "source": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}",
+      "translated": "Sort: ${if (recentFirst) \"Newest first\" else \"Oldest first\"}"
     },
     {
       "id": "native.android.c6bf8751e2a7f5c7",
@@ -1892,6 +1997,26 @@
       "id": "native.android.bf4f2bc2e1d10e54",
       "source": "Layout: Detailed",
       "translated": "版面配置：詳細"
+    },
+    {
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Searching sessions"
+    },
+    {
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No matching sessions"
+    },
+    {
+      "id": "native.android.11c1a8c944bea0ae",
+      "source": "Try a different search or clear the current query.",
+      "translated": "Try a different search or clear the current query."
+    },
+    {
+      "id": "native.android.63dab4ce8d8ef26a",
+      "source": "Clear Search",
+      "translated": "Clear Search"
     },
     {
       "id": "native.android.75bff03b36200e7b",
@@ -1974,6 +2099,26 @@
       "translated": "OpenClaw"
     },
     {
+      "id": "native.android.f46b06f8550516e4",
+      "source": "Unarchive",
+      "translated": "Unarchive"
+    },
+    {
+      "id": "native.android.a157cb1bddfc3b79",
+      "source": "Delete…",
+      "translated": "Delete…"
+    },
+    {
+      "id": "native.android.283c9264772e2024",
+      "source": "← Back",
+      "translated": "← Back"
+    },
+    {
+      "id": "native.android.fff8fad5db365fa6",
+      "source": "Remove from group",
+      "translated": "Remove from group"
+    },
+    {
       "id": "native.android.6637da0312da85f9",
       "source": "Pin",
       "translated": "釘選"
@@ -1992,6 +2137,41 @@
       "id": "native.android.a9619e8ed4fd6aa2",
       "source": "Mark as unread",
       "translated": "標示為未讀"
+    },
+    {
+      "id": "native.android.c2dcfd6ce61bb9a7",
+      "source": "Rename…",
+      "translated": "Rename…"
+    },
+    {
+      "id": "native.android.7e4fef64a05f84f4",
+      "source": "Fork",
+      "translated": "Fork"
+    },
+    {
+      "id": "native.android.442655ac5b85b24d",
+      "source": "Move to group",
+      "translated": "Move to group"
+    },
+    {
+      "id": "native.android.e78c3cf125b5a40c",
+      "source": "Archive",
+      "translated": "Archive"
+    },
+    {
+      "id": "native.android.11e20947d40764fb",
+      "source": "Rename group…",
+      "translated": "Rename group…"
+    },
+    {
+      "id": "native.android.f9b342d9485114cf",
+      "source": "New group…",
+      "translated": "New group…"
+    },
+    {
+      "id": "native.android.ecfbc9a95c3ca671",
+      "source": "Delete group…",
+      "translated": "Delete group…"
     },
     {
       "id": "native.android.54c10a1eec2fa17c",
@@ -2299,6 +2479,16 @@
       "translated": "OpenClaw 可以接收所選提醒。"
     },
     {
+      "id": "native.android.f0397533c269b90c",
+      "source": "Forward Notifications",
+      "translated": "Forward Notifications"
+    },
+    {
+      "id": "native.android.a04ee29c0a3b68f5",
+      "source": "Quiet Hours",
+      "translated": "Quiet Hours"
+    },
+    {
       "id": "native.android.ebeec52e498bc128",
       "source": "Granted",
       "translated": "已授權"
@@ -2374,6 +2564,21 @@
       "translated": "手機功能"
     },
     {
+      "id": "native.android.2d1dd1a2e9dae8e9",
+      "source": "Camera",
+      "translated": "Camera"
+    },
+    {
+      "id": "native.android.3104a266665b9e19",
+      "source": "Precise Location",
+      "translated": "Precise Location"
+    },
+    {
+      "id": "native.android.c38c2616e6b13dd4",
+      "source": "Photos",
+      "translated": "Photos"
+    },
+    {
       "id": "native.android.7d943661c4341ef0",
       "source": "Allow photo library access.",
       "translated": "允許相片圖庫存取權限。"
@@ -2384,6 +2589,11 @@
       "translated": "已授予所選或完整相片存取權限。"
     },
     {
+      "id": "native.android.74fb102d11305307",
+      "source": "Installed Apps",
+      "translated": "Installed Apps"
+    },
+    {
       "id": "native.android.8ed8ecbbd6112e81",
       "source": "App list stays on this phone.",
       "translated": "App 清單會保留在這支手機上。"
@@ -2392,6 +2602,16 @@
       "id": "native.android.bdafaceb7af93f5a",
       "source": "OpenClaw can list launcher-visible apps.",
       "translated": "OpenClaw 可以列出啟動器可見的 App。"
+    },
+    {
+      "id": "native.android.be89d5601904322a",
+      "source": "Keep Awake",
+      "translated": "Keep Awake"
+    },
+    {
+      "id": "native.android.66e7775ab738ed4f",
+      "source": "Canvas Status",
+      "translated": "Canvas Status"
     },
     {
       "id": "native.android.4ea310efb1f0e7ff",
@@ -2409,9 +2629,9 @@
       "translated": "允許背景位置存取？"
     },
     {
-      "id": "native.android.9d149d1ad66e42f9",
-      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
-      "translated": "OpenClaw 只會在你配對的 Gateway 要求時檢查位置。 "
+      "id": "native.android.031d3ed6fb8a6559",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+      "translated": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background."
     },
     {
       "id": "native.android.c48805f3de1d72ca",
@@ -2457,6 +2677,11 @@
       "id": "native.android.66aad1078731e6a3",
       "source": "Forget gateway?",
       "translated": "忘記 Gateway？"
+    },
+    {
+      "id": "native.android.fc2b37bf96ebd49d",
+      "source": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?",
+      "translated": "Remove ${entry?.name ?: \"this gateway\"} and its saved credentials from this phone?"
     },
     {
       "id": "native.android.c6c8e0c4b8a9a7cf",
@@ -2699,9 +2924,24 @@
       "translated": "開啟 ${license.title}"
     },
     {
+      "id": "native.android.d66786c625242bbf",
+      "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
+      "translated": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code."
+    },
+    {
       "id": "native.android.cfffa5b838a65ca4",
       "source": "Check",
       "translated": "檢查"
+    },
+    {
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway."
+    },
+    {
+      "id": "native.android.3a3bea53e6a6ada7",
+      "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
+      "translated": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready."
     },
     {
       "id": "native.android.877490cc2551c8b2",
@@ -2804,11 +3044,6 @@
       "translated": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}"
     },
     {
-      "id": "native.android.28ecef67eb7d30b2",
-      "source": "No limits reported",
-      "translated": "未回報限制"
-    },
-    {
       "id": "native.android.35d4bc86e9ba395d",
       "source": "Off",
       "translated": "關閉"
@@ -2832,6 +3067,26 @@
       "id": "native.android.f36439e78187c554",
       "source": "Payload Text",
       "translated": "承載文字"
+    },
+    {
+      "id": "native.android.d89f6d465e3e4725",
+      "source": "No apps selected. Nothing forwards until you add apps.",
+      "translated": "No apps selected. Nothing forwards until you add apps."
+    },
+    {
+      "id": "native.android.f38672bd0713cb8b",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} allowed to forward."
+    },
+    {
+      "id": "native.android.eeabea3c662af708",
+      "source": "No apps blocked. Apps can forward unless you add blocks.",
+      "translated": "No apps blocked. Apps can forward unless you add blocks."
+    },
+    {
+      "id": "native.android.8db7e536cf5ffaf4",
+      "source": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding.",
+      "translated": "$selectedCount ${if (selectedCount == 1) \"app\" else \"apps\"} blocked from forwarding."
     },
     {
       "id": "native.android.30d8b822fa68d6c4",
@@ -2872,6 +3127,11 @@
       "id": "native.android.586490ecd89b15cc",
       "source": "ACTIVE AGENT",
       "translated": "使用中的代理程式"
+    },
+    {
+      "id": "native.android.5fb62fa35b740ba6",
+      "source": "$agentName is working",
+      "translated": "$agentName is working"
     },
     {
       "id": "native.android.c9a9b5795b73925d",
@@ -2959,6 +3219,11 @@
       "translated": "無"
     },
     {
+      "id": "native.android.70c2bdc593d2259b",
+      "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
+      "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
+    },
+    {
       "id": "native.android.7178756ffe9e4c72",
       "source": "Recent conversations",
       "translated": "最近的對話"
@@ -3039,6 +3304,16 @@
       "translated": "已鎖定"
     },
     {
+      "id": "native.android.bbf9d9dc946efe85",
+      "source": "Account",
+      "translated": "Account"
+    },
+    {
+      "id": "native.android.13edbcfbe3598233",
+      "source": "Licenses",
+      "translated": "Licenses"
+    },
+    {
       "id": "native.android.ca1451df912ed5cf",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "translated": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
@@ -3067,16 +3342,6 @@
       "id": "native.android.22d0e2dfa67399d3",
       "source": "$count providers",
       "translated": "$count 個提供者"
-    },
-    {
-      "id": "native.android.5905ff41489004c6",
-      "source": "$ready/${skills.size} ready",
-      "translated": "$ready/${skills.size} 已就緒"
-    },
-    {
-      "id": "native.android.087c72ddfc807c5c",
-      "source": "No skills",
-      "translated": "無 Skills"
     },
     {
       "id": "native.android.560fea9426127f28",
@@ -3434,6 +3699,21 @@
       "translated": "即時對話"
     },
     {
+      "id": "native.android.9d977253fdcda216",
+      "source": "OpenClaw speaking",
+      "translated": "OpenClaw speaking"
+    },
+    {
+      "id": "native.android.1babfd757bbcfeb4",
+      "source": "Realtime voice",
+      "translated": "Realtime voice"
+    },
+    {
+      "id": "native.android.4a273a765eedc369",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
       "id": "native.android.33ec06cb156adf64",
       "source": "Talk settings",
       "translated": "對話設定"
@@ -3594,6 +3874,11 @@
       "translated": "無法解碼此圖片。"
     },
     {
+      "id": "native.android.6384b9802cfdacfe",
+      "source": "$text ",
+      "translated": "$text "
+    },
+    {
       "id": "native.android.cd2033b0a82a72dd",
       "source": "$index.",
       "translated": "$index."
@@ -3719,6 +4004,11 @@
       "translated": "... +${toolCalls.size - 6} more"
     },
     {
+      "id": "native.android.552a4d6f5110e6a3",
+      "source": "user",
+      "translated": "user"
+    },
+    {
       "id": "native.android.b3ff30d4e0b3ce58",
       "source": "You",
       "translated": "你"
@@ -3737,6 +4027,11 @@
       "id": "native.android.b728b15914267f57",
       "source": "Delete",
       "translated": "刪除"
+    },
+    {
+      "id": "native.android.5d4f893886312f82",
+      "source": "assistant",
+      "translated": "assistant"
     },
     {
       "id": "native.android.dfbd755eb43b4d26",
@@ -3767,6 +4062,11 @@
       "id": "native.android.09720189ba712747",
       "source": "Unsupported attachment",
       "translated": "不支援的附件"
+    },
+    {
+      "id": "native.android.794796c2c771a75b",
+      "source": "Some shared images were omitted or could not be added.",
+      "translated": "Some shared images were omitted or could not be added."
     },
     {
       "id": "native.android.22a4efbe2bab8b80",
@@ -3817,6 +4117,21 @@
       "id": "native.android.9df2c9d68bad169f",
       "source": "Ready when you are",
       "translated": "準備好了，等你開始"
+    },
+    {
+      "id": "native.android.569efec44d3ac9f8",
+      "source": "Start with a prompt, or use voice.",
+      "translated": "Start with a prompt, or use voice."
+    },
+    {
+      "id": "native.android.28238225371cf3c3",
+      "source": "Use the recovery options below to reconnect.",
+      "translated": "Use the recovery options below to reconnect."
+    },
+    {
+      "id": "native.android.55bd10b5ca2368db",
+      "source": "Chat is checking Gateway health.",
+      "translated": "Chat is checking Gateway health."
     },
     {
       "id": "native.android.6bbe3c5b5193d985",
@@ -4069,6 +4384,16 @@
       "translated": "OpenClaw 會在此顯示核准、失敗的工作和頻道問題。"
     },
     {
+      "id": "native.android.7a6a37643fcfb2d9",
+      "source": "Accept",
+      "translated": "Accept"
+    },
+    {
+      "id": "native.android.969f267b28a69e16",
+      "source": "Location",
+      "translated": "Location"
+    },
+    {
       "id": "native.android.c5e56f0e8af094fb",
       "source": "Speaking · waiting for reply",
       "translated": "正在說話 · 等待回覆"
@@ -4102,6 +4427,11 @@
       "id": "native.android.01ac388cd8ae0732",
       "source": "Sending queued voice",
       "translated": "正在傳送佇列中的語音"
+    },
+    {
+      "id": "native.android.a4cd123d7ec88d53",
+      "source": "Voice reply timed out; retrying queued turn",
+      "translated": "Voice reply timed out; retrying queued turn"
     },
     {
       "id": "native.android.b4f67e96603515bd",
@@ -4274,6 +4604,11 @@
       "translated": "OpenClaw Share"
     },
     {
+      "id": "native.apple.382fd936eaf238f7",
+      "source": "Just received your iOS share + request, working on it.",
+      "translated": "Just received your iOS share + request, working on it."
+    },
+    {
       "id": "native.apple.23834d0ff7589921",
       "source": "Camera",
       "translated": "相機"
@@ -4284,9 +4619,9 @@
       "translated": "麥克風"
     },
     {
-      "id": "native.apple.28740d4b2df6637c",
-      "source": "\\\"\\(trimmed)\\\"",
-      "translated": "\\\"\\(trimmed)\\\""
+      "id": "native.apple.5ec8cdd5af7c54a7",
+      "source": "\"\\(trimmed)\"",
+      "translated": "\"\\(trimmed)\""
     },
     {
       "id": "native.apple.a811eb3e4d2174d5",
@@ -4419,14 +4754,14 @@
       "translated": "尚無 dream diary"
     },
     {
-      "id": "native.apple.a6a454a28f1db7df",
-      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
-      "translated": "Gateway 在目前作用中的代理工作區中找不到 DREAMS.md 或 dreams.md。"
-    },
-    {
       "id": "native.apple.bb7c4a8dbc801a19",
       "source": "\\(diary.path) exists but has no readable content.",
       "translated": "\\(diary.path) 存在但沒有可讀取的內容。"
+    },
+    {
+      "id": "native.apple.a6a454a28f1db7df",
+      "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
+      "translated": "Gateway 在目前作用中的代理工作區中找不到 DREAMS.md 或 dreams.md。"
     },
     {
       "id": "native.apple.11ae1c140df749a6",
@@ -4434,14 +4769,14 @@
       "translated": "日誌無法使用"
     },
     {
-      "id": "native.apple.e9772e2a1bbfb483",
-      "source": "Connect a gateway to read dream diary entries.",
-      "translated": "連接 Gateway 以讀取 dream diary 項目。"
-    },
-    {
       "id": "native.apple.6f80c38b0b83c057",
       "source": "The gateway did not return dream diary content.",
       "translated": "Gateway 未傳回 dream diary 內容。"
+    },
+    {
+      "id": "native.apple.e9772e2a1bbfb483",
+      "source": "Connect a gateway to read dream diary entries.",
+      "translated": "連接 Gateway 以讀取 dream diary 項目。"
     },
     {
       "id": "native.apple.95300e4dfd7aad42",
@@ -4474,14 +4809,14 @@
       "translated": "沒有階段狀態"
     },
     {
-      "id": "native.apple.3ce988bd2b2215b2",
-      "source": "Connect a gateway to load dreaming phases.",
-      "translated": "連接 Gateway 以載入 Dreaming 階段。"
-    },
-    {
       "id": "native.apple.128c6782a7b1d919",
       "source": "The gateway did not return dreaming phase details.",
       "translated": "Gateway 未傳回 Dreaming 階段詳細資訊。"
+    },
+    {
+      "id": "native.apple.3ce988bd2b2215b2",
+      "source": "Connect a gateway to load dreaming phases.",
+      "translated": "連接 Gateway 以載入 Dreaming 階段。"
     },
     {
       "id": "native.apple.95e346b05c4acf8a",
@@ -4492,6 +4827,16 @@
       "id": "native.apple.da9b0546b320aa00",
       "source": "no repair needed",
       "translated": "不需要修復"
+    },
+    {
+      "id": "native.apple.43258a1742cabdb6",
+      "source": "\\(index)",
+      "translated": "\\(index)"
+    },
+    {
+      "id": "native.apple.2cb500a4a64c9a05",
+      "source": "No diary prose for this day.",
+      "translated": "No diary prose for this day."
     },
     {
       "id": "native.apple.d6d76334ab8bbf86",
@@ -4534,14 +4879,14 @@
       "translated": "沒有已連接的實例"
     },
     {
-      "id": "native.apple.36618248cdaccc84",
-      "source": "Connect a gateway to inspect connected instances.",
-      "translated": "連接 Gateway 以檢查已連接的實例。"
-    },
-    {
       "id": "native.apple.26327e8fdd0a869b",
       "source": "The gateway did not report any system presence entries.",
       "translated": "Gateway 未回報任何系統線上狀態項目。"
+    },
+    {
+      "id": "native.apple.36618248cdaccc84",
+      "source": "Connect a gateway to inspect connected instances.",
+      "translated": "連接 Gateway 以檢查已連接的實例。"
     },
     {
       "id": "native.apple.e51fe4f1d2c94caa",
@@ -4604,6 +4949,16 @@
       "translated": "未回報任何項目。"
     },
     {
+      "id": "native.apple.41526676f6d4d2cf",
+      "source": "\\(scopesCount) scopes",
+      "translated": "\\(scopesCount) scopes"
+    },
+    {
+      "id": "native.apple.58bcd0a6ffe9de8a",
+      "source": "\\(rolesCount) roles",
+      "translated": "\\(rolesCount) roles"
+    },
+    {
       "id": "native.apple.828de90d8dfed4ad",
       "source": "Scheduler",
       "translated": "排程器"
@@ -4662,6 +5017,11 @@
       "id": "native.apple.4bee0220d011ab53",
       "source": "Usage",
       "translated": "用量"
+    },
+    {
+      "id": "native.apple.49160020f0318366",
+      "source": "Default",
+      "translated": "Default"
     },
     {
       "id": "native.apple.5fbed24f057edea8",
@@ -4794,14 +5154,14 @@
       "translated": "沒有排程工作"
     },
     {
-      "id": "native.apple.ae4aa2339b285164",
-      "source": "Connect a gateway to load scheduled work.",
-      "translated": "連接 Gateway 以載入已排程的工作。"
-    },
-    {
       "id": "native.apple.0cd04bacdbcd8fa5",
       "source": "The gateway has no visible cron jobs.",
       "translated": "Gateway 沒有可見的 cron 工作。"
+    },
+    {
+      "id": "native.apple.ae4aa2339b285164",
+      "source": "Connect a gateway to load scheduled work.",
+      "translated": "連接 Gateway 以載入已排程的工作。"
     },
     {
       "id": "native.apple.13e776bd20f1df1c",
@@ -4934,14 +5294,14 @@
       "translated": "Skills 無法使用"
     },
     {
-      "id": "native.apple.37c0e98e8a49fe44",
-      "source": "Connect a gateway to load workspace skills.",
-      "translated": "連接 Gateway 以載入工作區 Skills。"
-    },
-    {
       "id": "native.apple.698f37c66a7d9436",
       "source": "Try a different search or refresh from the gateway.",
       "translated": "請嘗試其他搜尋，或從 Gateway 重新整理。"
+    },
+    {
+      "id": "native.apple.37c0e98e8a49fe44",
+      "source": "Connect a gateway to load workspace skills.",
+      "translated": "連接 Gateway 以載入工作區 Skills。"
     },
     {
       "id": "native.apple.61ebcf220ca6f7f4",
@@ -5574,6 +5934,11 @@
       "translated": "重新命名群組"
     },
     {
+      "id": "native.apple.a87991de580598a9",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
+    },
+    {
       "id": "native.apple.ffaad4538bcfe1ac",
       "source": "Activity",
       "translated": "活動"
@@ -5597,6 +5962,11 @@
       "id": "native.apple.4813254a14ae910f",
       "source": "Recent activity",
       "translated": "最近活動"
+    },
+    {
+      "id": "native.apple.18b4b1d1291e8402",
+      "source": "Loading",
+      "translated": "Loading"
     },
     {
       "id": "native.apple.f7b3242d69bc344b",
@@ -5644,19 +6014,34 @@
       "translated": "工作階段活動離線"
     },
     {
-      "id": "native.apple.f47ceff451b1cce8",
-      "source": "Connect to the gateway to load recent chat activity.",
-      "translated": "連線至 Gateway 以載入最近的聊天活動。"
-    },
-    {
       "id": "native.apple.e3586d8a603f67e0",
       "source": "Start a chat and it will appear here.",
       "translated": "開始聊天後，它會顯示在這裡。"
     },
     {
+      "id": "native.apple.f47ceff451b1cce8",
+      "source": "Connect to the gateway to load recent chat activity.",
+      "translated": "連線至 Gateway 以載入最近的聊天活動。"
+    },
+    {
+      "id": "native.apple.9094f48f7ebd28c5",
+      "source": "Chat",
+      "translated": "Chat"
+    },
+    {
       "id": "native.apple.fb6493b448a3f62a",
       "source": "Open",
       "translated": "開啟"
+    },
+    {
+      "id": "native.apple.c61170392d1aa557",
+      "source": "Offline",
+      "translated": "Offline"
+    },
+    {
+      "id": "native.apple.225dcb2dfdcaa76f",
+      "source": "Try again after the gateway reconnects.",
+      "translated": "Try again after the gateway reconnects."
     },
     {
       "id": "native.apple.39681d2062a338cf",
@@ -5744,14 +6129,14 @@
       "translated": "未載入提案"
     },
     {
-      "id": "native.apple.bacbe7d1ade39252",
-      "source": "Connect from Settings to load Skill Workshop proposals.",
-      "translated": "從「設定」連線以載入 Skill Workshop 提案。"
-    },
-    {
       "id": "native.apple.401016421351cd1d",
       "source": "New proposals will appear here when agents draft skills.",
       "translated": "當 agents 起草 skills 時，新的提案會顯示在這裡。"
+    },
+    {
+      "id": "native.apple.bacbe7d1ade39252",
+      "source": "Connect from Settings to load Skill Workshop proposals.",
+      "translated": "從「設定」連線以載入 Skill Workshop 提案。"
     },
     {
       "id": "native.apple.610d75ef598b0732",
@@ -5924,14 +6309,14 @@
       "translated": "未載入卡片"
     },
     {
-      "id": "native.apple.60483b8876b7f59f",
-      "source": "Connect from Settings to load workboard cards.",
-      "translated": "請從「設定」連線以載入 workboard 卡片。"
-    },
-    {
       "id": "native.apple.d150c79eaa14ec76",
       "source": "Create a card or change the filter.",
       "translated": "建立卡片或變更篩選條件。"
+    },
+    {
+      "id": "native.apple.60483b8876b7f59f",
+      "source": "Connect from Settings to load workboard cards.",
+      "translated": "請從「設定」連線以載入 workboard 卡片。"
     },
     {
       "id": "native.apple.24fb5469bb5a5b37",
@@ -6394,6 +6779,11 @@
       "translated": "選擇 OpenClaw 何時可以將此 iPhone 的位置分享給 gateway 工具。"
     },
     {
+      "id": "native.apple.d5eb77296d18a08b",
+      "source": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?",
+      "translated": "Forget \\(self.pendingForgetGateway?.name ?? \"gateway\")?"
+    },
+    {
       "id": "native.apple.ab8d7959b6ab66f9",
       "source": "Forget Gateway",
       "translated": "忘記 Gateway"
@@ -6474,6 +6864,11 @@
       "translated": "語音喚醒"
     },
     {
+      "id": "native.apple.27942ed8539c84c6",
+      "source": "\\(endpoint) • TLS",
+      "translated": "\\(endpoint) • TLS"
+    },
+    {
       "id": "native.apple.0a3f566ac6a35d90",
       "source": "Discovered",
       "translated": "已探索"
@@ -6484,14 +6879,14 @@
       "translated": "已探索 • TLS"
     },
     {
-      "id": "native.apple.a9a778465dfe1198",
-      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
-      "translated": "已為手錶排入設定佇列。請在代碼過期前開啟 OpenClaw。"
-    },
-    {
       "id": "native.apple.3503aca018f04865",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "translated": "設定已送出。在手錶上開啟 OpenClaw 以連線。"
+    },
+    {
+      "id": "native.apple.a9a778465dfe1198",
+      "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
+      "translated": "已為手錶排入設定佇列。請在代碼過期前開啟 OpenClaw。"
     },
     {
       "id": "native.apple.fbf8fb158f556a76",
@@ -6502,6 +6897,11 @@
       "id": "native.apple.ad28c6e82fda63b0",
       "source": "Not configured",
       "translated": "未設定"
+    },
+    {
+      "id": "native.apple.3ba1d988ea9c9a21",
+      "source": "Connected",
+      "translated": "Connected"
     },
     {
       "id": "native.apple.0e6f25ab4a59543a",
@@ -6649,6 +7049,11 @@
       "translated": "核准"
     },
     {
+      "id": "native.apple.ca97c3ccc7e33122",
+      "source": "Out-of-app approval alerts need notification permission.",
+      "translated": "Out-of-app approval alerts need notification permission."
+    },
+    {
       "id": "native.apple.bbc85e1645e8ccf1",
       "source": "No gateway actions are waiting for review.",
       "translated": "沒有 Gateway 動作正在等待審核。"
@@ -6659,14 +7064,14 @@
       "translated": "檢閱待處理的 gateway 動作。"
     },
     {
+      "id": "native.apple.32a85f247d3bc0af",
+      "source": "Alerts Off",
+      "translated": "Alerts Off"
+    },
+    {
       "id": "native.apple.561d865ad24910d2",
       "source": "Apple Watch",
       "translated": "Apple Watch"
-    },
-    {
-      "id": "native.apple.1bd0f0b41f4d4750",
-      "source": "Install the OpenClaw watch app before enabling direct mode.",
-      "translated": "在啟用直連模式前，請先安裝 OpenClaw 手錶 App。"
     },
     {
       "id": "native.apple.df05bfb397806b0d",
@@ -6674,9 +7079,19 @@
       "translated": "中繼仍可使用；直連模式會新增一個獨立的 Gateway 節點。"
     },
     {
+      "id": "native.apple.1bd0f0b41f4d4750",
+      "source": "Install the OpenClaw watch app before enabling direct mode.",
+      "translated": "在啟用直連模式前，請先安裝 OpenClaw 手錶 App。"
+    },
+    {
       "id": "native.apple.cfa1c0be2d607257",
       "source": "Installed",
       "translated": "已安裝"
+    },
+    {
+      "id": "native.apple.3710cda9cb13870f",
+      "source": "Reachable",
+      "translated": "Reachable"
     },
     {
       "id": "native.apple.59405b82eb08ae1e",
@@ -7474,6 +7889,11 @@
       "translated": "語音與通話設定"
     },
     {
+      "id": "native.apple.877fb5c1abfaafa1",
+      "source": "Not loaded",
+      "translated": "Not loaded"
+    },
+    {
       "id": "native.apple.05c434bb5fe3c275",
       "source": "Gateway permission required",
       "translated": "需要 Gateway 權限"
@@ -7879,6 +8299,16 @@
       "translated": "如果需要手動主機，請開啟「設定」。"
     },
     {
+      "id": "native.apple.1c9a058b7bb966b6",
+      "source": "\\(host):\\(port)",
+      "translated": "\\(host):\\(port)"
+    },
+    {
+      "id": "native.apple.47d9865a941033d5",
+      "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
+      "translated": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)"
+    },
+    {
       "id": "native.apple.8ef0909bddf2f9ee",
       "source": "Trust this gateway?",
       "translated": "信任此 gateway？"
@@ -8164,6 +8594,11 @@
       "translated": "離線"
     },
     {
+      "id": "native.apple.4a98b3a346be2662",
+      "source": "No chat messages yet",
+      "translated": "No chat messages yet"
+    },
+    {
       "id": "native.apple.0b1eff808df04e2b",
       "source": "Approval",
       "translated": "核准"
@@ -8174,14 +8609,19 @@
       "translated": "此核准已"
     },
     {
+      "id": "native.apple.4e3a9dc13016600b",
+      "source": "This approval was already set to Always Allow.",
+      "translated": "此核准已設為永遠允許。"
+    },
+    {
       "id": "native.apple.4864b3b8c6ed7158",
       "source": "Approval set to Always Allow.",
       "translated": "核准已設為永遠允許。"
     },
     {
-      "id": "native.apple.4e3a9dc13016600b",
-      "source": "This approval was already set to Always Allow.",
-      "translated": "此核准已設為永遠允許。"
+      "id": "native.apple.1a8232361f3d72fb",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
     },
     {
       "id": "native.apple.11687a3d87afd0d7",
@@ -8254,6 +8694,11 @@
       "translated": "需要處理"
     },
     {
+      "id": "native.apple.7f671f0202cb1d9b",
+      "source": "Retry",
+      "translated": "Retry"
+    },
+    {
       "id": "native.apple.e71e20089bcc4cfb",
       "source": "Ready to Connect",
       "translated": "準備連線"
@@ -8299,14 +8744,14 @@
       "translated": "設定連結"
     },
     {
-      "id": "native.apple.6bfb611862fb1687",
-      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
-      "translated": "純文字可能會暴露憑證。只有在您信任此本機網路和主機時才繼續。"
-    },
-    {
       "id": "native.apple.3329c7f367f10c78",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "translated": "請檢查此端點。只有在您點一下「連線」後，才會套用憑證。"
+    },
+    {
+      "id": "native.apple.6bfb611862fb1687",
+      "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
+      "translated": "純文字可能會暴露憑證。只有在您信任此本機網路和主機時才繼續。"
     },
     {
       "id": "native.apple.2f00ef4bc35ecb8d",
@@ -8347,6 +8792,11 @@
       "id": "native.apple.eae3bd9e4e9112a0",
       "source": "Copy setup code command",
       "translated": "複製設定代碼命令"
+    },
+    {
+      "id": "native.apple.88792f11a553bab7",
+      "source": "Copied",
+      "translated": "Copied"
     },
     {
       "id": "native.apple.e8b4dc00cd23ae73",
@@ -8624,6 +9074,16 @@
       "translated": "連線"
     },
     {
+      "id": "native.apple.5b46de1ccb06852b",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
+    },
+    {
+      "id": "native.apple.e5f6435b9cb5a2d8",
+      "source": "unknown relay error",
+      "translated": "unknown relay error"
+    },
+    {
       "id": "native.apple.f2ea327bfea8b8e3",
       "source": "Talk",
       "translated": "交談"
@@ -8742,6 +9202,11 @@
       "id": "native.apple.e91893761485b9e8",
       "source": "Gateway default",
       "translated": "Gateway 預設"
+    },
+    {
+      "id": "native.apple.e5c9d5012c42a604",
+      "source": "Routed on this phone",
+      "translated": "Routed on this phone"
     },
     {
       "id": "native.apple.a29418bbb3169404",
@@ -9014,6 +9479,11 @@
       "translated": "開啟 Gateway 設定"
     },
     {
+      "id": "native.apple.f90c1fb8880c70c0",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.3b21081fb5ce84ba",
       "source": "Not checked",
       "translated": "未檢查"
@@ -9052,6 +9522,16 @@
       "id": "native.apple.0a0e11e7aefde770",
       "source": "Load failed",
       "translated": "載入失敗"
+    },
+    {
+      "id": "native.apple.f2be0b00a9d003fe",
+      "source": "Realtime Voice",
+      "translated": "Realtime Voice"
+    },
+    {
+      "id": "native.apple.571d17c55ce80675",
+      "source": "Talk Voice",
+      "translated": "Talk Voice"
     },
     {
       "id": "native.apple.8b95eb816538a735",
@@ -9097,6 +9577,11 @@
       "id": "native.apple.7c027ae095940485",
       "source": "Chat error",
       "translated": "聊天錯誤"
+    },
+    {
+      "id": "native.apple.465b84d5ff3f3717",
+      "source": "Gateway Relay",
+      "translated": "Gateway Relay"
     },
     {
       "id": "native.apple.c48dc51b49089432",
@@ -9154,9 +9639,9 @@
       "translated": "請在您的 gateway 上核准此要求。核准送達後，Talk 將自動開始。"
     },
     {
-      "id": "native.apple.bd7d6f4323b9c3c2",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
-      "translated": "此裝置需要 gateway 核准，Talk 才能使用即時語音。音訊將直接來自 "
+      "id": "native.apple.80faa829f543c03c",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "translated": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider."
     },
     {
       "id": "native.apple.88b0a2e2986fcebf",
@@ -9194,6 +9679,26 @@
       "translated": "OpenClaw 會在受信任的本機網路上將此 Apple Watch 直接連線到您的 Gateway。"
     },
     {
+      "id": "native.apple.f01783596898f5d6",
+      "source": "Unknown",
+      "translated": "Unknown"
+    },
+    {
+      "id": "native.apple.7d8e032476dee789",
+      "source": "Main",
+      "translated": "Main"
+    },
+    {
+      "id": "native.apple.c7d56c96499accff",
+      "source": "Off",
+      "translated": "Off"
+    },
+    {
+      "id": "native.apple.9df4056896cf6c02",
+      "source": "Gateway HTTP error (\\(self.status))",
+      "translated": "Gateway HTTP error (\\(self.status))"
+    },
+    {
       "id": "native.apple.d4c7af4a7bfeb382",
       "source": "Ready to connect",
       "translated": "準備連線"
@@ -9207,6 +9712,21 @@
       "id": "native.apple.0e0763442f318e2f",
       "source": "Use iPhone Settings to enable direct connection.",
       "translated": "使用 iPhone 設定以啟用直接連線。"
+    },
+    {
+      "id": "native.apple.f3cc640d74e3b4b5",
+      "source": "Connected",
+      "translated": "Connected"
+    },
+    {
+      "id": "native.apple.9486a204b499e24a",
+      "source": "Ready",
+      "translated": "Ready"
+    },
+    {
+      "id": "native.apple.ca02fd2965efe74e",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.732051c3e897a9f1",
@@ -9304,14 +9824,14 @@
       "translated": "設定"
     },
     {
-      "id": "native.apple.08583448d9b2455e",
-      "source": "Open iPhone Settings → Apple Watch",
-      "translated": "開啟 iPhone 設定 → Apple Watch"
-    },
-    {
       "id": "native.apple.c7d87356e6cdb374",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "translated": "OpenClaw 啟用時使用 Wi-Fi 或行動網路"
+    },
+    {
+      "id": "native.apple.08583448d9b2455e",
+      "source": "Open iPhone Settings → Apple Watch",
+      "translated": "開啟 iPhone 設定 → Apple Watch"
     },
     {
       "id": "native.apple.f748dad8f2ce22ae",
@@ -9449,6 +9969,11 @@
       "translated": "要檢閱的指令"
     },
     {
+      "id": "native.apple.a4fc6006c24b42df",
+      "source": "Sending decision...",
+      "translated": "Sending decision..."
+    },
+    {
       "id": "native.apple.337c2164038d1a5a",
       "source": "You",
       "translated": "你"
@@ -9499,6 +10024,11 @@
       "translated": "核准"
     },
     {
+      "id": "native.apple.2cf742a80121a8ea",
+      "source": "Pending review",
+      "translated": "Pending review"
+    },
+    {
       "id": "native.apple.507b63347d559665",
       "source": "Review Command",
       "translated": "檢閱指令"
@@ -9517,6 +10047,11 @@
       "id": "native.apple.096fb24013ac5455",
       "source": "Deny",
       "translated": "拒絕"
+    },
+    {
+      "id": "native.apple.f84adc6a026a3aaf",
+      "source": "Review command below",
+      "translated": "Review command below"
     },
     {
       "id": "native.apple.5ac0c79487a492b4",
@@ -9639,24 +10174,24 @@
       "translated": "OpenClaw 無法安裝到「應用程式」中。請手動將其移至該處，然後開啟該副本。"
     },
     {
-      "id": "native.apple.088b39cc34b44e54",
-      "source": "Install OpenClaw in Applications?",
-      "translated": "要將 OpenClaw 安裝到「應用程式」中嗎？"
-    },
-    {
       "id": "native.apple.7f86f5acf3d32ec2",
       "source": "Replace the older OpenClaw in Applications?",
       "translated": "要取代「應用程式」中較舊的 OpenClaw 嗎？"
     },
     {
-      "id": "native.apple.a77a46d0ca32551f",
-      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
-      "translated": "OpenClaw 會將自身複製到「應用程式」並在該處重新開啟，以確保更新與登入時啟動維持穩定。"
+      "id": "native.apple.088b39cc34b44e54",
+      "source": "Install OpenClaw in Applications?",
+      "translated": "要將 OpenClaw 安裝到「應用程式」中嗎？"
     },
     {
       "id": "native.apple.c8898d685457401f",
       "source": "This copy is newer than the installed app. OpenClaw will replace it and reopen from Applications.",
       "translated": "此副本比已安裝的應用程式更新。OpenClaw 會將其取代並從「應用程式」重新開啟。"
+    },
+    {
+      "id": "native.apple.a77a46d0ca32551f",
+      "source": "OpenClaw will copy itself to Applications and reopen there so updates and launch at login stay reliable.",
+      "translated": "OpenClaw 會將自身複製到「應用程式」並在該處重新開啟，以確保更新與登入時啟動維持穩定。"
     },
     {
       "id": "native.apple.22ebb7b228c8275a",
@@ -9819,6 +10354,11 @@
       "translated": "麥克風"
     },
     {
+      "id": "native.apple.533965afb8350ace",
+      "source": "Degraded",
+      "translated": "Degraded"
+    },
+    {
       "id": "native.apple.90dacdcac6e6bd80",
       "source": "Enabled",
       "translated": "已啟用"
@@ -9954,6 +10494,11 @@
       "translated": "錯誤"
     },
     {
+      "id": "native.apple.60f2b09010a7809b",
+      "source": "Config invalid; fix it in ~/.openclaw/openclaw.json.",
+      "translated": "Config invalid; fix it in ~/.openclaw/openclaw.json."
+    },
+    {
       "id": "native.apple.313dabb10c37e00c",
       "source": "Logged out and cleared credentials.",
       "translated": "已登出並清除認證資料。"
@@ -9964,14 +10509,14 @@
       "translated": "找不到 WhatsApp 工作階段。"
     },
     {
-      "id": "native.apple.53f4d1e63fb7d589",
-      "source": "No Telegram token configured.",
-      "translated": "未設定 Telegram 權杖。"
-    },
-    {
       "id": "native.apple.de729686d8ba05d6",
       "source": "Telegram token cleared.",
       "translated": "已清除 Telegram 權杖。"
+    },
+    {
+      "id": "native.apple.53f4d1e63fb7d589",
+      "source": "No Telegram token configured.",
+      "translated": "未設定 Telegram 權杖。"
     },
     {
       "id": "native.apple.0a65101d40a6704c",
@@ -9994,14 +10539,14 @@
       "translated": "Config"
     },
     {
-      "id": "native.apple.8103e662c0e40760",
-      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
-      "translated": "使用結構描述驅動的表單編輯 ~/.openclaw/openclaw.json。"
-    },
-    {
       "id": "native.apple.e7afd1797978a4fd",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "translated": "此分頁在 Nix 模式中為唯讀。請透過 Nix 編輯 config 並重新建置。"
+    },
+    {
+      "id": "native.apple.8103e662c0e40760",
+      "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
+      "translated": "使用結構描述驅動的表單編輯 ~/.openclaw/openclaw.json。"
     },
     {
       "id": "native.apple.a3465ec90e435ea9",
@@ -10074,6 +10619,11 @@
       "translated": "已降級：\\(message)"
     },
     {
+      "id": "native.apple.d0c8044293c26723",
+      "source": "unknown gateway error",
+      "translated": "unknown gateway error"
+    },
+    {
       "id": "native.apple.47eb7fbdc9792b54",
       "source": "Today",
       "translated": "今天"
@@ -10094,9 +10644,9 @@
       "translated": "Crestodian"
     },
     {
-      "id": "native.apple.2a00563ee9d35dd3",
-      "source": "Your AI-powered setup helper. It can check status, fix config, ",
-      "translated": "由 AI 驅動的設定助手。它可以檢查狀態、修正設定，"
+      "id": "native.apple.4398066b42292ca3",
+      "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      "translated": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels."
     },
     {
       "id": "native.apple.648423d89aec0c13",
@@ -10347,6 +10897,11 @@
       "id": "native.apple.75ea8e8d38238dfd",
       "source": "Do not fail the job if announce fails",
       "translated": "如果播報失敗，不要讓工作失敗"
+    },
+    {
+      "id": "native.apple.ecf3f166f2b6a13e",
+      "source": "Untitled job",
+      "translated": "Untitled job"
     },
     {
       "id": "native.apple.2c7610400993c954",
@@ -10604,6 +11159,11 @@
       "translated": "請檢查「設定」→「連線」，或使用「除錯」→「重設遠端通道」，然後再試一次。"
     },
     {
+      "id": "native.apple.226341f8c8b5d459",
+      "source": "[\\(host)]",
+      "translated": "[\\(host)]"
+    },
+    {
       "id": "native.apple.4c70e8fb1c642be1",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "translated": "要終止 \\(listener.command) (\\(listener.pid)) 嗎？"
@@ -10754,9 +11314,9 @@
       "translated": "寫入輪替診斷記錄 (JSONL)"
     },
     {
-      "id": "native.apple.78ca12c226ea35ef",
-      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
-      "translated": "將輪替的僅限本機記錄寫入 ~/Library/Logs/OpenClaw/ 下。 "
+      "id": "native.apple.5437c7d545b749ca",
+      "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      "translated": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging."
     },
     {
       "id": "native.apple.5b35a89bea603457",
@@ -11019,6 +11579,11 @@
       "translated": "深層連結已封鎖"
     },
     {
+      "id": "native.apple.f65276f4e789db3c",
+      "source": "\\(urlText.prefix(500))…",
+      "translated": "\\(urlText.prefix(500))…"
+    },
+    {
       "id": "native.apple.50f1211af2a1945e",
       "source": "Run OpenClaw agent?",
       "translated": "要執行 OpenClaw 代理嗎？"
@@ -11064,9 +11629,9 @@
       "translated": "模式不得為空。"
     },
     {
-      "id": "native.apple.7b81869cd37132d0",
-      "source": "Path patterns only. Include '/', '~', or '\\\\'.",
-      "translated": "僅限路徑模式。請包含 '/'、'~' 或 '\\\\'。"
+      "id": "native.apple.e69fc6a151dd8879",
+      "source": "Path patterns only. Include '/', '~', or '\\'.",
+      "translated": "Path patterns only. Include '/', '~', or '\\'."
     },
     {
       "id": "native.apple.5b9878c76d9a0995",
@@ -11079,6 +11644,11 @@
       "translated": "無法儲存 exec 核准。顯示的是最後已知的設定；請重試變更。"
     },
     {
+      "id": "native.apple.1b8ba1cf6f9dfdc9",
+      "source": "missing:\\(hash)",
+      "translated": "missing:\\(hash)"
+    },
+    {
       "id": "native.apple.db0fa6b60bd859f8",
       "source": ":\\(endpoint.port)",
       "translated": ":\\(endpoint.port)"
@@ -11089,19 +11659,29 @@
       "translated": "尚未找到任何 Gateway。"
     },
     {
-      "id": "native.apple.2a5e0e9e073b8db1",
-      "source": "Click a discovered gateway to fill the SSH target.",
-      "translated": "點選已探索到的 Gateway 以填入 SSH 目標。"
-    },
-    {
       "id": "native.apple.08a145c293ac0695",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "translated": "點選已探索到的 Gateway 以填入 Gateway URL。"
     },
     {
+      "id": "native.apple.2a5e0e9e073b8db1",
+      "source": "Click a discovered gateway to fill the SSH target.",
+      "translated": "點選已探索到的 Gateway 以填入 SSH 目標。"
+    },
+    {
       "id": "native.apple.66ad783199ef9729",
       "source": "Discover OpenClaw gateways on your LAN",
       "translated": "在您的 LAN 上探索 OpenClaw Gateway"
+    },
+    {
+      "id": "native.apple.110f6e64e25dcd2e",
+      "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
+      "translated": " (local: \\(projectEntrypoint ?? \"unknown\"))"
+    },
+    {
+      "id": "native.apple.e1c93fb7ef1b6cb8",
+      "source": "(\\(gatewayLabel))",
+      "translated": "(\\(gatewayLabel))"
     },
     {
       "id": "native.apple.f33dc515a78428f1",
@@ -11122,6 +11702,11 @@
       "id": "native.apple.151e5b5ab7d08a2a",
       "source": "not linked",
       "translated": "未連結"
+    },
+    {
+      "id": "native.apple.4bd8ea604f3c21fa",
+      "source": "unknown error",
+      "translated": "unknown error"
     },
     {
       "id": "native.apple.7b5eaba753440639",
@@ -11414,14 +11999,14 @@
       "translated": "建議設定"
     },
     {
-      "id": "native.apple.ff5020c25b825be3",
-      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
-      "translated": "使用 Tailscale Serve，讓 gateway 擁有有效的 HTTPS 憑證。"
-    },
-    {
       "id": "native.apple.5eebc911fb011a34",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "translated": "使用 Tailscale 加上 SSH tunnel，以取得穩定的私人存取。"
+    },
+    {
+      "id": "native.apple.ff5020c25b825be3",
+      "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
+      "translated": "使用 Tailscale Serve，讓 gateway 擁有有效的 HTTPS 憑證。"
     },
     {
       "id": "native.apple.773d2937062cf86c",
@@ -11764,14 +12349,14 @@
       "translated": "前進"
     },
     {
-      "id": "native.apple.fae2cf18519da0d5",
-      "source": "OpenClaw",
-      "translated": "OpenClaw"
-    },
-    {
       "id": "native.apple.13a7356f48278757",
       "source": "OpenClaw - Voice Wake live meter active",
       "translated": "OpenClaw - 語音喚醒即時計量器已啟用"
+    },
+    {
+      "id": "native.apple.fae2cf18519da0d5",
+      "source": "OpenClaw",
+      "translated": "OpenClaw"
     },
     {
       "id": "native.apple.ef59188264be95d4",
@@ -11939,14 +12524,14 @@
       "translated": "重設遠端通道"
     },
     {
-      "id": "native.apple.a03ddd3d711b5a36",
-      "source": "Verbose Logging (Main): Off",
-      "translated": "詳細記錄（Main）：關閉"
-    },
-    {
       "id": "native.apple.e9868e7cdc856b06",
       "source": "Verbose Logging (Main): On",
       "translated": "詳細記錄（Main）：開啟"
+    },
+    {
+      "id": "native.apple.a03ddd3d711b5a36",
+      "source": "Verbose Logging (Main): Off",
+      "translated": "詳細記錄（Main）：關閉"
     },
     {
       "id": "native.apple.ecde91c32bcc0da5",
@@ -11954,14 +12539,14 @@
       "translated": "詳細程度"
     },
     {
-      "id": "native.apple.b0785f8c2ae712ff",
-      "source": "File Logging: Off",
-      "translated": "檔案記錄：關閉"
-    },
-    {
       "id": "native.apple.4f577b502efb658c",
       "source": "File Logging: On",
       "translated": "檔案記錄：開啟"
+    },
+    {
+      "id": "native.apple.b0785f8c2ae712ff",
+      "source": "File Logging: Off",
+      "translated": "檔案記錄：關閉"
     },
     {
       "id": "native.apple.f9dfd69b4f83afa1",
@@ -12037,6 +12622,11 @@
       "id": "native.apple.3e248379359c7593",
       "source": "Disconnected (using System default)",
       "translated": "已中斷連線（使用系統預設值）"
+    },
+    {
+      "id": "native.apple.0c726ae72b63e9dc",
+      "source": "\\(firstLine.prefix(87))…",
+      "translated": "\\(firstLine.prefix(87))…"
     },
     {
       "id": "native.apple.5a99e1ae62fe0ab9",
@@ -12179,24 +12769,24 @@
       "translated": "\\(label) 無法完成測試。顯示詳細資料以檢查或複製錯誤。"
     },
     {
-      "id": "native.apple.f3f900bed1ccf58b",
-      "source": "Looking for AI you already use…",
-      "translated": "正在尋找您已在使用的 AI…"
-    },
-    {
       "id": "native.apple.87f0d2248ff12e38",
       "source": "Waiting for the previous AI test to finish…",
       "translated": "正在等待前一個 AI 測試完成…"
     },
     {
-      "id": "native.apple.c7a02803addf11fa",
-      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
-      "translated": "正在檢查 Claude Code、Codex、Gemini 及已儲存的 API 金鑰。"
+      "id": "native.apple.f3f900bed1ccf58b",
+      "source": "Looking for AI you already use…",
+      "translated": "正在尋找您已在使用的 AI…"
     },
     {
       "id": "native.apple.e3e27d22fd2312a2",
       "source": "OpenClaw will check again before changing any inference settings.",
       "translated": "OpenClaw 會在變更任何推論設定前再次檢查。"
+    },
+    {
+      "id": "native.apple.c7a02803addf11fa",
+      "source": "Checking for Claude Code, Codex, Gemini, and saved API keys.",
+      "translated": "正在檢查 Claude Code、Codex、Gemini 及已儲存的 API 金鑰。"
     },
     {
       "id": "native.apple.0fd3e5267cdf8250",
@@ -12427,6 +13017,11 @@
       "id": "native.apple.65fe24f910ca50cb",
       "source": "Copy error",
       "translated": "複製錯誤"
+    },
+    {
+      "id": "native.apple.6f51ff950befb37a",
+      "source": "<redacted secret>",
+      "translated": "<redacted secret>"
     },
     {
       "id": "native.apple.722995710f90cfc6",
@@ -12664,14 +13259,14 @@
       "translated": "/Applications/OpenClaw.app/.../openclaw"
     },
     {
-      "id": "native.apple.ab88df30f426b434",
-      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
-      "translated": "提示：保持 Tailscale 啟用，讓你的 gateway 持續可連線。"
-    },
-    {
       "id": "native.apple.56e9b0831ec1eded",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "translated": "提示：使用 Tailscale Serve，讓 gateway 具備有效的 HTTPS 憑證。"
+    },
+    {
+      "id": "native.apple.ab88df30f426b434",
+      "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
+      "translated": "提示：保持 Tailscale 啟用，讓你的 gateway 持續可連線。"
     },
     {
       "id": "native.apple.2e11404d7539301e",
@@ -12844,9 +13439,9 @@
       "translated": "使用面板 + Canvas"
     },
     {
-      "id": "native.apple.b0c3df725bfafbec",
-      "source": "Open the menu bar panel for quick chat; the agent can show previews ",
-      "translated": "開啟選單列面板以快速聊天；代理可以顯示預覽 "
+      "id": "native.apple.774cf9fe7e3e289e",
+      "source": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas.",
+      "translated": "Open the menu bar panel for quick chat; the agent can show previews and richer visuals in Canvas."
     },
     {
       "id": "native.apple.9b44b38b75a868d8",
@@ -12944,14 +13539,14 @@
       "translated": "拒絕"
     },
     {
-      "id": "native.apple.2e9d9d1f5d4346d4",
-      "source": "A device wants to connect to OpenClaw.",
-      "translated": "有裝置想要連線至 OpenClaw。"
-    },
-    {
       "id": "native.apple.11b1b5e9dd510766",
       "source": "A node wants to connect to OpenClaw.",
       "translated": "有節點想要連線至 OpenClaw。"
+    },
+    {
+      "id": "native.apple.2e9d9d1f5d4346d4",
+      "source": "A device wants to connect to OpenClaw.",
+      "translated": "有裝置想要連線至 OpenClaw。"
     },
     {
       "id": "native.apple.2412e85f7d11395e",
@@ -12962,6 +13557,16 @@
       "id": "native.apple.a09a61f4efe1e63e",
       "source": "OpenClaw Mac app",
       "translated": "OpenClaw Mac 應用程式"
+    },
+    {
+      "id": "native.apple.6b29ec65de666dab",
+      "source": "Operator",
+      "translated": "Operator"
+    },
+    {
+      "id": "native.apple.7a62dc7bc8d3fab9",
+      "source": "Mac",
+      "translated": "Mac"
     },
     {
       "id": "native.apple.6223e5f12aa9464b",
@@ -13204,9 +13809,9 @@
       "translated": "此裝置需要配對核准"
     },
     {
-      "id": "native.apple.59ca961e52333852",
-      "source": "Paste the token configured on the gateway host. ",
-      "translated": "貼上在 Gateway 主機上設定的權杖。 "
+      "id": "native.apple.b52cb4aae7ca6573",
+      "source": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      "translated": "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`."
     },
     {
       "id": "native.apple.bbb87d21ce8a291e",
@@ -13214,9 +13819,9 @@
       "translated": "檢查 Gateway 主機上的 `gateway.auth.token` 或 `OPENCLAW_GATEWAY_TOKEN`，然後再試一次。"
     },
     {
-      "id": "native.apple.d517136ce6599ed7",
-      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. ",
-      "translated": "此 Gateway 已設為權杖驗證，但 Gateway 主機上未設定 `gateway.auth.token`。 "
+      "id": "native.apple.c26f61d639591f81",
+      "source": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway.",
+      "translated": "This gateway is set to token auth, but no `gateway.auth.token` is configured on the gateway host. If the gateway uses an environment variable instead, set `OPENCLAW_GATEWAY_TOKEN` before starting the gateway."
     },
     {
       "id": "native.apple.83145f8f53d7be34",
@@ -13224,14 +13829,14 @@
       "translated": "從已配對的 OpenClaw 用戶端掃描或貼上新的設定碼，然後再試一次。"
     },
     {
-      "id": "native.apple.4230f873600b819e",
-      "source": "This onboarding flow does not support password auth yet. ",
-      "translated": "此入門設定流程尚不支援密碼驗證。 "
+      "id": "native.apple.a8bf4f7ab4a35dc0",
+      "source": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry.",
+      "translated": "This onboarding flow does not support password auth yet. Reconfigure the gateway to use token auth, then retry."
     },
     {
-      "id": "native.apple.5123702739aace5f",
-      "source": "Approve this device from an already-paired OpenClaw client. ",
-      "translated": "從已配對的 OpenClaw 用戶端核准此裝置。 "
+      "id": "native.apple.52c0f97f0b3bb792",
+      "source": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again.",
+      "translated": "Approve this device from an already-paired OpenClaw client. In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
     },
     {
       "id": "native.apple.e73170e4ab1dbe8f",
@@ -13259,9 +13864,9 @@
       "translated": "此 Gateway 使用密碼驗證。macOS 上的遠端引導目前尚無法收集 Gateway 密碼。"
     },
     {
-      "id": "native.apple.37d1f4842869452a",
-      "source": "Pairing required. In an already-paired OpenClaw client, ",
-      "translated": "需要配對。在已配對的 OpenClaw 用戶端中，"
+      "id": "native.apple.3e5a2b2a24f73418",
+      "source": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.",
+      "translated": "Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again."
     },
     {
       "id": "native.apple.58e76e9c8b04290a",
@@ -13592,6 +14197,11 @@
       "id": "native.apple.8f5459c837515766",
       "source": "No skills reported yet",
       "translated": "尚未回報任何 skill"
+    },
+    {
+      "id": "native.apple.84c069138aa2c31d",
+      "source": "Reading the Gateway skill catalog.",
+      "translated": "Reading the Gateway skill catalog."
     },
     {
       "id": "native.apple.ddac24dd3c4ad758",
@@ -14104,6 +14714,11 @@
       "translated": "無聲音"
     },
     {
+      "id": "native.apple.458f94aded551547",
+      "source": "this Mac",
+      "translated": "this Mac"
+    },
+    {
       "id": "native.apple.0577606e681fcf35",
       "source": "Voice Wake requires macOS 26 or newer",
       "translated": "Voice Wake 需要 macOS 26 或更新版本"
@@ -14269,6 +14884,11 @@
       "translated": "系統預設"
     },
     {
+      "id": "native.apple.a8fb74eafee3d446",
+      "source": "Unavailable",
+      "translated": "Unavailable"
+    },
+    {
       "id": "native.apple.5135e9bec6346f0d",
       "source": "Disconnected (using System default)",
       "translated": "已中斷連線（使用系統預設）"
@@ -14394,6 +15014,11 @@
       "translated": "（本機已篩選）"
     },
     {
+      "id": "native.apple.a0a9d0973963de42",
+      "source": "(none)",
+      "translated": "(none)"
+    },
+    {
       "id": "native.apple.4730f0dfb78617a2",
       "source": "Invalid URL: \\(raw)",
       "translated": "無效的 URL：\\(raw)"
@@ -14417,6 +15042,11 @@
       "id": "native.apple.9e54815f3eca97bf",
       "source": " — \\(option.hint!)",
       "translated": " — \\(option.hint!)"
+    },
+    {
+      "id": "native.apple.e70b56cadc8fbac3",
+      "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
+      "translated": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]"
     },
     {
       "id": "native.apple.dbc2ff188682dee3",
@@ -14559,6 +15189,11 @@
       "translated": "Gateway 已連線"
     },
     {
+      "id": "native.apple.b6adfcd17a6e73d7",
+      "source": "Message…",
+      "translated": "Message…"
+    },
+    {
       "id": "native.apple.c622ecbe64757e20",
       "source": "Input tokens: \\(input)",
       "translated": "輸入 token：\\(input)"
@@ -14614,6 +15249,11 @@
       "translated": "內容用量"
     },
     {
+      "id": "native.apple.769b7dcea4708c40",
+      "source": "Image",
+      "translated": "Image"
+    },
+    {
       "id": "native.apple.8509385953c19619",
       "source": "\\(display.emoji) \\(display.title)",
       "translated": "\\(display.emoji) \\(display.title)"
@@ -14622,6 +15262,11 @@
       "id": "native.apple.6426e369511b043c",
       "source": "Message usage",
       "translated": "訊息用量"
+    },
+    {
+      "id": "native.apple.3c8c3679fd99c074",
+      "source": "Voice note",
+      "translated": "Voice note"
     },
     {
       "id": "native.apple.aff6385b0a8dd0ac",
@@ -14804,6 +15449,31 @@
       "translated": "取消封存"
     },
     {
+      "id": "native.apple.c4e808a2ec8d49f5",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"
+    },
+    {
+      "id": "native.apple.4e7e29be3f05b828",
+      "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'",
+      "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, '', payload, updated_at\nFROM cached_transcripts_pre_v3\nWHERE lower(trim(session_key)) GLOB 'agent:*:*'"
+    },
+    {
+      "id": "native.apple.e743b1178c2fdec8",
+      "source": "Chat transcript",
+      "translated": "Chat transcript"
+    },
+    {
+      "id": "native.apple.9add620a81268972",
+      "source": "Attachment",
+      "translated": "Attachment"
+    },
+    {
+      "id": "native.apple.0149100bb5c8b985",
+      "source": "Message",
+      "translated": "Message"
+    },
+    {
       "id": "native.apple.5824df4efbf6c977",
       "source": "Retry Send",
       "translated": "重新傳送"
@@ -14867,6 +15537,16 @@
       "id": "native.apple.82c2287cd78da56f",
       "source": "\\(baseName).jpg",
       "translated": "\\(baseName).jpg"
+    },
+    {
+      "id": "native.apple.61b7d1ecf7fdae3e",
+      "source": "\\(invocation) ",
+      "translated": "\\(invocation) "
+    },
+    {
+      "id": "native.apple.788a4fe0a4885066",
+      "source": "See attached.",
+      "translated": "See attached."
     },
     {
       "id": "native.apple.2b45abdc56b2caed",
@@ -15122,6 +15802,21 @@
       "id": "native.apple.0cb1206714c2bf4d",
       "source": "Setup",
       "translated": "設定"
+    },
+    {
+      "id": "native.apple.081a07c7306b223e",
+      "source": "gateway connect failed",
+      "translated": "gateway connect failed"
+    },
+    {
+      "id": "native.apple.2f45f005d2a7c3c2",
+      "source": "Apple Watch",
+      "translated": "Apple Watch"
+    },
+    {
+      "id": "native.apple.e97067187c9a359d",
+      "source": "\\(preview)…",
+      "translated": "\\(preview)…"
     }
   ]
 }

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -46,6 +46,19 @@ type NativeTranslationArtifact = {
   locale: string;
   version: 1;
 };
+export type NativeI18nQualityFinding = {
+  code:
+    | "adjacent-duplicate-word"
+    | "android-language-picker-source-equal"
+    | "same-source-contradiction"
+    | "source-equal";
+  id: string;
+  locale: string;
+  relatedIds?: string[];
+  source: string;
+  translated: string;
+  words?: string[];
+};
 type NativeTranslator = typeof translateNativeEntries;
 type NativeLocaleSyncOptions = {
   glossary?: Array<{ source: string; target: string }>;
@@ -125,18 +138,13 @@ const ANDROID_BUILTIN_UI_CALLS = new Set([
   "TextButton",
   "TopAppBar",
 ]);
-const CONDITIONAL_BRANCHES = [
-  /\bif\s*\([^)]*\)\s*"((?:\\.|[^"\\])*)"\s*else\s*"((?:\\.|[^"\\])*)"/gu,
-  /\?\s*"((?:\\.|[^"\\])*)"\s*:\s*"((?:\\.|[^"\\])*)"/gu,
-];
 const UI_STRING_NAME_RE =
   /(?:title|subtitle|body|message|label|text|description|detail|prompt|placeholder|help)$/iu;
 const APPLE_STRING_PROPERTY = /\bvar\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*String\s*\{/gu;
-const APPLE_SWITCH_BRANCH =
-  /(?:\bcase\b[^:\n]+|\bdefault)\s*:\s*(?:return\s+)?"((?:\\.|[^"\\])*)"/gu;
+const APPLE_SWITCH_BRANCH_START = /(?:\bcase\b[^:\n]+|\bdefault)\s*:\s*(?:return\s+)?/gu;
 const ANDROID_STRING_FUNCTION =
   /\bfun\s+([A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*:\s*String\s*(=|\{)/gu;
-const ANDROID_WHEN_BRANCH = /(?:[^\n{}]+|\belse)\s*->\s*"((?:\\.|[^"\\])*)"/gu;
+const ANDROID_WHEN_BRANCH_START = /(?:[^\n{}]+|\belse)\s*->\s*/gu;
 const ANDROID_RESOURCE_STRINGS = /<string\b[^>]*>([\s\S]*?)<\/string>/gu;
 const ANDROID_RESOURCE_COLLECTIONS =
   /<(?:string-array|plurals)\b[^>]*>([\s\S]*?)<\/(?:string-array|plurals)>/gu;
@@ -176,6 +184,12 @@ const EXCLUDED_PATH_RE = /(?:^|[\\/])(?:Tests?|UITests?|test|Preview(?:s)?)(?:$|
 const EXCLUDED_FILE_RE = /(?:Tests?|UITests?|Previews?|Testing)\.(?:swift|kt|kts)$/u;
 const BUILD_SETTING_RE = /\$\([A-Za-z0-9_.-]+\)/gu;
 const NATIVE_I18N_LOCALE_SET = new Set<string>(NATIVE_I18N_LOCALES);
+const ANDROID_LANGUAGE_PICKER_PATH =
+  "apps/android/app/src/main/java/ai/openclaw/app/AppLanguage.kt";
+const ANDROID_LANGUAGE_PICKER_SOURCES = new Set([
+  "Follow Android · $systemLanguageTag",
+  "OpenClaw translations · $languageTag",
+]);
 
 function isAsciiLowercaseLetter(character: string): boolean {
   return character >= "a" && character <= "z";
@@ -481,26 +495,67 @@ function readKotlinStringLiteral(
   return null;
 }
 
-function extractKotlinStringLiterals(source: string, start: number, end: number) {
-  const values: Array<{ offset: number; value: string }> = [];
-  let cursor = start;
-  while (cursor < end) {
-    const openingQuote = source.indexOf('"', cursor);
-    if (openingQuote < 0 || openingQuote >= end) {
-      break;
-    }
-    const literal = readKotlinStringLiteral(source, openingQuote);
-    if (!literal || literal.end > end) {
-      break;
-    }
-    values.push({ offset: openingQuote, value: literal.value });
-    cursor = literal.end;
+function readMultilineStringLiteral(
+  source: string,
+  openingQuote: number,
+): { end: number; value: string } | null {
+  if (!source.startsWith('"""', openingQuote)) {
+    return null;
   }
-  return values;
+  const closingQuote = source.indexOf('"""', openingQuote + 3);
+  if (closingQuote < 0) {
+    return null;
+  }
+  return {
+    end: closingQuote + 3,
+    value: decodeMultilineLiteral(source.slice(openingQuote + 3, closingQuote)),
+  };
 }
 
-function extractSwiftUiCalls(
+function readNativeStringLiteral(
+  surface: NativeI18nSurface,
+  source: string,
+  openingQuote: number,
+): { end: number; value: string } | null {
+  return (
+    readMultilineStringLiteral(source, openingQuote) ??
+    (surface === "apple"
+      ? readSwiftStringLiteral(source, openingQuote)
+      : readKotlinStringLiteral(source, openingQuote))
+  );
+}
+
+function readAdjacentStringLiterals(
+  surface: NativeI18nSurface,
+  source: string,
+  openingQuote: number,
+): { end: number; fragments: number; value: string } | null {
+  const first = readNativeStringLiteral(surface, source, openingQuote);
+  if (!first) {
+    return null;
+  }
+  const values = [first.value];
+  let cursor = first.end;
+  for (;;) {
+    const separator = source.slice(cursor).match(/^\s*\+\s*/u)?.[0];
+    if (!separator) {
+      return { end: cursor, fragments: values.length, value: values.join("") };
+    }
+    cursor += separator.length;
+    const next = readNativeStringLiteral(surface, source, cursor);
+    // A runtime concatenation is not a compile-time literal. Dropping the whole
+    // candidate prevents the inventory from preserving a misleading prefix.
+    if (!next) {
+      return null;
+    }
+    values.push(next.value);
+    cursor = next.end;
+  }
+}
+
+function extractUiCalls(
   entries: Candidate[],
+  surface: NativeI18nSurface,
   repoPath: string,
   source: string,
   uiCallNames: ReadonlySet<string>,
@@ -510,32 +565,13 @@ function extractSwiftUiCalls(
       continue;
     }
     const offset = match.index ?? 0;
-    let cursor = offset + match[0].length;
-    const first = readSwiftStringLiteral(source, cursor);
-    if (!first) {
+    const openingQuote = offset + match[0].length;
+    const literal = readAdjacentStringLiterals(surface, source, openingQuote);
+    if (!literal) {
       continue;
     }
-    const values = [first.value];
-    cursor = first.end;
-    let unsupportedConcatenation = false;
-    while (true) {
-      const separator = source.slice(cursor).match(/^\s*\+\s*/u)?.[0];
-      if (!separator) {
-        break;
-      }
-      cursor += separator.length;
-      const next = readSwiftStringLiteral(source, cursor);
-      if (!next) {
-        unsupportedConcatenation = true;
-        break;
-      }
-      values.push(next.value);
-      cursor = next.end;
-    }
-    if (!unsupportedConcatenation) {
-      const kind = values.length > 1 ? "ui-call-concatenated" : "ui-call";
-      addCandidate(entries, "apple", repoPath, values.join(""), kind, lineNumber(source, offset));
-    }
+    const kind = literal.fragments > 1 ? "ui-call-concatenated" : "ui-call";
+    addCandidate(entries, surface, repoPath, literal.value, kind, lineNumber(source, offset));
   }
 }
 
@@ -652,11 +688,175 @@ function addCandidate(
   entries.push({ kind, line, path: repoPath, source: normalized, surface });
 }
 
-function extractCandidates(
+function findCapturedLiteralOffset(
+  source: string,
+  match: RegExpMatchArray,
+  value: string,
+  searchStart: number,
+): number | null {
+  const matchEnd = (match.index ?? 0) + match[0].length;
+  const normal = source.indexOf(`"${value}"`, searchStart);
+  const multiline = source.indexOf(`"""${value}"""`, searchStart);
+  const offsets = [normal, multiline].filter((offset) => offset >= 0 && offset < matchEnd);
+  return offsets.length > 0 ? Math.min(...offsets) : null;
+}
+
+function addCapturedLiteralCandidates(
+  entries: Candidate[],
   surface: NativeI18nSurface,
   repoPath: string,
   source: string,
-  uiCallNames: ReadonlySet<string>,
+  match: RegExpMatchArray,
+  kind: string,
+) {
+  let searchStart = match.index ?? 0;
+  for (const value of match.slice(1)) {
+    if (!value) {
+      continue;
+    }
+    const openingQuote = findCapturedLiteralOffset(source, match, value, searchStart);
+    if (openingQuote === null) {
+      continue;
+    }
+    const literal = readAdjacentStringLiterals(surface, source, openingQuote);
+    if (literal) {
+      addCandidate(
+        entries,
+        surface,
+        repoPath,
+        literal.value,
+        literal.fragments > 1 ? `${kind}-concatenated` : kind,
+        lineNumber(source, openingQuote),
+      );
+      searchStart = literal.end;
+    } else {
+      searchStart = openingQuote + 1;
+    }
+  }
+}
+
+function skipWhitespaceAndBrace(source: string, offset: number): number {
+  let cursor = offset;
+  while (cursor < source.length && /\s/u.test(source[cursor])) {
+    cursor += 1;
+  }
+  if (source[cursor] === "{") {
+    cursor += 1;
+    while (cursor < source.length && /\s/u.test(source[cursor])) {
+      cursor += 1;
+    }
+  }
+  if (source.startsWith("return", cursor) && !isAsciiAlphaNumeric(source[cursor + 6] ?? "")) {
+    cursor += 6;
+    while (cursor < source.length && /\s/u.test(source[cursor])) {
+      cursor += 1;
+    }
+  }
+  return cursor;
+}
+
+function addConditionalBranchPair(
+  entries: Candidate[],
+  surface: NativeI18nSurface,
+  repoPath: string,
+  source: string,
+  firstOffset: number,
+  separator: RegExp,
+) {
+  const firstStart = skipWhitespaceAndBrace(source, firstOffset);
+  const first = readAdjacentStringLiterals(surface, source, firstStart);
+  if (!first) {
+    return;
+  }
+  const remainder = source.slice(first.end);
+  const separatorMatch = remainder.match(separator);
+  if (!separatorMatch) {
+    return;
+  }
+  const secondStart = skipWhitespaceAndBrace(source, first.end + separatorMatch[0].length);
+  const second = readAdjacentStringLiterals(surface, source, secondStart);
+  if (!second) {
+    return;
+  }
+  for (const branch of [
+    { offset: firstStart, value: first.value },
+    { offset: secondStart, value: second.value },
+  ]) {
+    addCandidate(
+      entries,
+      surface,
+      repoPath,
+      branch.value,
+      "conditional-branch",
+      lineNumber(source, branch.offset),
+    );
+  }
+}
+
+function extractConditionalBranches(
+  entries: Candidate[],
+  surface: NativeI18nSurface,
+  repoPath: string,
+  source: string,
+) {
+  for (const match of source.matchAll(/\bif\s*\([^)]*\)\s*/gu)) {
+    addConditionalBranchPair(
+      entries,
+      surface,
+      repoPath,
+      source,
+      (match.index ?? 0) + match[0].length,
+      /^\s*\}?\s*else\s*/u,
+    );
+  }
+  for (const match of source.matchAll(/\?\s*/gu)) {
+    addConditionalBranchPair(
+      entries,
+      surface,
+      repoPath,
+      source,
+      (match.index ?? 0) + match[0].length,
+      /^\s*:\s*/u,
+    );
+  }
+}
+
+function addBranchCandidates(
+  entries: Candidate[],
+  surface: NativeI18nSurface,
+  repoPath: string,
+  source: string,
+  bodyOffset: number,
+  body: string,
+  branchStart: RegExp,
+) {
+  for (const branch of body.matchAll(branchStart)) {
+    const openingQuote = skipWhitespaceAndBrace(
+      source,
+      bodyOffset + (branch.index ?? 0) + branch[0].length,
+    );
+    const literal = readAdjacentStringLiterals(surface, source, openingQuote);
+    if (literal) {
+      addCandidate(
+        entries,
+        surface,
+        repoPath,
+        literal.value,
+        "conditional-branch",
+        lineNumber(source, openingQuote),
+      );
+    }
+  }
+}
+
+export function extractNativeI18nCandidates(
+  surface: NativeI18nSurface,
+  repoPath: string,
+  source: string,
+  uiCallNames: ReadonlySet<string> = new Set([
+    ...APPLE_BUILTIN_UI_CALLS,
+    ...ANDROID_BUILTIN_UI_CALLS,
+  ]),
 ): Candidate[] {
   const entries: Candidate[] = [];
   const patterns: Array<readonly [RegExp, string]> =
@@ -667,7 +867,6 @@ function extractCandidates(
           [APPLE_LOCALIZED_STRING_MULTILINE_CALLS, "ui-localized-call-multiline"],
           [APPLE_MODIFIER_CALLS, "ui-modifier"],
           [APPLE_MODIFIER_MULTILINE_CALLS, "ui-modifier-multiline"],
-          ...CONDITIONAL_BRANCHES.map((pattern) => [pattern, "conditional-branch"] as const),
         ]
       : [
           [ANDROID_CALLS, "ui-call"],
@@ -675,20 +874,15 @@ function extractCandidates(
           [ANDROID_CHOOSER_ARGS, "ui-chooser"],
           [ANDROID_DIALOG_CALLS, "ui-dialog"],
           [ANDROID_UI_STATE_TEXT, "ui-state-text"],
-          ...CONDITIONAL_BRANCHES.map((pattern) => [pattern, "conditional-branch"] as const),
         ];
   for (const [pattern, kind] of patterns) {
     for (const match of source.matchAll(pattern)) {
-      const offset = match.index ?? 0;
-      for (const value of match.slice(1)) {
-        if (value) {
-          addCandidate(entries, surface, repoPath, value, kind, lineNumber(source, offset));
-        }
-      }
+      addCapturedLiteralCandidates(entries, surface, repoPath, source, match, kind);
     }
   }
+  extractConditionalBranches(entries, surface, repoPath, source);
+  extractUiCalls(entries, surface, repoPath, source, uiCallNames);
   if (surface === "apple") {
-    extractSwiftUiCalls(entries, repoPath, source, uiCallNames);
     for (const property of source.matchAll(APPLE_STRING_PROPERTY)) {
       const name = property[1];
       const openingBrace = (property.index ?? 0) + property[0].lastIndexOf("{");
@@ -700,18 +894,15 @@ function extractCandidates(
       if (!/\bswitch\b/u.test(body)) {
         continue;
       }
-      for (const branch of body.matchAll(APPLE_SWITCH_BRANCH)) {
-        if (branch[1]) {
-          addCandidate(
-            entries,
-            surface,
-            repoPath,
-            branch[1],
-            "conditional-branch",
-            lineNumber(source, openingBrace + 1 + (branch.index ?? 0)),
-          );
-        }
-      }
+      addBranchCandidates(
+        entries,
+        surface,
+        repoPath,
+        source,
+        openingBrace + 1,
+        body,
+        APPLE_SWITCH_BRANCH_START,
+      );
     }
     for (const match of source.matchAll(APPLE_NAMED_LITERALS)) {
       const argumentName = match[1];
@@ -727,13 +918,13 @@ function extractCandidates(
       const multiline = match[2];
       const literal = multiline ?? match[3];
       if (literal) {
-        addCandidate(
+        addCapturedLiteralCandidates(
           entries,
           surface,
           repoPath,
-          literal,
+          source,
+          match,
           multiline === undefined ? "ui-named-argument" : "ui-named-argument-multiline",
-          lineNumber(source, match.index ?? 0),
         );
       }
     }
@@ -753,17 +944,20 @@ function extractCandidates(
           continue;
         }
         const body = source.slice(bodyStart, closingBrace);
-        for (const returnLine of body.matchAll(/\breturn\b([^\n]*)/gu)) {
-          const lineStart = bodyStart + (returnLine.index ?? 0);
-          const lineEnd = lineStart + returnLine[0].length;
-          for (const literal of extractKotlinStringLiterals(source, lineStart, lineEnd)) {
+        for (const returnKeyword of body.matchAll(/\breturn\b/gu)) {
+          const openingQuote = skipWhitespaceAndBrace(
+            source,
+            bodyStart + (returnKeyword.index ?? 0) + returnKeyword[0].length,
+          );
+          const literal = readAdjacentStringLiterals(surface, source, openingQuote);
+          if (literal) {
             addCandidate(
               entries,
               surface,
               repoPath,
               literal.value,
               "conditional-branch",
-              lineNumber(source, literal.offset),
+              lineNumber(source, openingQuote),
             );
           }
         }
@@ -778,34 +972,27 @@ function extractCandidates(
           continue;
         }
         const body = source.slice(openingBrace + 1, closingBrace);
-        for (const branch of body.matchAll(ANDROID_WHEN_BRANCH)) {
-          if (!branch[1]) {
-            continue;
-          }
-          addCandidate(
-            entries,
-            surface,
-            repoPath,
-            branch[1],
-            "conditional-branch",
-            lineNumber(source, openingBrace + 1 + (branch.index ?? 0)),
-          );
-        }
+        addBranchCandidates(
+          entries,
+          surface,
+          repoPath,
+          source,
+          openingBrace + 1,
+          body,
+          ANDROID_WHEN_BRANCH_START,
+        );
         continue;
       }
-      const expressionLine = expression.split("\n", 1)[0] ?? "";
-      for (const literal of extractKotlinStringLiterals(
-        source,
-        bodyStart,
-        bodyStart + expressionLine.length,
-      )) {
+      const openingQuote = skipWhitespaceAndBrace(source, bodyStart);
+      const literal = readAdjacentStringLiterals(surface, source, openingQuote);
+      if (literal) {
         addCandidate(
           entries,
           surface,
           repoPath,
           literal.value,
           "conditional-branch",
-          lineNumber(source, literal.offset),
+          lineNumber(source, openingQuote),
         );
       }
     }
@@ -821,14 +1008,7 @@ function extractCandidates(
       ) {
         continue;
       }
-      addCandidate(
-        entries,
-        surface,
-        repoPath,
-        match[2],
-        "ui-named-argument",
-        lineNumber(source, match.index ?? 0),
-      );
+      addCapturedLiteralCandidates(entries, surface, repoPath, source, match, "ui-named-argument");
     }
   }
   if (surface === "android" && /\/res\/values\/[^/]+\.xml$/u.test(repoPath)) {
@@ -878,7 +1058,11 @@ function extractCandidates(
       }
     }
   }
-  return entries;
+  return [
+    ...new Map(
+      entries.map((entry) => [[entry.surface, entry.path, entry.source].join("\u0000"), entry]),
+    ).values(),
+  ];
 }
 
 async function walkFiles(root: string, surface: NativeI18nSurface): Promise<string[]> {
@@ -1044,7 +1228,7 @@ export async function collectNativeI18nEntries(
     }
   }
   const entries = typedSources.flatMap(({ repoPath, source, surface }) =>
-    extractCandidates(surface, repoPath, source, uiCallNames),
+    extractNativeI18nCandidates(surface, repoPath, source, uiCallNames),
   );
   return assignNativeI18nIds(entries, stableEntries);
 }
@@ -1061,10 +1245,19 @@ async function syncNativeI18n(options: {
   const entries = await collectNativeI18nEntries(currentInventory.entries);
   const expected = render(entries);
   const current = currentInventory.raw;
-  if (current !== expected && options.checkOnly) {
-    throw new Error(
-      "native app i18n inventory drift detected. Run `pnpm native:i18n:sync` and commit apps/.i18n/native-source.json.",
+  if (options.checkOnly) {
+    const findings = await checkNativeLocaleArtifacts(currentInventory.entries);
+    for (const finding of findings) {
+      process.stdout.write(`native-app-i18n: advisory=${JSON.stringify(finding)}\n`);
+    }
+    process.stdout.write(
+      `native-app-i18n: locale-artifacts=${NATIVE_I18N_LOCALES.length} advisories=${findings.length}\n`,
     );
+    if (current !== expected) {
+      throw new Error(
+        "native app i18n inventory drift detected. Run `pnpm native:i18n:sync` and commit apps/.i18n/native-source.json.",
+      );
+    }
   }
   if (current !== expected && options.write) {
     await mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
@@ -1088,6 +1281,217 @@ async function loadGlossary(locale: string): Promise<Array<{ source: string; tar
   }
 }
 
+function glossaryHash(glossary: readonly { source: string; target: string }[]): string {
+  return createHash("sha256").update(JSON.stringify(glossary)).digest("hex");
+}
+
+function adjacentDuplicateWords(value: string, locale: string): string[] {
+  const words = [...value.matchAll(/[\p{L}\p{M}\p{N}]+/gu)].map((match) => match[0]);
+  const duplicates = new Set<string>();
+  for (let index = 1; index < words.length; index += 1) {
+    if (
+      words[index - 1].normalize("NFKC").toLocaleLowerCase(locale) ===
+      words[index].normalize("NFKC").toLocaleLowerCase(locale)
+    ) {
+      duplicates.add(words[index]);
+    }
+  }
+  return [...duplicates].toSorted(compareCodePoints);
+}
+
+function collectNativeI18nQualityFindings(
+  locale: string,
+  inventory: readonly NativeI18nEntry[],
+  entries: readonly { id: string; source: string; translated: string }[],
+): NativeI18nQualityFinding[] {
+  const inventoryById = new Map(inventory.map((entry) => [entry.id, entry]));
+  const translatedBySource = new Map<string, Array<{ id: string; translated: string }>>();
+  for (const entry of entries) {
+    const existing = translatedBySource.get(entry.source) ?? [];
+    existing.push({ id: entry.id, translated: entry.translated });
+    translatedBySource.set(entry.source, existing);
+  }
+
+  const findings: NativeI18nQualityFinding[] = [];
+  for (const entry of entries) {
+    const sourceEqual = entry.translated === entry.source;
+    if (sourceEqual) {
+      findings.push({ code: "source-equal", locale, ...entry });
+      const relatedIds = (translatedBySource.get(entry.source) ?? [])
+        .filter((candidate) => candidate.id !== entry.id && candidate.translated !== entry.source)
+        .map((candidate) => candidate.id)
+        .toSorted(compareCodePoints);
+      if (relatedIds.length > 0) {
+        findings.push({
+          code: "same-source-contradiction",
+          locale,
+          ...entry,
+          relatedIds,
+        });
+      }
+      const inventoryEntry = inventoryById.get(entry.id);
+      if (
+        inventoryEntry?.surface === "android" &&
+        inventoryEntry.path === ANDROID_LANGUAGE_PICKER_PATH &&
+        ANDROID_LANGUAGE_PICKER_SOURCES.has(entry.source)
+      ) {
+        findings.push({
+          code: "android-language-picker-source-equal",
+          locale,
+          ...entry,
+        });
+      }
+    }
+
+    const words = adjacentDuplicateWords(entry.translated, locale);
+    if (words.length > 0) {
+      findings.push({
+        code: "adjacent-duplicate-word",
+        locale,
+        ...entry,
+        words,
+      });
+    }
+  }
+  return findings.toSorted(
+    (left, right) =>
+      compareCodePoints(left.locale, right.locale) ||
+      compareCodePoints(left.code, right.code) ||
+      compareCodePoints(left.id, right.id),
+  );
+}
+
+function describeArtifactValue(value: unknown): string {
+  return typeof value === "string" ? JSON.stringify(value) : String(value);
+}
+
+export function validateNativeLocaleArtifact(
+  locale: string,
+  inventory: readonly NativeI18nEntry[],
+  artifactValue: unknown,
+  glossary: readonly { source: string; target: string }[] = [],
+): NativeI18nQualityFinding[] {
+  const errors: string[] = [];
+  if (!artifactValue || typeof artifactValue !== "object" || Array.isArray(artifactValue)) {
+    throw new Error(`invalid native locale artifact ${locale}: expected an object`);
+  }
+  const artifact = artifactValue as {
+    entries?: unknown;
+    glossaryHash?: unknown;
+    locale?: unknown;
+    version?: unknown;
+  };
+  if (artifact.version !== 1) {
+    errors.push(`version must be 1, got ${describeArtifactValue(artifact.version)}`);
+  }
+  if (artifact.locale !== locale) {
+    errors.push(
+      `locale must be ${JSON.stringify(locale)}, got ${describeArtifactValue(artifact.locale)}`,
+    );
+  }
+  const expectedGlossaryHash = glossaryHash(glossary);
+  if (artifact.glossaryHash !== expectedGlossaryHash) {
+    errors.push(
+      `glossaryHash must be ${expectedGlossaryHash}, got ${describeArtifactValue(artifact.glossaryHash)}`,
+    );
+  }
+  if (!Array.isArray(artifact.entries)) {
+    errors.push("entries must be an array");
+  }
+
+  const rawEntries = Array.isArray(artifact.entries) ? artifact.entries : [];
+  const entries: Array<{ id: string; source: string; translated: string }> = [];
+  const seenIds = new Set<string>();
+  for (const [index, value] of rawEntries.entries()) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      errors.push(`entries[${index}] must be an object`);
+      continue;
+    }
+    const entry = value as { id?: unknown; source?: unknown; translated?: unknown };
+    if (
+      typeof entry.id !== "string" ||
+      typeof entry.source !== "string" ||
+      typeof entry.translated !== "string"
+    ) {
+      errors.push(`entries[${index}] must contain string id, source, and translated fields`);
+      continue;
+    }
+    if (seenIds.has(entry.id)) {
+      errors.push(`duplicate id ${JSON.stringify(entry.id)}`);
+    }
+    seenIds.add(entry.id);
+    entries.push({ id: entry.id, source: entry.source, translated: entry.translated });
+  }
+
+  if (rawEntries.length !== inventory.length) {
+    errors.push(`entry count must be ${inventory.length}, got ${rawEntries.length}`);
+  }
+  for (let index = 0; index < Math.min(entries.length, inventory.length); index += 1) {
+    const actual = entries[index];
+    const expected = inventory[index];
+    if (actual.id !== expected.id) {
+      errors.push(
+        `entries[${index}].id must be ${JSON.stringify(expected.id)}, got ${JSON.stringify(actual.id)}`,
+      );
+    }
+    if (actual.source !== expected.source) {
+      errors.push(`entries[${index}].source does not match inventory id ${expected.id}`);
+    }
+    if (!actual.translated.trim()) {
+      errors.push(`entries[${index}].translated must be nonempty for ${actual.id}`);
+    } else if (
+      structuralTokenSignature(actual.source) !== structuralTokenSignature(actual.translated)
+    ) {
+      errors.push(`translation changed structural tokens or line breaks for ${actual.id}`);
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(`invalid native locale artifact ${locale}:\n- ${errors.join("\n- ")}`);
+  }
+  return collectNativeI18nQualityFindings(locale, inventory, entries);
+}
+
+export async function checkNativeLocaleArtifacts(
+  inventory: readonly NativeI18nEntry[],
+  translationsDir = TRANSLATIONS_DIR,
+): Promise<NativeI18nQualityFinding[]> {
+  const expectedFiles = NATIVE_I18N_LOCALES.map((locale) => `${locale}.json`).toSorted(
+    compareCodePoints,
+  );
+  const actualFiles = (await readdir(translationsDir, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => entry.name)
+    .toSorted(compareCodePoints);
+  const errors: string[] = [];
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+    errors.push(
+      `locale files must be ${JSON.stringify(expectedFiles)}, got ${JSON.stringify(actualFiles)}`,
+    );
+  }
+
+  const findings: NativeI18nQualityFinding[] = [];
+  for (const locale of NATIVE_I18N_LOCALES) {
+    const artifactPath = path.join(translationsDir, `${locale}.json`);
+    try {
+      const artifact: unknown = JSON.parse(await readFile(artifactPath, "utf8"));
+      findings.push(
+        ...validateNativeLocaleArtifact(locale, inventory, artifact, await loadGlossary(locale)),
+      );
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(`native locale artifact validation failed:\n${errors.join("\n")}`);
+  }
+  return findings.toSorted(
+    (left, right) =>
+      compareCodePoints(left.locale, right.locale) ||
+      compareCodePoints(left.code, right.code) ||
+      compareCodePoints(left.id, right.id),
+  );
+}
+
 export async function syncNativeLocale(
   locale: string,
   entries: NativeI18nEntry[],
@@ -1097,7 +1501,7 @@ export async function syncNativeLocale(
   // artifacts keep the shared translation-memory handoff current between them.
   const artifactPath = path.join(options.translationsDir ?? TRANSLATIONS_DIR, `${locale}.json`);
   const glossary = options.glossary ?? (await loadGlossary(locale));
-  const glossaryHash = createHash("sha256").update(JSON.stringify(glossary)).digest("hex");
+  const currentGlossaryHash = glossaryHash(glossary);
   let previousRaw = "";
   let previous: NativeTranslationArtifact = {
     entries: [],
@@ -1112,7 +1516,7 @@ export async function syncNativeLocale(
     // The first refresh creates the locale artifact.
   }
   const previousById = new Map(previous.entries.map((entry) => [entry.id, entry]));
-  const glossaryChanged = previous.glossaryHash !== glossaryHash;
+  const glossaryChanged = previous.glossaryHash !== currentGlossaryHash;
   const pending = entries
     .filter((entry) => {
       const current = previousById.get(entry.id);
@@ -1131,7 +1535,7 @@ export async function syncNativeLocale(
   const artifact: NativeTranslationArtifact = {
     version: 1,
     locale,
-    glossaryHash,
+    glossaryHash: currentGlossaryHash,
     entries: entries.map((entry) => ({
       id: entry.id,
       source: entry.source,
@@ -1139,12 +1543,20 @@ export async function syncNativeLocale(
         translated.get(entry.id) ?? previousById.get(entry.id)?.translated ?? entry.source,
     })),
   };
-  for (const entry of artifact.entries) {
-    if (structuralTokenSignature(entry.source) !== structuralTokenSignature(entry.translated)) {
+  try {
+    validateNativeLocaleArtifact(locale, entries, artifact, glossary);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const structural = message.match(
+      /translation changed structural tokens or line breaks for ([^\s]+)/u,
+    );
+    if (structural?.[1]) {
       throw new Error(
-        `native translation changed placeholders or line breaks for ${locale}:${entry.id}`,
+        `native translation changed placeholders or line breaks for ${locale}:${structural[1]}`,
+        { cause: error },
       );
     }
+    throw error;
   }
   const rendered = `${JSON.stringify(artifact, null, 2)}\n`;
   const changed = previousRaw !== rendered;

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -994,6 +994,22 @@ export function extractNativeI18nCandidates(
           "conditional-branch",
           lineNumber(source, openingQuote),
         );
+        continue;
+      }
+      const elvisFallback = expression.match(/^\s*[^\n]*\?:\s*/u);
+      if (elvisFallback) {
+        const fallbackQuote = skipWhitespaceAndBrace(source, bodyStart + elvisFallback[0].length);
+        const fallback = readAdjacentStringLiterals(surface, source, fallbackQuote);
+        if (fallback) {
+          addCandidate(
+            entries,
+            surface,
+            repoPath,
+            fallback.value,
+            "conditional-branch",
+            lineNumber(source, fallbackQuote),
+          );
+        }
       }
     }
     for (const match of source.matchAll(ANDROID_NAMED_LITERALS)) {

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -91,9 +91,9 @@ const NATIVE_SOURCE_READ_CONCURRENCY = 32;
 const APPLE_UI_MULTILINE_CALLS =
   /(?:Text|Label|Button|TextField|SecureField|Picker|Section|LabeledContent|Toggle|Menu|ShareLink|Link|TextEditor|ProgressView|Gauge|DisclosureGroup|ControlGroup|DatePicker|Stepper)\s*\(\s*"""([\s\S]*?)"""/gu;
 const APPLE_LOCALIZED_STRING_CALLS =
-  /\b(?:String\s*\(\s*localized:|LocalizedStringResource\s*\()\s*"((?:\\.|[^"\\])*)"/gu;
+  /\b(?:String\s*\(\s*localized:|LocalizedString(?:Key|Resource)\s*\()\s*"((?:\\.|[^"\\])*)"/gu;
 const APPLE_LOCALIZED_STRING_MULTILINE_CALLS =
-  /\b(?:String\s*\(\s*localized:|LocalizedStringResource\s*\()\s*"""([\s\S]*?)"""/gu;
+  /\b(?:String\s*\(\s*localized:|LocalizedString(?:Key|Resource)\s*\()\s*"""([\s\S]*?)"""/gu;
 const APPLE_CALL_START = /\b([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*/gu;
 const APPLE_MODIFIER_CALLS =
   /\.(?:navigationTitle|accessibilityLabel|accessibilityHint|help|alert|confirmationDialog)\s*\(\s*"((?:\\.|[^"\\])*)"/gu;
@@ -126,6 +126,8 @@ const ANDROID_BUILTIN_UI_CALLS = new Set([
   "Label",
   "LazyColumn",
   "LazyRow",
+  "nativeString",
+  "nativeStringResource",
   "OutlinedButton",
   "OutlinedTextField",
   "RadioButton",
@@ -775,13 +777,11 @@ function addConditionalBranchPair(
   }
   const secondStart = skipWhitespaceAndBrace(source, first.end + separatorMatch[0].length);
   const second = readAdjacentStringLiterals(surface, source, secondStart);
-  if (!second) {
-    return;
+  const branches = [{ offset: firstStart, value: first.value }];
+  if (second) {
+    branches.push({ offset: secondStart, value: second.value });
   }
-  for (const branch of [
-    { offset: firstStart, value: first.value },
-    { offset: secondStart, value: second.value },
-  ]) {
+  for (const branch of branches) {
     addCandidate(
       entries,
       surface,

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -1,16 +1,26 @@
+import { createHash } from "node:crypto";
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   assignNativeI18nIds,
   collectNativeI18nEntries,
+  extractNativeI18nCandidates,
   isConditionalBranchIdentifier,
   NATIVE_I18N_LOCALES,
   parseNativeI18nCommand,
   syncNativeLocale,
   type NativeI18nEntry,
+  validateNativeLocaleArtifact,
 } from "../../scripts/native-app-i18n.ts";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
+
+type NativeTranslationArtifact = {
+  entries: Array<{ id: string; source: string; translated: string }>;
+  glossaryHash: string;
+  locale: string;
+  version: 1;
+};
 
 describe("native app i18n inventory", () => {
   it("keeps IDs stable across extractor classification changes", () => {
@@ -147,6 +157,89 @@ describe("native app i18n inventory", () => {
     expect(isConditionalBranchIdentifier("abc123A")).toBe(false);
     expect(isConditionalBranchIdentifier("already_lowercase")).toBe(false);
     expect(isConditionalBranchIdentifier(`a${"A".repeat(4_096)}!`)).toBe(false);
+  });
+
+  it("joins adjacent literals across supported Swift and Kotlin UI expressions", () => {
+    const swift = extractNativeI18nCandidates(
+      "apple",
+      "apps/ios/Fixture.swift",
+      `
+        struct Fixture: View {
+          var body: some View {
+            SettingsPageHeader(
+              title: "Settings",
+              subtitle: "Named " + "argument")
+              .help("Modifier " + "details")
+            Button("Swift first " + "argument") {}
+            Text(enabled ? "Enabled " + "now" : "Disabled " + "now")
+          }
+
+          var statusText: String {
+            switch state {
+            case .ready:
+              "Switch " + "ready"
+            default:
+              return "Switch " + "waiting"
+            }
+          }
+        }
+      `,
+      new Set(["Button", "SettingsPageHeader", "Text"]),
+    );
+    const kotlin = extractNativeI18nCandidates(
+      "android",
+      "apps/android/Fixture.kt",
+      `
+        @Composable
+        fun Fixture() {
+          Text("Kotlin first " + "argument")
+          Text(text = "Named " + "argument")
+        }
+
+        fun statusText(state: State): String = when (state) {
+          State.Ready -> "When " + "ready"
+          else -> "When " + "waiting"
+        }
+
+        fun messageText(enabled: Boolean): String {
+          if (enabled) return "Return " + "enabled"
+          return "Return " + "disabled"
+        }
+      `,
+    );
+    const sources = [...swift, ...kotlin].map((entry) => entry.source);
+
+    expect(sources).toEqual(
+      expect.arrayContaining([
+        "Named argument",
+        "Modifier details",
+        "Swift first argument",
+        "Enabled now",
+        "Disabled now",
+        "Switch ready",
+        "Switch waiting",
+        "Kotlin first argument",
+        "When ready",
+        "When waiting",
+        "Return enabled",
+        "Return disabled",
+      ]),
+    );
+    expect(
+      sources.some((source) =>
+        [
+          "Named ",
+          "Modifier ",
+          "Enabled ",
+          "Disabled ",
+          "Switch ",
+          "Swift first ",
+          "Kotlin first ",
+          "When ",
+          "Return ",
+        ].includes(source),
+      ),
+    ).toBe(false);
   });
 
   it("collects stable Android and Apple UI entries", async () => {
@@ -330,6 +423,52 @@ describe("native app i18n inventory", () => {
     expect(
       entries.some((entry) => entry.source === "Some channel status checks did not complete."),
     ).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.source ===
+          "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.source ===
+          "Cron changes require operator.admin. Setup codes intentionally do not grant it. Reconnect with the gateway's shared token or password to request admin access. If this device still lacks it, approve the pending scope upgrade from an existing admin client.",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.source ===
+          "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.source ===
+          "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.source ===
+          "Paste the token configured on the gateway host. On the gateway host, run `openclaw config get gateway.auth.token`. If the gateway uses an environment variable instead, use `OPENCLAW_GATEWAY_TOKEN`.",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some((entry) =>
+        [
+          "Your AI-powered setup helper. It can check status, fix config, ",
+          "Cron changes require operator.admin. Setup codes intentionally do not grant it. ",
+          "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from ",
+          "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. ",
+          "Paste the token configured on the gateway host. ",
+        ].includes(entry.source),
+      ),
+    ).toBe(false);
     expect(
       entries.some(
         (entry) =>
@@ -565,6 +704,190 @@ describe("native app i18n inventory", () => {
     } finally {
       cleanupTempDirs(tempDirs);
     }
+  });
+
+  it("rejects invalid locale artifact metadata, inventory, and translations", () => {
+    const inventory: NativeI18nEntry[] = [
+      {
+        id: "native.android.greeting",
+        kind: "ui-call",
+        line: 1,
+        path: "apps/android/Greeting.kt",
+        source: "Hello ${name}\nNext",
+        surface: "android",
+      },
+      {
+        id: "native.apple.other",
+        kind: "ui-call",
+        line: 1,
+        path: "apps/ios/Other.swift",
+        source: "Other",
+        surface: "apple",
+      },
+    ];
+    const emptyGlossaryHash = createHash("sha256").update(JSON.stringify([])).digest("hex");
+    const createArtifact = (): NativeTranslationArtifact => ({
+      version: 1,
+      locale: "sv",
+      glossaryHash: emptyGlossaryHash,
+      entries: [
+        {
+          id: inventory[0].id,
+          source: inventory[0].source,
+          translated: "Hej ${name}\nNästa",
+        },
+        {
+          id: inventory[1].id,
+          source: inventory[1].source,
+          translated: "Annat",
+        },
+      ],
+    });
+    const cases: Array<{
+      expected: string;
+      mutate: (artifact: NativeTranslationArtifact) => unknown;
+    }> = [
+      {
+        expected: "version must be 1",
+        mutate: (artifact) => ({ ...artifact, version: 2 }),
+      },
+      {
+        expected: 'locale must be "sv"',
+        mutate: (artifact) => ({ ...artifact, locale: "de" }),
+      },
+      {
+        expected: "glossaryHash must be",
+        mutate: (artifact) => ({ ...artifact, glossaryHash: "stale" }),
+      },
+      {
+        expected: "entry count must be 2, got 1",
+        mutate: (artifact) => ({ ...artifact, entries: artifact.entries.slice(0, 1) }),
+      },
+      {
+        expected: 'entries[0].id must be "native.android.greeting"',
+        mutate: (artifact) => ({ ...artifact, entries: artifact.entries.toReversed() }),
+      },
+      {
+        expected: "entries[0].source does not match inventory",
+        mutate: (artifact) => ({
+          ...artifact,
+          entries: [{ ...artifact.entries[0], source: "Changed" }, artifact.entries[1]],
+        }),
+      },
+      {
+        expected: 'duplicate id "native.android.greeting"',
+        mutate: (artifact) => ({
+          ...artifact,
+          entries: [artifact.entries[0], { ...artifact.entries[1], id: artifact.entries[0].id }],
+        }),
+      },
+      {
+        expected: "entries[1].translated must be nonempty",
+        mutate: (artifact) => ({
+          ...artifact,
+          entries: [artifact.entries[0], { ...artifact.entries[1], translated: "  " }],
+        }),
+      },
+      {
+        expected: "translation changed structural tokens or line breaks",
+        mutate: (artifact) => ({
+          ...artifact,
+          entries: [{ ...artifact.entries[0], translated: "Hej\nNästa" }, artifact.entries[1]],
+        }),
+      },
+      {
+        expected: "translation changed structural tokens or line breaks",
+        mutate: (artifact) => ({
+          ...artifact,
+          entries: [
+            { ...artifact.entries[0], translated: "Hej ${name} Nästa" },
+            artifact.entries[1],
+          ],
+        }),
+      },
+    ];
+
+    expect(validateNativeLocaleArtifact("sv", inventory, createArtifact())).toEqual([]);
+    for (const testCase of cases) {
+      expect(() =>
+        validateNativeLocaleArtifact("sv", inventory, testCase.mutate(createArtifact())),
+      ).toThrow(testCase.expected);
+    }
+  });
+
+  it("emits deterministic advisory translation-quality findings", () => {
+    const inventory: NativeI18nEntry[] = [
+      {
+        id: "native.android.language-picker",
+        kind: "conditional-branch",
+        line: 89,
+        path: "apps/android/app/src/main/java/ai/openclaw/app/AppLanguage.kt",
+        source: "OpenClaw translations · $languageTag",
+        surface: "android",
+      },
+      {
+        id: "native.android.inspect",
+        kind: "ui-call",
+        line: 1,
+        path: "apps/android/Workshop.kt",
+        source: "Inspect",
+        surface: "android",
+      },
+      {
+        id: "native.apple.inspect",
+        kind: "ui-call",
+        line: 1,
+        path: "apps/ios/Workshop.swift",
+        source: "Inspect",
+        surface: "apple",
+      },
+      {
+        id: "native.android.voice-note",
+        kind: "ui-call",
+        line: 1,
+        path: "apps/android/Voice.kt",
+        source: "Record voice note",
+        surface: "android",
+      },
+    ];
+    const artifact: NativeTranslationArtifact = {
+      version: 1,
+      locale: "id",
+      glossaryHash: createHash("sha256").update(JSON.stringify([])).digest("hex"),
+      entries: [
+        {
+          id: inventory[0].id,
+          source: inventory[0].source,
+          translated: inventory[0].source,
+        },
+        {
+          id: inventory[1].id,
+          source: inventory[1].source,
+          translated: inventory[1].source,
+        },
+        {
+          id: inventory[2].id,
+          source: inventory[2].source,
+          translated: "Periksa",
+        },
+        {
+          id: inventory[3].id,
+          source: inventory[3].source,
+          translated: "Ghi ghi chú thoại",
+        },
+      ],
+    };
+
+    const findings = validateNativeLocaleArtifact("id", inventory, artifact);
+    expect(findings.map((finding) => `${finding.code}:${finding.id}`)).toEqual([
+      "adjacent-duplicate-word:native.android.voice-note",
+      "android-language-picker-source-equal:native.android.language-picker",
+      "same-source-contradiction:native.android.inspect",
+      "source-equal:native.android.inspect",
+      "source-equal:native.android.language-picker",
+    ]);
+    expect(findings[0]?.words).toEqual(["ghi"]);
+    expect(findings[2]?.relatedIds).toEqual(["native.apple.inspect"]);
   });
 
   it("validates locale refresh arguments before write paths run", () => {

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -172,6 +172,7 @@ describe("native app i18n inventory", () => {
               .help("Modifier " + "details")
             Button("Swift first " + "argument") {}
             Text(enabled ? "Enabled " + "now" : "Disabled " + "now")
+            Text(LocalizedStringKey("Localized key"))
           }
 
           var statusText: String {
@@ -194,6 +195,7 @@ describe("native app i18n inventory", () => {
         fun Fixture() {
           Text("Kotlin first " + "argument")
           Text(text = "Named " + "argument")
+          Icon(contentDescription = if (enabled) "Open \${row.title}" else row.title)
         }
 
         fun statusText(state: State): String = when (state) {
@@ -216,9 +218,11 @@ describe("native app i18n inventory", () => {
         "Swift first argument",
         "Enabled now",
         "Disabled now",
+        "Localized key",
         "Switch ready",
         "Switch waiting",
         "Kotlin first argument",
+        "Open ${row.title}",
         "When ready",
         "When waiting",
         "Return enabled",
@@ -270,7 +274,11 @@ describe("native app i18n inventory", () => {
         ),
     ).toBe(true);
     expect(entries.some((entry) => entry.source === "QR Scanner Unavailable")).toBe(true);
-    expect(entries.some((entry) => entry.source === "Request ID: \\(value)")).toBe(true);
+    expect(
+      entries.some((entry) =>
+        new Set(["Request ID: \\(value)", "Request ID: %@"]).has(entry.source),
+      ),
+    ).toBe(true);
     expect(entries.some((entry) => entry.source === "Open ${row.title}")).toBe(true);
     expect(entries.some((entry) => entry.source === "Preview · $domain")).toBe(true);
     expect(entries.some((entry) => entry.source === "Approval command copied")).toBe(true);
@@ -319,35 +327,23 @@ describe("native app i18n inventory", () => {
     expect(entries.some((entry) => entry.source === "Run now")).toBe(true);
     expect(entries.some((entry) => entry.source === "Loading chat")).toBe(true);
     expect(
+      entries.some((entry) => entry.surface === "android" && entry.source === "Search OpenClaw"),
+    ).toBe(true);
+    expect(
       entries.some(
         (entry) =>
-          entry.surface === "android" &&
-          entry.kind === "ui-named-argument" &&
-          entry.source === "Search OpenClaw",
+          entry.path.endsWith("/ChatMessageActions.kt") && entry.source === "Message actions",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) => entry.path.endsWith("/ChatMessageActions.kt") && entry.source === "Reply",
       ),
     ).toBe(true);
     expect(
       entries.some(
         (entry) =>
-          entry.path.endsWith("/ChatMessageActions.kt") &&
-          entry.kind === "ui-named-argument" &&
-          entry.source === "Message actions",
-      ),
-    ).toBe(true);
-    expect(
-      entries.some(
-        (entry) =>
-          entry.path.endsWith("/ChatMessageActions.kt") &&
-          entry.kind === "ui-named-argument" &&
-          entry.source === "Reply",
-      ),
-    ).toBe(true);
-    expect(
-      entries.some(
-        (entry) =>
-          entry.path.endsWith("/ChatMessageActions.kt") &&
-          entry.kind === "ui-chooser" &&
-          entry.source === "Share message",
+          entry.path.endsWith("/ChatMessageActions.kt") && entry.source === "Share message",
       ),
     ).toBe(true);
     expect(entries.some((entry) => entry.source === "What would you like to work on?")).toBe(true);
@@ -383,7 +379,6 @@ describe("native app i18n inventory", () => {
       entries.some(
         (entry) =>
           entry.path === "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift" &&
-          entry.kind === "ui-named-argument" &&
           entry.source === "Details",
       ),
     ).toBe(true);
@@ -391,17 +386,13 @@ describe("native app i18n inventory", () => {
       entries.some(
         (entry) =>
           entry.path === "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift" &&
-          entry.kind === "ui-named-argument" &&
           entry.source === "Open Settings",
       ),
     ).toBe(true);
     expect(entries.some((entry) => entry.source === "No sessions yet")).toBe(true);
     expect(
       entries.some(
-        (entry) =>
-          entry.path.endsWith("/ChatSheets.swift") &&
-          entry.kind === "ui-named-argument" &&
-          entry.source === "Search sessions",
+        (entry) => entry.path.endsWith("/ChatSheets.swift") && entry.source === "Search sessions",
       ),
     ).toBe(true);
     expect(entries.some((entry) => entry.source === "Don't show this again")).toBe(true);

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -207,6 +207,9 @@ describe("native app i18n inventory", () => {
           if (enabled) return "Return " + "enabled"
           return "Return " + "disabled"
         }
+
+        fun warningText(summary: Summary): String =
+          summary.warning ?: "Fallback warning"
       `,
     );
     const sources = [...swift, ...kotlin].map((entry) => entry.source);
@@ -227,6 +230,7 @@ describe("native app i18n inventory", () => {
         "When waiting",
         "Return enabled",
         "Return disabled",
+        "Fallback warning",
       ]),
     );
     expect(


### PR DESCRIPTION
Closes #103691

## What Problem This Solves

Fixes an issue where native locale refreshes could leave source and per-locale artifacts structurally stale when Swift or Kotlin UI copy moved into helper calls, conditional branches, or typed fallback expressions.

## Why This Change Was Made

The native inventory now extracts the supported runtime localization shapes, preserves stable IDs across source movement, validates every locale artifact against the exact canonical inventory, and reports deterministic translation-quality advisories. The generated source and all 21 locale artifacts are reconciled to the current 3,163-entry inventory.

## User Impact

Maintainers now get a fail-closed native localization check before stale IDs, missing entries, placeholder drift, or malformed locale metadata can land. Runtime app behavior is unchanged by this PR.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/native-app-i18n.test.ts` — 10/10 passed.
- `node --import tsx scripts/native-app-i18n.ts check` — 21 locale artifacts valid, 3,163 entries, no drift.
- Blacksmith Testbox `tbx_01kxaa8995gx89bc6g1rywx5pk` — path-scoped `check:changed` passed scripts/test/app formatting, tsgo, and lint lanes.
- Autoreview: `23ab1753c7c` and `50ed89c35c0` clean. The validator commit's only finding requested generated artifacts; `7d6fea7d4b6` supplies them and the exact checker passes. Full-branch review correctly refused the 1.79 MB generated bundle at the 180 KB safety limit.