### PR TITLE
fix(macos): unblock node transport reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Mac App node reconnects:** let node transport re-establish while disconnect lifecycle cleanup drains behind the existing route barrier, preventing a suspended callback from leaving the watchdog stuck in disconnect cleanup while still gating readiness and invokes.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Mac App node reconnects:** let node transport re-establish while disconnect lifecycle cleanup drains behind the existing route barrier, preventing a suspended callback from leaving the watchdog stuck in disconnect cleanup while still gating readiness and invokes.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -807,7 +807,9 @@ extension GatewayNodeSession {
         // The underlying channel can auto-reconnect; resetting state here ensures we surface a fresh
         // onConnected callback once a new snapshot arrives after reconnect.
         self.resetConnectionState()
-        let lifecycleCallback = self.enqueueLifecycleCallback(
+        // Transport reconnect must not wait on owner callbacks that can suspend
+        // indefinitely. The lifecycle barrier still gates readiness and invokes.
+        _ = self.enqueueLifecycleCallback(
             immediate: {
                 // Release held input before waiting for a connected callback that
                 // may already be suspended in owner code.
@@ -817,11 +819,8 @@ extension GatewayNodeSession {
                 // This cleanup runs after all older lifecycle callbacks, so they
                 // cannot resume later and restore a disconnected route.
                 await onDisconnected?(reason)
+                await self.awaitActiveInvokes(activeInvokes)
             })
-        if !self.isExecutingLifecycleCallback() {
-            await lifecycleCallback.task.value
-        }
-        await self.awaitActiveInvokes(activeInvokes)
     }
 
     private func markSnapshotReceived() {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -1087,7 +1087,61 @@ struct GatewayNodeSessionTests {
         await gateway._test_notifyConnectedIfNeeded(
             admissionGeneration: staleAdmissionGeneration)
 
+        try await waitUntil("disconnect callback completed") {
+            await lifecycle.values().contains("disconnected")
+        }
         #expect(await lifecycle.values() == ["connected", "disconnected"])
+        await gateway.disconnect()
+    }
+
+    @Test
+    func `transport reconnect does not wait for blocked disconnect lifecycle`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let invalidationGate = AsyncGate()
+        let lifecycle = DisconnectProbe()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: ["computer"],
+            commands: ["computer.act"],
+            permissions: [:],
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            clientDisplayName: "macOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://first.example.invalid")),
+            token: nil,
+            bootstrapToken: nil,
+            password: nil,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: { await lifecycle.record("connected") },
+            onDisconnected: { _ in await lifecycle.record("disconnected") },
+            onInvoke: { req in
+                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            },
+            onRouteInvalidated: { await invalidationGate.wait() })
+        let firstTask = try #require(session.latestTask())
+        try await waitUntil("receive loop armed before disconnect") {
+            firstTask.hasPendingReceiveHandler()
+        }
+
+        firstTask.emitReceiveFailure()
+        try await waitUntil("disconnect lifecycle blocked") {
+            await invalidationGate.hasStarted()
+        }
+        try await waitUntil("replacement transport connected") {
+            session.snapshotMakeCount() == 2
+        }
+        #expect(await lifecycle.values() == ["connected"])
+
+        await invalidationGate.release()
+        try await waitUntil("replacement lifecycle completed") {
+            await lifecycle.values() == ["connected", "disconnected", "connected"]
+        }
         await gateway.disconnect()
     }
 


### PR DESCRIPTION
## What Problem This Solves

Closes #105087.

After a Gateway connection dropped, a macOS app node could remain permanently stuck in disconnect cleanup. The watchdog retried, but every reconnect failed with `gateway disconnect cleanup in progress` until the app process was restarted.

The regression came from #103422 / `461772868da324d70be1d545f5951a628abbdc75`: transport teardown awaited the session disconnect handler, while that handler awaited owner lifecycle callbacks and active invokes.

## Why This Change Was Made

`GatewayNodeSession` now queues disconnect lifecycle cleanup and immediately releases the transport actor. Active-invoke draining remains inside the ordered lifecycle callback, so the existing lifecycle/admission generation barrier still prevents readiness and invoke dispatch until cleanup completes.

This keeps the owner boundary intact: the transport can reconnect, while node lifecycle ordering remains owned by `GatewayNodeSession`.

## User Impact

macOS app nodes recover automatically after transient Gateway disconnects, including when a route-invalidation callback is suspended. Users no longer need to restart the app to restore the node.

## Evidence

- Regression test: `transport reconnect does not wait for blocked disconnect lifecycle` proves a replacement websocket is created while disconnect lifecycle cleanup is blocked, while the replacement connected callback remains gated until cleanup completes.
- MiniClaw macOS: `swift test --package-path apps/shared/OpenClawKit --filter GatewayNodeSessionTests` — 53 tests passed.
- Blacksmith Testbox: `pnpm check:changed` — passed on `tbx_01kxagsq690v5r0yt52p88cc7j`.
- Fresh autoreview: no accepted/actionable findings.
- Live pre-fix reproduction: stable 2026.7.2 Mac App remained stuck after Gateway recovery while its colocated CLI node reconnected.
