### PR TITLE
fix: keep MCP Apps aligned with runtime tool policy

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -5,7 +5,7 @@ import { normalizeToolParameterSchema } from "@openclaw/ai/internal/openai";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
-import { setPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
+import { getPluginToolMeta, setPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
 import { matchesMcpToolFilterPattern } from "./agent-bundle-mcp-filter.js";
 import {
   buildSafeToolName,
@@ -25,6 +25,53 @@ import type { AnyAgentTool } from "./tools/common.js";
 
 function isAppOnlyTool(tool: McpCatalogTool): boolean {
   return tool.uiVisibility !== undefined && !tool.uiVisibility.includes("model");
+}
+
+function buildAppToolPolicyProjections(params: {
+  catalog: McpToolCatalog;
+  modelTools: readonly AnyAgentTool[];
+  reservedToolNames?: Iterable<string>;
+}): AnyAgentTool[] {
+  const tools = params.modelTools.filter(
+    (tool) => getPluginToolMeta(tool)?.mcp?.operation === "tool",
+  );
+  const reservedNames = normalizeReservedToolNames([
+    ...(params.reservedToolNames ?? []),
+    ...params.modelTools.map((tool) => tool.name),
+  ]);
+  const appOnlyTools = params.catalog.tools.filter(isAppOnlyTool).toSorted((a, b) => {
+    const serverOrder = a.safeServerName.localeCompare(b.safeServerName);
+    return serverOrder || a.toolName.localeCompare(b.toolName);
+  });
+  for (const tool of appOnlyTools) {
+    const name = buildSafeToolName({
+      serverName: tool.safeServerName,
+      toolName: tool.toolName,
+      reservedNames,
+    });
+    reservedNames.add(normalizeLowercaseStringOrEmpty(name));
+    const projection: AnyAgentTool = {
+      name,
+      label: tool.title ?? tool.toolName,
+      description: tool.description || tool.fallbackDescription,
+      parameters: normalizeToolParameterSchema(tool.inputSchema),
+      execute: async () => {
+        throw new Error("MCP App policy projections cannot execute tools");
+      },
+    };
+    setPluginToolMeta(projection, {
+      pluginId: "bundle-mcp",
+      optional: false,
+      mcp: {
+        serverName: tool.serverName,
+        safeServerName: tool.safeServerName,
+        toolName: tool.toolName,
+        operation: "tool",
+      },
+    });
+    tools.push(projection);
+  }
+  return tools.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 function toAgentToolResult(params: {
@@ -351,6 +398,7 @@ export async function materializeBundleMcpToolsForRun(params: {
   disposeRuntime?: () => Promise<void>;
 }): Promise<BundleMcpToolRuntime> {
   let disposed = false;
+  let allowedAppToolsByServer: Map<string, Set<string>> | undefined;
   const releaseLease = params.runtime.acquireLease?.();
   params.runtime.markUsed();
   let catalog;
@@ -372,6 +420,9 @@ export async function materializeBundleMcpToolsForRun(params: {
         result,
       });
       if (params.runtime.mcpAppsEnabled && tool.uiResourceUri) {
+        const allowedAppToolNames = allowedAppToolsByServer
+          ? (allowedAppToolsByServer.get(tool.serverName) ?? new Set<string>())
+          : undefined;
         const view = await fetchMcpAppView({
           runtime: params.runtime,
           serverName: tool.serverName,
@@ -379,6 +430,7 @@ export async function materializeBundleMcpToolsForRun(params: {
           uiResourceUri: tool.uiResourceUri,
           toolInput: input,
           toolResult: result,
+          ...(allowedAppToolNames ? { allowedAppToolNames } : {}),
         });
         if (view) {
           (agentResult.details as Record<string, unknown>).mcpAppPreview =
@@ -432,12 +484,31 @@ export async function materializeBundleMcpToolsForRun(params: {
         }
       : undefined,
   });
+  const appTools = buildAppToolPolicyProjections({
+    catalog,
+    modelTools: tools,
+    reservedToolNames: params.reservedToolNames,
+  });
 
   return {
     tools,
+    appTools,
     ...(catalog.diagnostics && catalog.diagnostics.length > 0
       ? { diagnostics: catalog.diagnostics }
       : {}),
+    restrictAppTools: (allowedTools) => {
+      const next = new Map<string, Set<string>>();
+      for (const allowedTool of allowedTools) {
+        const mcp = getPluginToolMeta(allowedTool)?.mcp;
+        if (!mcp || mcp.operation !== "tool") {
+          continue;
+        }
+        const names = next.get(mcp.serverName) ?? new Set<string>();
+        names.add(mcp.toolName);
+        next.set(mcp.serverName, names);
+      }
+      allowedAppToolsByServer = next;
+    },
     dispose: async () => {
       if (disposed) {
         return;

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -408,9 +408,12 @@ export async function materializeBundleMcpToolsForRun(params: {
     releaseLease?.();
     throw error;
   }
+  const reservedToolNames = params.reservedToolNames
+    ? Array.from(params.reservedToolNames)
+    : undefined;
   const tools = buildBundleMcpToolsFromCatalog({
     catalog,
-    reservedToolNames: params.reservedToolNames,
+    reservedToolNames,
     createExecute: (tool) => async (_toolCallId: string, input: unknown) => {
       params.runtime.markUsed();
       const result = await params.runtime.callTool(tool.serverName, tool.toolName, input);
@@ -487,7 +490,7 @@ export async function materializeBundleMcpToolsForRun(params: {
   const appTools = buildAppToolPolicyProjections({
     catalog,
     modelTools: tools,
-    reservedToolNames: params.reservedToolNames,
+    reservedToolNames,
   });
 
   return {

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -62,6 +62,7 @@ async function writeListToolsMcpServer(params: {
   callToolIsError?: boolean;
   callToolJsonRpcError?: boolean;
   resourceListJsonRpcError?: boolean;
+  resourceReadJsonRpcError?: boolean;
 }): Promise<void> {
   await writeExecutable(
     params.filePath,
@@ -90,6 +91,7 @@ const tools = ${JSON.stringify(
 const callToolIsError = ${params.callToolIsError === true};
 const callToolJsonRpcError = ${params.callToolJsonRpcError === true};
 const resourceListJsonRpcError = ${params.resourceListJsonRpcError === true};
+const resourceReadJsonRpcError = ${params.resourceReadJsonRpcError === true};
 
 let buffer = "";
 let listCount = 0;
@@ -200,6 +202,22 @@ function handle(message) {
       jsonrpc: "2.0",
       id: message.id,
       result: { resources: [] },
+    });
+    return;
+  }
+  if (message.method === "resources/read") {
+    if (resourceReadJsonRpcError) {
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { code: -32000, message: "resource read failed" },
+      });
+      return;
+    }
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { contents: [{ uri: message.params?.uri, text: "resource ok" }] },
     });
   }
 }
@@ -1631,6 +1649,48 @@ process.on("SIGINT", shutdown);`,
       await expect(runtime.listResources("failing")).rejects.toThrow(
         'bundle-mcp server "failing" is paused after repeated tool failures',
       );
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not pause tools after optional preview read failures", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-preview-failure-"));
+    const serverPath = path.join(tempDir, "preview-failure.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { tools: {}, resources: {} },
+      resourceReadJsonRpcError: true,
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-preview-failure",
+      sessionKey: "agent:test:session-preview-failure",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            failing: { command: process.execPath, args: [serverPath] },
+          },
+        },
+      },
+    });
+
+    try {
+      if (!runtime.readResource) {
+        throw new Error("Expected test runtime to expose resource utilities");
+      }
+      for (let index = 0; index < 3; index += 1) {
+        await expect(
+          runtime.readResource("failing", "ui://demo/app", { failureBackoff: "ignore" }),
+        ).rejects.toThrow("resource read failed");
+      }
+      await expect(runtime.callTool("failing", "slow_tool", {})).resolves.toMatchObject({
+        isError: false,
+      });
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -21,6 +21,7 @@ import { matchesMcpToolFilterPattern } from "./agent-bundle-mcp-filter.js";
 import { sanitizeServerName } from "./agent-bundle-mcp-names.js";
 import type {
   McpCatalogTool,
+  McpRequestOptions,
   McpServerCatalog,
   McpToolCatalog,
   McpToolCatalogDiagnostic,
@@ -438,20 +439,26 @@ export function createSessionMcpRuntime(params: {
   const runGuardedServerRequest = async <T>(
     serverName: string,
     request: () => Promise<T>,
+    options?: McpRequestOptions,
   ): Promise<T> => {
+    const tracksFailureBackoff = options?.failureBackoff !== "ignore";
     const nowMs = Date.now();
     const backoff = serverBackoff.get(serverName);
-    if (backoff?.retryAfterMs && nowMs < backoff.retryAfterMs) {
+    if (tracksFailureBackoff && backoff?.retryAfterMs && nowMs < backoff.retryAfterMs) {
       throw new Error(
         `bundle-mcp server "${serverName}" is paused after repeated tool failures; retry after ${new Date(backoff.retryAfterMs).toISOString()}`,
       );
     }
     try {
       const result = await request();
-      serverBackoff.delete(serverName);
+      if (tracksFailureBackoff) {
+        serverBackoff.delete(serverName);
+      }
       return result;
     } catch (error) {
-      recordServerToolFailure(serverName, nowMs);
+      if (tracksFailureBackoff) {
+        recordServerToolFailure(serverName, nowMs);
+      }
       throw error;
     }
   };
@@ -882,15 +889,17 @@ export function createSessionMcpRuntime(params: {
         session.client.listTools(requestParams, { timeout: session.requestTimeoutMs }),
       );
     },
-    async listResources(serverName) {
+    async listResources(serverName, options) {
       failIfDisposed();
       await getCatalog();
       const session = requireConnectedSession(serverName);
-      return await runGuardedServerRequest(serverName, async () =>
-        listAllResources(session.client, session.requestTimeoutMs),
+      return await runGuardedServerRequest(
+        serverName,
+        async () => listAllResources(session.client, session.requestTimeoutMs),
+        options,
       );
     },
-    async readResource(serverName, uri) {
+    async readResource(serverName, uri, options) {
       failIfDisposed();
       await getCatalog();
       const session = requireConnectedSession(serverName);
@@ -898,6 +907,7 @@ export function createSessionMcpRuntime(params: {
         serverName,
         async () =>
           await session.client.readResource({ uri }, { timeout: session.requestTimeoutMs }),
+        options,
       );
     },
     async listResourceTemplates(serverName, requestParams) {

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -11,6 +11,7 @@ import {
 import type { McpCatalogTool } from "./agent-bundle-mcp-types.js";
 import type { McpToolCatalogDiagnostic } from "./agent-bundle-mcp-types.js";
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
+import { applyEmbeddedAttemptToolsAllow } from "./embedded-agent-runner/run/attempt-tool-construction-plan.js";
 
 const mcpAppMocks = vi.hoisted(() => ({ fetchMcpAppView: vi.fn() }));
 
@@ -133,6 +134,16 @@ describe("createBundleMcpToolRuntime", () => {
     });
 
     expect(runtime.tools.map((tool) => tool.name)).toEqual(["demo__model_tool"]);
+    expect(runtime.appTools?.map((tool) => tool.name)).toEqual([
+      "demo__app_tool",
+      "demo__hidden_tool",
+      "demo__model_tool",
+    ]);
+    expect(
+      applyEmbeddedAttemptToolsAllow(runtime.appTools ?? [], ["demo__model_tool"], {
+        toolMeta: (tool) => getPluginToolMeta(tool),
+      }).map((tool) => tool.name),
+    ).toEqual(["demo__model_tool"]);
   });
 
   it("attaches app previews without converting typed image results to text", async () => {
@@ -157,12 +168,16 @@ describe("createBundleMcpToolRuntime", () => {
     });
     sessionRuntime.mcpAppsEnabled = true;
     const materialized = await materializeBundleMcpToolsForRun({ runtime: sessionRuntime });
+    materialized.restrictAppTools?.(materialized.tools);
 
     const result = await materialized.tools[0].execute("call-1", {}, undefined, undefined);
     expect(result.content).toEqual([{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }]);
     expect(result.details).toMatchObject({
       mcpAppPreview: { mcpApp: { viewId: "cv_app" } },
     });
+    expect(mcpAppMocks.fetchMcpAppView).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedAppToolNames: new Set(["show"]) }),
+    );
   });
 
   it("materializes bundle MCP tools and executes them", async () => {

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -327,6 +327,31 @@ describe("createBundleMcpToolRuntime", () => {
     expect(runtime.tools.map((tool) => tool.name)).toEqual(["bundleProbe__bundle_probe-2"]);
   });
 
+  it("reuses one-shot reserved names for App-only policy projections", async () => {
+    function* reservedToolNames() {
+      yield "demo__app_tool";
+    }
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({
+        serverName: "demo",
+        tools: [
+          {
+            serverName: "demo",
+            safeServerName: "demo",
+            toolName: "app_tool",
+            inputSchema: { type: "object" },
+            fallbackDescription: "app",
+            uiVisibility: ["app"],
+          },
+        ],
+      }),
+      reservedToolNames: reservedToolNames(),
+    });
+
+    expect(runtime.tools).toEqual([]);
+    expect(runtime.appTools?.map((tool) => tool.name)).toEqual(["demo__app_tool-2"]);
+  });
+
   it("preserves catalog diagnostics when MCP servers fail tool listing", async () => {
     const diagnostics = [
       {

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -11,7 +11,10 @@ import type { AnyAgentTool } from "./tools/common.js";
 /** Materialized MCP tools plus diagnostics and cleanup handle for one run. */
 export type BundleMcpToolRuntime = {
   tools: AnyAgentTool[];
+  /** All MCP tool-call projections, including App-only tools, for policy evaluation. */
+  appTools?: AnyAgentTool[];
   diagnostics?: readonly McpToolCatalogDiagnostic[];
+  restrictAppTools?: (tools: readonly AnyAgentTool[]) => void;
   dispose: () => Promise<void>;
 };
 
@@ -68,6 +71,10 @@ export type McpToolCatalogDiagnostic = {
   message: string;
 };
 
+export type McpRequestOptions = {
+  failureBackoff?: "track" | "ignore";
+};
+
 /** Live MCP runtime bound to one session/workspace. */
 export type SessionMcpRuntime = {
   sessionId: string;
@@ -87,8 +94,8 @@ export type SessionMcpRuntime = {
   markUsed: () => void;
   callTool: (serverName: string, toolName: string, input: unknown) => Promise<CallToolResult>;
   listTools?: (serverName: string, params?: { cursor?: string }) => Promise<ListToolsResult>;
-  listResources?: (serverName: string) => Promise<unknown>;
-  readResource?: (serverName: string, uri: string) => Promise<unknown>;
+  listResources?: (serverName: string, options?: McpRequestOptions) => Promise<unknown>;
+  readResource?: (serverName: string, uri: string, options?: McpRequestOptions) => Promise<unknown>;
   listResourceTemplates?: (
     serverName: string,
     params?: { cursor?: string },

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1976,6 +1976,22 @@ export async function runEmbeddedAttempt(
       conversationCapabilityProfile: runtimeCapabilityProfile,
       warn: (message) => log.warn(message),
     });
+    if (bundleMcpRuntime?.restrictAppTools) {
+      const runtimeAllowedAppTools = applyEmbeddedAttemptToolsAllow(
+        bundleMcpRuntime.appTools ?? bundleMcpRuntime.tools,
+        effectiveToolsAllow,
+        { toolMeta: (tool) => getPluginToolMeta(tool) },
+      );
+      const allowedAppTools = applyFinalEffectiveToolPolicy({
+        bundledTools: runtimeAllowedAppTools,
+        config: params.config,
+        conversationCapabilityProfile: runtimeCapabilityProfile,
+        warn: (message) => log.warn(message),
+      });
+      // The view outlives this attempt. Capture policy against the complete MCP
+      // catalog now, including App-only tools that never enter the model surface.
+      bundleMcpRuntime.restrictAppTools(allowedAppTools);
+    }
     const normalizedBundledTools =
       filteredBundledTools.length > 0
         ? normalizeAgentRuntimeTools({

--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -83,6 +83,39 @@ describe("MCP App UI resources", () => {
     ).toBeUndefined();
   });
 
+  it("keeps valid Apps when optional listing metadata fails", async () => {
+    const readResource = vi.fn(async () => ({
+      contents: [
+        {
+          uri: "ui://demo/app",
+          mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+          text: "<html>demo</html>",
+        },
+      ],
+    }));
+    const sessionRuntime = runtime(readResource);
+    sessionRuntime.listResources = vi.fn(async () => {
+      throw new Error("resources/list unavailable");
+    });
+
+    const result = await fetchMcpAppView({
+      runtime: sessionRuntime,
+      serverName: "demo",
+      toolName: "show",
+      uiResourceUri: "ui://demo/app",
+      toolInput: {},
+      toolResult: { content: [] },
+    });
+
+    expect(result?.viewId).toMatch(/^mcp-app-/u);
+    expect(readResource).toHaveBeenCalledWith("demo", "ui://demo/app", {
+      failureBackoff: "ignore",
+    });
+    expect(sessionRuntime.listResources).toHaveBeenCalledWith("demo", {
+      failureBackoff: "ignore",
+    });
+  });
+
   it("rejects oversized and incorrectly typed resources", async () => {
     for (const content of [
       {

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -28,6 +28,7 @@ export type McpAppViewLease = {
   html: string;
   csp?: McpAppCsp;
   permissions?: McpAppPermissions;
+  allowedAppToolNames?: ReadonlySet<string>;
   toolInput: unknown;
   toolResult: CallToolResult;
   expiresAtMs: number;
@@ -150,15 +151,24 @@ async function resolveListingUiMeta(
   serverName: string,
   uri: string,
 ): Promise<Record<string, unknown> | undefined> {
-  const listed = await runtime.listResources?.(serverName);
-  const resources = Array.isArray(listed)
-    ? listed
-    : Array.isArray(asRecord(listed)?.resources)
-      ? (asRecord(listed)?.resources as unknown[])
-      : [];
-  const resource = resources.map(asRecord).find((entry) => entry?.uri === uri);
-  const { _meta: metadata } = resource ?? {};
-  return asRecord(asRecord(metadata)?.ui);
+  try {
+    const listed = await runtime.listResources?.(serverName, { failureBackoff: "ignore" });
+    const resources = Array.isArray(listed)
+      ? listed
+      : Array.isArray(asRecord(listed)?.resources)
+        ? (asRecord(listed)?.resources as unknown[])
+        : [];
+    const resource = resources.map(asRecord).find((entry) => entry?.uri === uri);
+    const { _meta: metadata } = resource ?? {};
+    return asRecord(asRecord(metadata)?.ui);
+  } catch (error) {
+    // UI resources may be omitted from resources/list. Listing metadata is only
+    // a fallback, so its failure must not discard valid resources/read content.
+    logWarn(
+      `mcp-app: failed to read optional listing metadata for ${uri} from "${serverName}": ${formatErrorMessage(error)}`,
+    );
+    return undefined;
+  }
 }
 
 export async function fetchMcpAppView(params: {
@@ -168,6 +178,7 @@ export async function fetchMcpAppView(params: {
   uiResourceUri: string;
   toolInput: unknown;
   toolResult: CallToolResult;
+  allowedAppToolNames?: ReadonlySet<string>;
 }): Promise<{ viewId: string; title: string } | undefined> {
   let releaseRuntimeLease: (() => void) | undefined;
   try {
@@ -175,7 +186,9 @@ export async function fetchMcpAppView(params: {
       return undefined;
     }
     const result = asRecord(
-      await params.runtime.readResource(params.serverName, params.uiResourceUri),
+      await params.runtime.readResource(params.serverName, params.uiResourceUri, {
+        failureBackoff: "ignore",
+      }),
     );
     const contents = Array.isArray(result?.contents) ? result.contents : [];
     if (contents.length !== 1) {
@@ -209,6 +222,9 @@ export async function fetchMcpAppView(params: {
       html,
       ...(csp ? { csp } : {}),
       ...(permissions ? { permissions } : {}),
+      ...(params.allowedAppToolNames
+        ? { allowedAppToolNames: new Set(params.allowedAppToolNames) }
+        : {}),
       toolInput: params.toolInput,
       toolResult: params.toolResult,
       expiresAtMs: Date.now() + MCP_APP_VIEW_TTL_MS,

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -117,6 +117,9 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   },
   { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
+  // The dedicated Apps listener and origin are created once during Gateway
+  // startup; disposing MCP runtimes cannot move or create that HTTP server.
+  { prefix: "mcp.apps", kind: "restart" },
   { prefix: "mcp", kind: "hot", actions: ["dispose-mcp-runtimes"] },
   { prefix: "plugins.load", kind: "restart" },
   { prefix: "plugins.installs", kind: "restart" },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -204,6 +204,21 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartReasons).toContain("gateway.port");
   });
 
+  it("restarts the gateway when MCP Apps listener config changes", () => {
+    const plan = buildGatewayReloadPlan([
+      "mcp.apps.enabled",
+      "mcp.apps.sandboxPort",
+      "mcp.apps.sandboxOrigin",
+    ]);
+    expect(plan.restartGateway).toBe(true);
+    expect(plan.restartReasons).toEqual([
+      "mcp.apps.enabled",
+      "mcp.apps.sandboxPort",
+      "mcp.apps.sandboxOrigin",
+    ]);
+    expect(plan.disposeMcpRuntimes).toBe(false);
+  });
+
   it("restarts the gateway for operator terminal config changes", () => {
     // The terminal drives the Control UI CSP + bootstrap (both document-load
     // time) and live PTYs, none of which hot-update a connected client, so a

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -29,6 +29,7 @@ import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
   buildGatewayReloadPlan,
   diffConfigPaths,
+  diffGatewayReloadPaths,
   type GatewayReloadPlan,
   listPluginInstallTimestampMetadataPaths,
   listPluginInstallWholeRecordPaths,
@@ -131,6 +132,29 @@ describe("diffConfigPaths", () => {
       "plugins.installs.lossless.resolvedAt",
     ]);
   });
+
+  it.each([
+    {
+      label: "added",
+      prev: {},
+      next: { mcp: { apps: { enabled: true } } },
+    },
+    {
+      label: "removed",
+      prev: { mcp: { apps: { enabled: true } } },
+      next: {},
+    },
+  ])(
+    "preserves the Apps restart boundary when the whole MCP config is $label",
+    ({ prev, next }) => {
+      const changedPaths = diffGatewayReloadPaths(prev, next);
+      const plan = buildGatewayReloadPlan(changedPaths);
+
+      expect(changedPaths).toEqual(["mcp", "mcp.apps"]);
+      expect(plan.restartGateway).toBe(true);
+      expect(plan.restartReasons).toContain("mcp.apps");
+    },
+  );
 });
 
 describe("buildGatewayReloadPlan", () => {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -76,6 +76,26 @@ function firstSkillsChangedPath(changedPaths: string[]): string | undefined {
   return changedPaths.find(matchesSkillsInvalidationPrefix);
 }
 
+export function diffGatewayReloadPaths(
+  prevConfig: OpenClawConfig,
+  nextConfig: OpenClawConfig,
+): string[] {
+  const changedPaths = diffConfigPaths(prevConfig, nextConfig);
+  if (!changedPaths.includes("mcp")) {
+    return changedPaths;
+  }
+  // Adding or removing the whole `mcp` object collapses to the broad `mcp`
+  // path. Preserve the startup-only Apps boundary so that transition still
+  // restarts the listener instead of only disposing cached MCP runtimes.
+  return [
+    ...changedPaths,
+    ...diffConfigPaths(
+      { mcp: { apps: prevConfig.mcp?.apps } },
+      { mcp: { apps: nextConfig.mcp?.apps } },
+    ),
+  ];
+}
+
 function isNoopReloadPlan(plan: GatewayReloadPlan): boolean {
   return (
     !plan.restartGateway &&
@@ -214,7 +234,7 @@ export function startGatewayConfigReloader(opts: {
     nextCompareConfig: OpenClawConfig,
     afterWrite?: ConfigWriteNotification["afterWrite"],
   ) => {
-    const configChangedPaths = diffConfigPaths(currentCompareConfig, nextCompareConfig);
+    const configChangedPaths = diffGatewayReloadPaths(currentCompareConfig, nextCompareConfig);
     const configPluginInstallTimestampNoopPaths = listPluginInstallTimestampMetadataPaths(
       currentCompareConfig,
       nextCompareConfig,

--- a/src/gateway/server-methods/mcp-app.test.ts
+++ b/src/gateway/server-methods/mcp-app.test.ts
@@ -27,6 +27,7 @@ const view = {
   toolName: "show",
   uiResourceUri: "ui://demo/app",
   html: "<html>demo</html>",
+  allowedAppToolNames: undefined as ReadonlySet<string> | undefined,
   toolInput: { city: "Paris" },
   toolResult: { content: [{ type: "text", text: "ok" }] },
   expiresAtMs: Date.now() + 60_000,
@@ -91,6 +92,7 @@ describe("MCP App gateway bridge", () => {
     view.requestCount = 0;
     view.toolCallCount = 0;
     view.activeRequests = 0;
+    view.allowedAppToolNames = undefined;
     mocks.getMcpAppViewLease.mockReset().mockReturnValue(view);
     mocks.completeDeferredSessionMcpRuntimeRetirement.mockReset().mockResolvedValue(false);
     mocks.peekSessionMcpRuntime.mockReset().mockReturnValue(runtime());
@@ -143,6 +145,19 @@ describe("MCP App gateway bridge", () => {
     ]);
 
     const denied = await invoke("mcp.app.callTool", { ...params, toolName: "model-only" });
+    expect(denied.mock.calls[0]?.[0]).toBe(false);
+  });
+
+  it("keeps the originating run allowlist authoritative for App calls", async () => {
+    view.allowedAppToolNames = new Set(["shared"]);
+    const params = { sessionKey: "agent:main:main", viewId: "cv_app" };
+
+    const listed = await invoke("mcp.app.listTools", params);
+    expect(listed.mock.calls[0]?.[1].tools.map((tool: { name: string }) => tool.name)).toEqual([
+      "shared",
+    ]);
+
+    const denied = await invoke("mcp.app.callTool", { ...params, toolName: "app-only" });
     expect(denied.mock.calls[0]?.[0]).toBe(false);
   });
 

--- a/src/gateway/server-methods/mcp-app.ts
+++ b/src/gateway/server-methods/mcp-app.ts
@@ -46,6 +46,10 @@ function isAppCallableListedTool(tool: Tool): boolean {
   return visibility === undefined || visibility.includes("app");
 }
 
+function isAllowedByView(view: McpAppViewLease, toolName: string): boolean {
+  return view.allowedAppToolNames === undefined || view.allowedAppToolNames.has(toolName);
+}
+
 function requireActiveView(params: Record<string, unknown>): {
   runtime: SessionMcpRuntime;
   view: McpAppViewLease;
@@ -87,14 +91,14 @@ async function withActiveView<T>(
 
 async function requireCallableTool(
   runtime: SessionMcpRuntime,
-  serverName: string,
+  view: McpAppViewLease,
   toolName: string,
 ): Promise<McpCatalogTool> {
   const catalog = await runtime.getCatalog();
   const tool = catalog.tools.find(
-    (entry) => entry.serverName === serverName && entry.toolName === toolName,
+    (entry) => entry.serverName === view.serverName && entry.toolName === toolName,
   );
-  if (!tool || !isAppCallableTool(tool)) {
+  if (!tool || !isAppCallableTool(tool) || !isAllowedByView(view, toolName)) {
     throw new Error(`MCP tool "${toolName}" is not app-callable`);
   }
   return tool;
@@ -140,7 +144,7 @@ export const mcpAppHandlers: GatewayRequestHandlers = {
       async () =>
         await withActiveView(params, "tool", async ({ runtime, view }) => {
           const toolName = requireString(params, "toolName");
-          await requireCallableTool(runtime, view.serverName, toolName);
+          await requireCallableTool(runtime, view, toolName);
           return await runtime.callTool(view.serverName, toolName, params.arguments ?? {});
         }),
     );
@@ -159,7 +163,12 @@ export const mcpAppHandlers: GatewayRequestHandlers = {
           ]);
           const allowed = new Set(
             catalog.tools
-              .filter((tool) => tool.serverName === view.serverName && isAppCallableTool(tool))
+              .filter(
+                (tool) =>
+                  tool.serverName === view.serverName &&
+                  isAppCallableTool(tool) &&
+                  isAllowedByView(view, tool.toolName),
+              )
               .map((tool) => tool.toolName),
           );
           return {

--- a/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts
@@ -20,6 +20,7 @@ import { getPluginToolMeta } from "../../../../dist/plugins/tools.js";
 import { createE2eStateDir } from "../../../../scripts/e2e/lib/temp-state-dir.ts";
 
 const require = createRequire(import.meta.url);
+const APP_URI = "ui://docker-probe/app";
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -37,9 +38,27 @@ import { McpServer } from ${JSON.stringify(sdkMcpServerPath)};
 import { StdioServerTransport } from ${JSON.stringify(sdkStdioServerPath)};
 
 const server = new McpServer({ name: "agent-bundle-mcp-tools-probe", version: "1.0.0" });
-server.tool("docker_probe", "Docker OpenClaw MCP tool availability probe", async () => ({
+const probeTool = server.tool("docker_probe", "Docker OpenClaw MCP tool availability probe", async () => ({
   content: [{ type: "text", text: "agent-bundle-mcp-tools-ok" }],
 }));
+probeTool.update({ _meta: { ui: { resourceUri: ${JSON.stringify(APP_URI)} } } });
+const companionTool = server.tool("app_companion", "MCP App-only companion", async () => ({
+  content: [{ type: "text", text: "companion-called" }],
+}));
+companionTool.update({ _meta: { ui: { visibility: ["app"] } } });
+server.registerResource(
+  "docker_probe_app",
+  ${JSON.stringify(APP_URI)},
+  { mimeType: "text/html;profile=mcp-app" },
+  async (uri) => ({
+    contents: [{
+      uri: uri.href,
+      mimeType: "text/html;profile=mcp-app",
+      text: "<!doctype html><main>Docker MCP App</main>",
+      _meta: { ui: { csp: { connectDomains: ["https://api.example.com"] } } },
+    }],
+  }),
+);
 
 await server.connect(new StdioServerTransport());
 `,
@@ -83,6 +102,7 @@ async function main() {
       profile: "coding",
     },
     mcp: {
+      apps: { enabled: true },
       servers: {
         dockerProbe: {
           command: "node",
@@ -108,6 +128,7 @@ async function main() {
       getPluginToolMeta(probeTool)?.pluginId === "bundle-mcp",
       "expected materialized MCP tool to be tagged as bundle-mcp",
     );
+    materialized.restrictAppTools?.([probeTool]);
 
     const result = await probeTool.execute("docker-mcp-probe", {}, undefined, undefined);
     assert(
@@ -116,6 +137,10 @@ async function main() {
       ),
       "expected materialized MCP tool execution result",
     );
+    const resultDetails = result.details as Record<string, unknown>;
+    const preview = resultDetails.mcpAppPreview as { mcpApp?: { viewId?: string } } | undefined;
+    const viewId = preview?.mcpApp?.viewId;
+    assert(viewId, "expected MCP App preview from real stdio server");
 
     const coding = applyPolicy({ tools: materialized.tools, config: cfg });
     assert(
@@ -198,6 +223,7 @@ async function main() {
             minimal: minimalCustom.map((tool) => tool.name),
             denied: deniedCustom.map((tool) => tool.name),
           },
+          mcpApp: { viewId, preview: true },
         },
         null,
         2,

--- a/ui/src/components/mcp-app-view.ts
+++ b/ui/src/components/mcp-app-view.ts
@@ -18,7 +18,7 @@ type McpAppViewPayload = {
   sandboxPort: number;
   sandboxOrigin?: string;
   html: string;
-  csp?: Record<string, unknown>;
+  csp?: HostSandboxCsp;
   toolInput: unknown;
   toolResult: unknown;
 };
@@ -26,6 +26,8 @@ type McpAppViewPayload = {
 type HostContext = NonNullable<
   NonNullable<ConstructorParameters<typeof AppBridge>[3]>["hostContext"]
 >;
+type HostCapabilities = ConstructorParameters<typeof AppBridge>[2];
+type HostSandboxCsp = NonNullable<NonNullable<HostCapabilities["sandbox"]>["csp"]>;
 
 function hostContext(element: Element | undefined, height: number): HostContext {
   const rect = element?.getBoundingClientRect();
@@ -46,6 +48,15 @@ function hostContext(element: Element | undefined, height: number): HostContext 
       hover: window.matchMedia?.("(hover: hover)").matches,
     },
     safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  };
+}
+
+export function buildMcpAppHostCapabilities(csp?: HostSandboxCsp): HostCapabilities {
+  return {
+    openLinks: {},
+    serverResources: {},
+    serverTools: {},
+    sandbox: { csp: csp ?? {} },
   };
 }
 
@@ -252,7 +263,7 @@ export class McpAppView extends LitElement {
       const bridge = new OpenClawAppBridge(
         null,
         { name: "OpenClaw", version: "1.0.0" },
-        { openLinks: {}, serverResources: {}, serverTools: {} },
+        buildMcpAppHostCapabilities(payload.csp),
         { hostContext: hostContext(mount, this.height) },
       );
       bridge.oncalltool = async (params) =>

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -28,7 +28,10 @@ vi.mock("../tool-display.ts", () => ({
   },
 }));
 
-import { resolveMcpAppSandboxUrl } from "../../../components/mcp-app-view.ts";
+import {
+  buildMcpAppHostCapabilities,
+  resolveMcpAppSandboxUrl,
+} from "../../../components/mcp-app-view.ts";
 import { t } from "../../../i18n/index.ts";
 import {
   formatDistinctCollapsedToolSummaryText,
@@ -66,6 +69,15 @@ function pointerClick(element: Element) {
 }
 
 describe("tool-cards", () => {
+  it("advertises the CSP actually applied to MCP Apps", () => {
+    expect(
+      buildMcpAppHostCapabilities({ connectDomains: ["https://api.example.com"] }),
+    ).toMatchObject({
+      sandbox: { csp: { connectDomains: ["https://api.example.com"] } },
+    });
+    expect(buildMcpAppHostCapabilities()).toMatchObject({ sandbox: { csp: {} } });
+  });
+
   it("accepts only the dedicated-origin MCP App sandbox endpoint", () => {
     expect(
       resolveMcpAppSandboxUrl(


### PR DESCRIPTION
Related: #69039

AI-assisted: implementation and review were performed with Codex.

## What Problem This Solves

Fixes issues where MCP App previews could disappear when optional resource listing failed, App-only tools could escape the originating run's effective tool policy, repeated preview-read failures could pause normal MCP calls, applied sandbox CSP was not advertised to the App, and Apps listener changes appeared hot-reloadable even though they require a Gateway restart.

## Why This Change Was Made

This follows up on the review feedback from #69039. It evaluates the complete MCP tool catalog, including App-only tools, through the same runtime and layered policy pipeline as model-visible tools; keeps optional preview discovery outside server-failure backoff; advertises the CSP actually applied by the host; and classifies `mcp.apps` listener changes as restart-required. Sandbox parent authentication is intentionally outside this follow-up.

## User Impact

MCP Apps remain available when servers omit or fail optional listing, App calls cannot exceed the tool policy of the run that opened the view, preview failures no longer disable unrelated MCP calls, Apps receive accurate CSP capabilities, and listener configuration changes take effect predictably after restart.

## Evidence

- Focused hosted tests: 538 assertions passed across MCP runtime, materialization, policy, Gateway, reload, and Control UI coverage.
- Regression follow-up: 99 focused assertions passed after adding complete-catalog App policy evaluation.
- Full changed-surface gate: `check:changed` passed on Blacksmith Testbox `tbx_01kxaddh6pywtjwvhcd9yhpecj` (core/UI/test-root typechecks, format, lint, and architecture guards).
- Package proof: OpenClaw and Control UI builds passed; npm tarball integrity passed.
- Live functional proof: `test:docker:agent-bundle-mcp-tools` passed from the packed artifact against a real stdio MCP server, including tool discovery, resource read, MCP App preview creation, profile filtering, and provider-bound tool serialization.
- Fresh pre-ship autoreview: no accepted or actionable findings.
