### PR TITLE
fix(node): foreground pairing no longer exits early

### DIFF
--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -166,6 +166,62 @@ describe("runNodeHost", () => {
     expect(mocks.capturedGatewayClients[0]?.request).not.toHaveBeenCalled();
   });
 
+  it("keeps a ref'd lifetime handle until a ready foreground host stops", async () => {
+    mocks.startGatewayClientWhenEventLoopReady.mockResolvedValueOnce({
+      ready: true,
+      aborted: false,
+      elapsedMs: 0,
+    });
+    const unref = vi.fn();
+    const interval = { unref } as unknown as ReturnType<typeof setInterval>;
+    const setIntervalSpy = vi.spyOn(global, "setInterval").mockReturnValue(interval);
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval").mockImplementation(() => {});
+    const processOnceSpy = vi.spyOn(process, "once");
+    const previousExitCode = process.exitCode;
+    try {
+      const running = runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 });
+      await vi.waitFor(() =>
+        expect(processOnceSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function)),
+      );
+
+      expect(setIntervalSpy).toHaveBeenCalledOnce();
+      expect(unref).not.toHaveBeenCalled();
+      expect(clearIntervalSpy).not.toHaveBeenCalled();
+
+      const onSigterm = processOnceSpy.mock.calls.find(([event]) => event === "SIGTERM")?.[1];
+      expect(onSigterm).toBeTypeOf("function");
+      onSigterm?.("SIGTERM");
+      await running;
+
+      expect(clearIntervalSpy).toHaveBeenCalledWith(interval);
+      expect(mocks.capturedGatewayClients[0]?.stop).toHaveBeenCalledOnce();
+    } finally {
+      process.exitCode = previousExitCode;
+      processOnceSpy.mockRestore();
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
+  });
+
+  it("clears the lifetime handle when gateway startup rejects", async () => {
+    const startupError = new Error("gateway startup failed");
+    mocks.startGatewayClientWhenEventLoopReady.mockRejectedValueOnce(startupError);
+    const interval = {} as ReturnType<typeof setInterval>;
+    const setIntervalSpy = vi.spyOn(global, "setInterval").mockReturnValue(interval);
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval").mockImplementation(() => {});
+    try {
+      await expect(runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 })).rejects.toBe(
+        startupError,
+      );
+
+      expect(clearIntervalSpy).toHaveBeenCalledWith(interval);
+      expect(mocks.capturedGatewayClients[0]?.stop).toHaveBeenCalledOnce();
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
+  });
+
   it("declares the built-in MCP command family before any server is configured", async () => {
     await expect(
       runNodeHost({

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -178,11 +178,19 @@ describe("runNodeHost", () => {
     const clearIntervalSpy = vi.spyOn(global, "clearInterval").mockImplementation(() => {});
     const processOnceSpy = vi.spyOn(process, "once");
     const previousExitCode = process.exitCode;
+    let resolveCloseMcp: (() => void) | undefined;
+    mocks.closeMcpManager.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCloseMcp = resolve;
+        }),
+    );
     try {
       const running = runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 });
       await vi.waitFor(() =>
         expect(processOnceSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function)),
       );
+      await vi.waitFor(() => expect(startNodeHostMcpManager).toHaveBeenCalled());
 
       expect(setIntervalSpy).toHaveBeenCalledOnce();
       expect(unref).not.toHaveBeenCalled();
@@ -191,11 +199,19 @@ describe("runNodeHost", () => {
       const onSigterm = processOnceSpy.mock.calls.find(([event]) => event === "SIGTERM")?.[1];
       expect(onSigterm).toBeTypeOf("function");
       onSigterm?.("SIGTERM");
+      await vi.waitFor(() => expect(mocks.capturedGatewayClients[0]?.stop).toHaveBeenCalledOnce());
+
+      expect(clearIntervalSpy).not.toHaveBeenCalled();
+      resolveCloseMcp?.();
       await running;
 
       expect(clearIntervalSpy).toHaveBeenCalledWith(interval);
-      expect(mocks.capturedGatewayClients[0]?.stop).toHaveBeenCalledOnce();
     } finally {
+      for (const [event, listener] of processOnceSpy.mock.calls) {
+        if ((event === "SIGINT" || event === "SIGTERM") && typeof listener === "function") {
+          process.off(event, listener);
+        }
+      }
       process.exitCode = previousExitCode;
       processOnceSpy.mockRestore();
       setIntervalSpy.mockRestore();

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -181,8 +181,8 @@ describe("runNodeHost", () => {
     let resolveCloseMcp: (() => void) | undefined;
     mocks.closeMcpManager.mockImplementationOnce(
       () =>
-        new Promise<void>((resolve) => {
-          resolveCloseMcp = resolve;
+        new Promise<undefined>((resolve) => {
+          resolveCloseMcp = () => resolve(undefined);
         }),
     );
     try {

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -439,17 +439,26 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     process.off("SIGINT", onSigint);
     process.off("SIGTERM", onSigterm);
   };
+  const stopClientAndMcp = async () => {
+    client.stop();
+    try {
+      await closeMcpRuntime();
+    } finally {
+      clearInterval(lifetimeInterval);
+    }
+  };
   const finish = async (exitCode: number) => {
     if (stopping) {
       return;
     }
     stopping = true;
     removeSignalHandlers();
-    clearInterval(lifetimeInterval);
-    client.stop();
-    await closeMcpRuntime();
-    process.exitCode = exitCode;
-    resolveStopped?.();
+    try {
+      await stopClientAndMcp();
+    } finally {
+      process.exitCode = exitCode;
+      resolveStopped?.();
+    }
   };
   const onSigint = () => void finish(130);
   const onSigterm = () => void finish(143);
@@ -476,9 +485,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       return;
     }
     removeSignalHandlers();
-    clearInterval(lifetimeInterval);
-    client.stop();
-    await closeMcpRuntime();
+    await stopClientAndMcp();
     throw error;
   }
   if (!readiness.ready) {
@@ -487,9 +494,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       return;
     }
     removeSignalHandlers();
-    clearInterval(lifetimeInterval);
-    client.stop();
-    await closeMcpRuntime();
+    await stopClientAndMcp();
     throw new Error("node host gateway event loop readiness timeout");
   }
   await stopped;

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -432,6 +432,9 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const stopped = new Promise<void>((resolve) => {
     resolveStopped = resolve;
   });
+  // A pending Promise alone does not keep Node alive. Pairing pauses can close
+  // the last socket, so retain a handle until a signal finishes the foreground host.
+  const lifetimeInterval = setInterval(() => {}, 1_000_000);
   const removeSignalHandlers = () => {
     process.off("SIGINT", onSigint);
     process.off("SIGTERM", onSigterm);
@@ -442,6 +445,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     }
     stopping = true;
     removeSignalHandlers();
+    clearInterval(lifetimeInterval);
     client.stop();
     await closeMcpRuntime();
     process.exitCode = exitCode;
@@ -463,13 +467,27 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       return manager;
     },
   );
-  const readiness = await readinessPromise;
+  let readiness;
+  try {
+    readiness = await readinessPromise;
+  } catch (error) {
+    if (stopping) {
+      await stopped;
+      return;
+    }
+    removeSignalHandlers();
+    clearInterval(lifetimeInterval);
+    client.stop();
+    await closeMcpRuntime();
+    throw error;
+  }
   if (!readiness.ready) {
     if (stopping) {
       await stopped;
       return;
     }
     removeSignalHandlers();
+    clearInterval(lifetimeInterval);
     client.stop();
     await closeMcpRuntime();
     throw new Error("node host gateway event loop readiness timeout");


### PR DESCRIPTION
Fixes #104999

## What Problem This Solves

Fixes an issue where operators running `openclaw node run` would see the node stop with exit code 13 while device pairing was waiting for approval.

## Why This Change Was Made

The foreground node host now owns a referenced lifetime handle while startup, pairing, and shutdown are active. The handle is released only after terminal readiness failures or signal-driven MCP cleanup completes, so pending Promises cannot let Node exit early and cleanup cannot recreate the same failure.

## User Impact

Foreground node hosts remain running while an operator approves device pairing, then connect normally. Startup failures and shutdown still terminate cleanly without leaking signal handlers or lifetime handles.

## Evidence

- Final head: `97b5668d109cabca0d22b1000bfa579c1118dafd`.
- The rebased branch has the same stable patch id as the four-OS proven head.
- `pnpm test:serial src/node-host/runner.test.ts` passed 18/18 in Crabbox run `run_35cddd65a639`.
- `pnpm check:changed` passed in Testbox `tbx_01kxaeb8yz20cz91v13cbbtfb5`.
- Four-OS gateway pairing pond passed:
  - Linux: `run_c70b173a741e`
  - macOS arm64: `run_206b6a4a693e`
  - Windows WSL2: `run_d9d2e36ad21e`
  - Windows native: `run_cbbcdbb28760`
- Each pond run proved manual device approval, the separate node command gate, successful `system.which`, disconnect observation, and tokenless reconnect using the persisted device token.
- Exact-head hosted CI passed: https://github.com/openclaw/openclaw/actions/runs/29185944275
- Fresh final autoreview reported no actionable findings with confidence 0.94.
