### PR TITLE
fix(i18n): retry batches that drop placeholders

### DIFF
--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -490,14 +490,21 @@ function buildSystemPrompt(targetLocale: string, glossary: readonly GlossaryEntr
   return lines.join("\n");
 }
 
-function buildBatchPrompt(items: readonly TranslationBatchItem[]): string {
+export function buildBatchPrompt(
+  items: readonly TranslationBatchItem[],
+  validationError?: string,
+): string {
   const payload = Object.fromEntries(items.map((item) => [item.key, item.text]));
-  return [
-    "Translate this JSON object.",
-    "Return ONLY a JSON object with the same keys.",
-    "",
-    JSON.stringify(payload, null, 2),
-  ].join("\n");
+  const lines = ["Translate this JSON object.", "Return ONLY a JSON object with the same keys."];
+  if (validationError) {
+    lines.push(
+      "",
+      "Your previous response failed validation. Correct that exact failure in the new response:",
+      validationError,
+    );
+  }
+  lines.push("", JSON.stringify(payload, null, 2));
+  return lines.join("\n");
 }
 
 function formatDuration(ms: number): string {
@@ -1344,20 +1351,26 @@ async function translateBatch(
   const batchLabel = formatBatchLabel(context);
   const splitDepth = context.splitDepth ?? 0;
   let lastError: Error | null = null;
+  let validationError: string | undefined;
   for (let attempt = 0; attempt < TRANSLATE_MAX_ATTEMPTS; attempt += 1) {
     const attemptNumber = attempt + 1;
     const attemptLabel = `${batchLabel} attempt ${attemptNumber}/${TRANSLATE_MAX_ATTEMPTS}`;
     const startedAt = Date.now();
     logProgress(`${attemptLabel}: start keys=${items.length}`);
+    let promptCompleted = false;
     try {
       const raw = await (
         await clientAccess.getClient()
-      ).prompt(buildBatchPrompt(items), attemptLabel);
+      ).prompt(buildBatchPrompt(items, validationError), attemptLabel);
+      promptCompleted = true;
       const translated = parseTranslationBatchReply(raw, items, context.locale);
       logProgress(`${attemptLabel}: done (${formatDuration(Date.now() - startedAt)})`);
       return translated;
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
+      if (promptCompleted) {
+        validationError = lastError.message;
+      }
       await clientAccess.resetClient();
       logProgress(
         `${attemptLabel}: failed after ${formatDuration(Date.now() - startedAt)}: ${lastError.message}`,

--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   appendBoundedProcessOutput,
+  buildBatchPrompt,
   parseTranslationBatchReply,
   runProcess,
   shouldReuseExistingTranslation,
@@ -75,6 +76,22 @@ describe("control-ui-i18n process runner", () => {
         "ar",
       ),
     ).toEqual(new Map([["configView.viewPendingChange", "Pending change ({count})"]]));
+  });
+
+  it("feeds the exact validation failure back into a retry prompt", () => {
+    const items = [
+      {
+        cacheKey: "cache-key",
+        key: "configView.viewPendingChange",
+        text: "View pending change ({count})",
+        textHash: "text-hash",
+      },
+    ];
+    const validationError = "ar:configView.viewPendingChange expected {count} got {}";
+
+    expect(buildBatchPrompt(items, validationError)).toContain(
+      `failed validation. Correct that exact failure in the new response:\n${validationError}`,
+    );
   });
 
   it("ships no recorded English fallbacks", () => {


### PR DESCRIPTION
Related: #105038

## What Problem This Solves

Control UI locale refreshes already reject placeholder-invalid batch responses, but a retry receives the same generic translation prompt. That can make the model repeat the same malformed response and exhaust a bounded retry.

## Why This Change Was Made

This restack keeps current main's canonical batch validator and feeds the exact validation failure from a completed model response into the next retry prompt. Provider and timeout failures remain excluded from validation feedback, and final whole-locale validation stays as defense in depth.

## User Impact

No direct product UI change. Maintainers get more reliable locale refresh automation because a model that drops a required `{placeholder}` receives concrete repair context on its next bounded attempt.

## Evidence

- Current head `d009591e1f90c866deb2d55073540b15cef314fe` contains two scoped commits.
- Blacksmith Testbox `tbx_01kxanfxeeebrm6fy1y5df62sn`: `pnpm test:serial test/scripts/control-ui-i18n.test.ts`, 9/9 passed.
- Live Arabic refresh: 946 pending keys across 48 batches completed with zero fallbacks; a dropped `{count}` placeholder was corrected on the next validation-informed retry.
- Provider-free locale check: all 20 generated locales clean with zero fallbacks.
- Generated locale refresh workflow succeeded: https://github.com/openclaw/openclaw/actions/runs/29184942050
- Fresh final autoreview at the current head: no actionable findings.
