### PR TITLE
fix(usage-bar): reject partial-integer input in fixed/meter verb args

### DIFF
--- a/src/auto-reply/usage-bar/translator.ts
+++ b/src/auto-reply/usage-bar/translator.ts
@@ -122,7 +122,7 @@ function applyVerb(name: string, args: string[], value: unknown, vocab: Vocab): 
     case "num":
       return num(value);
     case "fixed": {
-      const digits = args[0] ? Number.parseInt(args[0], 10) || 0 : 2;
+      const digits = args[0] && /^\d+$/.test(args[0]) ? Number.parseInt(args[0], 10) : 2;
       return fixed(value, digits);
     }
     case "dur":
@@ -143,7 +143,7 @@ function applyVerb(name: string, args: string[], value: unknown, vocab: Vocab): 
       return Object.hasOwn(table, lower) ? table[lower] : value;
     }
     case "meter": {
-      const width = args[0] ? Number.parseInt(args[0], 10) || 5 : 5;
+      const width = args[0] && /^\d+$/.test(args[0]) ? Number.parseInt(args[0], 10) : 5;
       const scale = args.length > 1 ? vocab[expectDefined(args[1], "args entry at 1")] : undefined;
       return meter(value, width, scale);
     }


### PR DESCRIPTION
## Summary

`parseInt("3abc", 10)` returns `3` instead of `NaN`, and the `||` fallback silently swallowed `NaN` from empty or negative inputs. Validate with `/^\d+$/` before `parseInt` so partial-integer and non-numeric args fall back to the default value instead of producing a truncated number.

## Bug

```ts
// Before: parseInt partial match, || swallows NaN
const digits = args[0] ? Number.parseInt(args[0], 10) || 0 : 2;
const width = args[0] ? Number.parseInt(args[0], 10) || 5 : 5;
```

Input `"3abc"` → digits=3 (should be default 2), `"100abc"` → width=100 (unbounded).

## Fix

Validate arg with `/^\d+$/` before parsing; non-matching args fall back to default.

## Test plan

- [ ] Verify `"3abc"` falls back to default instead of returning 3
- [ ] Verify `"0"` returns 0 for digits (fixed precision), 5 for width (meter default)
- [ ] Verify valid numeric args still work