### PR TITLE
feat(android): adopt per-device app sessions

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -331,7 +331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 127,
+      "line": 128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -339,7 +339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 129,
+      "line": 130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -347,7 +347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 131,
+      "line": 132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -355,7 +355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 133,
+      "line": 134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -363,7 +363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 135,
+      "line": 136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -371,7 +371,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 697,
+      "line": 698,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -379,7 +379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1596,
+      "line": 1628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job started.",
       "surface": "android",
@@ -387,7 +387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1596,
+      "line": 1628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron run queued.",
       "surface": "android",
@@ -395,7 +395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1640,
+      "line": 1672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job disabled.",
       "surface": "android",
@@ -403,7 +403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1640,
+      "line": 1672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job enabled.",
       "surface": "android",
@@ -411,7 +411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3247,
+      "line": 3279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -419,7 +419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3249,
+      "line": 3281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -427,7 +427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3251,
+      "line": 3283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -435,7 +435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4025,
+      "line": 4056,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -443,7 +443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4027,
+      "line": 4058,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+Creates or adopts Android's existing per-device chat session before loading connected history, preserving prior conversations while isolating each device. Thanks @snowzlmbot.
 Routes exec approval review through the Gateway's durable approval records, including first-answer-wins results from other authorized surfaces, fail-closed reconciliation after ambiguous writes, and compatibility with older Gateway v4 peers.
 Keeps Android session search in the Sessions screen with direct focus, clear controls, and accurate loading and no-match states. Thanks @IWhatsskill.
 Shows the localized app version, Git commit, and build date together on the About screen, with real provenance in repository-backed debug builds.

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -12,6 +12,7 @@ OpenClaw Android is the officially released Google Play app. It connects to an O
 - [x] QR code scanning in onboarding
 - [x] Performance improvements
 - [x] Streaming support in chat UI
+- [x] Dedicated per-device Android chat session created/adopted on connect without resetting history
 - [x] Request camera/location and other permissions in onboarding/settings flow
 - [x] Push notifications for gateway/chat status updates
 - [x] Security hardening (biometric lock, token handling, safer defaults)

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -11,6 +11,7 @@ import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatThinkingLevelSelection
 import ai.openclaw.app.chat.ChatTranscriptCache
+import ai.openclaw.app.chat.MainSessionBinding
 import ai.openclaw.app.chat.MessageSpeechClient
 import ai.openclaw.app.chat.MessageSpeechController
 import ai.openclaw.app.chat.MessageSpeechState
@@ -915,9 +916,11 @@ class NodeRuntime private constructor(
         replaceGatewayMethods(hello.methods)
         _operatorScopes.value = normalizeOperatorScopes(hello.authScopes)
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
-        syncMainSessionKey(resolveAgentIdFromMainSessionKey(hello.mainSessionKey))
-        // Every successful connection refreshes history; reconnects preserve local run ownership.
-        chat.onGatewayConnected()
+        val mainSessionKey =
+          prepareMainSessionKey(resolveAgentIdFromMainSessionKey(hello.mainSessionKey))
+        // Create/adopt before history refresh; this keeps the first connected read on the
+        // device-owned session without changing the shipped key or its existing transcript.
+        chat.onGatewayConnected(mainSessionBinding(mainSessionKey))
         refreshGatewayControlPage()
         updateStatus {
           operatorConnectionProblem = null
@@ -1381,15 +1384,44 @@ class NodeRuntime private constructor(
 
   private fun syncMainSessionKey(agentId: String?) {
     val resolvedKey = resolveNodeMainSessionKey(agentId)
-    // Always push the resolved session key into TalkMode, even when the
-    // state flow value is unchanged, so lazy TalkMode instances do not
-    // stay on the default "main" session key.
     talkMode.setMainSessionKey(resolvedKey)
     if (_mainSessionKey.value == resolvedKey) return
     _mainSessionKey.value = resolvedKey
-    chat.applyMainSessionKey(resolvedKey)
+    if (operatorConnected) {
+      chat.prepareMainSessionKey(resolvedKey)
+      chat.onGatewayConnected(mainSessionBinding(resolvedKey))
+    } else {
+      chat.applyMainSessionKey(resolvedKey)
+    }
     updateHomeCanvasState()
   }
+
+  private fun prepareMainSessionKey(agentId: String?): String {
+    val resolvedKey = resolveNodeMainSessionKey(agentId)
+    // Always push into TalkMode so a lazy instance cannot retain the "main" alias.
+    talkMode.setMainSessionKey(resolvedKey)
+    if (_mainSessionKey.value != resolvedKey) {
+      _mainSessionKey.value = resolvedKey
+      updateHomeCanvasState()
+    }
+    chat.prepareMainSessionKey(resolvedKey)
+    return resolvedKey
+  }
+
+  private fun selectMainSessionKey(agentId: String) {
+    val resolvedKey = resolveNodeMainSessionKey(agentId)
+    talkMode.setMainSessionKey(resolvedKey)
+    _mainSessionKey.value = resolvedKey
+    chat.prepareAndSelectMainSessionKey(resolvedKey)
+    chat.onGatewayConnected(mainSessionBinding(resolvedKey))
+    updateHomeCanvasState()
+  }
+
+  private fun mainSessionBinding(sessionKey: String): MainSessionBinding =
+    MainSessionBinding(
+      key = sessionKey,
+      label = buildAndroidAppSessionLabel(prefs.displayName.value, identityStore.loadOrCreate().deviceId),
+    )
 
   private fun updateStatus(update: () -> Unit = {}) {
     synchronized(gatewayStatusLock) {
@@ -3642,8 +3674,7 @@ class NodeRuntime private constructor(
     // Agent selection owns every main-session consumer; switching chat alone would
     // leave Talk mode and the home canvas bound to the previous agent.
     selectedChatAgentId = normalizedAgentId
-    syncMainSessionKey(normalizedAgentId)
-    chat.switchSession(_mainSessionKey.value)
+    selectMainSessionKey(normalizedAgentId)
   }
 
   suspend fun fetchChatSessionList(

--- a/apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt
@@ -25,3 +25,13 @@ internal fun buildNodeMainSessionKey(
   val resolvedAgentId = agentId?.trim().orEmpty().ifEmpty { "main" }
   return "agent:$resolvedAgentId:node-${deviceId.take(12)}"
 }
+
+/** Human-readable, device-unique label applied when Android creates or adopts its session. */
+internal fun buildAndroidAppSessionLabel(
+  displayName: String?,
+  deviceId: String,
+): String {
+  val deviceSuffix = deviceId.take(12)
+  val displaySuffix = displayName?.trim()?.take(96)?.takeIf { it.isNotEmpty() }
+  return listOfNotNull("OpenClaw App", displaySuffix, deviceSuffix).joinToString(" · ")
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -45,6 +45,19 @@ internal data class ChatCacheScope(
   val connectionGeneration: Long,
 )
 
+internal data class MainSessionBinding(
+  val key: String,
+  val label: String,
+)
+
+private class MainSessionReadiness(
+  val gatewayScope: ChatCacheScope,
+  val binding: MainSessionBinding,
+  val ready: CompletableDeferred<Unit>,
+) {
+  var job: Job? = null
+}
+
 class ChatController internal constructor(
   private val scope: CoroutineScope,
   private val json: Json,
@@ -162,6 +175,13 @@ class ChatController internal constructor(
   private val historyRequestSequence = AtomicLong(0)
   private val modelSelectionGeneration = AtomicLong(0)
   private val sessionsRequestSequence = AtomicLong(0)
+
+  // Every live history path awaits this gateway/session readiness. Per-gateway locking keeps
+  // rapid agent switches from letting an older lookup refresh before the new session is ready.
+  private val mainSessionAdoptionLocks = ConcurrentHashMap<String, Mutex>()
+  private val desiredMainSessions = ConcurrentHashMap<String, MainSessionBinding>()
+  private val mainSessionReadinessLock = Any()
+  private var mainSessionReadiness: MainSessionReadiness? = null
   private val gatewayScopeApplyLock = Any()
   private var latestAppliedHistoryRequest = 0L
   private var latestAppliedInFlightRunId: String? = null
@@ -229,6 +249,7 @@ class ChatController internal constructor(
 
   /** Clears transient chat state when the operator gateway session disconnects. */
   fun onDisconnected(message: String) {
+    retireMainSessionReadiness()
     historyLoadGeneration.incrementAndGet()
     restoreRunStateOnReconnect = true
     reconnectRecoveryGeneration = null
@@ -260,6 +281,92 @@ class ChatController internal constructor(
 
   /** Refreshes the connected gateway while preserving recovery ownership after a disconnect. */
   fun onGatewayConnected() {
+    refreshConnectedGateway()
+  }
+
+  /** Creates/adopts the app-owned main session before connected history can load. */
+  internal fun onGatewayConnected(mainSession: MainSessionBinding) {
+    val requestScope = currentCacheScope()
+    if (requestScope == null) {
+      refreshConnectedGateway()
+      return
+    }
+    desiredMainSessions[requestScope.gatewayId] = mainSession
+    val readiness =
+      MainSessionReadiness(
+        gatewayScope = requestScope,
+        binding = mainSession,
+        ready = CompletableDeferred(),
+      )
+    val adoptionJob =
+      scope.launch(start = CoroutineStart.LAZY) {
+        try {
+          val adoptionLock = mainSessionAdoptionLocks.computeIfAbsent(requestScope.gatewayId) { Mutex() }
+          adoptionLock.withLock {
+            if (desiredMainSessions[requestScope.gatewayId] != mainSession) return@withLock
+            try {
+              val describeParams = buildJsonObject { put("key", JsonPrimitive(mainSession.key)) }
+              val describeResponse =
+                requestGatewayBound(requestScope.gatewayId, "sessions.describe", describeParams.toString())
+              val describeRoot = json.parseToJsonElement(describeResponse).asObjectOrNull() ?: error("invalid sessions.describe response")
+              if (!describeRoot.containsKey("session")) error("sessions.describe returned no session field")
+              if (desiredMainSessions[requestScope.gatewayId] != mainSession) return@withLock
+              val existingSession = describeRoot["session"].asObjectOrNull()
+              val existingLabel =
+                existingSession
+                  ?.get("label")
+                  .asStringOrNull()
+                  ?.trim()
+                  ?.takeIf { it.isNotEmpty() }
+              if (existingSession == null) {
+                val createParams =
+                  buildJsonObject {
+                    put("key", JsonPrimitive(mainSession.key))
+                    put("agentId", JsonPrimitive(resolveAgentIdForSessionKey(mainSession.key)))
+                    put("label", JsonPrimitive(mainSession.label))
+                  }
+                requestGatewayBound(requestScope.gatewayId, "sessions.create", createParams.toString())
+              } else if (existingLabel == null) {
+                // An existing unlabeled session owns upgrade history already. Patch metadata instead
+                // of replaying create lifecycle behavior against that live session.
+                val patchParams =
+                  buildJsonObject {
+                    put("key", JsonPrimitive(mainSession.key))
+                    put("label", JsonPrimitive(mainSession.label))
+                  }
+                requestGatewayBound(requestScope.gatewayId, "sessions.patch", patchParams.toString())
+              }
+            } catch (err: CancellationException) {
+              throw err
+            } catch (_: Throwable) {
+              // History remains usable under the already-bound key when adoption cannot be verified.
+            }
+          }
+        } finally {
+          readiness.ready.complete(Unit)
+        }
+        // A superseded connect owns the next refresh and must not inherit this response.
+        if (
+          synchronized(mainSessionReadinessLock) { mainSessionReadiness === readiness } &&
+          requestScope == currentCacheScope() &&
+          desiredMainSessions[requestScope.gatewayId] == mainSession
+        ) {
+          refreshConnectedGateway()
+        }
+      }
+    readiness.job = adoptionJob
+    val supersededReadiness =
+      synchronized(mainSessionReadinessLock) {
+        val current = mainSessionReadiness
+        mainSessionReadiness = readiness
+        current
+      }
+    supersededReadiness?.job?.cancel()
+    supersededReadiness?.ready?.complete(Unit)
+    adoptionJob.start()
+  }
+
+  private fun refreshConnectedGateway() {
     if (!restoreRunStateOnReconnect) {
       refresh()
       return
@@ -270,6 +377,7 @@ class ChatController internal constructor(
 
   /** Invalidates and clears gateway-bound UI state before a target switch can race old responses. */
   fun onGatewayScopeChanging(retireRunState: Boolean = false) {
+    retireMainSessionReadiness()
     synchronized(gatewayScopeApplyLock) {
       if (retireRunState) {
         restoreRunStateOnReconnect = false
@@ -298,6 +406,17 @@ class ChatController internal constructor(
       // Outbox rows are gateway-scoped too; the next publish repopulates them for the new scope.
       _outboxItems.value = emptyList()
     }
+  }
+
+  private fun retireMainSessionReadiness() {
+    val staleReadiness =
+      synchronized(mainSessionReadinessLock) {
+        val current = mainSessionReadiness
+        mainSessionReadiness = null
+        current
+      }
+    staleReadiness?.job?.cancel()
+    staleReadiness?.ready?.complete(Unit)
   }
 
   /** Restores the selected gateway's local state without waiting for transport availability. */
@@ -330,6 +449,28 @@ class ChatController internal constructor(
 
   /** Rebinds chat to a new canonical main session key after gateway hello/agent changes. */
   fun applyMainSessionKey(mainSessionKey: String) {
+    bindMainSessionKey(mainSessionKey, loadHistory = true)
+  }
+
+  /** Rebinds without loading; the connected lifecycle creates/adopts the session first. */
+  internal fun prepareMainSessionKey(mainSessionKey: String) {
+    bindMainSessionKey(mainSessionKey, loadHistory = false)
+  }
+
+  /** Selects a newly chosen agent's main session without racing history ahead of adoption. */
+  internal fun prepareAndSelectMainSessionKey(mainSessionKey: String) {
+    val selectedKey = mainSessionKey.trim()
+    if (selectedKey.isEmpty()) return
+    prepareSessionSelection(selectedKey)
+    bindMainSessionKey(mainSessionKey, loadHistory = false)
+    val key = normalizeRequestedSessionKey(mainSessionKey)
+    if (_sessionKey.value != key) beginHistoryLoad(key, clearMessages = true)
+  }
+
+  private fun bindMainSessionKey(
+    mainSessionKey: String,
+    loadHistory: Boolean,
+  ) {
     val trimmed = mainSessionKey.trim()
     if (trimmed.isEmpty()) return
     val nextState =
@@ -341,6 +482,7 @@ class ChatController internal constructor(
     appliedMainSessionKey = nextState.appliedMainSessionKey
     if (_sessionKey.value == nextState.currentSessionKey) return
     val generation = beginHistoryLoad(nextState.currentSessionKey, clearMessages = true)
+    if (!loadHistory) return
     scope.launch {
       bootstrap(
         sessionKey = nextState.currentSessionKey,
@@ -682,16 +824,20 @@ class ChatController internal constructor(
   fun switchSession(sessionKey: String) {
     val key = normalizeRequestedSessionKey(sessionKey)
     if (key.isEmpty()) return
-    if (key != unreadPatchSessionKey) {
-      unreadPatchSessionKey = key
-      unreadPatchRequested = false
-    }
-    acknowledgeUnreadIfNeeded(key, _sessions.value.firstOrNull { it.key == key })
+    prepareSessionSelection(key)
     if (key == _sessionKey.value) return
     val generation = beginHistoryLoad(key, clearMessages = true)
     scope.launch {
       bootstrap(sessionKey = key, generation = generation, forceHealth = true, refreshSessions = false)
     }
+  }
+
+  private fun prepareSessionSelection(key: String) {
+    if (key != unreadPatchSessionKey) {
+      unreadPatchSessionKey = key
+      unreadPatchRequested = false
+    }
+    acknowledgeUnreadIfNeeded(key, _sessions.value.firstOrNull { it.key == key })
   }
 
   private fun beginHistoryLoad(
@@ -1321,6 +1467,13 @@ class ChatController internal constructor(
     val requestSequence = historyRequestSequence.incrementAndGet()
     val requestModelSelectionGeneration = modelSelectionGeneration.get()
     val requestCacheScope = currentCacheScope()
+    awaitMainSessionReadiness(sessionKey, requestCacheScope)
+    if (
+      !isCurrentHistoryLoad(sessionKey, _sessionKey.value, generation, historyLoadGeneration.get()) ||
+      requestCacheScope != currentCacheScope()
+    ) {
+      return false
+    }
     val history =
       try {
         val historyJson =
@@ -1415,6 +1568,20 @@ class ChatController internal constructor(
     persistTranscript(requestCacheScope, sessionKey, history.messages)
     confirmDurableSendsFromHistory(requestCacheScope, history)
     return true
+  }
+
+  private suspend fun awaitMainSessionReadiness(
+    sessionKey: String,
+    requestScope: ChatCacheScope?,
+  ) {
+    val readiness =
+      synchronized(mainSessionReadinessLock) {
+        mainSessionReadiness
+          ?.takeIf { state ->
+            state.gatewayScope == requestScope && state.binding.key == sessionKey
+          }?.ready
+      }
+    readiness?.await()
   }
 
   /** Canonical history is the only proof that retires journaled sends; every apply checks it. */

--- a/apps/android/app/src/test/java/ai/openclaw/app/SessionKeyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SessionKeyTest.kt
@@ -13,6 +13,15 @@ class SessionKeyTest {
   }
 
   @Test
+  fun buildAndroidAppSessionLabelIncludesDeviceDisplayName() {
+    assertEquals("OpenClaw App · 1234567890ab", buildAndroidAppSessionLabel(null, "1234567890abcdef"))
+    assertEquals(
+      "OpenClaw App · Pixel · 1234567890ab",
+      buildAndroidAppSessionLabel(" Pixel ", "1234567890abcdef"),
+    )
+  }
+
+  @Test
   fun resolveAgentIdFromMainSessionKeyParsesCanonicalAgentKey() {
     assertEquals("ops", resolveAgentIdFromMainSessionKey("agent:ops:main"))
     assertNull(resolveAgentIdFromMainSessionKey("global"))

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -27,7 +27,323 @@ class ChatControllerReconnectRestoreTest {
 
   private fun TestScope.newController(gateway: ScriptedGateway): ChatController = ChatController(scope = this, json = json, requestGateway = gateway::request)
 
+  private fun TestScope.newScopedController(gateway: ScriptedGateway): ChatController =
+    ChatController(
+      scope = this,
+      json = json,
+      requestGateway = gateway::request,
+      requestGatewayForGateway = { _, method, paramsJson -> gateway.request(method, paramsJson) },
+      cacheScope = { ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 1) },
+    )
+
   private val userTurn = ReplayHistoryMessage("user", "keep working", 1_000)
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun connectedRefreshCreatesDeviceSessionBeforeLoadingHistory() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":null}""")
+      gateway.respondWith("sessions.create", """{"ok":true,"key":"$sessionKey"}""")
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+
+      controller.load("agent:main:custom")
+      runCurrent()
+      gateway.calls.clear()
+      controller.prepareAndSelectMainSessionKey(sessionKey)
+      controller.onGatewayConnected(MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device"))
+      runCurrent()
+
+      val describeIndex = gateway.calls.indexOfFirst { it.method == "sessions.describe" }
+      val createIndex = gateway.calls.indexOfFirst { it.method == "sessions.create" }
+      val historyIndex = gateway.calls.indexOfFirst { it.method == "chat.history" }
+      assertTrue(describeIndex >= 0)
+      assertTrue(createIndex > describeIndex)
+      assertTrue(historyIndex > createIndex)
+      assertEquals(sessionKey, controller.sessionKey.value)
+      val createParams = json.parseToJsonElement(gateway.calls[createIndex].paramsJson.orEmpty()).jsonObject
+      assertEquals(sessionKey, createParams["key"]?.jsonPrimitive?.content)
+      assertEquals("main", createParams["agentId"]?.jsonPrimitive?.content)
+      assertEquals("OpenClaw App · Pixel · device", createParams["label"]?.jsonPrimitive?.content)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun connectedRefreshContinuesWhenSessionAdoptionFails() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":null}""")
+      gateway.respond("sessions.create") { error("create unavailable") }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device"))
+      runCurrent()
+
+      assertEquals(1, gateway.callCount("sessions.create"))
+      assertEquals(1, gateway.callCount("chat.history"))
+      assertEquals(sessionKey, controller.sessionKey.value)
+      assertNull(controller.errorText.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun connectedRefreshLabelsExistingSessionWithoutRecreatingIt() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":{"key":"$sessionKey"}}""")
+      gateway.respondWith("sessions.patch", """{"ok":true,"key":"$sessionKey"}""")
+      gateway.respondWith("chat.history", historyResponse("existing-session", listOf(userTurn)))
+      val controller = newScopedController(gateway)
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device"))
+      runCurrent()
+
+      assertEquals(0, gateway.callCount("sessions.create"))
+      val patchIndex = gateway.calls.indexOfFirst { it.method == "sessions.patch" }
+      val historyIndex = gateway.calls.indexOfFirst { it.method == "chat.history" }
+      assertTrue(patchIndex >= 0)
+      assertTrue(historyIndex > patchIndex)
+      val patchParams = json.parseToJsonElement(gateway.calls[patchIndex].paramsJson.orEmpty()).jsonObject
+      assertEquals(sessionKey, patchParams["key"]?.jsonPrimitive?.content)
+      assertEquals("OpenClaw App · Pixel · device", patchParams["label"]?.jsonPrimitive?.content)
+      assertEquals(listOf("keep working"), controller.messages.value.map { it.content.first().text })
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun agentSelectionAcknowledgesUnreadDeviceSession() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "sessions.describe",
+        """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}""",
+      )
+      gateway.respondWith("sessions.patch", """{"ok":true,"key":"$sessionKey"}""")
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"patch","sessionKey":"$sessionKey","session":{"key":"$sessionKey","unread":true}}""",
+      )
+
+      controller.prepareAndSelectMainSessionKey(sessionKey)
+      controller.onGatewayConnected(MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device"))
+      runCurrent()
+
+      val patchParams =
+        gateway.calls
+          .first { it.method == "sessions.patch" }
+          .paramsJson
+          .orEmpty()
+      assertTrue(patchParams.contains("\"key\":\"$sessionKey\""))
+      assertTrue(patchParams.contains("\"unread\":false"))
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectRevalidatesWithoutOverwritingExistingLabel() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      var storedLabel: String? = null
+      gateway.respond("sessions.describe") {
+        storedLabel?.let { """{"session":{"key":"$sessionKey","label":"$it"}}""" }
+          ?: """{"session":null}"""
+      }
+      gateway.respond("sessions.create") { paramsJson ->
+        storedLabel =
+          json
+            .parseToJsonElement(paramsJson.orEmpty())
+            .jsonObject["label"]
+            ?.jsonPrimitive
+            ?.content
+        """{"ok":true,"key":"$sessionKey"}"""
+      }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+      val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(binding)
+      runCurrent()
+      controller.onDisconnected("Reconnecting…")
+      controller.onGatewayConnected(binding)
+      runCurrent()
+
+      assertEquals(1, gateway.callCount("sessions.create"))
+      assertEquals(2, gateway.callCount("sessions.describe"))
+      assertEquals(2, gateway.callCount("chat.history"))
+
+      storedLabel = "My Android session"
+      controller.onGatewayConnected(binding.copy(label = "OpenClaw App · Renamed · device"))
+      runCurrent()
+
+      assertEquals(1, gateway.callCount("sessions.create"))
+      assertEquals(3, gateway.callCount("sessions.describe"))
+      assertEquals(3, gateway.callCount("chat.history"))
+      assertEquals("My Android session", storedLabel)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun agentSwitchWaitsForTheLatestSessionAdoption() =
+    runTest {
+      val firstDescribe = CompletableDeferred<String>()
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.describe") { paramsJson ->
+        val key =
+          json
+            .parseToJsonElement(paramsJson.orEmpty())
+            .jsonObject["key"]
+            ?.jsonPrimitive
+            ?.content
+        if (key == "agent:first:node-device") firstDescribe.await() else """{"session":null}"""
+      }
+      gateway.respond("sessions.create") { paramsJson ->
+        val key =
+          json
+            .parseToJsonElement(paramsJson.orEmpty())
+            .jsonObject["key"]
+            ?.jsonPrimitive
+            ?.content
+        """{"ok":true,"key":"$key"}"""
+      }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+
+      controller.prepareAndSelectMainSessionKey("agent:first:node-device")
+      controller.onGatewayConnected(MainSessionBinding("agent:first:node-device", "OpenClaw App · Pixel · device"))
+      runCurrent()
+      controller.prepareAndSelectMainSessionKey("agent:second:node-device")
+      controller.onGatewayConnected(MainSessionBinding("agent:second:node-device", "OpenClaw App · Pixel · device"))
+      controller.refresh()
+      runCurrent()
+
+      assertEquals(0, gateway.callCount("chat.history"))
+      firstDescribe.complete("""{"session":null}""")
+      runCurrent()
+
+      val createIndex = gateway.calls.indexOfLast { it.method == "sessions.create" }
+      val historyCalls = gateway.calls.withIndex().filter { it.value.method == "chat.history" }
+      assertTrue(createIndex >= 0)
+      assertTrue(historyCalls.isNotEmpty())
+      assertTrue(historyCalls.all { it.index > createIndex })
+      assertTrue(historyCalls.all { gateway.sessionKeyOf(it.value.paramsJson) == "agent:second:node-device" })
+      assertEquals("agent:second:node-device", controller.sessionKey.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectRecoveryWaitsForSessionReadiness() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val reconnectDescribe = CompletableDeferred<String>()
+      var reconnecting = false
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.describe") {
+        if (reconnecting) {
+          reconnectDescribe.await()
+        } else {
+          """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}"""
+        }
+      }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+      val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(binding)
+      runCurrent()
+      val historyCallsBeforeReconnect = gateway.callCount("chat.history")
+      controller.onDisconnected("Reconnecting…")
+      reconnecting = true
+      controller.onGatewayConnected(binding)
+      controller.handleGatewayEvent("tick", null)
+      runCurrent()
+
+      assertEquals(historyCallsBeforeReconnect, gateway.callCount("chat.history"))
+      reconnectDescribe.complete(
+        """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}""",
+      )
+      runCurrent()
+      assertTrue(gateway.callCount("chat.history") > historyCallsBeforeReconnect)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectCancelsStaleAdoptionAndRetriesOnTheNewTransport() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val staleDescribe = CompletableDeferred<String>()
+      var describeCalls = 0
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.describe") {
+        describeCalls += 1
+        if (describeCalls == 1) {
+          staleDescribe.await()
+        } else {
+          """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}"""
+        }
+      }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+      val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(binding)
+      runCurrent()
+      assertEquals(1, describeCalls)
+
+      controller.onDisconnected("Reconnecting…")
+      controller.onGatewayConnected(binding)
+      runCurrent()
+
+      assertEquals(2, describeCalls)
+      assertEquals(1, gateway.callCount("chat.history"))
+      assertEquals(sessionKey, controller.sessionKey.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectRecreatesSessionDeletedWhileDisconnected() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      var sessionExists = false
+      gateway.respond("sessions.describe") {
+        if (sessionExists) {
+          """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}"""
+        } else {
+          """{"session":null}"""
+        }
+      }
+      gateway.respond("sessions.create") {
+        sessionExists = true
+        """{"ok":true,"key":"$sessionKey"}"""
+      }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+      val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(binding)
+      runCurrent()
+      sessionExists = false
+      controller.onDisconnected("Reconnecting…")
+      controller.onGatewayConnected(binding)
+      runCurrent()
+
+      assertEquals(2, gateway.callCount("sessions.describe"))
+      assertEquals(2, gateway.callCount("sessions.create"))
+    }
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -227,12 +227,24 @@ class ChatControllerReconnectRestoreTest {
       controller.refresh()
       runCurrent()
 
-      assertEquals(0, gateway.callCount("chat.history"))
+      val createIndexBeforeFirstDescribeCompletes =
+        gateway.calls.indexOfLast { it.method == "sessions.create" }
+      val historyCallsBeforeFirstDescribeCompletes =
+        gateway.calls.withIndex().filter { it.value.method == "chat.history" }
+      assertTrue(createIndexBeforeFirstDescribeCompletes >= 0)
+      assertTrue(historyCallsBeforeFirstDescribeCompletes.isNotEmpty())
+      assertTrue(historyCallsBeforeFirstDescribeCompletes.all { it.index > createIndexBeforeFirstDescribeCompletes })
+      assertTrue(
+        historyCallsBeforeFirstDescribeCompletes.all {
+          gateway.sessionKeyOf(it.value.paramsJson) == "agent:second:node-device"
+        },
+      )
       firstDescribe.complete("""{"session":null}""")
       runCurrent()
 
       val createIndex = gateway.calls.indexOfLast { it.method == "sessions.create" }
       val historyCalls = gateway.calls.withIndex().filter { it.value.method == "chat.history" }
+      assertEquals(1, gateway.callCount("sessions.create"))
       assertTrue(createIndex >= 0)
       assertTrue(historyCalls.isNotEmpty())
       assertTrue(historyCalls.all { it.index > createIndex })


### PR DESCRIPTION
Related: #45854
Supersedes #101927 because GitHub's maintainer-edit shadow ref diverged from the contributor fork branch and stopped accepting fixups/CI updates.

## What Problem This Solves

Android already isolates each device on a stable `agent:<agent>:node-<device>` chat key, but the app did not explicitly create/adopt that session before connected history loaded. A new installation could read history before the app-owned session was ready, while renaming the key would strand existing Android conversations.

## Why This Change Was Made

- keep the shipped `node-<device>` key so upgrades retain existing history and context
- derive a device-unique `OpenClaw App · <device> · <id>` label
- describe and create/adopt the same explicit key before connected history can load
- patch metadata non-destructively when an existing upgrade session lacks a label
- serialize readiness per gateway and make reconnect, agent-switch, refresh, and deleted-session paths wait for the current adoption
- preserve a user-customized existing label and recreate a deleted session on reconnect
- keep unread acknowledgement intact when agent selection prepares the app-owned session
- remove the proposed 257-line manual emulator workflow from the product diff

The Gateway's explicit-key `sessions.create` path preserves an existing session ID/transcript. The final implementation therefore adopts the established key rather than migrating to `openclaw-app-*`.

## User Impact

Android users keep their existing device-specific conversation across upgrades. New and reconnected app sessions are ready before history loads, receive a recognizable device-unique label, and retain correct unread state across agent switches.

## Evidence

- exact-head hosted CI is required for final head `0f4d2c7fa961`; prior-head Android Play/third-party tests, ktlint, native-i18n, and repository lint passed
- focused regressions cover create-before-history ordering, metadata-only labeling, adoption failure fallback, reconnect revalidation, custom-label preservation, deleted-session recreation, agent-switch supersession, stale-transport cancellation/retry, reconnect readiness, and unread acknowledgement
- Gateway `sessions.create` implementation and tests inspected: an existing explicit key keeps its session ID/transcript while applying metadata
- structured autoreview is clean after fixing the existing-unlabeled metadata path and stale-transport reconnect ownership
- the contributor's earlier emulator artifact demonstrated the end-to-end `sessions.create` then `chat.history` integration shape

## Evidence Source Map

- stable upgrade key and device label: `apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt`
- connect and agent-selection ownership: `apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt`
- readiness/adoption boundary: `apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt`
- focused behavior coverage: `apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt`
- original live emulator artifact: https://github.com/snowzlmbot/openclaw/actions/runs/28907001143/artifacts/8154958242

## Risk

Bounded to Android chat connection/session lifecycle. Adoption failures remain non-blocking so older or temporarily unavailable Gateways still load history under the already-bound key. The existing key and transcript are unchanged.

## Rollback

Revert this PR to stop explicit readiness/adoption; the existing `node-*` session and history remain intact.

## Docs Updated

- `apps/android/README.md`
- `apps/android/CHANGELOG.md`

Release note: create/adopt Android's existing per-device chat session before history loads, preserving prior conversations and unread state. Thanks @snowzlmbot.
