### PR TITLE
fix(android): bound structured chat image decoding

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -6203,7 +6203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 326,
+      "line": 327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
       "source": "$index.",
       "surface": "android",
@@ -6211,7 +6211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 729,
+      "line": 730,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
       "source": "Image unavailable",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -3131,13 +3131,16 @@ internal fun parseChatMessageContent(el: JsonElement): ChatMessageContent? {
         text = obj["text"].asStringOrNull() ?: obj["content"].asStringOrNull(),
       )
 
-    "image", "audio" ->
+    "image", "audio" -> {
+      val type = obj["type"].asStringOrNull() ?: "image"
+      val inlineContent = obj["content"].asStringOrNull()?.takeIf { it.isNotBlank() }
       ChatMessageContent(
-        type = obj["type"].asStringOrNull() ?: "image",
+        type = type,
         mimeType = obj["mimeType"].asStringOrNull(),
         fileName = obj["fileName"].asStringOrNull(),
-        base64 = obj["content"].asStringOrNull()?.takeIf { it.isNotBlank() },
+        base64 = inlineContent?.takeIf { type != "image" || it.length <= CHAT_IMAGE_MAX_BASE64_CHARS },
       )
+    }
 
     "attachment" -> {
       val attachment = obj["attachment"].asObjectOrNull() ?: return null

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.chat
 import java.util.Locale
 
 private val visibleChatMessageRoles = setOf("user", "assistant", "system", "custom")
+internal const val CHAT_IMAGE_MAX_BASE64_CHARS = 300 * 1024
 
 /** Keeps transcript rows limited to roles Android renders as user-visible chat. */
 internal fun normalizeVisibleChatMessageRole(role: String?): String? =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.chat.CHAT_IMAGE_MAX_BASE64_CHARS
 import ai.openclaw.app.node.JpegSizeLimiter
 import android.content.ContentResolver
 import android.graphics.Bitmap
@@ -13,7 +14,6 @@ import kotlin.math.max
 import kotlin.math.roundToInt
 
 private const val CHAT_ATTACHMENT_MAX_WIDTH = 1600
-internal const val CHAT_IMAGE_MAX_BASE64_CHARS = 300 * 1024
 private const val CHAT_ATTACHMENT_START_QUALITY = 85
 private const val CHAT_DECODE_MAX_DIMENSION = 1600
 private const val CHAT_IMAGE_CACHE_BYTES = 16 * 1024 * 1024
@@ -80,6 +80,7 @@ internal fun decodeBase64Bitmap(
   base64: String,
   maxDimension: Int = CHAT_DECODE_MAX_DIMENSION,
 ): Bitmap? {
+  if (base64.length > CHAT_IMAGE_MAX_BASE64_CHARS) return null
   val cacheKey = "$maxDimension:${base64.length}:${base64.hashCode()}"
   decodedBitmapCache.get(cacheKey)?.let { return it }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.chat.CHAT_IMAGE_MAX_BASE64_CHARS
 import ai.openclaw.app.ui.mobileAccent
 import ai.openclaw.app.ui.mobileCallout
 import ai.openclaw.app.ui.mobileCaption1

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatMessageContentParsingTest.kt
@@ -49,6 +49,20 @@ class ChatMessageContentParsingTest {
   }
 
   @Test
+  fun dropsOversizedInlineImageContentBeforeRendering() {
+    val oversized = "A".repeat(CHAT_IMAGE_MAX_BASE64_CHARS + 1)
+    val image =
+      Json.parseToJsonElement(
+        """{"type":"image","mimeType":"image/png","fileName":"large.png","content":"$oversized"}""",
+      )
+
+    assertEquals(
+      ChatMessageContent(type = "image", mimeType = "image/png", fileName = "large.png", base64 = null),
+      parseChatMessageContent(image),
+    )
+  }
+
+  @Test
   fun parsesDirectAndAttachmentAudioBlocks() {
     val direct =
       Json.parseToJsonElement(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
@@ -1,6 +1,8 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.chat.CHAT_IMAGE_MAX_BASE64_CHARS
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ChatImageCodecTest {
@@ -14,5 +16,10 @@ class ChatImageCodecTest {
   fun normalizeAttachmentFileNameForcesJpegExtension() {
     assertEquals("photo.jpg", normalizeAttachmentFileName("photo.png"))
     assertEquals("image.jpg", normalizeAttachmentFileName(""))
+  }
+
+  @Test
+  fun decodeBase64BitmapRejectsOversizedInputBeforeDecode() {
+    assertNull(decodeBase64Bitmap("A".repeat(CHAT_IMAGE_MAX_BASE64_CHARS + 1)))
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMarkdownTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMarkdownTest.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.chat.CHAT_IMAGE_MAX_BASE64_CHARS
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.font.FontStyle


### PR DESCRIPTION
Closes #105053

## What Problem This Solves

Fixes an issue where Android users opening chat history containing a large structured image could make the app decode an unbounded base64 string before bitmap sampling, bypassing the limit already used for outbound and Markdown images.

## Why This Change Was Made

Moves the existing 300 KiB encoded-image budget to the chat model boundary, applies it while parsing structured image parts, and repeats the guard as the decoder's first instruction. Outbound attachments and Markdown data images continue using the same canonical limit; audio content is unchanged.

## User Impact

Oversized structured history images are skipped before base64 and bitmap allocation, reducing avoidable memory pressure and UI jank. Normal images, managed media references, Markdown images, outgoing attachments, and audio retain their existing behavior.

## Evidence

- Parser regression: a 307,201-character structured image is retained as metadata but its inline payload is dropped before rendering.
- Decoder regression: the same oversized input returns before Android `Base64.decode`, bitmap bounds, hashing, or caching.
- Existing Markdown boundary test now consumes the shared canonical constant.
- Structured Codex autoreview cycle 1 caught missing test imports after the constant move; both were fixed. Final autoreview: clean, no accepted/actionable findings.
- `git diff --check` passed.
- Blacksmith Testbox proof is unavailable: two fresh leases were terminated by the provider during hydration. The PR must not land until canonical hosted Android Play/third-party tests, build/lint, and ktlint pass on the exact SHA.

Provenance: structured content parsing was introduced in `d86ed21f3d6c3` by Ayaan Zaidi. Image previews in #104620 made the missing structured-image boundary user-visible; this fix preserves contributor credit without attributing the fix itself to either prior author.

AI-assisted by Codex. No agent transcript attached.
