### PR TITLE
fix(cron): recover trigger params when tool calls are flattened

### DIFF
--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -52,6 +52,7 @@ const CRON_RECOVERABLE_OBJECT_KEYS: ReadonlySet<string> = new Set([
   "agentId",
   "sessionKey",
   "failureAlert",
+  "trigger",
   "namePayload",
   "scheduleKind",
   "sessionTargetName",

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -119,6 +119,28 @@ describe("cron tool flat-params", () => {
     });
   });
 
+  it("recovers flat trigger params for add", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-flat-trigger-add", {
+      action: "add",
+      name: "triggered report",
+      everyMs: 60_000,
+      message: "send report",
+      trigger: { script: " json({ fire: true }) ", once: true },
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<{
+      schedule?: unknown;
+      payload?: unknown;
+      trigger?: unknown;
+    }>();
+    expect(method).toBe("cron.add");
+    expect(params.schedule).toEqual({ kind: "every", everyMs: 60_000 });
+    expect(params.payload).toEqual({ kind: "agentTurn", message: "send report" });
+    expect(params.trigger).toEqual({ script: "json({ fire: true })", once: true });
+  });
+
   it("rejects flat on-exit schedule shorthand for add", async () => {
     const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
 
@@ -244,6 +266,24 @@ describe("cron tool flat-params", () => {
     });
   });
 
+  it("recovers flat trigger params for update", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-flat-trigger-update", {
+      action: "update",
+      jobId: "job-trigger",
+      trigger: { script: " json({ fire: false }) " },
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<{
+      id?: string;
+      patch?: { trigger?: unknown };
+    }>();
+    expect(method).toBe("cron.update");
+    expect(params.id).toBe("job-trigger");
+    expect(params.patch?.trigger).toEqual({ script: "json({ fire: false })" });
+  });
+
   it("trims trailing whitespace from recognized job object keys (#95407)", async () => {
     const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
 
@@ -255,6 +295,7 @@ describe("cron tool flat-params", () => {
         "schedule ": { kind: "cron", expr: "30 10,20 * * *", tz: "Europe/Madrid" },
         "sessionTarget ": "isolated",
         "payload ": { kind: "agentTurn", message: "How's it going?" },
+        "trigger ": { script: "json({ fire: true })" },
         "enabled ": true,
       },
     });
@@ -264,6 +305,7 @@ describe("cron tool flat-params", () => {
       schedule?: unknown;
       sessionTarget?: string;
       payload?: unknown;
+      trigger?: unknown;
       enabled?: boolean;
     }>();
     expect(method).toBe("cron.add");
@@ -271,10 +313,12 @@ describe("cron tool flat-params", () => {
     expect(params.schedule).toBeDefined();
     expect(params.sessionTarget).toBe("isolated");
     expect(params.payload).toBeDefined();
+    expect(params.trigger).toEqual({ script: "json({ fire: true })" });
     expect(params.enabled).toBe(true);
     expect(params).not.toHaveProperty("schedule ");
     expect(params).not.toHaveProperty("sessionTarget ");
     expect(params).not.toHaveProperty("payload ");
+    expect(params).not.toHaveProperty("trigger ");
     expect(params).not.toHaveProperty("enabled ");
   });
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users asking the cron tool to create or update event-triggered jobs could lose the `trigger` object when a provider or model emitted the cron job fields as flattened tool-call arguments instead of nesting them under `job` or `patch`.

## Why This Change Was Made

The cron tool already exposes `trigger` in its model-facing job and patch schemas, and the gateway/cron normalizer already owns trigger validation. This change adds that existing schema field to the cron tool's recoverable object-key set so the current flat-params and padded-key recovery path treats `trigger` like the sibling cron job fields without adding new config, provider behavior, or cron trigger policy.

## User Impact

Event-triggered cron authoring through the model-facing cron tool keeps the trigger script and `once` setting when tool-call arguments are flattened or have recoverable key padding, so valid trigger jobs reach the gateway with the intended trigger payload.

## Evidence

- Claim proved: cron `add` and `update` recover flattened `trigger` objects, normalize trigger scripts through the existing cron normalizer, and trim recoverable padded `trigger ` job-object keys before gateway dispatch.
- Current-head proof at `3e054dfc0ed93250c8aeb6e28a399c6b25f0d978`: `node scripts/run-vitest.mjs src/agents/tools/cron-tool.flat-params.test.ts` passed with 1 file and 17 tests.
- Targeted format: `node_modules\.bin\oxfmt.CMD --check --threads=1 src\agents\tools\cron-tool-canonicalize.ts src\agents\tools\cron-tool.flat-params.test.ts` passed.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main --engine codex --codex-bin C:\Users\86158\.codex\codex-pixel-autoreview.cmd` passed with no accepted/actionable findings.
- Duplicate search: open self PRs had no cron flat-trigger overlap; live open PR and issue searches for `cron trigger flat params` returned no overlapping results.
- Observed result: flattened cron add calls now dispatch `trigger: { script: "json({ fire: true })", once: true }`, flattened cron update calls now dispatch `patch.trigger`, and recoverable padded `trigger ` keys are canonicalized before the mocked gateway call.