### PR TITLE
fix(macos): make parallel gateway auth tests reliable

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/ConnectCommandTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConnectCommandTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import OpenClawKit
 import Testing
+@testable import OpenClawKit
 @testable import OpenClawMacCLI
 
 private final class CLIConnectAuthRecorder: @unchecked Sendable {
@@ -83,7 +83,7 @@ struct ConnectCommandTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": tempDir.path]) {
+        try await DeviceIdentityStore.withStateDirectory(tempDir) {
             var config = GatewayConfig()
             config.mode = "remote"
             config.remoteToken = "gateway-a-config-token" // pragma: allowlist secret
@@ -135,7 +135,7 @@ struct ConnectCommandTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": tempDir.path]) {
+        try await DeviceIdentityStore.withStateDirectory(tempDir) {
             var configA = GatewayConfig()
             configA.mode = "remote"
             configA.remoteUrl = "wss://gateway-a.example.test"

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
@@ -201,7 +201,7 @@ struct GatewayChannelConnectTests {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
-        return try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": tempDir.path]) {
+        return try await DeviceIdentityStore.withStateDirectory(tempDir) {
             try await operation()
         }
     }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelDeviceTokenRetryTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelDeviceTokenRetryTests.swift
@@ -1,7 +1,7 @@
 import CryptoKit
 import Foundation
-import OpenClawKit
 import Testing
+@testable import OpenClawKit
 
 extension NSLock {
     fileprivate func withDeviceRetryLock<T>(_ body: () -> T) -> T {
@@ -108,7 +108,7 @@ struct GatewayChannelDeviceTokenRetryTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": tempDir.path]) {
+        try await DeviceIdentityStore.withStateDirectory(tempDir) {
             let identity = DeviceIdentityStore.loadOrCreate()
             let key = SymmetricKey(size: .bits256)
             let url = try #require(URL(string: "ws://example.invalid"))
@@ -172,7 +172,7 @@ struct GatewayChannelDeviceTokenRetryTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": tempDir.path]) {
+        try await DeviceIdentityStore.withStateDirectory(tempDir) {
             let identity = DeviceIdentityStore.loadOrCreate()
             _ = DeviceAuthStore.storeToken(
                 deviceId: identity.deviceId,

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelShutdownTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelShutdownTests.swift
@@ -1,7 +1,7 @@
 import Foundation
-import OpenClawKit
 import Testing
 @testable import OpenClaw
+@testable import OpenClawKit
 
 private actor GatewayHandshakeGate {
     private var started = false
@@ -74,7 +74,7 @@ struct GatewayChannelShutdownTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": tempDir.path]) {
+        try await DeviceIdentityStore.withStateDirectory(tempDir) {
             let identity = DeviceIdentityStore.loadOrCreate()
             let responseGate = GatewayHandshakeGate()
             let snapshots = GatewaySnapshotProbe()

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -1,10 +1,10 @@
 import Foundation
-@testable import OpenClaw
-@testable import OpenClawIPC
-import OpenClawKit
-@testable import OpenClawMacCLI
 import OpenClawProtocol
 import Testing
+@testable import OpenClaw
+@testable import OpenClawIPC
+@testable import OpenClawKit
+@testable import OpenClawMacCLI
 
 private func makeGatewayGenerationSnapshot(version: String) -> HelloOk {
     HelloOk(
@@ -737,7 +737,7 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": tempDir.path]) {
+        try await DeviceIdentityStore.withStateDirectory(tempDir) {
             let unscopedToken = "legacy-unscoped-token"
             let routeAToken = "route-a-device-token"
             let routeAAuth = try await self.connectAuth(

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlUIAuthTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlUIAuthTests.swift
@@ -1,7 +1,7 @@
 import Foundation
-import OpenClawKit
 import Testing
 @testable import OpenClaw
+@testable import OpenClawKit
 
 private final class ControlUIEndpointSource: @unchecked Sendable {
     private let lock = NSLock()
@@ -91,7 +91,7 @@ struct GatewayConnectionControlUIAuthTests {
         try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: stateDir) }
 
-        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": stateDir.path]) {
+        try await DeviceIdentityStore.withStateDirectory(stateDir) {
             let identity = DeviceIdentityStore.loadOrCreate()
             _ = DeviceAuthStore.storeToken(
                 deviceId: identity.deviceId,
@@ -151,7 +151,7 @@ struct GatewayConnectionControlUIAuthTests {
         try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: stateDir) }
 
-        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": stateDir.path]) {
+        try await DeviceIdentityStore.withStateDirectory(stateDir) {
             let identity = DeviceIdentityStore.loadOrCreate()
             _ = DeviceAuthStore.storeToken(
                 deviceId: identity.deviceId,

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -1,10 +1,10 @@
 import CryptoKit
 import Foundation
-@testable import OpenClaw
 import OpenClawChatUI
-import OpenClawKit
 import OpenClawProtocol
 import Testing
+@testable import OpenClaw
+@testable import OpenClawKit
 
 private actor ActivationMarkerObservation {
     private var observed = false
@@ -2521,7 +2521,7 @@ struct OnboardingAISetupTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": tempDir.path]) {
+        try await DeviceIdentityStore.withStateDirectory(tempDir) {
             let identity = DeviceIdentityStore.loadOrCreate()
             let deviceAuthGatewayID = "local"
             let originalToken = "receipt-device-token-a"

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
@@ -48,6 +48,7 @@ public struct DeviceIdentity: Codable, Sendable {
 
 enum DeviceIdentityPaths {
     private static let stateDirEnv = ["OPENCLAW_STATE_DIR"]
+    @TaskLocal static var scopedStateDirURL: URL?
 
     /// Entitlements are baked into the code signature, so resolve the gate once per process.
     /// Every identity load and DeviceAuthStore read/write resolves the state dir through here;
@@ -84,6 +85,11 @@ enum DeviceIdentityPaths {
     }
 
     private static func stateDirOverrideURL() -> URL? {
+        // Test-scoped stores must win over the process environment. Parallel Swift tests
+        // otherwise race whenever another suite temporarily swaps OPENCLAW_STATE_DIR.
+        if let scopedStateDirURL = self.scopedStateDirURL {
+            return scopedStateDirURL
+        }
         for key in self.stateDirEnv {
             if let raw = getenv(key) {
                 let value = String(cString: raw).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -188,6 +194,17 @@ public enum DeviceIdentityStore {
 
     public static func loadOrCreate() -> DeviceIdentity {
         self.loadOrCreate(profile: .primary)
+    }
+
+    static func withStateDirectory<T>(
+        _ url: URL,
+        operation: () async throws -> T,
+        isolation: isolated (any Actor)? = #isolation) async rethrows -> T
+    {
+        try await DeviceIdentityPaths.$scopedStateDirURL.withValue(
+            url,
+            operation: operation,
+            isolation: isolation)
     }
 
     public static func loadOrCreate(profile: GatewayDeviceIdentityProfile) -> DeviceIdentity {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -5,6 +5,40 @@ import Testing
 
 @Suite(.serialized)
 struct DeviceIdentityStoreTests {
+    @Test
+    func `task scoped state directories isolate concurrent identity stores`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let stateDirectories = [
+            root.appendingPathComponent("a", isDirectory: true),
+            root.appendingPathComponent("b", isDirectory: true),
+        ]
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let observed = await withTaskGroup(of: String.self) { group in
+            for stateDirectory in stateDirectories {
+                group.addTask {
+                    await DeviceIdentityStore.withStateDirectory(stateDirectory) {
+                        let identity = DeviceIdentityStore.loadOrCreate()
+                        await Task.yield()
+                        #expect(DeviceIdentityStore.loadOrCreate().deviceId == identity.deviceId)
+                        return identity.deviceId
+                    }
+                }
+            }
+            return await group.reduce(into: Set<String>()) { result, deviceId in
+                result.insert(deviceId)
+            }
+        }
+
+        #expect(observed.count == stateDirectories.count)
+        for stateDirectory in stateDirectories {
+            #expect(FileManager.default.fileExists(
+                atPath: stateDirectory.appendingPathComponent("identity/device.json").path))
+        }
+    }
+
     @Test(.stateDirectoryIsolated)
     func `device auth store reports failed durable writes`() throws {
         let tempDir = FileManager.default.temporaryDirectory


### PR DESCRIPTION
Related: #102883

## What Problem This Solves

Fixes an issue where macOS Gateway auth tests would fail nondeterministically under parallel Swift testing even though each failing test passed in isolation.

## Why This Change Was Made

Device identity and auth storage resolved `OPENCLAW_STATE_DIR` from the process environment on every access. The existing environment lock protected only tests participating in that lock, so unrelated concurrent Gateway tasks could observe a temporary directory belonging to another test. A task-local state-directory scope now follows the test's child tasks without mutating process-global state; all device-store Gateway tests use that scope. Production environment resolution is unchanged.

## User Impact

No user-visible runtime behavior changes. Maintainers get deterministic parallel coverage for route-scoped Gateway device authentication without serializing the macOS test suite.

## Evidence

- Hosted before-state: [macos-swift attempt 1](https://github.com/openclaw/openclaw/actions/runs/29174833667/attempts/1) failed different route-token assertions across retries, then the rerun passed.
- `swift test --package-path apps/shared/OpenClawKit --filter "task scoped state directories isolate concurrent identity stores"` — 1/1 passed.
- `swift test --package-path apps/macos --parallel --filter 'Gateway(ConnectionControl|ChannelDeviceTokenRetry)'` — 12 consecutive passes, 24 tests across 4 suites per run.
- `swift test --package-path apps/macos --parallel` — two complete passes, 1,183 tests across 136 suites. Two additional repetitions failed only in the separate pre-existing `OnboardingViewSmokeTests` pending-state race; all affected Gateway suites passed in those runs.
- Remote `pnpm check:changed` on Blacksmith Testbox `tbx_01kxadeqx6grr37c251ajfzkta` — passed.
- Fresh autoreview — no findings, patch correct at 0.91 confidence.
