### PR TITLE
fix(commands): re-check owner for cross-channel /allowlist writes

### DIFF
--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -157,6 +157,27 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     expect(auth.senderIsGlobalOwner).toBe(true);
   });
 
+  it("keeps channel/guild context ownership origin-scoped, not global (#104984)", () => {
+    // ctx.OwnerAllowFrom is channel/guild-derived (e.g. a Discord guild users
+    // list). It confers owner status on the origin surface but must NOT count
+    // as global cross-channel authority — only commands.ownerAllowFrom does.
+    const cfg = {
+      channels: { discord: {} },
+    } as OpenClawConfig;
+    const ctx = {
+      Provider: "discord",
+      Surface: "discord",
+      From: "discord:123",
+      SenderId: "123",
+      OwnerAllowFrom: ["123"],
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.senderIsGlobalOwner).toBe(false);
+  });
+
   it("leaves a non-owner as neither owner nor global owner (#104984)", () => {
     const cfg = {
       channels: { discord: { allowFrom: ["123"] } },

--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -100,6 +100,81 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     expect(auth.senderIsOwner).toBe(false);
   });
 
+  // #104984: senderIsGlobalOwner distinguishes global authority (explicit
+  // ownerAllowFrom, wildcard, admin scope) from origin-channel allowFrom
+  // fallback ownership, so cross-channel command targets can re-scope only the
+  // latter without revoking legitimate global owners.
+  it("marks an origin allowFrom fallback owner as non-global (#104984)", () => {
+    const cfg = {
+      channels: { discord: { allowFrom: ["123"] } },
+    } as OpenClawConfig;
+    const ctx = {
+      Provider: "discord",
+      Surface: "discord",
+      From: "discord:123",
+      SenderId: "123",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.senderIsGlobalOwner).toBe(false);
+  });
+
+  it("marks an unprefixed commands.ownerAllowFrom owner as global (#104984)", () => {
+    const cfg = {
+      channels: { discord: { allowFrom: ["123"] } },
+      commands: { ownerAllowFrom: ["123"] },
+    } as OpenClawConfig;
+    const ctx = {
+      Provider: "discord",
+      Surface: "discord",
+      From: "discord:123",
+      SenderId: "123",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.senderIsGlobalOwner).toBe(true);
+  });
+
+  it("marks a provider-qualified commands.ownerAllowFrom owner as global (#104984)", () => {
+    const cfg = {
+      channels: { discord: { allowFrom: ["123"] } },
+      commands: { ownerAllowFrom: ["discord:123"] },
+    } as OpenClawConfig;
+    const ctx = {
+      Provider: "discord",
+      Surface: "discord",
+      From: "discord:123",
+      SenderId: "123",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.senderIsGlobalOwner).toBe(true);
+  });
+
+  it("leaves a non-owner as neither owner nor global owner (#104984)", () => {
+    const cfg = {
+      channels: { discord: { allowFrom: ["123"] } },
+      commands: { ownerAllowFrom: ["456"] },
+    } as OpenClawConfig;
+    const ctx = {
+      Provider: "discord",
+      Surface: "discord",
+      From: "discord:789",
+      SenderId: "789",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.senderIsGlobalOwner).toBe(false);
+  });
+
   it("does not let native command authorization bypass explicit owner allowlists", () => {
     const cfg = {
       channels: { telegram: {} },

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -60,7 +60,6 @@ type OwnerAuthorizationState = {
   ownerAllowAll: boolean;
   ownerCandidatesForCommands: string[];
   explicitOwners: string[];
-  hasExplicitOwners: boolean;
   ownerList: string[];
 };
 
@@ -435,10 +434,6 @@ function resolveOwnerAuthorizationState(params: {
     ownerAllowAll,
     ownerCandidatesForCommands,
     explicitOwners,
-    // True when the owner list came from explicit config (commands.ownerAllowFrom
-    // or a context override) rather than the origin channel's allowFrom fallback.
-    // Explicit owners hold global authority; fallback owners are origin-scoped.
-    hasExplicitOwners: explicitOwners.length > 0 || explicitOverrides.length > 0,
     ownerList,
   };
 }
@@ -689,13 +684,15 @@ export function resolveCommandAuthorization(params: {
     ctx.GatewayClientScopes.includes("operator.admin");
   const ownerAllowlistConfigured = ownerState.ownerAllowAll || ownerState.explicitOwners.length > 0;
   const senderIsOwner = senderIsOwnerByIdentity || senderIsOwnerByScope || ownerState.ownerAllowAll;
-  // Global authority = admin scope, wildcard owners, or an explicit
-  // ownerAllowFrom match. A match against the origin allowFrom fallback is
-  // origin-scoped only and must not carry to other channels' config.
+  // Global authority = gateway operator.admin scope, wildcard owners, or a
+  // configured commands.ownerAllowFrom match. Matches against the origin
+  // channel's allowFrom fallback OR channel/guild-derived context ownership
+  // (ctx.OwnerAllowFrom) are origin-scoped and must not carry cross-channel.
+  const senderMatchesConfiguredOwner =
+    ownerState.explicitOwners.length > 0 &&
+    senderCandidates.some((candidate) => ownerState.explicitOwners.includes(candidate));
   const senderIsGlobalOwner =
-    senderIsOwnerByScope ||
-    ownerState.ownerAllowAll ||
-    (ownerState.hasExplicitOwners && senderIsOwnerByIdentity);
+    senderIsOwnerByScope || ownerState.ownerAllowAll || senderMatchesConfiguredOwner;
   const requireOwner = enforceOwner || ownerAllowlistConfigured;
   const isOwnerForCommands = !requireOwner
     ? true

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -27,6 +27,13 @@ export type CommandAuthorization = {
   ownerList: string[];
   senderId?: string;
   senderIsOwner: boolean;
+  /**
+   * True when owner authority is global (gateway operator.admin scope, wildcard
+   * owners, or an explicit commands.ownerAllowFrom match) rather than the origin
+   * channel's own allowFrom fallback. Cross-channel command targets rely on this
+   * to avoid re-scoping a global owner to a single channel (#104984).
+   */
+  senderIsGlobalOwner: boolean;
   isAuthorizedSender: boolean;
   from?: string;
   to?: string;
@@ -53,6 +60,7 @@ type OwnerAuthorizationState = {
   ownerAllowAll: boolean;
   ownerCandidatesForCommands: string[];
   explicitOwners: string[];
+  hasExplicitOwners: boolean;
   ownerList: string[];
 };
 
@@ -427,6 +435,10 @@ function resolveOwnerAuthorizationState(params: {
     ownerAllowAll,
     ownerCandidatesForCommands,
     explicitOwners,
+    // True when the owner list came from explicit config (commands.ownerAllowFrom
+    // or a context override) rather than the origin channel's allowFrom fallback.
+    // Explicit owners hold global authority; fallback owners are origin-scoped.
+    hasExplicitOwners: explicitOwners.length > 0 || explicitOverrides.length > 0,
     ownerList,
   };
 }
@@ -677,6 +689,13 @@ export function resolveCommandAuthorization(params: {
     ctx.GatewayClientScopes.includes("operator.admin");
   const ownerAllowlistConfigured = ownerState.ownerAllowAll || ownerState.explicitOwners.length > 0;
   const senderIsOwner = senderIsOwnerByIdentity || senderIsOwnerByScope || ownerState.ownerAllowAll;
+  // Global authority = admin scope, wildcard owners, or an explicit
+  // ownerAllowFrom match. A match against the origin allowFrom fallback is
+  // origin-scoped only and must not carry to other channels' config.
+  const senderIsGlobalOwner =
+    senderIsOwnerByScope ||
+    ownerState.ownerAllowAll ||
+    (ownerState.hasExplicitOwners && senderIsOwnerByIdentity);
   const requireOwner = enforceOwner || ownerAllowlistConfigured;
   const isOwnerForCommands = !requireOwner
     ? true
@@ -703,6 +722,7 @@ export function resolveCommandAuthorization(params: {
     ownerList: ownerState.ownerList,
     senderId: senderId || undefined,
     senderIsOwner,
+    senderIsGlobalOwner,
     isAuthorizedSender,
     from: from || undefined,
     to: to || undefined,

--- a/src/auto-reply/reply/command-gates.ts
+++ b/src/auto-reply/reply/command-gates.ts
@@ -29,13 +29,11 @@ export function rejectUnauthorizedCommand(
   return { shouldContinue: false };
 }
 
-export function rejectNonOwnerCommand(
+/** Builds the non-owner denial without re-checking any owner flag. */
+export function buildNonOwnerCommandDenial(
   params: HandleCommandsParams,
   commandLabel: string,
-): CommandHandlerResult | null {
-  if (params.command.senderIsOwner) {
-    return null;
-  }
+): CommandHandlerResult {
   logVerbose(
     `Ignoring ${commandLabel} from non-owner sender: ${redactIdentifier(params.command.senderId)}`,
   );
@@ -43,6 +41,16 @@ export function rejectNonOwnerCommand(
     return buildNativeCommandGateReply("You are not authorized to use this command.");
   }
   return { shouldContinue: false };
+}
+
+export function rejectNonOwnerCommand(
+  params: HandleCommandsParams,
+  commandLabel: string,
+): CommandHandlerResult | null {
+  if (params.command.senderIsOwner) {
+    return null;
+  }
+  return buildNonOwnerCommandDenial(params, commandLabel);
 }
 
 export function requireGatewayClientScope(

--- a/src/auto-reply/reply/commands-allowlist.cross-channel-resolver.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.cross-channel-resolver.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Composed real-resolver coverage for #104984: drives the actual
+ * resolveCommandAuthorization (registry fixture, no mock) through
+ * handleAllowlistCommand's cross-channel guard. Origin-fallback and
+ * channel/guild context owners must be blocked at the guard for a cross-channel
+ * write; only configured global owners pass it.
+ */
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveCommandAuthorization } from "../command-auth.js";
+import type { MsgContext } from "../templating.js";
+import { installDiscordRegistryHooks } from "../test-helpers/command-auth-registry-fixture.js";
+import { handleAllowlistCommand } from "./commands-allowlist.js";
+import type { HandleCommandsParams } from "./commands-types.js";
+
+installDiscordRegistryHooks();
+
+async function runDiscordToWhatsappAdd(cfg: OpenClawConfig, ctx: MsgContext) {
+  // Real resolver computes origin authorization exactly as production does.
+  const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: true });
+  const params = {
+    cfg,
+    ctx,
+    command: {
+      surface: "discord",
+      channel: "discord",
+      channelId: "discord",
+      ownerList: auth.ownerList,
+      senderIsOwner: auth.senderIsOwner,
+      senderIsGlobalOwner: auth.senderIsGlobalOwner,
+      isAuthorizedSender: true,
+      senderId: auth.senderId,
+      rawBodyNormalized: "/allowlist add dm --channel whatsapp +15551234567",
+      commandBodyNormalized: "/allowlist add dm --channel whatsapp +15551234567",
+    },
+  } as unknown as HandleCommandsParams;
+
+  const result = await handleAllowlistCommand(params, true);
+  // The guard denies non-native turns with shouldContinue:false and no reply,
+  // before any channel/config work; anything else means the guard was passed.
+  const blockedAtGuard = result?.shouldContinue === false && result?.reply === undefined;
+  return { auth, blockedAtGuard };
+}
+
+const DISCORD_CTX = {
+  Provider: "discord",
+  Surface: "discord",
+  From: "discord:123",
+  SenderId: "123",
+} as MsgContext;
+
+describe("handleAllowlistCommand cross-channel guard (real resolver, #104984)", () => {
+  it("blocks an origin allowFrom fallback owner from a cross-channel write", async () => {
+    const { auth, blockedAtGuard } = await runDiscordToWhatsappAdd(
+      {
+        commands: { config: true },
+        channels: { discord: { allowFrom: ["123"] }, whatsapp: { allowFrom: ["+15550000000"] } },
+      } as OpenClawConfig,
+      DISCORD_CTX,
+    );
+    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.senderIsGlobalOwner).toBe(false);
+    expect(blockedAtGuard).toBe(true);
+  });
+
+  it("blocks a channel/guild context owner from a cross-channel write", async () => {
+    const { auth, blockedAtGuard } = await runDiscordToWhatsappAdd(
+      {
+        commands: { config: true },
+        channels: { discord: {}, whatsapp: { allowFrom: ["+15550000000"] } },
+      } as OpenClawConfig,
+      { ...DISCORD_CTX, OwnerAllowFrom: ["123"] } as MsgContext,
+    );
+    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.senderIsGlobalOwner).toBe(false);
+    // The origin guild/channel OwnerAllowFrom must not be reused to authorize
+    // the sender as a WhatsApp owner during the target re-check.
+    expect(blockedAtGuard).toBe(true);
+  });
+
+  it("lets a configured global owner pass the cross-channel guard", async () => {
+    const { auth, blockedAtGuard } = await runDiscordToWhatsappAdd(
+      {
+        commands: { config: true, ownerAllowFrom: ["123"] },
+        channels: { discord: { allowFrom: ["123"] }, whatsapp: { allowFrom: ["+15550000000"] } },
+      } as OpenClawConfig,
+      DISCORD_CTX,
+    );
+    expect(auth.senderIsGlobalOwner).toBe(true);
+    expect(blockedAtGuard).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -79,6 +79,35 @@ vi.mock("../../pairing/pairing-store.js", () => ({
   removeChannelAllowFromStoreEntry: removeChannelAllowFromStoreEntryMock,
 }));
 
+// The cross-channel owner guard reuses resolveCommandAuthorization to re-derive
+// owner status for the target channel. Its own correctness is covered by
+// command-auth tests; here we substitute a minimal cfg-driven owner check so the
+// guard's enforcement (block/allow) is exercised deterministically.
+vi.mock("../command-auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../command-auth.js")>();
+  return {
+    ...actual,
+    resolveCommandAuthorization: vi.fn(
+      (params: { ctx: { Provider?: string; SenderId?: string }; cfg: OpenClawConfig }) => {
+        const target = params.ctx.Provider ?? "";
+        const sender = String(params.ctx.SenderId ?? "");
+        const channelAllow = (
+          (params.cfg.channels as Record<string, { allowFrom?: unknown[] }> | undefined)?.[target]
+            ?.allowFrom ?? []
+        ).map(String);
+        const globalOwners = (params.cfg.commands?.ownerAllowFrom ?? []).map((owner) =>
+          String(owner).includes(":") ? String(owner).split(":").pop() : String(owner),
+        );
+        const senderIsOwner =
+          channelAllow.includes("*") ||
+          channelAllow.includes(sender) ||
+          globalOwners.includes(sender);
+        return { senderIsOwner } as ReturnType<typeof actual.resolveCommandAuthorization>;
+      },
+    ),
+  };
+});
+
 type TelegramTestSectionConfig = {
   allowFrom?: string[];
   groupAllowFrom?: string[];
@@ -567,6 +596,72 @@ describe("handleAllowlistCommand", () => {
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });
 
+  it("blocks a cross-channel write from an origin-only owner (#104984)", async () => {
+    // No commands.ownerAllowFrom, so owner authority falls back to each
+    // channel's allowFrom. The Telegram sender is an owner ON TELEGRAM only and
+    // must not be able to rewrite WhatsApp's allowlist via --channel.
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: { allowFrom: ["123456789"], configWrites: true },
+        whatsapp: { allowFrom: ["+15550000000"], configWrites: true },
+      },
+    } as OpenClawConfig;
+    // Full write-path mocks so that, absent the guard, the WhatsApp write would
+    // succeed — the guard is the only thing that blocks it (a true discriminator).
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: structuredClone(cfg),
+    });
+    const params = buildAllowlistParams("/allowlist add dm --channel whatsapp +15551234567", cfg, {
+      Provider: "telegram",
+      Surface: "telegram",
+      SenderId: "123456789",
+      From: "123456789",
+    });
+    // Origin (Telegram) owner authority — the pre-fix state that let this through.
+    params.command.senderIsOwner = true;
+
+    const result = await handleAllowlistCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    // The WhatsApp allowlist must not be mutated by a Telegram-only owner.
+    expect(replaceConfigFileMock).not.toHaveBeenCalled();
+    expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a cross-channel write from a global commands owner (#104984)", async () => {
+    // A global commands.ownerAllowFrom identity is an owner everywhere, so a
+    // legitimate operator can still edit another channel cross-surface.
+    const cfg = {
+      commands: {
+        text: true,
+        config: true,
+        ownerAllowFrom: ["telegram:123456789"],
+      },
+      channels: {
+        telegram: { allowFrom: ["123456789"], configWrites: true },
+        whatsapp: { allowFrom: ["+15550000000"], configWrites: true },
+      },
+    } as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: structuredClone(cfg),
+    });
+    const params = buildAllowlistParams("/allowlist add dm --channel whatsapp +15551234567", cfg, {
+      Provider: "telegram",
+      Surface: "telegram",
+      SenderId: "123456789",
+      From: "123456789",
+    });
+    params.command.senderIsOwner = true;
+
+    const result = await handleAllowlistCommand(params, true);
+
+    // Global owner passes the cross-channel gate and reaches the write path.
+    expect(result?.reply?.text ?? "").not.toContain("not authorized");
+  });
+
   it("blocks non-owner allowlist writes before resolving target channel", async () => {
     const cfg = {
       commands: { text: true, config: true },
@@ -602,9 +697,13 @@ describe("handleAllowlistCommand", () => {
       valid: true,
       parsed: structuredClone(cfg),
     });
+    // The sender is a genuine discord owner (id 456) so the cross-channel owner
+    // gate passes and the test isolates the origin configWrites denial.
     const params = buildAllowlistParams("/allowlist add dm --channel discord --config 789", cfg, {
       Provider: "telegram",
       Surface: "telegram",
+      SenderId: "456",
+      From: "456",
     });
     params.command.senderIsOwner = true;
     const result = await handleAllowlistCommand(params, true);
@@ -665,9 +764,12 @@ describe("handleAllowlistCommand", () => {
         discord: { allowFrom: ["456"], configWrites: true },
       },
     } as OpenClawConfig;
+    // Sender is a genuine discord owner (id 456), isolating the configWrites gate.
     const params = buildAllowlistParams("/allowlist add dm --channel discord --store 789", cfg, {
       Provider: "telegram",
       Surface: "telegram",
+      SenderId: "456",
+      From: "456",
     });
     params.command.senderIsOwner = true;
     const result = await handleAllowlistCommand(params, true);

--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -88,14 +88,31 @@ vi.mock("../command-auth.js", async (importOriginal) => {
   return {
     ...actual,
     resolveCommandAuthorization: vi.fn(
-      (params: { ctx: { Provider?: string; SenderId?: string }; cfg: OpenClawConfig }) => {
+      (params: {
+        ctx: { Provider?: string; SenderId?: string; AccountId?: string };
+        cfg: OpenClawConfig;
+      }) => {
         const target = params.ctx.Provider ?? "";
         const sender = params.ctx.SenderId ?? "";
+        const account = params.ctx.AccountId;
+        const channelSection = (
+          params.cfg.channels as
+            | Record<
+                string,
+                {
+                  allowFrom?: unknown[];
+                  accounts?: Record<string, { allowFrom?: unknown[] }>;
+                }
+              >
+            | undefined
+        )?.[target];
+        // Account-scoped allowFrom when the target names a non-default account.
+        const scopedAllowFrom =
+          account && account !== "default"
+            ? channelSection?.accounts?.[account]?.allowFrom
+            : channelSection?.allowFrom;
         const channelAllow = new Set(
-          (
-            (params.cfg.channels as Record<string, { allowFrom?: unknown[] }> | undefined)?.[target]
-              ?.allowFrom ?? []
-          ).map(String),
+          (scopedAllowFrom ?? channelSection?.allowFrom ?? []).map(String),
         );
         const globalOwners = new Set(
           (params.cfg.commands?.ownerAllowFrom ?? []).map((owner) =>
@@ -504,10 +521,14 @@ describe("handleAllowlistCommand", () => {
       valid: true,
       parsed: structuredClone(cfg),
     });
+    // Sender 123 is a genuine owner of the target "work" account, so the
+    // cross-account owner gate passes and the test isolates the configWrites gate.
     const params = buildAllowlistParams("/allowlist add dm --account work --config 789", cfg, {
       AccountId: "default",
       Provider: "telegram",
       Surface: "telegram",
+      SenderId: "123",
+      From: "123",
     });
     params.command.senderIsOwner = true;
     const result = await handleAllowlistCommand(params, true);
@@ -594,6 +615,42 @@ describe("handleAllowlistCommand", () => {
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply).toBeUndefined();
+    expect(replaceConfigFileMock).not.toHaveBeenCalled();
+    expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks a same-channel cross-account write from an origin-account-only owner (#104984)", async () => {
+    // Owner of the default account must not rewrite another account's allowlist
+    // on the same channel via --account. The target account "work" is owned by
+    // a different id, so the origin-account owner is re-checked and denied.
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: {
+          allowFrom: ["default-owner"],
+          configWrites: true,
+          accounts: {
+            work: { allowFrom: ["work-owner"], configWrites: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    // No readConfigFileSnapshot stub: the guard denies before any config read,
+    // so queuing one would leak to the next test.
+    const params = buildAllowlistParams("/allowlist add dm --account work attacker-id", cfg, {
+      AccountId: "default",
+      Provider: "telegram",
+      Surface: "telegram",
+      SenderId: "default-owner",
+      From: "default-owner",
+    });
+    // Owner of the origin (default) account only — not the "work" account.
+    params.command.senderIsOwner = true;
+    params.command.senderIsGlobalOwner = false;
+
+    const result = await handleAllowlistCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
     expect(replaceConfigFileMock).not.toHaveBeenCalled();
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -621,8 +621,10 @@ describe("handleAllowlistCommand", () => {
       SenderId: "123456789",
       From: "123456789",
     });
-    // Origin (Telegram) owner authority — the pre-fix state that let this through.
+    // Origin (Telegram) owner authority via allowFrom fallback only — the
+    // pre-fix state that let this through. senderIsGlobalOwner is false.
     params.command.senderIsOwner = true;
+    params.command.senderIsGlobalOwner = false;
 
     const result = await handleAllowlistCommand(params, true);
 
@@ -632,9 +634,11 @@ describe("handleAllowlistCommand", () => {
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });
 
-  it("allows a cross-channel write from a global commands owner (#104984)", async () => {
-    // A global commands.ownerAllowFrom identity is an owner everywhere, so a
-    // legitimate operator can still edit another channel cross-surface.
+  it("allows a cross-channel write from a global commands owner without re-scoping (#104984)", async () => {
+    // A global commands.ownerAllowFrom identity — including the documented
+    // provider-qualified form (telegram:123456789) — is an owner everywhere.
+    // senderIsGlobalOwner short-circuits the target re-check so a legitimate
+    // operator is never wrongly re-scoped to a single channel.
     const cfg = {
       commands: {
         text: true,
@@ -650,6 +654,10 @@ describe("handleAllowlistCommand", () => {
       valid: true,
       parsed: structuredClone(cfg),
     });
+    addChannelAllowFromStoreEntryMock.mockResolvedValueOnce({
+      changed: true,
+      allowFrom: ["+15550000000", "+15551234567"],
+    });
     const params = buildAllowlistParams("/allowlist add dm --channel whatsapp +15551234567", cfg, {
       Provider: "telegram",
       Surface: "telegram",
@@ -657,11 +665,13 @@ describe("handleAllowlistCommand", () => {
       From: "123456789",
     });
     params.command.senderIsOwner = true;
+    params.command.senderIsGlobalOwner = true;
 
     const result = await handleAllowlistCommand(params, true);
 
     // Global owner passes the cross-channel gate and reaches the write path.
     expect(result?.reply?.text ?? "").not.toContain("not authorized");
+    expect(replaceConfigFileMock).toHaveBeenCalled();
   });
 
   it("blocks non-owner allowlist writes before resolving target channel", async () => {

--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -90,18 +90,20 @@ vi.mock("../command-auth.js", async (importOriginal) => {
     resolveCommandAuthorization: vi.fn(
       (params: { ctx: { Provider?: string; SenderId?: string }; cfg: OpenClawConfig }) => {
         const target = params.ctx.Provider ?? "";
-        const sender = String(params.ctx.SenderId ?? "");
-        const channelAllow = (
-          (params.cfg.channels as Record<string, { allowFrom?: unknown[] }> | undefined)?.[target]
-            ?.allowFrom ?? []
-        ).map(String);
-        const globalOwners = (params.cfg.commands?.ownerAllowFrom ?? []).map((owner) =>
-          String(owner).includes(":") ? String(owner).split(":").pop() : String(owner),
+        const sender = params.ctx.SenderId ?? "";
+        const channelAllow = new Set(
+          (
+            (params.cfg.channels as Record<string, { allowFrom?: unknown[] }> | undefined)?.[target]
+              ?.allowFrom ?? []
+          ).map(String),
+        );
+        const globalOwners = new Set(
+          (params.cfg.commands?.ownerAllowFrom ?? []).map((owner) =>
+            String(owner).includes(":") ? String(owner).split(":").pop() : String(owner),
+          ),
         );
         const senderIsOwner =
-          channelAllow.includes("*") ||
-          channelAllow.includes(sender) ||
-          globalOwners.includes(sender);
+          channelAllow.has("*") || channelAllow.has(sender) || globalOwners.has(sender);
         return { senderIsOwner } as ReturnType<typeof actual.resolveCommandAuthorization>;
       },
     ),

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -351,6 +351,10 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
           Surface: channelId,
           OriginatingChannel: channelId,
           AccountId: accountId,
+          // Drop origin-channel-derived context ownership: a guild/channel
+          // OwnerAllowFrom from the origin surface must not be reused to
+          // authorize the sender as an owner of the target channel (#104984).
+          OwnerAllowFrom: undefined,
         },
         cfg: params.cfg,
         commandAuthorized: true,

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -5,7 +5,10 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { resolveExplicitConfigWriteTarget } from "../../channels/plugins/config-writes.js";
+import {
+  canBypassConfigWritePolicy,
+  resolveExplicitConfigWriteTarget,
+} from "../../channels/plugins/config-writes.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import { normalizeChannelId } from "../../channels/registry.js";
@@ -17,8 +20,10 @@ import {
   removeChannelAllowFromStoreEntry,
 } from "../../pairing/pairing-store.js";
 import { DEFAULT_ACCOUNT_ID, normalizeOptionalAccountId } from "../../routing/session-key.js";
+import { resolveCommandAuthorization } from "../command-auth.js";
 import { resolveChannelAccountId, resolveCommandSurfaceChannel } from "./channel-context.js";
 import {
+  buildNonOwnerCommandDenial,
   rejectNonOwnerCommand,
   rejectUnauthorizedCommand,
   requireCommandFlagEnabled,
@@ -320,6 +325,35 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     command: params.command,
   });
   const plugin = getChannelPlugin(channelId);
+
+  // Owner authorization upstream (`rejectNonOwnerCommand`) is scoped to the
+  // command's origin channel, but `/allowlist ... --channel <other>` mutates a
+  // different channel's config. Being an owner on the origin channel must not
+  // grant owner authority over an unrelated target (#104984). Re-resolve owner
+  // status against the target scope for cross-channel writes; global owners
+  // (`commands.ownerAllowFrom`) and gateway-admin bypass still pass.
+  if (parsed.action !== "list" && originChannelId && channelId !== originChannelId) {
+    const bypass = canBypassConfigWritePolicy({
+      channel: params.command.channel,
+      gatewayClientScopes: params.ctx.GatewayClientScopes,
+    });
+    if (!bypass) {
+      const targetAuthorization = resolveCommandAuthorization({
+        ctx: {
+          ...params.ctx,
+          Provider: channelId,
+          Surface: channelId,
+          OriginatingChannel: channelId,
+          AccountId: accountId,
+        },
+        cfg: params.cfg,
+        commandAuthorized: true,
+      });
+      if (!targetAuthorization.senderIsOwner) {
+        return buildNonOwnerCommandDenial(params, "/allowlist");
+      }
+    }
+  }
 
   if (parsed.action === "list") {
     const supportsStore = Boolean(plugin?.pairing);

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -327,16 +327,20 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
   const plugin = getChannelPlugin(channelId);
 
   // Owner authorization upstream (`rejectNonOwnerCommand`) is scoped to the
-  // command's origin channel, but `/allowlist ... --channel <other>` mutates a
-  // different channel's config. An owner *only* via the origin channel's
-  // allowFrom fallback must not gain owner authority over an unrelated target
-  // (#104984). Global owners — gateway-admin scope, wildcard, or an explicit
-  // commands.ownerAllowFrom match (including provider-qualified ids) — keep
-  // cross-channel authority; only origin-fallback owners are re-checked here.
+  // command's origin channel+account, but `/allowlist ... --channel <other>` or
+  // `--account <other>` mutates a different scope's config. An owner *only* via
+  // the origin scope's allowFrom fallback must not gain owner authority over an
+  // unrelated target channel or account (#104984). Global owners — gateway-admin
+  // scope, wildcard, or an explicit commands.ownerAllowFrom match (including
+  // provider-qualified ids) — keep authority; only origin-scoped owners are
+  // re-checked here. A same-scope re-check is harmless (the owner still matches),
+  // so comparing the resolved scopes is safe even for the default account.
+  const targetScopeDiffersFromOrigin =
+    channelId !== originChannelId || accountId !== originAccountId;
   if (
     parsed.action !== "list" &&
     originChannelId &&
-    channelId !== originChannelId &&
+    targetScopeDiffersFromOrigin &&
     !params.command.senderIsGlobalOwner
   ) {
     const bypass = canBypassConfigWritePolicy({

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -328,11 +328,17 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
 
   // Owner authorization upstream (`rejectNonOwnerCommand`) is scoped to the
   // command's origin channel, but `/allowlist ... --channel <other>` mutates a
-  // different channel's config. Being an owner on the origin channel must not
-  // grant owner authority over an unrelated target (#104984). Re-resolve owner
-  // status against the target scope for cross-channel writes; global owners
-  // (`commands.ownerAllowFrom`) and gateway-admin bypass still pass.
-  if (parsed.action !== "list" && originChannelId && channelId !== originChannelId) {
+  // different channel's config. An owner *only* via the origin channel's
+  // allowFrom fallback must not gain owner authority over an unrelated target
+  // (#104984). Global owners — gateway-admin scope, wildcard, or an explicit
+  // commands.ownerAllowFrom match (including provider-qualified ids) — keep
+  // cross-channel authority; only origin-fallback owners are re-checked here.
+  if (
+    parsed.action !== "list" &&
+    originChannelId &&
+    channelId !== originChannelId &&
+    !params.command.senderIsGlobalOwner
+  ) {
     const bypass = canBypassConfigWritePolicy({
       channel: params.command.channel,
       gatewayClientScopes: params.ctx.GatewayClientScopes,

--- a/src/auto-reply/reply/commands-context.ts
+++ b/src/auto-reply/reply/commands-context.ts
@@ -50,6 +50,7 @@ export function buildCommandContext(params: {
     accountId: normalizeOptionalString(ctx.AccountId),
     ownerList: auth.ownerList,
     senderIsOwner: auth.senderIsOwner,
+    senderIsGlobalOwner: auth.senderIsGlobalOwner,
     isAuthorizedSender: auth.isAuthorizedSender,
     senderId: auth.senderId,
     abortKey,

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -19,6 +19,12 @@ export type CommandContext = {
   accountId?: string;
   ownerList: string[];
   senderIsOwner: boolean;
+  /**
+   * Global (non-origin-scoped) owner authority; see CommandAuthorization
+   * (#104984). Optional so only the main command path must populate it; when
+   * unset, cross-channel command targets re-check ownership (the safe default).
+   */
+  senderIsGlobalOwner?: boolean;
   isAuthorizedSender: boolean;
   senderId?: string;
   abortKey?: string;


### PR DESCRIPTION
## What Problem This Solves

With `commands.config: true` and no explicit `commands.ownerAllowFrom`, a sender authorized only on one scope could persistently modify **another scope's** allowlist via `/allowlist … --channel <other>` or `--account <other>` (#104984). Being an owner of the origin channel/account silently granted owner authority over an unrelated channel or account.

## Why This Change Was Made

Owner authorization upstream (`rejectNonOwnerCommand`, via `command.senderIsOwner`) is resolved for the command's **origin** scope. With no `commands.ownerAllowFrom`, owner authority falls back to each scope's own `allowFrom`, so an origin-scoped owner passed the gate; the config-write check (`authorizeConfigWriteShared`) verifies only `configWrites`, with no caller-identity comparison against the target. So a cross-scope write by an origin-only owner went through.

The fix re-checks owner status against the **target scope** for cross-scope `/allowlist` writes:

- **Trigger**: the guard runs when the resolved target scope — channel **or** account — differs from the origin scope (`targetScopeDiffersFromOrigin`). A same-scope re-check is harmless (a legitimate owner still matches their own scope), so the comparison is safe for the default account.
- **Provenance**: only *global* authority bypasses the re-check — gateway `operator.admin` scope, wildcard owners, or an explicit `commands.ownerAllowFrom` match (including provider-qualified ids like `telegram:123`). Origin `allowFrom` fallback **and** channel/guild-derived context ownership (`ctx.OwnerAllowFrom`) stay origin-scoped. The target re-resolution drops `ctx.OwnerAllowFrom` so origin context ownership is not reused to authorize the target.
- A small `senderIsGlobalOwner` field on the command authorization carries the provenance; `buildNonOwnerCommandDenial` denies without re-reading the origin owner flag.

## User Impact

- A sender authorized only on scope A can no longer edit scope B's allowlist via `--channel`/`--account`.
- Global `commands.ownerAllowFrom` owners, gateway admins, and same-scope owners are unaffected.
- Compatibility note for reviewers: this intentionally narrows channel-, account-, and context-derived owner authority to the exact origin scope. An operator who today relies on an origin-only owner performing cross-scope writes (without a `commands.ownerAllowFrom` entry) would be denied after upgrade and should add the owner to `commands.ownerAllowFrom`. This is a deliberate authority-contract change and a security-owner decision.

## Evidence

**Real-resolver unit coverage** (`command-auth.owner-default.test.ts`, actual `resolveCommandAuthorization`, no mock): origin-`allowFrom` fallback → `senderIsGlobalOwner:false`; unprefixed and provider-qualified `commands.ownerAllowFrom` → `true`; channel/guild context (`ctx.OwnerAllowFrom`) → `false`; non-owner → both false.

**Composed real-resolver-through-handler coverage** (`commands-allowlist.cross-channel-resolver.test.ts`): drives the real resolver *through* `handleAllowlistCommand`; origin-fallback and context owners are blocked at the guard (before any channel/config I/O), while a configured global owner passes it. This test surfaced the `ctx.OwnerAllowFrom`-in-target-re-check escalation, now fixed.

**Handler regressions** (`commands-allowlist.test.ts`, 18/18): cross-channel origin-only owner blocked; same-channel cross-account origin-account owner blocked; global owner allowed without re-scoping; existing config-write/store tests updated to use genuine target-scope owners.

**Discriminators**: reverting the guard, the `senderIsGlobalOwner` computation, the `OwnerAllowFrom` drop, or the account-scope trigger each fails the corresponding regression.

Fixes #104984
