### PR TITLE
fix(qa): avoid login shell in cron watcher

### DIFF
--- a/qa/scenarios/scheduling/cron-condition-watcher.yaml
+++ b/qa/scenarios/scheduling/cron-condition-watcher.yaml
@@ -59,7 +59,10 @@ flow:
               wakeMode: now
               payload:
                 kind: command
-                argv: ["sh", "-lc", "printf QA-CONDITION-WATCHER-OK"]
+                argv:
+                  - node
+                  - -e
+                  - "process.stdout.write('QA-CONDITION-WATCHER-OK')"
               delivery:
                 mode: none
             - timeoutMs: 30000


### PR DESCRIPTION
## What Problem This Solves

Resolves a QA failure where the cron condition-watcher scenario captured hosted-runner login-profile stderr instead of the command's exact output.

## Why This Change Was Made

The scenario now uses exact Node argv because it validates scheduler state, natural firing, and once-disarm behavior, not login-shell startup. The shipped `--command <shell>` contract remains unchanged.

## User Impact

No user-visible runtime behavior changes. Maintainers get deterministic cron QA across hosted environments.

## Evidence

- Before: `cron-condition-watcher` failed with 154 `/run/blacksmith/job.env: declare: not found` lines from `sh -lc`.
- After on Testbox `tbx_01kxaj5j5tgy12ky6fc6h18tx4`: `personal-reminder-roundtrip`, `cron-one-minute-ping`, and `cron-condition-watcher` passed 3/3.
- `pnpm test:serial extensions/qa-lab/src/scenario-catalog.test.ts`: 38/38 passed.
- `pnpm check:changed -- qa/scenarios/scheduling/cron-condition-watcher.yaml`: passed after rebasing to current `origin/main`.
- Fresh autoreview: clean.
- Hosted run: https://github.com/openclaw/openclaw/actions/runs/29183587600
