### PR TITLE
fix(moonshot): forward abort signal through Kimi web search provider

### DIFF
--- a/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
@@ -216,6 +216,7 @@ async function runKimiSearch(params: {
   baseUrl: string;
   model: string;
   timeoutSeconds: number;
+  signal?: AbortSignal;
 }): Promise<KimiSearchResult> {
   const endpoint = `${params.baseUrl.trim().replace(/\/$/, "")}/chat/completions`;
   const messages: Array<Record<string, unknown>> = [{ role: "user", content: params.query }];
@@ -227,6 +228,7 @@ async function runKimiSearch(params: {
       {
         url: endpoint,
         timeoutSeconds: params.timeoutSeconds,
+        signal: params.signal,
         init: {
           method: "POST",
           headers: {
@@ -341,6 +343,7 @@ async function runKimiSearch(params: {
 export async function executeKimiWebSearchProviderTool(
   ctx: { config?: OpenClawConfig; searchConfig?: SearchConfigRecord },
   args: Record<string, unknown>,
+  opts?: { signal?: AbortSignal },
 ): Promise<Record<string, unknown>> {
   const searchConfig = mergeScopedSearchConfig(
     ctx.searchConfig,
@@ -392,6 +395,7 @@ export async function executeKimiWebSearchProviderTool(
     baseUrl,
     model,
     timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
+    signal: opts?.signal,
   });
   if (!result.grounded) {
     return {

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -1,30 +1,11 @@
 // Moonshot tests cover kimi web search provider plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
-import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
+import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { testing } from "../test-api.js";
 import { createKimiWebSearchProvider } from "./kimi-web-search-provider.js";
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
-
-function withEnv(overrides: Record<string, string>, run: () => void): void {
-  const previous = new Map<string, string | undefined>();
-  for (const [key, value] of Object.entries(overrides)) {
-    previous.set(key, process.env[key]);
-    process.env[key] = value;
-  }
-  try {
-    run();
-  } finally {
-    for (const [key, value] of previous) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-  }
-}
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -284,6 +265,42 @@ describe("kimi web search provider", () => {
         },
       }),
     ).toBeUndefined();
+  });
+
+  it("forwards the execution abort signal to an in-flight Kimi search", async () => {
+    const fetchMock = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new Error(String(init.signal?.reason ?? "Aborted"))),
+            {
+              once: true,
+            },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await withEnvAsync({ KIMI_API_KEY: "kimi-test-key" }, async () => {
+      const controller = new AbortController();
+      const tool = createKimiWebSearchProvider().createTool({ config: {}, searchConfig: {} });
+      if (!tool) {
+        throw new Error("Expected tool definition");
+      }
+
+      const search = tool.execute(
+        { query: "unique Kimi abort regression" },
+        {
+          signal: controller.signal,
+        },
+      );
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+      controller.abort(new Error("Kimi search cancelled"));
+
+      await expect(search).rejects.toThrow("Kimi search cancelled");
+      expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+    });
   });
 
   it("uses config apiKey when provided", () => {

--- a/extensions/moonshot/src/kimi-web-search-provider.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.ts
@@ -60,9 +60,11 @@ export function createKimiWebSearchProvider(): WebSearchProviderPlugin {
       description:
         "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search.",
       parameters: KimiSearchSchema,
-      execute: async (args) => {
+      execute: async (args, context) => {
         const { executeKimiWebSearchProviderTool } = await loadKimiWebSearchProviderRuntime();
-        return await executeKimiWebSearchProviderTool(ctx, args);
+        return await executeKimiWebSearchProviderTool(ctx, args, {
+          signal: context?.signal,
+        });
       },
     }),
   };


### PR DESCRIPTION
## What Problem This Solves

Cancelling an agent run does not cancel its Kimi (Moonshot) web-search HTTP request. The Kimi provider drops the execution context at its owner boundary, so both an already-aborted run and an in-flight cancellation can still complete a network request after the caller has stopped.

## Why This Change Was Made

Forward the existing optional execution `AbortSignal` through the original Kimi provider owner modules: `createTool.execute(args, context)` -> `executeKimiWebSearchProviderTool` -> `runKimiSearch` -> the existing trusted, SSRF-guarded web-search endpoint. This matches sibling Google and SearXNG providers; no new config, fallback, cache behavior, timeout policy, auth behavior, or SDK surface is introduced.

## User Impact

An already-cancelled Kimi search makes no upstream request. Cancelling a search already in flight promptly rejects the real HTTP request with the caller's original abort reason. Normal and cached search behavior are unchanged.

## Evidence

Maintainer independently ran the identical actual production Kimi provider and SSRF-guarded HTTP path against a real localhost HTTP CONNECT proxy, both on current `main` and this refreshed contributor head:

```json
{"version":"before","mode":"preaborted","callerAborted":true,"upstreamRequests":1,"tunnels":1,"status":"completed","provider":"kimi"}
{"version":"before","mode":"inflight","callerAborted":true,"upstreamRequests":1,"tunnels":2,"status":"completed","provider":"kimi"}
{"version":"after","mode":"preaborted","callerAborted":true,"upstreamRequests":0,"tunnels":0,"status":"rejected","error":"caller-cancelled-before-request"}
{"version":"after","mode":"inflight","callerAborted":true,"upstreamRequests":1,"tunnels":1,"status":"rejected","error":"caller-cancelled-during-request"}
```

Real proxy tunnels, production provider execution, production SSRF guard, and production HTTP dispatcher were used; no mocked gateway, external API credentials, or paid API traffic.

Focused owner + sibling provider regression command:

```sh
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-s02-105125-moonshot node scripts/run-vitest.mjs extensions/moonshot/src/kimi-web-search-provider.test.ts extensions/google/web-search-provider.test.ts extensions/searxng/src/searxng-search-provider.test.ts
```

Result: **60 passing tests across 3 files and 2 Vitest shards**. Targeted existing repository `oxlint` also passes for the colocated regression.

Fresh independent structured review: `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --engine codex --thinking xhigh` — `gpt-5.6-sol`, clean, confidence 0.99.

The refreshed patch intentionally retains only the two original production owner modules and one existing colocated regression test (**+8/-2 production lines, +37/-20 test lines**). The redundant 212-line standalone proof file was removed; the pre-existing unsafe local environment-mutation helper was replaced by the canonical existing SDK `withEnv` helper because the hosted security scanner correctly rejects that old helper when the file changes. Original human contributor and July 12 authored date are preserved.
