### PR TITLE
fix(android): stop canceled work from surfacing failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Android cancellation:** propagate canceled Talk synthesis, location, and motion requests instead of converting retired work into visible failure results.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Android cancellation:** propagate canceled Talk synthesis, location, and motion requests instead of converting retired work into visible failure results.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.location.LocationManager
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -160,6 +161,8 @@ class LocationHandler private constructor(
         code = "LOCATION_TIMEOUT",
         message = "LOCATION_TIMEOUT: no fix in time",
       )
+    } catch (err: CancellationException) {
+      throw err
     } catch (err: Throwable) {
       val message = err.message ?: "LOCATION_UNAVAILABLE: no fix"
       return GatewaySession.InvokeResult.error(code = "LOCATION_UNAVAILABLE", message = message)

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
@@ -9,6 +9,7 @@ import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.os.SystemClock
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeoutOrNull
@@ -317,6 +318,8 @@ class MotionHandler private constructor(
       )
     } catch (err: IllegalArgumentException) {
       GatewaySession.InvokeResult.error(code = "MOTION_UNAVAILABLE", message = err.message ?: "MOTION_UNAVAILABLE")
+    } catch (err: CancellationException) {
+      throw err
     } catch (err: Throwable) {
       GatewaySession.InvokeResult.error(
         code = "MOTION_UNAVAILABLE",
@@ -353,6 +356,8 @@ class MotionHandler private constructor(
       )
     } catch (err: IllegalArgumentException) {
       GatewaySession.InvokeResult.error(code = "MOTION_UNAVAILABLE", message = err.message ?: "MOTION_UNAVAILABLE")
+    } catch (err: CancellationException) {
+      throw err
     } catch (err: Throwable) {
       GatewaySession.InvokeResult.error(
         code = "MOTION_UNAVAILABLE",

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkSpeakClient.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkSpeakClient.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.voice
 
 import ai.openclaw.app.gateway.GatewaySession
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -58,6 +59,8 @@ internal class TalkSpeakClient(
           paramsJson = json.encodeToString(TalkSpeakRequest.from(text = text, directive = directive)),
           timeoutMs = 45_000,
         )
+      } catch (err: CancellationException) {
+        throw err
       } catch (err: Throwable) {
         return TalkSpeakResult.Failure(err.message ?: "talk.speak request failed")
       }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/LocationHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/LocationHandlerTest.kt
@@ -3,11 +3,13 @@ package ai.openclaw.app.node
 import ai.openclaw.app.LocationMode
 import android.content.Context
 import android.location.LocationManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class LocationHandlerTest : NodeHandlerRobolectricTest() {
@@ -204,6 +206,28 @@ class LocationHandlerTest : NodeHandlerRobolectricTest() {
       assertFalse(result.ok)
       assertEquals("LOCATION_UNAVAILABLE", result.error?.code)
       assertEquals("gps offline", result.error?.message)
+    }
+
+  @Test
+  fun handleLocationGet_propagatesParentCancellation() =
+    runTest {
+      val handler =
+        LocationHandler.forTesting(
+          appContext = appContext(),
+          dataSource =
+            FakeLocationDataSource(
+              fineGranted = true,
+              coarseGranted = true,
+              failure = CancellationException("request retired"),
+            ),
+        )
+
+      try {
+        handler.handleLocationGet(null)
+        fail("expected cancellation to propagate")
+      } catch (err: CancellationException) {
+        assertEquals("request retired", err.message)
+      }
     }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/MotionHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/MotionHandlerTest.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.node
 
 import android.content.Context
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -9,6 +10,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class MotionHandlerTest : NodeHandlerRobolectricTest() {
@@ -88,6 +90,46 @@ class MotionHandlerTest : NodeHandlerRobolectricTest() {
       assertFalse(result.ok)
       assertEquals("MOTION_UNAVAILABLE", result.error?.code)
       assertTrue(result.error?.message?.contains("PEDOMETER_RANGE_UNAVAILABLE") == true)
+    }
+
+  @Test
+  fun handleMotionActivity_propagatesParentCancellation() =
+    runTest {
+      val handler =
+        MotionHandler.forTesting(
+          appContext(),
+          FakeMotionDataSource(
+            hasPermission = true,
+            activityError = CancellationException("invoke retired"),
+          ),
+        )
+
+      try {
+        handler.handleMotionActivity(null)
+        fail("expected cancellation to propagate")
+      } catch (err: CancellationException) {
+        assertEquals("invoke retired", err.message)
+      }
+    }
+
+  @Test
+  fun handleMotionPedometer_propagatesParentCancellation() =
+    runTest {
+      val handler =
+        MotionHandler.forTesting(
+          appContext(),
+          FakeMotionDataSource(
+            hasPermission = true,
+            pedometerError = CancellationException("invoke retired"),
+          ),
+        )
+
+      try {
+        handler.handleMotionPedometer(null)
+        fail("expected cancellation to propagate")
+      } catch (err: CancellationException) {
+        assertEquals("invoke retired", err.message)
+      }
     }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkSpeakClientTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkSpeakClientTest.kt
@@ -2,9 +2,11 @@ package ai.openclaw.app.voice
 
 import ai.openclaw.app.gateway.GatewayConnectErrorDetails
 import ai.openclaw.app.gateway.GatewaySession
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class TalkSpeakClientTest {
@@ -127,5 +129,21 @@ class TalkSpeakClientTest {
 
       val result = client.synthesize(text = "Hello", directive = null)
       assertTrue(result is TalkSpeakResult.FallbackToLocal)
+    }
+
+  @Test
+  fun propagatesRequestCancellation() =
+    runTest {
+      val client =
+        TalkSpeakClient(
+          requestDetailed = { _, _, _ -> throw CancellationException("talk stopped") },
+        )
+
+      try {
+        client.synthesize(text = "Hello", directive = null)
+        fail("expected cancellation to propagate")
+      } catch (err: CancellationException) {
+        assertEquals("talk stopped", err.message)
+      }
     }
 }


### PR DESCRIPTION
Closes #105045

## What Problem This Solves

Fixes an issue where Android users stopping Talk work or retiring location and motion invocations could receive a stale failure because parent coroutine cancellation was converted into an ordinary error result.

## Why This Change Was Made

Rethrows `CancellationException` at the three suspending owner boundaries while preserving the existing operation-owned location timeout mapping. The motion activity and pedometer siblings use the same lifecycle rule, matching the established camera-handler behavior.

## User Impact

Canceled Android Talk, location, and motion work now terminates quietly instead of showing or emitting a misleading failure. Genuine provider, sensor, permission, and location-timeout errors remain unchanged.

## Evidence

- Blacksmith Testbox through Crabbox `tbx_01kxaen3v1cp4zvqes57qqj9hs`:
  - `:app:testPlayDebugUnitTest` and `:app:testThirdPartyDebugUnitTest` passed for `TalkSpeakClientTest`, `LocationHandlerTest`, and `MotionHandlerTest`.
  - `:app:ktlintCheck` passed.
- Regression coverage injects named cancellation at Talk RPC, location fetch, motion activity, and pedometer boundaries and requires the same exception to reach the caller.
- Existing `handleLocationGet_mapsTimeoutToLocationTimeout` remains green, proving `TimeoutCancellationException` catch ordering is preserved.
- Structured Codex autoreview: clean, no accepted/actionable findings.
- Source-blind behavior contract written for live Talk UI and Gateway node-invoke cancellation. Full black-box execution is not claimed here because the current Android emulator lane has no external control for retiring an in-flight Talk/node request; hosted Android build and flavor tests remain required before landing.

Provenance: Talk request failure mapping was introduced in `98d593956493` by Ayaan Zaidi. The location and motion broad catches were carried from the initial Android handler import `aa91000a5d1b`. This PR is maintainer-authored and does not attribute either author as the current fix author.

AI-assisted by Codex. No agent transcript attached.
