### PR TITLE
fix(slack): preserve resolved secrets for slash replies

### DIFF
--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -1668,6 +1668,54 @@ describe("slack slash command session metadata", () => {
     );
   });
 
+  it("adopts matching runtime refreshes after resolving monitor secrets", async () => {
+    const harness = createPolicyHarness({
+      channelId: "D123",
+      channelName: "directmessage",
+      resolveChannelName: async () => ({ name: "directmessage", type: "im" }),
+    });
+    const sourceCfg = (harness.ctx as { cfg: OpenClawConfig }).cfg;
+    const resolvedCfg = {
+      ...sourceCfg,
+      channels: {
+        slack: {
+          accounts: {
+            default: {
+              botToken: "xoxb-resolved",
+              appToken: "xapp-resolved",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const refreshedSourceCfg = {
+      ...sourceCfg,
+      session: { dmScope: "per-channel-peer" },
+    } as OpenClawConfig;
+    const refreshedResolvedCfg = {
+      ...resolvedCfg,
+      session: { dmScope: "per-channel-peer" },
+    } as OpenClawConfig;
+    (harness.ctx as { cfg: OpenClawConfig }).cfg = resolvedCfg;
+    setRuntimeConfigSnapshot(resolvedCfg, sourceCfg);
+    await registerCommands(harness.ctx, harness.account);
+    setRuntimeConfigSnapshot(refreshedResolvedCfg, refreshedSourceCfg);
+
+    await runSlashHandler({
+      commands: harness.commands,
+      command: {
+        channel_id: harness.channelId,
+        channel_name: harness.channelName,
+      },
+    });
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: refreshedResolvedCfg,
+      }),
+    );
+  });
+
   it("calls recordSessionMetaFromInbound after dispatching a slash command", async () => {
     const harness = createPolicyHarness({ groupPolicy: "open" });
     await registerAndRunPolicySlash({ harness });

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -1557,6 +1557,64 @@ describe("slack slash command session metadata", () => {
   const { deliverSlackSlashRepliesMock, recordSessionMetaFromInboundMock, resolveAgentRouteMock } =
     getSlackSlashMocks();
 
+  it("keeps the monitor's resolved secrets when the runtime snapshot is unrelated", async () => {
+    const harness = createPolicyHarness({
+      channelId: "D123",
+      channelName: "directmessage",
+      resolveChannelName: async () => ({ name: "directmessage", type: "im" }),
+    });
+    const resolvedCfg = {
+      ...(harness.ctx as { cfg: OpenClawConfig }).cfg,
+      channels: {
+        slack: {
+          accounts: {
+            default: {
+              botToken: "xoxb-resolved",
+              appToken: "xapp-resolved",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    (harness.ctx as { cfg: OpenClawConfig }).cfg = resolvedCfg;
+    const unresolvedSnapshot = {
+      channels: {
+        slack: {
+          accounts: {
+            default: {
+              botToken: {
+                source: "env",
+                provider: "default",
+                id: "SLACK_BOT_TOKEN",
+              },
+              appToken: {
+                source: "env",
+                provider: "default",
+                id: "SLACK_APP_TOKEN",
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(unresolvedSnapshot, unresolvedSnapshot);
+    await registerCommands(harness.ctx, harness.account);
+
+    await runSlashHandler({
+      commands: harness.commands,
+      command: {
+        channel_id: harness.channelId,
+        channel_name: harness.channelName,
+      },
+    });
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: resolvedCfg,
+      }),
+    );
+  });
+
   it("refreshes slash routing config between invocations", async () => {
     const harness = createPolicyHarness({
       channelId: "D123",

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -392,6 +392,7 @@ export async function registerSlackMonitorSlashCommands(params: {
   const slashCommand = resolveSlackSlashCommandConfig(
     ctx.slashCommand ?? account.config.slashCommand,
   );
+  const startupRuntimeSourceConfig = getRuntimeConfigSourceSnapshot();
 
   const handleSlashCommand = async (p: {
     command: SlackCommandMiddlewareArgs["command"];
@@ -420,12 +421,15 @@ export async function registerSlackMonitorSlashCommands(params: {
           }
         : createSlackResponseUrlBudget(respondWithoutBudget);
     const respond = responseBudget.respond;
+    const applicableRuntimeConfig = selectApplicableRuntimeConfig({
+      inputConfig: startupRuntimeSourceConfig ?? ctx.cfg,
+      runtimeConfig: getRuntimeConfigSnapshot(),
+      runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
+    });
     const cfg =
-      selectApplicableRuntimeConfig({
-        inputConfig: ctx.cfg,
-        runtimeConfig: getRuntimeConfigSnapshot(),
-        runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
-      }) ?? ctx.cfg;
+      applicableRuntimeConfig === startupRuntimeSourceConfig
+        ? ctx.cfg
+        : (applicableRuntimeConfig ?? ctx.cfg);
     try {
       if (ctx.shouldDropMismatchedSlackEvent?.(body)) {
         await ack();

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -21,7 +21,11 @@ import {
 } from "openclaw/plugin-sdk/native-command-config-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
-import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import {
@@ -416,7 +420,12 @@ export async function registerSlackMonitorSlashCommands(params: {
           }
         : createSlackResponseUrlBudget(respondWithoutBudget);
     const respond = responseBudget.respond;
-    const cfg = getRuntimeConfigSnapshot() ?? ctx.cfg;
+    const cfg =
+      selectApplicableRuntimeConfig({
+        inputConfig: ctx.cfg,
+        runtimeConfig: getRuntimeConfigSnapshot(),
+        runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
+      }) ?? ctx.cfg;
     try {
       if (ctx.shouldDropMismatchedSlackEvent?.(body)) {
         await ack();


### PR DESCRIPTION
## What Problem This Solves

Slack slash commands can fail with an unresolved SecretRef even though the Slack monitor is connected and the secret remains available in the process environment.

The confusing part is that OpenClaw has two representations of the same configuration:

```text
Source configuration:
botToken = SecretRef("SLACK_BOT_TOKEN")

Resolved runtime configuration:
botToken = "xoxb-..."
```

A SecretRef is an instruction for obtaining a secret, not the secret value itself. During startup, OpenClaw resolves the source configuration and gives the Slack monitor a runtime configuration containing the token. That is why Socket Mode can connect successfully.

Later, the slash handler currently reads the process-wide runtime snapshot unconditionally:

```ts
const cfg = getRuntimeConfigSnapshot() ?? ctx.cfg;
```

When that snapshot was produced from a different source configuration, it can still contain the raw SecretRef. The handler then discards the monitor's working resolved configuration and passes the raw reference into reply dispatch. Secret resolution correctly refuses to treat that reference as a token, so the command fails even though the environment variable never disappeared.

The failure flow is:

```text
secret exists in the environment
  -> startup resolves it
  -> Slack monitor connects with resolved credentials
  -> slash handler discards the resolved monitor config
  -> slash handler selects a snapshot containing a raw SecretRef
  -> reply dispatch fails on the unresolved reference
```

## Why This Change Was Made

The slash handler now uses the shared runtime-config applicability selector. It adopts a runtime refresh only when the snapshot's source configuration matches the monitor's input configuration. Otherwise, it preserves the monitor's already-resolved configuration.

```text
Snapshot descends from the monitor's source config?
  yes -> use the newer resolved runtime snapshot
  no  -> retain the monitor's resolved config
```

This restores the focused runtime-selection change that was removed while narrowing #104736 to command registration precedence.

## User Impact

Slash commands continue through reply dispatch instead of returning Slack's generic command-handling error. This does not add another secret lookup or make secrets globally readable; it prevents a resolved credential from being replaced by an inapplicable raw configuration reference.

## Evidence

- Added a regression test with resolved monitor credentials and a runtime snapshot whose source does not match the monitor configuration and still contains unresolved SecretRefs.
- The existing routing-refresh test continues to cover adoption of an applicable runtime update.
- Local validation was attempted twice after PR creation, but dependency installation was blocked by registry HTTP 403 responses before Vitest started. Hosted CI remains the validation path.
