### PR TITLE
fix(config): bracket array indices and surface rejected enum value in validation messages (issue #104854)

### DIFF
--- a/src/config/validation.test.ts
+++ b/src/config/validation.test.ts
@@ -433,4 +433,40 @@ describe("mapZodIssueToConfigIssue", () => {
       expect(result.message).toBe("Invalid input");
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Issue #104854: bracket-notation paths and rejected enum value
+  // ---------------------------------------------------------------------------
+
+  describe("issue 104854 message clarity", () => {
+    it("renders numeric path segments as bracket notation", () => {
+      const result = testing.mapZodIssueToConfigIssue({
+        code: "invalid_enum_value",
+        path: ["agents", "list", 3, "tools", "profile"],
+        message: 'Invalid enum value, expected "minimal"',
+        received: "none",
+      });
+      expect(result.path).toBe("agents.list[3].tools.profile");
+    });
+
+    it("surfaces the rejected value with got: for enum issues", () => {
+      const result = testing.mapZodIssueToConfigIssue({
+        code: "invalid_enum_value",
+        path: ["agents", "list", 0, "tools", "profile"],
+        message: 'Invalid enum value, expected "minimal"',
+        received: "none",
+      });
+      expect(result.message).toContain('got: "none"');
+    });
+
+    it("does not append got: for non-enum issues", () => {
+      const result = testing.mapZodIssueToConfigIssue({
+        code: "custom",
+        path: ["channels", "telegram", "botToken"],
+        message: "invalid bot token",
+        received: "none",
+      });
+      expect(result.message).not.toContain("got:");
+    });
+  });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -204,7 +204,17 @@ function toConfigPathSegments(pathLocal3: unknown): ConfigPathSegment[] {
 }
 
 function formatConfigPath(segments: readonly ConfigPathSegment[]): string {
-  return segments.join(".");
+  if (segments.length === 0) {
+    return "";
+  }
+  let out = String(segments[0]);
+  for (let i = 1; i < segments.length; i++) {
+    const segment = segments[i];
+    // Use bracket notation for numeric (array-index) segments so the path is
+    // unambiguous and grep-able, e.g. `agents.list[3].tools.profile`.
+    out += typeof segment === "number" ? `[${segment}]` : `.${segment}`;
+  }
+  return out;
 }
 
 function formatMissingOfficialExternalPluginWarning(
@@ -825,7 +835,21 @@ export function collectUnsupportedSecretRefPolicyIssues(raw: unknown): ConfigVal
 function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
   const record = toIssueRecord(issue);
   const pathItem = formatConfigPath(toConfigPathSegments(record?.path));
-  const message = typeof record?.message === "string" ? record.message : "Invalid input";
+  let message = typeof record?.message === "string" ? record.message : "Invalid input";
+
+  // Surface the rejected value for enum/invalid-value issues. Zod's
+  // invalid_enum_value / invalid_literal issues carry a `received` field that
+  // is otherwise dropped before formatting; appending it tells the user exactly
+  // what they set wrong. See issue #104854.
+  const received = record?.received;
+  if (
+    typeof record?.code === "string" &&
+    (record.code === "invalid_enum_value" || record.code === "invalid_literal") &&
+    received !== undefined &&
+    received !== null
+  ) {
+    message = `${message}, got: ${JSON.stringify(received)}`;
+  }
 
   // Numeric ceiling/floor hints (too_big / too_small with numeric origin).
   // Append a parenthesized bound alongside Zod's native message,


### PR DESCRIPTION
## What Problem This Solves

Config validation error messages are hard to act on:

1. **Array indices render as dot segments** — `agents.list.3.tools.profile` looks like a property path, not an array index. Users cannot grep or jump to the offending entry.
2. **The rejected value is dropped** — Zod's `invalid_enum_value` issue carries a `received` field (e.g. `"none"`), but `mapZodIssueToConfigIssue` discarded it, so the message only says which values are allowed, never what was actually set.

Both make a misconfiguration slower to locate and fix.

## Evidence

- `src/config/validation.ts:206` `formatConfigPath` used `segments.join(".")`, turning numeric (array-index) segments into dot paths.
- `src/config/validation.ts:825` `mapZodIssueToConfigIssue` read `record.message` but never the Zod `received` field for enum/literal rejections.
- Existing test file `src/config/validation.test.ts` exercises `testing.mapZodIssueToConfigIssue` directly; new cases added there cover bracket notation and `got:`.

## Fix

- `formatConfigPath` now emits bracket notation for numeric segments: `agents.list[3].tools.profile`.
- `mapZodIssueToConfigIssue` appends `, got: <received>` for `invalid_enum_value` / `invalid_literal` issues (JSON-stringified), leaving all other messages unchanged.

This is the two contained, low-risk parts of #104854. The line-number-in-source mapping described in the issue requires a raw-text walk over `ConfigFileSnapshot.raw` and is intentionally out of scope here to keep the diff minimal and behavior-preserving.

Closes #104854
