### PR TITLE
fix(status): summarize inline token refresh logs

### DIFF
--- a/src/commands/status-all/gateway.test.ts
+++ b/src/commands/status-all/gateway.test.ts
@@ -52,6 +52,42 @@ describe("summarizeLogTail", () => {
     expect(lines).toEqual(["[openai] token refresh 401 invalid_grant · re-auth required"]);
   });
 
+  it("summarizes single-line OAuth JSON diagnostics", () => {
+    const sentinel = "[gateway] synthetic sentinel after OAuth JSON";
+    const lines = summarizeLogTail([
+      `[openai] Token refresh failed: 401 ${JSON.stringify({
+        error: {
+          code: "invalid_grant",
+          message: "Session invalidated due to signing in again",
+        },
+      })}`,
+      sentinel,
+    ]);
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("token refresh 401 invalid_grant");
+    expect(lines[0]).toContain("re-auth required");
+    expect(lines[1]).toBe(sentinel);
+  });
+
+  it("keeps later logs after single-line OAuth JSON string braces", () => {
+    const sentinel = "[gateway] synthetic sentinel after OAuth JSON";
+    const lines = summarizeLogTail([
+      `[openai] Token refresh failed: 401 ${JSON.stringify({
+        error: {
+          code: "invalid_grant",
+          message: "Session invalidated { due to signing in again",
+        },
+      })}`,
+      sentinel,
+    ]);
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("token refresh 401 invalid_grant");
+    expect(lines[0]).toContain("re-auth required");
+    expect(lines[1]).toBe(sentinel);
+  });
+
   it("consumes an incomplete OAuth JSON block through the end of the tail", () => {
     const lines = summarizeLogTail([
       "[openai] Token refresh failed: 401 {",

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -99,7 +99,9 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
     }
 
     // "[openai] Token refresh failed: 401 { ...json... }"
-    const tokenRefresh = line.match(/^\[([^\]]+)\]\s+Token refresh failed:\s*(\d+)\s*(\{)?\s*$/);
+    const tokenRefresh = line.match(
+      /^\[([^\]]+)\]\s+Token refresh failed:\s*(\d+)(?:\s+(\{.*))?\s*$/,
+    );
     if (tokenRefresh) {
       const tag = tokenRefresh[1] ?? "unknown";
       const status = tokenRefresh[2] ?? "unknown";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw status-all` gateway log diagnostics could leave single-line OAuth token refresh JSON as raw log text instead of summarizing the re-auth hint when the gateway log wrote the status and JSON payload on the same line.

## Why This Change Was Made

The status-all gateway log summarizer already consumes multiline token-refresh JSON blocks and classifies their OAuth error reason. This change keeps that owner-local parsing path but lets the token-refresh matcher accept an inline JSON payload after the status code, so multiline and single-line gateway log records follow the same summary contract without changing auth, provider, config, or gateway logging behavior.

## User Impact

Operators running `openclaw status-all` get the same compact token-refresh diagnosis for inline gateway log records that they already get for multiline records, while following log lines remain visible.

## Evidence

- Claim proved: the status-all gateway log diagnosis path summarizes single-line OAuth token refresh JSON diagnostics, preserves following log lines, and keeps the existing multiline token-refresh behavior.
- Current-head proof at `39a0385631668919c758fbbb0140f0ff0069c207`: GitHub `Real behavior proof` passed on the current head.
- Current-head CI at `39a0385631668919c758fbbb0140f0ff0069c207`: GitHub CI run `29556365951` passed `openclaw/ci-gate`, including `check-test-types`, `check-dependencies`, `check-lint`, `build-artifacts`, and all QA smoke profiles.
- Diff hygiene: `git diff --check HEAD~1..HEAD` passed locally on the rebased head.
- Observed result: inline `Token refresh failed: 401 {"error":...}` records now produce the compact `token refresh 401 invalid_grant` / `re-auth required` diagnosis, including the case where the JSON message string contains braces, and the next gateway log line is still included.