### PR TITLE
ci(perf): pin PID-aware Kova evaluator

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -48,7 +48,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: a2dd84e7d65507e614afaff850d3932d18c859b6
+        default: 0a6d104f44753edef94462375c8b614e03fa378f
         type: string
 
 permissions:
@@ -96,7 +96,7 @@ jobs:
             live: "true"
             include_filters: "scenario:agent-cold-warm-message"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || 'a2dd84e7d65507e614afaff850d3932d18c859b6' }}
+      KOVA_REF: ${{ inputs.kova_ref || '0a6d104f44753edef94462375c8b614e03fa378f' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -40,7 +40,7 @@ function findStep(name: string): WorkflowStep {
 describe("OpenClaw performance workflow", () => {
   it("pins the Kova evaluator that reads truncated agent payloads", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "a2dd84e7d65507e614afaff850d3932d18c859b6";
+    const kovaRef = "0a6d104f44753edef94462375c8b614e03fa378f";
 
     expect(workflow).toContain(`default: ${kovaRef}`);
     expect(workflow).toContain(`inputs.kova_ref || '${kovaRef}'`);


### PR DESCRIPTION
## Summary

- What Problem This Solves: LTS performance validation pins a Kova evaluator that reports pre-restart spans from the retired Gateway PID as active leaks.
- Why This Change Was Made: pin the immutable PID-aware evaluator revision already landed and cross-platform validated in Kova.
- User Impact: no OpenClaw runtime behavior changes; intentional warm restart evidence no longer fails LTS release performance proof.
- Evidence: workflow contract tests, workflow lint, Kova owner CI, and fresh autoreview are green.

## Linked context

Related #105028 and #105042.

Requested as part of maintainer extended-stable release validation.

## Real behavior proof

- Before: LTS performance run 29179335780 failed repeat 1 because an unmatched span belonged to the retired Gateway PID; repeats 2 and 3 passed after restart.
- Kova `0a6d104f44753edef94462375c8b614e03fa378f` evaluates required spans on the latest Gateway PID while retaining interrupted prior-PID spans as restart evidence.
- Owner repository PR: https://github.com/openclaw/Kova/pull/46
- Owner repository CI: https://github.com/openclaw/Kova/actions/runs/29181561373

## Tests and validation

- `pnpm test test/scripts/openclaw-performance-workflow.test.ts`: 7/7 passed.
- `pnpm check:workflows`: passed after installing the workflow's required pre-commit runtime on Testbox.
- `git diff --check`: passed.
- Fresh autoreview: clean, no accepted/actionable findings.

## Risk checklist

- User-visible behavior changed: No.
- Config, environment, or migration behavior changed: No.
- Security, auth, secrets, network, or tool execution behavior changed: No.
- Highest risk: external evaluator pin. Mitigated by full immutable SHA, owner-repository macOS and Ubuntu CI, and a matching workflow contract assertion.

## Current review state

Next action: hosted PR CI, merge into `extended-stable/2026.6.33`, then exact-head LTS performance and full release validation.

