### PR TITLE
fix(browser): normalize geolocation permission origins

### DIFF
--- a/extensions/browser/src/browser/routes/agent.storage.test.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.test.ts
@@ -114,7 +114,7 @@ describe("browser storage route parsing", () => {
           latitude: "48.2082",
           longitude: 16.3738,
           accuracy: "12.5",
-          origin: " https://example.com ",
+          origin: " https://example.com/path?query=1#hash ",
         }),
       ).toEqual({
         clear: false,
@@ -125,18 +125,17 @@ describe("browser storage route parsing", () => {
       });
     });
 
-    it("allows clearing without coordinates", () => {
+    it("allows clearing without parsing unused geolocation fields", () => {
       expect(
         parseGeolocationOptions({
           clear: true,
-          latitude: "",
-          longitude: "",
+          latitude: "not-used",
+          longitude: "not-used",
           accuracy: "not-used",
-          origin: " https://example.com ",
+          origin: "not a url",
         }),
       ).toEqual({
         clear: true,
-        origin: "https://example.com",
       });
     });
 
@@ -159,6 +158,15 @@ describe("browser storage route parsing", () => {
       expect(() => parseGeolocationOptions({ latitude: 48, longitude: 16, accuracy: -1 })).toThrow(
         "accuracy must be non-negative.",
       );
+    });
+
+    it("rejects malformed and non-http geolocation origins", () => {
+      expect(() =>
+        parseGeolocationOptions({ latitude: 48, longitude: 16, origin: "file:///tmp/page.html" }),
+      ).toThrow("origin must be an http(s) origin");
+      expect(() =>
+        parseGeolocationOptions({ latitude: 48, longitude: 16, origin: "not a url" }),
+      ).toThrow("origin must be an http(s) origin");
     });
   });
 });

--- a/extensions/browser/src/browser/routes/agent.storage.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.ts
@@ -18,7 +18,13 @@ import {
 } from "./agent.shared.js";
 import { readOptionalRouteFiniteNumber, readRouteFiniteNumber } from "./route-numeric.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
-import { asyncBrowserRoute, jsonError, toBoolean, toStringOrEmpty } from "./utils.js";
+import {
+  asyncBrowserRoute,
+  jsonError,
+  readHttpOrigin,
+  toBoolean,
+  toStringOrEmpty,
+} from "./utils.js";
 
 type StorageKind = "local" | "session";
 
@@ -113,6 +119,18 @@ function assertRange(
   return value;
 }
 
+function readOptionalHttpOrigin(raw: unknown): string | undefined {
+  const value = toStringOrEmpty(raw);
+  if (!value) {
+    return undefined;
+  }
+  const origin = readHttpOrigin(value);
+  if (!origin) {
+    throw new Error("origin must be an http(s) origin");
+  }
+  return origin;
+}
+
 /** Parse cookie options accepted by browser storage mutation routes. */
 export function parseCookieSetOptions(cookie: Record<string, unknown>): CookieSetOptions {
   return {
@@ -134,10 +152,10 @@ export function parseCookieSetOptions(cookie: Record<string, unknown>): CookieSe
 /** Parse geolocation override options accepted by context mutation routes. */
 export function parseGeolocationOptions(body: Record<string, unknown>): GeolocationOptions {
   const clear = toBoolean(body.clear) ?? false;
-  const origin = toStringOrEmpty(body.origin) || undefined;
   if (clear) {
-    return { clear, origin };
+    return { clear };
   }
+  const origin = readOptionalHttpOrigin(body.origin);
   const latitude = assertRange(
     readRouteFiniteNumber(body.latitude, "latitude"),
     "latitude",

--- a/extensions/browser/src/browser/routes/permissions.ts
+++ b/extensions/browser/src/browser/routes/permissions.ts
@@ -22,6 +22,7 @@ import {
   getProfileContext,
   jsonBrowserError,
   jsonError,
+  readHttpOrigin,
   runProfileRouteOperation,
   toStringOrEmpty,
 } from "./utils.js";
@@ -44,22 +45,6 @@ type GrantPermissionsBody = {
   timeoutMs?: unknown;
   targetId?: unknown;
 };
-
-function readOrigin(raw: unknown): string | null {
-  const value = toStringOrEmpty(raw);
-  if (!value) {
-    return null;
-  }
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return null;
-    }
-    return parsed.origin;
-  } catch {
-    return null;
-  }
-}
 
 function readPermissions(raw: unknown): string[] | null {
   if (!Array.isArray(raw)) {
@@ -169,7 +154,7 @@ export function registerBrowserPermissionRoutes(
     "/permissions/grant",
     asyncBrowserRoute(async (req, res) => {
       const body = (req.body ?? {}) as GrantPermissionsBody;
-      const origin = readOrigin(body.origin);
+      const origin = readHttpOrigin(body.origin);
       if (!origin) {
         return jsonError(res, 400, "origin must be an http(s) origin");
       }

--- a/extensions/browser/src/browser/routes/utils.ts
+++ b/extensions/browser/src/browser/routes/utils.ts
@@ -111,6 +111,20 @@ export function toStringOrEmpty(value: unknown) {
   return "";
 }
 
+/** Return a canonical HTTP origin, or null when the route value is absent or invalid. */
+export function readHttpOrigin(value: unknown): string | null {
+  const raw = toStringOrEmpty(value);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Coerce route boolean values from booleans or common string forms. */
 export function toBoolean(value: unknown) {
   if (typeof value === "boolean") {


### PR DESCRIPTION
## What Problem This Solves

An explicit Browser geolocation `origin` could reach the Playwright adapter as arbitrary text while the sibling permissions route already required a canonical HTTP(S) origin. This produced inconsistent validation and allowed malformed or opaque origins to fail after Browser work had already begun.

Supersedes #104799. The contributor fork could accept the small maintainer refactor through GitHub's file API, but could not accept the required current-`main` rebase through Git transport. This takeover preserves the reviewed patch without publishing the repository-wide rebase as synthetic file changes.

## Why This Change Was Made

- Move the existing HTTP(S) origin parser into the established Browser route utilities instead of adding a single-purpose module.
- Canonicalize explicit geolocation page URLs with `URL.origin` and reject malformed or non-HTTP(S) values before tab lookup or browser mutation.
- Return immediately for `clear=true`, because coordinates and origin are unused while clearing.
- Keep the sibling permissions route on the same parser.
- Reduce the original patch from +192/-26 to +51/-26 by deleting duplicate route-server scaffolding.

Playwright 1.61.1 already canonicalizes valid permission URLs internally; this change deliberately improves the OpenClaw route boundary and error timing rather than claiming valid page URLs were previously unusable.

## User Impact

Full HTTP(S) page URLs remain accepted and are reduced to their origin before the Browser adapter runs. Malformed and non-HTTP(S) explicit origins now return a clear 400 response. Geolocation clearing remains functional even when callers include stale, malformed fields that the clear operation does not use.

## Evidence

- Sanitized public-network AWS Crabbox `cbx_aa9fef6da003`, run `run_e67e2fe52422`: focused Browser storage and permission suites passed, 2 files / 21 tests.
- Fresh full-patch autoreview: clean, no accepted/actionable findings, confidence 0.98.
- Canonical `oxfmt` check and `git diff --check`: passed.
- Direct dependency review: Playwright 1.61.1 `BrowserContext.grantPermissions` canonicalizes `new URL(origin).origin`; its public type documents an origin such as `https://example.com`.
- Commit retains `Co-authored-by: llagy007 <0668001470@xydigit.com>`.

