### PR TITLE
fix(cli): warn that attach --print-config prints a live bearer token

### DIFF
--- a/docs/cli/attach.md
+++ b/docs/cli/attach.md
@@ -36,6 +36,10 @@ Options:
 - `--bin <path>` selects the Claude Code binary. Default: `claude`.
 - `--print-config` writes the temporary `.mcp.json`, prints the launch command and env, and leaves the grant live until TTL expiry (it does not spawn Claude Code or revoke the grant).
 
+<Warning>
+The env that `--print-config` prints to stdout includes a live `OPENCLAW_MCP_TOKEN` bearer credential. Treat it as a secret: do not paste it into logs, chat transcripts, or shared reports.
+</Warning>
+
 Pass either a positional target or `--session`, not both. Short references are
 resolved before the scoped attach grant is minted; a missing session is never
 created implicitly.

--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -125,6 +125,17 @@ describe("openclaw attach (action)", () => {
     expect(out).not.toContain("attach.revoke");
   });
 
+  it("--print-config: warns on stderr that the printed env carries a live bearer token", async () => {
+    await runAttach("--print-config", "--session", "agent:main:cli");
+    const errLine = logs.find((line) => line.startsWith("ERR:"));
+    expect(errLine).toContain("OPENCLAW_MCP_TOKEN");
+    expect(errLine).toContain("secret");
+    // Warning must land before the JSON payload, not interleaved after it.
+    const warnIndex = logs.indexOf(errLine ?? "");
+    const jsonIndex = logs.findIndex((line) => line.includes('"sessionKey"'));
+    expect(warnIndex).toBeLessThan(jsonIndex);
+  });
+
   it("calls attach.grant in CLI mode with an auto-resolved device identity (operator.admin regression guard)", async () => {
     // Regression guard: attach.grant is operator.admin-scoped. mode BACKEND or an explicit
     // deviceIdentity:null drops the operator device identity → the gateway rejects with

--- a/src/cli/attach-cli.ts
+++ b/src/cli/attach-cli.ts
@@ -138,6 +138,12 @@ export async function registerAttachCli(program: Command, _argv: string[] = proc
         const claudeArgs = ["--strict-mcp-config", "--mcp-config", configPath];
 
         if (opts.printConfig) {
+          // The env block below carries a live, unrevoked bearer token. Warn on
+          // stderr (separate from the JSON on stdout) so a tester piping/copying
+          // stdout output doesn't miss that it must be treated as a secret.
+          defaultRuntime.error(
+            "WARNING: the JSON below includes a live OPENCLAW_MCP_TOKEN bearer credential (env.OPENCLAW_MCP_TOKEN). Treat it as a secret: do not paste it into logs, chat transcripts, or shared reports.",
+          );
           defaultRuntime.log(
             JSON.stringify(
               {


### PR DESCRIPTION
Related: #104517 — partial mitigation. Options 2–4 in that issue remain open.

## What Problem This Solves

`openclaw attach --print-config` prints the full MCP grant config, including
`env.OPENCLAW_MCP_TOKEN` — a live, unrevoked bearer credential — as plain JSON on
stdout with no indication that it is sensitive. Anyone copying that output into a
log, chat transcript, screen share, or bug report can leak the live token without
realizing it. As reported in #104517, this surfaced during a 2026.7.1-beta.5 canary
run where the report artifact had to be manually redacted afterwards.

## Why This Change Was Made

Adds a warning printed to **stderr** immediately before the JSON payload is printed
to **stdout**. Interactive users see it; scripted consumers that pipe or parse the
JSON are not affected, because the existing stdout output is unchanged by this
patch.

This implements only option 1 of #104517 (a clear warning). It deliberately does
not redact the token or reshape the printed config: that would break the documented
copy/launch workflow, and #104517 carries `needs-product-decision`,
`needs-security-review`, and `no-new-fix-pr`, so the shape of a log-safe default is
a maintainer call rather than something to settle inside a bugfix PR. The issue
stays open either way — this PR does not close it.

## User Impact

Interactive users who do not redirect stderr now get an explicit warning that the
printed env carries a live bearer token and must be treated as a secret.

Two limits are worth stating plainly:

- **The token is still in the default stdout output.** This reduces the chance of
  accidental copying; it does not remove the exposure.
- **stderr now carries one more line for this command.** Wrappers that treat any
  stderr output as failure will see it. (For context, the capture below shows this
  Node build already emitting a SQLite `ExperimentalWarning` on stderr for the same
  command.) stdout consumers are unaffected.

## Evidence

Sections 1–4 below were produced at head `45e0b05fefc136cc43153f18d3b019c6d272904e`;
section 3 used a single deliberate one-line mutation, described in place. The branch
has since been rebased onto latest `main` — #120893 rewrote this area — and the same
additions were re-applied at head `85c61d0cfffb1026837fbec355f3f6202a6794f4`, where the
focused suite is green at 17/17 and the net diff is still `+21 −0` across three files:
`src/cli/attach-cli.ts` (+6), `src/cli/attach-cli.action.test.ts` (+11), and
`docs/cli/attach.md` (+4, the same boundary in the public reference).

### 1. Real behavior — real CLI, real Gateway, real grant

A dev Gateway was started on a free port inside an isolated `OPENCLAW_STATE_DIR`,
and the real CLI entry point was then invoked against it with:

```
attach --print-config --session agent:main:cli
```

This is a real Gateway process minting a real scoped grant, not a mocked gateway or
a stubbed runtime. The operator's default gateway port (18789) was never bound, per
`AGENTS.md` ("Live gateway tests: session-owned dev gateway only — isolated
`OPENCLAW_STATE_DIR` + free port"). The Gateway was torn down at the end of the run
and the grant is TTL-bound to that throwaway state directory.

stdout and stderr were captured on separate streams. `[REDACTED-TOKEN]`, `[PATH]`
and `[PORT]` are redaction markers applied by me, not literal output.

**stdout** — the configuration handoff:

```text
{
  "sessionKey": "agent:main:cli",
  "expiresAt": "2026-08-09T10:00:38.754Z",
  "env": {
    "OPENCLAW_MCP_TOKEN": "[REDACTED-TOKEN]"
  },
  "configPath": "[PATH]",
  "launch": [
    "claude",
    "--strict-mcp-config",
    "--mcp-config",
    "[PATH]"
  ]
}
Grant is live until 2026-08-09T10:00:38.754Z and auto-expires; it is not revoked here. Launch with the env above, then delete [PATH] when done.
```

**stderr** — the new warning:

```text
(node:[PORT]) ExperimentalWarning: SQLite is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
WARNING: the JSON below includes a live OPENCLAW_MCP_TOKEN bearer credential (env.OPENCLAW_MCP_TOKEN). Treat it as a secret: *** not paste it into logs, chat transcripts, or shared reports.
```

CLI exit code: `0`.

> The `***` in that last line is my redaction tooling over-matching, not CLI output.
> The literal string is `do not`, visible in this PR's diff. I have left the capture
> as produced rather than hand-editing it.

### 2. Focused regression test

```
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/attach-cli.action.test.ts --reporter=verbose

 ✓ --print-config: mints + writes config + prints launch, does NOT revoke or name a nonexistent command 779ms
 ✓ --print-config: warns on stderr that the printed env carries a live bearer token 2ms
 ✓ calls attach.grant in CLI mode with an auto-resolved device identity (operator.admin regression guard) 1ms
 ✓ rejects a non-positive --ttl before minting 1ms
 ✓ rejects malformed --ttl 0x10 before minting 0ms
 ✓ rejects malformed --ttl 1.5 before minting 0ms
 ✓ rejects malformed --ttl 1e3 before minting 0ms
 ✓ rejects an empty --ttl rather than silently defaulting 0ms
 ✓ passes a positive --ttl through to attach.grant 1ms
 ✓ errors on a malformed attach.grant response instead of crashing 0ms
 ✓ spawns Claude Code and revokes the grant when the child exits 2ms
 ✓ revokes once and surfaces a launch failure when the child errors 2ms
 ✓ warns when revoke fails but still exits with the child status 2ms
 ✓ detaches its signal handlers after the child exits (no listener leak) 2ms
 ✓ errors on a grant with a non-numeric expiresAtMs instead of crashing on toISOString 0ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Duration  1.89s
```

(The common `src/cli/attach-cli.action.test.ts > openclaw attach (action) >` prefix
is trimmed from each line above for width; nothing else is omitted.)

### 3. Mutation proof — the test asserts the stream, not just the text

Starting from the head above and changing only `defaultRuntime.error` to
`defaultRuntime.log` for this one call — i.e. sending the warning to stdout instead
of stderr — the new test fails, because no `ERR:`-prefixed line is emitted:

```
AssertionError: the given combination of arguments (undefined and string) is invalid for this assertion.
 ❯ src/cli/attach-cli.action.test.ts:107:21
    105|     await runAttach("--print-config", "--session", "agent:main:cli");
    106|     const errLine = logs.find((line) => line.startsWith("ERR:"));
    107|     expect(errLine).toContain("OPENCLAW_MCP_TOKEN");
       |                     ^

[vitest] FAILED (exit 1)
```

Reverting that one line makes it pass again, so the test is guarding the stream
choice rather than only the message text.

### 4. Hygiene

```
$ pnpm exec oxfmt --check --threads=1 src/cli/attach-cli.ts src/cli/attach-cli.action.test.ts
$ git diff --check upstream/main...HEAD
```

Both pass.

### 5. Rank-up moves from the latest ClawSweeper review (2026-08-10T04:55Z)

| Move | Status |
|---|---|
| "Obtain an explicit maintainer decision on accepting the unconditional stderr warning." | **Not applied — a contributor cannot apply this one.** It is answered by a maintainer, not by a code change. It is not skipped: it is restated as the single question at the bottom of this PR, and I will act on whichever answer is given. |

## Residual risks

Neither of these is resolved here, and I am not claiming otherwise.

1. **stderr now carries one warning line.** A wrapper that treats any stderr output as
   failure will observe it. stdout and the exit code are unchanged.
2. **stdout still contains a live bearer token by default.** This PR warns and
   documents; it does not redact. A log-safe output mode is the design decision
   #104517 is holding, and implementing it here would pre-empt an issue labelled
   `needs-product-decision`, `needs-security-review`, and `no-new-fix-pr`.

## Maintainer decision

> Is the unconditional stderr warning acceptable to land as-is? stdout and the exit
> code stay unchanged; wrappers that treat any stderr output as failure will see one
> new line.

- **Yes** — nothing further is needed from me.
- **No** — I will make it TTY-only or flag-gated on this same branch. I will not open
  another fix PR; #104517 carries `no-new-fix-pr`.

A one-word answer is enough.

**Allow edits by maintainers** is enabled on this PR.

This PR is agent-assisted. The evidence above was collected by running the listed
commands at the stated head.
