### PR TITLE
fix(transcript): keep pagination cursors out of secret masking on resume

### DIFF
--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -84,6 +84,61 @@ describe("redactTranscriptMessage", () => {
     expect(text).toContain("end");
   });
 
+  it("keeps pagination cursors readable while still masking credential tool args (#104992)", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "feishu_doc",
+          arguments: {
+            page_token: "PGabc123XYZ",
+            next_page_token: "NXTpage456",
+            page_cursor: "PC789",
+            doc_token: "DOCsecret999",
+            app_secret: "REALSECRETzzz",
+          },
+        },
+      ],
+    } as unknown as AgentMessage;
+    const args = (
+      msgContent(redactTranscriptMessage(msg, cfg("tools"))) as Array<{
+        arguments: Record<string, string>;
+      }>
+    )[0].arguments;
+    // Pagination cursors are opaque paging state — replaying a "***" mask as a
+    // real cursor silently pages from the start, so keep them intact.
+    expect(args.page_token).toBe("PGabc123XYZ");
+    expect(args.next_page_token).toBe("NXTpage456");
+    expect(args.page_cursor).toBe("PC789");
+    // Genuine credentials stay masked.
+    expect(args.doc_token).toBe("***");
+    expect(args.app_secret).toBe("***");
+  });
+
+  it("still masks a secret-shaped value even under an exempt pagination key (#104992)", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "feishu_doc",
+          arguments: { page_token: "sk-abcdef1234567890xyz" },
+        },
+      ],
+    } as unknown as AgentMessage;
+    const args = (
+      msgContent(redactTranscriptMessage(msg, cfg("tools"))) as Array<{
+        arguments: Record<string, string>;
+      }>
+    )[0].arguments;
+    // Value-pattern redaction still runs on exempt keys, so an embedded real
+    // secret shape is masked even though the key itself is allowed through.
+    expect(args.page_token).not.toContain("sk-abcdef1234567890xyz");
+  });
+
   it("redacts thinking block", () => {
     const msg = {
       role: "assistant",

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -106,7 +106,7 @@ describe("redactTranscriptMessage", () => {
       msgContent(redactTranscriptMessage(msg, cfg("tools"))) as Array<{
         arguments: Record<string, string>;
       }>
-    )[0].arguments;
+    )[0]!.arguments;
     // Pagination cursors are opaque paging state — replaying a "***" mask as a
     // real cursor silently pages from the start, so keep them intact.
     expect(args.page_token).toBe("PGabc123XYZ");
@@ -133,7 +133,7 @@ describe("redactTranscriptMessage", () => {
       msgContent(redactTranscriptMessage(msg, cfg("tools"))) as Array<{
         arguments: Record<string, string>;
       }>
-    )[0].arguments;
+    )[0]!.arguments;
     // Value-pattern redaction still runs on exempt keys, so an embedded real
     // secret shape is masked even though the key itself is allowed through.
     expect(args.page_token).not.toContain("sk-abcdef1234567890xyz");

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -49,6 +49,14 @@ function redactTranscriptText(value: string, cfg?: OpenClawConfig): string {
   return redactSensitiveText(value, redactTranscriptOptions(cfg));
 }
 
+// Pagination cursors are opaque paging state, not credentials, but the generic
+// secret-key heuristic masks any `*_token` key. In persisted transcripts that is
+// harmful: on resume the model replays the `***` mask as a real cursor and the
+// platform silently pages from the start, returning wrong data with no error
+// (#104992). Exempt only unambiguous page cursors — the `page` marker rules out
+// credentials — and keep this transcript-scoped so logs still redact them.
+const TRANSCRIPT_PAGINATION_CURSOR_KEY_RE = /^(?:next[_-]?)?page[_-]?token$|^page[_-]?cursor$/i;
+
 function redactTranscriptStructuredFieldValue(
   key: string,
   value: string,
@@ -56,6 +64,11 @@ function redactTranscriptStructuredFieldValue(
 ): string {
   if (cfg?.logging?.redactSensitive === "off") {
     return value;
+  }
+  if (TRANSCRIPT_PAGINATION_CURSOR_KEY_RE.test(key)) {
+    // Keep the cursor readable, but still run value-pattern redaction so an
+    // embedded registered/known secret shape is masked even here.
+    return redactTranscriptText(value, cfg);
   }
   return redactSensitiveFieldValue(key, value, redactTranscriptOptions(cfg));
 }

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -49,9 +49,6 @@ function redactTranscriptText(value: string, cfg?: OpenClawConfig): string {
   return redactSensitiveText(value, redactTranscriptOptions(cfg));
 }
 
-// Preserve unambiguous pagination state in transcripts; global logs still redact it.
-const TRANSCRIPT_PAGINATION_CURSOR_KEY_RE = /^(?:next[_-]?)?page[_-]?token$|^page[_-]?cursor$/i;
-
 function redactTranscriptStructuredFieldValue(
   key: string,
   value: string,
@@ -60,11 +57,10 @@ function redactTranscriptStructuredFieldValue(
   if (cfg?.logging?.redactSensitive === "off") {
     return value;
   }
-  if (TRANSCRIPT_PAGINATION_CURSOR_KEY_RE.test(key)) {
-    // Value-pattern redaction still masks embedded secrets.
-    return redactTranscriptText(value, cfg);
-  }
-  return redactSensitiveFieldValue(key, value, redactTranscriptOptions(cfg));
+  // Preserve pagination state only in transcripts; value-pattern and global log redaction remain.
+  return /^(?:next[_-]?)?page[_-]?token$|^page[_-]?cursor$/i.test(key)
+    ? redactTranscriptText(value, cfg)
+    : redactSensitiveFieldValue(key, value, redactTranscriptOptions(cfg));
 }
 
 function isPlainTranscriptObject(value: object): value is Record<string, unknown> {
@@ -72,13 +68,11 @@ function isPlainTranscriptObject(value: object): value is Record<string, unknown
   return prototype === Object.prototype || prototype === null;
 }
 
-function isImageMimeType(value: unknown): value is string {
-  return typeof value === "string" && /^image\//iu.test(value.trim());
-}
+const isImageMimeType = (value: unknown): value is string =>
+  typeof value === "string" && /^image\//iu.test(value.trim());
 
-function normalizeImageMimeType(value: unknown): string | undefined {
-  return isImageMimeType(value) ? value.trim().toLowerCase() : undefined;
-}
+const normalizeImageMimeType = (value: unknown): string | undefined =>
+  isImageMimeType(value) ? value.trim().toLowerCase() : undefined;
 
 function imageMimeTypeForRecord(value: Record<string, unknown>): string | undefined {
   return (

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -49,12 +49,7 @@ function redactTranscriptText(value: string, cfg?: OpenClawConfig): string {
   return redactSensitiveText(value, redactTranscriptOptions(cfg));
 }
 
-// Pagination cursors are opaque paging state, not credentials, but the generic
-// secret-key heuristic masks any `*_token` key. In persisted transcripts that is
-// harmful: on resume the model replays the `***` mask as a real cursor and the
-// platform silently pages from the start, returning wrong data with no error
-// (#104992). Exempt only unambiguous page cursors — the `page` marker rules out
-// credentials — and keep this transcript-scoped so logs still redact them.
+// Preserve unambiguous pagination state in transcripts; global logs still redact it.
 const TRANSCRIPT_PAGINATION_CURSOR_KEY_RE = /^(?:next[_-]?)?page[_-]?token$|^page[_-]?cursor$/i;
 
 function redactTranscriptStructuredFieldValue(
@@ -66,8 +61,7 @@ function redactTranscriptStructuredFieldValue(
     return value;
   }
   if (TRANSCRIPT_PAGINATION_CURSOR_KEY_RE.test(key)) {
-    // Keep the cursor readable, but still run value-pattern redaction so an
-    // embedded registered/known secret shape is masked even here.
+    // Value-pattern redaction still masks embedded secrets.
     return redactTranscriptText(value, cfg);
   }
   return redactSensitiveFieldValue(key, value, redactTranscriptOptions(cfg));


### PR DESCRIPTION
## What Problem This Solves

Persisted session transcripts mask any `*_token`-shaped tool-call argument to `***`, including **pagination cursors** like `page_token` / `next_page_token`. When the session resumes, the redacted transcript is rebuilt into model context and the model reuses the `***` mask as a real cursor. For pagination that fails silently: the platform treats an invalid cursor as page 1 and returns wrong data with no error — failure mode **C** in #104992, which was 19 of the reporter's 25 masked-argument hits.

## Why This Change Was Made

The transcript redactor routes structured field values through `redactSensitiveFieldValue` (`src/logging/redact.ts`), whose key heuristic `STRUCTURED_SECRET_ENV_FIELD_RE` matches `^(?:[A-Z0-9]+[_-])+TOKEN$` — i.e. every `*_token` key, credential or not. Pagination cursors are opaque paging state, not credentials, so masking them corrupts resumed context.

This change exempts **only unambiguous page cursors** (`page_token`, `next_page_token`, `page_cursor`, case/`-`/`_` variants) in the transcript redaction path (`src/agents/transcript-redact.ts`). The `page` marker rules out credentials. Two safety properties are preserved:

- **Value-pattern redaction still runs** on the exempt keys, so a real secret shape embedded in a cursor value is still masked (verified below).
- **Transcript-scoped only** — the global logging redactor is untouched, so logs keep redacting `page_token` for defense in depth.

Genuine credential arguments (`doc_token`, `app_secret`, `token`, `api_key`, …) stay masked. The issue's failure modes A (`doc_token` reuse) and B (`exec` command secrets) require the reporter's architectural options 1/2 (reversible-sentinel store resolved at the tool layer, like SecretRef) and are intentionally left for a maintainer decision; this PR takes the safe, self-contained win for mode C.

## User Impact

- Resumed sessions no longer page from the start with a `***` cursor; continued pagination returns the correct next page.
- No change for real credentials in transcripts or for any value in logs.

## Evidence

**Executed real-module before/after** (`redactTranscriptMessage`, the actual persistence entry point, tsx over source):

Before (main) — cursors masked, breaking resume:
```json
{ "page_token": "***", "doc_token": "***", "app_secret": "***", "cursor": "CURxyz" }
```

After (this PR) — cursors readable, credentials still masked:
```json
{
  "page_token": "PGabc123XYZ",
  "next_page_token": "NXTpage456",
  "page_cursor": "PC789",
  "doc_token": "***",
  "app_secret": "***",
  "cursor": "CURxyz"
}
```

**Embedded-secret defense** — a real Anthropic key shape placed *inside* an exempt `page_token` value is still masked (`"sk-ant-api03-EMBEDDED…"` → `"sk-ant…cdef"`), proving value-pattern redaction still runs on exempt keys.

**Regression tests** (`node scripts/run-vitest.mjs run src/agents/transcript-redact.test.ts` → 50/50): one test asserts cursors survive while `doc_token`/`app_secret` stay masked; a second asserts a secret-shaped value under an exempt key is still masked. Reverting only `transcript-redact.ts` fails the first test, confirming it gates the fix.

Refs #104992
