### PR TITLE
test(ui): update automations tab expectation

### DIFF
--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -147,12 +147,12 @@ function createProps(overrides: Partial<AgentsProps> = {}): AgentsProps {
 }
 
 describe("renderAgents", () => {
-  it("renders Memory after Cron and scopes the panel to the selected agent", () => {
+  it("renders Memory after Automations and scopes the panel to the selected agent", () => {
     const container = document.createElement("div");
     render(renderAgents(createProps({ activePanel: "memory" })), container);
 
     const tabs = [...container.querySelectorAll(".agent-tab")].map((tab) => directText(tab));
-    expect(tabs.slice(-2)).toEqual(["Cron Jobs", "Memory"]);
+    expect(tabs.slice(-2)).toEqual(["Automations", "Memory"]);
     const panel = container.querySelector<HTMLElement & { agentId: string }>(
       "openclaw-agent-memory-panel",
     );


### PR DESCRIPTION
## Summary

- update the Agents tab regression assertion for the Cron Jobs to Automations rename
- keep the test description aligned with the rendered label

## Proof

- `pnpm --dir ui test src/pages/agents/view.test.ts` (10 passed)

Fixes the attributable `checks-ui` failure on current `main`.
