### PR TITLE
fix: reduce same-build Gateway restart latency

### DIFF
--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -402,6 +402,12 @@ describe("runDoctorConfigPreflight state migration", () => {
 
     expect(acquireStartupMigrationLease).not.toHaveBeenCalled();
     expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyStateDir).not.toHaveBeenCalled();
+    expect(repairLegacyCronStoreWithoutPrompt).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyTaskStateSidecars).not.toHaveBeenCalled();
+    expect(runPostCorePluginConvergence).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshot).toHaveBeenCalledOnce();
   });
 
   it("blocks gateway readiness when startup migrations leave warnings", async () => {

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -191,12 +191,12 @@ export async function runDoctorConfigPreflight(
     crossStateDirImports?: boolean;
   } = {},
 ): Promise<DoctorConfigPreflightResult> {
-  const stateMigrations =
-    options.migrateState !== false ? await loadDoctorStateMigrations() : undefined;
+  const stateMigrationsRequested = options.migrateState !== false;
   const startupCheckpoint =
     options.requireStartupMigrationCheckpoint === true
       ? await import("../infra/startup-migration-checkpoint.js")
       : undefined;
+  let stateMigrations: Awaited<ReturnType<typeof loadDoctorStateMigrations>> | undefined;
   let startupMigrationEnv = process.env;
   let shouldRecordStartupCheckpoint = false;
   let startupMigrationLease: StartupMigrationLease | undefined;
@@ -215,7 +215,7 @@ export async function runDoctorConfigPreflight(
     // The gateway uses this last-moment guard to ensure its prepared config did not change before
     // any automatic migration mutates state. A rejected guard skips every state migration stage.
     const stateMigrationsAllowed =
-      stateMigrations === undefined ||
+      !stateMigrationsRequested ||
       options.beforeStateMigrations === undefined ||
       (await options.beforeStateMigrations());
     if (startupCheckpoint && !stateMigrationsAllowed) {
@@ -241,6 +241,12 @@ export async function runDoctorConfigPreflight(
         startupMigrationHeartbeat.unref?.();
       }
     }
+    // A current version checkpoint proves this state root already completed every automatic
+    // migration. Keep repeated Gateway boots out of the legacy/plugin migration import graph.
+    stateMigrations =
+      stateMigrationsRequested && (!startupCheckpoint || shouldRecordStartupCheckpoint)
+        ? await loadDoctorStateMigrations()
+        : undefined;
     if (stateMigrations && stateMigrationsAllowed) {
       const { autoMigrateLegacyStateDir } = stateMigrations;
       const stateDirResult = await autoMigrateLegacyStateDir({ env: process.env });

--- a/src/infra/startup-migration-checkpoint.test.ts
+++ b/src/infra/startup-migration-checkpoint.test.ts
@@ -29,13 +29,67 @@ describe("startup migration checkpoint", () => {
     };
 
     expect(readStartupMigrationVersion(env)).toBeNull();
-    expect(needsStartupMigrationCheckpoint({ env, version: "2026.7.1" })).toBe(true);
+    expect(
+      needsStartupMigrationCheckpoint({
+        env,
+        version: "2026.7.1",
+        buildIdentity: "2026-07-11T00:00:00.000Z",
+      }),
+    ).toBe(true);
 
-    recordSuccessfulStartupMigrations({ env, version: "2026.7.1", nowMs: 1234 });
+    recordSuccessfulStartupMigrations({
+      env,
+      version: "2026.7.1",
+      buildIdentity: "2026-07-11T00:00:00.000Z",
+      nowMs: 1234,
+    });
 
     expect(readStartupMigrationVersion(env)).toBe("2026.7.1");
-    expect(needsStartupMigrationCheckpoint({ env, version: "2026.7.1" })).toBe(false);
-    expect(needsStartupMigrationCheckpoint({ env, version: "2026.7.2" })).toBe(true);
+    expect(
+      needsStartupMigrationCheckpoint({
+        env,
+        version: "2026.7.1",
+        buildIdentity: "2026-07-11T00:00:00.000Z",
+      }),
+    ).toBe(false);
+    expect(
+      needsStartupMigrationCheckpoint({
+        env,
+        version: "2026.7.1",
+        buildIdentity: "2026-07-11T00:01:00.000Z",
+      }),
+    ).toBe(true);
+    expect(
+      needsStartupMigrationCheckpoint({
+        env,
+        version: "2026.7.2",
+        buildIdentity: "2026-07-11T00:00:00.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the fast path disabled without immutable build provenance", () => {
+    const env = {
+      OPENCLAW_STATE_DIR: startupMigrationTempDirs.make("openclaw-startup-migration-"),
+    };
+
+    recordSuccessfulStartupMigrations({
+      env,
+      version: "2026.7.1",
+      buildIdentity: null,
+      nowMs: 1234,
+    });
+
+    expect(needsStartupMigrationCheckpoint({ env, version: "2026.7.1", buildIdentity: null })).toBe(
+      true,
+    );
+    expect(
+      needsStartupMigrationCheckpoint({
+        env,
+        version: "2026.7.1",
+        buildIdentity: "2026-07-11T00:00:00.000Z",
+      }),
+    ).toBe(true);
   });
 
   it("serializes startup migrations with an expiring shared-state lease", () => {

--- a/src/infra/startup-migration-checkpoint.ts
+++ b/src/infra/startup-migration-checkpoint.ts
@@ -1,5 +1,6 @@
 // Coordinates gateway startup migration version checkpoints in shared state.
 import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
 import type { DatabaseSync } from "node:sqlite";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { withOpenClawStateStartupMigrationCheckpointDatabase } from "../state/openclaw-state-db.js";
@@ -17,6 +18,7 @@ type StartupMigrationCheckpointDatabase = Pick<
 >;
 
 const STARTUP_MIGRATION_META_KEY = "startup-migrations";
+const STARTUP_MIGRATION_BUILD_SEPARATOR = "\n";
 const STARTUP_MIGRATION_LEASE_SCOPE = "startup-migrations";
 const STARTUP_MIGRATION_LEASE_KEY = "global";
 const STARTUP_MIGRATION_LEASE_TTL_MS = 5 * 60_000;
@@ -26,6 +28,36 @@ export type StartupMigrationLease = {
   release: () => void;
   readonly owner: string;
 };
+
+function formatStartupMigrationCheckpoint(version: string, buildIdentity: string): string {
+  return `${version}${STARTUP_MIGRATION_BUILD_SEPARATOR}${buildIdentity}`;
+}
+
+// Built-at provenance changes when mutable source is rebuilt even if package version and commit do
+// not. Missing provenance deliberately keeps migrations enabled instead of trusting stale code.
+function resolveStartupMigrationBuildIdentity(moduleUrl: string = import.meta.url): string | null {
+  try {
+    const require = createRequire(moduleUrl);
+    for (const candidate of [
+      "./build-info.json",
+      "../build-info.json",
+      "../../dist/build-info.json",
+    ]) {
+      try {
+        const info = require(candidate) as { builtAt?: unknown };
+        if (typeof info.builtAt !== "string" || !info.builtAt.trim()) {
+          continue;
+        }
+        return info.builtAt.trim();
+      } catch {
+        // Try the next packaged/source-build location.
+      }
+    }
+  } catch {
+    // Missing build provenance disables the fast path below.
+  }
+  return null;
+}
 
 function withStartupMigrationCheckpointDatabase<T>(
   env: NodeJS.ProcessEnv,
@@ -43,7 +75,7 @@ function writeStartupMigrationCheckpointDatabase<T>(
   );
 }
 
-export function readStartupMigrationVersion(env: NodeJS.ProcessEnv = process.env): string | null {
+function readStartupMigrationCheckpoint(env: NodeJS.ProcessEnv): string | null {
   return withStartupMigrationCheckpointDatabase(env, (db) => {
     const stateDb = getNodeSqliteKysely<StartupMigrationCheckpointDatabase>(db);
     const row = executeSqliteQueryTakeFirstSync(
@@ -57,13 +89,31 @@ export function readStartupMigrationVersion(env: NodeJS.ProcessEnv = process.env
   });
 }
 
+export function readStartupMigrationVersion(env: NodeJS.ProcessEnv = process.env): string | null {
+  return (
+    readStartupMigrationCheckpoint(env)?.split(STARTUP_MIGRATION_BUILD_SEPARATOR, 1)[0] ?? null
+  );
+}
+
 export function needsStartupMigrationCheckpoint(
   params: {
+    buildIdentity?: string | null;
     env?: NodeJS.ProcessEnv;
     version?: string;
   } = {},
 ): boolean {
-  return readStartupMigrationVersion(params.env) !== (params.version ?? VERSION);
+  const env = params.env ?? process.env;
+  const buildIdentity =
+    params.buildIdentity === undefined
+      ? resolveStartupMigrationBuildIdentity()
+      : params.buildIdentity;
+  if (buildIdentity === null) {
+    return true;
+  }
+  return (
+    readStartupMigrationCheckpoint(env) !==
+    formatStartupMigrationCheckpoint(params.version ?? VERSION, buildIdentity)
+  );
 }
 
 export function acquireStartupMigrationLease(
@@ -162,6 +212,7 @@ export function acquireStartupMigrationLease(
 
 export function recordSuccessfulStartupMigrations(
   params: {
+    buildIdentity?: string | null;
     env?: NodeJS.ProcessEnv;
     lease?: StartupMigrationLease;
     version?: string;
@@ -170,7 +221,13 @@ export function recordSuccessfulStartupMigrations(
 ): void {
   const env = params.env ?? process.env;
   const version = params.version ?? VERSION;
+  const buildIdentity =
+    params.buildIdentity === undefined
+      ? resolveStartupMigrationBuildIdentity()
+      : params.buildIdentity;
   const nowMs = params.nowMs ?? Date.now();
+  const checkpoint =
+    buildIdentity === null ? version : formatStartupMigrationCheckpoint(version, buildIdentity);
   writeStartupMigrationCheckpointDatabase(env, (db) => {
     const stateDb = getNodeSqliteKysely<StartupMigrationCheckpointDatabase>(db);
     if (params.lease) {
@@ -197,18 +254,18 @@ export function recordSuccessfulStartupMigrations(
         .values({
           meta_key: STARTUP_MIGRATION_META_KEY,
           role: "global",
-          schema_version: 1,
+          schema_version: buildIdentity === null ? 1 : 2,
           agent_id: null,
-          app_version: version,
+          app_version: checkpoint,
           created_at: nowMs,
           updated_at: nowMs,
         })
         .onConflict((conflict) =>
           conflict.column("meta_key").doUpdateSet({
             role: "global",
-            schema_version: 1,
+            schema_version: buildIdentity === null ? 1 : 2,
             agent_id: null,
-            app_version: version,
+            app_version: checkpoint,
             updated_at: nowMs,
           }),
         ),


### PR DESCRIPTION
Closes #105043

## What Problem This Solves

Fixes an issue where operators restarting an already-migrated Gateway build would wait several extra seconds for the completed legacy/plugin migration graph to load and converge again before readiness.

## Why This Change Was Made

The Gateway now checks its successful startup-migration checkpoint before importing the migration graph and skips that graph only when both the OpenClaw version and immutable build identity match. Fresh state, rebuilds, version changes, and builds without provenance continue to run migrations before readiness; the runtime-plugin prewarm remains unchanged because its synchronous loader cannot safely run at the readiness boundary.

## User Impact

Same-build Gateway restarts become ready materially faster without weakening migration safety. On the measured AWS Crabbox host, repeat `/readyz` p50 fell from 7.119 seconds to 4.618 seconds (35.1%), while a rebuild still forced the required 7.414-second migration boot once.

## Evidence

- Node startup control, same host/state: five restarts, `/readyz` p50 7118.5 ms; migration/bootstrap 4455.8-4531.4 ms. Crabbox `run_d419f6fff0f1`.
- Final same-build result: first post-rebuild boot 7414.3 ms, then five checkpointed restarts 4568.6-4631.0 ms; p50 4618.1 ms; migration/bootstrap 247.2-249.1 ms. Crabbox `run_a3ba98e7650b`.
- Final live OpenAI proof: fresh Gateway `/readyz` 7302.5 ms; `openai/gpt-5.6` completed a substantial build turn in 104440 ms and produced 21 files / 19714 bytes with no stderr. Crabbox `run_c6c2d2ef8be7`.
- `corepack pnpm test src/commands/doctor-config-preflight.state-migration.test.ts src/infra/startup-migration-checkpoint.test.ts` — 25 tests passed on Blacksmith Testbox `tbx_01kxahgfnrqy4w0qt98s2kkt5k`.
- `corepack pnpm check:changed -- src/commands/doctor-config-preflight.state-migration.test.ts src/commands/doctor-config-preflight.ts src/infra/startup-migration-checkpoint.test.ts src/infra/startup-migration-checkpoint.ts` — passed format, API baseline, core/test types, lint, database-first, import-cycle, runtime-sidecar, and related guards on the same Testbox.
- `node scripts/build-all.mjs cliStartup` plus canonical build-info generation — passed on AWS Crabbox `run_e5fcb919989b`.
- Fresh autoreview after addressing two accepted findings: no actionable findings; overall patch correct.

All benchmark evidence is timing/count summaries. API keys, prompts, model response text, and workspace contents are not included.

Release-note context is kept here because `CHANGELOG.md` is release-owned for normal PRs.
