### PR TITLE
test: reset bundled plugin dir after facade tests

### DIFF
--- a/src/plugin-sdk/facade-loader.test.ts
+++ b/src/plugin-sdk/facade-loader.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { setBundledPluginsDirOverrideForTest } from "../plugins/bundled-dir.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
 import {
   listImportedBundledPluginFacadeIds,
@@ -173,6 +174,7 @@ afterEach(() => {
   for (const dir of trustedBundledPluginFixtureRoots.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
+  setBundledPluginsDirOverrideForTest(undefined);
   delete (globalThis as typeof globalThis & Record<string, unknown>)[FACADE_LOADER_GLOBAL];
   if (originalBundledPluginsDir === undefined) {
     delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;


### PR DESCRIPTION
## Summary

- What Problem This Solves: LTS plugin SDK tests can inherit a cached bundled-plugin fixture directory after the fixture is deleted, making later provider-catalog tests order-dependent.
- Why This Change Was Made: reset the same bundled-directory resolver state that the facade runtime tests already reset.
- User Impact: none; this is deterministic test cleanup for the extended-stable release branch.
- Evidence: the exact plugin SDK shard passed 383/383 tests in three consecutive Testbox repetitions after the change.

Intentionally out of scope: backporting main's broader bundled-provider parity changes, whose assumptions do not match this LTS branch.

## Linked context

Related #105028

Requested as part of maintainer release validation for `extended-stable/2026.6.33`.

## Real behavior proof

- Behavior or issue addressed: order-dependent plugin SDK test failure caused by cached deleted fixture state.
- Real environment tested: hosted Linux Testbox.
- Exact steps: ran `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugin-sdk.config.ts --reporter=verbose` three times on the exact patched tree.
- Observed result: all three repetitions passed 383/383 tests.
- What was not tested: no product runtime behavior changed.
- Proof limitations: none for the touched test-only surface.

## Tests and validation

- Three consecutive full plugin SDK shard repetitions: passed.
- `git diff --check`: passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- Before fix: run 29181606083 failed 2/383 assertions when facade-loader tests ran before provider-catalog tests.

## Risk checklist

- User-visible behavior changed: No.
- Config, environment, or migration behavior changed: No.
- Security, auth, secrets, network, or tool execution behavior changed: No.
- Highest risk: masking a fixture cleanup mistake. Mitigated by resetting only the documented test override/cache seam after fixture deletion.

## Current review state

Next action: hosted PR CI, then merge into `extended-stable/2026.6.33`.

