### PR TITLE
fix(qa): assert goal context from provider input

### DIFF
--- a/qa/scenarios/goals/goal-context-next-turn.yaml
+++ b/qa/scenarios/goals/goal-context-next-turn.yaml
@@ -111,7 +111,6 @@ flow:
               expr: liveTurnTimeoutMs(env, 60000)
           saveAs: secondReply
         - assert:
-            expr: "String(secondTurnRequest.prompt ?? '').includes(config.expectedGoalContext)"
-            message:
-              expr: "`second-turn provider prompt missed active goal context: ${String(secondTurnRequest.prompt ?? '')}`"
+            expr: "String(secondTurnRequest.allInputText ?? '').includes(config.expectedGoalContext)"
+            message: second-turn provider request input missed active goal context
       detailsExpr: "`goal start reply=${goalStartReply.text}; second reply=${secondReply.text}`"

--- a/qa/scenarios/goals/goal-context-survives-compaction.yaml
+++ b/qa/scenarios/goals/goal-context-survives-compaction.yaml
@@ -168,7 +168,6 @@ flow:
               expr: liveTurnTimeoutMs(env, 60000)
           saveAs: postCompactionReply
         - assert:
-            expr: "String(postCompactionRequest.prompt ?? '').includes(config.expectedGoalContext)"
-            message:
-              expr: "`post-compaction provider prompt missed active goal context: ${String(postCompactionRequest.prompt ?? '')}`"
+            expr: "String(postCompactionRequest.allInputText ?? '').includes(config.expectedGoalContext)"
+            message: post-compaction provider request input missed active goal context
       detailsExpr: "`compact=${compactReply.text}; post-compaction=${postCompactionReply.text}`"


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the active-goal QA scenarios inspected only the bare user prompt even though current inbound metadata is delivered to the model through the runtime-context carrier. The scenarios could therefore report that active goal context was missing despite the provider receiving it.

## Why This Change Was Made

The request lookup still uses `prompt` to select the exact user turn, while the goal-context assertion now inspects `allInputText`, the mock provider's complete recorded text input. This matches the current runtime boundary without broadening production behavior.

## User Impact

No runtime behavior changes. Maintainers get reliable regression coverage for active session-goal context on ordinary next turns and after manual compaction.

## Evidence

- `tbx_01kxay4837x5hk2y1bcnzkrpex`: both exact mock-provider scenarios passed (`2/2`).
- `tbx_01kxay4gagz3vsn4rfqqvs9vcc`: `corepack pnpm check:changed`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.
