### PR TITLE
fix(android): preserve TLS hostname context

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.withContext
 import java.io.EOFException
 import java.net.ConnectException
 import java.net.InetSocketAddress
+import java.net.Socket
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
@@ -19,11 +20,13 @@ import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SNIHostName
 import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
 import javax.net.ssl.SSLException
 import javax.net.ssl.SSLParameters
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509ExtendedTrustManager
 import javax.net.ssl.X509TrustManager
 
 /** TLS pinning inputs for a discovered or manually configured gateway endpoint. */
@@ -63,20 +66,56 @@ fun buildGatewayTlsConfig(
   onStore: ((String) -> Unit)? = null,
 ): GatewayTlsConfig? {
   if (params == null) return null
+  return buildGatewayTlsConfig(
+    params = params,
+    defaultTrust = defaultTrustManager(),
+    onStore = onStore,
+  )
+}
+
+internal fun buildGatewayTlsConfig(
+  params: GatewayTlsParams,
+  defaultTrust: X509TrustManager,
+  onStore: ((String) -> Unit)? = null,
+): GatewayTlsConfig {
   val expected =
     params.expectedFingerprint
       ?.let(::normalizeGatewayTlsFingerprint)
       ?.takeIf { it.isNotBlank() }
-  val defaultTrust = defaultTrustManager()
+  val usesPlatformTrust = expected == null && !params.allowTOFU
 
   @SuppressLint("CustomX509TrustManager")
   val trustManager =
-    object : X509TrustManager {
+    object : X509ExtendedTrustManager() {
       override fun checkClientTrusted(
         chain: Array<X509Certificate>,
         authType: String,
       ) {
         defaultTrust.checkClientTrusted(chain, authType)
+      }
+
+      override fun checkClientTrusted(
+        chain: Array<X509Certificate>,
+        authType: String,
+        socket: Socket,
+      ) {
+        if (defaultTrust is X509ExtendedTrustManager) {
+          defaultTrust.checkClientTrusted(chain, authType, socket)
+        } else {
+          checkClientTrusted(chain, authType)
+        }
+      }
+
+      override fun checkClientTrusted(
+        chain: Array<X509Certificate>,
+        authType: String,
+        engine: SSLEngine,
+      ) {
+        if (defaultTrust is X509ExtendedTrustManager) {
+          defaultTrust.checkClientTrusted(chain, authType, engine)
+        } else {
+          checkClientTrusted(chain, authType)
+        }
       }
 
       override fun checkServerTrusted(
@@ -99,6 +138,31 @@ fun buildGatewayTlsConfig(
           return
         }
         defaultTrust.checkServerTrusted(chain, authType)
+      }
+
+      override fun checkServerTrusted(
+        chain: Array<X509Certificate>,
+        authType: String,
+        socket: Socket,
+      ) {
+        if (usesPlatformTrust && defaultTrust is X509ExtendedTrustManager) {
+          // Preserve the connected hostname for Android's domain-aware platform trust manager.
+          defaultTrust.checkServerTrusted(chain, authType, socket)
+        } else {
+          checkServerTrusted(chain, authType)
+        }
+      }
+
+      override fun checkServerTrusted(
+        chain: Array<X509Certificate>,
+        authType: String,
+        engine: SSLEngine,
+      ) {
+        if (usesPlatformTrust && defaultTrust is X509ExtendedTrustManager) {
+          defaultTrust.checkServerTrusted(chain, authType, engine)
+        } else {
+          checkServerTrusted(chain, authType)
+        }
       }
 
       override fun getAcceptedIssuers(): Array<X509Certificate> = defaultTrust.acceptedIssuers
@@ -147,11 +211,23 @@ internal suspend fun probeGatewayTlsFingerprint(
     val fingerprintRef = AtomicReference<String?>(null)
     val probeTrustManager =
       @SuppressLint("CustomX509TrustManager")
-      object : X509TrustManager {
+      object : X509ExtendedTrustManager() {
         override fun checkClientTrusted(
           chain: Array<X509Certificate>,
           authType: String,
         ): Unit = throw CertificateException("gateway TLS probe does not accept client certificates")
+
+        override fun checkClientTrusted(
+          chain: Array<X509Certificate>,
+          authType: String,
+          socket: Socket,
+        ) = checkClientTrusted(chain, authType)
+
+        override fun checkClientTrusted(
+          chain: Array<X509Certificate>,
+          authType: String,
+          engine: SSLEngine,
+        ) = checkClientTrusted(chain, authType)
 
         override fun checkServerTrusted(
           chain: Array<X509Certificate>,
@@ -162,6 +238,18 @@ internal suspend fun probeGatewayTlsFingerprint(
           // Abort validation after capture; the probe is not deciding trust.
           throw CertificateException("gateway TLS probe captured fingerprint")
         }
+
+        override fun checkServerTrusted(
+          chain: Array<X509Certificate>,
+          authType: String,
+          socket: Socket,
+        ) = checkServerTrusted(chain, authType)
+
+        override fun checkServerTrusted(
+          chain: Array<X509Certificate>,
+          authType: String,
+          engine: SSLEngine,
+        ) = checkServerTrusted(chain, authType)
 
         override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
       }

--- a/apps/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/android/app/src/main/res/xml/network_security_config.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config xmlns:tools="http://schemas.android.com/tools">
-  <!-- This app is primarily used on a trusted tailnet; allow cleartext for IP-based endpoints too. -->
+  <!-- This app is primarily used on a trusted tailnet; allow cleartext for every endpoint. -->
   <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration" />
-  <!-- Allow HTTP for tailnet/local dev endpoints (e.g. canvas/background web). -->
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="true">openclaw.local</domain>
-  </domain-config>
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="true">ts.net</domain>
-  </domain-config>
 </network-security-config>

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayTlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayTlsTest.kt
@@ -1,17 +1,17 @@
 package ai.openclaw.app.gateway
 
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketException
 import java.security.cert.X509Certificate
-import javax.net.ssl.SSLEngine
 import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
 import javax.net.ssl.X509ExtendedTrustManager
 import kotlin.concurrent.thread
-import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Test
 
 class GatewayTlsTest {
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayTlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayTlsTest.kt
@@ -1,8 +1,5 @@
 package ai.openclaw.app.gateway
 
-import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Test
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
@@ -12,6 +9,9 @@ import javax.net.ssl.SSLEngine
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509ExtendedTrustManager
 import kotlin.concurrent.thread
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 class GatewayTlsTest {
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayTlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayTlsTest.kt
@@ -7,9 +7,43 @@ import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketException
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509ExtendedTrustManager
 import kotlin.concurrent.thread
 
 class GatewayTlsTest {
+  @Test
+  fun buildGatewayTlsConfig_forwardsPlatformTrustWithSocketAndEngineContext() {
+    val defaultTrust = RecordingExtendedTrustManager()
+    val config =
+      buildGatewayTlsConfig(
+        params =
+          GatewayTlsParams(
+            required = true,
+            expectedFingerprint = null,
+            allowTOFU = false,
+            stableId = "gateway-1",
+          ),
+        defaultTrust = defaultTrust,
+      )
+    val extendedTrust = config.trustManager as X509ExtendedTrustManager
+
+    Socket().use { socket ->
+      extendedTrust.checkServerTrusted(emptyArray(), "RSA", socket)
+    }
+    extendedTrust.checkServerTrusted(
+      emptyArray(),
+      "RSA",
+      SSLContext.getDefault().createSSLEngine(),
+    )
+
+    assertEquals(1, defaultTrust.serverSocketCalls)
+    assertEquals(1, defaultTrust.serverEngineCalls)
+    assertEquals(0, defaultTrust.serverTwoArgumentCalls)
+  }
+
   @Test
   fun probeGatewayTlsFingerprint_reportsHandshakeTimeoutAfterTcpConnect() =
     runBlocking {
@@ -107,6 +141,54 @@ class GatewayTlsTest {
       runCatching { serverSocket.close() }
       worker.join(1_000)
     }
+  }
+
+  private class RecordingExtendedTrustManager : X509ExtendedTrustManager() {
+    var serverTwoArgumentCalls = 0
+    var serverSocketCalls = 0
+    var serverEngineCalls = 0
+
+    override fun checkClientTrusted(
+      chain: Array<X509Certificate>,
+      authType: String,
+    ) = Unit
+
+    override fun checkClientTrusted(
+      chain: Array<X509Certificate>,
+      authType: String,
+      socket: Socket,
+    ) = Unit
+
+    override fun checkClientTrusted(
+      chain: Array<X509Certificate>,
+      authType: String,
+      engine: SSLEngine,
+    ) = Unit
+
+    override fun checkServerTrusted(
+      chain: Array<X509Certificate>,
+      authType: String,
+    ) {
+      serverTwoArgumentCalls += 1
+    }
+
+    override fun checkServerTrusted(
+      chain: Array<X509Certificate>,
+      authType: String,
+      socket: Socket,
+    ) {
+      serverSocketCalls += 1
+    }
+
+    override fun checkServerTrusted(
+      chain: Array<X509Certificate>,
+      authType: String,
+      engine: SSLEngine,
+    ) {
+      serverEngineCalls += 1
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
   }
 
   private companion object {


### PR DESCRIPTION
## What Problem This Solves

Android 15's platform `RootTrustManager` requires hostname-bearing `Socket` or `SSLEngine` trust checks when domain-specific network security configuration is present. The gateway TLS wrapper currently collapses those calls into the two-argument `X509TrustManager` method, so Android loses the hostname and rejects otherwise valid TLS handshakes.

Closes #59090.
Supersedes #58478.

## Why This Change Was Made

- implement `X509ExtendedTrustManager` for the gateway and probe wrappers
- forward socket/engine context to the platform trust manager in platform-trust mode
- preserve the existing pin and TOFU fingerprint path for those overloads
- remove redundant domain entries from the permissive local gateway network-security config
- inject a recording extended trust manager in tests and prove socket/engine forwarding without falling back to the context-free overload

This follows Android 15's platform contract directly: the context-free overload rejects domain-specific configurations, while the extended overloads derive the hostname from the socket or engine.

The original diagnosis and implementation direction came from @whisky0809 in #58478; contributor credit is retained in the commit.

## User Impact

Android users can connect to gateways on Android 15+ without the platform rejecting the TLS check solely because the hostname context was discarded. Pinning and TOFU behavior are unchanged.

## Evidence

- `git diff --check origin/main...HEAD`
- focused `GatewayTlsTest` regression covers both `Socket` and `SSLEngine` forwarding
- Blacksmith Testbox `tbx_01kxaghb0xeedjpcxzxrfh86y8`: focused `GatewayTlsTest` and full Android `ktlintCheck` passed on Gradle 9.6.1
- two-pass structured autoreview: clean after strengthening the regression test
- Android 15 AOSP `RootTrustManager` source inspected for the exact overload behavior
- hosted Android CI is required before landing

Gradle 10 is not released. Gradle 9.6.1 and Android Gradle Plugin 9.2.1 are the latest stable releases; AGP 9.2.1 currently emits its own Gradle-10 project-dependency deprecation from `VariantDependenciesBuilder`.

Release note: fix Android 15 gateway TLS handshakes by preserving hostname context through extended trust-manager overloads. Thanks @whisky0809.
