### PR TITLE
fix(ports-format): validate parsed port numbers are in valid TCP range 1–65535

### DIFF
--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -4,6 +4,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { PortListener, PortListenerKind, PortUsage } from "./ports-types.js";
+import { MAX_TCP_PORT } from "./tcp-port.js";
 
 /** Classifies a listener as OpenClaw Gateway, SSH tunnel, known non-gateway, or unknown. */
 export function classifyPortListener(listener: PortListener, _port: number): PortListenerKind {
@@ -54,7 +55,7 @@ function parseListenerAddress(address: string): { host: string; port: number } |
       expectDefined(bracketMatch[2], "bracket match capture group 2"),
       10,
     );
-    return Number.isFinite(port)
+    return Number.isFinite(port) && port >= 1 && port <= MAX_TCP_PORT
       ? { host: normalizeLowercaseStringOrEmpty(bracketMatch[1]), port }
       : null;
   }
@@ -68,7 +69,7 @@ function parseListenerAddress(address: string): { host: string; port: number } |
     return null;
   }
   const port = Number.parseInt(portToken, 10);
-  return Number.isFinite(port) ? { host, port } : null;
+  return Number.isFinite(port) && port >= 1 && port <= MAX_TCP_PORT ? { host, port } : null;
 }
 
 // Dual-stack listener output can include IPv4-mapped IPv6 addresses; keep them


### PR DESCRIPTION
## Summary

`parseListenerAddress` only checked `Number.isFinite` for port values parsed from listener addresses like `[::1]:99999` or `127.0.0.1:0`, producing out-of-range port numbers. Add the 1–65535 range check using the existing `MAX_TCP_PORT` constant, consistent with `tcp-port.ts` and `bonjour-discovery.ts`.

## Bug

```ts
// Before: any finite number accepted as a port
return Number.isFinite(port) ? { host, port } : null;
```

Port 0 or port 99999 would be returned as valid.

## Fix

Check `port >= 1 && port <= MAX_TCP_PORT` in both the bracket-match and last-colon code paths.

## Test plan

- [ ] Verify `127.0.0.1:0` returns null
- [ ] Verify `127.0.0.1:99999` returns null
- [ ] Verify `127.0.0.1:8080` still works