### PR TITLE
style(ui): format default sidebar routes

### DIFF
--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -40,9 +40,7 @@ export type SidebarNavRoute = (typeof SIDEBAR_NAV_ROUTES)[number];
 
 // Sessions are the sidebar's core content; Automations is the only page pinned
 // by default. Users pin more via the customize menu.
-export const DEFAULT_SIDEBAR_PINNED_ROUTES = [
-  "cron",
-] as const satisfies readonly SidebarNavRoute[];
+export const DEFAULT_SIDEBAR_PINNED_ROUTES = ["cron"] as const satisfies readonly SidebarNavRoute[];
 
 /**
  * Normalize a persisted pinned-route list. Returns null when the value is not a


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the repository-wide format check on `ui/src/app-navigation.ts`, which blocks otherwise unrelated pull requests and main CI.

## Why This Change Was Made

Applies the canonical `oxfmt` output to the default pinned sidebar route declaration. No behavior changes.

## User Impact

No user-visible change. Main and dependent PR CI can pass formatting again.

## Evidence

- `node_modules/.bin/oxfmt --write ui/src/app-navigation.ts`
- `node_modules/.bin/oxfmt --check ui/src/app-navigation.ts`
- `git diff --check`
- failure source: CI run `29182399927`, job `86622468249`
