### PR TITLE
fix(memory-wiki): honor deadline and skip supplement exhaustive fallback

### DIFF
--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -448,6 +448,7 @@ describe("memory tools", () => {
         agentSessionKey: "agent:marketing-agent:main",
         sandboxed: true,
         corpus,
+        signal: expect.any(AbortSignal),
       });
     },
   );

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -163,6 +163,7 @@ export async function searchMemoryCorpusSupplements(params: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   corpus?: "memory" | "wiki" | "all" | "sessions";
+  signal?: AbortSignal;
 }): Promise<MemoryCorpusSearchResult[]> {
   if (params.corpus === "memory" || params.corpus === "sessions") {
     return [];

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -724,6 +724,7 @@ export function createMemorySearchTool(options: {
                         agentSessionKey: options.agentSessionKey,
                         sandboxed: options.sandboxed,
                         corpus: requestedCorpus,
+                        signal: deadlineSignal,
                       }),
                   )
                 : [];

--- a/extensions/memory-wiki/src/corpus-supplement.test.ts
+++ b/extensions/memory-wiki/src/corpus-supplement.test.ts
@@ -72,6 +72,8 @@ describe("memory-wiki corpus supplement", () => {
       maxResults: 4,
       searchBackend: "local",
       searchCorpus: "wiki",
+      signal: undefined,
+      exhaustiveFallback: false,
     });
     expect(queryMocks.getMemoryWikiPage).toHaveBeenCalledWith({
       config: expect.objectContaining({
@@ -90,6 +92,33 @@ describe("memory-wiki corpus supplement", () => {
       searchBackend: "local",
       searchCorpus: "wiki",
     });
+  });
+
+  it("forwards deadline signal and disables exhaustive fallback for supplement search (#104719)", async () => {
+    const resolveConfig = vi.fn<MemoryWikiConfigResolver>((agentId, currentAppConfig) =>
+      resolveMemoryWikiAgentConfig({ config, appConfig: currentAppConfig, agentId }),
+    );
+    const supplement = createWikiCorpusSupplement({
+      resolveConfig,
+      getAppConfig: () => appConfig,
+    });
+    const signal = AbortSignal.abort();
+
+    await supplement.search({
+      query: "deadline",
+      maxResults: 2,
+      agentId: "support",
+      signal,
+    });
+
+    expect(queryMocks.searchMemoryWiki).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal,
+        exhaustiveFallback: false,
+        query: "deadline",
+        maxResults: 2,
+      }),
+    );
   });
 
   it("fails closed before querying when multi-agent context is missing", async () => {

--- a/extensions/memory-wiki/src/corpus-supplement.ts
+++ b/extensions/memory-wiki/src/corpus-supplement.ts
@@ -14,6 +14,7 @@ export function createWikiCorpusSupplement(params: {
       agentId?: string;
       agentSessionKey?: string;
       sandboxed?: boolean;
+      signal?: AbortSignal;
     }) => {
       const appConfig = params.getAppConfig();
       const config = params.resolveConfig(input.agentId, appConfig);
@@ -27,6 +28,10 @@ export function createWikiCorpusSupplement(params: {
         maxResults: input.maxResults,
         searchBackend: "local",
         searchCorpus: "wiki",
+        signal: input.signal,
+        // memory_search supplements must not fall through to full-vault scans
+        // past the tool deadline; direct wiki_search keeps exhaustive fallback.
+        exhaustiveFallback: false,
       });
     },
     get: async (input: {

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -285,21 +285,30 @@ describe("searchMemoryWiki", () => {
     let started = 0;
     const originalReadFile = fs.readFile.bind(fs);
     const readFileSpy = vi.spyOn(fs, "readFile").mockImplementation(async (file, encoding) => {
-      const filePath = String(file);
+      const filePath =
+        typeof file === "string"
+          ? file
+          : file instanceof URL
+            ? file.pathname
+            : file.toString();
       if (!filePath.includes(`${path.sep}sources${path.sep}page-`)) {
         return originalReadFile(file, encoding as BufferEncoding);
       }
       started += 1;
       running += 1;
       peak = Math.max(peak, running);
-      await new Promise<void>((resolve) => setTimeout(resolve, 25));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 25);
+      });
       running -= 1;
       return originalReadFile(file, encoding as BufferEncoding);
     });
 
     const controller = new AbortController();
     const readPromise = readQueryableWikiPages(rootDir, controller.signal);
-    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 10);
+    });
     controller.abort();
     const pages = await readPromise;
     readFileSpy.mockRestore();

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -7,7 +7,12 @@ import type { OpenClawConfig } from "../api.js";
 import { compileMemoryWikiVault } from "./compile.js";
 import type { MemoryWikiPluginConfig } from "./config.js";
 import { renderWikiMarkdown } from "./markdown.js";
-import { getMemoryWikiPage, isSessionMemoryPath, searchMemoryWiki } from "./query.js";
+import {
+  getMemoryWikiPage,
+  isSessionMemoryPath,
+  readQueryableWikiPages,
+  searchMemoryWiki,
+} from "./query.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const {
@@ -255,6 +260,54 @@ describe("searchMemoryWiki", () => {
     });
 
     expect(results).toEqual([]);
+  });
+
+  it("reads wiki pages with bounded concurrency and stops claiming after abort (#104719)", async () => {
+    const { rootDir } = await createQueryVault({ initialize: true });
+    const pageCount = 24;
+    for (let i = 0; i < pageCount; i += 1) {
+      await fs.writeFile(
+        path.join(rootDir, "sources", `page-${String(i).padStart(2, "0")}.md`),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "source",
+            id: `source.page${i}`,
+            title: `Page ${i}`,
+          },
+          body: `# Page ${i}\n\nbody ${i}\n`,
+        }),
+        "utf8",
+      );
+    }
+
+    let running = 0;
+    let peak = 0;
+    let started = 0;
+    const originalReadFile = fs.readFile.bind(fs);
+    const readFileSpy = vi.spyOn(fs, "readFile").mockImplementation(async (file, encoding) => {
+      const filePath = String(file);
+      if (!filePath.includes(`${path.sep}sources${path.sep}page-`)) {
+        return originalReadFile(file, encoding as BufferEncoding);
+      }
+      started += 1;
+      running += 1;
+      peak = Math.max(peak, running);
+      await new Promise<void>((resolve) => setTimeout(resolve, 25));
+      running -= 1;
+      return originalReadFile(file, encoding as BufferEncoding);
+    });
+
+    const controller = new AbortController();
+    const readPromise = readQueryableWikiPages(rootDir, controller.signal);
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    controller.abort();
+    const pages = await readPromise;
+    readFileSpy.mockRestore();
+
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(16);
+    expect(started).toBeLessThan(pageCount);
+    expect(pages.length).toBeLessThan(pageCount);
   });
 
   it("skips malformed pages while searching the rest of the vault (#96125)", async () => {

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -288,10 +288,12 @@ describe("searchMemoryWiki", () => {
       let filePath: string;
       if (typeof file === "string") {
         filePath = file;
+      } else if (file instanceof URL) {
+        filePath = file.pathname;
       } else if (Buffer.isBuffer(file)) {
         filePath = file.toString("utf8");
       } else {
-        filePath = file.pathname;
+        return originalReadFile(file, encoding as BufferEncoding);
       }
       if (!filePath.includes(`${path.sep}sources${path.sep}page-`)) {
         return originalReadFile(file, encoding as BufferEncoding);

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -285,12 +285,14 @@ describe("searchMemoryWiki", () => {
     let started = 0;
     const originalReadFile = fs.readFile.bind(fs);
     const readFileSpy = vi.spyOn(fs, "readFile").mockImplementation(async (file, encoding) => {
-      const filePath =
-        typeof file === "string"
-          ? file
-          : file instanceof URL
-            ? file.pathname
-            : file.toString();
+      let filePath: string;
+      if (typeof file === "string") {
+        filePath = file;
+      } else if (Buffer.isBuffer(file)) {
+        filePath = file.toString("utf8");
+      } else {
+        filePath = file.pathname;
+      }
       if (!filePath.includes(`${path.sep}sources${path.sep}page-`)) {
         return originalReadFile(file, encoding as BufferEncoding);
       }

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -209,6 +209,54 @@ describe("searchMemoryWiki", () => {
     expect(getActiveMemorySearchManagerMock).not.toHaveBeenCalled();
   });
 
+  it("skips full-vault fallback when exhaustiveFallback is false (#104719)", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.alpha", title: "Alpha Source" },
+        body: "# Alpha Source\n\nalpha body text\n",
+      }),
+      "utf8",
+    );
+
+    // Without a digest, normal search scans the vault; supplement path must not.
+    const supplementResults = await searchMemoryWiki({
+      config,
+      query: "alpha",
+      exhaustiveFallback: false,
+    });
+    const directResults = await searchMemoryWiki({ config, query: "alpha" });
+
+    expect(supplementResults).toEqual([]);
+    expect(directResults).toHaveLength(1);
+    expect(directResults[0]?.path).toBe("sources/alpha.md");
+  });
+
+  it("returns early when the deadline signal is already aborted (#104719)", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.alpha", title: "Alpha Source" },
+        body: "# Alpha Source\n\nalpha body text\n",
+      }),
+      "utf8",
+    );
+
+    const results = await searchMemoryWiki({
+      config,
+      query: "alpha",
+      signal: AbortSignal.abort(),
+    });
+
+    expect(results).toEqual([]);
+  });
+
   it("skips malformed pages while searching the rest of the vault (#96125)", async () => {
     const { rootDir, config } = await createQueryVault({ initialize: true });
     await fs.writeFile(

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -262,6 +262,9 @@ async function listWikiMarkdownFiles(rootDir: string): Promise<string[]> {
   return files.toSorted((left, right) => left.localeCompare(right));
 }
 
+/** Match compile-time page reads so exhaustive wiki search keeps throughput. */
+const READ_QUERYABLE_WIKI_PAGES_CONCURRENCY = 16;
+
 export async function readQueryableWikiPages(
   rootDir: string,
   signal?: AbortSignal,
@@ -278,21 +281,40 @@ async function readQueryableWikiPagesByPaths(
   files: string[],
   signal?: AbortSignal,
 ): Promise<QueryableWikiPage[]> {
-  // Sequential reads so an abort can stop further I/O mid-batch (Promise.all
-  // would keep launching reads after the deadline fires).
-  const pages: QueryableWikiPage[] = [];
-  for (const relativePath of files) {
-    if (signal?.aborted) {
-      break;
-    }
-    const absolutePath = path.join(rootDir, relativePath);
-    const raw = await fs.readFile(absolutePath, "utf8");
-    const summary = toWikiPageSummary({ absolutePath, relativePath, raw });
-    if (summary) {
-      pages.push({ ...summary, raw });
-    }
+  if (signal?.aborted || files.length === 0) {
+    return [];
   }
-  return pages;
+
+  // Bounded workers preserve direct-search throughput; abort is checked before
+  // claiming the next path so deadlines stop new I/O (in-flight reads settle).
+  const results: Array<QueryableWikiPage | undefined> = Array.from({ length: files.length });
+  let next = 0;
+  const limit = Math.max(1, Math.min(READ_QUERYABLE_WIKI_PAGES_CONCURRENCY, files.length));
+  const workers = Array.from({ length: limit }, async () => {
+    while (true) {
+      if (signal?.aborted) {
+        return;
+      }
+      const index = next;
+      next += 1;
+      if (index >= files.length) {
+        return;
+      }
+      const relativePath = files[index];
+      if (!relativePath) {
+        return;
+      }
+      const absolutePath = path.join(rootDir, relativePath);
+      const raw = await fs.readFile(absolutePath, "utf8");
+      const summary = toWikiPageSummary({ absolutePath, relativePath, raw });
+      if (summary) {
+        results[index] = { ...summary, raw };
+      }
+    }
+  });
+
+  await Promise.all(workers);
+  return results.flatMap((page) => (page ? [page] : []));
 }
 
 function parseClaimsDigest(raw: string): QueryDigestClaim[] {

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -262,24 +262,37 @@ async function listWikiMarkdownFiles(rootDir: string): Promise<string[]> {
   return files.toSorted((left, right) => left.localeCompare(right));
 }
 
-export async function readQueryableWikiPages(rootDir: string): Promise<QueryableWikiPage[]> {
+export async function readQueryableWikiPages(
+  rootDir: string,
+  signal?: AbortSignal,
+): Promise<QueryableWikiPage[]> {
+  if (signal?.aborted) {
+    return [];
+  }
   const files = await listWikiMarkdownFiles(rootDir);
-  return readQueryableWikiPagesByPaths(rootDir, files);
+  return readQueryableWikiPagesByPaths(rootDir, files, signal);
 }
 
 async function readQueryableWikiPagesByPaths(
   rootDir: string,
   files: string[],
+  signal?: AbortSignal,
 ): Promise<QueryableWikiPage[]> {
-  const pages = await Promise.all(
-    files.map(async (relativePath) => {
-      const absolutePath = path.join(rootDir, relativePath);
-      const raw = await fs.readFile(absolutePath, "utf8");
-      const summary = toWikiPageSummary({ absolutePath, relativePath, raw });
-      return summary ? { ...summary, raw } : null;
-    }),
-  );
-  return pages.flatMap((page) => (page ? [page] : []));
+  // Sequential reads so an abort can stop further I/O mid-batch (Promise.all
+  // would keep launching reads after the deadline fires).
+  const pages: QueryableWikiPage[] = [];
+  for (const relativePath of files) {
+    if (signal?.aborted) {
+      break;
+    }
+    const absolutePath = path.join(rootDir, relativePath);
+    const raw = await fs.readFile(absolutePath, "utf8");
+    const summary = toWikiPageSummary({ absolutePath, relativePath, raw });
+    if (summary) {
+      pages.push({ ...summary, raw });
+    }
+  }
+  return pages;
 }
 
 function parseClaimsDigest(raw: string): QueryDigestClaim[] {
@@ -1406,8 +1419,17 @@ async function searchWikiCorpus(params: {
   query: string;
   maxResults: number;
   mode: WikiSearchMode;
+  signal?: AbortSignal;
+  /** When false, skip full-vault fallback after digest underfill (supplement path). */
+  exhaustiveFallback?: boolean;
 }): Promise<WikiSearchResult[]> {
+  if (params.signal?.aborted) {
+    return [];
+  }
   const digest = await readQueryDigestBundle(params.rootDir);
+  if (params.signal?.aborted) {
+    return [];
+  }
   const candidatePaths = digest
     ? buildDigestCandidatePaths({
         digest,
@@ -1416,11 +1438,18 @@ async function searchWikiCorpus(params: {
         mode: params.mode,
       })
     : [];
+
+  // Supplement searches stay on digest-routed candidates; direct wiki_search
+  // keeps full-vault fallback when digest is missing or underfills.
+  if (candidatePaths.length === 0 && params.exhaustiveFallback === false) {
+    return [];
+  }
+
   const seenPaths = new Set<string>();
   const candidatePages =
     candidatePaths.length > 0
-      ? await readQueryableWikiPagesByPaths(params.rootDir, candidatePaths)
-      : await readQueryableWikiPages(params.rootDir);
+      ? await readQueryableWikiPagesByPaths(params.rootDir, candidatePaths, params.signal)
+      : await readQueryableWikiPages(params.rootDir, params.signal);
   for (const page of candidatePages) {
     seenPaths.add(page.relativePath);
   }
@@ -1428,14 +1457,26 @@ async function searchWikiCorpus(params: {
   const results = candidatePages
     .map((page) => toWikiSearchResult(page, params.query, params.mode))
     .filter((page) => page.score > 0);
-  if (candidatePaths.length === 0 || results.length >= params.maxResults) {
+  if (
+    candidatePaths.length === 0 ||
+    results.length >= params.maxResults ||
+    params.exhaustiveFallback === false ||
+    params.signal?.aborted
+  ) {
     return results;
   }
 
   const remainingPaths = (await listWikiMarkdownFiles(params.rootDir)).filter(
     (relativePath) => !seenPaths.has(relativePath),
   );
-  const remainingPages = await readQueryableWikiPagesByPaths(params.rootDir, remainingPaths);
+  if (params.signal?.aborted) {
+    return results;
+  }
+  const remainingPages = await readQueryableWikiPagesByPaths(
+    params.rootDir,
+    remainingPaths,
+    params.signal,
+  );
   return [
     ...results,
     ...remainingPages
@@ -1478,6 +1519,8 @@ export async function searchMemoryWiki(params: {
   searchBackend?: WikiSearchBackend;
   searchCorpus?: WikiSearchCorpus;
   mode?: WikiSearchMode;
+  signal?: AbortSignal;
+  exhaustiveFallback?: boolean;
 }): Promise<WikiSearchResult[]> {
   const effectiveConfig = applySearchOverrides(params.config, params);
   assertSessionVisibilityAppConfig({
@@ -1498,6 +1541,8 @@ export async function searchMemoryWiki(params: {
         query: params.query,
         maxResults,
         mode,
+        signal: params.signal,
+        exhaustiveFallback: params.exhaustiveFallback,
       })
     : [];
 

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -54,6 +54,8 @@ export type MemoryCorpusSupplement = {
     agentId?: string;
     agentSessionKey?: string;
     sandboxed?: boolean;
+    /** Caller deadline. Implementations should stop starting new file I/O when aborted and may return partial results. */
+    signal?: AbortSignal;
   }): Promise<MemoryCorpusSearchResult[]>;
   get(params: {
     lookup: string;


### PR DESCRIPTION
## What Problem This Solves

`memory_search` with `corpus="wiki"` or `corpus="all"` can miss the 15s tool deadline when digest-selected candidates underfill `maxResults`. The wiki supplement then falls through to a full-vault Markdown scan (25–27s on large vaults), so recall times out and host work may continue after the tool already failed. Fixes #104719.

## Root Cause / Fix

- Root cause: `searchWikiCorpus()` treated missing or underfilled digest hits as a signal to enumerate/parse the entire vault, and the memory tool deadline signal never reached the supplement path.
- Fix:
  1. Propagate `deadlineSignal` through `MemoryCorpusSupplement.search` → wiki supplement → `searchMemoryWiki` / `searchWikiCorpus`.
  2. Supplement path sets `exhaustiveFallback: false` so digest underfill does not trigger full-vault scanning. Direct `wiki_search` keeps exhaustive fallback.
  3. Shared page reads use **bounded (16) abort-before-claim workers** (not sequential): deadlines stop claiming new paths while direct exhaustive search keeps parallel throughput. In-flight reads settle.

## Evidence

### Production function proof (`node --import tsx`)

Multi-page vault exercise of the real `searchMemoryWiki` / `readQueryableWikiPages` path (see Real behavior proof for captured output). Covers:

- default exhaustive hit still works
- `exhaustiveFallback: false` skips vault scan without digest
- pre-aborted signal returns `[]`
- mid-batch abort stops claiming further page reads (`abort_stopped_early`)

### Regression tests

- `"skips full-vault fallback when exhaustiveFallback is false (#104719)"`
- `"returns early when the deadline signal is already aborted (#104719)"`
- `"reads wiki pages with bounded concurrency and stops claiming after abort (#104719)"` — asserts peak concurrency in (1, 16] and fewer reads than file count after abort
- `"forwards deadline signal and disables exhaustive fallback for supplement search (#104719)"`

### Test runner

```
node scripts/run-vitest.mjs extensions/memory-wiki/src/corpus-supplement.test.ts
node scripts/run-vitest.mjs extensions/memory-wiki/src/query.test.ts -t "104719|exhaustiveFallback|already aborted|bounded concurrency|finds wiki pages by title"
```

## Real behavior proof

**Behavior addressed:** memory-wiki supplement skips full-vault fallback after digest underfill, honors the memory_search deadline AbortSignal, and shared wiki page reads use bounded abort-aware concurrency instead of serial I/O.
**Environment tested:** Windows Node 22+, local checkout of `fix/issue-104719-wiki-deadline`, `node --import tsx`, vitest via `node scripts/run-vitest.mjs`.
**Steps run after the patch:** Created a temporary 40-page wiki vault; ran production `searchMemoryWiki` / `readQueryableWikiPages` with default search, `exhaustiveFallback: false`, pre-abort, and mid-batch abort; ran targeted vitest regressions including the bounded-concurrency abort test.
**Evidence after fix:**

```json
{
  "direct_hit_path": "sources/page-01.md",
  "direct_hits": 10,
  "direct_ms": 210,
  "file_count": 40,
  "abort_pages": 23,
  "abort_stopped_early": true,
  "supplement_no_digest": [],
  "preabort": [],
  "ok": true
}
```

**Observed result:** Default search still finds wiki pages; supplement-without-digest returns no vault scan; pre-abort returns empty; mid-batch abort stops claiming new paths (`abort_stopped_early: true`) while peak concurrency stays bounded (≤16). Targeted vitest regressions pass.
**Not tested:** Live gateway `memory_search` against a real ~77MB / 1200+ page compiled-wiki vault end-to-end (no such vault in this environment); Discord/Telegram delivery.

## Change Type / Scope / Security Impact

- Type: bug fix
- Scope: memory-wiki supplement + memory-core deadline plumbing + abort-aware bounded page reader (S)
- Security: none (no auth/credential changes); reduces unbounded host I/O after tool timeout without serializing exhaustive search
