### PR TITLE
fix(gateway): suspension waits for accepted node work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway suspension node events:** retain accepted node agent dispatches, voice session writes, and delivery receipts as tracked root work so suspension cannot acknowledge and then drop or snapshot those detached continuations.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway suspension node events:** retain accepted node agent dispatches, voice session writes, and delivery receipts as tracked root work so suspension cannot acknowledge and then drop or snapshot those detached continuations.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -1,8 +1,19 @@
 // Gateway node event tests protect how node clients surface inbound commands,
 // delivery metadata, pairing state, and outbound payload lifecycle events.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  prepareGatewaySuspend,
+  resetGatewaySuspendCoordinatorForTest,
+  resumeGatewaySuspend,
+} from "../infra/gateway-suspend-coordinator.js";
+import {
+  getActiveGatewayRootWorkCount,
+  resetGatewayWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import type { loadSessionEntry as loadSessionEntryType } from "./session-utils.js";
@@ -121,6 +132,7 @@ const runtimeMocks = vi.hoisted(() => ({
     },
   ),
   resolveOutboundTarget: vi.fn(({ to }: { to: string }) => ({ ok: true, to })),
+  sendDurableMessageBatch: vi.fn(async () => ({ status: "sent" })),
   resolveSessionAgentId: vi.fn(() => "main"),
   resolveSessionModelRef: vi.fn(
     (_cfg: OpenClawConfig, entry?: { model?: string; modelProvider?: string }) => ({
@@ -163,6 +175,62 @@ const canonicalizeSessionEntryAliasesMock = runtimeMocks.canonicalizeSessionEntr
 const loadSessionEntryMock = runtimeMocks.loadSessionEntry;
 const registerApnsRegistrationVi = runtimeMocks.registerApnsRegistration;
 const normalizeChannelIdVi = runtimeMocks.normalizeChannelId;
+const sendDurableMessageBatchMock = runtimeMocks.sendDurableMessageBatch;
+
+beforeEach(() => {
+  resetGatewaySuspendCoordinatorForTest();
+  resetGatewayWorkAdmission();
+});
+
+afterEach(() => {
+  resetGatewaySuspendCoordinatorForTest();
+  resetGatewayWorkAdmission();
+});
+
+async function runAdmittedNodeEvent(
+  ctx: NodeEventContext,
+  nodeId: string,
+  event: Parameters<typeof handleNodeEvent>[2],
+): Promise<void> {
+  const admission = tryBeginGatewayRootWorkAdmission();
+  expect(admission).not.toBeNull();
+  try {
+    await admission?.run(async () => {
+      await handleNodeEvent(ctx, nodeId, event);
+    });
+  } finally {
+    admission?.release();
+  }
+}
+
+function expectSuspendBusyWithRootWork(requestId: string): void {
+  expect(
+    prepareGatewaySuspend({
+      requestId,
+      pauseScheduling: vi.fn(),
+      resumeScheduling: vi.fn(),
+    }),
+  ).toMatchObject({
+    status: "busy",
+    blockers: expect.arrayContaining([expect.objectContaining({ kind: "root-request", count: 1 })]),
+  });
+}
+
+function expectSuspendReady(requestId: string): void {
+  const result = prepareGatewaySuspend({
+    requestId,
+    pauseScheduling: vi.fn(),
+    resumeScheduling: vi.fn(),
+  });
+  expect(result).toMatchObject({ status: "ready", activeCount: 0, blockers: [] });
+  if (result.status === "ready") {
+    expect(resumeGatewaySuspend(result.suspensionId)).toMatchObject({
+      ok: true,
+      status: "running",
+      resumed: true,
+    });
+  }
+}
 
 const execEventHeartbeatOptions = (sessionKey?: string) => ({
   source: "exec-event",
@@ -973,8 +1041,27 @@ describe("voice transcript events", () => {
     await Promise.resolve();
 
     expect(agentCommandMock).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledTimes(1));
     expect(String(mockCallArg(warn))).toContain("voice session-store update failed");
+  });
+
+  it("keeps an accepted detached session-store touch visible to suspension", async () => {
+    const touch = createDeferred();
+    canonicalizeSessionEntryAliasesMock.mockImplementationOnce(() => touch.promise);
+
+    await runAdmittedNodeEvent(buildCtx(), "node-v-suspend", {
+      event: "voice.transcript",
+      payloadJSON: JSON.stringify({
+        text: "persist before suspension",
+        sessionKey: "voice-suspend-session",
+      }),
+    });
+
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(1));
+    expectSuspendBusyWithRootWork("voice-touch-busy");
+    touch.resolve();
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    expectSuspendReady("voice-touch-ready");
   });
 
   it("preserves existing session metadata when touching the store for voice transcripts", async () => {
@@ -1272,6 +1359,8 @@ describe("agent request events", () => {
     loadSessionEntryMock.mockClear();
     normalizeChannelIdVi.mockClear();
     normalizeChannelIdVi.mockImplementation((channel?: string | null) => channel ?? null);
+    sendDurableMessageBatchMock.mockReset();
+    sendDurableMessageBatchMock.mockResolvedValue({ status: "sent" });
     parseMessageWithAttachmentsMock.mockResolvedValue({
       message: "parsed message",
       images: [],
@@ -1319,6 +1408,48 @@ describe("agent request events", () => {
     expect(canonicalizeSessionEntryAliasesMock).toHaveBeenCalledTimes(1);
     expect(agentCommandMock).toHaveBeenCalledTimes(1);
     expectFields(mockCallArg(agentCommandMock), { sessionKey });
+  });
+
+  it("keeps an accepted detached agent dispatch visible to suspension", async () => {
+    const dispatch = createDeferred<never>();
+    agentCommandMock.mockImplementationOnce(() => dispatch.promise);
+
+    await runAdmittedNodeEvent(buildCtx(), "node-agent-suspend", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        message: "finish before suspension",
+        sessionKey: "agent:main:suspend-agent",
+      }),
+    });
+
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(1));
+    expectSuspendBusyWithRootWork("agent-dispatch-busy");
+    dispatch.resolve(undefined as never);
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    expectSuspendReady("agent-dispatch-ready");
+  });
+
+  it("keeps an accepted detached receipt delivery visible to suspension", async () => {
+    const receipt = createDeferred<{ status: "sent" }>();
+    sendDurableMessageBatchMock.mockImplementationOnce(() => receipt.promise);
+
+    await runAdmittedNodeEvent(buildCtx(), "node-receipt-suspend", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        message: "acknowledge before suspension",
+        sessionKey: "agent:main:suspend-receipt",
+        deliver: true,
+        receipt: true,
+        channel: "telegram",
+        to: "123",
+      }),
+    });
+
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(1));
+    expectSuspendBusyWithRootWork("receipt-delivery-busy");
+    receipt.resolve({ status: "sent" });
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    expectSuspendReady("receipt-delivery-ready");
   });
 
   it.each([

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -15,6 +15,7 @@ import {
   scopedHeartbeatWakeOptionsForPolicy,
 } from "../infra/event-session-routing.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
+import { runWithGatewayIndependentRootWorkContinuation } from "../process/gateway-work-admission.js";
 import { resolveAgentHarnessSessionContextError } from "../sessions/agent-harness-session-key.js";
 import {
   NODE_PRESENCE_ALIVE_EVENT,
@@ -80,7 +81,11 @@ function dispatchNodeAgentCommand(
   nodeId: string,
   input: NodeAgentCommandInput,
 ): void {
-  void agentCommandFromIngress(input, defaultRuntime, ctx.deps).catch((err: unknown) => {
+  // The node RPC can finish before the agent starts its own session admission.
+  // Reserve a root now so suspension cannot acknowledge and then strand the turn.
+  void runWithGatewayIndependentRootWorkContinuation(() =>
+    agentCommandFromIngress(input, defaultRuntime, ctx.deps),
+  ).catch((err: unknown) => {
     ctx.logGateway.warn(`agent failed node=${nodeId}: ${formatForLog(err)}`);
   });
 }
@@ -300,14 +305,18 @@ function queueSessionStoreTouch(params: {
   sessionId: string;
   now: number;
 }) {
-  void touchSessionStore({
-    storePath: params.storePath,
-    canonicalKey: params.canonicalKey,
-    storeKeys: params.storeKeys,
-    entry: params.entry,
-    sessionId: params.sessionId,
-    now: params.now,
-  }).catch((err: unknown) => {
+  // Voice dispatch intentionally does not wait for persistence, but a host
+  // snapshot must not race the accepted write after its node RPC returns.
+  void runWithGatewayIndependentRootWorkContinuation(() =>
+    touchSessionStore({
+      storePath: params.storePath,
+      canonicalKey: params.canonicalKey,
+      storeKeys: params.storeKeys,
+      entry: params.entry,
+      sessionId: params.sessionId,
+      now: params.now,
+    }),
+  ).catch((err: unknown) => {
     params.ctx.logGateway.warn("voice session-store update failed: " + formatForLog(err));
   });
 }
@@ -591,14 +600,18 @@ export const handleNodeEvent = async (
       }
 
       if (wantsReceipt && deliveryChannel && deliveryTo) {
-        void sendReceiptAck({
-          cfg,
-          deps: ctx.deps,
-          sessionKey: canonicalKey,
-          channel: deliveryChannel,
-          to: deliveryTo,
-          text: receiptText,
-        }).catch((err: unknown) => {
+        // Delivery stays detached from agent startup, but remains part of the
+        // accepted node request until the durable send settles.
+        void runWithGatewayIndependentRootWorkContinuation(() =>
+          sendReceiptAck({
+            cfg,
+            deps: ctx.deps,
+            sessionKey: canonicalKey,
+            channel: deliveryChannel,
+            to: deliveryTo,
+            text: receiptText,
+          }),
+        ).catch((err: unknown) => {
           ctx.logGateway.warn(`agent receipt failed node=${nodeId}: ${formatForLog(err)}`);
         });
       } else if (wantsReceipt) {


### PR DESCRIPTION
Related: #103618

AI-assisted: reviewed, implemented, stress-tested, and live-verified with Codex.

## What Problem This Solves

Fixes an issue where operators suspending a gateway after an accepted node event could receive a ready response while detached agent dispatch, voice-session persistence, or receipt delivery was still running. A host snapshot or shutdown in that window could drop acknowledged work or capture stale state.

## Why This Change Was Made

Node-event continuations now use the gateway's existing independent root-work contract. They remain non-blocking for the node RPC, but suspension stays busy until each accepted continuation settles. No protocol, config, or compatibility surface changes.

## User Impact

Gateway suspension now waits for accepted node-originated agent turns, voice-session writes, and delivery receipts. Operators can suspend only at a consistent idle boundary instead of racing these detached continuations.

## Evidence

- Focused Testbox run: `src/gateway/server-node-events.test.ts`, 110/110 passing.
- Broad suspension matrix: 489 tests passing across gateway, protocol, infra, cron, process, and agent paths.
- Changed-file gate: clean on Blacksmith Testbox `tbx_01kxambz0pjj01gjs8ek5vb7vr`, including formatting, lint, core typechecks, database-first guard, import-cycle guard, and Plugin SDK baseline.
- Docker lifecycle: `pnpm test:docker:gateway-network` passing, including same-container stop/start and post-restart verification.
- Live AWS Crabbox `run_978f285a8c62`: real `openai/gpt-5.6-luna` agent turn with an 8-second tool call returned `busy`; idle prepare returned `ready`; health/readiness/admin admission behaved correctly; the gateway survived a 5-second `SIGSTOP`/`SIGCONT`; resume recovered readiness; a second same-session OpenAI turn recalled a run-unique phrase.
- Source-blind behavior contract: `satisfies_contract`, no findings or blockers.
- Fresh local autoreview: no accepted or actionable findings; patch rated correct at 0.90 confidence.
