### PR TITLE
fix(duckduckgo): decode relative result URLs

### DIFF
--- a/extensions/duckduckgo/src/ddg-client.ts
+++ b/extensions/duckduckgo/src/ddg-client.ts
@@ -97,8 +97,7 @@ function stripHtml(html: string): string {
 
 function decodeDuckDuckGoUrl(rawUrl: string): string {
   try {
-    const normalized = rawUrl.startsWith("//") ? `https:${rawUrl}` : rawUrl;
-    const parsed = new URL(normalized);
+    const parsed = new URL(rawUrl, "https://duckduckgo.com");
     const uddg = parsed.searchParams.get("uddg");
     if (uddg) {
       return uddg;

--- a/extensions/duckduckgo/src/ddg-search-provider.test.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.test.ts
@@ -199,6 +199,9 @@ describe("duckduckgo web search provider", () => {
         "https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fsearch%3Fq%3Dclaw",
       ),
     ).toBe("https://example.com/search?q=claw");
+    expect(
+      ddgClientTesting.decodeDuckDuckGoUrl("/l/?kh=-1&uddg=https%3A%2F%2Fexample.net%2Frelative"),
+    ).toBe("https://example.net/relative");
     expect(ddgClientTesting.decodeDuckDuckGoUrl("https://example.com")).toBe("https://example.com");
     expect(ddgClientTesting.decodeHtmlEntities("Fish &amp; Chips&nbsp;&hellip; &#39;ok&#39;")).toBe(
       "Fish & Chips ... 'ok'",
@@ -236,6 +239,10 @@ describe("duckduckgo web search provider", () => {
         Example &amp; Co
       </a>
       <a class="result__snippet">Fast&nbsp;search &hellip; with details</a>
+      <a class="result__a" href="/l/?uddg=https%3A%2F%2Fexample.net%2Frelative">
+        Relative redirect
+      </a>
+      <a class="result__snippet">Relative snippet</a>
       <a class="result__a" href="https://example.org/direct">Direct result</a>
       <a class="result__snippet">Second snippet</a>
     `;
@@ -245,6 +252,11 @@ describe("duckduckgo web search provider", () => {
         title: "Example & Co",
         url: "https://example.com",
         snippet: "Fast search ... with details",
+      },
+      {
+        title: "Relative redirect",
+        url: "https://example.net/relative",
+        snippet: "Relative snippet",
       },
       {
         title: "Direct result",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where DuckDuckGo web search results could expose DuckDuckGo-relative redirect paths such as /l/?uddg=... instead of the real destination URL when the HTML result page uses relative tracking links.

## Why This Change Was Made

The DuckDuckGo provider now resolves result hrefs against the DuckDuckGo origin before reading the existing uddg redirect parameter. This keeps direct result URLs and existing absolute/protocol-relative redirect handling unchanged while covering the same owner-local parsing invariant for root-relative redirect links.

## User Impact

Users choosing DuckDuckGo as their web search provider now receive usable destination URLs for relative redirect results instead of local DuckDuckGo tracking paths.

## Evidence

- Claim proved: DuckDuckGo result URL parsing decodes direct URLs, absolute/protocol-relative redirect URLs, and root-relative /l/?uddg=... redirect URLs, including through parsed HTML search results.
- Preserved real DuckDuckGo root-relative proof: a public Stack Overflow report for `requests.get('http://duckduckgo.com/html/?q=hello')` records a DuckDuckGo HTML result href as `/l/?kh=-1&uddg=https%3A%2F%2Fwww.example.com`, and the accepted answer parses the same root-relative href shape by reading the `uddg` destination parameter: https://stackoverflow.com/questions/52801138/scraping-site-returns-different-href-for-a-link
- Live DuckDuckGo proof at 4874d80e7116ac25cfd25546b08a2a42c0ef1898: a browser-loaded https://html.duckduckgo.com/html?q=openclaw%20github&kp=-1 page returned 10 a.result__a links, was not challenge-blocked, and the first live result href was //duckduckgo.com/l/?uddg=https%3A%2F%2Fgithub.com%2Fopenclaw&rut=<redacted>.
- Current-branch parser proof for that live result at 4874d80e7116ac25cfd25546b08a2a42c0ef1898: node --import tsx --input-type=module - imported extensions/duckduckgo/src/ddg-client.ts, parsed the captured live DuckDuckGo result anchor, and printed decodedUrl: "https://github.com/openclaw", title: "openclaw - GitHub", resultCount: 1.
- Focused regression proof at 4874d80e7116ac25cfd25546b08a2a42c0ef1898: node scripts/run-vitest.mjs extensions/duckduckgo/src/ddg-search-provider.test.ts passed with 1 file and 11 tests, covering direct URLs, absolute DuckDuckGo redirects, root-relative /l/?uddg=... redirects, and parsed HTML search results.
- Targeted format: node_modules\.bin\oxfmt.CMD --check --threads=1 extensions\duckduckgo\src\ddg-client.ts extensions\duckduckgo\src\ddg-search-provider.test.ts passed.
- Committed diff hygiene: git diff --check HEAD~1..HEAD passed.
- Review proof: python .agents\skills\autoreview\scripts\autoreview --mode local --engine codex --codex-bin <relay codex wrapper> passed with no accepted/actionable findings.
- Duplicate search: open and closed PR plus open issue searches for DuckDuckGo relative URL returned no overlapping result.