### PR TITLE
test(agents): keep model discovery assertions hermetic against bundled plugin runtime

### DIFF
--- a/src/agents/agent-model-discovery.test.ts
+++ b/src/agents/agent-model-discovery.test.ts
@@ -2,9 +2,23 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { discoverAuthStorage, discoverModels } from "./agent-model-discovery.js";
+
+// Discovery must not cold-load bundled plugin runtime: with build artifacts
+// present, the openai plugin's normalizeResolvedModel currently overrides
+// authored models.json api values, making these assertions machine-dependent.
+// The ambient plugin metadata snapshot is cleared for the same reason.
+beforeEach(() => {
+  vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  clearCurrentPluginMetadataSnapshot();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 function writeModelsJson(agentDir: string, modelId: string): void {
   fs.writeFileSync(


### PR DESCRIPTION
## What Problem This Solves

`src/agents/agent-model-discovery.test.ts` ("preserves authored OpenAI Completions while normalizing models.json entries", added in #104685) is machine-dependent: whenever bundled plugin runtime is loadable (build artifacts under `dist/`/`dist-runtime`, i.e. every real install and any CI runner whose build phase succeeded), the openai plugin's `normalizeResolvedModel` overrides the authored `api` and the test fails. `checks-node-agentic-agents-core-runtime` failed exactly on runs with successful builds (e.g. Actions runs 29171103095, 29172850471, 29180979878); `main`'s only completed post-#104685 run passed the shard only because its build job failed.

## Why This Change Was Made

Per the agents test guardrails, discovery-data tests must not cold-load bundled plugin runtime. The test now stubs `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` and clears the ambient plugin metadata snapshot, so it deterministically asserts the no-plugin-runtime contract on every machine. The underlying product question (should an authored `openai-completions` route survive plugin normalization when route auth-availability says otherwise) is tracked in #105035.

## User Impact

None at runtime; unblocks CI stability for every branch built after #104685.

## Evidence

- Reproduced deterministically in a checkout with `dist`/`dist-runtime` present: test failed before this change, passes after (2/2). Probe at merge-base `94faf4d789ac` (pure `main`) with plugin runtime active returns `openai-responses` for the authored entry, proving the pre-existing breakage is independent of any feature branch.
- Full diagnostic chain in #105035.
