### PR TITLE
fix(gateway): keep terminal scrollback tails UTF-16 safe

### DIFF
--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -317,6 +317,22 @@ describe("TerminalSessionManager output ring", () => {
     expect(manager.snapshot(outcome.sessionId)).toBe("456789AB");
   });
 
+  it("drops a leading unpaired surrogate when an oversized chunk bisects an emoji", async () => {
+    const fake = makeFakePty();
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => fake,
+      scrollbackChars: 8,
+    });
+    const outcome = await manager.open(baseRequest());
+    if (!outcome.ok) {
+      throw new Error("expected open");
+    }
+    // 7 A's + 🤖 (2 units) + 7 B's = 16; raw slice(-8) starts on 🤖's low half.
+    fake.emitData(`${"A".repeat(7)}🤖${"B".repeat(7)}`);
+    expect(manager.snapshot(outcome.sessionId)).toBe("BBBBBBB");
+  });
+
   it("returns undefined for unknown sessions", () => {
     const manager = new TerminalSessionManager({ emit: vi.fn() });
     expect(manager.snapshot("nope")).toBeUndefined();

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -1,6 +1,7 @@
 // Owns the lifecycle of operator terminal sessions: one PTY per open, bound to
 // the connection that opened it, streamed back over the gateway event channel.
 import { randomUUID } from "node:crypto";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { spawnTerminalPty, type TerminalPtyHandle } from "./pty.js";
 
 /** Emits one terminal event frame to the single owning connection. */
@@ -73,8 +74,11 @@ class TerminalOutputRing {
 
   push(chunk: string): void {
     if (chunk.length >= this.cap) {
-      this.chunks = [chunk.slice(chunk.length - this.cap)];
-      this.total = this.cap;
+      // Cap is UTF-16 code units; raw slice() can start on a low surrogate when a
+      // single oversized PTY write places an emoji across the retained-tail edge.
+      const kept = sliceUtf16Safe(chunk, -this.cap);
+      this.chunks = [kept];
+      this.total = kept.length;
       return;
     }
     this.chunks.push(chunk);

--- a/src/gateway/terminal/session-manager.utf16-scrollback.test.ts
+++ b/src/gateway/terminal/session-manager.utf16-scrollback.test.ts
@@ -1,0 +1,128 @@
+// Caller-path proof: an oversized real node-pty write that bisects an emoji at
+// the scrollback cap must stay well-formed through TerminalSessionManager →
+// snapshot/attach replay → terminal.text.
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { terminalHandlers } from "../server-methods/terminal.js";
+import { buildTerminalEnv, resolveTerminalLaunch } from "./launch.js";
+import { TerminalSessionManager } from "./session-manager.js";
+
+const SCROLLBACK_CHARS = 8;
+const EMOJI = "🤖";
+const EXPECTED_TAIL = "B".repeat(SCROLLBACK_CHARS - 1);
+
+/** Payload engineered so raw `.slice(-cap)` starts on 🤖's low surrogate. */
+function buildOversizedEmojiBoundaryChunk(cap: number): string {
+  return `${"A".repeat(cap - 1)}${EMOJI}${"B".repeat(cap - 1)}`;
+}
+
+function hasUnpairedSurrogate(text: string): boolean {
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = text.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("terminal scrollback UTF-16 safety", () => {
+  it.skipIf(process.platform === "win32")(
+    "keeps an oversized real node-pty write on a valid UTF-16 boundary through snapshot and terminal.text",
+    async () => {
+      const chunk = buildOversizedEmojiBoundaryChunk(SCROLLBACK_CHARS);
+      expect(chunk.length).toBe(SCROLLBACK_CHARS * 2);
+      const rawTail = chunk.slice(chunk.length - SCROLLBACK_CHARS);
+      expect(hasUnpairedSurrogate(rawTail)).toBe(true);
+      expect(rawTail.charCodeAt(0)).toBe(0xdd16);
+
+      const emit = vi.fn();
+      const manager = new TerminalSessionManager({
+        emit,
+        // Production default: real @lydell/node-pty via spawnTerminalPty.
+        scrollbackChars: SCROLLBACK_CHARS,
+        // Keep the session alive across disconnect so attach can replay the ring.
+        detachGraceMs: 60_000,
+      });
+
+      // Spawn Node itself under a real PTY so one stdout.write is the oversized
+      // chunk (same boundary class as Control UI scrollback), then stay alive
+      // long enough for snapshot / terminal.text / reattach.
+      const outcome = await manager.open({
+        connId: "conn-1",
+        agentId: "main",
+        cwd: process.cwd(),
+        shell: process.execPath,
+        args: [
+          "-e",
+          `process.stdout.write(${JSON.stringify(chunk)}); setTimeout(() => {}, 30_000)`,
+        ],
+        cols: 80,
+        rows: 24,
+        env: buildTerminalEnv(process.env),
+      });
+      expect(outcome.ok).toBe(true);
+      if (!outcome.ok) {
+        return;
+      }
+
+      try {
+        await vi.waitFor(
+          () => {
+            expect(manager.snapshot(outcome.sessionId)).toBe(EXPECTED_TAIL);
+          },
+          { timeout: 5_000 },
+        );
+
+        const snapshot = manager.snapshot(outcome.sessionId);
+        expect(snapshot).toBeDefined();
+        expect(hasUnpairedSurrogate(snapshot ?? "")).toBe(false);
+        expect(snapshot?.startsWith(EMOJI)).toBe(false);
+        // Confirm data crossed a real PTY onData → emit path (not a fake handle).
+        expect(emit.mock.calls.some((call) => call[1] === "terminal.data")).toBe(true);
+
+        const respond = vi.fn();
+        const runtimeConfig = { gateway: { terminal: { enabled: true } } } as OpenClawConfig;
+        const context = {
+          getRuntimeConfig: () => runtimeConfig,
+          resolveTerminalLaunchPolicy: (agentId?: string) =>
+            resolveTerminalLaunch({
+              config: runtimeConfig,
+              enabled: true,
+              agentId,
+              configuredShell: undefined,
+            }),
+          isTerminalEnabled: () => true,
+          terminalSessions: manager,
+          logGateway: { info: vi.fn() },
+        } as unknown as Parameters<(typeof terminalHandlers)["terminal.text"]>[0]["context"];
+        await terminalHandlers["terminal.text"]({
+          params: { sessionId: outcome.sessionId },
+          respond,
+          context,
+          client: { connId: "conn-1", connect: {} },
+        } as unknown as Parameters<(typeof terminalHandlers)["terminal.text"]>[0]);
+
+        expect(respond).toHaveBeenCalledWith(true, { text: snapshot });
+        const respondedText = respond.mock.calls[0]?.[1]?.text as string;
+        expect(hasUnpairedSurrogate(respondedText)).toBe(false);
+
+        manager.handleDisconnect("conn-1");
+        const attached = manager.attach("conn-2", outcome.sessionId);
+        expect(attached?.buffer).toBe(snapshot);
+        expect(hasUnpairedSurrogate(attached?.buffer ?? "")).toBe(false);
+      } finally {
+        manager.close("conn-2", outcome.sessionId);
+        manager.close("conn-1", outcome.sessionId);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Gateway terminal scrollback (`TerminalOutputRing`) keeps a UTF-16 code-unit capped buffer for attach replay and `terminal.text`. When a single PTY write is at least as large as the configured scrollback cap, the ring retained the tail with raw `chunk.slice(chunk.length - cap)`. If an emoji or other non-BMP character sits across that cut, the snapshot/replay/text payload can start with a lone low surrogate (often rendered as U+FFFD).

This is the same class of bug as worker SSH tunnel stderr tails (`#104621`) and worker bootstrap UTF-16 truncation (`#104619`), on the Control UI / Gateway terminal path.

## Why This Change Was Made

Reuse `sliceUtf16Safe` from `@openclaw/normalization-core/utf16-slice` for the oversized-chunk retention path only. Multi-chunk eviction still drops whole PTY write chunks and is unchanged. Cap semantics stay “UTF-16 code units”; after a safe slice the stored `total` matches the kept string length so the ring cannot overshoot when the leading surrogate is dropped.

## User Impact

**Before:** An oversized PTY write that placed an emoji across the scrollback edge could corrupt the leading character of attach replay / `terminal.text`.

**After:** The same write drops the incomplete surrogate at the edge, so reattach and text fetch stay well-formed.

## Evidence

- Changed: `src/gateway/terminal/session-manager.ts` (`TerminalOutputRing.push` oversized path)
- Unit: `src/gateway/terminal/session-manager.test.ts` → `drops a leading unpaired surrogate when an oversized chunk bisects an emoji`
- Real PTY caller path: `src/gateway/terminal/session-manager.utf16-scrollback.test.ts` → production `spawnTerminalPty` (`@lydell/node-pty`) → manager ring → `terminal.text` → attach replay
- Exact tested head: `67da87669148da5766b97cbe1727a94ce8a04e2f`

Engineered payload (`scrollbackChars: 8`): `"A".repeat(7) + "🤖" + "B".repeat(7)`. Raw `.slice(-8)` starts on 🤖's low surrogate (`0xDD16`); safe retention keeps `"BBBBBBB"`.

### Unit + real node-pty proof

```bash
node scripts/run-vitest.mjs src/gateway/terminal/session-manager.utf16-scrollback.test.ts src/gateway/terminal/session-manager.test.ts --reporter=verbose
```

```text
 ✓ |gateway-core| ... > keeps an oversized real node-pty write on a valid UTF-16 boundary through snapshot and terminal.text 98ms
 ✓ |gateway-methods| ... > drops a leading unpaired surrogate when an oversized chunk bisects an emoji 0ms
 Test Files  8 passed (8)
      Tests  96 passed (96)
[test] passed 1 Vitest shard in 5.12s
```

## Real behavior proof

- **Behavior or issue addressed:** Gateway terminal scrollback / `terminal.text` / attach replay no longer split UTF-16 surrogate pairs when a single oversized PTY write places an emoji across the retained-tail edge.
- **Canonical reachability path:** Control UI / gateway terminal → `TerminalSessionManager.open` → production `spawnTerminalPty` (`@lydell/node-pty`) → PTY `onData` → `TerminalOutputRing.push` → `snapshot` / `terminalHandlers["terminal.text"]` / `attach` replay buffer.
- **Boundary crossed:** Real node-pty process stdout → session ring → operator-facing `terminal.text` and reattach replay.
- **Shared helper / provider constraint check:** Uses existing `sliceUtf16Safe` from `@openclaw/normalization-core/utf16-slice` (same helper family as worker tunnel stderr tails and bootstrap failure truncation). Whole-chunk eviction and cap-as-UTF-16-code-units semantics are unchanged.
- **Real environment tested:** Local macOS Node source checkout; production `TerminalSessionManager` with default `spawnTerminalPty` spawning `process.execPath` under a real PTY that writes one oversized emoji-boundary payload and stays alive for snapshot/text/reattach.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs src/gateway/terminal/session-manager.utf16-scrollback.test.ts src/gateway/terminal/session-manager.test.ts --reporter=verbose
# plus standalone tsx proof invoking TerminalSessionManager + real spawnTerminalPty
```

- **Evidence after fix:**

```text
standalone-proof: TerminalSessionManager real node-pty UTF-16 scrollback
{
  "behavior": "terminal scrollback oversized PTY tail",
  "pty": "real @lydell/node-pty via spawnTerminalPty",
  "payloadLength": 16,
  "rawTailLength": 8,
  "rawStartsWithLoneLow": true,
  "rawFirstCodeUnit": "dd16",
  "snapshot": "BBBBBBB",
  "snapshotEqualsExpected": true,
  "snapshotStartsWithLone": false,
  "terminalText": "BBBBBBB",
  "terminalTextOk": true,
  "attachReplay": "BBBBBBB",
  "attachOk": true,
  "sawTerminalData": true
}
standalone-proof: done

 ✓ ... > keeps an oversized real node-pty write on a valid UTF-16 boundary through snapshot and terminal.text
 ✓ ... > drops a leading unpaired surrogate when an oversized chunk bisects an emoji
 Test Files  8 passed (8)
      Tests  96 passed (96)
```

- **Observed result after fix:** For an oversized PTY write of 7×`A` + 🤖 + 7×`B`, raw `.slice(-8)` still starts on a lone low surrogate (`dd16`), while snapshot / `terminal.text` / attach replay are exactly `"BBBBBBB"` — no emoji, no U+FFFD, no unpaired surrogate. Real `terminal.data` events were observed from node-pty.
- **What was not tested:** Live Control UI browser recording; Windows (test skipped on win32; no Windows-specific behavior change in the helper path).
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
