### PR TITLE
fix(tui): validate Unicode codepoint upper bound in Kitty keyboard parser

### DIFF
--- a/src/tui/components/custom-editor.ts
+++ b/src/tui/components/custom-editor.ts
@@ -31,7 +31,7 @@ function decodeAltGrPrintable(data: string): string | undefined {
   if (typeof baseLayoutKey !== "number" || baseLayoutKey === codepoint) {
     return undefined;
   }
-  if (!Number.isFinite(codepoint) || codepoint < 32) {
+  if (!Number.isFinite(codepoint) || codepoint < 32 || codepoint > 0x10ffff) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

The codepoint check in `parseKittyAltCtrlShortcut` only rejected values below 32 but accepted values above U+10FFFF, which would cause `String.fromCodePoint()` to throw a `RangeError`. Add the upper-bound check so the try/catch is only reached for edge cases, not for any oversized terminal escape payload.

## Bug

```ts
// Before: no upper bound check
if (!Number.isFinite(codepoint) || codepoint < 32) { return undefined; }
try { return String.fromCodePoint(codepoint); } catch { return undefined; }
```

A crafted CSI u sequence with codepoint `9999999999999` passes `Number.isFinite` and `>= 32` checks but throws `RangeError` in `String.fromCodePoint()`.

## Fix

Add `codepoint > 0x10ffff` to the guard condition.

## Test plan

- [ ] Verify oversized codepoints (>0x10FFFF) return undefined without throwing
- [ ] Verify normal key combos (e.g. Alt+Ctrl+letter) still work