### PR TITLE
fix(generation): cap reference media inputs

### DIFF
--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -1125,6 +1125,7 @@ describe("createMusicGenerateTool", () => {
       config: asConfig({
         agents: {
           defaults: {
+            mediaMaxMb: 7,
             musicGenerationModel: { primary: "minimax/music-2.6", timeoutMs: 180_000 },
           },
         },
@@ -1147,9 +1148,11 @@ describe("createMusicGenerateTool", () => {
     }
     expect(loadCall[0]).toBe("http://198.18.0.153/reference.png");
     const loadOptions = loadCall[1] as {
+      maxBytes?: number;
       requestInit?: { signal?: unknown };
       ssrfPolicy?: unknown;
     };
+    expect(loadOptions.maxBytes).toBe(7 * 1024 * 1024);
     expect(loadOptions.requestInit?.signal).toBeInstanceOf(AbortSignal);
     expect(loadOptions.ssrfPolicy).toEqual({ allowRfc2544BenchmarkRange: true });
     expect(generateMusicOptions().timeoutMs).toBe(180_000);
@@ -1159,6 +1162,42 @@ describe("createMusicGenerateTool", () => {
       timeoutMs: 30_000,
       url: "http://198.18.0.153/reference.png",
     });
+  });
+
+  it("rejects inline reference images over the configured media cap", async () => {
+    vi.spyOn(musicGenerationRuntime, "listRuntimeMusicGenerationProviders").mockReturnValue([
+      {
+        id: "minimax",
+        defaultModel: "music-2.6",
+        models: ["music-2.6"],
+        capabilities: {
+          edit: { enabled: true, maxInputImages: 1 },
+        },
+        generateMusic: vi.fn(async () => {
+          throw new Error("not used");
+        }),
+      },
+    ]);
+    const tool = expectMusicGenerateTool(
+      createMusicGenerateTool({
+        config: asConfig({
+          agents: {
+            defaults: {
+              mediaMaxMb: 1 / (1024 * 1024),
+              musicGenerationModel: { primary: "minimax/music-2.6" },
+            },
+          },
+        }),
+      }),
+    );
+
+    await expect(
+      tool.execute("call-1", {
+        prompt: "night-drive synthwave",
+        image: "data:image/png;base64,AAAA",
+      }),
+    ).rejects.toThrow("Invalid data URL: payload exceeds size limit.");
+    expect(musicGenerationRuntime.generateMusic).not.toHaveBeenCalled();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -9,7 +9,10 @@ import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
+import {
+  resolveConfiguredMediaMaxBytes,
+  resolveGeneratedMediaMaxBytes,
+} from "../../media/configured-max-bytes.js";
 import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
@@ -294,6 +297,7 @@ const defaultScheduleMusicGenerateBackgroundWork = createDefaultMediaGenerateBac
 
 async function loadReferenceImages(params: {
   inputs: string[];
+  maxBytes?: number;
   workspaceDir?: string;
   sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
   ssrfPolicy?: SsrFPolicy;
@@ -357,9 +361,10 @@ async function loadReferenceImages(params: {
       resolvedPath ? [resolvedPath] : undefined,
     );
     const media = isDataUrl
-      ? decodeDataUrl(resolvedInput)
+      ? decodeDataUrl(resolvedInput, { maxBytes: params.maxBytes })
       : params.sandboxConfig
         ? await loadWebMedia(resolvedPath ?? resolvedInput, {
+            maxBytes: params.maxBytes,
             sandboxValidated: true,
             readFile: createSandboxBridgeReadFile({ sandbox: params.sandboxConfig }),
           })
@@ -373,6 +378,7 @@ async function loadReferenceImages(params: {
             });
             try {
               return await loadWebMedia(resolvedPath ?? resolvedInput, {
+                maxBytes: params.maxBytes,
                 localRoots,
                 requestInit: signal ? { signal } : undefined,
                 ssrfPolicy: params.ssrfPolicy,
@@ -710,8 +716,10 @@ export function createMusicGenerateTool(options?: {
         return duplicateGuardResult;
       }
       const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
+      const configuredMediaMaxBytes = resolveConfiguredMediaMaxBytes(effectiveCfg);
       const loadedReferenceImages = await loadReferenceImages({
         inputs: imageInputs,
+        maxBytes: configuredMediaMaxBytes,
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -1584,6 +1584,33 @@ describe("createVideoGenerateTool", () => {
     expect(call.inputImages?.[1]?.role).toBe("last_frame");
   });
 
+  it("rejects inline reference images over the configured media cap", async () => {
+    mockVideoPluginProvider({
+      imageToVideo: { enabled: true, maxInputImages: 1 },
+    });
+    const generateSpy = vi.spyOn(videoGenerationRuntime, "generateVideo");
+    const tool = expectVideoGenerateTool(
+      createVideoGenerateTool({
+        config: asConfig({
+          agents: {
+            defaults: {
+              mediaMaxMb: 1 / (1024 * 1024),
+              videoGenerationModel: { primary: "video-plugin/vid-v1" },
+            },
+          },
+        }),
+      }),
+    );
+
+    await expect(
+      tool.execute("call-1", {
+        prompt: "lobster",
+        image: "data:image/png;base64,AAAA",
+      }),
+    ).rejects.toThrow("Invalid data URL: payload exceeds size limit.");
+    expect(generateSpy).not.toHaveBeenCalled();
+  });
+
   it("passes direct remote reference URLs to the provider without local media loading", async () => {
     mockVideoPluginProvider({
       imageToVideo: { enabled: true, maxInputImages: 1 },
@@ -1622,6 +1649,7 @@ describe("createVideoGenerateTool", () => {
       config: asConfig({
         agents: {
           defaults: {
+            mediaMaxMb: 7,
             videoGenerationModel: { primary: "video-plugin/vid-v1" },
           },
         },
@@ -1639,7 +1667,8 @@ describe("createVideoGenerateTool", () => {
 
     const loadCall = firstMockCall(vi.mocked(webMedia.loadWebMedia));
     expect(loadCall?.[0]).toBe("/tmp/reference.png");
-    const loadOptions = loadCall?.[1] as { ssrfPolicy?: unknown } | undefined;
+    const loadOptions = loadCall?.[1] as { maxBytes?: number; ssrfPolicy?: unknown } | undefined;
+    expect(loadOptions?.maxBytes).toBe(7 * 1024 * 1024);
     expect(loadOptions?.ssrfPolicy).toEqual({ allowRfc2544BenchmarkRange: true });
   });
 

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -8,7 +8,10 @@ import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
+import {
+  resolveConfiguredMediaMaxBytes,
+  resolveGeneratedMediaMaxBytes,
+} from "../../media/configured-max-bytes.js";
 import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
@@ -629,7 +632,7 @@ async function loadReferenceAssets(params: {
     );
     const media = isDataUrl
       ? params.expectedKind === "image"
-        ? decodeDataUrl(resolvedInput)
+        ? decodeDataUrl(resolvedInput, { maxBytes: params.maxBytes })
         : (() => {
             throw new ToolInputError(
               `${params.expectedKind} data: URLs are not supported for video_generate.`,
@@ -1129,9 +1132,11 @@ export function createVideoGenerateTool(options?: {
       if (duplicateGuardResult) {
         return duplicateGuardResult;
       }
+      const configuredMediaMaxBytes = resolveConfiguredMediaMaxBytes(effectiveCfg);
       const loadedReferenceImages = await loadReferenceAssets({
         inputs: imageInputs,
         expectedKind: "image",
+        maxBytes: configuredMediaMaxBytes,
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,
@@ -1147,6 +1152,7 @@ export function createVideoGenerateTool(options?: {
       const loadedReferenceVideos = await loadReferenceAssets({
         inputs: videoInputs,
         expectedKind: "video",
+        maxBytes: configuredMediaMaxBytes,
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,
@@ -1161,6 +1167,7 @@ export function createVideoGenerateTool(options?: {
       const loadedReferenceAudios = await loadReferenceAssets({
         inputs: audioInputs,
         expectedKind: "audio",
+        maxBytes: configuredMediaMaxBytes,
         workspaceDir: options?.workspaceDir,
         sandboxConfig,
         ssrfPolicy: remoteMediaSsrfPolicy,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users calling `video_generate` or `music_generate` with inline or locally loaded reference media could exceed `agents.defaults.mediaMaxMb` before the generation provider was called.

## Why This Change Was Made

The video and music generation tools now reuse the existing configured media byte cap when resolving reference media, matching the bounded reference-image path already used by `image_generate`. This stays inside the built-in generation tool boundary and does not add config, schema, provider, or direct hosted-URL behavior.

## User Impact

Users who lower `agents.defaults.mediaMaxMb` get consistent reference media enforcement across image, video, and music generation tools, with oversized inline reference images rejected before provider execution.

## Evidence

- Claim proved: `music_generate` rejects an oversized inline reference image before provider execution when a music generation provider is configured; focused regression coverage also proves the same configured cap is applied to `video_generate` references and loaded media paths.
- Current-head proof at `3476f66fb27cc26dce0663a54013d3f9f49e73bd`:
  - `node scripts/run-vitest.mjs src/agents/tools/music-generate-tool.test.ts` passed with 1 file and 17 tests, including the inline reference image cap path where `generateMusic` is not called after `Invalid data URL: payload exceeds size limit.`
  - `node scripts/run-vitest.mjs src/agents/tools/video-generate-tool.test.ts` passed with 1 file and 39 tests, including oversized inline reference rejection and configured-cap propagation for video reference media.
  - GitHub exact-head CI for `3476f66fb27cc26dce0663a54013d3f9f49e73bd` passed the previously failing `check-test-types` gate and `openclaw/ci-gate`.
- Targeted format: `node_modules\.bin\oxfmt.CMD --check --threads=1 src\agents\tools\video-generate-tool.ts src\agents\tools\music-generate-tool.ts src\agents\tools\video-generate-tool.test.ts src\agents\tools\music-generate-tool.test.ts` passed.
- Diff hygiene: `git diff --check 4a675228af5758d6205b7d8a058f2a1d42948721^..HEAD` passed.