### PR TITLE
fix(release): repair beta6 validation regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **LM Studio and xAI repaired tool calls:** emit the terminal tool-call event before completion when promoting serialized plain-text tool calls, preserving the complete streaming lifecycle for consumers.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
@@ -1725,6 +1726,7 @@ Shipped baseline exclusions: v2026.6.11 (10 PRs: #87298, #89949, #90811, #92020,
 - **PR #104892** fix(release): preserve original PRs for named backports. Thanks @vincentkoc.
 - **PR #104975** fix(release): restore pnpm package artifacts.
 - **PR #104957** fix(release): verify named backport provenance. Thanks @vincentkoc.
+
 ## 2026.6.11
 
 We heard the feedback. v2026.6.11 focuses on the rough edges that make OpenClaw feel less dependable, with fixes for misplaced replies, stuck sends, reconnects, model setup failures, and safer admin defaults.

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -124,6 +124,7 @@ export function resolveContextEngineBootstrapProjectionDecision(params: {
   expectedBinding: ReturnType<typeof buildContextEngineBinding>;
   projection: CodexContextEngineThreadBootstrapProjection;
   dynamicToolsFingerprint: string;
+  legacyDynamicToolsFingerprint?: string;
 }): { project: boolean; reason: string } {
   const bindingProjection = params.startupBinding?.contextEngine?.projection;
   if (!params.startupBinding?.threadId || !bindingProjection) {
@@ -144,6 +145,7 @@ export function resolveContextEngineBootstrapProjectionDecision(params: {
     !areCodexDynamicToolFingerprintsCompatible({
       previous: params.startupBinding.dynamicToolsFingerprint,
       next: params.dynamicToolsFingerprint,
+      nextLegacy: params.legacyDynamicToolsFingerprint,
     })
   ) {
     return { project: true, reason: "dynamic-tools-mismatch" };

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -244,6 +244,7 @@ import {
   buildTurnCollaborationMode,
   buildTurnStartParams,
   codexDynamicToolsFingerprint,
+  codexLegacyDynamicToolsFingerprint,
   resolveCodexAppServerThreadModelSelection,
   type CodexAppServerThreadLifecycleBinding,
   type CodexContextEngineThreadBootstrapProjection,
@@ -1077,6 +1078,7 @@ export async function runCodexAppServerAttempt(
           ),
           projection: contextEngineProjection,
           dynamicToolsFingerprint: codexDynamicToolsFingerprint(toolBridge.specs),
+          legacyDynamicToolsFingerprint: codexLegacyDynamicToolsFingerprint(toolBridge.specs),
         })
       : { project: true, reason: "per-turn-projection" };
     embeddedAgentLog.info("codex app-server context-engine projection decision", {

--- a/src/agents/session-runtime-compat.ts
+++ b/src/agents/session-runtime-compat.ts
@@ -24,6 +24,27 @@ export function resolvePersistedSessionRuntimeId(
   return normalizeOptionalAgentRuntimeId(entry?.agentHarnessId);
 }
 
+/** Resolves a runtime id only when it can serve the selected provider. */
+export function resolveCompatibleAgentRuntimeForProvider(params: {
+  provider?: string | null;
+  runtime?: string | null;
+  cfg?: OpenClawConfig;
+}): string | undefined {
+  const runtime = normalizeOptionalAgentRuntimeId(params.runtime);
+  if (!runtime || isDefaultAgentRuntimeId(runtime)) {
+    return undefined;
+  }
+  if (runtime === "openclaw") {
+    return runtime;
+  }
+  const provider = params.provider?.trim().toLowerCase() ?? "";
+  // The Codex harness owns both OpenClaw's virtual Codex namespace and canonical OpenAI routes.
+  if (runtime === "codex" && (provider === "codex" || provider === "openai")) {
+    return runtime;
+  }
+  return isCliRuntimeAliasForProvider({ provider, runtime, cfg: params.cfg }) ? runtime : undefined;
+}
+
 /** Resolves a persisted runtime override only when it can serve the selected provider. */
 export function resolveSessionRuntimeOverrideForProvider(params: {
   provider?: string | null;
@@ -32,16 +53,9 @@ export function resolveSessionRuntimeOverrideForProvider(params: {
 }): string | undefined {
   // agentHarnessId records the runtime that produced the existing transcript;
   // it must not override the runtime selected for the next turn.
-  const runtime = normalizeOptionalAgentRuntimeId(params.entry?.agentRuntimeOverride);
-  if (!runtime || isDefaultAgentRuntimeId(runtime)) {
-    return undefined;
-  }
-  if (runtime === "openclaw") {
-    return runtime;
-  }
-  const provider = params.provider?.trim().toLowerCase() ?? "";
-  if (provider === "openai" && runtime === "codex") {
-    return runtime;
-  }
-  return isCliRuntimeAliasForProvider({ provider, runtime, cfg: params.cfg }) ? runtime : undefined;
+  return resolveCompatibleAgentRuntimeForProvider({
+    provider: params.provider,
+    runtime: params.entry?.agentRuntimeOverride,
+    cfg: params.cfg,
+  });
 }

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -85,6 +85,19 @@ describe("resolveSessionRuntimeOverrideForProvider", () => {
     ).toBeUndefined();
   });
 
+  it.each([
+    { provider: "openai", expected: "codex" },
+    { provider: "codex", expected: "codex" },
+    { provider: "anthropic", expected: undefined },
+  ])("resolves Codex runtime compatibility for $provider", ({ provider, expected }) => {
+    expect(
+      resolveSessionRuntimeOverrideForProvider({
+        provider,
+        entry: { agentRuntimeOverride: "codex" },
+      }),
+    ).toBe(expected);
+  });
+
   it("keeps CLI runtime pins only when the runtime serves the selected provider", () => {
     cliBackendsTesting.setDepsForTest({
       resolveRuntimeCliBackends: () => [],

--- a/src/auto-reply/reply/directive-handling.model-runtime.ts
+++ b/src/auto-reply/reply/directive-handling.model-runtime.ts
@@ -3,9 +3,11 @@ import {
   isDefaultAgentRuntimeId,
   normalizeOptionalAgentRuntimeId,
 } from "../../agents/agent-runtime-id.js";
-import { resolveCliRuntimeModelBackendBinding } from "../../agents/cli-backends.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
-import { resolveSessionRuntimeOverrideForProvider } from "../../agents/session-runtime-compat.js";
+import {
+  resolveCompatibleAgentRuntimeForProvider,
+  resolveSessionRuntimeOverrideForProvider,
+} from "../../agents/session-runtime-compat.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
@@ -42,21 +44,15 @@ export function resolveModelRuntimeDirective(params: {
   if (isDefaultAgentRuntimeId(runtime)) {
     return { kind: "clear" };
   }
-  if (runtime === "openclaw") {
-    return { kind: "set", runtime };
-  }
 
   const provider = normalizeProviderId(params.provider);
-  if (provider === "openai" && runtime === "codex") {
-    return { kind: "set", runtime };
-  }
-  const backend = resolveCliRuntimeModelBackendBinding({
-    config: params.cfg,
+  const compatibleRuntime = resolveCompatibleAgentRuntimeForProvider({
     provider,
     runtime,
+    cfg: params.cfg,
   });
-  if (backend) {
-    return { kind: "set", runtime: backend.runtime };
+  if (compatibleRuntime) {
+    return { kind: "set", runtime: compatibleRuntime };
   }
 
   return {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1306,14 +1306,17 @@ describe("/model chat UX", () => {
     expect(sessionEntry.authProfileOverride).toBe(OPENAI_DATE_PROFILE_ID);
   });
 
-  it("persists provider-compatible runtime overrides for mixed-content messages", async () => {
+  it.each([
+    ["openai/gpt-4o", "openai", "gpt-4o"],
+    ["codex/gpt-5.5", "codex", "gpt-5.5"],
+  ])("persists provider-compatible runtime overrides for %s", async (modelKey, provider, model) => {
     const { persisted, sessionEntry } = await persistModelDirectiveForTest({
-      command: "/model openai/gpt-4o --runtime codex hello",
-      allowedModelKeys: ["openai/gpt-4o"],
+      command: `/model ${modelKey} --runtime codex hello`,
+      allowedModelKeys: [modelKey],
     });
 
-    expect(sessionEntry.providerOverride).toBe("openai");
-    expect(sessionEntry.modelOverride).toBe("gpt-4o");
+    expect(sessionEntry.providerOverride).toBe(provider);
+    expect(sessionEntry.modelOverride).toBe(model);
     expect(sessionEntry.agentRuntimeOverride).toBe("codex");
     expect(persisted.runtimeChange).toEqual({ kind: "set", runtime: "codex" });
   });
@@ -1441,6 +1444,16 @@ describe("/model chat UX", () => {
       agentRuntimeOverride: "openclaw",
     });
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects the Codex runtime for providers the harness does not support", async () => {
+    const { persisted, sessionEntry } = await persistModelDirectiveForTest({
+      command: "/model anthropic/claude-opus-4-6 --runtime codex hello",
+      allowedModelKeys: ["anthropic/claude-opus-4-6"],
+    });
+
+    expect(persisted.errorText).toBe('Runtime "codex" is not supported for anthropic.');
+    expect(sessionEntry.agentRuntimeOverride).toBeUndefined();
   });
 
   it("rejects unsupported mixed thinking before mutating the model/runtime transaction", async () => {

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -519,86 +519,90 @@ describe("TUI PTY real backends", () => {
     LOCAL_TEST_TIMEOUT_MS,
   );
 
-  it.each(["gateway", "local"] as const)(
-    "renders safe validation-loop abort diagnostics through the real %s backend",
-    async (mode) => {
-      const fixture =
-        mode === "gateway"
-          ? await startGatewayModeTui({
-              queueMode: "followup",
-              invalidEditLoop: true,
-            })
-          : await startLocalModeTui({ invalidEditLoop: true });
-      let eventProbe: GatewayChatClient | undefined;
-      const probedEvents: Array<{ event: string; payload: unknown }> = [];
-      try {
-        if (fixture.kind === "gateway") {
-          let probeConnected = false;
-          eventProbe = new GatewayChatClient({
-            url: fixture.gateway.url,
-            token: fixture.gateway.gatewayToken,
-            allowInsecureLocalOperatorUi: false,
-          });
-          eventProbe.onConnected = () => {
-            probeConnected = true;
-          };
-          eventProbe.onEvent = ({ event, payload }) => {
-            probedEvents.push({ event, payload });
-          };
-          eventProbe.start();
+  function registerValidationLoopTests() {
+    it.each(["gateway", "local"] as const)(
+      "renders safe validation-loop abort diagnostics through the real %s backend",
+      async (mode) => {
+        const fixture =
+          mode === "gateway"
+            ? await startGatewayModeTui({
+                queueMode: "followup",
+                invalidEditLoop: true,
+              })
+            : await startLocalModeTui({ invalidEditLoop: true });
+        let eventProbe: GatewayChatClient | undefined;
+        const probedEvents: Array<{ event: string; payload: unknown }> = [];
+        try {
+          if (fixture.kind === "gateway") {
+            let probeConnected = false;
+            eventProbe = new GatewayChatClient({
+              url: fixture.gateway.url,
+              token: fixture.gateway.gatewayToken,
+              allowInsecureLocalOperatorUi: false,
+            });
+            eventProbe.onConnected = () => {
+              probeConnected = true;
+            };
+            eventProbe.onEvent = ({ event, payload }) => {
+              probedEvents.push({ event, payload });
+            };
+            eventProbe.start();
+            await waitFor({
+              timeoutMs: LOCAL_STARTUP_TIMEOUT_MS,
+              read: () => (probeConnected ? true : null),
+              onTimeout: () => new Error("Gateway event probe did not connect"),
+            });
+            await eventProbe.subscribeSessionEvents();
+          }
+          await fixture.run.waitForOutput(
+            mode === "gateway" ? "gateway connected" : "local ready",
+            LOCAL_STARTUP_TIMEOUT_MS,
+          );
+          await fixture.run.write("trigger malformed edit calls\r");
           await waitFor({
-            timeoutMs: LOCAL_STARTUP_TIMEOUT_MS,
-            read: () => (probeConnected ? true : null),
-            onTimeout: () => new Error("Gateway event probe did not connect"),
-          });
-          await eventProbe.subscribeSessionEvents();
-        }
-        await fixture.run.waitForOutput(
-          mode === "gateway" ? "gateway connected" : "local ready",
-          LOCAL_STARTUP_TIMEOUT_MS,
-        );
-        await fixture.run.write("trigger malformed edit calls\r");
-        await waitFor({
-          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
-          read: () => (fixture.mockModel.requests().length >= 2 ? true : null),
-          onTimeout: () =>
-            new Error(`model did not repeat the malformed edit call\n${fixture.run.output()}`),
-        });
-        if (eventProbe) {
-          await waitFor({
-            timeoutMs: 30_000,
-            read: () => {
-              const observed = probedEvents.some((event) => {
-                if (event.event !== "session.tool" || !event.payload) {
-                  return false;
-                }
-                const data = (event.payload as { data?: Record<string, unknown> }).data;
-                return typeof data?.toolErrorSummary === "string";
-              });
-              return observed ? true : null;
-            },
+            timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+            read: () => (fixture.mockModel.requests().length >= 2 ? true : null),
             onTimeout: () =>
-              new Error(`Gateway did not project a safe tool diagnostic (${probedEvents.length})`),
+              new Error(`model did not repeat the malformed edit call\n${fixture.run.output()}`),
           });
+          if (eventProbe) {
+            await waitFor({
+              timeoutMs: 30_000,
+              read: () => {
+                const observed = probedEvents.some((event) => {
+                  if (event.event !== "session.tool" || !event.payload) {
+                    return false;
+                  }
+                  const data = (event.payload as { data?: Record<string, unknown> }).data;
+                  return typeof data?.toolErrorSummary === "string";
+                });
+                return observed ? true : null;
+              },
+              onTimeout: () =>
+                new Error(
+                  `Gateway did not project a safe tool diagnostic (${probedEvents.length})`,
+                ),
+            });
+          }
+          await fixture.run.write("\u001b", { delay: false });
+          await fixture.run.waitForOutput(
+            "run aborted: edit tool validation failed:",
+            LOCAL_OUTPUT_TIMEOUT_MS,
+          );
+
+          expect(fixture.mockModel.requests().length).toBeGreaterThan(0);
+          expect(fixture.run.output()).not.toContain("Received arguments");
+
+          await fixture.run.write("/exit\r", { delay: false });
+          expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+        } finally {
+          eventProbe?.stop();
+          await fixture.cleanup();
         }
-        await fixture.run.write("\u001b", { delay: false });
-        await fixture.run.waitForOutput(
-          "run aborted: edit tool validation failed:",
-          LOCAL_OUTPUT_TIMEOUT_MS,
-        );
-
-        expect(fixture.mockModel.requests().length).toBeGreaterThan(0);
-        expect(fixture.run.output()).not.toContain("Received arguments");
-
-        await fixture.run.write("/exit\r", { delay: false });
-        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
-      } finally {
-        eventProbe?.stop();
-        await fixture.cleanup();
-      }
-    },
-    LOCAL_TEST_TIMEOUT_MS,
-  );
+      },
+      LOCAL_TEST_TIMEOUT_MS,
+    );
+  }
 
   it(
     "creates and adopts a fresh session through the real Gateway backend",
@@ -921,4 +925,8 @@ describe("TUI PTY real backends", () => {
     },
     LOCAL_TEST_TIMEOUT_MS,
   );
+
+  // Validation abort can terminalize the TUI before earlier command lanes
+  // finish unwinding. Keep it last so teardown owns that tail.
+  registerValidationLoopTests();
 });

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -661,7 +661,7 @@ describe("TUI PTY real backends", () => {
             read: () => {
               const output = fixture.run.output().slice(commandOffset);
               const matchedOutcome = output.match(
-                /new session: agent:main:tui-|abort the current run before \/new/,
+                /new session: agent:main:tui-|abort the current run before \/new|Parent session[\s\S]*?is still active; try[\s\S]*?again in a moment\./,
               )?.[0];
               if (!matchedOutcome) {
                 return null;

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -57,6 +57,14 @@ type WorkflowStep = {
   with?: Record<string, string>;
 };
 
+type WorkflowMatrixEntry = {
+  advisory?: boolean;
+  command?: string;
+  profiles?: string;
+  suite_group?: string;
+  suite_id?: string;
+};
+
 type WorkflowJob = {
   concurrency?: {
     group?: string;
@@ -69,6 +77,11 @@ type WorkflowJob = {
   outputs?: Record<string, string>;
   permissions?: Record<string, string>;
   "runs-on"?: string;
+  strategy?: {
+    matrix?: {
+      include?: WorkflowMatrixEntry[];
+    };
+  };
   "timeout-minutes"?: number | string;
   steps?: WorkflowStep[];
 };
@@ -106,6 +119,16 @@ function workflowStep(job: WorkflowJob, stepName: string): WorkflowStep {
     throw new Error(`Expected workflow step ${stepName}`);
   }
   return step;
+}
+
+function workflowMatrixEntry(path: string, jobName: string, suiteId: string): WorkflowMatrixEntry {
+  const entry = workflowJob(path, jobName).strategy?.matrix?.include?.find(
+    (candidate) => candidate.suite_id === suiteId,
+  );
+  if (!entry) {
+    throw new Error(`Expected workflow matrix entry ${suiteId} in ${jobName}`);
+  }
+  return entry;
 }
 
 function expectTextToIncludeAll(text: string | undefined, snippets: string[]): void {

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import type { UiSettings } from "../../app/settings.ts";
 import { createSessionCapability } from "../../lib/sessions/index.ts";
@@ -31,18 +31,9 @@ type TestChatHost = Omit<ChatHost, "settings"> & {
   settings?: Partial<UiSettings>;
 };
 
-const { executeSlashCommandMock, setLastActiveSessionKeyMock } = vi.hoisted(() => ({
-  executeSlashCommandMock: vi.fn(),
-  setLastActiveSessionKeyMock: vi.fn(),
-}));
+const executeSlashCommandMock = vi.hoisted(() => vi.fn());
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
-
-vi.mock("../../app/settings.ts", () => ({
-  normalizeChatAutoScrollMode: (value: unknown) =>
-    value === "always" || value === "off" ? value : "near-bottom",
-  setLastActiveSessionKey: (...args: unknown[]) => setLastActiveSessionKeyMock(...args),
-}));
 
 vi.mock("./chat-command-executor.ts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./chat-command-executor.ts")>();
@@ -158,6 +149,7 @@ function fetchUrl(source: MockCallSource, callIndex: number) {
 }
 
 function makeHost(overrides?: Partial<TestChatHost>): TestChatHost {
+  const settings = { lastActiveSessionKey: "", ...overrides?.settings };
   const host = {
     client: null,
     chatMessages: [],
@@ -200,7 +192,9 @@ function makeHost(overrides?: Partial<TestChatHost>): TestChatHost {
     toolStreamOrder: [],
     toolStreamSyncTimer: null,
     updateComplete: Promise.resolve(),
+    applySettings: vi.fn((next: UiSettings) => Object.assign(settings, next)),
     ...overrides,
+    settings,
   };
   const sessions = createSessionCapability({
     snapshot: {
@@ -1099,7 +1093,6 @@ describe("handleSendChat", () => {
 
   beforeEach(() => {
     executeSlashCommandMock.mockReset();
-    setLastActiveSessionKeyMock.mockReset();
   });
 
   afterEach(() => {
@@ -2952,7 +2945,9 @@ describe("handleSendChat", () => {
     expect(host.chatRunId).toBe("run-1");
     expect(host.chatStream).toBe("Working...");
     expect(host.chatQueue).toStrictEqual([]);
-    expect(setLastActiveSessionKeyMock).toHaveBeenCalledWith(expect.anything(), "agent:main:main");
+    expect(host.applySettings).toHaveBeenCalledWith(
+      expect.objectContaining({ lastActiveSessionKey: "agent:main:main" }),
+    );
   });
 
   it("restores queued steer items when chat.send returns terminal error", async () => {
@@ -2977,7 +2972,7 @@ describe("handleSendChat", () => {
     expect(host.chatStream).toBe("Working...");
     expect(host.chatQueue).toStrictEqual([original]);
     expect(host.lastError).toBe("Steer failed before it reached the run; try again.");
-    expect(setLastActiveSessionKeyMock).not.toHaveBeenCalled();
+    expect(host.applySettings).not.toHaveBeenCalled();
   });
 
   it("removes pending steer indicators when the run finishes", () => {
@@ -3242,9 +3237,4 @@ describe("handleAbortChat", () => {
     expect(host.pendingAbort).toBeUndefined();
     expect(host.chatMessage).toBe("draft");
   });
-});
-
-afterAll(() => {
-  vi.doUnmock("../../app/settings.ts");
-  vi.resetModules();
 });

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -19,6 +19,7 @@ import type { ChatPageHost } from "./chat-state.ts";
 
 type ExecuteSlashCommand = typeof executeSlashCommand;
 type TestChatHost = Omit<ChatHost, "settings"> & {
+  applySettings: (next: UiSettings) => void;
   basePath: string;
   chatAvatarUrl: string | null;
   chatAvatarSource?: string | null;


### PR DESCRIPTION
## What Problem This Solves

The beta6 candidate had three deterministic release-validation regressions:

- 29 Control UI chat-send failures from a shared Vitest settings-module mock leak.
- two Codex context-engine failures because hashed dynamic-tool fingerprints did not accept the immediately preceding legacy representation.
- the native Codex runtime was rejected for the canonical `codex/*` provider route.

## Why This Change Was Made

- Give the chat-send fixture the real host settings contract instead of relying on a worker-global module mock.
- Pass the already-supported legacy fingerprint into the thread-bootstrap compatibility decision.
- Backport the canonical main fix from `db39fe807202b259cf1269eae560c213e0c2afef`, centralizing provider/runtime compatibility while preserving rejection for unsupported pairs.

## User Impact

Beta6 retains native Codex runtime switching for both `codex/*` and `openai/*` routes. Existing pre-hash Codex thread bindings resume without unnecessary context reprojection. Control UI behavior is unchanged; its suite is deterministic under shared-worker ordering.

## Evidence

- Failed candidate UI job: https://github.com/openclaw/openclaw/actions/runs/29181488371/job/86619939595
- Failed plugin prerelease job: https://github.com/openclaw/openclaw/actions/runs/29181487775/job/86619931025
- Failed release-checks native runtime job: https://github.com/openclaw/openclaw/actions/runs/29181487474/job/86620171884
- Blacksmith Testbox `tbx_01kxadxjrn0dayyqn5assy8ck8`: focused chat-send 99/99 and full Control UI 143 files / 2,331 tests passed.
- Blacksmith Testbox `tbx_01kxaee72ew2mdqgrcxccpy6fk`: runtime/directive 328/328 and Codex context-engine 29/29 passed.
- Blacksmith Testbox `tbx_01kxagj2q2aygpzw0hxhhegx07`: full TUI PTY real-backend file 8/8 passed after registering terminalizing validation-abort cases last.
- Blacksmith Testbox `tbx_01kxah6wq8h2v9q22c6qnp6dme`: full TUI PTY real-backend file 8/8 passed after recognizing the Gateway's transient active-parent response in the existing bounded `/new` retry loop.
- Same Testbox: package-acceptance workflow contract file 48/48 passed after restoring the matrix lookup helper omitted by the beta6 feature backport.
- `git diff --check` passed.
- Fresh branch autoreview: clean, no accepted/actionable findings.

## Risk

The runtime change is an exact canonical backport already landed and validated on main. The fingerprint change uses the existing compatibility API and only admits the prior representation for the same next tool set. The TUI changes preserve all cases, follow main's canonical terminalizing-test ordering, and keep success mandatory after bounded busy-state retries. The package helper is the exact test contract required by the existing matrix assertions. No config, secret, or migration surface changes.

## Current review state

Awaiting exact-head hosted PR CI. After merge, rerun the three failed lanes and full beta release validation on the new `release/2026.7.1` head.
