### PR TITLE
fix(gateway): reject base64 data URLs with invalid padding in image size check

### DIFF
--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -175,11 +175,14 @@ function validateManagedImageBuffer(
   }
 }
 
-function estimateBase64DecodedByteLength(base64: string): number {
+function estimateBase64DecodedByteLength(base64: string): number | null {
   const normalized = base64.replace(/\s+/g, "");
   const paddingMatch = /=+$/u.exec(normalized);
-  const padding = Math.min(paddingMatch?.[0].length ?? 0, 2);
-  return Math.floor((normalized.length * 3) / 4) - padding;
+  const paddingLength = paddingMatch?.[0].length ?? 0;
+  if (paddingLength > 2) {
+    return null;
+  }
+  return Math.floor((normalized.length * 3) / 4) - paddingLength;
 }
 
 function getManagedImageMetadataLimitError(
@@ -305,7 +308,8 @@ function parseImageDataUrl(
     return { kind: "non-image-data-url" };
   }
 
-  if (estimateBase64DecodedByteLength(base64Part) > limits.maxBytes) {
+  const estimatedBytes = estimateBase64DecodedByteLength(base64Part);
+  if (estimatedBytes === null || estimatedBytes > limits.maxBytes) {
     throw createManagedImageAttachmentError(
       `Managed image attachment ${JSON.stringify(alt)} exceeds the ${formatLimitMiB(limits.maxBytes)} byte limit`,
     );


### PR DESCRIPTION
## Summary

`estimateBase64DecodedByteLength` clamped padding to 2 with `Math.min`, so inputs with 3+ trailing `=` characters would silently undercount decoded bytes. Return `null` for invalid padding (>2 `=`) and reject at the call site.

## Bug

```ts
// Before: Math.min clamped padding, silently undercounting
const padding = Math.min(paddingMatch?.[0].length ?? 0, 2);
```

A base64 string ending in `===` (3 padding chars) is invalid per RFC 4648, but the estimation would subtract only 2, undercounting the real decoded size and potentially bypassing the `maxBytes` limit.

## Fix

Return `null` when `paddingLength > 2` and handle `null` at the call site by rejecting the attachment.

## Test plan

- [ ] Verify base64 with 3+ trailing `=` is rejected
- [ ] Verify valid base64 with 0/1/2 padding still works
- [ ] Verify size estimation matches actual decoded length for valid inputs