### PR TITLE
refactor(line): remove unused rich-menu user helpers

### DIFF
--- a/extensions/line/runtime-api.ts
+++ b/extensions/line/runtime-api.ts
@@ -165,11 +165,7 @@ export {
   getRichMenu,
   getRichMenuIdOfUser,
   getRichMenuList,
-  linkRichMenuToUser,
-  linkRichMenuToUsers,
   setDefaultRichMenu,
-  unlinkRichMenuFromUser,
-  unlinkRichMenuFromUsers,
   uploadRichMenuImage,
 } from "./src/rich-menu.js";
 export type {

--- a/extensions/line/src/rich-menu.ts
+++ b/extensions/line/src/rich-menu.ts
@@ -13,7 +13,6 @@ type RichMenuRequest = messagingApi.RichMenuRequest;
 type RichMenuResponse = messagingApi.RichMenuResponse;
 type RichMenuArea = messagingApi.RichMenuArea;
 type Action = messagingApi.Action;
-const USER_BATCH_SIZE = 500;
 // LINE counts rich-menu names and chat-bar text in grapheme clusters, unlike most message fields.
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
@@ -70,14 +69,6 @@ function getBlobClient(opts: RichMenuOpts): messagingApi.MessagingApiBlobClient 
   return new messagingApi.MessagingApiBlobClient({
     channelAccessToken: token,
   });
-}
-
-function chunkUserIds(userIds: string[]): string[][] {
-  const batches: string[][] = [];
-  for (let i = 0; i < userIds.length; i += USER_BATCH_SIZE) {
-    batches.push(userIds.slice(i, i + USER_BATCH_SIZE));
-  }
-  return batches;
 }
 
 function truncateGraphemes(input: string, maxLength: number): string {
@@ -168,64 +159,6 @@ export async function getDefaultRichMenuId(opts: RichMenuOpts): Promise<string |
     return response.richMenuId ?? null;
   } catch {
     return null;
-  }
-}
-
-export async function linkRichMenuToUser(
-  userId: string,
-  richMenuId: string,
-  opts: RichMenuOpts,
-): Promise<void> {
-  const client = getClient(opts);
-  await client.linkRichMenuIdToUser(userId, richMenuId);
-
-  if (opts.verbose) {
-    logVerbose(`line: linked rich menu ${richMenuId} to user ${userId}`);
-  }
-}
-
-export async function linkRichMenuToUsers(
-  userIds: string[],
-  richMenuId: string,
-  opts: RichMenuOpts,
-): Promise<void> {
-  const client = getClient(opts);
-
-  for (const batch of chunkUserIds(userIds)) {
-    await client.linkRichMenuIdToUsers({
-      richMenuId,
-      userIds: batch,
-    });
-  }
-
-  if (opts.verbose) {
-    logVerbose(`line: linked rich menu ${richMenuId} to ${userIds.length} users`);
-  }
-}
-
-export async function unlinkRichMenuFromUser(userId: string, opts: RichMenuOpts): Promise<void> {
-  const client = getClient(opts);
-  await client.unlinkRichMenuIdFromUser(userId);
-
-  if (opts.verbose) {
-    logVerbose(`line: unlinked rich menu from user ${userId}`);
-  }
-}
-
-export async function unlinkRichMenuFromUsers(
-  userIds: string[],
-  opts: RichMenuOpts,
-): Promise<void> {
-  const client = getClient(opts);
-
-  for (const batch of chunkUserIds(userIds)) {
-    await client.unlinkRichMenuIdFromUsers({
-      userIds: batch,
-    });
-  }
-
-  if (opts.verbose) {
-    logVerbose(`line: unlinked rich menu from ${userIds.length} users`);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Removes unused internal LINE rich-menu user-linking helpers that remained exported through the plugin runtime surface despite having no production callers.

## Why This Change Was Made

Exact codebase-memory graph queries and repository-wide searches showed that the four wrappers had no incoming callers, while their batching helper and constant were reachable only through those wrappers. The supported LINE plugin API and retained rich-menu workflow are unchanged.

## User Impact

No user-visible behavior changes. The LINE plugin ships a smaller internal runtime surface with 71 fewer dead production lines.

## Evidence

- Exact graph query: each removed wrapper had only its defining module as an incoming edge.
- Repository-wide search: no callers outside the deleted helper island.
- `node scripts/run-vitest.mjs extensions/line/src/rich-menu.test.ts src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts` — 23 tests passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/line/runtime-api.ts extensions/line/src/rich-menu.ts` — passed.
- `git diff --check` — passed.
- Autoreview: `gpt-5.6-sol`, medium reasoning, clean with no actionable findings (`0.88`).
- Remote `check:changed` pre-push was blocked by Testbox lifecycle failures and direct AWS bootstrap failures; hosted PR CI will provide the broad gate before merge.

AI-assisted. No transcript attached per maintainer preference.
