### PR TITLE
fix: preserve parent abort reasons through request timeouts

### DIFF
--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -349,19 +349,38 @@ describe("buildTimeoutAbortSignal", () => {
     }
   });
 
-  it("does not log when a parent signal aborts first", async () => {
+  it("preserves the parent reason when a parent signal aborts first", async () => {
     const parent = new AbortController();
+    const reason = new Error("parent stopped");
     const { signal, cleanup } = buildTimeoutAbortSignal({
       timeoutMs: 25,
       signal: parent.signal,
       operation: "unit-test",
     });
 
-    parent.abort();
+    parent.abort(reason);
     await vi.advanceTimersByTimeAsync(25);
 
     expect(signal?.aborted).toBe(true);
-    expect(signal?.reason).not.toMatchObject({ name: "TimeoutError" });
+    expect(signal?.reason).toBe(reason);
+    expect(warn).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("preserves an already-aborted parent reason", () => {
+    const parent = new AbortController();
+    const reason = new Error("parent already stopped");
+    parent.abort(reason);
+
+    const { signal, cleanup } = buildTimeoutAbortSignal({
+      timeoutMs: 25,
+      signal: parent.signal,
+      operation: "unit-test",
+    });
+
+    expect(signal?.aborted).toBe(true);
+    expect(signal?.reason).toBe(reason);
     expect(warn).not.toHaveBeenCalled();
 
     cleanup();

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -28,6 +28,11 @@ export function bindAbortRelay(controller: AbortController): () => void {
   return relayAbort.bind(controller);
 }
 
+/** Relays a parent abort while preserving its reason. */
+function relayAbortReason(this: AbortController, signal: AbortSignal) {
+  this.abort(signal.reason);
+}
+
 function sanitizeTimeoutLogUrl(rawUrl: string | undefined): string | undefined {
   const trimmed = rawUrl?.trim();
   if (!trimmed) {
@@ -137,10 +142,10 @@ export function buildTimeoutAbortSignal(params: TimeoutAbortSignalParams): {
     );
   };
   scheduleTimeout();
-  const onAbort = bindAbortRelay(controller);
-  if (signal) {
+  const onAbort = signal ? relayAbortReason.bind(controller, signal) : undefined;
+  if (signal && onAbort) {
     if (signal.aborted) {
-      controller.abort();
+      controller.abort(signal.reason);
     } else {
       signal.addEventListener("abort", onAbort, { once: true });
     }
@@ -162,7 +167,7 @@ export function buildTimeoutAbortSignal(params: TimeoutAbortSignalParams): {
       if (timeoutId) {
         clearTimeout(timeoutId);
       }
-      if (signal) {
+      if (signal && onAbort) {
         signal.removeEventListener("abort", onAbort);
       }
     },


### PR DESCRIPTION
Related: #104121

AI-assisted fix; implementation and focused proof reviewed before submission.

## What Problem This Solves

Fixes an issue where a caller aborting a timed request with a specific reason would instead expose the generic `AbortError`. This left the PluralKit cancellation regression on `main` failing deterministically because `preflight stopped` became `This operation was aborted`.

## Why This Change Was Made

`buildTimeoutAbortSignal` now relays the parent signal's exact `reason` for both already-aborted parents and parents that abort after composition. This matches Node's `AbortSignal.any` contract while retaining the helper's refreshable timeout and explicit listener cleanup.

Direct helper coverage locks both parent-abort paths. The existing Discord PluralKit regression remains unchanged and now passes.

## User Impact

Timed request helpers preserve caller cancellation reasons instead of replacing them with a generic abort. There is no new configuration or public API shape.

## Evidence

- Before fix, Blacksmith Testbox through Crabbox `tbx_01kxafw5h3femja1dm085rkz2e` reproduced `extensions/discord/src/pluralkit.test.ts`: 5 passed, 1 failed; expected `preflight stopped`, received `This operation was aborted` ([run](https://github.com/openclaw/openclaw/actions/runs/29182566896)).
- After fix, same Node 24 Testbox: `corepack pnpm test src/utils/fetch-timeout.test.ts extensions/discord/src/pluralkit.test.ts` — 31 passed across 2 files.
- `corepack pnpm check:changed` on the same Testbox — passed selected core production/test formatting, typecheck, lint, API baseline, and guard lanes.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean; no accepted/actionable findings.
- `git diff --check` — clean.

Contract reference: [Node.js AbortSignal.any](https://nodejs.org/docs/latest-v24.x/api/globals.html#static-method-abortsignalanysignals) preserves the reason from the signal that triggered the abort.
