### PR TITLE
fix(parallel): reject invalid search counts

### DIFF
--- a/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
@@ -1,8 +1,6 @@
 import {
-  DEFAULT_SEARCH_COUNT,
   mergeScopedSearchConfig,
   readCachedSearchPayload,
-  readPositiveIntegerParam,
   readStringArrayParam,
   readStringParam,
   resolveProviderWebSearchPluginConfig,
@@ -47,15 +45,7 @@ export async function executeParallelFreeWebSearchProviderTool(
   if (searchQueries.length === 0) {
     return invalidSearchQueriesPayload();
   }
-  const requestedCount = readPositiveIntegerParam(args, "count", {
-    max: 40,
-    message: "count must be an integer from 1 to 40.",
-  });
-  const configuredCount =
-    typeof searchConfig?.maxResults === "number" ? searchConfig.maxResults : undefined;
-  const count = resolveParallelSearchCount(
-    requestedCount ?? configuredCount ?? DEFAULT_SEARCH_COUNT,
-  );
+  const count = resolveParallelSearchCount(args, searchConfig?.maxResults);
   const sessionId = normalizeParallelSessionId(
     readStringParam(args, "session_id"),
     PARALLEL_FREE_SESSION_ID_MAX_LENGTH,

--- a/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
@@ -2,7 +2,7 @@ import {
   DEFAULT_SEARCH_COUNT,
   mergeScopedSearchConfig,
   readCachedSearchPayload,
-  readNumberParam,
+  readPositiveIntegerParam,
   readStringArrayParam,
   readStringParam,
   resolveProviderWebSearchPluginConfig,
@@ -47,10 +47,15 @@ export async function executeParallelFreeWebSearchProviderTool(
   if (searchQueries.length === 0) {
     return invalidSearchQueriesPayload();
   }
-  const requestedCount =
-    readNumberParam(args, "count", { integer: true }) ??
-    (typeof searchConfig?.maxResults === "number" ? searchConfig.maxResults : undefined);
-  const count = resolveParallelSearchCount(requestedCount ?? DEFAULT_SEARCH_COUNT);
+  const requestedCount = readPositiveIntegerParam(args, "count", {
+    max: 40,
+    message: "count must be an integer from 1 to 40.",
+  });
+  const configuredCount =
+    typeof searchConfig?.maxResults === "number" ? searchConfig.maxResults : undefined;
+  const count = resolveParallelSearchCount(
+    requestedCount ?? configuredCount ?? DEFAULT_SEARCH_COUNT,
+  );
   const sessionId = normalizeParallelSessionId(
     readStringParam(args, "session_id"),
     PARALLEL_FREE_SESSION_ID_MAX_LENGTH,

--- a/extensions/parallel/src/parallel-free-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.test.ts
@@ -157,4 +157,23 @@ describe("parallel-free web search provider", () => {
     expect(result.error).toBe("invalid_search_queries");
     expect(endpointMockState.calls).toHaveLength(0);
   });
+
+  it("rejects invalid counts before calling the free MCP", async () => {
+    const provider = createParallelFreeWebSearchProvider();
+    const tool = provider.createTool({ config: {}, searchConfig: {} });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    for (const count of [4.5, "3abc", 41]) {
+      await expect(
+        tool.execute({
+          objective: "Count validation",
+          search_queries: ["count validation"],
+          count,
+        }),
+      ).rejects.toThrow("count must be an integer from 1 to 40.");
+    }
+    expect(endpointMockState.calls).toHaveLength(0);
+  });
 });

--- a/extensions/parallel/src/parallel-free-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.test.ts
@@ -76,7 +76,7 @@ describe("parallel-free web search provider", () => {
     expect(provider.autoDetectOrder).toBeUndefined();
   });
 
-  it("advertises the free MCP's tighter 100-char session_id cap in its tool schema", () => {
+  it("advertises the shared count contract and free MCP's tighter session_id cap", () => {
     const provider = createParallelFreeWebSearchProvider();
     const tool = provider.createTool({ config: {}, searchConfig: {} });
     if (!tool) {
@@ -86,6 +86,12 @@ describe("parallel-free web search provider", () => {
       tool.parameters as { properties: Record<string, { maxLength?: number }> }
     ).properties.session_id;
     expect(expectDefined(sessionIdParam, "Parallel session_id parameter").maxLength).toBe(100);
+    const countParam = (
+      tool.parameters as {
+        properties: Record<string, { type?: string; minimum?: number; maximum?: number }>;
+      }
+    ).properties.count;
+    expect(countParam).toMatchObject({ type: "integer", minimum: 1, maximum: 40 });
   });
 
   it("searches via the free MCP and brands the result, with no API key", async () => {

--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -4,6 +4,8 @@
 // lives here instead of being copied into each runtime.
 import {
   buildSearchCacheKey,
+  DEFAULT_SEARCH_COUNT,
+  readPositiveIntegerParam,
   resolveSiteName,
   wrapWebContent,
 } from "openclaw/plugin-sdk/provider-web-search";
@@ -40,7 +42,17 @@ export type ParallelSearchResponse = {
   usage?: unknown;
 };
 
-export function resolveParallelSearchCount(value: number): number {
+export function resolveParallelSearchCount(
+  args: Record<string, unknown>,
+  configuredCount: unknown,
+): number {
+  const requestedCount = readPositiveIntegerParam(args, "count", {
+    max: PARALLEL_MAX_SEARCH_COUNT,
+    message: `count must be an integer from 1 to ${PARALLEL_MAX_SEARCH_COUNT}.`,
+  });
+  const value =
+    requestedCount ??
+    (typeof configuredCount === "number" ? configuredCount : DEFAULT_SEARCH_COUNT);
   return Math.max(1, Math.min(PARALLEL_MAX_SEARCH_COUNT, Math.floor(value)));
 }
 

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -9,7 +9,7 @@ import {
   mergeScopedSearchConfig,
   readCachedSearchPayload,
   readConfiguredSecretString,
-  readNumberParam,
+  readPositiveIntegerParam,
   readProviderEnvValue,
   readStringArrayParam,
   readStringParam,
@@ -203,12 +203,17 @@ export async function executeParallelWebSearchProviderTool(
   if (searchQueries.length === 0) {
     return invalidSearchQueriesPayload();
   }
-  const requestedCount =
-    readNumberParam(args, "count", { integer: true }) ??
-    (typeof searchConfig?.maxResults === "number" ? searchConfig.maxResults : undefined);
+  const requestedCount = readPositiveIntegerParam(args, "count", {
+    max: 40,
+    message: "count must be an integer from 1 to 40.",
+  });
+  const configuredCount =
+    typeof searchConfig?.maxResults === "number" ? searchConfig.maxResults : undefined;
   // Always pass max_results so Parallel matches the openclaw web_search default
   // of 5 instead of Parallel's own default of 10.
-  const count = resolveParallelSearchCount(requestedCount ?? DEFAULT_SEARCH_COUNT);
+  const count = resolveParallelSearchCount(
+    requestedCount ?? configuredCount ?? DEFAULT_SEARCH_COUNT,
+  );
   const sessionId = normalizeParallelSessionId(
     readStringParam(args, "session_id"),
     PARALLEL_SESSION_ID_MAX_LENGTH,

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -5,11 +5,9 @@ import {
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import {
-  DEFAULT_SEARCH_COUNT,
   mergeScopedSearchConfig,
   readCachedSearchPayload,
   readConfiguredSecretString,
-  readPositiveIntegerParam,
   readProviderEnvValue,
   readStringArrayParam,
   readStringParam,
@@ -203,17 +201,9 @@ export async function executeParallelWebSearchProviderTool(
   if (searchQueries.length === 0) {
     return invalidSearchQueriesPayload();
   }
-  const requestedCount = readPositiveIntegerParam(args, "count", {
-    max: 40,
-    message: "count must be an integer from 1 to 40.",
-  });
-  const configuredCount =
-    typeof searchConfig?.maxResults === "number" ? searchConfig.maxResults : undefined;
   // Always pass max_results so Parallel matches the openclaw web_search default
   // of 5 instead of Parallel's own default of 10.
-  const count = resolveParallelSearchCount(
-    requestedCount ?? configuredCount ?? DEFAULT_SEARCH_COUNT,
-  );
+  const count = resolveParallelSearchCount(args, searchConfig?.maxResults);
   const sessionId = normalizeParallelSessionId(
     readStringParam(args, "session_id"),
     PARALLEL_SESSION_ID_MAX_LENGTH,

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -88,6 +88,19 @@ describe("parallel web search provider", () => {
     expect(pluginEntry.enabled).toBe(true);
   });
 
+  it("advertises count as an integer from 1 to 40", () => {
+    const tool = createParallelWebSearchProvider().createTool({ config: {}, searchConfig: {} });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const countParam = (
+      tool.parameters as {
+        properties: Record<string, { type?: string; minimum?: number; maximum?: number }>;
+      }
+    ).properties.count;
+    expect(countParam).toMatchObject({ type: "integer", minimum: 1, maximum: 40 });
+  });
+
   it("keeps the lightweight contract surface aligned with provider metadata", () => {
     const provider = createParallelWebSearchProvider();
     const contractProvider = createContractParallelWebSearchProvider();
@@ -322,10 +335,16 @@ describe("parallel web search provider", () => {
     expect(testing.normalizeParallelResults(null)).toEqual([]);
   });
 
-  it("clamps Parallel result counts to the documented 1-40 range", () => {
-    expect(testing.resolveParallelSearchCount(5)).toBe(5);
-    expect(testing.resolveParallelSearchCount(120)).toBe(40);
-    expect(testing.resolveParallelSearchCount(0)).toBe(1);
+  it("resolves configured counts while strictly validating the tool schema range", () => {
+    expect(testing.resolveParallelSearchCount({}, undefined)).toBe(5);
+    expect(testing.resolveParallelSearchCount({}, 120)).toBe(40);
+    expect(testing.resolveParallelSearchCount({}, 0)).toBe(1);
+    expect(testing.resolveParallelSearchCount({ count: 40 }, 5)).toBe(40);
+    for (const count of [0, 4.5, "3abc", 41]) {
+      expect(() => testing.resolveParallelSearchCount({ count }, 5)).toThrow(
+        "count must be an integer from 1 to 40.",
+      );
+    }
   });
 
   it("returns a stable missing-key payload that points at the real config path", () => {

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -421,6 +421,28 @@ describe("parallel web search provider", () => {
     expect(result).toMatchObject({ provider: "parallel" });
   });
 
+  it("rejects invalid counts before calling Parallel", async () => {
+    const provider = createParallelWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { parallel: { apiKey: "par-secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    for (const count of [4.5, "3abc", 41]) {
+      await expect(
+        tool.execute({
+          objective: "Count validation",
+          search_queries: ["count validation"],
+          count,
+        }),
+      ).rejects.toThrow("count must be an integer from 1 to 40.");
+    }
+    expect(endpointMockState.calls).toHaveLength(0);
+  });
+
   it("prefers explicit objective+search_queries over the generic `query` fallback when all are present", async () => {
     endpointMockState.responses.push(
       new Response(JSON.stringify({ search_id: "x", session_id: "y", results: [] }), {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting Parallel web search providers could pass malformed or out-of-range `count` values and still have the provider request proceed after local coercion or clamping.

## Why This Change Was Made

The paid Parallel REST provider and the free Parallel Search MCP provider now use the same strict positive-integer count validation at their tool boundary before building provider requests. This keeps the existing default/configured `maxResults` fallback and final 1-40 normalization while rejecting caller-supplied `count` values that do not match the advertised schema.

## User Impact

Parallel web search calls now fail fast with a clear count validation error for fractional, malformed string, or over-limit result counts instead of silently sending a different `max_results` value upstream.

## Evidence

- Claim proved: paid `parallel` and free `parallel-free` web search tools reject fractional, malformed-string, and over-limit `count` values before provider transport, while valid/default count behavior still works.
- Current-head GitHub proof at `dce41e646bbcf4182680e0479f76624705fd7c61`: `Real behavior proof` passed, `checks-node-changed` passed, `check-test-types` passed, and `openclaw/ci-gate` passed.
- Current-head real-behavior proof check: https://github.com/openclaw/openclaw/actions/runs/29594021999/job/87929889827 passed.
- Current-head CI gate: https://github.com/openclaw/openclaw/actions/runs/29594023311/job/87930929069 passed.
- Current-head branch diff hygiene: `git diff --check upstream/main...HEAD` passed.
- Duplicate search: open PR and issue searches for `parallel count max_results web_search` returned no overlapping results.