### PR TITLE
feat(cli): draw the pixel lobster mascot beside the wizard banner wordmark

### DIFF
--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
@@ -14,6 +15,7 @@ import {
   moveToTrash,
   normalizeGatewayTokenInput,
   openUrl,
+  printWizardHeader,
   probeGatewayConfiguredModel,
   probeGatewayReachable,
   resolveBrowserOpenCommand,
@@ -29,6 +31,41 @@ import {
 describe("onboard error summaries", () => {
   it("keeps the bounded first line UTF-16 well-formed", () => {
     expect(testing.summarizeError(`${"x".repeat(118)}🚀tail\nignored`)).toBe(`${"x".repeat(118)}…`);
+  });
+});
+
+describe("printWizardHeader", () => {
+  const withColumns = (columns: number | undefined, run: () => void) => {
+    const previous = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+    Object.defineProperty(process.stdout, "columns", { value: columns, configurable: true });
+    try {
+      run();
+    } finally {
+      if (previous) {
+        Object.defineProperty(process.stdout, "columns", previous);
+      } else {
+        delete (process.stdout as { columns?: number }).columns;
+      }
+    }
+  };
+
+  it("prints the mascot beside the wordmark with claws above the text line", () => {
+    const log = vi.fn();
+    withColumns(120, () => printWizardHeader({ log } as unknown as RuntimeEnv));
+    const output = stripAnsi(String(log.mock.calls[0]?.[0]));
+    const rows = output.split("\n");
+    // Claw row stands alone above the wordmark; the eye row shares a line with it.
+    expect(rows[0]).toBe("▄███▄     ▄███▄");
+    expect(rows[2]).toContain("█▀▀▀█ █▀▀▀█ █▀▀▀▀ █▄  █ █▀▀▀▀ █     █▀▀▀█ █   █");
+    expect(rows[3]).toContain("██ █ ██");
+  });
+
+  it("falls back to the plain title on narrow terminals", () => {
+    const log = vi.fn();
+    withColumns(50, () => printWizardHeader({ log } as unknown as RuntimeEnv));
+    const output = String(log.mock.calls[0]?.[0]);
+    expect(output).toContain("OPENCLAW");
+    expect(output).not.toContain("█");
   });
 });
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -11,12 +11,12 @@ import {
   ConnectErrorDetailCodes,
   readConnectErrorDetailCode,
 } from "../../packages/gateway-protocol/src/connect-error-details.js";
-import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import {
   decorativeEmoji,
   supportsDecorativeEmoji,
 } from "../../packages/terminal-core/src/decorative-emoji.js";
 import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.js";
+import { theme } from "../../packages/terminal-core/src/theme.js";
 import { resolveAgentEffectiveModelPrimary, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   DEFAULT_AGENT_WORKSPACE_DIR,
@@ -169,23 +169,46 @@ export function validateGatewayPasswordInput(value: unknown): string | undefined
   return undefined;
 }
 
-/** Prints the onboarding banner. */
+// Wizard banner art, pregenerated from pixel bitmaps (two pixel rows per
+// terminal row via ▀▄█). The mascot rows and wordmark rows are separate so the
+// mascot can take the accent color; the wordmark starts on mascot row 2, which
+// keeps the claws poking above the text line. Keep row alignment when editing.
+const WIZARD_MASCOT_ART = [
+  "▄███▄     ▄███▄",
+  "▀█▄█▀     ▀█▄█▀",
+  "     ▀▄ ▄▀",
+  "    ██ █ ██",
+  "    ▀█████▀",
+  "   ▄█▀ █ ▀█▄",
+] as const;
+const WIZARD_MASCOT_WIDTH = 15;
+const WIZARD_WORDMARK_ROW_OFFSET = 2;
+
+const WIZARD_WORDMARK_ART = [
+  "█▀▀▀█ █▀▀▀█ █▀▀▀▀ █▄  █ █▀▀▀▀ █     █▀▀▀█ █   █",
+  "█   █ █▀▀▀▀ █▀▀▀  █ ▀▄█ █     █     █▀▀▀█ █▄▀▄█",
+  "▀▀▀▀▀ ▀     ▀▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀▀▀ ▀   ▀ ▀   ▀",
+] as const;
+const WIZARD_HEADER_WIDTH = WIZARD_MASCOT_WIDTH + 3 + 47;
+
+/** Prints the onboarding banner: pixel mascot beside the OPENCLAW wordmark. */
 export function printWizardHeader(runtime: RuntimeEnv) {
-  const bannerWidth = 54;
-  const icon = decorativeEmoji("🦞");
-  const title = supportsDecorativeEmoji() && icon ? `${icon} OPENCLAW ${icon}` : "OPENCLAW";
-  const pad = Math.max(0, bannerWidth - visibleWidth(title));
-  const titleLine = `${" ".repeat(Math.floor(pad / 2))}${title}${" ".repeat(Math.ceil(pad / 2))}`;
-  const header = [
-    "▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄",
-    "██░▄▄▄░██░▄▄░██░▄▄▄██░▀██░██░▄▄▀██░████░▄▄▀██░███░██",
-    "██░███░██░▀▀░██░▄▄▄██░█░█░██░█████░████░▀▀░██░█░█░██",
-    "██░▀▀▀░██░█████░▀▀▀██░██▄░██░▀▀▄██░▀▀░█░██░██▄▀▄▀▄██",
-    "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀",
-    titleLine,
-    " ",
-  ].join("\n");
-  runtime.log(header);
+  // Narrow terminals (mobile SSH) would wrap the art mid-glyph; fall back to
+  // the plain title line the way the compact CLI banner handles tight widths.
+  const columns = process.stdout.columns ?? 80;
+  if (columns < WIZARD_HEADER_WIDTH) {
+    const icon = decorativeEmoji("🦞");
+    runtime.log(supportsDecorativeEmoji() && icon ? `${icon} OPENCLAW ${icon}\n` : "OPENCLAW\n");
+    return;
+  }
+  const lines = WIZARD_MASCOT_ART.map((mascotRow, index) => {
+    const wordmarkRow = WIZARD_WORDMARK_ART[index - WIZARD_WORDMARK_ROW_OFFSET];
+    if (!wordmarkRow) {
+      return theme.accent(mascotRow);
+    }
+    return `${theme.accent(mascotRow.padEnd(WIZARD_MASCOT_WIDTH))}   ${wordmarkRow}`;
+  });
+  runtime.log(`${lines.join("\n")}\n`);
 }
 
 /** Records wizard provenance metadata on config writes. */


### PR DESCRIPTION
## What Problem This Solves

The `openclaw doctor` / `openclaw onboard` / `openclaw configure` startup banner was a generic inverted dot-matrix wordmark box with a redundant emoji title line under it. It read as filler and carried none of the product's lobster identity, while the CLI already has a lobster-art tradition (the rare-day banner critter in `src/cli/lobster-art.ts`).

## Why This Change Was Made

Peter asked for startup art that is "uniquely ours" and picked this variant from five rendered candidates (pinch, periscope, mascot, big-claw lockup, Kilroy): the pixel lobster mascot — claws, antennae, eyes, tail fan — sitting beside a clean half-block OPENCLAW wordmark, with the claws poking above the text line. The mascot takes the lobster accent color (`theme.accent`) while the wordmark stays in the terminal's default foreground, so the banner now matches the palette the rest of the CLI uses.

The art is stored as two aligned string arrays (mascot vs wordmark rows) so the color split needs no ANSI splicing, and narrow terminals (below 65 columns, e.g. mobile SSH) fall back to the plain `🦞 OPENCLAW 🦞` title line instead of wrapping mid-glyph — mirroring how the compact CLI banner already handles tight widths.

## User Impact

Everyone running `openclaw doctor`, `openclaw onboard`, or `openclaw configure` in an interactive terminal sees the new mascot banner. Non-interactive/JSON paths are unchanged (the header was already only printed by these wizard flows). No config, flag, or output-contract changes.

## Evidence

Rendered in a real terminal (Ghostty, macOS):

![variant A](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/cli-wizard-mascot-banner/wizard-banner-variant-a.png)

Explored candidates (side-by-side variants; A chosen): https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/cli-wizard-mascot-banner/wizard-banner-variants-explored.png

- New tests: `printWizardHeader` wide path (mascot beside wordmark, claw row above the text line) and narrow-terminal fallback in `src/commands/onboard-helpers.test.ts`.
- Autoreview (codex, gpt-5.6-sol, xhigh): clean, no accepted/actionable findings — "patch is correct (0.96)".
- oxfmt + oxlint clean on both touched files.
- Focused vitest run + full gates via hosted CI/Testbox (Testbox delegated leases flaked mid-hydration twice; hosted CI on this PR is the authoritative run).
