### PR TITLE
fix(zalo): send text when media URL is blank

### DIFF
--- a/extensions/zalo/src/send.test.ts
+++ b/extensions/zalo/src/send.test.ts
@@ -106,6 +106,53 @@ describe("zalo send", () => {
     expect(successful.receipt.parts[0]?.kind).toBe("media");
   });
 
+  it("treats a blank media URL on message sends as absent", async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      result: { message_id: "z-msg-blank-media" },
+    });
+
+    const result = await sendMessageZalo("dm-chat-blank-media", "hello text", {
+      token: "zalo-token",
+      mediaUrl: "   ",
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      "zalo-token",
+      {
+        chat_id: "dm-chat-blank-media",
+        text: "hello text",
+      },
+      undefined,
+    );
+    expect(sendPhotoMock).not.toHaveBeenCalled();
+    requireSuccessfulSend(result, "z-msg-blank-media");
+  });
+
+  it("trims media URLs before routing message sends through the photo API", async () => {
+    sendPhotoMock.mockResolvedValueOnce({
+      ok: true,
+      result: { message_id: "z-photo-trimmed" },
+    });
+
+    const result = await sendMessageZalo("dm-chat-trimmed-media", "caption text", {
+      token: "zalo-token",
+      mediaUrl: "  https://example.com/photo.jpg  ",
+    });
+
+    expect(sendPhotoMock).toHaveBeenCalledWith(
+      "zalo-token",
+      {
+        chat_id: "dm-chat-trimmed-media",
+        photo: "https://example.com/photo.jpg",
+        caption: "caption text",
+      },
+      undefined,
+    );
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    requireSuccessfulSend(result, "z-photo-trimmed");
+  });
+
   it("fails fast for missing token or blank photo URLs", async () => {
     const missingToken = await sendMessageZalo("dm-chat-3", "hello", {});
     expectFailedSend(missingToken, "No Zalo bot token configured");

--- a/extensions/zalo/src/send.ts
+++ b/extensions/zalo/src/send.ts
@@ -155,8 +155,9 @@ export async function sendMessageZalo(
   }
   const { context } = resolved;
 
-  if (options.mediaUrl) {
-    return sendPhotoZalo(context.chatId, options.mediaUrl, {
+  const mediaUrl = options.mediaUrl?.trim();
+  if (mediaUrl) {
+    return sendPhotoZalo(context.chatId, mediaUrl, {
       ...options,
       token: context.token,
       caption: text || options.caption,


### PR DESCRIPTION
﻿Closes #105078

## What Problem This Solves

Fixes an issue where users sending a Zalo text message with a whitespace-only media value would see the send fail instead of delivering the text.

The message action path preserves the raw `media` parameter, so a value like `"   "` stayed truthy when it reached the Zalo send helper. `sendMessageZalo()` then routed the request to the photo branch, where the blank photo URL failed with `No photo URL provided`.

## Why This Change Was Made

The fix keeps the behavior local to the Zalo transport helper: trim `mediaUrl` once before choosing the photo-vs-text branch, and pass the trimmed URL to the photo API only when it is still non-empty.

Direct photo sends still fail fast for missing or blank photo URLs. Real media sends continue to use the photo branch, now with leading/trailing whitespace normalized at the same decision point.

## User Impact

Zalo users can send normal text messages even if the optional media field is present but only contains whitespace.

When a real media URL is provided with accidental leading or trailing spaces, the send still routes through the photo API with the normalized URL.

## Evidence

Focused regression coverage was added for both affected branches:

- `mediaUrl: "   "` sends text through the message API and does not call the photo API.
- `mediaUrl: "  https://example.com/photo.jpg  "` sends media through the photo API with `photo: "https://example.com/photo.jpg"`.
- Direct `sendPhotoZalo()` still rejects a missing or blank photo URL, so explicit photo sends keep their existing validation behavior.

Call chain covered by the tests and code path:

```text
message tool send
  -> zaloMessageActions.handleAction()
  -> sendMessageZalo()
  -> text send when trimmed mediaUrl is empty
```

Sibling surfaces checked: Zalo channel and action runtimes both delegate through `sendMessageZalo()`. This PR does not claim a live Zalo API reproduction; it proves the local transport routing failure and focused regression behavior.

Overlap checked: no open PR was found touching `extensions/zalo/src/send.ts` or `extensions/zalo/src/actions.ts`; related Zalo PRs are nearby but on different files or semantics.

Validation run locally:

```text
git diff --check -- extensions/zalo/src/send.ts extensions/zalo/src/send.test.ts
node scripts/run-vitest.mjs run extensions/zalo/src/send.test.ts extensions/zalo/src/actions.test.ts
```

Result:

```text
Test Files  2 passed (2)
Tests       8 passed (8)
```
