### PR TITLE
refactor(models): trim private catalog exports

### DIFF
--- a/packages/model-catalog-core/src/model-catalog-normalize.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.test.ts
@@ -1,6 +1,6 @@
 // Model Catalog Core tests cover model catalog normalize behavior.
 import { describe, expect, it } from "vitest";
-import { normalizeModelCatalog, normalizeModelCatalogRows } from "./index.js";
+import { normalizeModelCatalog, normalizeModelCatalogProviderRows } from "./index.js";
 import { buildModelCatalogMergeKey, buildModelCatalogRef } from "./model-catalog-refs.js";
 
 describe("model catalog normalization", () => {
@@ -203,26 +203,25 @@ describe("model catalog normalization", () => {
   });
 
   it("builds normalized rows with provider defaults and stable refs", () => {
-    const rows = normalizeModelCatalogRows({
-      source: "manifest",
-      providers: {
-        OpenAI: {
-          baseUrl: "https://api.openai.com/v1",
-          api: "openai-responses",
-          headers: {
-            "x-provider": "openai",
-          },
-          models: [
-            {
-              id: "GPT-5.4",
-              headers: {
-                "x-model": "gpt-5.4",
-              },
-              input: ["image"],
-            },
-          ],
+    const rows = normalizeModelCatalogProviderRows({
+      provider: "OpenAI",
+      providerCatalog: {
+        baseUrl: "https://api.openai.com/v1",
+        api: "openai-responses",
+        headers: {
+          "x-provider": "openai",
         },
+        models: [
+          {
+            id: "GPT-5.4",
+            headers: {
+              "x-model": "gpt-5.4",
+            },
+            input: ["image"],
+          },
+        ],
       },
+      source: "manifest",
     });
 
     expect(rows).toEqual([

--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -763,15 +763,3 @@ export function normalizeModelCatalogProviderRows(params: {
 
   return rows.toSorted((a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id));
 }
-
-/** Normalize all provider catalogs into sorted runtime rows. */
-export function normalizeModelCatalogRows(params: {
-  providers: Record<string, ModelCatalogProvider>;
-  source: ModelCatalogSource;
-}): NormalizedModelCatalogRow[] {
-  return Object.entries(params.providers)
-    .flatMap(([provider, providerCatalog]) =>
-      normalizeModelCatalogProviderRows({ provider, providerCatalog, source: params.source }),
-    )
-    .toSorted((a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id));
-}

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -53,7 +53,7 @@ export function setCurrentManifestModelIdNormalizationRecords(
 }
 
 /** Return the current process-local manifest normalization policy snapshot. */
-export function getCurrentManifestModelIdNormalizationPolicies():
+function getCurrentManifestModelIdNormalizationPolicies():
   | ReadonlyMap<string, ManifestModelIdNormalizationProvider>
   | undefined {
   return currentManifestModelIdNormalizationPolicies;


### PR DESCRIPTION
## What Problem This Solves

Removes two unused exports from the private model-catalog core package: a redundant aggregate normalizer and an implementation-only process-local policy getter.

## Why This Change Was Made

Exact codebase-memory graph queries and repository-wide searches found no external callers for either symbol. The test-only aggregate normalizer is deleted in favor of the retained provider-level API, and the policy getter remains private beside its only caller.

## User Impact

No user-visible behavior changes. The private package exposes a smaller, more intentional surface with 13 fewer net lines.

## Evidence

- Exact graph and repository-wide symbol searches found no consumers outside the defining modules and one direct-only test.
- `node scripts/run-vitest.mjs packages/model-catalog-core/src/model-catalog-normalize.test.ts packages/model-catalog-core/src/model-catalog-refs.test.ts packages/model-catalog-core/src/configured-model-refs.test.ts packages/model-catalog-core/src/provider-model-id-normalization.test.ts src/model-catalog/manifest-planner.test.ts src/model-catalog/provider-index-planner.test.ts` - 6 files, 34 tests passed across 2 Vitest shards.
- Targeted oxlint passed.
- Targeted oxfmt check passed.
- `git diff --check` passed.
- Fresh post-rebase autoreview with `gpt-5.6-sol` at medium reasoning found no actionable issues (`0.96` confidence).
- The first hosted build exposed that privatizing five transitive declaration names increased the rolled-up Plugin SDK `.d.ts`; those changes were removed, leaving only the two genuinely dead exports.
- Blacksmith Testbox leases `tbx_01kxancwbt5tn89g9ndba79bes` and `tbx_01kxap2bbe9r2q6v7wxase5gjv` were stopped after delegated Git fetch and direct SSH/rsync sync paths stalled; hosted exact-head CI will supply the broad remote gate.

AI-assisted; the implementation, caller audit, dependency boundary, and verification evidence were reviewed against the exact diff.
