### PR TITLE
fix(gateway): revoke attach grants on deletion

### DIFF
--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1022,7 +1022,10 @@ async function deleteSqliteSessionEntryLifecycleInternal(
         kind: "delete",
         previous: {
           ...(current.entry.sessionId ? { sessionId: current.entry.sessionId } : {}),
-          sessionKeys: targetSnapshot.rows.map((row) => row.sessionKey),
+          sessionKeys: uniqueStrings([
+            normalizeSqliteSessionKey(params.target.canonicalKey),
+            ...targetSnapshot.rows.map((row) => row.sessionKey),
+          ]),
         },
       });
     }

--- a/src/gateway/mcp-grant-store.test.ts
+++ b/src/gateway/mcp-grant-store.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { emitSessionIdentityMutation } from "../sessions/session-lifecycle-events.js";
 import {
   activateMcpLoopbackClientGrantCapture,
   attachGrantStoreSize,
@@ -71,6 +72,34 @@ describe("mcp-grant-store", () => {
     mintAttachGrant({ sessionKey: "agent:main:y", nowMs: T0 });
     expect(revokeAttachGrantsForSession("agent:main:x")).toBe(2);
     expect(attachGrantStoreSize()).toBe(1);
+  });
+
+  it("revokes only grants bound to a committed session deletion", () => {
+    const target = mintAttachGrant({ sessionKey: "agent:main:target", nowMs: T0 });
+    const unrelated = mintAttachGrant({ sessionKey: "agent:main:unrelated", nowMs: T0 });
+
+    emitSessionIdentityMutation({
+      kind: "delete",
+      previous: {
+        sessionId: "target-session-id",
+        sessionKeys: ["agent:main:target"],
+      },
+    });
+
+    expect(resolveAttachGrant(target.token, T0)).toBeUndefined();
+    expect(resolveAttachGrant(unrelated.token, T0)).toBeDefined();
+  });
+
+  it("preserves grants when session identity is reset instead of deleted", () => {
+    const target = mintAttachGrant({ sessionKey: "agent:main:target", nowMs: T0 });
+
+    emitSessionIdentityMutation({
+      kind: "reset",
+      previous: { sessionId: "old-session-id", sessionKeys: ["agent:main:target"] },
+      current: { sessionId: "new-session-id", sessionKeys: ["agent:main:target"] },
+    });
+
+    expect(resolveAttachGrant(target.token, T0)).toBeDefined();
   });
 
   it("clamps TTL: default for non-positive, ceiling at 12h", () => {

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -7,6 +7,8 @@ import type {
 } from "../auto-reply/get-reply-options.types.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import { onSessionIdentityMutation } from "../sessions/session-lifecycle-events.js";
 
 export type McpLoopbackRequestContext = {
   sessionKey: string;
@@ -73,6 +75,22 @@ const MAX_TTL_MS = 12 * 60 * 60 * 1000;
 
 const grantsByToken = new Map<string, McpAttachGrant>();
 const clientGrantsByToken = new Map<string, StoredMcpLoopbackClientGrant>();
+let sessionDeletionObserverStarted = false;
+
+function ensureSessionDeletionObserver(): void {
+  if (sessionDeletionObserverStarted) {
+    return;
+  }
+  sessionDeletionObserverStarted = true;
+  onSessionIdentityMutation((mutation) => {
+    if (mutation.kind !== "delete") {
+      return;
+    }
+    for (const sessionKey of mutation.previous.sessionKeys) {
+      revokeAttachGrantsForSession(sessionKey);
+    }
+  });
+}
 
 function clampTtlMs(ttlMs: number | undefined): number {
   if (!Number.isFinite(ttlMs) || (ttlMs as number) <= 0) {
@@ -91,6 +109,7 @@ export function mintAttachGrant(params: {
     throw new Error("mintAttachGrant: sessionKey is required");
   }
   const nowMs = params.nowMs ?? Date.now();
+  ensureSessionDeletionObserver();
   // Mint sweeps stale entries so abandoned grants do not accumulate.
   sweepExpiredAttachGrants(nowMs);
   const grant: McpAttachGrant = {
@@ -127,6 +146,18 @@ export function revokeAttachGrantsForSession(sessionKey: string): number {
   let removed = 0;
   for (const [token, grant] of grantsByToken) {
     if (grant.sessionKey === key) {
+      grantsByToken.delete(token);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+export function revokeAttachGrantsForAgent(agentId: string): number {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  let removed = 0;
+  for (const [token, grant] of grantsByToken) {
+    if (parseAgentSessionKey(grant.sessionKey)?.agentId === normalizedAgentId) {
       grantsByToken.delete(token);
       removed += 1;
     }

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -4,6 +4,11 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { FsSafeError } from "../../infra/fs-safe.js";
+import {
+  mintAttachGrant,
+  resetAttachGrantsForTest,
+  resolveAttachGrant,
+} from "../mcp-grant-store.js";
 /* ------------------------------------------------------------------ */
 /* Mocks                                                              */
 /* ------------------------------------------------------------------ */
@@ -207,6 +212,7 @@ const { testing: agentsTesting, agentsHandlers } = await import("./agents.js");
 /* ------------------------------------------------------------------ */
 
 beforeEach(() => {
+  resetAttachGrantsForTest();
   agentsTesting.resetDepsForTests();
   mocks.listAgentEntries.mockImplementation((cfg: unknown) => getAgentList(cfg));
   mocks.findAgentEntryIndex.mockImplementation((list: unknown, agentId?: string) =>
@@ -1127,6 +1133,17 @@ describe("agents.delete", () => {
     expect(mocks.writeConfigFile).toHaveBeenCalled();
     // moveToTrashBestEffort calls fs.access then movePathToTrash for each dir
     expect(mocks.movePathToTrash).toHaveBeenCalled();
+  });
+
+  it("revokes only attach grants owned by the deleted agent", async () => {
+    const deletedAgentGrant = mintAttachGrant({ sessionKey: "agent:test-agent:work" });
+    const unrelatedGrant = mintAttachGrant({ sessionKey: "agent:other:work" });
+
+    const { promise } = makeCall("agents.delete", { agentId: "test-agent", deleteFiles: false });
+    await promise;
+
+    expect(resolveAttachGrant(deletedAgentGrant.token)).toBeUndefined();
+    expect(resolveAttachGrant(unrelatedGrant.token)).toBeDefined();
   });
 
   it("trashes workspace attestations when deleting the last workspace owner", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -48,6 +48,7 @@ import { root, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
 import { movePathToTrash } from "../../plugin-sdk/browser-maintenance.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
+import { revokeAttachGrantsForAgent } from "../mcp-grant-store.js";
 import { listAgentsForGateway } from "../session-utils.js";
 import {
   AgentConfigPreconditionError,
@@ -733,6 +734,8 @@ export const agentsHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "agent delete did not commit"));
       return;
     }
+
+    revokeAttachGrantsForAgent(agentId);
 
     // Purge session store entries so orphaned sessions cannot be targeted (#65524).
     await purgeAgentSessionStoreEntries(cfg, agentId);

--- a/src/gateway/server-methods/attach.test.ts
+++ b/src/gateway/server-methods/attach.test.ts
@@ -6,7 +6,10 @@ import { attachHandlers } from "./attach.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const loadSessionEntryMock = vi.hoisted(() =>
-  vi.fn((_sessionKey: string) => ({ entry: undefined as Record<string, unknown> | undefined })),
+  vi.fn((sessionKey: string) => ({
+    canonicalKey: sessionKey,
+    entry: undefined as Record<string, unknown> | undefined,
+  })),
 );
 
 vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => {
@@ -29,7 +32,10 @@ describe("attach gateway methods", () => {
   beforeEach(() => {
     resetAttachGrantsForTest();
     loadSessionEntryMock.mockReset();
-    loadSessionEntryMock.mockReturnValue({ entry: undefined });
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+      canonicalKey: sessionKey,
+      entry: undefined,
+    }));
   });
   afterEach(async () => {
     resetAttachGrantsForTest();
@@ -64,6 +70,23 @@ describe("attach gateway methods", () => {
     expect(resolveAttachGrant(body.token)?.sessionKey).toBe("agent:main:attach-method");
   });
 
+  it("attach.grant binds aliases to the canonical logical session key", async () => {
+    loadSessionEntryMock.mockReturnValue({
+      canonicalKey: "agent:main:discord:group:attach",
+      entry: { sessionId: "alias-session" },
+    });
+    const respond = vi.fn();
+
+    await expectDefined(
+      attachHandlers["attach.grant"],
+      'attachHandlers["attach.grant"] test invariant',
+    )(grantOpts("discord:group:attach", respond));
+
+    const body = respond.mock.calls[0]?.[1] as { sessionKey: string; token: string };
+    expect(body.sessionKey).toBe("agent:main:discord:group:attach");
+    expect(resolveAttachGrant(body.token)?.sessionKey).toBe(body.sessionKey);
+  });
+
   it("rejects attach grants for reserved harness sessions", async () => {
     const respond = vi.fn();
     await expectDefined(
@@ -82,6 +105,7 @@ describe("attach gateway methods", () => {
 
   it("allows an existing unlocked legacy harness-prefixed session", async () => {
     loadSessionEntryMock.mockReturnValue({
+      canonicalKey: "agent:main:harness:legacy-notes",
       entry: { sessionId: "legacy-session", modelSelectionLocked: false },
     });
     const respond = vi.fn();
@@ -101,6 +125,7 @@ describe("attach gateway methods", () => {
 
   it("rejects attach grants for existing locked harness sessions", async () => {
     loadSessionEntryMock.mockReturnValue({
+      canonicalKey: "agent:main:harness:codex:supervision:native-thread",
       entry: {
         sessionId: "locked-session",
         agentHarnessId: "codex",

--- a/src/gateway/server-methods/attach.ts
+++ b/src/gateway/server-methods/attach.ts
@@ -32,10 +32,10 @@ export const attachHandlers: GatewayRequestHandlers = {
   "attach.grant": async ({ params, respond, context }) => {
     const grantParams = paramRecord(params);
     const cfg = context.getRuntimeConfig();
-    const sessionKey = readString(grantParams, "sessionKey") ?? resolveMainSessionKey(cfg);
-    const harnessEntry = isAgentHarnessSessionKey(sessionKey)
-      ? resolveSessionEntryAccessTarget({ cfg, sessionKey }).entry
-      : undefined;
+    const requestedSessionKey = readString(grantParams, "sessionKey") ?? resolveMainSessionKey(cfg);
+    const sessionTarget = resolveSessionEntryAccessTarget({ cfg, sessionKey: requestedSessionKey });
+    const sessionKey = sessionTarget.canonicalKey;
+    const harnessEntry = isAgentHarnessSessionKey(sessionKey) ? sessionTarget.entry : undefined;
     if (
       isAgentHarnessSessionKey(sessionKey) &&
       (!harnessEntry || isAgentHarnessSessionStoreEntryProtected(sessionKey, harnessEntry))

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -1,23 +1,34 @@
-// Session delete lifecycle tests protect transcript deletion, ACP metadata,
-// active-run cleanup, hooks, thread bindings, and browser/MCP cleanup.
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterEach, expect, test } from "vitest";
+// Session delete lifecycle tests protect transcript deletion, ACP metadata,
+// active-run cleanup, hooks, thread bindings, and browser/MCP cleanup.
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, expect, test, vi } from "vitest";
 import {
   readAcpSessionMeta,
   writeAcpSessionMetaForMigration,
 } from "../acp/runtime/session-meta.js";
 import { getRegistryWorktree } from "../agents/worktrees/registry.js";
 import { managedWorktrees } from "../agents/worktrees/service.js";
+import { getRuntimeConfig } from "../config/config.js";
+import { deleteSessionEntryLifecycle } from "../config/sessions.js";
 import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import {
   beginSessionWorkAdmission,
   runExclusiveSessionLifecycleMutation,
 } from "../sessions/session-lifecycle-admission.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
+import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { resetAttachGrantsForTest, resolveAttachGrant } from "./mcp-grant-store.js";
+import { closeMcpLoopbackServer } from "./mcp-http.js";
+import { attachHandlers } from "./server-methods/attach.js";
+import type { GatewayRequestHandlerOptions } from "./server-methods/types.js";
 import { embeddedRunMock, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
@@ -41,6 +52,56 @@ const {
   resetConfiguredGlobalAgentSessionStore,
 } = setupGatewaySessionsTestHarness();
 const execFileAsync = promisify(execFile);
+type SessionLifecycleTestDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "session_entries" | "session_routes" | "sessions"
+>;
+
+function seedRawLegacySessionRow(params: {
+  storePath: string;
+  sessionId: string;
+  sessionKey: string;
+}): void {
+  const databasePath = resolveSqliteTargetFromSessionStorePath(params.storePath, {
+    agentId: "main",
+  }).path;
+  if (!databasePath) {
+    throw new Error("expected SQLite session store path");
+  }
+  const updatedAt = Date.now();
+  runOpenClawAgentWriteTransaction(
+    (database) => {
+      const db = getNodeSqliteKysely<SessionLifecycleTestDatabase>(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        db.insertInto("sessions").values({
+          session_id: params.sessionId,
+          session_key: params.sessionKey,
+          created_at: updatedAt,
+          updated_at: updatedAt,
+        }),
+      );
+      executeSqliteQuerySync(
+        database.db,
+        db.insertInto("session_routes").values({
+          session_key: params.sessionKey,
+          session_id: params.sessionId,
+          updated_at: updatedAt,
+        }),
+      );
+      executeSqliteQuerySync(
+        database.db,
+        db.insertInto("session_entries").values({
+          session_id: params.sessionId,
+          session_key: params.sessionKey,
+          entry_json: JSON.stringify({ sessionId: params.sessionId, updatedAt }),
+          updated_at: updatedAt,
+        }),
+      );
+    },
+    { agentId: "main", path: databasePath },
+  );
+}
 
 async function initializeRemoteBackedGitWorkspace(root: string): Promise<string> {
   const workspace = path.join(root, "workspace");
@@ -64,7 +125,9 @@ async function initializeRemoteBackedGitWorkspace(root: string): Promise<string>
   return await fs.realpath(workspace);
 }
 
-afterEach(() => {
+afterEach(async () => {
+  resetAttachGrantsForTest();
+  await closeMcpLoopbackServer();
   closeOpenClawStateDatabaseForTest();
 });
 
@@ -232,6 +295,84 @@ test("sessions.delete rejects main and aborts active runs", async () => {
     targetSessionKey: "agent:main:discord:group:dev",
     reason: "session-delete",
   });
+});
+
+test("sessions.delete revokes outstanding MCP attach grants for the deleted session", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      "discord:group:attach": sessionStoreEntry("sess-attach"),
+    },
+  });
+  const grantRespond = vi.fn();
+  await expectDefined(
+    attachHandlers["attach.grant"],
+    'attachHandlers["attach.grant"] test invariant',
+  )({
+    params: { sessionKey: "discord:group:attach" },
+    respond: grantRespond,
+    context: { getRuntimeConfig },
+  } as unknown as GatewayRequestHandlerOptions);
+  const grant = grantRespond.mock.calls[0]?.[1] as { sessionKey: string; token: string };
+  const unrelatedRespond = vi.fn();
+  await expectDefined(
+    attachHandlers["attach.grant"],
+    'attachHandlers["attach.grant"] test invariant',
+  )({
+    params: { sessionKey: "unrelated" },
+    respond: unrelatedRespond,
+    context: { getRuntimeConfig },
+  } as unknown as GatewayRequestHandlerOptions);
+  const unrelatedGrant = unrelatedRespond.mock.calls[0]?.[1] as { token: string };
+
+  expect(grant.sessionKey).toBe("agent:main:discord:group:attach");
+  await expectSessionDeleteSucceeds({ key: "discord:group:attach" });
+
+  expect(resolveAttachGrant(grant.token)).toBeUndefined();
+  expect(resolveAttachGrant(unrelatedGrant.token)).toBeDefined();
+});
+
+test("committed deletion revokes canonical grants for raw legacy alias-only rows", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const legacyKey = "discord:group:legacy-attach";
+  const canonicalKey = "agent:main:discord:group:legacy-attach";
+  seedRawLegacySessionRow({
+    storePath,
+    sessionId: "sess-legacy-attach",
+    sessionKey: legacyKey,
+  });
+  const grantRespond = vi.fn();
+  await expectDefined(
+    attachHandlers["attach.grant"],
+    'attachHandlers["attach.grant"] test invariant',
+  )({
+    params: { sessionKey: legacyKey },
+    respond: grantRespond,
+    context: { getRuntimeConfig },
+  } as unknown as GatewayRequestHandlerOptions);
+  const grant = grantRespond.mock.calls[0]?.[1] as { sessionKey: string; token: string };
+  const unrelatedRespond = vi.fn();
+  await expectDefined(
+    attachHandlers["attach.grant"],
+    'attachHandlers["attach.grant"] test invariant',
+  )({
+    params: { sessionKey: "unrelated-legacy-control" },
+    respond: unrelatedRespond,
+    context: { getRuntimeConfig },
+  } as unknown as GatewayRequestHandlerOptions);
+  const unrelatedGrant = unrelatedRespond.mock.calls[0]?.[1] as { token: string };
+
+  expect(grant.sessionKey).toBe(canonicalKey);
+  const deletion = await deleteSessionEntryLifecycle({
+    agentId: "main",
+    archiveTranscript: false,
+    storePath,
+    target: { canonicalKey, storeKeys: [canonicalKey, legacyKey] },
+  });
+  expect(deletion.deleted).toBe(true);
+
+  expect(resolveAttachGrant(grant.token)).toBeUndefined();
+  expect(resolveAttachGrant(unrelatedGrant.token)).toBeDefined();
 });
 
 test("sessions.delete preserves locked archived sessions and deletes ordinary archived sessions", async () => {

--- a/src/plugins/runtime/runtime-agent.test.ts
+++ b/src/plugins/runtime/runtime-agent.test.ts
@@ -3,6 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadTranscriptEvents } from "../../config/sessions/session-accessor.js";
+import {
+  mintAttachGrant,
+  resetAttachGrantsForTest,
+  resolveAttachGrant,
+} from "../../gateway/mcp-grant-store.js";
 import { createGatewaySession } from "../../gateway/session-create-service.js";
 import {
   interruptSessionWorkAdmissions,
@@ -159,9 +164,11 @@ describe("plugin runtime session creation", () => {
 
   it("rolls back the exact created entry and transcript when initialization fails", async () => {
     await withOpenClawTestState({ label: "plugin-runtime-session-create-rollback" }, async () => {
+      resetAttachGrantsForTest();
       const runtime = createRuntimeAgent();
       const key = "agent:main:dashboard:codex-binding-failure";
       let sessionFile: string | undefined;
+      let grantToken: string | undefined;
 
       await expect(
         runtime.session.createSessionEntry({
@@ -173,6 +180,7 @@ describe("plugin runtime session creation", () => {
           },
           afterCreate: async (created) => {
             sessionFile = created.entry.sessionFile;
+            grantToken = mintAttachGrant({ sessionKey: key }).token;
             throw new Error("native binding failed");
           },
         }),
@@ -183,14 +191,17 @@ describe("plugin runtime session creation", () => {
       );
       expect(sessionFile).toBeTruthy();
       expect(fs.existsSync(sessionFile ?? "")).toBe(false);
+      expect(resolveAttachGrant(grantToken ?? "")).toBeUndefined();
     });
   });
 
   it("rolls back a plugin-owned locked CLI session when initialization fails", async () => {
     await withOpenClawTestState({ label: "plugin-runtime-cli-session-rollback" }, async () => {
+      resetAttachGrantsForTest();
       const runtime = createRuntimeAgent();
       const key = "agent:main:catalog-adopt:claude:rollback";
       const storePath = runtime.session.resolveStorePath(undefined, { agentId: "main" });
+      let grantToken: string | undefined;
       let sessionId: string | undefined;
       let sessionFile: string | undefined;
 
@@ -212,6 +223,7 @@ describe("plugin runtime session creation", () => {
           afterCreate: async (created) => {
             sessionId = created.sessionId;
             sessionFile = created.entry.sessionFile;
+            grantToken = mintAttachGrant({ sessionKey: key }).token;
             throw new Error("history import failed");
           },
         }),
@@ -230,6 +242,7 @@ describe("plugin runtime session creation", () => {
           storePath,
         }),
       ).resolves.toEqual([]);
+      expect(resolveAttachGrant(grantToken ?? "")).toBeUndefined();
     });
   });
 

--- a/src/tasks/cron-run-continuation-cleanup.integration.test.ts
+++ b/src/tasks/cron-run-continuation-cleanup.integration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getRuntimeConfig } from "../config/config.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  mintAttachGrant,
+  resetAttachGrantsForTest,
+  resolveAttachGrant,
+} from "../gateway/mcp-grant-store.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { removeCronRunContinuationSessionIfIdle } from "./cron-run-continuation-cleanup.js";
+
+describe("cron continuation attach-grant lifecycle", () => {
+  it("revokes the exact grant after persisted continuation deletion", async () => {
+    await withOpenClawTestState({ label: "cron-continuation-grant-revocation" }, async () => {
+      resetAttachGrantsForTest();
+      const sessionKey = "agent:main:cron:one-shot:run:run-123";
+      const unrelatedKey = "agent:main:unrelated";
+      const storePath = resolveStorePath(getRuntimeConfig().session?.store, { agentId: "main" });
+      await replaceSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        {
+          sessionId: "run-123",
+          updatedAt: 123,
+          lifecycleRevision: "revision-1",
+          cronRunContinuation: {
+            basePersisted: true,
+            lifecycleRevision: "revision-1",
+            phase: "ready",
+          },
+        },
+      );
+      const target = mintAttachGrant({ sessionKey });
+      const unrelated = mintAttachGrant({ sessionKey: unrelatedKey });
+
+      await removeCronRunContinuationSessionIfIdle(sessionKey);
+
+      expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toBeUndefined();
+      expect(resolveAttachGrant(target.token)).toBeUndefined();
+      expect(resolveAttachGrant(unrelated.token)).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- canonicalize MCP attach grants onto the resolved logical session key
- revoke outstanding attach grants from the committed session-identity deletion event, regardless of deletion caller
- revoke all grants owned by an agent after the agent-config deletion commit
- cover RPC deletion, cron continuation cleanup, and plugin/harness initialization rollback
- preserve unrelated agent/session grants and keep reset/archive semantics unchanged

## What Problem This Solves

`attach.grant` previously stored the caller-provided session key verbatim. Session deletion resolves aliases to a canonical key, but no production deletion path revoked attach grants. As a result:

- deleting a session could leave its bearer valid until TTL expiry
- alias-bound grants could not be reliably revoked by canonical session deletion
- deleting an agent could leave grants for its removed sessions valid

Codex treats the configured environment bearer as a persistent MCP credential, so lifecycle revocation belongs on the OpenClaw server boundary.

## Ownership and ordering

- Grant creation uses the existing session-access resolver instead of adding a second canonicalization policy.
- The grant store subscribes once, on first mint, to the existing session-identity mutation boundary.
- Only committed `delete` mutations revoke grants, synchronously after the session transaction commits. Every deleted canonical/alias key in the mutation is covered, so RPC deletion, cron cleanup, and plugin/harness rollback share one owner boundary.
- Failed/no-op deletions emit no committed deletion event. Reset emits `reset`, which the listener deliberately ignores.
- Agent grants are also revoked after the agent-config deletion commit. Subsequent session-store purge and file trash operations are best-effort and do not roll the agent back.
- CLI `--print-config` behavior is unchanged; normal spawned attach clients still explicitly revoke on exit/error.

## Evidence

### Exact-head live gateway/MCP proof and CI

Reproducible portable harness and complete sanitized command transcript: [public proof artifact](https://gist.github.com/arcabotai/22ed734eea1bbce29f5977aff184e341)

The live artifact runs the unmodified production source through the repository's `pnpm openclaw` launcher on the exact current head. Current-head CI independently passed the production build, type, lint, boundary, security, and relevant test shards; its sole remaining failure is an unrelated current-base dead-export allowlist mismatch in untouched Control UI files.

The artifact records distinct persisted session keys plus non-secret SHA-256 prefixes for the target and unrelated bearers. The same target fingerprint appears before and after `sessions.delete`, while the unrelated fingerprint remains authorized.

```text
Environment: Daytona Linux x86_64, Node v22.22.1
Exact PR head: fb137a71e7288e7e166a717bfec8ae8f2fecf562

install_pass=1
runtime_mode=tsx-production-source
current_head_ci_build=passed
gateway_ready=1
sessions_created=2
grants_minted=2

invalid_control_status=401
bound_grant_before_delete_status=200
unrelated_grant_before_delete_status=200
session_delete_committed=1
bound_grant_after_delete_status=401
unrelated_grant_after_delete_status=200

invalid_control_body={"error":"unauthorized"}
revoked_grant_body={"error":"unauthorized"}
unrelated_grant_body={"ok":true}
response_bodies_verified=1
proof_result=pass
```

Production paths exercised:

- started the real Gateway from the exact PR head through the repository's source launcher
- created two persisted sessions through `sessions.patch`
- minted two grants through the real `attach --print-config` → `attach.grant` path
- exercised bearer authorization through MCP loopback `DELETE /mcp`
- committed target deletion through `sessions.delete`
- retried the same target bearer and observed `401 unauthorized`
- retried the unrelated bearer and observed continued `200 {"ok":true}`

The proof used synthetic credentials only. Token values and temporary MCP config paths were deleted before sandbox teardown; the retained transcript contains outcomes only.

### Focused regression suite

```text
node scripts/run-vitest.mjs \
  src/gateway/mcp-grant-store.test.ts \
  src/gateway/server-methods/attach.test.ts \
  src/gateway/server-methods/agents-mutate.test.ts \
  src/gateway/server.sessions.delete-lifecycle.test.ts \
  src/tasks/cron-run-continuation-cleanup.integration.test.ts \
  src/plugins/runtime/runtime-agent.test.ts

3 focused Vitest shards passed on the exact current head
```

Post-format verification:

```text
oxfmt --check: passed on all 10 changed files
oxlint: 0 warnings / 0 errors on all 10 changed files
check:test-types: passed
runtime import cycles: 0
full build: passed
```

Regression coverage exercises the real `attach.grant` alias flow, canonical response and storage, raw legacy alias-only rows, direct deletion-event filtering, RPC session deletion, real persisted cron continuation cleanup, ordinary and plugin-owned initialization rollback, unrelated-grant preservation, reset preservation, and agent-scoped revocation.

## Codex contract checked

- `codex-rs/codex-mcp/src/connection_manager.rs`: MCP client startup and environment bearer configuration
- `codex-rs/rmcp-client/src/auth_status.rs`: `bearer_token_env_var` authentication and streamable HTTP bearer behavior

No config/default surface changes. No database migration.

