### PR TITLE
test(ui): bound chat hover browser wait

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -572,7 +572,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("reveals message context on timestamp hover and keeps click-to-open", async () => {
+  it("reveals message context on timestamp hover and keeps click-to-open", { timeout: 20_000 }, async () => {
     if (!realChatServer) {
       throw new Error("Expected the Control UI server to be ready");
     }


### PR DESCRIPTION
## Summary

- Gives the timestamp-hover browser regression its own 20-second test budget.
- Keeps every existing hover, layout, and click assertion unchanged.
- Prevents the outer Vitest default from expiring before the test's existing 10-second browser wait.

## Linked context

Requested as part of July beta release validation cleanup.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: the browser test timed out at the default 5 seconds while its inner element wait permits 10 seconds.
- Real environment tested: Blacksmith Testbox Chromium run.
- Exact steps or command run after this patch: focused `pnpm test ui/src/pages/chat/chat-responsive.browser.test.ts` through the repository Crabbox wrapper.
- Evidence after fix: 55/55 tests passed; the affected case passed in 1.529 seconds.
- Observed result after fix: the browser contract remains fully asserted with a bounded outer timeout.
- What was not tested: full beta validation is running separately.
- Proof limitations or environment constraints: Tahoe remains stopped; no macOS proof was run.
- Before evidence: https://github.com/openclaw/openclaw/actions/runs/29184485559/job/86628035477

## Tests and validation

- Focused Testbox Chromium suite: 55/55 passed.
- `git diff --check`: passed.
- Fresh autoreview: clean, no actionable findings.

## Risk checklist

- User-visible behavior change: No.
- Config, environment, or migration behavior change: No.
- Security, auth, secrets, network, or tool execution behavior change: No.
- Highest-risk area: accidentally masking a deterministic UI regression.
- Mitigation: assertions and inner waits are unchanged; only the contradictory outer budget is raised and remains bounded.

## Current review state

Next action: hosted CI, then land into `release/2026.7.1` if green.

No author action is pending.
