### PR TITLE
feat(telegram): add rich outbound location and video notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Telegram rich outbound:** send round video notes and native location or venue cards through the existing message send action, with portable location validation and no new Telegram-only action names. (#97556) Thanks @paulislava.
-
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)
 - **Meta provider:** add bundled `muse-spark-1.1` model support with Responses API streaming, tool calls, encrypted reasoning replay, onboarding, and standalone npm/ClawHub distribution. (#102873) Thanks @HamidShojanazeri.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Telegram rich outbound:** send round video notes and native location or venue cards through the existing message send action, with portable location validation and no new Telegram-only action names. (#97556) Thanks @paulislava.
+
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.
 - **OpenAI GPT-5.6 defaults:** use `openai/gpt-5.6` (Sol alias) for fresh API-key setup and exact `openai/gpt-5.6-sol` for fresh Codex/OAuth setup, while preserving existing primaries, fallbacks, aliases, and explicit GPT-5.5 selections. (#103234)
 - **Meta provider:** add bundled `muse-spark-1.1` model support with Responses API streaming, tool calls, encrypted reasoning replay, onboarding, and standalone npm/ClawHub distribution. (#102873) Thanks @HamidShojanazeri.

--- a/docs/channels/location.md
+++ b/docs/channels/location.md
@@ -1,5 +1,5 @@
 ---
-summary: "Inbound channel location parsing (Telegram, WhatsApp, Matrix, LINE) and context fields"
+summary: "Channel location parsing and portable outbound location payloads"
 read_when:
   - Adding or modifying channel location parsing
   - Using location context fields in agent prompts or tools
@@ -62,6 +62,12 @@ When a location is present, these fields are added to `ctx`:
 When the channel does not set an explicit source, OpenClaw infers it: live shares become `live`, locations with a name or address become `place`, everything else is `pin`.
 
 The prompt renderer treats `LocationName`, `LocationAddress`, and `LocationCaption` as untrusted metadata and serializes them through the same bounded JSON path used for other channel context.
+
+## Outbound payloads
+
+The message tool and Plugin SDK use the same `NormalizedLocation` shape for portable outbound locations. A coordinate-only payload represents a pin. Channels with native venue support may map `name` plus `address` to a venue card.
+
+Telegram currently exposes this through `message(action="send")`. Its first implementation is deliberately standalone: location payloads cannot be mixed with text or media, and incomplete venue pairs fail instead of silently dropping a name or address. Unsupported channels do not advertise the location parameter.
 
 ## Channel notes
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -614,6 +614,25 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 }
 ```
 
+    ### Locations and venues
+
+    Use the existing `send` action with one standalone `location` object. Coordinates send a native pin; adding both `name` and `address` sends a native venue card. Location sends cannot be combined with message text or media.
+
+```json5
+{
+  action: "send",
+  channel: "telegram",
+  to: "123456789",
+  location: {
+    latitude: 48.858844,
+    longitude: 2.294351,
+    accuracy: 12,
+    name: "Eiffel Tower",
+    address: "Champ de Mars, Paris",
+  },
+}
+```
+
     ### Stickers
 
     Inbound: static WEBP is downloaded and processed (placeholder `<media:sticker>`); animated TGS and video WEBM are skipped.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -530,6 +530,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Text formatting
   - H2: Context fields
+  - H2: Outbound payloads
   - H2: Channel notes
   - H2: Related
 

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -33,6 +33,14 @@ const sendDurableMessageBatch = vi.fn(
       mediaUrl?: string;
       mediaUrls?: string[];
       audioAsVoice?: boolean;
+      videoAsNote?: boolean;
+      location?: {
+        latitude: number;
+        longitude: number;
+        accuracy?: number;
+        name?: string;
+        address?: string;
+      };
       delivery?: {
         pin?: true | { enabled?: boolean; notify?: boolean; required?: boolean };
       };
@@ -85,6 +93,7 @@ const sendDurableMessageBatch = vi.fn(
         params.threadId == null ? undefined : Number.parseInt(String(params.threadId), 10),
       quoteText: telegramData?.quoteText,
       asVoice: payload.audioAsVoice,
+      asVideoNote: payload.videoAsNote,
       silent: params.silent,
       forceDocument: params.forceDocument,
       mediaLocalRoots: params.mediaAccess?.localRoots,
@@ -1398,6 +1407,76 @@ describe("handleTelegramAction", () => {
         telegramConfig(),
       ),
     ).rejects.toThrow(/content required/i);
+  });
+
+  it("maps video notes through the existing durable send action", async () => {
+    await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "123456",
+        mediaUrl: "https://example.com/note.mp4",
+        asVideoNote: true,
+      },
+      telegramConfig(),
+    );
+
+    const durableCall = mockCall(sendDurableMessageBatch, 0, "durable video note");
+    expect(requireRecord(durableCall[0], "durable video note params")).toMatchObject({
+      payloads: [
+        {
+          text: "",
+          mediaUrls: ["https://example.com/note.mp4"],
+          videoAsNote: true,
+        },
+      ],
+    });
+    const sendCall = mockCall(sendMessageTelegram, 0, "video note");
+    expect(requireRecord(sendCall[2], "video note options").asVideoNote).toBe(true);
+  });
+
+  it("accepts a standalone normalized location", async () => {
+    await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "123456",
+        location: {
+          latitude: 48.858844,
+          longitude: 2.294351,
+          name: "  Eiffel Tower ",
+          address: " Champ de Mars ",
+        },
+      },
+      telegramConfig(),
+    );
+
+    const durableCall = mockCall(sendDurableMessageBatch, 0, "durable location");
+    expect(requireRecord(durableCall[0], "durable location params")).toMatchObject({
+      payloads: [
+        {
+          text: "",
+          location: {
+            latitude: 48.858844,
+            longitude: 2.294351,
+            name: "Eiffel Tower",
+            address: "Champ de Mars",
+          },
+        },
+      ],
+    });
+  });
+
+  it("rejects location sends mixed with text or media", async () => {
+    await expect(
+      handleTelegramAction(
+        {
+          action: "sendMessage",
+          to: "123456",
+          content: "caption",
+          location: { latitude: 1, longitude: 2 },
+        },
+        telegramConfig(),
+      ),
+    ).rejects.toThrow(/cannot be combined/i);
   });
 
   it("renders presentation text when message content is omitted", async () => {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -11,6 +11,7 @@ import {
   resolvePollMaxSelections,
   resolveReactionMessageId,
 } from "openclaw/plugin-sdk/channel-actions";
+import { normalizeOutboundLocation } from "openclaw/plugin-sdk/channel-inbound";
 import {
   buildOutboundSessionContext,
   sendDurableMessageBatch,
@@ -36,7 +37,6 @@ import {
   resolveTelegramTargetChatType,
 } from "./inline-buttons.js";
 import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
-import { normalizeTelegramOutboundLocation } from "./normalize.js";
 import { resolveTelegramPollVisibility } from "./poll-visibility.js";
 import { resolveTelegramReactionLevel } from "./reaction-level.js";
 import {
@@ -457,7 +457,7 @@ export async function handleTelegramAction(
     const to = normalizeTelegramOutboundTarget(readStringParam(params, "to", { required: true }));
     const mediaUrls = readTelegramSendMediaUrls(params);
     const firstMediaUrl = mediaUrls[0];
-    const location = normalizeTelegramOutboundLocation(params.location);
+    const location = normalizeOutboundLocation(params.location);
     const presentation = normalizeMessagePresentation(params.presentation);
     const buttons = resolveTelegramButtonsFromParams(params, presentation);
     const content = readTelegramSendContent({

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -36,6 +36,7 @@ import {
   resolveTelegramTargetChatType,
 } from "./inline-buttons.js";
 import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
+import { normalizeTelegramOutboundLocation } from "./normalize.js";
 import { resolveTelegramPollVisibility } from "./poll-visibility.js";
 import { resolveTelegramReactionLevel } from "./reaction-level.js";
 import {
@@ -221,6 +222,7 @@ function readTelegramSendContent(params: {
   args: Record<string, unknown>;
   mediaUrl?: string;
   hasButtons: boolean;
+  hasLocation?: boolean;
   interactive?: unknown;
   presentation?: MessagePresentation;
 }) {
@@ -255,7 +257,7 @@ function readTelegramSendContent(params: {
       content = fallback;
     }
   }
-  if (content == null && !params.mediaUrl && !params.hasButtons) {
+  if (content == null && !params.mediaUrl && !params.hasButtons && !params.hasLocation) {
     throw new Error("content required.");
   }
   return content ?? "";
@@ -290,6 +292,8 @@ function buildTelegramActionSendPayload(params: {
   content: string;
   mediaUrls: string[];
   asVoice?: boolean;
+  asVideoNote?: boolean;
+  location?: ReplyPayload["location"];
   pin?: ReturnType<typeof normalizeTelegramDeliveryPin>;
   buttons?: ReturnType<typeof resolveTelegramButtonsFromParams>;
   quoteText?: string;
@@ -305,6 +309,8 @@ function buildTelegramActionSendPayload(params: {
     text: params.content,
     ...(params.mediaUrls.length > 0 ? { mediaUrls: params.mediaUrls } : {}),
     ...(params.asVoice === true ? { audioAsVoice: true } : {}),
+    ...(params.asVideoNote === true ? { videoAsNote: true } : {}),
+    ...(params.location ? { location: params.location } : {}),
     ...(params.pin ? { delivery: { pin: params.pin } } : {}),
     ...(telegramData ? { channelData: { telegram: telegramData } } : {}),
   };
@@ -451,15 +457,24 @@ export async function handleTelegramAction(
     const to = normalizeTelegramOutboundTarget(readStringParam(params, "to", { required: true }));
     const mediaUrls = readTelegramSendMediaUrls(params);
     const firstMediaUrl = mediaUrls[0];
+    const location = normalizeTelegramOutboundLocation(params.location);
     const presentation = normalizeMessagePresentation(params.presentation);
     const buttons = resolveTelegramButtonsFromParams(params, presentation);
     const content = readTelegramSendContent({
       args: params,
       mediaUrl: firstMediaUrl,
       hasButtons: Array.isArray(buttons) && buttons.length > 0,
+      hasLocation: Boolean(location),
       interactive: params.interactive,
       presentation,
     });
+    const asVideoNote = readBooleanParam(params, "asVideoNote") ?? false;
+    if (location && (content.trim() || mediaUrls.length > 0 || asVideoNote)) {
+      throw new Error("Telegram location sends cannot be combined with message text or media.");
+    }
+    if (asVideoNote && mediaUrls.length !== 1) {
+      throw new Error("Telegram video notes require exactly one media attachment.");
+    }
     if (buttons) {
       const inlineButtonsScope = resolveTelegramInlineButtonsScope({
         cfg,
@@ -505,6 +520,7 @@ export async function handleTelegramAction(
       messageThreadId: messageThreadId ?? undefined,
       quoteText: quoteText ?? undefined,
       asVoice: readBooleanParam(params, "asVoice"),
+      asVideoNote,
       silent: readBooleanParam(params, "silent"),
       forceDocument:
         readBooleanParam(params, "forceDocument") ??
@@ -515,6 +531,8 @@ export async function handleTelegramAction(
       content,
       mediaUrls,
       asVoice: sendOptions.asVoice,
+      asVideoNote: sendOptions.asVideoNote,
+      location,
       pin: normalizeTelegramDeliveryPin(params),
       buttons,
       quoteText,

--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -58,6 +58,22 @@ describe("telegram actions contract", () => {
     expect(capabilities).toContain("inlineButtons");
   });
 
+  it("advertises rich send parameters without adding Telegram-only actions", () => {
+    const discovery = telegramPlugin.actions?.describeMessageTool?.({
+      cfg: {
+        channels: { telegram: { botToken: "test-token-placeholder" } },
+      } as OpenClawConfig,
+    });
+    const schema = discovery?.schema;
+    const contributions = Array.isArray(schema) ? schema : schema ? [schema] : [];
+    const properties = Object.assign({}, ...contributions.map((entry) => entry.properties));
+
+    expect(discovery?.actions).not.toContain("sendVideoNote");
+    expect(discovery?.actions).not.toContain("sendLocation");
+    expect(properties).toHaveProperty("asVideoNote");
+    expect(properties).toHaveProperty("location");
+  });
+
   it("does not advertise inline buttons for non-empty legacy Telegram capabilities without inlineButtons", () => {
     const capabilities = telegramPlugin.agentPrompt?.messageToolCapabilities?.({
       cfg: {
@@ -214,5 +230,35 @@ describe("telegram actions contract", () => {
       presentation,
       channelData: { telegram: { quoteText: "snake case quote" } },
     });
+  });
+
+  it("routes video-note and location hints through durable core delivery", async () => {
+    const prepareSendPayload = telegramPlugin.actions?.prepareSendPayload;
+    const location = { latitude: 48.858844, longitude: 2.294351 };
+
+    await expect(
+      prepareSendPayload?.({
+        ctx: {
+          channel: "telegram",
+          action: "send",
+          cfg: {} as OpenClawConfig,
+          params: { asVideoNote: true },
+        },
+        to: "123456",
+        payload: { mediaUrl: "file:///tmp/note.mp4", videoAsNote: true },
+      }),
+    ).resolves.toEqual({ mediaUrl: "file:///tmp/note.mp4", videoAsNote: true });
+    await expect(
+      prepareSendPayload?.({
+        ctx: {
+          channel: "telegram",
+          action: "send",
+          cfg: {} as OpenClawConfig,
+          params: { location },
+        },
+        to: "123456",
+        payload: { location },
+      }),
+    ).resolves.toEqual({ location });
   });
 });

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -22,7 +22,10 @@ import {
   resolveTelegramPollActionGateState,
 } from "./accounts.js";
 import { isTelegramInlineButtonsEnabled } from "./inline-buttons.js";
-import { createTelegramPollExtraToolSchemas } from "./message-tool-schema.js";
+import {
+  createTelegramPollExtraToolSchemas,
+  createTelegramRichSendExtraToolSchemas,
+} from "./message-tool-schema.js";
 
 const loadTelegramActionRuntime = createLazyRuntimeModule(() => import("./action-runtime.js"));
 
@@ -72,7 +75,10 @@ function prepareTelegramSendPayload({
   ctx,
   payload,
 }: Parameters<NonNullable<ChannelMessageActionAdapter["prepareSendPayload"]>>[0]) {
-  if (ctx.action !== "send" || !payload.presentation) {
+  if (
+    ctx.action !== "send" ||
+    (!payload.presentation && !payload.location && payload.videoAsNote !== true)
+  ) {
     return null;
   }
   const quoteText = readStringParam(ctx.params, "quoteText");
@@ -191,6 +197,12 @@ function describeTelegramMessageTool({
   if (discovery.pollEnabled) {
     schema.push({
       properties: createTelegramPollExtraToolSchemas(),
+      visibility: "all-configured",
+    });
+  }
+  if (discovery.isEnabled("sendMessage")) {
+    schema.push({
+      properties: createTelegramRichSendExtraToolSchemas(),
       visibility: "all-configured",
     });
   }

--- a/extensions/telegram/src/message-tool-schema.ts
+++ b/extensions/telegram/src/message-tool-schema.ts
@@ -9,3 +9,40 @@ export function createTelegramPollExtraToolSchemas() {
     pollPublic: Type.Optional(Type.Boolean()),
   };
 }
+
+/** Schema additions for Telegram-native rich sends through the existing send action. */
+export function createTelegramRichSendExtraToolSchemas() {
+  return {
+    asVideoNote: Type.Optional(
+      Type.Boolean({
+        description:
+          "Send one video attachment as a round Telegram video note. Captions are delivered separately.",
+      }),
+    ),
+    location: Type.Optional(
+      Type.Object(
+        {
+          latitude: Type.Number({ minimum: -90, maximum: 90 }),
+          longitude: Type.Number({ minimum: -180, maximum: 180 }),
+          accuracy: Type.Optional(
+            Type.Number({
+              description: "Pin uncertainty radius in meters.",
+              minimum: 0,
+              maximum: 1500,
+            }),
+          ),
+          name: Type.Optional(
+            Type.String({ description: "Venue name; requires address.", minLength: 1 }),
+          ),
+          address: Type.Optional(
+            Type.String({ description: "Venue address; requires name.", minLength: 1 }),
+          ),
+        },
+        {
+          description:
+            "Standalone Telegram location. Coordinates send a pin; name plus address sends a venue. Do not combine with message or media.",
+        },
+      ),
+    ),
+  };
+}

--- a/extensions/telegram/src/normalize.ts
+++ b/extensions/telegram/src/normalize.ts
@@ -1,5 +1,4 @@
 // Telegram helper module supports normalize behavior.
-import type { NormalizedLocation } from "openclaw/plugin-sdk/channel-inbound";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeTelegramLookupTarget, parseTelegramTarget } from "./targets.js";
 
@@ -44,64 +43,4 @@ export function normalizeTelegramMessagingTarget(raw: string): string | undefine
 
 export function looksLikeTelegramTargetId(raw: string): boolean {
   return normalizeTelegramTargetBody(raw) !== undefined;
-}
-
-function readOptionalLocationText(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-export function normalizeTelegramOutboundLocation(value: unknown): NormalizedLocation | undefined {
-  if (value == null) {
-    return undefined;
-  }
-  if (typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("location must be an object.");
-  }
-  const raw = value as Record<string, unknown>;
-  const latitude = raw.latitude;
-  const longitude = raw.longitude;
-  if (
-    typeof latitude !== "number" ||
-    !Number.isFinite(latitude) ||
-    latitude < -90 ||
-    latitude > 90
-  ) {
-    throw new Error("location.latitude must be a finite number between -90 and 90.");
-  }
-  if (
-    typeof longitude !== "number" ||
-    !Number.isFinite(longitude) ||
-    longitude < -180 ||
-    longitude > 180
-  ) {
-    throw new Error("location.longitude must be a finite number between -180 and 180.");
-  }
-  const accuracy = raw.accuracy;
-  if (
-    accuracy !== undefined &&
-    (typeof accuracy !== "number" || !Number.isFinite(accuracy) || accuracy < 0 || accuracy > 1500)
-  ) {
-    throw new Error("location.accuracy must be a finite number between 0 and 1500.");
-  }
-  const source = raw.source;
-  if (source !== undefined && source !== "pin" && source !== "place" && source !== "live") {
-    throw new Error("location.source must be pin, place, or live.");
-  }
-  const isLive = raw.isLive;
-  if (isLive !== undefined && typeof isLive !== "boolean") {
-    throw new Error("location.isLive must be a boolean.");
-  }
-  const name = readOptionalLocationText(raw.name);
-  const address = readOptionalLocationText(raw.address);
-  const caption = readOptionalLocationText(raw.caption);
-  return {
-    latitude,
-    longitude,
-    ...(accuracy !== undefined ? { accuracy } : {}),
-    ...(name ? { name } : {}),
-    ...(address ? { address } : {}),
-    ...(isLive !== undefined ? { isLive } : {}),
-    ...(source !== undefined ? { source } : {}),
-    ...(caption ? { caption } : {}),
-  };
 }

--- a/extensions/telegram/src/normalize.ts
+++ b/extensions/telegram/src/normalize.ts
@@ -1,4 +1,5 @@
 // Telegram helper module supports normalize behavior.
+import type { NormalizedLocation } from "openclaw/plugin-sdk/channel-inbound";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeTelegramLookupTarget, parseTelegramTarget } from "./targets.js";
 
@@ -43,4 +44,64 @@ export function normalizeTelegramMessagingTarget(raw: string): string | undefine
 
 export function looksLikeTelegramTargetId(raw: string): boolean {
   return normalizeTelegramTargetBody(raw) !== undefined;
+}
+
+function readOptionalLocationText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function normalizeTelegramOutboundLocation(value: unknown): NormalizedLocation | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("location must be an object.");
+  }
+  const raw = value as Record<string, unknown>;
+  const latitude = raw.latitude;
+  const longitude = raw.longitude;
+  if (
+    typeof latitude !== "number" ||
+    !Number.isFinite(latitude) ||
+    latitude < -90 ||
+    latitude > 90
+  ) {
+    throw new Error("location.latitude must be a finite number between -90 and 90.");
+  }
+  if (
+    typeof longitude !== "number" ||
+    !Number.isFinite(longitude) ||
+    longitude < -180 ||
+    longitude > 180
+  ) {
+    throw new Error("location.longitude must be a finite number between -180 and 180.");
+  }
+  const accuracy = raw.accuracy;
+  if (
+    accuracy !== undefined &&
+    (typeof accuracy !== "number" || !Number.isFinite(accuracy) || accuracy < 0 || accuracy > 1500)
+  ) {
+    throw new Error("location.accuracy must be a finite number between 0 and 1500.");
+  }
+  const source = raw.source;
+  if (source !== undefined && source !== "pin" && source !== "place" && source !== "live") {
+    throw new Error("location.source must be pin, place, or live.");
+  }
+  const isLive = raw.isLive;
+  if (isLive !== undefined && typeof isLive !== "boolean") {
+    throw new Error("location.isLive must be a boolean.");
+  }
+  const name = readOptionalLocationText(raw.name);
+  const address = readOptionalLocationText(raw.address);
+  const caption = readOptionalLocationText(raw.caption);
+  return {
+    latitude,
+    longitude,
+    ...(accuracy !== undefined ? { accuracy } : {}),
+    ...(name ? { name } : {}),
+    ...(address ? { address } : {}),
+    ...(isLive !== undefined ? { isLive } : {}),
+    ...(source !== undefined ? { source } : {}),
+    ...(caption ? { caption } : {}),
+  };
 }

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -832,14 +832,24 @@ describe("telegramOutbound", () => {
       cfg: {} as never,
       to: "12345",
       text: "",
-      payload: { location },
+      payload: {
+        location,
+        channelData: { telegram: { quoteText: "quoted location" } },
+      },
       accountId: "ops",
+      replyToId: "41",
     });
 
     expect(sendLocationTelegramMock).toHaveBeenCalledWith(
       "12345",
       location,
-      expect.objectContaining({ cfg: {}, accountId: "ops", buttons: undefined }),
+      expect.objectContaining({
+        cfg: {},
+        accountId: "ops",
+        buttons: undefined,
+        quoteText: "quoted location",
+        replyToMessageId: 41,
+      }),
     );
     expect(sendMessageTelegramMock).not.toHaveBeenCalled();
     expect(result).toEqual({

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -859,18 +859,51 @@ describe("telegramOutbound", () => {
     });
   });
 
-  it("rejects mixed Telegram location and text payloads", async () => {
-    await expect(
-      telegramOutbound.sendPayload!({
-        cfg: {} as never,
-        to: "12345",
-        text: "caption",
-        payload: {
-          text: "caption",
-          location: { latitude: 1, longitude: 2 },
-        },
+  it("sends cross-context location markers before the native location", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-marker",
+      chatId: "12345",
+    });
+    sendLocationTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-location",
+      chatId: "12345",
+    });
+    const location = { latitude: 1, longitude: 2 };
+
+    const result = await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "[from telegram:origin] ",
+      payload: {
+        text: "[from telegram:origin] ",
+        location,
+        channelData: { telegram: { quoteText: "quoted location" } },
+      },
+      replyToId: "41",
+    });
+
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      "[from telegram:origin] ",
+      expect.objectContaining({
+        replyToMessageId: undefined,
+        replyToIdSource: undefined,
+        replyToMode: undefined,
       }),
-    ).rejects.toThrow(/cannot be combined/i);
+    );
+    expect(sendLocationTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      location,
+      expect.objectContaining({
+        quoteText: "quoted location",
+        replyToMessageId: 41,
+      }),
+    );
+    expect(result).toEqual({
+      channel: "telegram",
+      messageId: "tg-location",
+      chatId: "12345",
+    });
   });
 
   it("backs declared durable final capabilities with delivery proofs", async () => {

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -827,6 +827,10 @@ describe("telegramOutbound", () => {
       name: "Eiffel Tower",
       address: "Champ de Mars",
     };
+    const promptContextSource = {
+      transcriptMessageId: "assistant-location",
+      deliverySignature: resolveTelegramPromptContextDeliverySignature({ location }),
+    };
 
     const result = await telegramOutbound.sendPayload!({
       cfg: {} as never,
@@ -834,7 +838,9 @@ describe("telegramOutbound", () => {
       text: "",
       payload: {
         location,
-        channelData: { telegram: { quoteText: "quoted location" } },
+        channelData: {
+          telegram: { quoteText: "quoted location", promptContextSource },
+        },
       },
       accountId: "ops",
       replyToId: "41",
@@ -849,6 +855,12 @@ describe("telegramOutbound", () => {
         buttons: undefined,
         quoteText: "quoted location",
         replyToMessageId: 41,
+        promptContextProjectionPlan: expect.objectContaining({
+          finalPart: true,
+          cursor: expect.objectContaining({
+            source: { transcriptMessageId: "assistant-location" },
+          }),
+        }),
       }),
     );
     expect(sendMessageTelegramMock).not.toHaveBeenCalled();

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -7,11 +7,13 @@ const sendMessageTelegramMock = vi.fn();
 const pinMessageTelegramMock = vi.fn();
 const reactMessageTelegramMock = vi.fn();
 const sendPollTelegramMock = vi.fn();
+const sendLocationTelegramMock = vi.fn();
 
 vi.mock("./send.js", () => ({
   pinMessageTelegram: (...args: unknown[]) => pinMessageTelegramMock(...args),
   reactMessageTelegram: (...args: unknown[]) => reactMessageTelegramMock(...args),
   sendPollTelegram: (...args: unknown[]) => sendPollTelegramMock(...args),
+  sendLocationTelegram: (...args: unknown[]) => sendLocationTelegramMock(...args),
   sendMessageTelegram: (...args: unknown[]) => sendMessageTelegramMock(...args),
 }));
 
@@ -66,6 +68,7 @@ describe("telegramOutbound", () => {
     reactMessageTelegramMock.mockReset();
     sendPollTelegramMock.mockReset();
     sendMessageTelegramMock.mockReset();
+    sendLocationTelegramMock.mockReset();
   });
 
   it("forwards mediaLocalRoots in direct media sends", async () => {
@@ -768,6 +771,96 @@ describe("telegramOutbound", () => {
     expect(options.mediaUrl).toBe("file:///tmp/note.ogg");
     expect(options.asVoice).toBe(true);
     expect(result).toEqual({ channel: "telegram", messageId: "tg-voice", chatId: "12345" });
+  });
+
+  it("forwards videoAsNote payload media to Telegram video-note sends", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-video-note", chatId: "12345" });
+
+    const result = await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: {
+        mediaUrl: "file:///tmp/note.mp4",
+        videoAsNote: true,
+      },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    const options = callOptionsAt(sendMessageTelegramMock, 0, "12345", "");
+    expect(options.mediaUrl).toBe("file:///tmp/note.mp4");
+    expect(options.asVideoNote).toBe(true);
+    expect(result).toEqual({
+      channel: "telegram",
+      messageId: "tg-video-note",
+      chatId: "12345",
+    });
+  });
+
+  it.each([
+    { name: "no attachment", mediaUrls: [] },
+    {
+      name: "multiple attachments",
+      mediaUrls: ["file:///tmp/one.mp4", "file:///tmp/two.mp4"],
+    },
+  ])("rejects video-note payloads with $name", async ({ mediaUrls }) => {
+    await expect(
+      telegramOutbound.sendPayload!({
+        cfg: {} as never,
+        to: "12345",
+        text: "",
+        payload: { mediaUrls, videoAsNote: true },
+        deps: { sendTelegram: sendMessageTelegramMock },
+      }),
+    ).rejects.toThrow("Telegram video notes require exactly one media attachment.");
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+  });
+
+  it("maps portable locations to Telegram native sends", async () => {
+    sendLocationTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-location",
+      chatId: "12345",
+    });
+    const location = {
+      latitude: 48.858844,
+      longitude: 2.294351,
+      name: "Eiffel Tower",
+      address: "Champ de Mars",
+    };
+
+    const result = await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: { location },
+      accountId: "ops",
+    });
+
+    expect(sendLocationTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      location,
+      expect.objectContaining({ cfg: {}, accountId: "ops", buttons: undefined }),
+    );
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      channel: "telegram",
+      messageId: "tg-location",
+      chatId: "12345",
+    });
+  });
+
+  it("rejects mixed Telegram location and text payloads", async () => {
+    await expect(
+      telegramOutbound.sendPayload!({
+        cfg: {} as never,
+        to: "12345",
+        text: "caption",
+        payload: {
+          text: "caption",
+          location: { latitude: 1, longitude: 2 },
+        },
+      }),
+    ).rejects.toThrow(/cannot be combined/i);
   });
 
   it("backs declared durable final capabilities with delivery proofs", async () => {

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -204,6 +204,7 @@ export async function sendTelegramPayloadMessages(params: {
     }
     return await params.sendLocation(params.to, payload.location, {
       ...params.baseOpts,
+      ...projectionOptions(true),
       buttons,
       quoteText,
     });

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -40,6 +40,7 @@ const TELEGRAM_POLL_OPTION_LIMIT = 12;
 type TelegramSendFn = typeof import("./send.js").sendMessageTelegram;
 type TelegramSendOpts = Parameters<TelegramSendFn>[2];
 type TelegramReactionFn = typeof import("./send.js").reactMessageTelegram;
+type TelegramLocationFn = typeof import("./send.js").sendLocationTelegram;
 type ResolveTelegramSendFn = (deps?: OutboundSendDeps) => Promise<TelegramSendFn>;
 type LoadTelegramSendModuleFn = () => Promise<TelegramSendModule>;
 
@@ -136,6 +137,7 @@ type CreateTelegramOutboundAdapterOptions = {
 
 export async function sendTelegramPayloadMessages(params: {
   send: TelegramSendFn;
+  sendLocation: TelegramLocationFn;
   react: TelegramReactionFn;
   to: string;
   payload: ReplyPayload;
@@ -178,7 +180,26 @@ export async function sendTelegramPayloadMessages(params: {
     ...params.baseOpts,
     quoteText,
     ...(payload.audioAsVoice === true ? { asVoice: true } : {}),
+    ...(payload.videoAsNote === true ? { asVideoNote: true } : {}),
   };
+  if (payload.location) {
+    if (
+      text.trim() ||
+      mediaUrls.length > 0 ||
+      reactionEmoji ||
+      payload.audioAsVoice === true ||
+      payload.videoAsNote === true
+    ) {
+      throw new Error("Telegram location sends cannot be combined with text, media, or reactions.");
+    }
+    return await params.sendLocation(params.to, payload.location, {
+      ...params.baseOpts,
+      buttons,
+    });
+  }
+  if (payload.videoAsNote === true && mediaUrls.length !== 1) {
+    throw new Error("Telegram video notes require exactly one media attachment.");
+  }
   const shouldConsumeImplicitReplyTarget =
     payloadOpts.replyToIdSource === "implicit" &&
     payloadOpts.replyToMode !== undefined &&
@@ -321,9 +342,10 @@ export function createTelegramOutboundAdapter(
         ...params,
         resolveSend,
       });
-      const { reactMessageTelegram } = await loadSendModule();
+      const { reactMessageTelegram, sendLocationTelegram } = await loadSendModule();
       const result = await sendTelegramPayloadMessages({
         send,
+        sendLocation: sendLocationTelegram,
         react: reactMessageTelegram,
         to: outboundTo,
         payload: params.payload,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -184,13 +184,23 @@ export async function sendTelegramPayloadMessages(params: {
   };
   if (payload.location) {
     if (
-      text.trim() ||
       mediaUrls.length > 0 ||
       reactionEmoji ||
       payload.audioAsVoice === true ||
       payload.videoAsNote === true
     ) {
-      throw new Error("Telegram location sends cannot be combined with text, media, or reactions.");
+      throw new Error("Telegram location sends cannot be combined with media or reactions.");
+    }
+    if (text.trim()) {
+      // Cross-context policy can add a required origin marker to an otherwise
+      // standalone location. Persist it as a separate send without stealing
+      // the location's native reply, quote, or buttons.
+      await params.send(params.to, text, {
+        ...params.baseOpts,
+        replyToMessageId: undefined,
+        replyToIdSource: undefined,
+        replyToMode: undefined,
+      });
     }
     return await params.sendLocation(params.to, payload.location, {
       ...params.baseOpts,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -195,6 +195,7 @@ export async function sendTelegramPayloadMessages(params: {
     return await params.sendLocation(params.to, payload.location, {
       ...params.baseOpts,
       buttons,
+      quoteText,
     });
   }
   if (payload.videoAsNote === true && mediaUrls.length !== 1) {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -59,6 +59,7 @@ const {
   pinMessageTelegram,
   reactMessageTelegram,
   renameForumTopicTelegram,
+  sendLocationTelegram,
   sendMessageTelegram: sendMessageTelegramImported,
   sendTypingTelegram,
   sendPollTelegram,
@@ -2430,6 +2431,86 @@ describe("sendMessageTelegram", () => {
       expect(Object.keys(params).toSorted()).toEqual(["caption", "parse_mode"]);
       expect(res.messageId).toBe("201");
     }
+  });
+
+  it.each([
+    {
+      name: "non-video media",
+      contentType: "image/png",
+      fileName: "photo.png",
+      forceDocument: false,
+    },
+    {
+      name: "forced documents",
+      contentType: "video/mp4",
+      fileName: "video.mp4",
+      forceDocument: true,
+    },
+  ])("rejects video notes backed by $name", async (testCase) => {
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-media"),
+      contentType: testCase.contentType,
+      fileName: testCase.fileName,
+    });
+
+    await expect(
+      sendMessageTelegram("123", "", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api: {},
+        mediaUrl: `https://example.com/${testCase.fileName}`,
+        asVideoNote: true,
+        forceDocument: testCase.forceDocument,
+      }),
+    ).rejects.toThrow("Telegram video notes require video media.");
+  });
+
+  it("sends native locations and venues with bounded accuracy", async () => {
+    const chatId = "123";
+    const sendLocation = vi.fn().mockResolvedValue({ message_id: 301, chat: { id: chatId } });
+    const sendVenue = vi.fn().mockResolvedValue({ message_id: 302, chat: { id: chatId } });
+    const api = { sendLocation, sendVenue } as unknown as TelegramApiOverride;
+
+    await sendLocationTelegram(
+      chatId,
+      { latitude: 48.858844, longitude: 2.294351, accuracy: 12 },
+      { cfg: TELEGRAM_TEST_CFG, token: "tok", api },
+    );
+    await sendLocationTelegram(
+      chatId,
+      {
+        latitude: 48.858844,
+        longitude: 2.294351,
+        name: "Eiffel Tower",
+        address: "Champ de Mars",
+      },
+      { cfg: TELEGRAM_TEST_CFG, token: "tok", api },
+    );
+
+    expect(sendLocation).toHaveBeenCalledWith(
+      chatId,
+      48.858844,
+      2.294351,
+      expect.objectContaining({ horizontal_accuracy: 12 }),
+    );
+    expect(sendVenue).toHaveBeenCalledWith(
+      chatId,
+      48.858844,
+      2.294351,
+      "Eiffel Tower",
+      "Champ de Mars",
+      expect.any(Object),
+    );
+  });
+
+  it("rejects incomplete Telegram venues", async () => {
+    await expect(
+      sendLocationTelegram(
+        "123",
+        { latitude: 1, longitude: 2, name: "Unnamed address" },
+        { cfg: TELEGRAM_TEST_CFG, token: "tok", api: {} },
+      ),
+    ).rejects.toThrow(/require both/i);
   });
 
   it("passes probed dimensions to regular video sends", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2474,7 +2474,13 @@ describe("sendMessageTelegram", () => {
     await sendLocationTelegram(
       chatId,
       { latitude: 48.858844, longitude: 2.294351, accuracy: 12 },
-      { cfg: TELEGRAM_TEST_CFG, token: "tok", api },
+      {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api,
+        replyToMessageId: 77,
+        quoteText: "quoted location",
+      },
     );
     await sendLocationTelegram(
       chatId,
@@ -2491,7 +2497,13 @@ describe("sendMessageTelegram", () => {
       chatId,
       48.858844,
       2.294351,
-      expect.objectContaining({ horizontal_accuracy: 12 }),
+      expect.objectContaining({
+        horizontal_accuracy: 12,
+        reply_parameters: expect.objectContaining({
+          message_id: 77,
+          quote: "quoted location",
+        }),
+      }),
     );
     expect(sendVenue).toHaveBeenCalledWith(
       chatId,

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1036,6 +1036,48 @@ describe("sendMessageTelegram", () => {
     expect(cursor.nextPartIndex).toBe(1);
   });
 
+  it("records transcript projection metadata for native locations", async () => {
+    const storePath = `/tmp/openclaw-telegram-location-context-${process.pid}-${Date.now()}.json`;
+    const cfg = { session: { store: storePath } };
+    const cursor = createTelegramPromptContextProjectionCursor({
+      transcriptMessageId: "assistant-location",
+    });
+    const sendLocation = vi.fn().mockResolvedValue({
+      message_id: 1498,
+      date: 1_779_394_746,
+      chat: { id: "123", type: "private" },
+      from: { id: 42, is_bot: true, first_name: "Kelaw" },
+      location: { latitude: 48.858844, longitude: 2.294351 },
+    });
+
+    await sendLocationTelegram(
+      "123",
+      { latitude: 48.858844, longitude: 2.294351 },
+      {
+        cfg,
+        token: "tok",
+        api: { sendLocation } as unknown as TelegramApiOverride,
+        promptContextProjectionPlan: { cursor, finalPart: true },
+      },
+    );
+
+    const cache = createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    });
+    const node = await cache.get({
+      accountId: "default",
+      chatId: "123",
+      messageId: "1498",
+    });
+
+    expect(node?.timestamp).toBe(1_779_394_746_000);
+    expect(node?.promptContextProjectionMarker).toEqual({
+      kind: "valid",
+      projection: { ...cursor.source, partIndex: 0, finalPart: true },
+    });
+    expect(cursor.nextPartIndex).toBe(1);
+  });
+
   it("normalizes raw code language HTML before sending", async () => {
     const chatId = "123";
     const text = [

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -181,6 +181,7 @@ type TelegramLocationSendOpts = Pick<
   | "messageThreadId"
   | "buttons"
   | "quoteText"
+  | "promptContextProjectionPlan"
   | "silent"
   | "onDeliveryResult"
 >;
@@ -1688,7 +1689,9 @@ async function sendLocationTelegramWithContext(
   const resolvedChatId = String(result?.chat?.id ?? chatId);
   recordSentMessage(chatId, messageId, cfg);
   await opts.onDeliveryResult?.({ messageId: String(messageId), chatId: resolvedChatId });
-  await recordOutboundMessageForPromptContext({
+  const projectionPlan = opts.promptContextProjectionPlan;
+  const projection = projectionPlan?.cursor.take(projectionPlan.finalPart);
+  const recorded = await recordOutboundMessageForPromptContext({
     cfg,
     account,
     ...(botUserId !== undefined ? { botUserId } : {}),
@@ -1699,7 +1702,11 @@ async function sendLocationTelegramWithContext(
     ...(acceptedParams?.message_thread_id !== undefined
       ? { messageThreadId: acceptedParams.message_thread_id }
       : {}),
+    promptContextProjection: projection,
   });
+  if (projection && !recorded) {
+    projectionPlan?.cursor.invalidate();
+  }
   logTelegramOutboundSendOk({
     accountId: account.accountId,
     chatId: resolvedChatId,

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -3,6 +3,7 @@ import * as grammy from "grammy";
 import { type ApiClientOptions, Bot, HttpError } from "grammy";
 import type { ReactionType, ReactionTypeEmoji } from "grammy/types";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import { formatLocationText, type NormalizedLocation } from "openclaw/plugin-sdk/channel-location";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -39,6 +40,7 @@ import {
   isTelegramRateLimitError,
   isTelegramServerError,
 } from "./network-errors.js";
+import { normalizeTelegramOutboundLocation } from "./normalize.js";
 import {
   recordOutboundMessageForPromptContext,
   type TelegramOutboundPromptContextMessage as TelegramMessageLike,
@@ -100,6 +102,8 @@ type TelegramApi = Bot["api"];
 export type TelegramApiOverride = Partial<TelegramApi>;
 type TelegramSendMessageParams = Parameters<TelegramApi["sendMessage"]>[2];
 type TelegramSendPollParams = Parameters<TelegramApi["sendPoll"]>[3];
+type TelegramSendLocationParams = Parameters<TelegramApi["sendLocation"]>[3];
+type TelegramSendVenueParams = Parameters<TelegramApi["sendVenue"]>[5];
 type TelegramEditMessageTextParams = Parameters<TelegramApi["editMessageText"]>[3];
 type TelegramEditMessageCaptionParams = Parameters<TelegramApi["editMessageCaption"]>[2];
 type TelegramCreateForumTopicParams = NonNullable<Parameters<TelegramApi["createForumTopic"]>[2]>;
@@ -160,6 +164,22 @@ type TelegramSendResult = {
   chatId: string;
   receipt?: MessageReceipt;
 };
+
+type TelegramLocationSendOpts = Pick<
+  TelegramSendOpts,
+  | "cfg"
+  | "token"
+  | "accountId"
+  | "verbose"
+  | "api"
+  | "retry"
+  | "gatewayClientScopes"
+  | "replyToMessageId"
+  | "messageThreadId"
+  | "buttons"
+  | "silent"
+  | "onDeliveryResult"
+>;
 
 type TelegramOutboundSuccessLogParams = {
   accountId: string;
@@ -1331,6 +1351,9 @@ async function sendMessageTelegramWithContext(
     let sendImageAsPhoto = true;
     const deliveryKind =
       opts.forceDocument === true && (kind === "image" || kind === "video") ? "document" : kind;
+    if (opts.asVideoNote === true && deliveryKind !== "video") {
+      throw new Error("Telegram video notes require video media.");
+    }
     if (deliveryKind === "image" && !isGif) {
       sendImageAsPhoto = await shouldSendTelegramImageAsPhoto(media.buffer);
     }
@@ -1562,6 +1585,131 @@ async function sendMessageTelegramWithContext(
     direction: "outbound",
   });
   return textResult;
+}
+
+/** Send a standalone location pin or named venue through Telegram's native payload. */
+export async function sendLocationTelegram(
+  to: string,
+  input: NormalizedLocation,
+  opts: TelegramLocationSendOpts,
+): Promise<TelegramSendResult> {
+  const context = resolveTelegramApiContext(opts);
+  return withTelegramApiContextLease(
+    context,
+    sendLocationTelegramWithContext(to, input, opts, context),
+  );
+}
+
+async function sendLocationTelegramWithContext(
+  to: string,
+  input: NormalizedLocation,
+  opts: TelegramLocationSendOpts,
+  context: TelegramApiContext,
+): Promise<TelegramSendResult> {
+  const location = normalizeTelegramOutboundLocation(input);
+  if (!location) {
+    throw new Error("Telegram location is required.");
+  }
+  const hasName = Boolean(location.name);
+  const hasAddress = Boolean(location.address);
+  if (hasName !== hasAddress) {
+    throw new Error("Telegram venues require both location.name and location.address.");
+  }
+
+  const { cfg, account, api } = context;
+  const botUserId = resolveTelegramBotUserIdFromToken(opts.token || account.token);
+  const target = parseTelegramTarget(to);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: target.chatId,
+    persistTarget: to,
+    verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
+  });
+  const threadParams = buildTelegramThreadReplyParams({
+    thread: resolveTelegramSendThreadSpec({
+      targetMessageThreadId: target.messageThreadId,
+      messageThreadId: opts.messageThreadId,
+      chatType: target.chatType,
+    }),
+    replyToMessageId: opts.replyToMessageId,
+  });
+  const replyMarkup = buildInlineKeyboard(opts.buttons);
+  const commonParams = {
+    ...threadParams,
+    ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
+    ...(opts.silent === true ? { disable_notification: true } : {}),
+  };
+  const requestWithChatNotFound = createRequestWithChatNotFound({
+    requestWithDiag: createTelegramNonIdempotentRequestWithDiag({
+      cfg,
+      account,
+      retry: opts.retry,
+      verbose: opts.verbose,
+    }),
+    chatId,
+    input: to,
+  });
+  const label = hasName ? "venue" : "location";
+  const delivery = await withTelegramNativeQuoteFallback({
+    label,
+    requestParams: commonParams,
+    request: (effectiveParams, retryLabel) =>
+      requestWithChatNotFound(
+        () =>
+          hasName
+            ? api.sendVenue(
+                chatId,
+                location.latitude,
+                location.longitude,
+                location.name ?? "",
+                location.address ?? "",
+                effectiveParams as TelegramSendVenueParams,
+              )
+            : api.sendLocation(chatId, location.latitude, location.longitude, {
+                ...effectiveParams,
+                ...(location.accuracy !== undefined
+                  ? { horizontal_accuracy: location.accuracy }
+                  : {}),
+              } as TelegramSendLocationParams),
+        retryLabel,
+      ),
+  });
+  const result = delivery.result;
+  const acceptedParams = toAcceptedThreadScopedParams(delivery.acceptedParams);
+  const messageId = resolveTelegramMessageIdOrThrow(result, `${label} send`);
+  const resolvedChatId = String(result?.chat?.id ?? chatId);
+  recordSentMessage(chatId, messageId, cfg);
+  await opts.onDeliveryResult?.({ messageId: String(messageId), chatId: resolvedChatId });
+  await recordOutboundMessageForPromptContext({
+    cfg,
+    account,
+    ...(botUserId !== undefined ? { botUserId } : {}),
+    chatId,
+    message: result,
+    messageId,
+    text: formatLocationText(location),
+    ...(acceptedParams?.message_thread_id !== undefined
+      ? { messageThreadId: acceptedParams.message_thread_id }
+      : {}),
+  });
+  logTelegramOutboundSendOk({
+    accountId: account.accountId,
+    chatId: resolvedChatId,
+    messageId: String(messageId),
+    operation: hasName ? "sendVenue" : "sendLocation",
+    deliveryKind: label,
+    messageThreadId: acceptedParams?.message_thread_id,
+    replyToMessageId: opts.replyToMessageId,
+    silent: opts.silent,
+  });
+  recordChannelActivity({
+    channel: "telegram",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+  return { messageId: String(messageId), chatId: resolvedChatId };
 }
 
 export async function sendTypingTelegram(

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -180,6 +180,7 @@ type TelegramLocationSendOpts = Pick<
   | "replyToMessageId"
   | "messageThreadId"
   | "buttons"
+  | "quoteText"
   | "silent"
   | "onDeliveryResult"
 >;
@@ -1637,6 +1638,8 @@ async function sendLocationTelegramWithContext(
       chatType: target.chatType,
     }),
     replyToMessageId: opts.replyToMessageId,
+    replyQuoteText: opts.quoteText,
+    useReplyIdAsQuoteSource: true,
   });
   const replyMarkup = buildInlineKeyboard(opts.buttons);
   const commonParams = {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -3,7 +3,11 @@ import * as grammy from "grammy";
 import { type ApiClientOptions, Bot, HttpError } from "grammy";
 import type { ReactionType, ReactionTypeEmoji } from "grammy/types";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-import { formatLocationText, type NormalizedLocation } from "openclaw/plugin-sdk/channel-location";
+import {
+  formatLocationText,
+  normalizeOutboundLocation,
+  type OutboundLocation,
+} from "openclaw/plugin-sdk/channel-inbound";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -40,7 +44,6 @@ import {
   isTelegramRateLimitError,
   isTelegramServerError,
 } from "./network-errors.js";
-import { normalizeTelegramOutboundLocation } from "./normalize.js";
 import {
   recordOutboundMessageForPromptContext,
   type TelegramOutboundPromptContextMessage as TelegramMessageLike,
@@ -1590,7 +1593,7 @@ async function sendMessageTelegramWithContext(
 /** Send a standalone location pin or named venue through Telegram's native payload. */
 export async function sendLocationTelegram(
   to: string,
-  input: NormalizedLocation,
+  input: OutboundLocation,
   opts: TelegramLocationSendOpts,
 ): Promise<TelegramSendResult> {
   const context = resolveTelegramApiContext(opts);
@@ -1602,11 +1605,11 @@ export async function sendLocationTelegram(
 
 async function sendLocationTelegramWithContext(
   to: string,
-  input: NormalizedLocation,
+  input: OutboundLocation,
   opts: TelegramLocationSendOpts,
   context: TelegramApiContext,
 ): Promise<TelegramSendResult> {
-  const location = normalizeTelegramOutboundLocation(input);
+  const location = normalizeOutboundLocation(input);
   if (!location) {
     throw new Error("Telegram location is required.");
   }

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -199,12 +199,12 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10624,
+      10627,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5349,
+      5350,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -276,6 +276,17 @@ export type AgentRuntimeReplyPayloadDelivery = {
   pin?: boolean | AgentRuntimeReplyPayloadDeliveryPin;
 };
 
+type AgentRuntimeReplyPayloadLocation = {
+  latitude: number;
+  longitude: number;
+  accuracy?: number;
+  name?: string;
+  address?: string;
+  isLive?: boolean;
+  source?: "pin" | "place" | "live";
+  caption?: string;
+};
+
 /** Portable reply payload emitted by agent runtimes before channel rendering. */
 export type AgentRuntimeReplyPayload = {
   text?: string;
@@ -296,6 +307,8 @@ export type AgentRuntimeReplyPayload = {
   replyToTag?: boolean;
   replyToCurrent?: boolean;
   audioAsVoice?: boolean;
+  videoAsNote?: boolean;
+  location?: AgentRuntimeReplyPayloadLocation;
   spokenText?: string;
   ttsSupplement?: {
     spokenText: string;

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -282,9 +282,6 @@ type AgentRuntimeReplyPayloadLocation = {
   accuracy?: number;
   name?: string;
   address?: string;
-  isLive?: boolean;
-  source?: "pin" | "place" | "live";
-  caption?: string;
 };
 
 /** Portable reply payload emitted by agent runtimes before channel rendering. */

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -1,3 +1,4 @@
+import type { NormalizedLocation } from "../channels/location.js";
 /** Reply payload contracts and metadata helpers shared by dispatch and channel renderers. */
 import type { ReplyToMode } from "../config/types.base.js";
 import type {
@@ -34,6 +35,10 @@ export type ReplyPayload = {
   replyToCurrent?: boolean;
   /** Send audio as voice message (bubble) instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
+  /** Send video media as a round video note when the channel supports it. */
+  videoAsNote?: boolean;
+  /** Channel-neutral geographic location or named place. */
+  location?: NormalizedLocation;
   /**
    * Text synthesized into an audio-only TTS payload. Exposed to hooks for
    * archival/search use when no visible channel text is sent.

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -1,4 +1,4 @@
-import type { NormalizedLocation } from "../channels/location.js";
+import type { OutboundLocation } from "../channels/location.js";
 /** Reply payload contracts and metadata helpers shared by dispatch and channel renderers. */
 import type { ReplyToMode } from "../config/types.base.js";
 import type {
@@ -38,7 +38,7 @@ export type ReplyPayload = {
   /** Send video media as a round video note when the channel supports it. */
   videoAsNote?: boolean;
   /** Channel-neutral geographic location or named place. */
-  location?: NormalizedLocation;
+  location?: OutboundLocation;
   /**
    * Text synthesized into an audio-only TTS payload. Exposed to hooks for
    * archival/search use when no visible channel text is sent.

--- a/src/channels/location.test.ts
+++ b/src/channels/location.test.ts
@@ -1,11 +1,11 @@
 // Location tests cover channel location payload normalization and display helpers.
 import { describe, expect, it } from "vitest";
-import { formatLocationText, normalizeLocation, toLocationContext } from "./location.js";
+import { formatLocationText, normalizeOutboundLocation, toLocationContext } from "./location.js";
 
 describe("provider location helpers", () => {
   it("normalizes bounded outbound coordinates and labels", () => {
     expect(
-      normalizeLocation({
+      normalizeOutboundLocation({
         latitude: 48.858844,
         longitude: 2.294351,
         accuracy: 12,
@@ -26,7 +26,13 @@ describe("provider location helpers", () => {
     [{ latitude: 0, longitude: -181 }, "longitude"],
     [{ latitude: 0, longitude: 0, accuracy: 1501 }, "accuracy"],
   ])("rejects invalid outbound location fields", (value, field) => {
-    expect(() => normalizeLocation(value)).toThrow(field);
+    expect(() => normalizeOutboundLocation(value)).toThrow(field);
+  });
+
+  it.each(["source", "isLive", "caption"])("rejects unsupported outbound %s semantics", (field) => {
+    expect(() =>
+      normalizeOutboundLocation({ latitude: 1, longitude: 2, [field]: "unsupported" }),
+    ).toThrow(`${field} is not supported`);
   });
 
   it("formats pin locations with accuracy", () => {

--- a/src/channels/location.test.ts
+++ b/src/channels/location.test.ts
@@ -1,8 +1,34 @@
 // Location tests cover channel location payload normalization and display helpers.
 import { describe, expect, it } from "vitest";
-import { formatLocationText, toLocationContext } from "./location.js";
+import { formatLocationText, normalizeLocation, toLocationContext } from "./location.js";
 
 describe("provider location helpers", () => {
+  it("normalizes bounded outbound coordinates and labels", () => {
+    expect(
+      normalizeLocation({
+        latitude: 48.858844,
+        longitude: 2.294351,
+        accuracy: 12,
+        name: "  Eiffel Tower ",
+        address: " Champ de Mars ",
+      }),
+    ).toEqual({
+      latitude: 48.858844,
+      longitude: 2.294351,
+      accuracy: 12,
+      name: "Eiffel Tower",
+      address: "Champ de Mars",
+    });
+  });
+
+  it.each([
+    [{ latitude: 91, longitude: 0 }, "latitude"],
+    [{ latitude: 0, longitude: -181 }, "longitude"],
+    [{ latitude: 0, longitude: 0, accuracy: 1501 }, "accuracy"],
+  ])("rejects invalid outbound location fields", (value, field) => {
+    expect(() => normalizeLocation(value)).toThrow(field);
+  });
+
   it("formats pin locations with accuracy", () => {
     const text = formatLocationText({
       latitude: 48.858844,

--- a/src/channels/location.test.ts
+++ b/src/channels/location.test.ts
@@ -35,6 +35,17 @@ describe("provider location helpers", () => {
     ).toThrow(`${field} is not supported`);
   });
 
+  it.each([
+    ["name", 123],
+    ["name", "   "],
+    ["address", false],
+    ["address", ""],
+  ])("rejects malformed outbound %s text", (field, value) => {
+    expect(() => normalizeOutboundLocation({ latitude: 1, longitude: 2, [field]: value })).toThrow(
+      `${field} must be a non-empty string`,
+    );
+  });
+
   it("formats pin locations with accuracy", () => {
     const text = formatLocationText({
       latitude: 48.858844,

--- a/src/channels/location.ts
+++ b/src/channels/location.ts
@@ -13,6 +13,70 @@ export type NormalizedLocation = {
   caption?: string;
 };
 
+function readOptionalLocationText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** Normalize a portable location payload at an outbound/plugin boundary. */
+export function normalizeLocation(
+  value: unknown,
+  label = "location",
+): NormalizedLocation | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  const raw = value as Record<string, unknown>;
+  const latitude = raw.latitude;
+  const longitude = raw.longitude;
+  if (
+    typeof latitude !== "number" ||
+    !Number.isFinite(latitude) ||
+    latitude < -90 ||
+    latitude > 90
+  ) {
+    throw new Error(`${label}.latitude must be a finite number between -90 and 90.`);
+  }
+  if (
+    typeof longitude !== "number" ||
+    !Number.isFinite(longitude) ||
+    longitude < -180 ||
+    longitude > 180
+  ) {
+    throw new Error(`${label}.longitude must be a finite number between -180 and 180.`);
+  }
+  const accuracy = raw.accuracy;
+  if (
+    accuracy !== undefined &&
+    (typeof accuracy !== "number" || !Number.isFinite(accuracy) || accuracy < 0 || accuracy > 1500)
+  ) {
+    throw new Error(`${label}.accuracy must be a finite number between 0 and 1500.`);
+  }
+  const source = raw.source;
+  if (source !== undefined && source !== "pin" && source !== "place" && source !== "live") {
+    throw new Error(`${label}.source must be pin, place, or live.`);
+  }
+  const isLive = raw.isLive;
+  if (isLive !== undefined && typeof isLive !== "boolean") {
+    throw new Error(`${label}.isLive must be a boolean.`);
+  }
+  const name = readOptionalLocationText(raw.name);
+  const address = readOptionalLocationText(raw.address);
+  const caption = readOptionalLocationText(raw.caption);
+  return {
+    latitude,
+    longitude,
+    ...(accuracy !== undefined ? { accuracy } : {}),
+    ...(name ? { name } : {}),
+    ...(address ? { address } : {}),
+    ...(isLive !== undefined ? { isLive } : {}),
+    ...(source !== undefined ? { source } : {}),
+    ...(caption ? { caption } : {}),
+  };
+}
+
 /** Location payload after default source and live-state inference. */
 type ResolvedLocation = NormalizedLocation & {
   source: LocationSource;

--- a/src/channels/location.ts
+++ b/src/channels/location.ts
@@ -13,15 +13,21 @@ export type NormalizedLocation = {
   caption?: string;
 };
 
+/** Portable outbound location fields supported by channel send adapters. */
+export type OutboundLocation = Pick<
+  NormalizedLocation,
+  "latitude" | "longitude" | "accuracy" | "name" | "address"
+>;
+
 function readOptionalLocationText(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 /** Normalize a portable location payload at an outbound/plugin boundary. */
-export function normalizeLocation(
+export function normalizeOutboundLocation(
   value: unknown,
   label = "location",
-): NormalizedLocation | undefined {
+): OutboundLocation | undefined {
   if (value == null) {
     return undefined;
   }
@@ -54,26 +60,19 @@ export function normalizeLocation(
   ) {
     throw new Error(`${label}.accuracy must be a finite number between 0 and 1500.`);
   }
-  const source = raw.source;
-  if (source !== undefined && source !== "pin" && source !== "place" && source !== "live") {
-    throw new Error(`${label}.source must be pin, place, or live.`);
-  }
-  const isLive = raw.isLive;
-  if (isLive !== undefined && typeof isLive !== "boolean") {
-    throw new Error(`${label}.isLive must be a boolean.`);
+  for (const unsupportedField of ["source", "isLive", "caption"] as const) {
+    if (raw[unsupportedField] !== undefined) {
+      throw new Error(`${label}.${unsupportedField} is not supported for outbound locations.`);
+    }
   }
   const name = readOptionalLocationText(raw.name);
   const address = readOptionalLocationText(raw.address);
-  const caption = readOptionalLocationText(raw.caption);
   return {
     latitude,
     longitude,
     ...(accuracy !== undefined ? { accuracy } : {}),
     ...(name ? { name } : {}),
     ...(address ? { address } : {}),
-    ...(isLive !== undefined ? { isLive } : {}),
-    ...(source !== undefined ? { source } : {}),
-    ...(caption ? { caption } : {}),
   };
 }
 

--- a/src/channels/location.ts
+++ b/src/channels/location.ts
@@ -19,8 +19,14 @@ export type OutboundLocation = Pick<
   "latitude" | "longitude" | "accuracy" | "name" | "address"
 >;
 
-function readOptionalLocationText(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+function readOptionalLocationText(value: unknown, label: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  return value.trim();
 }
 
 /** Normalize a portable location payload at an outbound/plugin boundary. */
@@ -65,8 +71,8 @@ export function normalizeOutboundLocation(
       throw new Error(`${label}.${unsupportedField} is not supported for outbound locations.`);
     }
   }
-  const name = readOptionalLocationText(raw.name);
-  const address = readOptionalLocationText(raw.address);
+  const name = readOptionalLocationText(raw.name, `${label}.name`);
+  const address = readOptionalLocationText(raw.address, `${label}.address`);
   return {
     latitude,
     longitude,

--- a/src/channels/message/outbound-bridge.ts
+++ b/src/channels/message/outbound-bridge.ts
@@ -162,6 +162,9 @@ function resolvePayloadReceiptKind(
   if (ctx.payload.interactive) {
     return "card";
   }
+  if (ctx.payload.location) {
+    return "card";
+  }
   if (ctx.payload.text?.trim() || ctx.text.trim()) {
     return "text";
   }

--- a/src/channels/message/rendered-batch.ts
+++ b/src/channels/message/rendered-batch.ts
@@ -41,7 +41,7 @@ function createRenderedMessageBatchPlanItem(
   if (payload.interactive) {
     kinds.push("interactive");
   }
-  if (payload.channelData) {
+  if (payload.channelData || payload.location) {
     kinds.push("channelData");
   }
   return {
@@ -52,7 +52,7 @@ function createRenderedMessageBatchPlanItem(
     ...(payload.audioAsVoice && mediaUrls.length > 0 ? { audioAsVoice: true } : {}),
     ...(presentationBlockCount > 0 ? { presentationBlockCount } : {}),
     ...(payload.interactive ? { hasInteractive: true } : {}),
-    ...(payload.channelData ? { hasChannelData: true } : {}),
+    ...(payload.channelData || payload.location ? { hasChannelData: true } : {}),
   };
 }
 
@@ -72,7 +72,7 @@ export function createRenderedMessageBatchPlan(
         voiceCount: plan.voiceCount + (payload.audioAsVoice && mediaCount > 0 ? 1 : 0),
         presentationCount: plan.presentationCount + (payload.presentation?.blocks?.length ? 1 : 0),
         interactiveCount: plan.interactiveCount + (payload.interactive ? 1 : 0),
-        channelDataCount: plan.channelDataCount + (payload.channelData ? 1 : 0),
+        channelDataCount: plan.channelDataCount + (payload.channelData || payload.location ? 1 : 0),
         items: plan.items,
       };
     },

--- a/src/channels/message/send.test.ts
+++ b/src/channels/message/send.test.ts
@@ -186,6 +186,38 @@ describe("withDurableMessageSendContext", () => {
     });
   });
 
+  it("records portable locations as structured payload data", async () => {
+    deliverOutboundPayloads.mockImplementationOnce(async (params: DeliveryIntentCallbackParams) => {
+      params.onDeliveryIntent?.({
+        id: "intent-location",
+        channel: "telegram",
+        to: "chat-1",
+        queuePolicy: "required",
+      });
+      return [{ channel: "telegram", messageId: "loc-1" }];
+    });
+    let intent: unknown;
+
+    await withDurableMessageSendContext(
+      {
+        cfg,
+        channel: "telegram",
+        to: "chat-1",
+        payloads: [{ location: { latitude: 1, longitude: 2 } }],
+      },
+      async (ctx) => {
+        const rendered = await ctx.render();
+        await ctx.send(rendered);
+        intent = ctx.intent;
+      },
+    );
+
+    expect((intent as DurableMessageSendIntent | undefined)?.renderedBatch?.plan).toMatchObject({
+      channelDataCount: 1,
+      items: [{ kinds: ["channelData"], hasChannelData: true }],
+    });
+  });
+
   it("forwards the durable send context signal to outbound delivery", async () => {
     const abortController = new AbortController();
     deliverOutboundPayloads.mockImplementationOnce(

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -2274,8 +2274,10 @@ async function deliverOutboundPayloadsCore(
             presentation: effectivePayload.presentation,
             interactive: effectivePayload.interactive,
             channelData: effectivePayload.channelData,
+            location: effectivePayload.location,
           }) ||
-          effectivePayload.audioAsVoice === true)
+          effectivePayload.audioAsVoice === true ||
+          effectivePayload.videoAsNote === true)
       ) {
         const beforeCount = results.length;
         const delivery = await deliveryHandler.sendPayload(

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -103,6 +103,30 @@ describe("runMessageAction send validation", () => {
     expect(result.kind).toBe("send");
   });
 
+  it.each([
+    { name: "text", extra: { message: "caption" } },
+    { name: "media", extra: { mediaUrl: "https://example.com/photo.jpg" } },
+  ])(
+    "rejects location sends mixed with $name before cross-context decoration",
+    async ({ extra }) => {
+      await expect(
+        runDrySend({
+          cfg: workspaceConfig,
+          actionParams: {
+            channel: "workspace",
+            target: "channel:C99999999",
+            location: { latitude: 48.858844, longitude: 2.294351 },
+            ...extra,
+          },
+          toolContext: {
+            currentChannelId: "C12345678",
+            currentChannelProvider: "workspace",
+          },
+        }),
+      ).rejects.toThrow(/cannot be combined/i);
+    },
+  );
+
   it("uses the current internal UI source as the message-tool-only send sink", async () => {
     const result = await runMessageAction({
       cfg: emptyConfig,

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -89,6 +89,20 @@ describe("runMessageAction send validation", () => {
     expect(result.kind).toBe("send");
   });
 
+  it("allows send when only a portable location is provided", async () => {
+    const result = await runDrySend({
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "workspace",
+        target: "#C12345678",
+        location: { latitude: 48.858844, longitude: 2.294351 },
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    });
+
+    expect(result.kind).toBe("send");
+  });
+
   it("uses the current internal UI source as the message-tool-only send sink", async () => {
     const result = await runMessageAction({
       cfg: emptyConfig,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -19,7 +19,7 @@ import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { resolveResponsePrefixTemplate } from "../../auto-reply/reply/response-prefix-template.js";
 import { normalizeChatType, type ChatType } from "../../channels/chat-type.js";
 import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
-import { normalizeLocation } from "../../channels/location.js";
+import { normalizeOutboundLocation } from "../../channels/location.js";
 import {
   normalizeConversationReadInvocationOrigin,
   type ConversationReadInvocationOrigin,
@@ -944,7 +944,7 @@ async function buildSendPayloadParts(params: {
     Boolean(mediaHint) || mediaUrlHints.length > 0 || attachmentMediaHints.length > 0;
   const hasPresentation = hasMessagePresentationBlocks(actionParams.presentation);
   const hasInteractive = hasInteractiveReplyBlocks(actionParams.interactive);
-  const location = normalizeLocation(actionParams.location);
+  const location = normalizeOutboundLocation(actionParams.location);
   const caption = readStringParam(actionParams, "caption", { allowEmpty: true }) ?? "";
   let message =
     readStringParam(actionParams, "message", {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -19,6 +19,7 @@ import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { resolveResponsePrefixTemplate } from "../../auto-reply/reply/response-prefix-template.js";
 import { normalizeChatType, type ChatType } from "../../channels/chat-type.js";
 import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
+import { normalizeLocation } from "../../channels/location.js";
 import {
   normalizeConversationReadInvocationOrigin,
   type ConversationReadInvocationOrigin,
@@ -523,6 +524,8 @@ function applySendPayloadPartsToActionParams(
   actionParams.mediaUrls = parts.mediaUrls;
   actionParams.asVoice = parts.asVoice || undefined;
   actionParams.audioAsVoice = parts.asVoice || undefined;
+  actionParams.asVideoNote = parts.payload.videoAsNote || undefined;
+  actionParams.location = parts.payload.location;
 }
 
 function collectMessageAttachmentMediaHints(value: unknown): string[] {
@@ -941,10 +944,11 @@ async function buildSendPayloadParts(params: {
     Boolean(mediaHint) || mediaUrlHints.length > 0 || attachmentMediaHints.length > 0;
   const hasPresentation = hasMessagePresentationBlocks(actionParams.presentation);
   const hasInteractive = hasInteractiveReplyBlocks(actionParams.interactive);
+  const location = normalizeLocation(actionParams.location);
   const caption = readStringParam(actionParams, "caption", { allowEmpty: true }) ?? "";
   let message =
     readStringParam(actionParams, "message", {
-      required: !hasMediaHint && !hasPresentation && !hasInteractive,
+      required: !hasMediaHint && !hasPresentation && !hasInteractive && !location,
       allowEmpty: true,
     }) ?? "";
   if (message.includes("\\n")) {
@@ -1020,9 +1024,10 @@ async function buildSendPayloadParts(params: {
       mediaUrls: mergedMediaUrls,
       presentation: actionParams.presentation,
       interactive: actionParams.interactive,
+      location,
     })
   ) {
-    throw new Error("send requires text or media");
+    throw new Error("send requires text or media or location");
   }
   if (message || !hasPresentation) {
     actionParams.message = message;
@@ -1038,6 +1043,7 @@ async function buildSendPayloadParts(params: {
     readBooleanParam(actionParams, "asVoice") ??
     readBooleanParam(actionParams, "audioAsVoice") ??
     parsed.audioAsVoice;
+  const asVideoNote = readBooleanParam(actionParams, "asVideoNote") ?? false;
   const bestEffort = readBooleanParam(actionParams, "bestEffort");
   const silent = readBooleanParam(actionParams, "silent");
   const mirrorMediaUrls =
@@ -1061,6 +1067,8 @@ async function buildSendPayloadParts(params: {
       ...(mediaUrl ? { mediaUrl } : {}),
       ...(mergedMediaUrls.length ? { mediaUrls: mergedMediaUrls } : {}),
       ...(asVoice ? { audioAsVoice: true } : {}),
+      ...(asVideoNote ? { videoAsNote: true } : {}),
+      ...(location ? { location } : {}),
       ...(presentation ? { presentation } : {}),
       ...(interactive ? { interactive } : {}),
       ...(delivery ? { delivery } : {}),

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1001,6 +1001,13 @@ async function buildSendPayloadParts(params: {
   }
   actionParams.mediaUrls = mergedMediaUrls.length > 0 ? [...mergedMediaUrls] : undefined;
 
+  if (
+    location &&
+    (message.trim() || mergedMediaUrls.length > 0 || hasPresentation || hasInteractive)
+  ) {
+    throw new Error("Location sends cannot be combined with message text or media.");
+  }
+
   if (params.channel && params.target) {
     message = await maybeApplyCrossContextMarker({
       cfg: params.cfg,

--- a/src/infra/outbound/reply-payload-normalize.ts
+++ b/src/infra/outbound/reply-payload-normalize.ts
@@ -2,7 +2,7 @@
 // outbound-supported reply payload fields.
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload as InternalReplyPayload } from "../../auto-reply/reply-payload.js";
-import { normalizeLocation } from "../../channels/location.js";
+import { normalizeOutboundLocation } from "../../channels/location.js";
 
 /**
  * Outbound-facing subset of reply payload fields accepted from loose producers.
@@ -45,7 +45,7 @@ export function normalizeOutboundReplyPayload(
   const channelData = readObjectValue(payload.channelData) as OutboundReplyPayload["channelData"];
   const sensitiveMedia = payload.sensitiveMedia === true ? true : undefined;
   const replyToId = readStringValue(payload.replyToId);
-  const location = normalizeLocation(payload.location);
+  const location = normalizeOutboundLocation(payload.location);
   const videoAsNote = payload.videoAsNote === true ? true : undefined;
   return {
     text,

--- a/src/infra/outbound/reply-payload-normalize.ts
+++ b/src/infra/outbound/reply-payload-normalize.ts
@@ -2,6 +2,7 @@
 // outbound-supported reply payload fields.
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload as InternalReplyPayload } from "../../auto-reply/reply-payload.js";
+import { normalizeLocation } from "../../channels/location.js";
 
 /**
  * Outbound-facing subset of reply payload fields accepted from loose producers.
@@ -18,6 +19,8 @@ export type OutboundReplyPayload = {
   channelData?: InternalReplyPayload["channelData"];
   sensitiveMedia?: boolean;
   replyToId?: string;
+  location?: InternalReplyPayload["location"];
+  videoAsNote?: boolean;
 };
 
 function readObjectValue(value: unknown): object | undefined {
@@ -42,6 +45,8 @@ export function normalizeOutboundReplyPayload(
   const channelData = readObjectValue(payload.channelData) as OutboundReplyPayload["channelData"];
   const sensitiveMedia = payload.sensitiveMedia === true ? true : undefined;
   const replyToId = readStringValue(payload.replyToId);
+  const location = normalizeLocation(payload.location);
+  const videoAsNote = payload.videoAsNote === true ? true : undefined;
   return {
     text,
     mediaUrls,
@@ -51,5 +56,7 @@ export function normalizeOutboundReplyPayload(
     channelData,
     sensitiveMedia,
     replyToId,
+    ...(location ? { location } : {}),
+    ...(videoAsNote ? { videoAsNote: true } : {}),
   };
 }

--- a/src/interactive/payload.test.ts
+++ b/src/interactive/payload.test.ts
@@ -60,6 +60,14 @@ describe("hasReplyContent", () => {
 });
 
 describe("hasReplyPayloadContent", () => {
+  it("treats portable locations as content", () => {
+    expect(
+      hasReplyPayloadContent({
+        location: { latitude: 1, longitude: 2 },
+      }),
+    ).toBe(true);
+  });
+
   it("trims text and falls back to channel data by default", () => {
     expect(
       hasReplyPayloadContent({

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -968,6 +968,7 @@ export function hasReplyPayloadContent(
     interactive?: unknown;
     presentation?: unknown;
     channelData?: unknown;
+    location?: unknown;
   },
   options?: {
     trimText?: boolean;
@@ -982,7 +983,7 @@ export function hasReplyPayloadContent(
     interactive: payload.interactive,
     presentation: payload.presentation,
     hasChannelData: options?.hasChannelData ?? hasReplyChannelData(payload.channelData),
-    extraContent: options?.extraContent,
+    extraContent: options?.extraContent ?? payload.location != null,
   });
 }
 

--- a/src/plugin-sdk/channel-inbound.ts
+++ b/src/plugin-sdk/channel-inbound.ts
@@ -78,8 +78,12 @@ export {
   // @deprecated Prefer `resolveInboundMentionDecision({ facts, policy })`.
   resolveMentionGatingWithBypass,
 } from "../channels/mention-gating.js";
-export type { LocationSource, NormalizedLocation } from "../channels/location.js";
-export { formatLocationText, toLocationContext } from "../channels/location.js";
+export type { LocationSource, NormalizedLocation, OutboundLocation } from "../channels/location.js";
+export {
+  formatLocationText,
+  normalizeOutboundLocation,
+  toLocationContext,
+} from "../channels/location.js";
 export type { LogFn } from "../channels/logging.js";
 export { logInboundDrop } from "../channels/logging.js";
 export { resolveInboundSessionEnvelopeContext } from "../channels/session-envelope.js";

--- a/src/plugin-sdk/channel-location.ts
+++ b/src/plugin-sdk/channel-location.ts
@@ -1,7 +1,3 @@
 /** @deprecated Compatibility subpath. Use `openclaw/plugin-sdk/channel-inbound`. */
-export type { LocationSource, NormalizedLocation, OutboundLocation } from "./channel-inbound.js";
-export {
-  formatLocationText,
-  normalizeOutboundLocation,
-  toLocationContext,
-} from "./channel-inbound.js";
+export type { LocationSource, NormalizedLocation } from "./channel-inbound.js";
+export { formatLocationText, toLocationContext } from "./channel-inbound.js";

--- a/src/plugin-sdk/channel-location.ts
+++ b/src/plugin-sdk/channel-location.ts
@@ -1,3 +1,7 @@
 /** @deprecated Compatibility subpath. Use `openclaw/plugin-sdk/channel-inbound`. */
-export type { LocationSource, NormalizedLocation } from "./channel-inbound.js";
-export { formatLocationText, toLocationContext } from "./channel-inbound.js";
+export type { LocationSource, NormalizedLocation, OutboundLocation } from "./channel-inbound.js";
+export {
+  formatLocationText,
+  normalizeOutboundLocation,
+  toLocationContext,
+} from "./channel-inbound.js";

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -170,7 +170,7 @@ export type {
   ChannelSetupInput,
 } from "../channels/plugins/types.public.js";
 export type { ChatType } from "../channels/chat-type.js";
-export type { NormalizedLocation } from "../channels/location.js";
+export type { NormalizedLocation, OutboundLocation } from "../channels/location.js";
 export type { ChannelDirectoryEntry } from "../channels/plugins/types.core.js";
 export type { ChannelOutboundAdapter } from "../channels/plugins/types.adapters.js";
 export type { PollInput } from "../polls.js";

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -336,6 +336,28 @@ describe("normalizeOutboundReplyPayload", () => {
     });
   });
 
+  it("normalizes portable location and video-note hints", () => {
+    expect(
+      normalizeOutboundReplyPayload({
+        location: {
+          latitude: 48.858844,
+          longitude: 2.294351,
+          name: "  Eiffel Tower ",
+          address: " Champ de Mars ",
+        },
+        videoAsNote: true,
+      }),
+    ).toMatchObject({
+      location: {
+        latitude: 48.858844,
+        longitude: 2.294351,
+        name: "Eiffel Tower",
+        address: "Champ de Mars",
+      },
+      videoAsNote: true,
+    });
+  });
+
   it("keeps the normalized deliverer from forwarding trustedLocalMedia", async () => {
     const handler = vi.fn(async () => {});
     const deliver = createNormalizedOutboundDeliverer(handler);

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -358,6 +358,17 @@ describe("normalizeOutboundReplyPayload", () => {
     });
   });
 
+  it.each(["source", "isLive", "caption"])(
+    "rejects unsupported outbound location %s semantics from loose payloads",
+    (field) => {
+      expect(() =>
+        normalizeOutboundReplyPayload({
+          location: { latitude: 1, longitude: 2, [field]: "unsupported" },
+        }),
+      ).toThrow(`${field} is not supported`);
+    },
+  );
+
   it("keeps the normalized deliverer from forwarding trustedLocalMedia", async () => {
     const handler = vi.fn(async () => {});
     const deliver = createNormalizedOutboundDeliverer(handler);

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -42,6 +42,10 @@ export type OutboundReplyPayload = {
   sensitiveMedia?: boolean;
   /** Platform message id that the outbound reply should target when supported. */
   replyToId?: string;
+  /** Portable geographic location or named place. */
+  location?: InternalReplyPayload["location"];
+  /** Ask supporting channels to render video media as a round video note. */
+  videoAsNote?: boolean;
 };
 
 /** Minimal payload shape used to identify reasoning/thinking replies. */


### PR DESCRIPTION
Related: #97556

## What Problem This Solves

Telegram agents could not use the ordinary `message(action=send)` path to send map locations, venue cards, or round video notes. The earlier proposal in #97556 also widened Telegram's action surface and mixed unrelated schema changes, making the branch unsafe to land.

## Why This Change Was Made

This is a maintainer rewrite of #97556 around the existing portable outbound contract. It adds normalized location and `asVideoNote` fields to the standard send path, carries them through durable delivery, and maps only at the Telegram transport boundary to `sendLocation`, `sendVenue`, or `sendVideoNote`. Location sends are standalone, and incompatible video-note requests fail closed before delivery.

Contributor credit for the original feature proposal is preserved in the commit and changelog.

AI-assisted: Codex implemented and reviewed the rewrite; the maintainer understands and accepts the resulting code and behavior.

## User Impact

Telegram users can ask an agent to send:

- a coordinate pin;
- a venue card with name and address;
- a round video note from one compatible video attachment.

Existing text, media, voice, poll, sticker, and reaction behavior remains unchanged. The new fields are documented for tool and plugin authors.

## Evidence

- Focused Blacksmith Testbox suite: 459 tests passed across shared channel, outbound, Plugin SDK, and Telegram paths; `pnpm check:changed` and `pnpm build` also passed on the initial implementation.
- Exact final stack: focused Telegram/shared regressions passed repeatedly on brokered AWS Crabbox, including the native-location projection, quote, cross-context marker, malformed-location, and video-note paths.
- Exact final stack: core and extension production/test `tsgo` lanes passed; touched files pass `oxfmt --check` and `git diff --check`.
- Final structured autoreview: clean, with no accepted or actionable findings.
- Telegram Bot API / grammY contracts for location, venue, and video-note sends were checked against official types and documentation.
- Real Telegram proof was attempted, but the runner stopped before creating a lease or session because the required local Convex credential file was unavailable. No live-delivery claim is made from the unit and contract tests.
