### PR TITLE
fix(context): keep treemap label truncation UTF-16 safe

### DIFF
--- a/src/auto-reply/reply/context-treemap.truncate-label.test.ts
+++ b/src/auto-reply/reply/context-treemap.truncate-label.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { truncateLabel } from "./context-treemap.js";
+
+const hasLoneSurrogate = (value: string): boolean =>
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(value);
+
+describe("truncateLabel", () => {
+  it("returns the value unchanged when within the char budget", () => {
+    expect(truncateLabel("short", 10)).toBe("short");
+  });
+
+  it("returns empty string for a non-positive budget", () => {
+    expect(truncateLabel("anything", 0)).toBe("");
+  });
+
+  it("does not split a surrogate pair at the truncation boundary", () => {
+    // 🦞 (2 UTF-16 code units) straddles the cut; a raw value.slice(0, n)
+    // would leave a trailing lone high surrogate (renders as �).
+    const label = "x🦞tail";
+    const out = truncateLabel(label, 2);
+    expect(hasLoneSurrogate(out)).toBe(false);
+    expect(out).not.toContain("�");
+  });
+
+  it("keeps a multibyte label surrogate-safe under the main truncation path", () => {
+    const label = `${"字".repeat(3)}🦞${"y".repeat(20)}`;
+    const out = truncateLabel(label, 5);
+    expect(hasLoneSurrogate(out)).toBe(false);
+    expect(Buffer.from(out, "utf8").toString("utf8")).toBe(out);
+    expect(out.length).toBeLessThanOrEqual(5);
+  });
+
+  it("preserves an intact surrogate pair that fits within the budget", () => {
+    const out = truncateLabel("🦞abc", 10);
+    expect(out).toBe("🦞abc");
+  });
+});

--- a/src/auto-reply/reply/context-treemap.ts
+++ b/src/auto-reply/reply/context-treemap.ts
@@ -4,6 +4,7 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import zlib from "node:zlib";
 import { expectDefined } from "@openclaw/normalization-core";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { estimateTokensFromChars } from "../../utils/cjk-chars.js";
@@ -132,7 +133,7 @@ function sanitizeLabel(value: string): string {
     .toUpperCase();
 }
 
-function truncateLabel(value: string, maxChars: number): string {
+export function truncateLabel(value: string, maxChars: number): string {
   if (maxChars <= 0) {
     return "";
   }
@@ -140,9 +141,9 @@ function truncateLabel(value: string, maxChars: number): string {
     return value;
   }
   if (maxChars <= 2) {
-    return value.slice(0, maxChars);
+    return truncateUtf16Safe(value, maxChars);
   }
-  return value.slice(0, maxChars - 1);
+  return truncateUtf16Safe(value, maxChars - 1);
 }
 
 function layoutBinary<T extends { value: number }>(rawItems: T[], rect: Rect): PositionedItem<T>[] {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a context-map treemap label built from a multibyte name — most
commonly a workspace **file name** containing an emoji or CJK character — can render a
broken trailing character (the Unicode replacement glyph `�`) when the label is clipped
to fit its cell.

`truncateLabel` in `src/auto-reply/reply/context-treemap.ts` clips over-long labels with
raw `value.slice(0, maxChars)` / `value.slice(0, maxChars - 1)`. A UTF-16 char-index slice
can cut through a surrogate pair, leaving a dangling code unit at the end of the drawn text.

**Concrete example:** `truncateLabel("x🦞workspace-file.ts", 2)` on current `main` returns
`"x\uD83E"` — a lone high surrogate (`U+D83E`, the leading half of `🦞`) with no low half,
which renders as `x�` in the treemap.

## Why This Change Was Made

Replace both raw clip paths with `truncateUtf16Safe(value, ...)` from
`@openclaw/normalization-core/utf16-slice`, which backs off a dangling surrogate half at the
cut. This matches the established tail-truncation pattern already adopted for other unfiltered
text surfaces (`fix(browser): keep Chrome stderr hint tail UTF-16 safe` #104603, and the SCP /
voice-call / file-transfer UTF-16 fixes #104148 / #104260). The helper short-circuits when the
string is already within budget, so ASCII labels are byte-for-byte unchanged; only the
truncation boundary becomes surrogate-safe.

## User Impact

**Before:** context-map (`/context map`) treemap labels for workspace files or tools whose
names contain emoji/CJK can show a replacement glyph (`�`) at the truncation boundary.

**After:** treemap labels remain well-formed Unicode — a boundary emoji is dropped whole
instead of being split into a lone surrogate. No change for ASCII labels.

## Evidence

- `src/auto-reply/reply/context-treemap.ts` — `truncateLabel` uses `truncateUtf16Safe` on both clip paths (`maxChars <= 2` and the main `maxChars - 1`).
- `packages/normalization-core/src/utf16-slice.ts` — shared surrogate-safe truncation helper (unchanged).
- Regression test: `src/auto-reply/reply/context-treemap.truncate-label.test.ts` — a label whose emoji straddles the `maxChars` cut asserts no lone surrogate / `�`, clean UTF-8 round-trip, and within-budget length; both clip paths covered, plus within-budget / zero-budget / intact-pair cases. The two surrogate cases fail on raw `.slice` and pass with the fix.
- Function probe against the real production `truncateLabel`:

```
$ node --import tsx -e "import('./src/auto-reply/reply/context-treemap.ts').then(m => …)"
input: "x🦞workspace-file.ts"
truncateLabel(label, 2): "x"          # was "x\uD83E" (lone high surrogate) before the fix
has lone surrogate: false
round-trips through UTF-8 cleanly: true
```
