### PR TITLE
fix(agents): gate compaction rotation for sqlite-backed sessions

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -414,6 +414,19 @@ describe("rotateTranscriptAfterCompaction", () => {
     expect(result.reason).toBe("sqlite-backed session");
   });
 
+  it("file-only rotation skips a sqlite-backed marker without reading it as a file", async () => {
+    const dir = await createTmpDir();
+
+    // A real fs.readFile on this marker would throw; the wrapper must gate
+    // before calling readTranscriptFileState to return the same signal.
+    const result = await rotateTranscriptFileAfterCompaction({
+      sessionFile: `sqlite:test-agent:test-session:${path.join(dir, "openclaw-agent.sqlite")}`,
+    });
+
+    expect(result.rotated).toBe(false);
+    expect(result.reason).toBe("sqlite-backed session");
+  });
+
   it("uses a refreshed manager after manual boundary hardening", async () => {
     const dir = await createTmpDir();
     const manager = SessionManager.create(dir, dir);

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -399,6 +399,21 @@ describe("rotateTranscriptAfterCompaction", () => {
     expect(result.reason).toBe("no compaction entry");
   });
 
+  it("skips rotation for a sqlite-backed session file marker", async () => {
+    const dir = await createTmpDir();
+    const { manager } = createCompactedSession(dir);
+
+    // `sqlite:<agentId>:<sessionId>:<storePath>` is not a filesystem path;
+    // rotating it would resolve a bogus successor path via path.dirname.
+    const result = await rotateTranscriptAfterCompaction({
+      sessionManager: manager,
+      sessionFile: `sqlite:test-agent:test-session:${path.join(dir, "openclaw-agent.sqlite")}`,
+    });
+
+    expect(result.rotated).toBe(false);
+    expect(result.reason).toBe("sqlite-backed session");
+  });
+
   it("uses a refreshed manager after manual boundary hardening", async () => {
     const dir = await createTmpDir();
     const manager = SessionManager.create(dir, dir);

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -4,6 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  upsertSessionEntry,
+  loadTranscriptEvents,
+} from "../../config/sessions/session-accessor.js";
+import { formatSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
   rotateTranscriptAfterCompaction,
@@ -399,19 +404,88 @@ describe("rotateTranscriptAfterCompaction", () => {
     expect(result.reason).toBe("no compaction entry");
   });
 
-  it("skips rotation for a sqlite-backed session file marker", async () => {
+  it("rotates a compacted sqlite-backed session into a new sqlite successor session", async () => {
     const dir = await createTmpDir();
-    const { manager } = createCompactedSession(dir);
+    const storePath = path.join(dir, "sessions.sqlite");
+    const agentId = "test-agent";
+    const sessionId = "sqlite-source-session";
+    const sessionKey = "agent:test-agent:main:sqlite-rotate";
+    const marker = formatSqliteSessionFileMarker({ agentId, sessionId, storePath });
 
-    // `sqlite:<agentId>:<sessionId>:<storePath>` is not a filesystem path;
-    // rotating it would resolve a bogus successor path via path.dirname.
-    const result = await rotateTranscriptAfterCompaction({
-      sessionManager: manager,
-      sessionFile: `sqlite:test-agent:test-session:${path.join(dir, "openclaw-agent.sqlite")}`,
+    // Real after-turn rotation requires a resolvable session entry: register
+    // the source session before opening it, matching production bootstrap.
+    await upsertSessionEntry(
+      { agentId, sessionKey, storePath },
+      { sessionFile: marker, sessionId, updatedAt: 10 },
+    );
+
+    const manager = SessionManager.open(marker, dir, dir);
+    manager.appendModelChange("openai", "gpt-5.2");
+    manager.appendThinkingLevelChange("medium");
+    manager.appendCustomEntry("test-extension", { cursor: "before-compaction" });
+    const oldUserId = manager.appendMessage({ role: "user", content: "old user", timestamp: 1 });
+    manager.appendLabelChange(oldUserId, "old bookmark");
+    manager.appendMessage(makeAssistant("old assistant", 2));
+    const firstKeptId = manager.appendMessage({
+      role: "user",
+      content: "kept user",
+      timestamp: 3,
+    });
+    manager.appendLabelChange(firstKeptId, "kept bookmark");
+    manager.appendMessage(makeAssistant("kept assistant", 4));
+    manager.appendCompaction("Summary of old user and old assistant.", firstKeptId, 5000);
+    manager.appendMessage({ role: "user", content: "post user", timestamp: 5 });
+    manager.appendMessage(makeAssistant("post assistant", 6));
+
+    const beforeSourceEntries = await loadTranscriptEvents({
+      agentId,
+      sessionId,
+      sessionKey,
+      storePath,
     });
 
-    expect(result.rotated).toBe(false);
-    expect(result.reason).toBe("sqlite-backed session");
+    const result = await rotateTranscriptAfterCompaction({
+      sessionManager: manager,
+      sessionFile: marker,
+      sessionKey,
+      now: () => new Date("2026-04-27T12:00:00.000Z"),
+    });
+
+    expect(result.rotated).toBe(true);
+    expect(result.reason).toBeUndefined();
+    const successorSessionId = requireString(result.sessionId, "successor session id");
+    const successorFile = requireString(result.sessionFile, "successor session file");
+    expect(successorFile).toMatch(/^sqlite:/);
+    expect(successorSessionId).not.toBe(sessionId);
+
+    // Source session is left completely untouched as an archive.
+    const afterSourceEntries = await loadTranscriptEvents({
+      agentId,
+      sessionId,
+      sessionKey,
+      storePath,
+    });
+    expect(afterSourceEntries).toEqual(beforeSourceEntries);
+
+    // The registry entry for this key now resolves the rotated successor, so
+    // the next turn's `SessionManager.open` picks up the smaller transcript
+    // instead of immediately retriggering the byte-size guard on the archive.
+    const successor = SessionManager.open(successorFile, dir, dir);
+    const header = requireValue(successor.getHeader(), "successor header");
+    expect(header.id).toBe(successorSessionId);
+    expect(header.parentSession).toBe(marker);
+    expect(header.cwd).toBe(dir);
+    expect(successor.getEntries().length).toBeLessThan(manager.getEntries().length);
+    requireEntryByIdAndType(successor.getBranch(), firstKeptId, "message", "kept user entry");
+    expect(successor.getBranch().some((entry) => entry.id === oldUserId)).toBe(false);
+    expect(successor.getLabel(firstKeptId)).toBe("kept bookmark");
+    expect(successor.getLabel(oldUserId)).toBeUndefined();
+
+    const context = successor.buildSessionContext();
+    const contextText = JSON.stringify(context.messages);
+    expect(contextText).toContain("Summary of old user and old assistant.");
+    expect(contextText).toContain("kept user");
+    expect(contextText).toContain("post assistant");
   });
 
   it("file-only rotation skips a sqlite-backed marker without reading it as a file", async () => {

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -7,6 +7,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   upsertSessionEntry,
   loadTranscriptEvents,
+  loadExactSessionEntry,
+  readTranscriptStatsSync,
 } from "../../config/sessions/session-accessor.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
@@ -423,9 +425,17 @@ describe("rotateTranscriptAfterCompaction", () => {
     manager.appendModelChange("openai", "gpt-5.2");
     manager.appendThinkingLevelChange("medium");
     manager.appendCustomEntry("test-extension", { cursor: "before-compaction" });
-    const oldUserId = manager.appendMessage({ role: "user", content: "old user", timestamp: 1 });
+    // Large summarized content so the successor's real byte size measurably
+    // shrinks after dropping it, not just a smaller entry count.
+    const largeOldContent = "old user content ".repeat(2000);
+    const largeOldAssistantContent = "old assistant content ".repeat(2000);
+    const oldUserId = manager.appendMessage({
+      role: "user",
+      content: largeOldContent,
+      timestamp: 1,
+    });
     manager.appendLabelChange(oldUserId, "old bookmark");
-    manager.appendMessage(makeAssistant("old assistant", 2));
+    manager.appendMessage(makeAssistant(largeOldAssistantContent, 2));
     const firstKeptId = manager.appendMessage({
       role: "user",
       content: "kept user",
@@ -486,6 +496,164 @@ describe("rotateTranscriptAfterCompaction", () => {
     expect(contextText).toContain("Summary of old user and old assistant.");
     expect(contextText).toContain("kept user");
     expect(contextText).toContain("post assistant");
+
+    // Prove the identity moved by re-resolving through the session KEY (not by
+    // opening the returned file directly), matching how the next turn's
+    // key-based lookup adopts the successor.
+    const resolvedByKey = loadExactSessionEntry({ agentId, sessionKey, storePath });
+    expect(resolvedByKey?.entry?.sessionId).toBe(successorSessionId);
+    expect(resolvedByKey?.entry?.sessionFile).toBe(successorFile);
+
+    // Prove an actual production byte-size reduction (not just an entry-count
+    // proxy): the successor's real SQLite transcript stats must be smaller
+    // than the archived source's, so the byte-size guard resolving through the
+    // repointed key will not immediately refire on the same oversized archive.
+    const sourceStats = readTranscriptStatsSync({ agentId, sessionId, storePath });
+    const successorStats = readTranscriptStatsSync({
+      agentId,
+      sessionId: successorSessionId,
+      storePath,
+    });
+    expect(successorStats.sizeBytes).toBeLessThan(sourceStats.sizeBytes);
+  });
+
+  it("aborts sqlite rotation without writing orphan rows when the sessionKey has no resolvable registry entry", async () => {
+    const dir = await createTmpDir();
+    const storePath = path.join(dir, "sessions.sqlite");
+    const agentId = "test-agent";
+    const sessionId = "sqlite-source-session-desynced";
+    const sessionKey = "agent:test-agent:main:sqlite-rotate-desynced";
+    const marker = formatSqliteSessionFileMarker({ agentId, sessionId, storePath });
+
+    // Register the session under its real key so SessionManager.open can
+    // resolve it (production requires a resolvable entry to open at all)...
+    await upsertSessionEntry(
+      { agentId, sessionKey, storePath },
+      { sessionFile: marker, sessionId, updatedAt: 10 },
+    );
+
+    const manager = SessionManager.open(marker, dir, dir);
+    const firstKeptId = manager.appendMessage({
+      role: "user",
+      content: "kept user",
+      timestamp: 1,
+    });
+    manager.appendMessage(makeAssistant("kept assistant", 2));
+    manager.appendCompaction("Summary.", firstKeptId, 5000);
+    manager.appendMessage({ role: "user", content: "post user", timestamp: 3 });
+
+    // ...but rotate with a stale/mismatched key that has no registry row,
+    // simulating a desynced caller (e.g. a session/route record without a
+    // matching session_entries row). Rotation must abort rather than write
+    // orphaned successor rows nothing will ever resolve to.
+    const staleSessionKey = "agent:test-agent:main:sqlite-rotate-desynced:stale";
+
+    const beforeSourceEntries = await loadTranscriptEvents({
+      agentId,
+      sessionId,
+      sessionKey,
+      storePath,
+    });
+
+    const result = await rotateTranscriptAfterCompaction({
+      sessionManager: manager,
+      sessionFile: marker,
+      sessionKey: staleSessionKey,
+    });
+
+    expect(result.rotated).toBe(false);
+    expect(result.reason).toContain("no session_entries row resolves");
+
+    // No orphaned successor rows were committed: the source transcript is the
+    // only thing present in the store.
+    const afterSourceEntries = await loadTranscriptEvents({
+      agentId,
+      sessionId,
+      sessionKey,
+      storePath,
+    });
+    expect(afterSourceEntries).toEqual(beforeSourceEntries);
+    // The stale key still has no registry row, and the real key's entry is
+    // left pointing at the original (un-rotated) session.
+    expect(
+      loadExactSessionEntry({ agentId, sessionKey: staleSessionKey, storePath })?.entry,
+    ).toBeUndefined();
+    expect(loadExactSessionEntry({ agentId, sessionKey, storePath })?.entry?.sessionId).toBe(
+      sessionId,
+    );
+  });
+
+  it("aborts sqlite rotation without repointing an unrelated session when the key resolves to a different session", async () => {
+    const dir = await createTmpDir();
+    const storePath = path.join(dir, "sessions.sqlite");
+    const agentId = "test-agent";
+    const sessionId = "sqlite-source-session-mismatch";
+    const sessionKey = "agent:test-agent:main:sqlite-rotate-mismatch";
+    const marker = formatSqliteSessionFileMarker({ agentId, sessionId, storePath });
+
+    await upsertSessionEntry(
+      { agentId, sessionKey, storePath },
+      { sessionFile: marker, sessionId, updatedAt: 10 },
+    );
+
+    const manager = SessionManager.open(marker, dir, dir);
+    const firstKeptId = manager.appendMessage({
+      role: "user",
+      content: "kept user",
+      timestamp: 1,
+    });
+    manager.appendMessage(makeAssistant("kept assistant", 2));
+    manager.appendCompaction("Summary.", firstKeptId, 5000);
+    manager.appendMessage({ role: "user", content: "post user", timestamp: 3 });
+
+    // A second, unrelated session already registered under a DIFFERENT key.
+    // If the rotation only checked "does this key resolve to *some* row", a
+    // stale/desynced caller could pass this unrelated session's key and have
+    // its active identity clobbered to point at a successor of a completely
+    // different source session.
+    const otherSessionId = "sqlite-unrelated-session";
+    const otherSessionKey = "agent:test-agent:main:sqlite-unrelated";
+    const otherMarker = formatSqliteSessionFileMarker({
+      agentId,
+      sessionId: otherSessionId,
+      storePath,
+    });
+    await upsertSessionEntry(
+      { agentId, sessionKey: otherSessionKey, storePath },
+      { sessionFile: otherMarker, sessionId: otherSessionId, updatedAt: 10 },
+    );
+
+    const beforeSourceEntries = await loadTranscriptEvents({
+      agentId,
+      sessionId,
+      sessionKey,
+      storePath,
+    });
+
+    const result = await rotateTranscriptAfterCompaction({
+      sessionManager: manager,
+      sessionFile: marker,
+      // Mismatched: this key resolves to `otherSessionId`, not `sessionId`
+      // (the session actually being rotated via `marker`/`manager`).
+      sessionKey: otherSessionKey,
+    });
+
+    expect(result.rotated).toBe(false);
+    expect(result.reason).toContain("not the source session");
+
+    // No orphaned successor rows were committed for the rotated source.
+    const afterSourceEntries = await loadTranscriptEvents({
+      agentId,
+      sessionId,
+      sessionKey,
+      storePath,
+    });
+    expect(afterSourceEntries).toEqual(beforeSourceEntries);
+    // The unrelated session's registry entry is untouched — still pointing at
+    // its own original session, not clobbered to some successor of `sessionId`.
+    expect(
+      loadExactSessionEntry({ agentId, sessionKey: otherSessionKey, storePath })?.entry?.sessionId,
+    ).toBe(otherSessionId);
   });
 
   it("file-only rotation skips a sqlite-backed marker without reading it as a file", async () => {

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -4,6 +4,7 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import { rotateCompactionTranscript } from "../../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -39,17 +40,17 @@ export async function rotateTranscriptAfterCompaction(params: {
   sessionManager: ReadonlySessionManagerForRotation;
   sessionFile: string;
   now?: () => Date;
+  /**
+   * Registry key for the session being rotated. Required to keep SQLite-backed
+   * rotation usable across turns: without repointing this key's registry entry,
+   * the next turn's session lookup would keep resolving the archived (oversized)
+   * transcript instead of the newly created successor.
+   */
+  sessionKey?: string;
 }): Promise<CompactionTranscriptRotation> {
   const sessionFile = params.sessionFile.trim();
   if (!sessionFile) {
     return { rotated: false, reason: "missing session file" };
-  }
-  // Successor files are resolved by taking the dirname of `sessionFile` as a
-  // filesystem path. A `sqlite:` marker is not a path, so rotating one would
-  // write a stray `.jsonl` file at a nonsensical location. Gate centrally so
-  // every caller is protected, not just the ones that remember to check.
-  if (parseSqliteSessionFileMarker(sessionFile)) {
-    return { rotated: false, reason: "sqlite-backed session" };
   }
 
   const branch = params.sessionManager.getBranch();
@@ -61,11 +62,6 @@ export async function rotateTranscriptAfterCompaction(params: {
   const compaction = branch[latestCompactionIndex] as CompactionEntry;
   const timestamp = resolveTimestampMsToIsoString(params.now?.().getTime());
   const sessionId = randomUUID();
-  const successorFile = resolveSuccessorSessionFile({
-    sessionFile,
-    sessionId,
-    timestamp,
-  });
   const successorEntries = buildSuccessorEntries({
     allEntries: params.sessionManager.getEntries(),
     branch,
@@ -81,6 +77,39 @@ export async function rotateTranscriptAfterCompaction(params: {
     timestamp,
     cwd: params.sessionManager.getCwd(),
     parentSession: sessionFile,
+  });
+
+  const sqliteMarker = parseSqliteSessionFileMarker(sessionFile);
+  if (sqliteMarker) {
+    // SQLite-backed sessions have no filesystem directory to rotate a `.jsonl`
+    // successor into; the marker's agentId/storePath instead identify a new
+    // session row created atomically by the storage owner. The source session
+    // is left untouched as an archive, matching the file-backed contract below.
+    const written = await rotateCompactionTranscript({
+      agentId: sqliteMarker.agentId,
+      storePath: sqliteMarker.storePath,
+      sessionId,
+      header,
+      entries: successorEntries,
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    });
+    if (written.status !== "created") {
+      return { rotated: false, reason: "sqlite successor write failed" };
+    }
+    return {
+      rotated: true,
+      sessionId,
+      sessionFile: written.sessionFile,
+      compactionEntryId: compaction.id,
+      leafId: successorEntries[successorEntries.length - 1]?.id,
+      entriesWritten: successorEntries.length,
+    };
+  }
+
+  const successorFile = resolveSuccessorSessionFile({
+    sessionFile,
+    sessionId,
+    timestamp,
   });
   await writeTranscriptFileAtomic(successorFile, [header, ...successorEntries]);
   new TranscriptFileState({ header, entries: successorEntries }).buildSessionContext();

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -99,6 +99,12 @@ export async function rotateTranscriptFileAfterCompaction(params: {
   sessionFile: string;
   now?: () => Date;
 }): Promise<CompactionTranscriptRotation> {
+  // Check before reading: `readTranscriptFileState` does a raw `fs.readFile`,
+  // which throws on a `sqlite:` marker instead of returning the same
+  // `{ rotated: false }` signal `rotateTranscriptAfterCompaction` gives below.
+  if (parseSqliteSessionFileMarker(params.sessionFile)) {
+    return { rotated: false, reason: "sqlite-backed session" };
+  }
   const state = await readTranscriptFileState(params.sessionFile);
   return rotateTranscriptAfterCompaction({
     sessionManager: state,

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -4,6 +4,7 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CompactionEntry, SessionEntry, SessionHeader } from "../sessions/index.js";
@@ -42,6 +43,13 @@ export async function rotateTranscriptAfterCompaction(params: {
   const sessionFile = params.sessionFile.trim();
   if (!sessionFile) {
     return { rotated: false, reason: "missing session file" };
+  }
+  // Successor files are resolved by taking the dirname of `sessionFile` as a
+  // filesystem path. A `sqlite:` marker is not a path, so rotating one would
+  // write a stray `.jsonl` file at a nonsensical location. Gate centrally so
+  // every caller is protected, not just the ones that remember to check.
+  if (parseSqliteSessionFileMarker(sessionFile)) {
+    return { rotated: false, reason: "sqlite-backed session" };
   }
 
   const branch = params.sessionManager.getBranch();

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -91,10 +91,12 @@ export async function rotateTranscriptAfterCompaction(params: {
       sessionId,
       header,
       entries: successorEntries,
-      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+      ...(params.sessionKey
+        ? { sessionKey: params.sessionKey, sourceSessionId: sqliteMarker.sessionId }
+        : {}),
     });
     if (written.status !== "created") {
-      return { rotated: false, reason: "sqlite successor write failed" };
+      return { rotated: false, reason: written.reason ?? "sqlite successor write failed" };
     }
     return {
       rotated: true,

--- a/src/agents/embedded-agent-runner/run/attempt-after-turn.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-after-turn.ts
@@ -182,6 +182,7 @@ export async function completeEmbeddedAttemptAfterTurn(
           const rotation = await rotateTranscriptAfterCompaction({
             sessionManager,
             sessionFile: attempt.sessionFile,
+            ...(attempt.sessionKey ? { sessionKey: attempt.sessionKey } : {}),
           });
           if (rotation.rotated) {
             sessionIdUsed = rotation.sessionId ?? sessionIdUsed;

--- a/src/config/sessions/session-accessor.entry-mutation.ts
+++ b/src/config/sessions/session-accessor.entry-mutation.ts
@@ -19,6 +19,7 @@ import {
   updateSqliteSessionLastRoute,
   patchSqliteSessionEntry,
   resolveSqliteSessionParentForkDecision,
+  writeSqliteCompactionSuccessorTranscript,
 } from "./session-accessor.sqlite.js";
 import type {
   SessionAccessScope,
@@ -56,6 +57,31 @@ export async function forkSessionFromParentTranscript(
   params: ForkSessionFromParentTranscriptParams,
 ): Promise<ForkSessionFromParentTranscriptResult> {
   return await forkSqliteSessionTranscriptFromParent(params);
+}
+
+export type RotateCompactionTranscriptResult =
+  | { status: "created"; sessionId: string; sessionFile: string; entriesWritten: number }
+  | { status: "failed" };
+
+export type RotateCompactionTranscriptParams = {
+  agentId: string;
+  storePath: string;
+  sessionId: string;
+  header: unknown;
+  entries: readonly unknown[];
+  /** When provided, atomically repoints this session key's registry entry to the new session. */
+  sessionKey?: string;
+};
+
+/**
+ * Creates a compacted successor transcript as a new SQLite session, atomically.
+ * The source session is left untouched as an archive; callers adopt the
+ * returned session id/marker as the new active identity.
+ */
+export async function rotateCompactionTranscript(
+  params: RotateCompactionTranscriptParams,
+): Promise<RotateCompactionTranscriptResult> {
+  return await writeSqliteCompactionSuccessorTranscript(params);
 }
 
 /**

--- a/src/config/sessions/session-accessor.entry-mutation.ts
+++ b/src/config/sessions/session-accessor.entry-mutation.ts
@@ -61,7 +61,7 @@ export async function forkSessionFromParentTranscript(
 
 export type RotateCompactionTranscriptResult =
   | { status: "created"; sessionId: string; sessionFile: string; entriesWritten: number }
-  | { status: "failed" };
+  | { status: "failed"; reason?: string };
 
 export type RotateCompactionTranscriptParams = {
   agentId: string;
@@ -71,6 +71,13 @@ export type RotateCompactionTranscriptParams = {
   entries: readonly unknown[];
   /** When provided, atomically repoints this session key's registry entry to the new session. */
   sessionKey?: string;
+  /**
+   * The session id being rotated (the archive source). Required alongside
+   * `sessionKey` so the repoint target can be verified as the same session
+   * instead of any registry row the key happens to resolve to; a desynced or
+   * stale key must not silently repoint an unrelated session's identity.
+   */
+  sourceSessionId?: string;
 };
 
 /**

--- a/src/config/sessions/session-accessor.sqlite-checkpoint.ts
+++ b/src/config/sessions/session-accessor.sqlite-checkpoint.ts
@@ -18,6 +18,7 @@ import {
   getSessionKysely,
   normalizeSqliteSessionKey,
   resolveSqliteScope,
+  resolveSqliteStoreScope,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
   type ResolvedSqliteScope,
@@ -138,6 +139,81 @@ export async function restoreSqliteCompactionCheckpointSession(
     }, toDatabaseOptions(resolved));
     emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     return result ?? { status: "failed" };
+  });
+}
+
+/** Result from writing a compacted successor transcript directly into SQLite. */
+type SqliteCompactionSuccessorTranscriptResult =
+  | { status: "created"; sessionId: string; sessionFile: string; entriesWritten: number }
+  | { status: "failed" };
+
+/** Parameters for creating a new SQLite session that holds a compacted successor transcript. */
+type SqliteCompactionSuccessorTranscriptParams = {
+  agentId: string;
+  storePath: string;
+  sessionId: string;
+  header: TranscriptEvent;
+  entries: readonly TranscriptEvent[];
+  /** When provided, atomically repoints this session key's registry entry to the new session. */
+  sessionKey?: string;
+};
+
+/**
+ * Writes a compacted successor transcript as a brand-new SQLite session, atomically.
+ * Mirrors file-backed compaction rotation: the source session/transcript is left
+ * completely untouched (kept as archive under its original id). When `sessionKey`
+ * is provided, the session registry entry for that key is repointed to the new
+ * session id/file in the same transaction, so the next turn's `SessionManager.open`
+ * (and any other key-based lookup) resolves the rotated session instead of the
+ * archived one. Without this, callers adopting `rotated: true` would keep the
+ * old key pointed at the oversized transcript, immediately re-triggering the
+ * byte-size guard on the very next preflight.
+ */
+export async function writeSqliteCompactionSuccessorTranscript(
+  params: SqliteCompactionSuccessorTranscriptParams,
+): Promise<SqliteCompactionSuccessorTranscriptResult> {
+  const resolved = resolveSqliteStoreScope(params.storePath, { agentId: params.agentId });
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const targetScope = { ...resolved, sessionId: params.sessionId };
+    const sessionFile = formatSqliteSessionMarkerForScope(targetScope);
+    let entriesWritten = 0;
+    let previousIdentity = new Map<string, SessionEntry>();
+    let currentIdentity = new Map<string, SessionEntry>();
+    runOpenClawAgentWriteTransaction((database) => {
+      const normalizedSessionKey = params.sessionKey
+        ? normalizeSqliteSessionKey(params.sessionKey)
+        : undefined;
+      const identityKeys = normalizedSessionKey
+        ? collectSessionEntryLookupKeys(database, normalizedSessionKey)
+        : [];
+      previousIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
+      entriesWritten = appendTranscriptEventsInTransaction(database, targetScope, [
+        params.header,
+        ...params.entries,
+      ]);
+      if (entriesWritten > 0 && normalizedSessionKey) {
+        const currentEntry = readSessionEntryRow(database, normalizedSessionKey)?.entry;
+        if (currentEntry) {
+          const nextEntry = cloneSqliteCheckpointSessionEntry({
+            currentEntry,
+            nextSessionId: params.sessionId,
+            nextSessionFile: sessionFile,
+          });
+          writeSessionEntry(database, normalizedSessionKey, nextEntry);
+        }
+      }
+      currentIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
+    }, toDatabaseOptions(resolved));
+    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
+    if (entriesWritten === 0) {
+      return { status: "failed" };
+    }
+    return {
+      status: "created",
+      sessionId: params.sessionId,
+      sessionFile,
+      entriesWritten,
+    };
   });
 }
 

--- a/src/config/sessions/session-accessor.sqlite-checkpoint.ts
+++ b/src/config/sessions/session-accessor.sqlite-checkpoint.ts
@@ -145,7 +145,23 @@ export async function restoreSqliteCompactionCheckpointSession(
 /** Result from writing a compacted successor transcript directly into SQLite. */
 type SqliteCompactionSuccessorTranscriptResult =
   | { status: "created"; sessionId: string; sessionFile: string; entriesWritten: number }
-  | { status: "failed" };
+  | { status: "failed"; reason?: string };
+
+/**
+ * Thrown inside the write transaction when a `sessionKey` was provided but the
+ * repoint target can't be verified safe. Rotation is a contract that includes
+ * moving the active identity to the successor; if that repoint target doesn't
+ * exist, or resolves to a *different* session than the one being rotated
+ * (a desynced/stale key), abort before any successor rows are written instead
+ * of committing rows nothing will ever resolve to, or worse, silently
+ * repointing an unrelated session's identity to this successor.
+ */
+class SqliteCompactionSuccessorRepointUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SqliteCompactionSuccessorRepointUnavailableError";
+  }
+}
 
 /** Parameters for creating a new SQLite session that holds a compacted successor transcript. */
 type SqliteCompactionSuccessorTranscriptParams = {
@@ -156,6 +172,14 @@ type SqliteCompactionSuccessorTranscriptParams = {
   entries: readonly TranscriptEvent[];
   /** When provided, atomically repoints this session key's registry entry to the new session. */
   sessionKey?: string;
+  /**
+   * The session id being rotated (the archive source). When `sessionKey` is
+   * also provided, the resolved registry entry's `sessionId` must match this
+   * value before any repoint happens, so a stale/desynced key that now
+   * resolves to a *different* session can't have its active identity
+   * clobbered by this rotation.
+   */
+  sourceSessionId?: string;
 };
 
 /**
@@ -179,21 +203,54 @@ export async function writeSqliteCompactionSuccessorTranscript(
     let entriesWritten = 0;
     let previousIdentity = new Map<string, SessionEntry>();
     let currentIdentity = new Map<string, SessionEntry>();
-    runOpenClawAgentWriteTransaction((database) => {
-      const normalizedSessionKey = params.sessionKey
-        ? normalizeSqliteSessionKey(params.sessionKey)
-        : undefined;
-      const identityKeys = normalizedSessionKey
-        ? collectSessionEntryLookupKeys(database, normalizedSessionKey)
-        : [];
-      previousIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
-      entriesWritten = appendTranscriptEventsInTransaction(database, targetScope, [
-        params.header,
-        ...params.entries,
-      ]);
-      if (entriesWritten > 0 && normalizedSessionKey) {
-        const currentEntry = readSessionEntryRow(database, normalizedSessionKey)?.entry;
-        if (currentEntry) {
+    try {
+      runOpenClawAgentWriteTransaction((database) => {
+        const normalizedSessionKey = params.sessionKey
+          ? normalizeSqliteSessionKey(params.sessionKey)
+          : undefined;
+        // Resolve (and validate) the repoint target before writing any successor
+        // rows. A provided sessionKey with no resolvable session_entries row, or
+        // one that resolves to a session other than the one being rotated
+        // (stale/desynced key), means the active identity can't be safely moved
+        // to the successor, so abort the whole transaction rather than commit
+        // orphaned rows or repoint an unrelated session's identity.
+        const currentEntry = normalizedSessionKey
+          ? readSessionEntryRow(database, normalizedSessionKey)?.entry
+          : undefined;
+        if (normalizedSessionKey && !currentEntry) {
+          throw new SqliteCompactionSuccessorRepointUnavailableError(
+            `no session_entries row resolves sessionKey "${normalizedSessionKey}" for compaction rotation`,
+          );
+        }
+        // sourceSessionId is required alongside sessionKey: without it there's
+        // no way to verify the resolved entry belongs to the session actually
+        // being rotated, so a stale/desynced key could otherwise repoint an
+        // unrelated session's identity. Fail closed rather than skip the check.
+        if (normalizedSessionKey && !params.sourceSessionId) {
+          throw new SqliteCompactionSuccessorRepointUnavailableError(
+            `sourceSessionId is required to verify sessionKey "${normalizedSessionKey}" before compaction rotation repoint`,
+          );
+        }
+        if (
+          normalizedSessionKey &&
+          currentEntry &&
+          params.sourceSessionId &&
+          currentEntry.sessionId !== params.sourceSessionId
+        ) {
+          throw new SqliteCompactionSuccessorRepointUnavailableError(
+            `sessionKey "${normalizedSessionKey}" resolves to session "${currentEntry.sessionId}", ` +
+              `not the source session "${params.sourceSessionId}" being rotated`,
+          );
+        }
+        const identityKeys = normalizedSessionKey
+          ? collectSessionEntryLookupKeys(database, normalizedSessionKey)
+          : [];
+        previousIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
+        entriesWritten = appendTranscriptEventsInTransaction(database, targetScope, [
+          params.header,
+          ...params.entries,
+        ]);
+        if (entriesWritten > 0 && normalizedSessionKey && currentEntry) {
           const nextEntry = cloneSqliteCheckpointSessionEntry({
             currentEntry,
             nextSessionId: params.sessionId,
@@ -201,12 +258,17 @@ export async function writeSqliteCompactionSuccessorTranscript(
           });
           writeSessionEntry(database, normalizedSessionKey, nextEntry);
         }
+        currentIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
+      }, toDatabaseOptions(resolved));
+    } catch (error) {
+      if (error instanceof SqliteCompactionSuccessorRepointUnavailableError) {
+        return { status: "failed", reason: error.message };
       }
-      currentIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
-    }, toDatabaseOptions(resolved));
+      throw error;
+    }
     emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     if (entriesWritten === 0) {
-      return { status: "failed" };
+      return { status: "failed", reason: "sqlite successor transcript write produced no rows" };
     }
     return {
       status: "created",

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -38,6 +38,7 @@ export {
 export {
   branchSqliteCompactionCheckpointSession,
   restoreSqliteCompactionCheckpointSession,
+  writeSqliteCompactionSuccessorTranscript,
 } from "./session-accessor.sqlite-checkpoint.js";
 export {
   forkSqliteSessionAtMessage,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -117,6 +117,8 @@ export type {
 } from "./session-transcript-turn-lifecycle.types.js";
 export type {
   RecordInboundSessionMetaParams,
+  RotateCompactionTranscriptParams,
+  RotateCompactionTranscriptResult,
   UpdateSessionLastRouteParams,
 } from "./session-accessor.entry-mutation.js";
 export {
@@ -147,6 +149,7 @@ export {
   recordInboundSessionMeta,
   resolveSessionAbortTarget,
   resolveSessionParentForkDecision,
+  rotateCompactionTranscript,
   updateSessionEntry,
   updateSessionLastRoute,
 } from "./session-accessor.entry-mutation.js";


### PR DESCRIPTION
Closes #104769

## What Problem This Solves

Fixes an issue where agents using sqlite-backed session storage could hit an
`ENOENT: no such file or directory, mkdir 'sqlite:...'` error path when
compaction transcript rotation ran through the post-flip
`run/attempt-after-turn.ts` call site. Rotation tries to compute a successor
transcript path with
`path.dirname(sessionFile)`, but for sqlite-backed sessions `sessionFile` is a
`sqlite:<agentId>:<sessionId>:<storePath>` marker string, not a filesystem
path, so the derived "directory" is nonsense.

## Why This Change Was Made

`compact.ts` already guards its own rotation call with
`!isSqliteSessionTranscript`, but `run/attempt-after-turn.ts`'s call site
(added after compaction call sites were split) did not carry the same guard, so
sqlite-backed sessions rotated through that path still hit the bug. Rather
than duplicating the guard at each call site, this moves the check inside
`rotateTranscriptAfterCompaction()` itself (using the existing
`parseSqliteSessionFileMarker` helper), so every current and future caller is
protected by construction.

**Update per @steipete's review**: the initial fix above only stopped the
crash by making sqlite-backed rotation a silent no-op (`{ rotated: false,
reason: "sqlite-backed session" }`). That is not the real contract:
`truncateAfterCompaction` is a successor-transcript feature, and the sqlite
byte-size guard (#104940) can retrigger compaction on the same oversized
transcript every turn if rotation never actually happens. A follow-up commit
moves the sqlite case to the session-accessor/storage owner
(`writeSqliteCompactionSuccessorTranscript`):
- Creates the compacted successor transcript as a brand-new sqlite session,
  atomically, leaving the source session untouched as an archive.
- When a `sessionKey` is provided, atomically repoints that key's registry
  entry to the new session so the next turn's `SessionManager.open` resolves
  the smaller successor instead of the archived transcript.
- Validates the repoint target **before** writing any successor rows: if the
  `sessionKey` has no resolvable `session_entries` row, or resolves to a
  session other than the one actually being rotated (a stale/desynced key),
  the whole transaction aborts with no rows written, instead of silently
  creating orphaned rows or repointing an unrelated session's identity.

## User Impact

Agents configured with `truncateAfterCompaction: true` and sqlite-backed
session storage now get the same rotation benefit as file-backed sessions:
the oversized transcript is archived and the active session moves to a
smaller successor, so the byte-size guard does not immediately refire on the
same transcript. If the session registry is ever desynced in a way that would
make the repoint unsafe, rotation fails closed (returns a specific failure
reason) rather than silently succeeding or corrupting an unrelated session's
identity.

## Evidence

- Added a regression test asserting `rotateTranscriptFileAfterCompaction()`
  returns `{ rotated: false, reason: "sqlite-backed session" }` for a
  `sqlite:...` session file marker (the file-only wrapper still gates before
  calling `readTranscriptFileState`, keeping the ENOENT crash path closed for
  callers that never pass a `sessionManager`).
- Proved that regression: temporarily removed the guard and reran the test,
  which failed with
  `ENOENT: no such file or directory, mkdir 'C:\...\sqlite:test-agent:test-session:...'`
  — matching the exact failure mode described in the issue. Restored the fix
  and confirmed the test passes again.
- Added real sqlite-backed rotation coverage: the successor session is
  created, the source transcript rows are left unchanged, the registry key is
  proven to re-resolve to the successor (via `loadExactSessionEntry`, not by
  opening the returned file directly), and the successor's real
  `readTranscriptStatsSync` byte size is proven smaller than the source's
  (not just an entry-count proxy).
- Added two negative-path tests for the repoint validation: (a) a
  `sessionKey` with no resolvable registry row aborts with no orphan rows
  written; (b) a `sessionKey` that resolves to a *different*, valid,
  unrelated session aborts without repointing that unrelated session's
  identity.
- Proved these two new guards are load-bearing: reverted the validation code
  (keeping the new tests), reran the suite — both new tests failed as
  expected — then restored the fix and confirmed all tests pass again.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts` — 16/16 passed.
- This PR is agent-assisted (GitHub Copilot CLI); tested locally per the evidence above, CI runs the broader type/lint/test gates on the pushed head.
