### PR TITLE
ci(test): harden LTS validation dependencies

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -60,7 +60,8 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  OCM_VERSION: v0.2.15
+  OCM_VERSION: v0.2.25
+  OCM_LINUX_X64_SHA256: 57530199d21eb5bfa29695749928b40fd2869484c7edff69b7c65bfc84f2f1aa
   KOVA_REPOSITORY: openclaw/Kova
   PERFORMANCE_MODEL_ID: gpt-5.5
   KOVA_SCENARIO_TIMEOUT_MS: "300000"
@@ -193,11 +194,45 @@ jobs:
           set -euo pipefail
           KOVA_SRC="${RUNNER_TEMP}/kova-src"
           echo "KOVA_SRC=$KOVA_SRC" >> "$GITHUB_ENV"
-          mkdir -p "$HOME/.local/bin" "$(dirname "$KOVA_SRC")"
-          curl -fsSL https://raw.githubusercontent.com/shakkernerd/ocm/main/install.sh \
-            | bash -s -- --version "$OCM_VERSION" --prefix "$HOME/.local" --force
-          git clone --filter=blob:none "https://github.com/${KOVA_REPOSITORY}.git" "$KOVA_SRC"
-          git -C "$KOVA_SRC" checkout "$KOVA_REF"
+          mkdir -p "$HOME/.local/bin" "$(dirname "$KOVA_SRC")" "${RUNNER_TEMP}/ocm-install"
+
+          ocm_archive="${RUNNER_TEMP}/ocm-${OCM_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            --retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused \
+            -o "$ocm_archive" \
+            "https://github.com/shakkernerd/ocm/releases/download/${OCM_VERSION}/ocm-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${OCM_LINUX_X64_SHA256}  ${ocm_archive}" | sha256sum -c -
+          tar -xzf "$ocm_archive" -C "${RUNNER_TEMP}/ocm-install"
+          install -m 0755 "${RUNNER_TEMP}/ocm-install/ocm" "$HOME/.local/bin/ocm"
+
+          git init -b main "$KOVA_SRC"
+          git -C "$KOVA_SRC" remote add origin "https://github.com/${KOVA_REPOSITORY}.git"
+          git -C "$KOVA_SRC" fetch --filter=blob:none --depth 1 origin "$KOVA_REF"
+          git -C "$KOVA_SRC" checkout --detach FETCH_HEAD
+          npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
+          node - "$KOVA_SRC" <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          const root = process.argv[2];
+          const packageJsonPath = require.resolve("mock-ai-provider/package.json", {
+            paths: [root],
+          });
+          const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+          const bin =
+            typeof packageJson.bin === "string"
+              ? packageJson.bin
+              : packageJson.bin?.["mock-ai-provider"];
+          if (typeof bin !== "string" || bin.length === 0) {
+            throw new Error("mock-ai-provider does not declare its CLI entrypoint");
+          }
+          fs.accessSync(path.resolve(path.dirname(packageJsonPath), bin), fs.constants.R_OK);
+          fs.accessSync(
+            path.join(root, "node_modules", ".bin", "mock-ai-provider"),
+            fs.constants.X_OK,
+          );
+          require.resolve("zod", { paths: [root] });
+          NODE
           cat > "$HOME/.local/bin/kova" <<EOF
           #!/usr/bin/env bash
           export KOVA_HOME="${KOVA_HOME}"

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -11,7 +11,12 @@ const ensureOpenClawModelsJsonMock = vi.fn<
     options?: unknown,
   ) => Promise<{ agentDir: string; wrote: boolean }>
 >(async () => ({ agentDir: "/tmp/agent", wrote: false }));
-const resolveModelMock = vi.fn<(...args: unknown[]) => Record<string, never>>(() => ({}));
+const resolveConfiguredModelRefMock = vi.fn(({ cfg }: { cfg: OpenClawConfig }) => {
+  const configured = cfg.agents?.defaults?.model;
+  const primary = typeof configured === "string" ? configured : configured?.primary;
+  const [provider = "openai", ...modelParts] = (primary ?? "openai/gpt-5.5").split("/");
+  return { provider, model: modelParts.join("/") };
+});
 
 vi.mock("../agents/agent-scope.js", () => ({
   resolveDefaultAgentDir: () => "/tmp/agent",
@@ -24,8 +29,10 @@ vi.mock("../agents/models-config.js", () => ({
     ensureOpenClawModelsJsonMock(config, agentDir, options),
 }));
 
-vi.mock("../agents/embedded-agent-runner/model.js", () => ({
-  resolveModel: (...args: unknown[]) => resolveModelMock(...args),
+vi.mock("../agents/model-selection.js", () => ({
+  isCliProvider: () => false,
+  resolveConfiguredModelRef: (params: { cfg: OpenClawConfig }) =>
+    resolveConfiguredModelRefMock(params),
 }));
 
 let prewarmConfiguredPrimaryModel: typeof import("./server-startup-post-attach.js").testing.prewarmConfiguredPrimaryModel;
@@ -53,7 +60,7 @@ describe("gateway startup primary model warmup", () => {
 
   beforeEach(() => {
     ensureOpenClawModelsJsonMock.mockClear();
-    resolveModelMock.mockClear();
+    resolveConfiguredModelRefMock.mockClear();
   });
 
   it("prewarms an explicit configured primary model", async () => {
@@ -73,7 +80,7 @@ describe("gateway startup primary model warmup", () => {
     });
 
     expectModelsJsonPrewarmCall(cfg);
-    expect(resolveModelMock).not.toHaveBeenCalled();
+    expect(resolveConfiguredModelRefMock).toHaveBeenCalledTimes(1);
   });
 
   it("skips warmup when no explicit primary model is configured", async () => {
@@ -83,7 +90,7 @@ describe("gateway startup primary model warmup", () => {
     });
 
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
-    expect(resolveModelMock).not.toHaveBeenCalled();
+    expect(resolveConfiguredModelRefMock).not.toHaveBeenCalled();
   });
 
   it("honors the startup model prewarm skip env", () => {
@@ -121,7 +128,7 @@ describe("gateway startup primary model warmup", () => {
     });
 
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
-    expect(resolveModelMock).not.toHaveBeenCalled();
+    expect(resolveConfiguredModelRefMock).not.toHaveBeenCalled();
   });
 
   it("warns when scoped models.json preparation fails", async () => {

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -41,9 +41,29 @@ describe("OpenClaw performance workflow", () => {
   it("pins the Kova evaluator that reads truncated agent payloads", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
     const kovaRef = "0a6d104f44753edef94462375c8b614e03fa378f";
+    const installRun = findStep("Install OCM and Kova").run ?? "";
 
     expect(workflow).toContain(`default: ${kovaRef}`);
     expect(workflow).toContain(`inputs.kova_ref || '${kovaRef}'`);
+    expect(installRun).toContain(
+      'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',
+    );
+    expect(installRun).toContain('require.resolve("mock-ai-provider/package.json", {');
+    expect(installRun).toContain('require.resolve("zod", { paths: [root] })');
+  });
+
+  it("pins and verifies the OCM release archive", () => {
+    const workflow = readFileSync(WORKFLOW, "utf8");
+    const installRun = findStep("Install OCM and Kova").run ?? "";
+
+    expect(workflow).toContain("OCM_VERSION: v0.2.25");
+    expect(workflow).toContain(
+      "OCM_LINUX_X64_SHA256: 57530199d21eb5bfa29695749928b40fd2869484c7edff69b7c65bfc84f2f1aa",
+    );
+    expect(installRun).toContain(
+      '"https://github.com/shakkernerd/ocm/releases/download/${OCM_VERSION}/ocm-x86_64-unknown-linux-gnu.tar.gz"',
+    );
+    expect(installRun).toContain('echo "${OCM_LINUX_X64_SHA256}  ${ocm_archive}" | sha256sum -c -');
   });
 
   it("keeps manual rehearsal reports artifact-only by default", () => {


### PR DESCRIPTION
## Summary

- What Problem This Solves: the extended-stable performance workflow downloads the removed OCM v0.2.15 asset through an unpinned remote installer, so Kova never starts.
- Why This Change Was Made: backport main's current immutable OCM archive, checksum verification, shallow Kova fetch, lockfile install, and dependency sanity checks.
- Also isolate the Gateway startup warmup test from the heavyweight embedded model module that timed out during this PR's otherwise unrelated CI run.
- User Impact: no product runtime behavior changes; LTS performance validation can install and run its pinned evaluator again.
- Evidence: exact failure log, workflow contract tests, workflow lint, and fresh autoreview.

## Linked context

Related #105081.

Requested as part of maintainer extended-stable release validation.

## Real behavior proof

- Failed exact-head performance run: https://github.com/openclaw/openclaw/actions/runs/29183180041
- Failing job: https://github.com/openclaw/openclaw/actions/runs/29183180041/job/86624475646
- Exact failure: the OCM v0.2.15 release archive returned HTTP 404 before Kova checkout or evaluation.
- Deep-profile and live-provider jobs concluded successfully because their lane-selection steps skipped installation for this dispatch; the selected mock-provider lane alone exercised the missing archive.

## Tests and validation

- `pnpm test test/scripts/openclaw-performance-workflow.test.ts`: 8/8 passed.
- `pnpm check:workflows`: passed.
- `git diff --check`: passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- `pnpm test src/gateway/server-startup.test.ts` repeated ten times on Testbox: all 100 project assertions passed; import time stayed bounded.

## Risk checklist

- User-visible behavior changed: No.
- Config, environment, or migration behavior changed: No.
- Security, auth, secrets, network, or tool execution behavior changed: workflow-only installer hardening.
- Highest risk: supply-chain download path. Mitigated by HTTPS-only archive retrieval, bounded retries, a pinned version and SHA-256, detached immutable Kova ref checkout, and `npm ci --ignore-scripts`. The additional test-only mock follows the canonical main fix `ce2c0d1b929a` and retains all five warmup assertions.

## Current review state

Next action: hosted PR CI, merge into `extended-stable/2026.6.33`, rerun exact-head performance, then rerun full LTS validation.
