### PR TITLE
fix(config): restore canonical flat streaming-key resolution and preserve discord preview mode in doctor migration

### DIFF
--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -138,8 +138,8 @@ without block replies. The `blockStreaming*` defaults live under
 
 ## Preview streaming modes
 
-Canonical key: `channels.<channel>.streaming` (nested `{ mode, ... }`; a
-top-level boolean is a legacy alias).
+Canonical key: `channels.<channel>.streaming` (nested `{ mode, ... }`; legacy
+top-level boolean/string spellings are rewritten by `openclaw doctor --fix`).
 
 | Mode       | Behavior                                                              |
 | ---------- | --------------------------------------------------------------------- |
@@ -150,8 +150,9 @@ top-level boolean is a legacy alias).
 
 `streaming.mode: "block"` is a preview-streaming mode for edit-capable
 channels such as Discord and Telegram; it does not by itself enable channel
-block delivery there. Use `streaming.block.enabled` (or the legacy
-`blockStreaming` channel key) for normal block replies. Microsoft Teams is the
+block delivery there. Use `streaming.block.enabled` for normal block replies
+(channels without a nested `streaming` config keep the flat `blockStreaming`
+key instead). Microsoft Teams is the
 exception: it has no draft-preview block transport, so `streaming.mode:
 "block"` disables native streaming entirely and the reply lands as regular
 block delivery instead of native partial/progress streaming. Mattermost also
@@ -185,11 +186,11 @@ Slack-only:
 
 ### Legacy key migration
 
-| Channel  | Legacy keys                                                 | Status                                                                                                                                                       |
-| -------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Telegram | `streamMode`, scalar/boolean `streaming`                    | Detected and migrated to `streaming.mode` by doctor/config compatibility paths                                                                               |
-| Discord  | `streamMode`, boolean `streaming`                           | Runtime aliases for the `streaming` enum; run `openclaw doctor --fix` to rewrite persisted config                                                            |
-| Slack    | `streamMode`; boolean `streaming`; legacy `nativeStreaming` | Runtime aliases for `streaming.mode` (and `streaming.nativeTransport` for the boolean/legacy forms); run `openclaw doctor --fix` to rewrite persisted config |
+| Channel  | Legacy keys                                                 | Status                                                                                                                                       |
+| -------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Telegram | `streamMode`, scalar/boolean `streaming`                    | Rewritten to `streaming.mode` by `openclaw doctor --fix`; not read at runtime                                                                |
+| Discord  | `streamMode`, boolean `streaming`                           | Rewritten to `streaming.mode` by `openclaw doctor --fix`; not read at runtime                                                                |
+| Slack    | `streamMode`; boolean `streaming`; legacy `nativeStreaming` | Rewritten to `streaming.mode` (and `streaming.nativeTransport` for the boolean/legacy forms) by `openclaw doctor --fix`; not read at runtime |
 
 ## Runtime behavior
 

--- a/extensions/discord/src/doctor-contract.ts
+++ b/extensions/discord/src/doctor-contract.ts
@@ -514,6 +514,10 @@ export function normalizeCompatibilityConfig({
       // Runtime mode resolution dropped legacy streamMode reads; the doctor
       // resolver keeps them so migration preserves configured intent.
       resolvedMode: resolveLegacyAliasStreamingMode(entry, "off"),
+      // Discord previews default to progress only while `streaming` is absent;
+      // migrating delivery-only aliases (e.g. blockStreaming) creates the
+      // object, so pin progress or migration silently disables previews.
+      aliasOnlyMode: "progress",
       includePreviewChunk: true,
     }),
     normalizeAccountExtra: ({ account, pathPrefix }) => {

--- a/extensions/discord/src/doctor-contract.ts
+++ b/extensions/discord/src/doctor-contract.ts
@@ -504,6 +504,16 @@ export function normalizeCompatibilityConfig({
   let changed;
   const bindingsToAdd: AgentBindingConfig[] = [];
 
+  // Discord previews default to progress only while `streaming` is absent;
+  // any present object (even without `mode`) resolves off. Migration must pin
+  // the entry's previous effective mode when delivery-only aliases create the
+  // object, or doctor silently flips preview behavior.
+  const discordEffectiveMode = (entry: Record<string, unknown>) =>
+    entry.streaming === undefined && entry.streamMode === undefined
+      ? "progress"
+      : resolveLegacyAliasStreamingMode(entry, "off");
+  const rootEffectiveMode = discordEffectiveMode(rawEntry);
+
   const aliases = normalizeLegacyChannelAliases({
     entry: rawEntry,
     pathPrefix: "channels.discord",
@@ -514,10 +524,11 @@ export function normalizeCompatibilityConfig({
       // Runtime mode resolution dropped legacy streamMode reads; the doctor
       // resolver keeps them so migration preserves configured intent.
       resolvedMode: resolveLegacyAliasStreamingMode(entry, "off"),
-      // Discord previews default to progress only while `streaming` is absent;
-      // migrating delivery-only aliases (e.g. blockStreaming) creates the
-      // object, so pin progress or migration silently disables previews.
-      aliasOnlyMode: "progress",
+      // Accounts without their own mode source inherit the root's effective
+      // mode at runtime (account `streaming` objects replace the root object
+      // wholesale on merge), so pin that. The root only hits the alias-only
+      // branch when both mode sources are absent, where this is "progress".
+      aliasOnlyMode: rootEffectiveMode,
       includePreviewChunk: true,
     }),
     normalizeAccountExtra: ({ account, pathPrefix }) => {

--- a/extensions/discord/src/doctor.test.ts
+++ b/extensions/discord/src/doctor.test.ts
@@ -8,6 +8,7 @@ import {
   maybeRepairDiscordNumericIds,
   scanDiscordNumericIdEntries,
 } from "./doctor.js";
+import { resolveDiscordPreviewStreamMode } from "./preview-streaming.js";
 
 function getDiscordCompatibilityNormalizer(): NonNullable<
   typeof discordDoctor.normalizeCompatibilityConfig
@@ -79,6 +80,31 @@ describe("discord doctor", () => {
       "Moved channels.discord.draftChunk → channels.discord.streaming.preview.chunk.",
       "Moved channels.discord.accounts.work.streaming (boolean) → channels.discord.accounts.work.streaming.mode (off).",
       "Moved channels.discord.accounts.work.blockStreamingCoalesce → channels.discord.accounts.work.streaming.block.coalesce.",
+    ]);
+  });
+
+  it("pins progress mode when migrating delivery-only aliases", () => {
+    const normalize = getDiscordCompatibilityNormalizer();
+
+    const result = normalize({
+      cfg: {
+        channels: {
+          discord: { blockStreaming: true },
+        },
+      } as never,
+    });
+
+    const migrated = result.config.channels?.discord as Record<string, unknown>;
+    expect(migrated).toEqual({
+      streaming: { mode: "progress", block: { enabled: true } },
+    });
+    // Effective preview-mode parity: `streaming` absent resolved to progress
+    // before migration, so the migrated object must keep progress instead of
+    // falling to the object-without-mode default (off).
+    expect(resolveDiscordPreviewStreamMode(migrated)).toBe(resolveDiscordPreviewStreamMode({}));
+    expect(result.changes).toEqual([
+      "Moved channels.discord.blockStreaming → channels.discord.streaming.block.enabled.",
+      "Set channels.discord.streaming.mode (progress) to keep the previous default while migrating flat streaming keys.",
     ]);
   });
 

--- a/extensions/discord/src/doctor.test.ts
+++ b/extensions/discord/src/doctor.test.ts
@@ -108,6 +108,34 @@ describe("discord doctor", () => {
     ]);
   });
 
+  it("pins the inherited root mode when migrating account delivery aliases", () => {
+    const normalize = getDiscordCompatibilityNormalizer();
+
+    // Account `streaming` objects replace the root object wholesale on merge,
+    // so the migrated account must carry the root mode it previously inherited.
+    const result = normalize({
+      cfg: {
+        channels: {
+          discord: {
+            streaming: { mode: "off" },
+            accounts: { work: { chunkMode: "newline" } },
+          },
+        },
+      } as never,
+    });
+
+    expect(result.config.channels?.discord).toEqual({
+      streaming: { mode: "off" },
+      accounts: {
+        work: { streaming: { mode: "off", chunkMode: "newline" } },
+      },
+    });
+    expect(result.changes).toEqual([
+      "Moved channels.discord.accounts.work.chunkMode → channels.discord.accounts.work.streaming.chunkMode.",
+      "Set channels.discord.accounts.work.streaming.mode (off) to keep the previous default while migrating flat streaming keys.",
+    ]);
+  });
+
   it("moves account voice.tts.edge into providers.microsoft", () => {
     const normalize = getDiscordCompatibilityNormalizer();
 

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -134,11 +134,10 @@ export function resolveMattermostAccount(params: {
     oncharPrefixes: merged.oncharPrefixes,
     requireMention,
     textChunkLimit: merged.textChunkLimit,
-    chunkMode: resolveChannelStreamingChunkMode(merged) ?? merged.chunkMode,
+    chunkMode: resolveChannelStreamingChunkMode(merged),
     streamingMode: resolveChannelPreviewStreamMode(merged, "partial"),
-    blockStreaming: resolveChannelStreamingBlockEnabled(merged) ?? merged.blockStreaming,
-    blockStreamingCoalesce:
-      resolveChannelStreamingBlockCoalesce(merged) ?? merged.blockStreamingCoalesce,
+    blockStreaming: resolveChannelStreamingBlockEnabled(merged),
+    blockStreamingCoalesce: resolveChannelStreamingBlockCoalesce(merged),
   };
 }
 

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -96,17 +96,15 @@ function resolveChunkModeForProvider(
   const accounts = cfgSection.accounts;
   if (accounts && typeof accounts === "object") {
     const direct = resolveAccountEntry(accounts, normalizedAccountId);
-    // Flat `chunkMode` is the canonical schema shape for channels without a
-    // nested streaming config (signal, irc, googlechat, whatsapp, SDK plugins),
-    // so it stays a first-class read here, not legacy compat. Core must not
-    // hardcode per-channel gating; nested-only channels reject flat keys in
-    // their strict schemas, so validated runtime config never carries them.
-    const directMode = resolveChannelStreamingChunkMode(direct) ?? direct?.chunkMode;
+    // resolveChannelStreamingChunkMode owns nested-first/flat-fallback
+    // precedence (flat `chunkMode` stays canonical for channels without a
+    // nested streaming schema). Do not re-read flat keys here.
+    const directMode = resolveChannelStreamingChunkMode(direct);
     if (directMode) {
       return directMode;
     }
   }
-  return resolveChannelStreamingChunkMode(cfgSection) ?? cfgSection.chunkMode;
+  return resolveChannelStreamingChunkMode(cfgSection);
 }
 
 export function resolveChunkMode(

--- a/src/auto-reply/reply/block-streaming.ts
+++ b/src/auto-reply/reply/block-streaming.ts
@@ -42,9 +42,7 @@ type ProviderBlockStreamingConfig = {
 function resolveScopedBlockStreamingCoalesce(
   config: ProviderBlockStreamingConfig | undefined,
 ): BlockStreamingCoalesceConfig | undefined {
-  return config
-    ? (resolveChannelStreamingBlockCoalesce(config) ?? config.blockStreamingCoalesce)
-    : undefined;
+  return config ? resolveChannelStreamingBlockCoalesce(config) : undefined;
 }
 
 function resolveProviderBlockStreamingCoalesce(params: {

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -95,9 +95,10 @@ describe("buildChannelProgressDraftLine", () => {
 });
 
 describe("streaming config resolution", () => {
-  // Legacy flat aliases are doctor-migrated (`openclaw doctor --fix`); runtime
-  // resolution reads only the canonical nested streaming shape.
-  it("ignores legacy flat streaming keys", () => {
+  // Flat delivery keys stay canonical for channels without a nested streaming
+  // schema and for SDK plugins; mode-family aliases (streamMode, scalar
+  // streaming, nativeStreaming) are doctor-migrated and unread at runtime.
+  it("resolves flat delivery keys while ignoring mode-family aliases", () => {
     const legacyEntry = {
       streamMode: "block",
       chunkMode: "newline",
@@ -108,10 +109,10 @@ describe("streaming config resolution", () => {
     } as never;
 
     expect(resolveChannelPreviewStreamMode(legacyEntry, "partial")).toBe("partial");
-    expect(resolveChannelStreamingChunkMode(legacyEntry)).toBeUndefined();
-    expect(resolveChannelStreamingBlockEnabled(legacyEntry)).toBeUndefined();
-    expect(resolveChannelStreamingPreviewChunk(legacyEntry)).toBeUndefined();
-    expect(resolveChannelStreamingBlockCoalesce(legacyEntry)).toBeUndefined();
+    expect(resolveChannelStreamingChunkMode(legacyEntry)).toBe("newline");
+    expect(resolveChannelStreamingBlockEnabled(legacyEntry)).toBe(true);
+    expect(resolveChannelStreamingPreviewChunk(legacyEntry)).toEqual({ minChars: 10 });
+    expect(resolveChannelStreamingBlockCoalesce(legacyEntry)).toEqual({ idleMs: 5 });
     expect(resolveChannelStreamingNativeTransport(legacyEntry)).toBeUndefined();
   });
 

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -34,12 +34,21 @@ export type StreamingCompatEntry = {
    * Mattermost) also accept a scalar mode string or boolean here.
    */
   streaming?: unknown;
+  chunkMode?: unknown;
+  blockStreaming?: unknown;
+  blockStreamingCoalesce?: unknown;
+  draftChunk?: unknown;
 };
 
-// Config reads consume the canonical nested streaming shape only. Legacy flat
-// keys (streamMode, chunkMode, blockStreaming, draftChunk,
-// blockStreamingCoalesce, nativeStreaming) are migrated by `openclaw doctor
-// --fix` via channel doctor contracts and are ignored at runtime.
+// Nested streaming config wins. The flat delivery keys (chunkMode,
+// blockStreaming, blockStreamingCoalesce, draftChunk) are still canonical for
+// channels without a nested streaming schema (Mattermost, WhatsApp, Google
+// Chat, IRC, Signal) and for external SDK plugins, so these public resolvers
+// keep reading them; dropping the fallback here silently disables configured
+// chunking/block delivery for those consumers. Remove the flat reads only
+// after the remaining bundled channels migrate to nested schemas + doctor
+// rules and the SDK deprecation window closes. Mode-family aliases
+// (streamMode, scalar/boolean streaming) are doctor-only and stay unread here.
 
 function asObjectRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -771,25 +780,37 @@ export function getChannelStreamingConfigObject(
 export function resolveChannelStreamingChunkMode(
   entry: StreamingCompatEntry | null | undefined,
 ): TextChunkMode | undefined {
-  return asTextChunkMode(getChannelStreamingConfigObject(entry)?.chunkMode);
+  return (
+    asTextChunkMode(getChannelStreamingConfigObject(entry)?.chunkMode) ??
+    asTextChunkMode(entry?.chunkMode)
+  );
 }
 
 export function resolveChannelStreamingBlockEnabled(
   entry: StreamingCompatEntry | null | undefined,
 ): boolean | undefined {
-  return asBoolean(getChannelStreamingConfigObject(entry)?.block?.enabled);
+  return (
+    asBoolean(getChannelStreamingConfigObject(entry)?.block?.enabled) ??
+    asBoolean(entry?.blockStreaming)
+  );
 }
 
 export function resolveChannelStreamingBlockCoalesce(
   entry: StreamingCompatEntry | null | undefined,
 ): BlockStreamingCoalesceConfig | undefined {
-  return asBlockStreamingCoalesceConfig(getChannelStreamingConfigObject(entry)?.block?.coalesce);
+  return (
+    asBlockStreamingCoalesceConfig(getChannelStreamingConfigObject(entry)?.block?.coalesce) ??
+    asBlockStreamingCoalesceConfig(entry?.blockStreamingCoalesce)
+  );
 }
 
 export function resolveChannelStreamingPreviewChunk(
   entry: StreamingCompatEntry | null | undefined,
 ): BlockStreamingChunkConfig | undefined {
-  return asBlockStreamingChunkConfig(getChannelStreamingConfigObject(entry)?.preview?.chunk);
+  return (
+    asBlockStreamingChunkConfig(getChannelStreamingConfigObject(entry)?.preview?.chunk) ??
+    asBlockStreamingChunkConfig(entry?.draftChunk)
+  );
 }
 
 export function resolveChannelStreamingPreviewToolProgress(

--- a/src/commands/doctor-legacy-config.test.ts
+++ b/src/commands/doctor-legacy-config.test.ts
@@ -19,6 +19,7 @@ function normalizeStreaming(params: {
   entry: Record<string, unknown>;
   pathPrefix: string;
   resolvedMode: string;
+  aliasOnlyMode?: string;
   resolvedNativeTransport?: unknown;
   offModeLegacyNotice?: (pathPrefix: string) => string;
 }) {
@@ -88,6 +89,67 @@ describe("normalizeCompatibilityConfigValues preview streaming aliases", () => {
     expect(res.changes).toEqual([
       "Moved channels.discord.streamMode → channels.discord.streaming.mode (off).",
       'channels.discord.streaming remains off by default to avoid Discord preview-edit rate limits; set channels.discord.streaming.mode="partial" to opt in explicitly.',
+    ]);
+  });
+
+  it("pins the previous default mode when delivery-only aliases create the streaming object", () => {
+    // Discord previews default to progress only while `streaming` is absent;
+    // without aliasOnlyMode the migrated object would resolve to off.
+    const res = normalizeStreaming({
+      entry: { blockStreaming: true },
+      pathPrefix: "channels.discord",
+      resolvedMode: "off",
+      aliasOnlyMode: "progress",
+    });
+
+    expect(res.entry.streaming).toEqual({ mode: "progress", block: { enabled: true } });
+    expect(res.changes).toEqual([
+      "Moved channels.discord.blockStreaming → channels.discord.streaming.block.enabled.",
+      "Set channels.discord.streaming.mode (progress) to keep the previous default while migrating flat streaming keys.",
+    ]);
+  });
+
+  it("keeps delivery-only alias migration mode-free without aliasOnlyMode", () => {
+    const res = normalizeStreaming({
+      entry: { blockStreaming: true },
+      pathPrefix: "channels.telegram",
+      resolvedMode: "partial",
+    });
+
+    expect(res.entry.streaming).toEqual({ block: { enabled: true } });
+    expect(res.changes).toEqual([
+      "Moved channels.telegram.blockStreaming → channels.telegram.streaming.block.enabled.",
+    ]);
+  });
+
+  it("does not apply aliasOnlyMode when a legacy mode source exists", () => {
+    const res = normalizeStreaming({
+      entry: { streamMode: "partial", blockStreaming: true },
+      pathPrefix: "channels.discord",
+      resolvedMode: "partial",
+      aliasOnlyMode: "progress",
+    });
+
+    expect(res.entry.streaming).toEqual({ mode: "partial", block: { enabled: true } });
+    expect(res.changes).toEqual([
+      "Moved channels.discord.streamMode → channels.discord.streaming.mode (partial).",
+      "Moved channels.discord.blockStreaming → channels.discord.streaming.block.enabled.",
+    ]);
+  });
+
+  it("does not apply aliasOnlyMode when a nested streaming object already exists", () => {
+    // A pre-existing object already resolved with object-without-mode
+    // semantics, so pinning a mode would change behavior instead of keeping it.
+    const res = normalizeStreaming({
+      entry: { streaming: { chunkMode: "newline" }, blockStreaming: true },
+      pathPrefix: "channels.discord",
+      resolvedMode: "off",
+      aliasOnlyMode: "progress",
+    });
+
+    expect(res.entry.streaming).toEqual({ chunkMode: "newline", block: { enabled: true } });
+    expect(res.changes).toEqual([
+      "Moved channels.discord.blockStreaming → channels.discord.streaming.block.enabled.",
     ]);
   });
 

--- a/src/config/channel-compat-normalization.ts
+++ b/src/config/channel-compat-normalization.ts
@@ -10,6 +10,13 @@ export type { CompatMutationResult };
 /** Resolved streaming values a channel doctor supplies while migrating legacy aliases. */
 export type LegacyStreamingAliasOptions = {
   resolvedMode: string;
+  /**
+   * Mode to persist when migration creates the `streaming` object from flat
+   * delivery aliases alone (no streamMode/scalar/boolean mode source). Only
+   * needed by channels whose "streaming absent" runtime default differs from
+   * their object-without-mode default (Discord: progress vs off).
+   */
+  aliasOnlyMode?: string;
   includePreviewChunk?: boolean;
   resolvedNativeTransport?: unknown;
   offModeLegacyNotice?: (pathPrefix: string) => string;
@@ -211,6 +218,25 @@ export function normalizeLegacyStreamingAliases(
     streaming.nativeTransport = params.resolvedNativeTransport;
     params.changes.push(
       `Moved ${params.pathPrefix}.streaming (boolean) → ${params.pathPrefix}.streaming.nativeTransport.`,
+    );
+    changed = true;
+  }
+
+  // Materializing `streaming` for delivery-only aliases would otherwise flip
+  // channels whose runtime treats "streaming absent" differently from an
+  // object without `mode` (Discord defaults to progress only when the whole
+  // object is absent). Pin the previous effective mode so migration never
+  // changes behavior. Guarded on `changed` so entries with no movable alias
+  // stay a no-op instead of minting a mode-only mutation.
+  if (
+    changed &&
+    beforeStreaming === undefined &&
+    streaming.mode === undefined &&
+    params.aliasOnlyMode !== undefined
+  ) {
+    streaming.mode = params.aliasOnlyMode;
+    params.changes.push(
+      `Set ${params.pathPrefix}.streaming.mode (${params.aliasOnlyMode}) to keep the previous default while migrating flat streaming keys.`,
     );
     changed = true;
   }

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -120,9 +120,11 @@ describe("channel-streaming", () => {
     ).toBe(false);
   });
 
-  it("ignores legacy flat fields when the canonical object is absent", () => {
-    // Doctor migrates the flat aliases (`openclaw doctor --fix`); runtime reads
-    // only the nested streaming shape.
+  it("resolves flat delivery keys when no nested streaming config exists", () => {
+    // Flat delivery keys stay canonical for channels without a nested
+    // streaming schema (Mattermost, WhatsApp, Google Chat, IRC, Signal) and
+    // for external SDK plugins; mode-family aliases (streamMode, scalar
+    // streaming, nativeStreaming) are doctor-only and stay unread.
     const entry = {
       chunkMode: "newline",
       blockStreaming: true,
@@ -132,11 +134,19 @@ describe("channel-streaming", () => {
     } as never;
 
     expect(getChannelStreamingConfigObject(entry)).toBeUndefined();
-    expect(resolveChannelStreamingChunkMode(entry)).toBeUndefined();
+    expect(resolveChannelStreamingChunkMode(entry)).toBe("newline");
     expect(resolveChannelStreamingNativeTransport(entry)).toBeUndefined();
-    expect(resolveChannelStreamingBlockEnabled(entry)).toBeUndefined();
-    expect(resolveChannelStreamingBlockCoalesce(entry)).toBeUndefined();
-    expect(resolveChannelStreamingPreviewChunk(entry)).toBeUndefined();
+    expect(resolveChannelStreamingBlockEnabled(entry)).toBe(true);
+    expect(resolveChannelStreamingBlockCoalesce(entry)).toEqual({
+      minChars: 120,
+      maxChars: 240,
+      idleMs: 500,
+    });
+    expect(resolveChannelStreamingPreviewChunk(entry)).toEqual({
+      minChars: 8,
+      maxChars: 16,
+      breakPreference: "newline",
+    });
     expect(resolveChannelStreamingPreviewToolProgress(entry)).toBe(true);
   });
 
@@ -155,9 +165,9 @@ describe("channel-streaming", () => {
         streaming: { mode: "block", block: { enabled: true } },
       }),
     ).toBe(true);
-    expect(
-      resolveChannelStreamingBlockEnabled({ streaming: "block", blockStreaming: false } as never),
-    ).toBeUndefined();
+    expect(resolveChannelStreamingBlockEnabled({ streaming: "block", blockStreaming: false })).toBe(
+      false,
+    );
   });
 
   it("selects a longer transcript candidate for ellipsis-truncated finals", async () => {


### PR DESCRIPTION
## What Problem This Solves

Post-land review of #104693 (streaming flat-key retirement, commit 508f6a29963) confirmed three defects:

1. **Discord doctor migration silently changes effective preview mode.** Migrating a delivery-only alias config (e.g. `channels.discord.blockStreaming: true` with no mode key) materializes the `streaming` object, which defeats Discord's `streaming`-absent → `progress` default (`resolveDiscordPreviewStreamMode`); an object without `mode` resolves `off`. Running `openclaw doctor --fix` disabled preview streaming for those users. Discord-only: Telegram/Slack/MS Teams resolve `partial` for both the absent and object-without-mode cases, and iMessage has no mode concept.
2. **Public SDK resolvers dropped flat-key reads while flat keys remain canonical elsewhere.** `resolveChannelStreamingChunkMode` / `...BlockEnabled` / `...BlockCoalesce` / `...PreviewChunk` (exported via `openclaw/plugin-sdk/channel-streaming` and `channel-outbound`) went nested-only, but the flat delivery keys are still the canonical schema shape for Mattermost, WhatsApp, Google Chat, IRC, and Signal — and for external SDK plugins. #104693 papered over this in-tree by re-reading flat keys at individual call sites (`src/auto-reply/chunk.ts`, `src/auto-reply/reply/block-streaming.ts`, `extensions/mattermost/src/mattermost/accounts.ts`), leaving third-party consumers silently broken and the precedence rule scattered across four owners.
3. **`docs/concepts/streaming.md` contradicted itself**: the top said flat keys are "not read at runtime" while later sections still recommended "the legacy `blockStreaming` channel key" and described Discord/Slack `streamMode` as "runtime aliases".

## Why This Change Was Made

- The doctor migration must never change effective behavior. A new `aliasOnlyMode` option on `normalizeLegacyStreamingAliases` pins the entry's previous effective mode when delivery-only aliases create the `streaming` object (guarded so entries with no movable alias stay a no-op). Discord passes its previous effective mode: `progress` at the root when both mode sources are absent, and the root's effective mode for accounts — account `streaming` objects replace the root object wholesale on merge, so accounts must carry the mode they previously inherited.
- Flat-fallback precedence belongs in one owner. The four shared resolvers now read nested-first with a flat fallback again (documented with the removal plan: after the remaining canonical-flat channels migrate to nested schemas + doctor rules and the SDK deprecation window closes), and the scattered call-site re-reads are deleted. For the six already-migrated channels the fallback is inert: their schemas reject flat keys, and startup blocks on schema-invalid config until `doctor --fix` runs.
- Docs now consistently describe doctor-owned migration; the flat-key guidance is scoped to channels whose schemas still keep those keys canonical.

## User Impact

- Discord users whose config only set delivery flat keys (e.g. `blockStreaming: true`) keep progress previews after `openclaw doctor --fix` instead of losing them; multi-account configs keep the mode each account previously inherited from the root.
- Third-party plugins and the canonical-flat channels resolve configured chunking/block delivery through the public SDK helpers again.
- Streaming docs no longer contradict runtime behavior.

## Evidence

- `resolveDiscordPreviewStreamMode` returns `progress` only when `params.streaming === undefined` (extensions/discord/src/preview-streaming.ts); `normalizeLegacyStreamingAliases` always assigns the materialized `streaming` object, so any alias migration flipped that default. Decision-table enumeration of divergent configs was verified against both resolver generations.
- Mattermost/WhatsApp/Google Chat/IRC/Signal schemas still declare flat `blockStreaming`/`chunkMode`/`blockStreamingCoalesce` as canonical (e.g. extensions/mattermost/src/config-schema-core.ts:146, src/config/zod-schema.providers-core.ts:1218/1342, zod-schema.providers-googlechat.ts:85, zod-schema.providers-whatsapp.ts:98).
- New regression tests: doctor pins `progress` for root delivery-only aliases and the inherited root mode for account aliases (extensions/discord/src/doctor.test.ts); `aliasOnlyMode` unit coverage incl. no-op guards (src/commands/doctor-legacy-config.test.ts); flat-fallback resolution restored in both resolver test suites (src/channels/streaming.test.ts, src/plugin-sdk/channel-streaming.test.ts).
- Testbox (Blacksmith, Linux Node 24): `pnpm test src/channels src/plugin-sdk src/commands src/auto-reply src/config extensions/discord extensions/mattermost` → 2019/2020 passed. The single failure is `extensions/discord/src/pluralkit.test.ts` ("relays parent cancellation"), which fails deterministically on clean `origin/main` as well (files byte-identical to main, import closure untouched by this branch; abort-reason propagation from #104121 — tracked separately).
- Autoreview (codex gpt-5.6-sol, xhigh, branch mode): first round found the account-inheritance gap and a stale core test (both fixed here); second round clean — "patch is correct (0.93), no actionable defects".

Follow-up (tracked): migrate the five canonical-flat channels to nested streaming schemas + doctor rules, after which the resolver flat fallback serves only external SDK plugins until its deprecation window closes.

Refs #104693.
