### PR TITLE
fix(cron-cli): reject duration values that overflow safe integer range

### DIFF
--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -252,6 +252,9 @@ export function parseDurationMs(input: string): number | null {
     // pure-digit string with "d"); tiny positive values can also floor to 0ms.
     return null;
   }
+  if (!Number.isSafeInteger(result)) {
+    return null;
+  }
   return result;
 }
 


### PR DESCRIPTION
## Summary

The cron-cli `parseDurationMs` only checked `Number.isFinite` but not `Number.isSafeInteger`, so inputs like `"999999999999999d"` would produce a precision-lossy millisecond value. The core `parse-duration.ts` already uses `roundSafeDurationMs` with `isSafeInteger`; align cron-cli's copy.

## Bug

```ts
// Before: only isFinite check
const result = Math.floor(n * factor);
if (!Number.isFinite(result) || result <= 0) { return null; }
return result;
```

Input `"999999999999999d"` → `86400000 * 999999999999999` exceeds `MAX_SAFE_INTEGER`, producing an imprecise value.

## Fix

Add `Number.isSafeInteger(result)` check after the existing `isFinite` check.

## Test plan

- [ ] Verify that `"999999999999999d"` returns `null` instead of an imprecise number
- [ ] Verify normal durations like `"30s"`, `"5m"`, `"1h"` still parse correctly