### PR TITLE
fix(update-check): reject partial-integer and unsafe-integer ahead/behind counts

### DIFF
--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -374,9 +374,14 @@ async function checkGitUpdateStatus(params: {
     if (parts.length < 2) {
       return null;
     }
-    const ahead = Number.parseInt(parts[0] ?? "", 10);
-    const behind = Number.parseInt(parts[1] ?? "", 10);
-    if (!Number.isFinite(ahead) || !Number.isFinite(behind)) {
+    const aRaw = parts[0] ?? "";
+    const bRaw = parts[1] ?? "";
+    if (!/^\d+$/.test(aRaw) || !/^\d+$/.test(bRaw)) {
+      return null;
+    }
+    const ahead = Number.parseInt(aRaw, 10);
+    const behind = Number.parseInt(bRaw, 10);
+    if (!Number.isSafeInteger(ahead) || !Number.isSafeInteger(behind)) {
       return null;
     }
     return { ahead, behind };


### PR DESCRIPTION
## Summary

`parseInt("42abc")` returns `42` instead of `NaN`, so a malformed `git rev-list --count` output would be silently accepted. Validate with `/^\d+$/` before parsing and use `Number.isSafeInteger` instead of `isFinite` to reject precision-lossy values.

## Bug

```ts
// Before: parseInt accepts partial integers
const ahead = Number.parseInt(parts[0] ?? "", 10);
const behind = Number.parseInt(parts[1] ?? "", 10);
if (!Number.isFinite(ahead) || !Number.isFinite(behind)) { return null; }
```

Input `"42abc 5"` → ahead=42, behind=5, silently accepted.

## Fix

Validate each part with `/^\d+$/` before `parseInt`, and use `Number.isSafeInteger` to catch overflow.

## Test plan

- [ ] Verify `"42abc 5"` returns null
- [ ] Verify `"42 5"` still works
- [ ] Verify `Number.MAX_SAFE_INTEGER+1` values return null