### PR TITLE
fix(agent-runner): make live tool-result truncation CJK-aware via estimateStringChars (issue #103847)

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -254,6 +254,33 @@ describe("getToolResultTextLength", () => {
   it("returns zero for non-toolResult messages", () => {
     expect(getToolResultTextLength(makeAssistantMessage("hello"))).toBe(0);
   });
+
+  it("inflates dense CJK text to token-equivalent length (issue #103847)", () => {
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      isError: false,
+      content: [{ type: "text", text: "中".repeat(16000) }],
+      timestamp: nextTimestamp(),
+    };
+    const measured = getToolResultTextLength(msg);
+    // CJK ≈ 1 token/char, so the token-equivalent length must be ~4x raw length.
+    expect(measured).toBeGreaterThan(16000 * 3);
+    expect(measured).toBeLessThanOrEqual(16000 * 4 + 1);
+  });
+
+  it("keeps ASCII length 1:1 with UTF-16", () => {
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      isError: false,
+      content: [{ type: "text", text: "a".repeat(16000) }],
+      timestamp: nextTimestamp(),
+    };
+    expect(getToolResultTextLength(msg)).toBe(16000);
+  });
 });
 
 describe("truncateToolResultMessage", () => {
@@ -276,6 +303,31 @@ describe("truncateToolResultMessage", () => {
       throw new Error("expected toolResult");
     }
     expect(getFirstToolResultText(result)).toContain("[persist-truncated]");
+  });
+
+  it("truncates dense CJK output that fits raw cap but exceeds token budget (issue #103847)", () => {
+    const contextWindowTokens = 8_000;
+    const maxChars = calculateMaxToolResultChars(contextWindowTokens);
+    expect(maxChars).toBe(16_000); // DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS
+
+    // 16000 CJK chars is ~16000 tokens, far above the ~4000-token budget the
+    // 16000-char cap implies. Before the fix this slipped through uncut.
+    const msg: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      isError: false,
+      content: [{ type: "text", text: "中".repeat(16_000) }],
+      timestamp: nextTimestamp(),
+    };
+    expect(getToolResultTextLength(msg)).toBeGreaterThan(maxChars);
+
+    const result = truncateToolResultMessage(msg, maxChars);
+    expect(result.role).toBe("toolResult");
+    if (result.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    expect(getToolResultTextLength(result)).toBeLessThanOrEqual(maxChars);
   });
 
   it("truncates Codex protocol toolResult content blocks and mirrored content", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -3,6 +3,7 @@
  */
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
+import { estimateStringChars } from "../../utils/cjk-chars.js";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { loadTranscriptEvents } from "../../config/sessions/session-accessor.js";
@@ -350,6 +351,12 @@ export function resolveLiveToolResultAggregateMaxChars(params: {
 
 /**
  * Get the total character count of text content blocks in a tool result message.
+ *
+ * Uses the CJK-aware {@link estimateStringChars} so the count reflects
+ * token-equivalent length (CJK ≈ 1 char/token, not the ~4 chars/token Latin
+ * heuristic). The live truncation cap is token-derived (`chars / 4`), so a raw
+ * UTF-16 length undercounts CJK content by up to 4x and lets oversized CJK
+ * tool results through. See issue #103847.
  */
 export function getToolResultTextLength(msg: AgentMessage): number {
   if (!msg || (msg as { role?: string }).role !== "toolResult") {
@@ -364,7 +371,7 @@ export function getToolResultTextLength(msg: AgentMessage): number {
     if (isToolResultTextBlock(block)) {
       const text = block.text;
       if (typeof text === "string") {
-        totalLength += text.length;
+        totalLength += estimateStringChars(text);
       }
     }
   }
@@ -397,8 +404,17 @@ export function truncateToolResultMessage(
     return msg;
   }
 
+  // Use token-equivalent lengths for proportional budget so CJK blocks (which
+  // are far longer in tokens than in UTF-16 units) are not starved of budget.
+  const blockLengths = content.map((block) =>
+    isToolResultTextBlock(block) && typeof block.text === "string"
+      ? estimateStringChars(block.text)
+      : 0,
+  );
+  const totalBlockLength = blockLengths.reduce((a, b) => a + b, 0) || 1;
+
   // Distribute the budget proportionally among text blocks
-  const newContent = content.map((block: unknown) => {
+  const newContent = content.map((block: unknown, index: number) => {
     if (!isToolResultTextBlock(block)) {
       return block; // Keep non-text blocks (images) as-is
     }
@@ -406,10 +422,11 @@ export function truncateToolResultMessage(
     if (typeof textBlock.text !== "string") {
       return block;
     }
+    const blockLength = blockLengths[index] || 0;
     // Proportional budget for this block
-    const blockShare = textBlock.text.length / totalTextChars;
+    const blockShare = blockLength / totalBlockLength;
     const defaultSuffix = suffixFactory(
-      Math.max(1, textBlock.text.length - Math.floor(maxChars * blockShare)),
+      Math.max(1, Math.floor(blockLength - maxChars * blockShare)),
     );
     const proportionalBudget = Math.floor(maxChars * blockShare);
     const blockBudget = Math.max(


### PR DESCRIPTION
## What Problem This Solves

The live per-turn tool-result truncation cap in `tool-result-truncation.ts` converts token budgets to character budgets with a flat 4-chars-per-token heuristic and no CJK/multibyte correction. `getToolResultTextLength` counted raw `text.length` (UTF-16 units), so a tool result made mostly of CJK text was accepted as fitting under the cap while its real token count was ~4x the budget the cap was meant to enforce. Oversized CJK tool output then dominated the next model turn.

## Evidence

- `src/agents/embedded-agent-runner/tool-result-truncation.ts:354` `getToolResultTextLength` summed `text.length` (raw UTF-16).
- `calculateMaxToolResultChars` / `calculateMaxToolResultCharsWithCap` derive `maxChars` from `tokens * 4` (Latin heuristic).
- Shared CJK-aware helper `estimateStringChars` exists at `src/utils/cjk-chars.ts:36` and is the codebase-standard fix (used by #104295 / #104088 etc.).
- Repro from the issue: 16000 dense CJK chars → `getToolResultTextLength` reported 16000 (raw) and the message was NOT truncated, though it is ~16000 tokens vs the ~4000-token budget the 16000-char cap implies.

## Fix

- `getToolResultTextLength` now uses `estimateStringChars(text)` (token-equivalent length) instead of raw `text.length`.
- The per-block proportional budget inside `truncateToolResultMessage` also uses the token-equivalent length so CJK blocks get a fair share rather than being starved.
- `estimateStringChars` is a no-op for ASCII (`text.length` unchanged), so non-CJK behavior is preserved.

Tests appended to the existing `tool-result-truncation.test.ts` (`getToolResultTextLength` and `truncateToolResultMessage` describe blocks).

Closes #103847
