### PR TITLE
ci(release): update Kova model pin files

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -253,7 +253,6 @@ jobs:
           const files = [
             "support/configure-openclaw-mock-auth.mjs",
             "support/configure-openclaw-live-auth.mjs",
-            "support/mock-openai-server.mjs",
             "states/mock-openai-provider.json"
           ];
           for (const rel of files) {

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -48,7 +48,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 0a6d104f44753edef94462375c8b614e03fa378f
+        default: 4dde6b6022d94058abced883343de7ee8ce69917
         type: string
 
 permissions:
@@ -97,7 +97,7 @@ jobs:
             live: "true"
             include_filters: "scenario:agent-cold-warm-message"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '0a6d104f44753edef94462375c8b614e03fa378f' }}
+      KOVA_REF: ${{ inputs.kova_ref || '4dde6b6022d94058abced883343de7ee8ce69917' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -337,7 +337,7 @@ jobs:
           status=${PIPESTATUS[0]}
           set -e
 
-          report_json="$(find "$REPORT_DIR" -maxdepth 1 -type f -name '*.json' -print | sort | tail -n 1)"
+          report_json="$(find "$REPORT_DIR" -maxdepth 1 -type f -name '*.json' ! -name '*.summary.json' -print | sort | tail -n 1)"
           if [[ -z "$report_json" ]]; then
             echo "Kova did not write a JSON report." >&2
             exit 1

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -117,6 +117,7 @@ describe("OpenClaw performance workflow", () => {
   it("requires the shared Kova report gate before tolerating partial verdicts", () => {
     const runKova = findStep("Run Kova");
 
+    expect(runKova.run).toContain("! -name '*.summary.json'");
     expect(runKova.run).toContain(
       'node "$PERFORMANCE_HELPER_DIR/scripts/lib/kova-report-gate.mjs" "$report_json"',
     );

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -66,6 +66,15 @@ describe("OpenClaw performance workflow", () => {
     expect(installRun).toContain('echo "${OCM_LINUX_X64_SHA256}  ${ocm_archive}" | sha256sum -c -');
   });
 
+  it("rewrites only Kova files that own the performance model pin", () => {
+    const pinModel = findStep("Pin Kova OpenAI model to GPT 5.5").run ?? "";
+
+    expect(pinModel).toContain('"support/configure-openclaw-mock-auth.mjs"');
+    expect(pinModel).toContain('"support/configure-openclaw-live-auth.mjs"');
+    expect(pinModel).toContain('"states/mock-openai-provider.json"');
+    expect(pinModel).not.toContain('"support/mock-openai-server.mjs"');
+  });
+
   it("keeps manual rehearsal reports artifact-only by default", () => {
     const workflow = readWorkflow();
     const detect = findStep("Detect clawgrit report token");

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -40,7 +40,7 @@ function findStep(name: string): WorkflowStep {
 describe("OpenClaw performance workflow", () => {
   it("pins the Kova evaluator that reads truncated agent payloads", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "0a6d104f44753edef94462375c8b614e03fa378f";
+    const kovaRef = "4dde6b6022d94058abced883343de7ee8ce69917";
     const installRun = findStep("Install OCM and Kova").run ?? "";
 
     expect(workflow).toContain(`default: ${kovaRef}`);


### PR DESCRIPTION
## Summary

- Removes a retired Kova support file from the LTS performance workflow's model-rewrite list.
- Adds regression coverage for the exact files that own the performance model pin.
- Restores the Kova mock-provider performance gate after the Kova revision update in #105093.

## Linked context

Related #105093

Requested as part of the July release-train validation cleanup.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: LTS product-performance fails before Kova starts because the workflow reads a file removed from pinned Kova commit `0a6d104f44753edef94462375c8b614e03fa378f`.
- Real environment tested: GitHub Actions failure plus Blacksmith Testbox.
- Exact steps or command run after this patch: focused workflow Vitest and `pnpm check:workflows` through the repository Crabbox wrapper on Testbox `tbx_01kxagrw2f2vhbfz5atjnr1k4h`.
- Evidence after fix: focused test passes 9/9; workflow checker passes zizmor and interpolation checks.
- Observed result after fix: the workflow rewrites the three existing Kova model-owner files and no longer attempts to read `support/mock-openai-server.mjs`.
- What was not tested: hosted product-performance rerun is pending this PR head.
- Proof limitations or environment constraints: Tahoe remains stopped; no macOS proof applies to this workflow-only fix.
- Before evidence: https://github.com/openclaw/openclaw/actions/runs/29184411533/job/86627823583

## Tests and validation

- `pnpm test test/scripts/openclaw-performance-workflow.test.ts` on Testbox: 9 passed.
- `pnpm check:workflows` on Testbox: passed.
- `git diff --check`: passed.
- Fresh autoreview: clean, no actionable findings.

Regression coverage now asserts the exact three current Kova model-pin files and rejects the retired file.

## Risk checklist

- User-visible behavior change: No.
- Config, environment, or migration behavior change: No.
- Security, auth, secrets, network, or tool execution behavior change: No.
- Highest-risk area: omitting a Kova file that also owns the selected model.
- Mitigation: exact pinned-Kova source grep plus a workflow regression test for the model-owner file list.

## Current review state

Next action: run hosted CI, rerun the narrow LTS product-performance workflow, then land if green.

No author action is pending.
