### PR TITLE
fix(gateway): queue agent runtime identity verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Agent node calls:** queue runtime-identity verification behind concurrent exec-approval updates so parallel node calls do not reject valid local agent credentials. (#105122)
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent node calls:** queue runtime-identity verification behind concurrent exec-approval updates so parallel node calls do not reject valid local agent credentials. (#105122)
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.

--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -497,7 +497,7 @@ describe("gateway tool defaults", () => {
           sessionId: "session-1",
         });
         expect(token).toEqual(expect.any(String));
-        expect(verifyAgentRuntimeIdentityToken(token)).toMatchObject({
+        await expect(verifyAgentRuntimeIdentityToken(token)).resolves.toMatchObject({
           messageActionContext: {
             sessionId: "session-1",
             requesterAccountId: "default",
@@ -704,7 +704,9 @@ describe("gateway tool defaults", () => {
       turnSourceAccountId: "work",
       turnSourceThreadId: 42,
     });
-    expect(verifyAgentRuntimeIdentityToken(call.agentRuntimeIdentityToken ?? "")).toMatchObject({
+    await expect(
+      verifyAgentRuntimeIdentityToken(call.agentRuntimeIdentityToken ?? ""),
+    ).resolves.toMatchObject({
       agentId: "ops",
       sessionKey: "agent:ops:telegram:direct:alice",
     });

--- a/src/gateway/agent-runtime-identity-token.test.ts
+++ b/src/gateway/agent-runtime-identity-token.test.ts
@@ -59,7 +59,7 @@ describe("agent runtime identity token", () => {
     expect(persistedToken).not.toHaveLength(0);
 
     const secondProcess = await importRuntimeTokenModule();
-    expect(secondProcess.verifyAgentRuntimeIdentityToken(token)).toEqual({
+    await expect(secondProcess.verifyAgentRuntimeIdentityToken(token)).resolves.toEqual({
       kind: "agentRuntime",
       agentId: "main",
       sessionKey: "session-1",
@@ -70,7 +70,9 @@ describe("agent runtime identity token", () => {
     const home = useTempHome();
     const runtimeToken = await importRuntimeTokenModule();
 
-    expect(runtimeToken.verifyAgentRuntimeIdentityToken("not-a-valid-token")).toBeUndefined();
+    await expect(
+      runtimeToken.verifyAgentRuntimeIdentityToken("not-a-valid-token"),
+    ).resolves.toBeUndefined();
     expect(fs.existsSync(execApprovalsPath(home))).toBe(false);
   });
 
@@ -91,7 +93,7 @@ describe("agent runtime identity token", () => {
     });
 
     expect(secondToken).not.toBe(token);
-    expect(secondProcess.verifyAgentRuntimeIdentityToken(token)).toBeUndefined();
+    await expect(secondProcess.verifyAgentRuntimeIdentityToken(token)).resolves.toBeUndefined();
   });
 
   it("round-trips signed message action context and rejects it after expiry", async () => {
@@ -113,7 +115,7 @@ describe("agent runtime identity token", () => {
       },
     });
 
-    expect(runtimeToken.verifyAgentRuntimeIdentityToken(token, 4000)).toMatchObject({
+    await expect(runtimeToken.verifyAgentRuntimeIdentityToken(token, 4000)).resolves.toMatchObject({
       kind: "agentRuntime",
       agentId: "main",
       sessionKey: "session-1",
@@ -129,6 +131,38 @@ describe("agent runtime identity token", () => {
         },
       },
     });
-    expect(runtimeToken.verifyAgentRuntimeIdentityToken(token, 5000)).toBeUndefined();
+    await expect(
+      runtimeToken.verifyAgentRuntimeIdentityToken(token, 5000),
+    ).resolves.toBeUndefined();
+  });
+
+  it("queues parallel verifications behind a same-process approvals update", async () => {
+    useTempHome();
+    const runtimeToken = await importRuntimeTokenModule();
+    const { updateExecApprovals } = await import("../infra/exec-approvals.js");
+    const token = await runtimeToken.mintAgentRuntimeIdentityToken({
+      agentId: "main",
+      sessionKey: "session-1",
+    });
+    let verifications: Array<ReturnType<typeof runtimeToken.verifyAgentRuntimeIdentityToken>> = [];
+
+    await updateExecApprovals({
+      update: () => {
+        // Verification can begin while another parallel agent call still owns
+        // the process-local approvals lock. It must queue behind that owner.
+        verifications = Array.from({ length: 8 }, () =>
+          runtimeToken.verifyAgentRuntimeIdentityToken(token),
+        );
+        return null;
+      },
+    });
+
+    await expect(Promise.all(verifications)).resolves.toEqual(
+      Array.from({ length: 8 }, () => ({
+        kind: "agentRuntime",
+        agentId: "main",
+        sessionKey: "session-1",
+      })),
+    );
   });
 });

--- a/src/gateway/agent-runtime-identity-token.test.ts
+++ b/src/gateway/agent-runtime-identity-token.test.ts
@@ -165,4 +165,27 @@ describe("agent runtime identity token", () => {
       })),
     );
   });
+
+  it("rechecks message action expiry after waiting for an approvals update", async () => {
+    useTempHome();
+    const runtimeToken = await importRuntimeTokenModule();
+    const { updateExecApprovals } = await import("../infra/exec-approvals.js");
+    const token = await runtimeToken.mintAgentRuntimeIdentityToken({
+      agentId: "main",
+      sessionKey: "session-1",
+      messageActionContext: { expiresAtMs: 5000 },
+    });
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(4000);
+    let verification!: ReturnType<typeof runtimeToken.verifyAgentRuntimeIdentityToken>;
+
+    await updateExecApprovals({
+      update: () => {
+        verification = runtimeToken.verifyAgentRuntimeIdentityToken(token);
+        nowSpy.mockReturnValue(5000);
+        return null;
+      },
+    });
+
+    await expect(verification).resolves.toBeUndefined();
+  });
 });

--- a/src/gateway/agent-runtime-identity-token.ts
+++ b/src/gateway/agent-runtime-identity-token.ts
@@ -4,7 +4,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../channels/plugins/types.public.js";
-import { ensureExecApprovalsSnapshot, loadExecApprovals } from "../infra/exec-approvals.js";
+import { ensureExecApprovalsSnapshot, loadExecApprovalsAsync } from "../infra/exec-approvals.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { AgentRuntimeMessageActionContext } from "./message-action-turn-capability.js";
 
@@ -25,8 +25,8 @@ type AgentRuntimeIdentityTokenPayload = {
   messageActionContext?: AgentRuntimeMessageActionContext;
 };
 
-function readSharedAgentRuntimeIdentitySecret(): string | null {
-  return loadExecApprovals().socket?.token?.trim() || null;
+async function readSharedAgentRuntimeIdentitySecret(): Promise<string | null> {
+  return (await loadExecApprovalsAsync()).socket?.token?.trim() || null;
 }
 
 async function requireSharedAgentRuntimeIdentitySecret(): Promise<string> {
@@ -192,10 +192,10 @@ export async function mintAgentRuntimeIdentityToken(params: {
 }
 
 /** Validate a presented agent runtime token and return the internal caller identity. */
-export function verifyAgentRuntimeIdentityToken(
+export async function verifyAgentRuntimeIdentityToken(
   value: string | null | undefined,
   nowMs: number = Date.now(),
-): AgentRuntimeIdentity | undefined {
+): Promise<AgentRuntimeIdentity | undefined> {
   const token = value?.trim();
   if (!token) {
     return undefined;
@@ -208,7 +208,7 @@ export function verifyAgentRuntimeIdentityToken(
   if (!payload) {
     return undefined;
   }
-  const sharedSecret = readSharedAgentRuntimeIdentitySecret();
+  const sharedSecret = await readSharedAgentRuntimeIdentitySecret();
   if (!sharedSecret || !signatureMatches(signature, signPayload(sharedSecret, payloadPart))) {
     return undefined;
   }

--- a/src/gateway/agent-runtime-identity-token.ts
+++ b/src/gateway/agent-runtime-identity-token.ts
@@ -194,7 +194,7 @@ export async function mintAgentRuntimeIdentityToken(params: {
 /** Validate a presented agent runtime token and return the internal caller identity. */
 export async function verifyAgentRuntimeIdentityToken(
   value: string | null | undefined,
-  nowMs: number = Date.now(),
+  nowMs?: number,
 ): Promise<AgentRuntimeIdentity | undefined> {
   const token = value?.trim();
   if (!token) {
@@ -204,12 +204,12 @@ export async function verifyAgentRuntimeIdentityToken(
   if (!payloadPart || !signature || extra.length > 0) {
     return undefined;
   }
-  const payload = decodePayload(payloadPart, nowMs);
-  if (!payload) {
-    return undefined;
-  }
   const sharedSecret = await readSharedAgentRuntimeIdentitySecret();
   if (!sharedSecret || !signatureMatches(signature, signPayload(sharedSecret, payloadPart))) {
+    return undefined;
+  }
+  const payload = decodePayload(payloadPart, nowMs ?? Date.now());
+  if (!payload) {
     return undefined;
   }
   return {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -2234,7 +2234,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
           connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND;
         let trustedAgentRuntimeIdentity:
-          | ReturnType<typeof verifyAgentRuntimeIdentityToken>
+          | Awaited<ReturnType<typeof verifyAgentRuntimeIdentityToken>>
           | undefined;
         if (typeof agentRuntimeIdentityToken === "string") {
           if (!canAcceptAgentRuntimeIdentity) {
@@ -2249,7 +2249,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             close(1008, truncateCloseReason(message));
             return;
           }
-          trustedAgentRuntimeIdentity = verifyAgentRuntimeIdentityToken(agentRuntimeIdentityToken);
+          trustedAgentRuntimeIdentity =
+            await verifyAgentRuntimeIdentityToken(agentRuntimeIdentityToken);
           if (!trustedAgentRuntimeIdentity) {
             const message = "invalid agent runtime identity token";
             markHandshakeFailure("agent-runtime-identity-invalid", {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1110,6 +1110,18 @@ export function loadExecApprovals(): ExecApprovalsFile {
   }
 }
 
+export async function loadExecApprovalsAsync(): Promise<ExecApprovalsFile> {
+  try {
+    return await withExecApprovalsReadLock(resolveExecApprovalsPath(), async () =>
+      loadExecApprovalsUnlocked(),
+    );
+  } catch {
+    // Match the synchronous reader's fail-closed contract while allowing
+    // same-process async writers to finish instead of rejecting valid state.
+    return createFailClosedExecApprovalsFallback();
+  }
+}
+
 type ExecApprovalsSyncLock = {
   descriptor: number;
   lockPath: string;


### PR DESCRIPTION
Fixes #105122

## What Problem This Solves

Parallel agent node calls could intermittently fail their local Gateway handshake with `invalid agent runtime identity token`, even though the same nodes and credentials worked immediately through direct operator calls.

The token mint path already used the async exec-approvals lock queue, but verification used the synchronous reader. If another agent call held the same process's async lock, the sync reader failed closed immediately and discarded the valid socket signing secret.

## Why This Change Was Made

- add an async, fail-closed exec-approvals reader that shares the existing process-local lock queue;
- make agent-runtime identity verification async and await it at the local backend handshake boundary;
- preserve invalid-token rejection, credential rotation, and the rule that verification never creates credentials;
- add a deterministic regression that starts eight verifications while the same process owns an approvals update.
- evaluate message-action context expiry after any lock wait so queued verification cannot extend a short-lived context.

This keeps lock ownership in the exec-approvals store instead of adding Gateway retries or weakening token validation.

## User Impact

Agents can call multiple connected nodes in parallel without valid local runtime credentials being rejected by same-process approvals contention.

## Evidence

- Blacksmith Testbox `tbx_01kxanbmjbp1jxkzytxvkbqzfg`: 201 focused tests passed across the Gateway identity-token, handshake-health, and agent Gateway-tool suites (`https://github.com/openclaw/openclaw/actions/runs/29185084684`).
- Blacksmith Testbox `tbx_01kxanq0yren9b55wvcvtv1ebw`: `pnpm check:changed` passed, including core/test typechecks, changed-file lint, import-cycle and database-first guards (`https://github.com/openclaw/openclaw/actions/runs/29185260975`).
- Blacksmith Testbox `tbx_01kxapnpkp516wv6dxzhq6hznc`: 205 focused tests passed after adding expiry-during-contention coverage (`https://github.com/openclaw/openclaw/actions/runs/29185718143`).
- Fresh structured autoreview: initial review found the expiry timestamp edge case; the repair rerun is clean with correctness 0.96.
- Live pre-fix reproduction is documented in #105122: six of eight parallel agent node calls failed while immediate sequential operator calls to the same nodes succeeded.
