### PR TITLE
fix(file-transfer): return invalid request errors for malformed node params

### DIFF
--- a/extensions/file-transfer/index.test.ts
+++ b/extensions/file-transfer/index.test.ts
@@ -90,4 +90,18 @@ describe("file-transfer plugin entry", () => {
     });
     expect(invokeNode).not.toHaveBeenCalled();
   });
+
+  it.each(["file.fetch", "dir.list", "dir.fetch", "file.write"])(
+    "rejects malformed %s params before importing runtime handlers",
+    async (command) => {
+      const entry = pluginEntry.nodeHostCommands?.find((item) => item.command === command);
+      if (!entry) {
+        throw new Error(`missing ${command} node-host command`);
+      }
+
+      await expect(entry.handle("{not-json")).rejects.toThrow(
+        "INVALID_REQUEST: paramsJSON malformed JSON",
+      );
+    },
+  );
 });

--- a/extensions/file-transfer/index.ts
+++ b/extensions/file-transfer/index.ts
@@ -18,7 +18,14 @@ type FileTransferToolDescriptor = Pick<
 >;
 
 function readNodeCommandParams(paramsJSON: string | null | undefined): unknown {
-  return paramsJSON ? JSON.parse(paramsJSON) : {};
+  if (!paramsJSON) {
+    return {};
+  }
+  try {
+    return JSON.parse(paramsJSON);
+  } catch {
+    throw new Error("INVALID_REQUEST: paramsJSON malformed JSON");
+  }
 }
 
 function createLazyTool(
@@ -45,9 +52,9 @@ const fileTransferNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
     cap: "file",
     dangerous: true,
     handle: async (paramsJSON) => {
+      const params = readNodeCommandParams(paramsJSON);
       const { handleFileFetch } = await import("./src/node-host/file-fetch.js");
-      const params = readNodeCommandParams(paramsJSON) as Parameters<typeof handleFileFetch>[0];
-      const result = await handleFileFetch(params);
+      const result = await handleFileFetch(params as Parameters<typeof handleFileFetch>[0]);
       return JSON.stringify(result);
     },
   },
@@ -56,9 +63,9 @@ const fileTransferNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
     cap: "file",
     dangerous: true,
     handle: async (paramsJSON) => {
+      const params = readNodeCommandParams(paramsJSON);
       const { handleDirList } = await import("./src/node-host/dir-list.js");
-      const params = readNodeCommandParams(paramsJSON) as Parameters<typeof handleDirList>[0];
-      const result = await handleDirList(params);
+      const result = await handleDirList(params as Parameters<typeof handleDirList>[0]);
       return JSON.stringify(result);
     },
   },
@@ -67,9 +74,9 @@ const fileTransferNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
     cap: "file",
     dangerous: true,
     handle: async (paramsJSON) => {
+      const params = readNodeCommandParams(paramsJSON);
       const { handleDirFetch } = await import("./src/node-host/dir-fetch.js");
-      const params = readNodeCommandParams(paramsJSON) as Parameters<typeof handleDirFetch>[0];
-      const result = await handleDirFetch(params);
+      const result = await handleDirFetch(params as Parameters<typeof handleDirFetch>[0]);
       return JSON.stringify(result);
     },
   },
@@ -78,9 +85,9 @@ const fileTransferNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
     cap: "file",
     dangerous: true,
     handle: async (paramsJSON) => {
+      const params = readNodeCommandParams(paramsJSON);
       const { handleFileWrite } = await import("./src/node-host/file-write.js");
-      const params = readNodeCommandParams(paramsJSON) as Parameters<typeof handleFileWrite>[0];
-      const result = await handleFileWrite(params);
+      const result = await handleFileWrite(params as Parameters<typeof handleFileWrite>[0]);
       return JSON.stringify(result);
     },
   },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where file-transfer node-host commands receiving malformed paramsJSON would load their runtime handlers and surface raw JSON syntax errors instead of the node-host malformed-params request boundary.

## Why This Change Was Made

The shared file-transfer command parser now rejects malformed paramsJSON before each lazy runtime handler import. This covers ile.fetch, dir.list, dir.fetch, and ile.write at the plugin entry boundary without changing file-transfer policy, config, schemas, or valid/empty parameter behavior.

## User Impact

Operators and agent callers get a stable INVALID_REQUEST: paramsJSON malformed JSON error for malformed file-transfer node command payloads, and malformed requests avoid unnecessary runtime handler loading.

## Evidence

- Claim proved: current head `7ad0d99d037f` returns the stable malformed-params error through the real node-host/plugin command dispatch path for all four affected file-transfer commands.
- Commands / artifacts:
  - `git diff --check HEAD~1..HEAD`
  - `node scripts/run-vitest.mjs extensions/file-transfer/index.test.ts`
  - Runtime transcript command: PowerShell stdin script importing `extensions/file-transfer/index.ts`, registering its `nodeHostCommands` in the active plugin registry, invoking `src/node-host/invoke.ts#handleInvoke` with `paramsJSON: "{not-json}"`, and capturing `node.invoke.result` via `node --import tsx --input-type=module -`.
  - GitHub Real behavior proof check passed: https://github.com/openclaw/openclaw/actions/runs/29186188989/job/86632960447
- Observed result:
  - `git diff --check HEAD~1..HEAD` passed.
  - `extensions/file-transfer/index.test.ts` passed with 6 tests passing.
  - Redacted runtime transcript from the node-host/plugin command path:

```text
node-host/plugin command runtime proof on HEAD 7ad0d99d037f
PASS file.fetch -> node.invoke.result ok=false error.code=INVALID_REQUEST message=Error: INVALID_REQUEST: paramsJSON malformed JSON
PASS dir.list -> node.invoke.result ok=false error.code=INVALID_REQUEST message=Error: INVALID_REQUEST: paramsJSON malformed JSON
PASS dir.fetch -> node.invoke.result ok=false error.code=INVALID_REQUEST message=Error: INVALID_REQUEST: paramsJSON malformed JSON
PASS file.write -> node.invoke.result ok=false error.code=INVALID_REQUEST message=Error: INVALID_REQUEST: paramsJSON malformed JSON
```

