### PR TITLE
fix(model-preflight): reject IPv4 octets with leading zeros in private-host check

### DIFF
--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -68,11 +68,13 @@ function normalizeProbeApi(providerConfig: ModelProviderConfig): PreflightApi | 
 }
 
 function isPrivateIpv4Host(host: string): boolean {
-  if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
+  const octetRe = /^(0|[1-9]\d{0,2})$/;
+  const parts = host.split(".");
+  if (parts.length !== 4 || !parts.every((part) => octetRe.test(part))) {
     return false;
   }
-  const octets = host.split(".").map((part) => Number.parseInt(part, 10));
-  if (octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+  const octets = parts.map((part) => Number.parseInt(part, 10));
+  if (octets.some((part) => part < 0 || part > 255)) {
     return false;
   }
   const [a, b] = octets;


### PR DESCRIPTION
## Summary

Octets like `"010"` or `"001"` were accepted by the `\d+` regex and parsed as decimal by `parseInt`, but leading zeros indicate octal notation in some contexts and are not valid in standard IPv4. Reject octets with leading zeros so `"010.0.0.1"` no longer matches private ranges.

## Bug

```ts
// Before: \d+ accepts leading zeros
if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) { return false; }
const octets = host.split(".").map((part) => Number.parseInt(part, 10));
```

Input `"010.0.0.1"` matches the regex and `parseInt` parses `010` as `10`, incorrectly classifying it as a private IP.

## Fix

Use a stricter per-octet regex `^(0|[1-9]\d{0,2})$` that rejects leading zeros.

## Test plan

- [ ] Verify `"010.0.0.1"` returns false (leading zero)
- [ ] Verify `"10.0.0.1"` returns true (private)
- [ ] Verify `"192.168.1.1"` returns true (private)
- [ ] Verify `"8.8.8.8"` returns false (public)