### PR TITLE
fix(updater): scope restart log audits to managed checkout

### DIFF
--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -788,6 +788,8 @@ function readManagedGatewayLaunchAgent(checkout) {
   const label = plist?.Label;
   const programArguments = plist?.ProgramArguments;
   const environmentVariables = plist?.EnvironmentVariables;
+  const workingDirectory =
+    typeof plist?.WorkingDirectory === "string" ? plist.WorkingDirectory : null;
   const serviceEnvironment = Object.fromEntries(
     Object.entries(environmentVariables ?? {}).filter((entry) => typeof entry[1] === "string"),
   );
@@ -832,6 +834,7 @@ function readManagedGatewayLaunchAgent(checkout) {
     runtime: gatewayCommand.runtime,
     serviceEnvironment,
     stateDir: gatewayCommand.stateDir,
+    workingDirectory,
     wrapperPath: gatewayCommand.wrapperPath,
   };
 }
@@ -1005,7 +1008,7 @@ export function parseLaunchctlArguments(output) {
     : [];
 }
 
-function runBuiltGatewayCli(checkout, args, deployment) {
+function runBuiltGatewayCli(checkout, args, deployment, options = {}) {
   const observedDeployment = deployment ?? readManagedGatewayLaunchAgent(checkout);
   const sourceEntrypoint = path.join(checkout, "dist/index.js");
   let managedDeployment = observedDeployment;
@@ -1033,6 +1036,7 @@ function runBuiltGatewayCli(checkout, args, deployment) {
     port,
     runtime,
     serviceEnvironment = {},
+    workingDirectory,
     wrapperPath,
   } = managedDeployment;
   const baseEnv = { ...process.env };
@@ -1093,10 +1097,10 @@ function runBuiltGatewayCli(checkout, args, deployment) {
           ]
         : [...invocationPrefix, ...args];
     return execFileSync(executable, callArgs, {
-      cwd: path.dirname(path.dirname(entrypoint)),
+      cwd: workingDirectory ?? path.dirname(path.dirname(entrypoint)),
       encoding: "utf8",
       env,
-      stdio: ["ignore", "pipe", "inherit"],
+      stdio: ["ignore", "pipe", options.stderr ?? "inherit"],
     });
   } finally {
     rmSync(overlayPath, { force: true });
@@ -1662,20 +1666,15 @@ function readFallbackGatewayLogs(sinceMs) {
 }
 
 function readConfiguredPluginLoadPaths(checkout, deployment) {
+  if (deployment && !deployment.workingDirectory) {
+    return null;
+  }
   try {
-    const output = execFileSync(
-      process.execPath,
-      ["openclaw.mjs", "config", "get", "plugins.load", "--json"],
-      {
-        cwd: checkout,
-        encoding: "utf8",
-        maxBuffer: 4 * 1024 * 1024,
-        env: {
-          ...process.env,
-          ...(deployment?.serviceEnvironment ?? {}),
-          ...(deployment?.configPath ? { OPENCLAW_CONFIG_PATH: deployment.configPath } : {}),
-        },
-      },
+    const output = runBuiltGatewayCli(
+      checkout,
+      ["config", "get", "plugins.load", "--json"],
+      deployment,
+      { stderr: "pipe" },
     );
     const paths = JSON.parse(output)?.paths;
     return Array.isArray(paths) ? paths.filter((entry) => typeof entry === "string") : [];

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1699,6 +1699,12 @@ export function resolveManagedPluginSourceRoots(report) {
   return roots;
 }
 
+export function resolveManagedGatewaySourceRoot(checkout, deployment) {
+  return typeof deployment?.entrypoint === "string" && deployment.entrypoint.length > 0
+    ? path.dirname(path.resolve(deployment.entrypoint))
+    : path.join(realpathSync(checkout), "dist");
+}
+
 function defaultAuditGatewayLogs(checkout, sinceMs, deployment = null) {
   let output;
   try {
@@ -1726,7 +1732,7 @@ function defaultAuditGatewayLogs(checkout, sinceMs, deployment = null) {
   const audit = parseGatewayLogAudit(
     output,
     sinceMs,
-    path.join(realpathSync(checkout), "dist"),
+    resolveManagedGatewaySourceRoot(checkout, deployment),
     readManagedPluginSourceRoots(checkout, deployment),
   );
   if (audit.errorCount > 0) {

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1521,9 +1521,17 @@ function summarizeGatewayLogEntry(entry) {
   };
 }
 
+function canonicalizeExistingPath(filePath) {
+  try {
+    return realpathSync(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
 function isPathWithinRoot(sourcePath, rootPath) {
-  const normalizedRoot = path.resolve(rootPath);
-  const normalizedSource = path.resolve(sourcePath);
+  const normalizedRoot = canonicalizeExistingPath(rootPath);
+  const normalizedSource = canonicalizeExistingPath(sourcePath);
   return (
     normalizedSource === normalizedRoot ||
     normalizedSource.startsWith(`${normalizedRoot}${path.sep}`)
@@ -1556,8 +1564,8 @@ function isCurrentGatewayLogSource(source, sourceRoot, managedSourceRoots) {
   ) {
     return true;
   }
-  const normalizedRoot = path.resolve(sourceRoot);
-  const normalizedSource = path.resolve(sourcePath);
+  const normalizedRoot = canonicalizeExistingPath(sourceRoot);
+  const normalizedSource = canonicalizeExistingPath(sourcePath);
   const checkoutRoot = path.dirname(normalizedRoot);
   let candidate = path.dirname(normalizedSource);
   while (candidate !== path.dirname(candidate)) {

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1542,6 +1542,10 @@ function isCurrentGatewayLogSource(source, sourceRoot, managedSourceRoots) {
   } catch {
     return true;
   }
+  const sourceFilePath = sourcePath.replace(/:\d+(?::\d+)?$/u, "");
+  if (sourceFilePath !== sourcePath && !existsSync(sourcePath) && existsSync(sourceFilePath)) {
+    sourcePath = sourceFilePath;
+  }
   if (
     isPathWithinRoot(sourcePath, sourceRoot) ||
     managedSourceRoots.some((rootPath) => isPathWithinRoot(sourcePath, rootPath))
@@ -1675,7 +1679,14 @@ function readConfiguredPluginLoadPaths(checkout, deployment) {
     );
     const paths = JSON.parse(output)?.paths;
     return Array.isArray(paths) ? paths.filter((entry) => typeof entry === "string") : [];
-  } catch {
+  } catch (error) {
+    const errorOutput = [error?.stdout, error?.stderr, error?.message]
+      .filter((entry) => typeof entry === "string" || Buffer.isBuffer(entry))
+      .map((entry) => String(entry))
+      .join("\n");
+    if (errorOutput.includes("Config path not found: plugins.load")) {
+      return [];
+    }
     return null;
   }
 }

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1666,18 +1666,32 @@ function readFallbackGatewayLogs(sinceMs) {
 }
 
 function readConfiguredPluginLoadPaths(checkout, deployment) {
-  if (deployment && !deployment.workingDirectory) {
+  let managedDeployment = deployment;
+  try {
+    managedDeployment ??= readManagedGatewayLaunchAgent(checkout);
+  } catch {
+    return null;
+  }
+  if (!managedDeployment.workingDirectory) {
     return null;
   }
   try {
     const output = runBuiltGatewayCli(
       checkout,
       ["config", "get", "plugins.load", "--json"],
-      deployment,
+      managedDeployment,
       { stderr: "pipe" },
     );
     const paths = JSON.parse(output)?.paths;
-    return Array.isArray(paths) ? paths.filter((entry) => typeof entry === "string") : [];
+    return Array.isArray(paths)
+      ? paths
+          .filter((entry) => typeof entry === "string")
+          .map((entry) =>
+            path.isAbsolute(entry)
+              ? entry
+              : path.resolve(managedDeployment.workingDirectory, entry),
+          )
+      : [];
   } catch (error) {
     const errorOutput = [error?.stdout, error?.stderr, error?.message]
       .filter((entry) => typeof entry === "string" || Buffer.isBuffer(entry))

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1517,7 +1517,19 @@ function summarizeGatewayLogEntry(entry) {
   };
 }
 
-function isCurrentGatewayLogSource(source, sourceRoot) {
+function isPathWithinRoot(sourcePath, rootPath) {
+  const normalizedRoot = path.resolve(rootPath);
+  const normalizedSource = path.resolve(sourcePath);
+  return (
+    normalizedSource === normalizedRoot ||
+    normalizedSource.startsWith(`${normalizedRoot}${path.sep}`)
+  );
+}
+
+function isCurrentGatewayLogSource(source, sourceRoot, managedSourceRoots) {
+  if (managedSourceRoots === null) {
+    return true;
+  }
   if (!sourceRoot) {
     return true;
   }
@@ -1530,14 +1542,14 @@ function isCurrentGatewayLogSource(source, sourceRoot) {
   } catch {
     return true;
   }
-  const normalizedRoot = path.resolve(sourceRoot);
-  const normalizedSource = path.resolve(sourcePath);
   if (
-    normalizedSource === normalizedRoot ||
-    normalizedSource.startsWith(`${normalizedRoot}${path.sep}`)
+    isPathWithinRoot(sourcePath, sourceRoot) ||
+    managedSourceRoots.some((rootPath) => isPathWithinRoot(sourcePath, rootPath))
   ) {
     return true;
   }
+  const normalizedRoot = path.resolve(sourceRoot);
+  const normalizedSource = path.resolve(sourcePath);
   const checkoutRoot = path.dirname(normalizedRoot);
   let candidate = path.dirname(normalizedSource);
   while (candidate !== path.dirname(candidate)) {
@@ -1616,9 +1628,9 @@ function summarizeGatewayLogAudit(entries) {
   };
 }
 
-export function parseGatewayLogAudit(output, sinceMs, sourceRoot = null) {
+export function parseGatewayLogAudit(output, sinceMs, sourceRoot = null, managedSourceRoots = []) {
   const entries = parseGatewayLogEntries(output, sinceMs).filter((entry) =>
-    isCurrentGatewayLogSource(entry.source, sourceRoot),
+    isCurrentGatewayLogSource(entry.source, sourceRoot, managedSourceRoots),
   );
   return summarizeGatewayLogAudit(entries);
 }
@@ -1645,7 +1657,30 @@ function readFallbackGatewayLogs(sinceMs) {
   return contents.join("\n");
 }
 
-function defaultAuditGatewayLogs(checkout, sinceMs) {
+function readConfiguredPluginLoadPaths(checkout, deployment) {
+  try {
+    const output = execFileSync(
+      process.execPath,
+      ["openclaw.mjs", "config", "get", "plugins.load", "--json"],
+      {
+        cwd: checkout,
+        encoding: "utf8",
+        maxBuffer: 4 * 1024 * 1024,
+        env: {
+          ...process.env,
+          ...(deployment?.serviceEnvironment ?? {}),
+          ...(deployment?.configPath ? { OPENCLAW_CONFIG_PATH: deployment.configPath } : {}),
+        },
+      },
+    );
+    const paths = JSON.parse(output)?.paths;
+    return Array.isArray(paths) ? paths.filter((entry) => typeof entry === "string") : [];
+  } catch {
+    return null;
+  }
+}
+
+function defaultAuditGatewayLogs(checkout, sinceMs, deployment = null) {
   let output;
   try {
     output = execFileSync(
@@ -1669,7 +1704,12 @@ function defaultAuditGatewayLogs(checkout, sinceMs) {
       throw error;
     }
   }
-  const audit = parseGatewayLogAudit(output, sinceMs, path.join(realpathSync(checkout), "dist"));
+  const audit = parseGatewayLogAudit(
+    output,
+    sinceMs,
+    path.join(realpathSync(checkout), "dist"),
+    readConfiguredPluginLoadPaths(checkout, deployment),
+  );
   if (audit.errorCount > 0) {
     throw new UpdateInvariantError(
       "gateway_restart_log_errors",
@@ -1694,7 +1734,7 @@ function verifyAndAuditGateway({
   } catch (error) {
     verificationError = error;
   }
-  const audit = auditGatewayLogs(checkout, sinceMs);
+  const audit = auditGatewayLogs(checkout, sinceMs, deployment);
   if (verificationError) {
     throw verificationError;
   }

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1665,7 +1665,7 @@ function readFallbackGatewayLogs(sinceMs) {
   return contents.join("\n");
 }
 
-function readConfiguredPluginLoadPaths(checkout, deployment) {
+function readManagedPluginSourceRoots(checkout, deployment) {
   let managedDeployment = deployment;
   try {
     managedDeployment ??= readManagedGatewayLaunchAgent(checkout);
@@ -1675,37 +1675,28 @@ function readConfiguredPluginLoadPaths(checkout, deployment) {
   try {
     const output = runBuiltGatewayCli(
       checkout,
-      ["config", "get", "plugins.load", "--json"],
+      ["plugins", "list", "--enabled", "--json"],
       managedDeployment,
       { stderr: "pipe" },
     );
-    return resolveConfiguredPluginLoadPaths(
-      JSON.parse(output)?.paths,
-      managedDeployment.workingDirectory,
-    );
-  } catch (error) {
-    const errorOutput = [error?.stdout, error?.stderr, error?.message]
-      .filter((entry) => typeof entry === "string" || Buffer.isBuffer(entry))
-      .map((entry) => String(entry))
-      .join("\n");
-    if (errorOutput.includes("Config path not found: plugins.load")) {
-      return [];
-    }
+    return resolveManagedPluginSourceRoots(JSON.parse(output));
+  } catch {
     return null;
   }
 }
 
-export function resolveConfiguredPluginLoadPaths(paths, workingDirectory) {
-  if (!Array.isArray(paths)) {
-    return [];
-  }
-  const entries = paths.filter((entry) => typeof entry === "string");
-  if (!workingDirectory && entries.some((entry) => !path.isAbsolute(entry))) {
+export function resolveManagedPluginSourceRoots(report) {
+  if (!Array.isArray(report?.plugins)) {
     return null;
   }
-  return entries.map((entry) =>
-    path.isAbsolute(entry) ? entry : path.resolve(workingDirectory, entry),
-  );
+  const roots = [];
+  for (const plugin of report.plugins) {
+    if (typeof plugin?.rootDir !== "string" || plugin.rootDir.length === 0) {
+      return null;
+    }
+    roots.push(plugin.rootDir);
+  }
+  return roots;
 }
 
 function defaultAuditGatewayLogs(checkout, sinceMs, deployment = null) {
@@ -1736,7 +1727,7 @@ function defaultAuditGatewayLogs(checkout, sinceMs, deployment = null) {
     output,
     sinceMs,
     path.join(realpathSync(checkout), "dist"),
-    readConfiguredPluginLoadPaths(checkout, deployment),
+    readManagedPluginSourceRoots(checkout, deployment),
   );
   if (audit.errorCount > 0) {
     throw new UpdateInvariantError(

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -17,6 +17,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import { detectChangedScope } from "../../../../scripts/ci-changed-scope.mjs";
 import { isDirectRunUrl } from "../../../../scripts/lib/direct-run.mjs";
 import {
@@ -1516,13 +1517,61 @@ function summarizeGatewayLogEntry(entry) {
   };
 }
 
-export function parseGatewayLogAudit(output, sinceMs) {
-  const entries = output
+function isCurrentGatewayLogSource(source, sourceRoot) {
+  if (!sourceRoot) {
+    return true;
+  }
+  if (typeof source !== "string" || source.length === 0) {
+    return true;
+  }
+  let sourcePath;
+  try {
+    sourcePath = source.startsWith("file:") ? fileURLToPath(source) : source;
+  } catch {
+    return true;
+  }
+  const normalizedRoot = path.resolve(sourceRoot);
+  const normalizedSource = path.resolve(sourcePath);
+  if (
+    normalizedSource === normalizedRoot ||
+    normalizedSource.startsWith(`${normalizedRoot}${path.sep}`)
+  ) {
+    return true;
+  }
+  const checkoutRoot = path.dirname(normalizedRoot);
+  let candidate = path.dirname(normalizedSource);
+  while (candidate !== path.dirname(candidate)) {
+    const packagePath = path.join(candidate, "package.json");
+    const gitPath = path.join(candidate, ".git");
+    if (existsSync(packagePath) && existsSync(gitPath)) {
+      try {
+        if (JSON.parse(readFileSync(packagePath, "utf8")).name === "openclaw") {
+          return candidate === checkoutRoot;
+        }
+      } catch {
+        return true;
+      }
+    }
+    candidate = path.dirname(candidate);
+  }
+  return true;
+}
+
+function parseGatewayLogEntries(output, sinceMs) {
+  return output
     .split("\n")
     .filter(Boolean)
     .flatMap((line) => {
       try {
         const raw = JSON.parse(line);
+        let sourceRecord = raw;
+        if (raw.type === "log" && typeof raw.raw === "string") {
+          try {
+            sourceRecord = JSON.parse(raw.raw);
+          } catch {
+            sourceRecord = raw;
+          }
+        }
         const rawLevel = raw.type === "log" ? raw.level : raw._meta?.logLevelName;
         const level = String(rawLevel ?? "").toLowerCase();
         const time = raw.time ?? raw._meta?.date;
@@ -1544,12 +1593,16 @@ export function parseGatewayLogAudit(output, sinceMs) {
             level,
             subsystem,
             message: raw.message ?? raw["1"] ?? raw["0"] ?? "",
+            source: sourceRecord._meta?.path?.fullFilePath ?? null,
           },
         ];
       } catch {
         return [];
       }
     });
+}
+
+function summarizeGatewayLogAudit(entries) {
   const errors = entries
     .filter((entry) => entry.level === "error" || entry.level === "fatal")
     .map(summarizeGatewayLogEntry);
@@ -1561,6 +1614,13 @@ export function parseGatewayLogAudit(output, sinceMs) {
     errors: errors.slice(0, 20),
     warnings: warnings.slice(0, 20),
   };
+}
+
+export function parseGatewayLogAudit(output, sinceMs, sourceRoot = null) {
+  const entries = parseGatewayLogEntries(output, sinceMs).filter((entry) =>
+    isCurrentGatewayLogSource(entry.source, sourceRoot),
+  );
+  return summarizeGatewayLogAudit(entries);
 }
 
 function localDateKey(date) {
@@ -1609,7 +1669,7 @@ function defaultAuditGatewayLogs(checkout, sinceMs) {
       throw error;
     }
   }
-  const audit = parseGatewayLogAudit(output, sinceMs);
+  const audit = parseGatewayLogAudit(output, sinceMs, path.join(realpathSync(checkout), "dist"));
   if (audit.errorCount > 0) {
     throw new UpdateInvariantError(
       "gateway_restart_log_errors",

--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1672,9 +1672,6 @@ function readConfiguredPluginLoadPaths(checkout, deployment) {
   } catch {
     return null;
   }
-  if (!managedDeployment.workingDirectory) {
-    return null;
-  }
   try {
     const output = runBuiltGatewayCli(
       checkout,
@@ -1682,16 +1679,10 @@ function readConfiguredPluginLoadPaths(checkout, deployment) {
       managedDeployment,
       { stderr: "pipe" },
     );
-    const paths = JSON.parse(output)?.paths;
-    return Array.isArray(paths)
-      ? paths
-          .filter((entry) => typeof entry === "string")
-          .map((entry) =>
-            path.isAbsolute(entry)
-              ? entry
-              : path.resolve(managedDeployment.workingDirectory, entry),
-          )
-      : [];
+    return resolveConfiguredPluginLoadPaths(
+      JSON.parse(output)?.paths,
+      managedDeployment.workingDirectory,
+    );
   } catch (error) {
     const errorOutput = [error?.stdout, error?.stderr, error?.message]
       .filter((entry) => typeof entry === "string" || Buffer.isBuffer(entry))
@@ -1702,6 +1693,19 @@ function readConfiguredPluginLoadPaths(checkout, deployment) {
     }
     return null;
   }
+}
+
+export function resolveConfiguredPluginLoadPaths(paths, workingDirectory) {
+  if (!Array.isArray(paths)) {
+    return [];
+  }
+  const entries = paths.filter((entry) => typeof entry === "string");
+  if (!workingDirectory && entries.some((entry) => !path.isAbsolute(entry))) {
+    return null;
+  }
+  return entries.map((entry) =>
+    path.isAbsolute(entry) ? entry : path.resolve(workingDirectory, entry),
+  );
 }
 
 function defaultAuditGatewayLogs(checkout, sinceMs, deployment = null) {

--- a/test/external-script-modules.d.ts
+++ b/test/external-script-modules.d.ts
@@ -190,7 +190,11 @@ declare module "*openclaw-live-updater/scripts/update-main.mjs" {
     owner: { pid: number; checkout?: string; startedAt?: string };
     release?: () => void;
   };
-  export function parseGatewayLogAudit(output: string, sinceMs: number): Record<string, unknown>;
+  export function parseGatewayLogAudit(
+    output: string,
+    sinceMs: number,
+    sourceRoot?: string | null,
+  ): Record<string, unknown>;
   export function prepareGatewaySuspension(
     checkout: string,
     callGateway?: (

--- a/test/external-script-modules.d.ts
+++ b/test/external-script-modules.d.ts
@@ -197,6 +197,10 @@ declare module "*openclaw-live-updater/scripts/update-main.mjs" {
     sourceRoot?: string | null,
     managedSourceRoots?: string[] | null,
   ): Record<string, unknown>;
+  export function resolveConfiguredPluginLoadPaths(
+    paths: unknown,
+    workingDirectory?: string,
+  ): string[] | null;
   export function prepareGatewaySuspension(
     checkout: string,
     callGateway?: (

--- a/test/external-script-modules.d.ts
+++ b/test/external-script-modules.d.ts
@@ -139,6 +139,7 @@ declare module "*openclaw-changelog-update/scripts/verify-release-notes.mjs" {
 declare module "*openclaw-live-updater/scripts/update-main.mjs" {
   type GatewayDeployment = Record<string, unknown> & {
     entrypoint: string;
+    workingDirectory?: string | null;
   };
   type UpdateResult = Record<string, unknown> & {
     actions: Record<string, unknown>;

--- a/test/external-script-modules.d.ts
+++ b/test/external-script-modules.d.ts
@@ -194,6 +194,7 @@ declare module "*openclaw-live-updater/scripts/update-main.mjs" {
     output: string,
     sinceMs: number,
     sourceRoot?: string | null,
+    managedSourceRoots?: string[] | null,
   ): Record<string, unknown>;
   export function prepareGatewaySuspension(
     checkout: string,

--- a/test/external-script-modules.d.ts
+++ b/test/external-script-modules.d.ts
@@ -197,10 +197,7 @@ declare module "*openclaw-live-updater/scripts/update-main.mjs" {
     sourceRoot?: string | null,
     managedSourceRoots?: string[] | null,
   ): Record<string, unknown>;
-  export function resolveConfiguredPluginLoadPaths(
-    paths: unknown,
-    workingDirectory?: string,
-  ): string[] | null;
+  export function resolveManagedPluginSourceRoots(report: unknown): string[] | null;
   export function prepareGatewaySuspension(
     checkout: string,
     callGateway?: (

--- a/test/external-script-modules.d.ts
+++ b/test/external-script-modules.d.ts
@@ -198,6 +198,10 @@ declare module "*openclaw-live-updater/scripts/update-main.mjs" {
     managedSourceRoots?: string[] | null,
   ): Record<string, unknown>;
   export function resolveManagedPluginSourceRoots(report: unknown): string[] | null;
+  export function resolveManagedGatewaySourceRoot(
+    checkout: string,
+    deployment?: GatewayDeployment | null,
+  ): string;
   export function prepareGatewaySuspension(
     checkout: string,
     callGateway?: (

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -308,6 +308,8 @@ describe("openclaw live updater", () => {
     const foreignRoot = path.join(root, "worktree/openclaw");
     mkdirSync(path.join(foreignRoot, ".git"), { recursive: true });
     writeFileSync(path.join(foreignRoot, "package.json"), '{"name":"openclaw"}\n');
+    const configuredPluginFile = path.join(foreignRoot, "configured-plugin.ts");
+    writeFileSync(configuredPluginFile, "export default {};\n");
     const output = [
       {
         type: "log",
@@ -366,6 +368,21 @@ describe("openclaw live updater", () => {
           },
         }),
       },
+      {
+        type: "log",
+        time: "2026-07-11T08:00:07.000Z",
+        level: "error",
+        message: "configured standalone plugin failure",
+        raw: JSON.stringify({
+          "0": "configured standalone plugin failure",
+          time: "2026-07-11T08:00:07.000Z",
+          _meta: {
+            date: "2026-07-11T08:00:07.000Z",
+            logLevelName: "ERROR",
+            path: { fullFilePath: `${configuredPluginFile}:12:3` },
+          },
+        }),
+      },
     ]
       .map((entry) => JSON.stringify(entry))
       .join("\n");
@@ -373,20 +390,22 @@ describe("openclaw live updater", () => {
     expect(
       parseGatewayLogAudit(output, Date.parse("2026-07-11T08:00:02.000Z"), sourceRoot, [
         path.join(foreignRoot, "extensions/configured"),
+        configuredPluginFile,
       ]),
     ).toMatchObject({
-      entries: 3,
-      errorCount: 3,
+      entries: 4,
+      errorCount: 4,
       errors: [
         { message: "managed failure" },
         { message: "installed plugin failure" },
         { message: "configured foreign-checkout plugin failure" },
+        { message: "configured standalone plugin failure" },
       ],
     });
 
     expect(
       parseGatewayLogAudit(output, Date.parse("2026-07-11T08:00:02.000Z"), sourceRoot, null),
-    ).toMatchObject({ entries: 4, errorCount: 4 });
+    ).toMatchObject({ entries: 5, errorCount: 5 });
   });
 
   test("retries bounded Gateway readiness after restart", () => {

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -349,17 +349,44 @@ describe("openclaw live updater", () => {
           },
         }),
       },
+      {
+        type: "log",
+        time: "2026-07-11T08:00:06.000Z",
+        level: "error",
+        message: "configured foreign-checkout plugin failure",
+        raw: JSON.stringify({
+          "0": "configured foreign-checkout plugin failure",
+          time: "2026-07-11T08:00:06.000Z",
+          _meta: {
+            date: "2026-07-11T08:00:06.000Z",
+            logLevelName: "ERROR",
+            path: {
+              fullFilePath: path.join(foreignRoot, "extensions/configured/dist/logger.js"),
+            },
+          },
+        }),
+      },
     ]
       .map((entry) => JSON.stringify(entry))
       .join("\n");
 
     expect(
-      parseGatewayLogAudit(output, Date.parse("2026-07-11T08:00:02.000Z"), sourceRoot),
+      parseGatewayLogAudit(output, Date.parse("2026-07-11T08:00:02.000Z"), sourceRoot, [
+        path.join(foreignRoot, "extensions/configured"),
+      ]),
     ).toMatchObject({
-      entries: 2,
-      errorCount: 2,
-      errors: [{ message: "managed failure" }, { message: "installed plugin failure" }],
+      entries: 3,
+      errorCount: 3,
+      errors: [
+        { message: "managed failure" },
+        { message: "installed plugin failure" },
+        { message: "configured foreign-checkout plugin failure" },
+      ],
     });
+
+    expect(
+      parseGatewayLogAudit(output, Date.parse("2026-07-11T08:00:02.000Z"), sourceRoot, null),
+    ).toMatchObject({ entries: 4, errorCount: 4 });
   });
 
   test("retries bounded Gateway readiness after restart", () => {

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -14,7 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, test } from "vitest";
 import {
   acquireMaintenanceLock,
@@ -252,6 +252,116 @@ describe("openclaw live updater", () => {
     });
   });
 
+  test("ignores restart-window logs emitted by a foreign OpenClaw checkout", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-log-attribution-"));
+    const sourceRoot = path.join(root, "managed/openclaw/dist");
+    const foreignRoot = path.join(root, "worktree/openclaw");
+    mkdirSync(path.join(foreignRoot, ".git"), { recursive: true });
+    writeFileSync(path.join(foreignRoot, "package.json"), '{"name":"openclaw"}\n');
+    const output = [
+      {
+        "0": '{"subsystem":"gateway"}',
+        "1": "managed warning",
+        time: "2026-07-11T08:00:03.000Z",
+        _meta: {
+          date: "2026-07-11T08:00:03.000Z",
+          logLevelName: "WARN",
+          path: { fullFilePath: `${sourceRoot}/subsystem-current.js` },
+        },
+      },
+      {
+        "0": "[tools] browser failed",
+        time: "2026-07-11T08:00:04.000Z",
+        _meta: {
+          date: "2026-07-11T08:00:04.000Z",
+          logLevelName: "ERROR",
+          path: {
+            fullFilePath: pathToFileURL(path.join(foreignRoot, "dist/console-foreign.js")).href,
+          },
+        },
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join("\n");
+
+    expect(
+      parseGatewayLogAudit(output, Date.parse("2026-07-11T08:00:02.000Z"), sourceRoot),
+    ).toEqual({
+      entries: 1,
+      errorCount: 0,
+      warningCount: 1,
+      errors: [],
+      warnings: [
+        {
+          time: "2026-07-11T08:00:03.000Z",
+          level: "warn",
+          subsystem: "gateway",
+          message: "managed warning",
+        },
+      ],
+    });
+  });
+
+  test("scopes embedded RPC records without dropping unattributed errors", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-rpc-log-attribution-"));
+    const sourceRoot = path.join(root, "managed/openclaw/dist");
+    const foreignRoot = path.join(root, "worktree/openclaw");
+    mkdirSync(path.join(foreignRoot, ".git"), { recursive: true });
+    writeFileSync(path.join(foreignRoot, "package.json"), '{"name":"openclaw"}\n');
+    const output = [
+      {
+        type: "log",
+        time: "2026-07-11T08:00:03.000Z",
+        level: "error",
+        message: "managed failure",
+      },
+      {
+        type: "log",
+        time: "2026-07-11T08:00:04.000Z",
+        level: "error",
+        message: "foreign failure",
+        raw: JSON.stringify({
+          "0": "foreign failure",
+          time: "2026-07-11T08:00:04.000Z",
+          _meta: {
+            date: "2026-07-11T08:00:04.000Z",
+            logLevelName: "ERROR",
+            path: {
+              fullFilePath: pathToFileURL(path.join(foreignRoot, "dist/console-foreign.js")).href,
+            },
+          },
+        }),
+      },
+      {
+        type: "log",
+        time: "2026-07-11T08:00:05.000Z",
+        level: "error",
+        message: "installed plugin failure",
+        raw: JSON.stringify({
+          "0": "installed plugin failure",
+          time: "2026-07-11T08:00:05.000Z",
+          _meta: {
+            date: "2026-07-11T08:00:05.000Z",
+            logLevelName: "ERROR",
+            path: {
+              fullFilePath: path.join(root, "extensions/example/dist/logger.js"),
+            },
+          },
+        }),
+      },
+    ]
+      .map((entry) => JSON.stringify(entry))
+      .join("\n");
+
+    expect(
+      parseGatewayLogAudit(output, Date.parse("2026-07-11T08:00:02.000Z"), sourceRoot),
+    ).toMatchObject({
+      entries: 2,
+      errorCount: 2,
+      errors: [{ message: "managed failure" }, { message: "installed plugin failure" }],
+    });
+  });
+
   test("retries bounded Gateway readiness after restart", () => {
     const { mirror } = makeFixture();
     writeBuild(mirror);
@@ -367,6 +477,8 @@ describe("openclaw live updater", () => {
     git(runtimeRoot, "clone", origin, snapshot);
     git(snapshot, "remote", "set-url", "origin", "https://github.com/openclaw/openclaw.git");
     git(snapshot, "checkout", "--detach", head);
+    chmodSync(path.join(snapshot, ".git/HEAD"), 0o600);
+    chmodSync(path.join(snapshot, ".git/config"), 0o600);
     writeBuild(snapshot);
     const entrypoint = path.join(snapshot, "dist/index.js");
 

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -304,6 +304,36 @@ describe("openclaw live updater", () => {
     });
   });
 
+  test("keeps managed restart logs when the deployment root is symlinked", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-log-symlink-attribution-"));
+    const releaseRoot = path.join(root, "releases/abc");
+    const releaseDist = path.join(releaseRoot, "dist");
+    const linkedRoot = path.join(root, "current");
+    mkdirSync(releaseDist, { recursive: true });
+    mkdirSync(path.join(releaseRoot, ".git"));
+    writeFileSync(path.join(releaseRoot, "package.json"), '{"name":"openclaw"}\n');
+    const sourceFile = path.join(releaseDist, "console-managed.js");
+    writeFileSync(sourceFile, "export {};\n");
+    symlinkSync(releaseRoot, linkedRoot);
+    const output = JSON.stringify({
+      "0": "managed failure",
+      time: "2026-07-11T08:00:03.000Z",
+      _meta: {
+        date: "2026-07-11T08:00:03.000Z",
+        logLevelName: "ERROR",
+        path: { fullFilePath: sourceFile },
+      },
+    });
+
+    expect(
+      parseGatewayLogAudit(
+        output,
+        Date.parse("2026-07-11T08:00:02.000Z"),
+        path.join(linkedRoot, "dist"),
+      ),
+    ).toMatchObject({ entries: 1, errorCount: 1 });
+  });
+
   test("scopes embedded RPC records without dropping unattributed errors", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-rpc-log-attribution-"));
     const sourceRoot = path.join(root, "managed/openclaw/dist");

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -29,6 +29,7 @@ import {
   prepareGatewaySuspension,
   replaceLaunchAgentProgramArgument,
   repointManagedGatewayDeployment,
+  resolveManagedGatewaySourceRoot,
   resolveManagedPluginSourceRoots,
   resolveManagedGatewayEntrypoint,
   runBuiltGatewayCall,
@@ -425,6 +426,14 @@ describe("openclaw live updater", () => {
     ]);
     expect(resolveManagedPluginSourceRoots({ plugins: [{ id: "unknown" }] })).toBeNull();
     expect(resolveManagedPluginSourceRoots({})).toBeNull();
+  });
+
+  test("scopes restart logs to the effective managed runtime", () => {
+    expect(
+      resolveManagedGatewaySourceRoot("/srv/openclaw", {
+        entrypoint: "/srv/runtime/gateway-abc/dist/index.js",
+      }),
+    ).toBe("/srv/runtime/gateway-abc/dist");
   });
 
   test("retries bounded Gateway readiness after restart", () => {

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -29,7 +29,7 @@ import {
   prepareGatewaySuspension,
   replaceLaunchAgentProgramArgument,
   repointManagedGatewayDeployment,
-  resolveConfiguredPluginLoadPaths,
+  resolveManagedPluginSourceRoots,
   resolveManagedGatewayEntrypoint,
   runBuiltGatewayCall,
   verifyGatewayReadiness,
@@ -409,15 +409,22 @@ describe("openclaw live updater", () => {
     ).toMatchObject({ entries: 5, errorCount: 5 });
   });
 
-  test("resolves configured plugin paths without requiring a service working directory", () => {
-    expect(resolveConfiguredPluginLoadPaths([], undefined)).toEqual([]);
-    expect(resolveConfiguredPluginLoadPaths(["/opt/openclaw-plugin"], undefined)).toEqual([
-      "/opt/openclaw-plugin",
+  test("uses every enabled plugin root reported by managed discovery", () => {
+    expect(
+      resolveManagedPluginSourceRoots({
+        plugins: [
+          { id: "configured", rootDir: "/opt/configured-plugin" },
+          { id: "workspace", rootDir: "/srv/workspace/.openclaw/extensions/workspace" },
+          { id: "global", rootDir: "/Users/test/.openclaw/extensions/global" },
+        ],
+      }),
+    ).toEqual([
+      "/opt/configured-plugin",
+      "/srv/workspace/.openclaw/extensions/workspace",
+      "/Users/test/.openclaw/extensions/global",
     ]);
-    expect(resolveConfiguredPluginLoadPaths(["./plugins/example"], undefined)).toBeNull();
-    expect(resolveConfiguredPluginLoadPaths(["./plugins/example"], "/srv/openclaw")).toEqual([
-      "/srv/openclaw/plugins/example",
-    ]);
+    expect(resolveManagedPluginSourceRoots({ plugins: [{ id: "unknown" }] })).toBeNull();
+    expect(resolveManagedPluginSourceRoots({})).toBeNull();
   });
 
   test("retries bounded Gateway readiness after restart", () => {

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -29,6 +29,7 @@ import {
   prepareGatewaySuspension,
   replaceLaunchAgentProgramArgument,
   repointManagedGatewayDeployment,
+  resolveConfiguredPluginLoadPaths,
   resolveManagedGatewayEntrypoint,
   runBuiltGatewayCall,
   verifyGatewayReadiness,
@@ -406,6 +407,17 @@ describe("openclaw live updater", () => {
     expect(
       parseGatewayLogAudit(output, Date.parse("2026-07-11T08:00:02.000Z"), sourceRoot, null),
     ).toMatchObject({ entries: 5, errorCount: 5 });
+  });
+
+  test("resolves configured plugin paths without requiring a service working directory", () => {
+    expect(resolveConfiguredPluginLoadPaths([], undefined)).toEqual([]);
+    expect(resolveConfiguredPluginLoadPaths(["/opt/openclaw-plugin"], undefined)).toEqual([
+      "/opt/openclaw-plugin",
+    ]);
+    expect(resolveConfiguredPluginLoadPaths(["./plugins/example"], undefined)).toBeNull();
+    expect(resolveConfiguredPluginLoadPaths(["./plugins/example"], "/srv/openclaw")).toEqual([
+      "/srv/openclaw/plugins/example",
+    ]);
   });
 
   test("retries bounded Gateway readiness after restart", () => {


### PR DESCRIPTION
## Summary

- parse embedded structured source paths from Gateway RPC log records
- ignore restart-window records only when they are proven to come from another OpenClaw Git checkout
- bind attribution to the exact managed runtime and every enabled plugin source root
- canonicalize symlinked runtime/plugin roots and keep discovery failures fail-closed

## Testing

- `pnpm exec vitest run test/scripts/openclaw-live-updater.test.ts` (52/52)
- `pnpm check:test-types`
- Blacksmith Testbox targeted foreign-checkout regression (`tbx_01kxam75z6aydm6res5e91a90z`)
- autoreview clean
