### PR TITLE
fix(browser): make ref uploads request-owned

### DIFF
--- a/extensions/browser/src/browser/pw-ai.ts
+++ b/extensions/browser/src/browser/pw-ai.ts
@@ -79,6 +79,7 @@ export {
   traceStartViaPlaywright,
   traceStopViaPlaywright,
   typeViaPlaywright,
+  uploadViaPlaywright,
   waitForDownloadViaPlaywright,
   waitForViaPlaywright,
 } from "./pw-tools-core.js";

--- a/extensions/browser/src/browser/pw-tools-core.downloads.ts
+++ b/extensions/browser/src/browser/pw-tools-core.downloads.ts
@@ -180,7 +180,6 @@ export async function uploadViaPlaywright(
   if (controller.signal.aborted) {
     rejectOnAbort();
   }
-  let active!: ActiveAtomicUpload;
   const execution = Promise.resolve().then(async () => {
     // Preserve the full predecessor cleanup chain even when this caller aborts
     // while queued; later owners must never skip an older in-flight click.
@@ -300,7 +299,7 @@ export async function uploadViaPlaywright(
     () => {},
     () => {},
   );
-  active = { controller, settled };
+  const active = { controller, settled };
   activeAtomicUploads.set(key, active);
   previous?.controller.abort(new Error("File upload was superseded by another waiter"));
   void settled.then(() => {

--- a/extensions/browser/src/browser/pw-tools-core.downloads.ts
+++ b/extensions/browser/src/browser/pw-tools-core.downloads.ts
@@ -3,20 +3,26 @@
  * tools.
  */
 import path from "node:path";
-import type { Page } from "playwright-core";
+import type { FileChooser, Page } from "playwright-core";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS } from "./constants.js";
 import type { BrowserDownloadResult } from "./download-types.js";
+import type { BrowserNavigationPolicyOptions } from "./navigation-guard.js";
 import { resolveStrictExistingUploadPaths } from "./paths.js";
 import { createDownloadCaptureForPage } from "./pw-download-capture.js";
 import {
   armObservedDialogResponseOnPage,
   ensurePageState,
+  forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
   refLocator,
   respondToObservedDialogOnPage,
   restoreRoleRefsForTarget,
 } from "./pw-session.js";
+import {
+  clickViaPlaywright,
+  setFileChooserFilesViaPlaywright,
+} from "./pw-tools-core.interactions.js";
 import {
   bumpDownloadArmId,
   bumpUploadArmId,
@@ -24,6 +30,18 @@ import {
   requireRef,
   toAIFriendlyError,
 } from "./pw-tools-core.shared.js";
+
+async function dismissFileChooser(page: Page): Promise<void> {
+  await page.keyboard.press("Escape").catch(() => {});
+}
+
+type ActiveAtomicUpload = {
+  controller: AbortController;
+  settled: Promise<void>;
+};
+
+const activeAtomicUploads = new Map<string, ActiveAtomicUpload>();
+const pendingUploadClaims = new Map<string, number>();
 
 function createExplicitDownloadCapture(params: {
   page: Page;
@@ -57,46 +75,249 @@ export async function armFileUploadViaPlaywright(opts: {
   paths?: string[];
   timeoutMs?: number;
 }): Promise<void> {
-  const page = await getPageForTargetId(opts);
-  const state = ensurePageState(page);
-  const timeout = normalizeTimeoutMs(opts.timeoutMs, DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS);
+  const key = opts.cdpUrl;
+  const armId = bumpUploadArmId();
+  pendingUploadClaims.set(key, armId);
+  try {
+    const active = activeAtomicUploads.get(key);
+    if (active) {
+      active.controller.abort(new Error("File upload was superseded by another waiter"));
+      await active.settled;
+    }
+    if (pendingUploadClaims.get(key) !== armId) {
+      return;
+    }
+    const page = await getPageForTargetId(opts);
+    if (pendingUploadClaims.get(key) !== armId) {
+      return;
+    }
+    const state = ensurePageState(page);
+    const timeout = normalizeTimeoutMs(opts.timeoutMs, DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS);
+    state.armIdUpload = armId;
 
-  state.armIdUpload = bumpUploadArmId();
-  const armId = state.armIdUpload;
-
-  // The waiter is intentionally detached: the tool call arms future browser UI,
-  // while the later user click opens the chooser.
-  void page
-    .waitForEvent("filechooser", { timeout })
-    .then(async (fileChooser) => {
-      if (state.armIdUpload !== armId) {
-        return;
-      }
-      if (!opts.paths?.length) {
-        // Playwright removed `FileChooser.cancel()`; best-effort close the chooser instead.
-        try {
-          await page.keyboard.press("Escape");
-        } catch {
-          // Best-effort.
+    // The waiter is intentionally detached: the tool call arms future browser UI,
+    // while the later user click opens the chooser.
+    void page
+      .waitForEvent("filechooser", { timeout })
+      .then(async (fileChooser) => {
+        if (state.armIdUpload !== armId) {
+          return;
         }
-        return;
-      }
-      const uploadPathsResult = await resolveStrictExistingUploadPaths({
-        requestedPaths: opts.paths,
+        if (!opts.paths?.length) {
+          // Playwright removed `FileChooser.cancel()`; best-effort close the chooser instead.
+          await dismissFileChooser(page);
+          return;
+        }
+        const uploadPathsResult = await resolveStrictExistingUploadPaths({
+          requestedPaths: opts.paths,
+        });
+        if (!uploadPathsResult.ok) {
+          await dismissFileChooser(page);
+          return;
+        }
+        await fileChooser.setFiles(uploadPathsResult.paths);
+      })
+      .catch(() => {
+        // Ignore timeouts; the chooser may never appear.
       });
-      if (!uploadPathsResult.ok) {
-        try {
-          await page.keyboard.press("Escape");
-        } catch {
-          // Best-effort.
-        }
+  } finally {
+    if (pendingUploadClaims.get(key) === armId) {
+      pendingUploadClaims.delete(key);
+    }
+  }
+}
+
+/** Clicks a ref and completes its file chooser as one request-owned operation. */
+export async function uploadViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    ref: string;
+    paths: string[];
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  } & BrowserNavigationPolicyOptions,
+): Promise<void> {
+  opts.signal?.throwIfAborted();
+  // Abort cleanup disconnects the shared Playwright connection, so ownership
+  // must cover every target on that connection before a successor reconnects.
+  const key = opts.cdpUrl;
+  const timeout = normalizeTimeoutMs(opts.timeoutMs, DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS);
+  const armId = bumpUploadArmId();
+  pendingUploadClaims.set(key, armId);
+  const previous = activeAtomicUploads.get(key);
+  const controller = new AbortController();
+  const abortFromCaller = () =>
+    controller.abort(opts.signal?.reason ?? new Error("File upload aborted"));
+  opts.signal?.addEventListener("abort", abortFromCaller, { once: true });
+  if (opts.signal?.aborted) {
+    abortFromCaller();
+  }
+  const deadline = Date.now() + timeout;
+  const timer = setTimeout(
+    () => controller.abort(new Error(`Timeout ${timeout}ms exceeded while completing file upload`)),
+    timeout,
+  );
+  let rejectAborted!: (reason: unknown) => void;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAborted = reject;
+  });
+  void aborted.catch(() => {});
+  let started = false;
+  let rejectQueuedAbort!: (reason: unknown) => void;
+  const queuedAbort = new Promise<never>((_resolve, reject) => {
+    rejectQueuedAbort = reject;
+  });
+  void queuedAbort.catch(() => {});
+  const rejectOnAbort = () => {
+    const reason = controller.signal.reason ?? new Error("File upload aborted");
+    rejectAborted(reason);
+    if (!started) {
+      rejectQueuedAbort(reason);
+    }
+  };
+  controller.signal.addEventListener("abort", rejectOnAbort, { once: true });
+  if (controller.signal.aborted) {
+    rejectOnAbort();
+  }
+  let active!: ActiveAtomicUpload;
+  const execution = Promise.resolve().then(async () => {
+    // Preserve the full predecessor cleanup chain even when this caller aborts
+    // while queued; later owners must never skip an older in-flight click.
+    await previous?.settled;
+    if (activeAtomicUploads.get(key) !== active || pendingUploadClaims.get(key) !== armId) {
+      throw controller.signal.reason ?? new Error("File upload was superseded by another waiter");
+    }
+    controller.signal.throwIfAborted();
+    const page = await Promise.race([getPageForTargetId(opts), aborted]);
+    if (activeAtomicUploads.get(key) !== active || pendingUploadClaims.get(key) !== armId) {
+      throw controller.signal.reason ?? new Error("File upload was superseded by another waiter");
+    }
+    controller.signal.throwIfAborted();
+    started = true;
+    const state = ensurePageState(page);
+    state.armIdUpload = armId;
+
+    let resolveChooser!: (chooser: FileChooser) => void;
+    let rejectChooser!: (reason: unknown) => void;
+    const chooserPromise = new Promise<FileChooser>((resolve, reject) => {
+      resolveChooser = resolve;
+      rejectChooser = reject;
+    });
+    void chooserPromise.catch(() => {});
+    let chooser: FileChooser | undefined;
+    let chooserListening = true;
+    const onChooser = (observed: FileChooser) => {
+      if (chooser) {
         return;
       }
-      await fileChooser.setFiles(uploadPathsResult.paths);
-    })
-    .catch(() => {
-      // Ignore timeouts; the chooser may never appear.
-    });
+      chooser = observed;
+      page.off("filechooser", onChooser);
+      chooserListening = false;
+      resolveChooser(observed);
+    };
+    page.on("filechooser", onChooser);
+
+    let phase: "idle" | "click" | "chooser" | "validation" | "setFiles" = "idle";
+    let abortCleanup: Promise<void> | undefined;
+    const onAbort = () => {
+      const reason = controller.signal.reason ?? new Error("File upload aborted");
+      rejectChooser(reason);
+      if (phase === "click" || phase === "setFiles") {
+        // Playwright actions do not consume our AbortSignal. Disconnect so a
+        // successor cannot start until the raw operation has actually settled.
+        abortCleanup ??= forceDisconnectPlaywrightForTarget({
+          cdpUrl: opts.cdpUrl,
+          targetId: opts.targetId,
+          ssrfPolicy: opts.ssrfPolicy,
+          reason: "file upload aborted",
+        }).catch(() => {});
+      }
+    };
+    controller.signal.addEventListener("abort", onAbort, { once: true });
+    if (controller.signal.aborted) {
+      onAbort();
+    }
+
+    try {
+      controller.signal.throwIfAborted();
+      phase = "click";
+      await clickViaPlaywright({
+        cdpUrl: opts.cdpUrl,
+        targetId: opts.targetId,
+        ref: opts.ref,
+        timeoutMs: Math.max(1, deadline - Date.now()),
+        ssrfPolicy: opts.ssrfPolicy,
+        browserProxyMode: opts.browserProxyMode,
+        resolvedPage: page,
+      });
+      phase = "chooser";
+      chooser = await chooserPromise;
+      if (state.armIdUpload !== armId) {
+        throw new Error("File upload was superseded by another waiter");
+      }
+      controller.signal.throwIfAborted();
+      phase = "validation";
+      const uploadPathsResult = await Promise.race([
+        resolveStrictExistingUploadPaths({ requestedPaths: opts.paths }),
+        aborted,
+      ]);
+      if (!uploadPathsResult.ok) {
+        throw new Error(uploadPathsResult.error);
+      }
+      controller.signal.throwIfAborted();
+      phase = "setFiles";
+      try {
+        await setFileChooserFilesViaPlaywright({
+          cdpUrl: opts.cdpUrl,
+          targetId: opts.targetId,
+          page,
+          fileChooser: chooser,
+          paths: uploadPathsResult.paths,
+          timeoutMs: Math.max(1, deadline - Date.now()),
+          ssrfPolicy: opts.ssrfPolicy,
+          browserProxyMode: opts.browserProxyMode,
+        });
+      } finally {
+        phase = "idle";
+      }
+      controller.signal.throwIfAborted();
+    } catch (error) {
+      throw controller.signal.aborted ? controller.signal.reason : error;
+    } finally {
+      controller.signal.removeEventListener("abort", onAbort);
+      if (chooserListening) {
+        page.off("filechooser", onChooser);
+      }
+      if (state.armIdUpload === armId) {
+        state.armIdUpload = bumpUploadArmId();
+      }
+      await abortCleanup;
+    }
+  });
+
+  const settled = execution.then(
+    () => {},
+    () => {},
+  );
+  active = { controller, settled };
+  activeAtomicUploads.set(key, active);
+  previous?.controller.abort(new Error("File upload was superseded by another waiter"));
+  void settled.then(() => {
+    controller.signal.removeEventListener("abort", rejectOnAbort);
+    if (activeAtomicUploads.get(key) === active) {
+      activeAtomicUploads.delete(key);
+    }
+    if (pendingUploadClaims.get(key) === armId) {
+      pendingUploadClaims.delete(key);
+    }
+  });
+  try {
+    await Promise.race([execution, queuedAbort]);
+  } finally {
+    clearTimeout(timer);
+    opts.signal?.removeEventListener("abort", abortFromCaller);
+  }
 }
 
 /** Accepts or dismisses a pending dialog, or arms the next matching dialog response. */

--- a/extensions/browser/src/browser/pw-tools-core.interactions.set-input-files.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.set-input-files.test.ts
@@ -21,12 +21,23 @@ const refLocator = vi.fn(() => {
   return locator;
 });
 const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
+const assertPageNavigationCompletedSafely = vi.fn(async () => {});
+const withPageNavigationRequestGuard = vi.fn(
+  async ({
+    action,
+    page: guardedPage,
+  }: {
+    action: (url: string) => Promise<unknown>;
+    page: { url: () => string };
+  }) => await action(guardedPage.url()),
+);
 
 const resolveStrictExistingUploadPaths =
   vi.fn<typeof import("./paths.js").resolveStrictExistingUploadPaths>();
 
 vi.mock("./pw-session.js", () => {
   return {
+    assertPageNavigationCompletedSafely,
     ensurePageState,
     forceDisconnectPlaywrightForTarget,
     getPageForTargetId,
@@ -34,16 +45,10 @@ vi.mock("./pw-session.js", () => {
     markObservedDialogsHandledRemotelyForPage,
     refLocator,
     restoreRoleRefsForTarget,
+    isPolicyDenyNavigationError: vi.fn(() => false),
+    quarantineBlockedNavigationTarget: vi.fn(async () => {}),
     wasBrowserNavigationSourcePreservedAfterPolicyDenial: vi.fn(() => false),
-    withPageNavigationRequestGuard: vi.fn(
-      async ({
-        action,
-        page: guardedPage,
-      }: {
-        action: (url: string) => Promise<unknown>;
-        page: { url: () => string };
-      }) => await action(guardedPage.url()),
-    ),
+    withPageNavigationRequestGuard,
   };
 });
 
@@ -69,6 +74,7 @@ function seedSingleLocatorPage(): {
   };
   page = {
     locator: vi.fn(() => ({ first: () => locator })),
+    url: vi.fn(() => "https://allowed.example/form"),
   };
   return { setInputFiles, elementHandle };
 }
@@ -101,6 +107,22 @@ describe("setInputFilesViaPlaywright", () => {
     expect(setInputFiles).toHaveBeenCalledWith(["/private/tmp/openclaw/uploads/ok.txt"]);
     expect(setInputFiles).toHaveBeenCalledTimes(1);
     expect(elementHandle).not.toHaveBeenCalled();
+  });
+
+  it("keeps assignment-triggered navigation inside the browser policy guard", async () => {
+    const { setInputFiles } = seedSingleLocatorPage();
+
+    await setInputFilesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      inputRef: "e7",
+      paths: ["/tmp/openclaw/uploads/ok.txt"],
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
+    });
+
+    expect(withPageNavigationRequestGuard).toHaveBeenCalledTimes(1);
+    expect(setInputFiles).toHaveBeenCalledTimes(1);
+    expect(assertPageNavigationCompletedSafely).toHaveBeenCalledTimes(1);
   });
 
   it("throws and skips setInputFiles when use-time validation fails", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -4,7 +4,7 @@
  */
 import { resolveNonNegativeIntegerOption } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { Frame, Page } from "playwright-core";
+import type { FileChooser, Frame, Page } from "playwright-core";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   ACT_MAX_BATCH_ACTIONS,
@@ -690,10 +690,15 @@ export async function clickViaPlaywright(
     delayMs?: number;
     timeoutMs?: number;
     signal?: AbortSignal;
+    resolvedPage?: Page;
   } & BrowserNavigationPolicyOptions,
 ): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
-  const page = await getRestoredPageForTarget(opts);
+  const page = opts.resolvedPage ?? (await getRestoredPageForTarget(opts));
+  if (opts.resolvedPage) {
+    ensurePageState(page);
+    restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
+  }
   const label = resolved.ref ?? resolved.selector!;
   const locator = resolved.ref
     ? refLocator(page, requireRef(resolved.ref))
@@ -1584,13 +1589,36 @@ async function captureElementScreenshotForLabels(
 }
 
 /** Sets file inputs for a role ref or selector with strict existing-path checks. */
-export async function setInputFilesViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  inputRef?: string;
-  element?: string;
-  paths: string[];
-}): Promise<void> {
+export async function setFileChooserFilesViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    page: Page;
+    fileChooser: FileChooser;
+    paths: string[];
+    timeoutMs: number;
+  } & BrowserNavigationPolicyOptions,
+): Promise<void> {
+  await awaitNavigationGuardedInteraction({
+    action: async () => {
+      await opts.fileChooser.setFiles(opts.paths, { timeout: opts.timeoutMs });
+    },
+    cdpUrl: opts.cdpUrl,
+    page: opts.page,
+    ...interactionNavigationPolicy(opts),
+    targetId: opts.targetId,
+  });
+}
+
+export async function setInputFilesViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    inputRef?: string;
+    element?: string;
+    paths: string[];
+  } & BrowserNavigationPolicyOptions,
+): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
@@ -1614,7 +1642,15 @@ export async function setInputFilesViaPlaywright(opts: {
   const resolvedPaths = resolvedResult.paths;
 
   try {
-    await locator.setInputFiles(resolvedPaths);
+    await awaitNavigationGuardedInteraction({
+      action: async () => {
+        await locator.setInputFiles(resolvedPaths);
+      },
+      cdpUrl: opts.cdpUrl,
+      page,
+      ...interactionNavigationPolicy(opts),
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toFriendlyInteractionError(err, inputRef || element);
   }

--- a/extensions/browser/src/browser/pw-tools-core.upload-paths.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.upload-paths.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover pw tools core.upload paths plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getPwToolsCoreSessionMocks,
   installPwToolsCoreTestHooks,
   setPwToolsCoreCurrentPage,
 } from "./pw-tools-core.test-harness.js";
@@ -14,6 +15,17 @@ const pathMocks = vi.hoisted(() => ({
     >(),
 }));
 
+const interactionMocks = vi.hoisted(() => ({
+  clickViaPlaywright: vi.fn(async () => {}),
+  setFileChooserFilesViaPlaywright: vi.fn(
+    async (opts: {
+      fileChooser: { setFiles: (paths: string[], options?: { timeout?: number }) => Promise<void> };
+      paths: string[];
+      timeoutMs: number;
+    }) => await opts.fileChooser.setFiles(opts.paths, { timeout: opts.timeoutMs }),
+  ),
+}));
+
 vi.mock("./paths.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./paths.js")>();
   return {
@@ -22,8 +34,12 @@ vi.mock("./paths.js", async (importOriginal) => {
   };
 });
 
+vi.mock("./pw-tools-core.interactions.js", () => interactionMocks);
+
 installPwToolsCoreTestHooks();
-const { armFileUploadViaPlaywright } = await import("./pw-tools-core.downloads.js");
+const sessionMocks = getPwToolsCoreSessionMocks();
+const { armFileUploadViaPlaywright, uploadViaPlaywright } =
+  await import("./pw-tools-core.downloads.js");
 
 function createFileChooserPageMocks() {
   const element = vi.fn(async () => {
@@ -39,8 +55,42 @@ function createFileChooserPageMocks() {
   return { fileChooser, press };
 }
 
+function createAtomicFileChooserPageMocks() {
+  const fileChooser = {
+    setFiles: vi.fn<(paths: string[], options?: { timeout?: number }) => Promise<void>>(
+      async () => {},
+    ),
+  };
+  type Listener = (chooser: typeof fileChooser) => void;
+  const listeners = new Set<Listener>();
+  const on = vi.fn((_event: "filechooser", listener: Listener) => {
+    listeners.add(listener);
+  });
+  const off = vi.fn((_event: "filechooser", listener: Listener) => {
+    listeners.delete(listener);
+  });
+  const press = vi.fn(async () => {});
+  const currentPage = { on, off, keyboard: { press } };
+  setPwToolsCoreCurrentPage(currentPage);
+  return {
+    currentPage,
+    emitChooser: (observed = fileChooser) => {
+      for (const listener of listeners) {
+        listener(observed);
+      }
+    },
+    fileChooser,
+    listenerCount: () => listeners.size,
+    off,
+    press,
+  };
+}
+
 describe("armFileUploadViaPlaywright upload path validation", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    interactionMocks.clickViaPlaywright.mockReset().mockResolvedValue(undefined);
+    interactionMocks.setFileChooserFilesViaPlaywright.mockClear();
     pathMocks.resolveStrictExistingUploadPaths.mockResolvedValue({
       ok: true,
       paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
@@ -84,5 +134,362 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
       expect(press).toHaveBeenCalledWith("Escape");
     });
     expect(fileChooser.setFiles).not.toHaveBeenCalled();
+  });
+
+  it("awaits synchronous chooser dispatch and file assignment", async () => {
+    const page = createAtomicFileChooserPageMocks();
+    let finishSetFiles!: () => void;
+    page.fileChooser.setFiles.mockImplementation(
+      async () =>
+        await new Promise<void>((resolve) => {
+          finishSetFiles = resolve;
+        }),
+    );
+    interactionMocks.clickViaPlaywright.mockImplementation(async () => page.emitChooser());
+
+    let settled = false;
+    const upload = uploadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      ref: "e12",
+      paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
+    }).then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => expect(page.fileChooser.setFiles).toHaveBeenCalledTimes(1));
+    expect(interactionMocks.clickViaPlaywright).toHaveBeenCalledWith(
+      expect.objectContaining({ resolvedPage: page.currentPage }),
+    );
+    expect(page.fileChooser.setFiles).toHaveBeenCalledWith(
+      ["/home/user/.openclaw/media/inbound/report.pdf"],
+      { timeout: expect.any(Number) },
+    );
+    expect(settled).toBe(false);
+    finishSetFiles();
+    await upload;
+    expect(page.listenerCount()).toBe(0);
+    expect(page.off).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts only the first chooser emitted by the guarded click", async () => {
+    const page = createAtomicFileChooserPageMocks();
+    const unrelatedChooser = { setFiles: vi.fn(async () => {}) };
+    interactionMocks.clickViaPlaywright.mockImplementation(async () => {
+      page.emitChooser();
+      page.emitChooser(unrelatedChooser);
+    });
+
+    await uploadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      ref: "e12",
+      paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
+    });
+
+    expect(page.fileChooser.setFiles).toHaveBeenCalledTimes(1);
+    expect(unrelatedChooser.setFiles).not.toHaveBeenCalled();
+    expect(page.listenerCount()).toBe(0);
+  });
+
+  it("removes the chooser listener when the guarded click fails", async () => {
+    const page = createAtomicFileChooserPageMocks();
+    interactionMocks.clickViaPlaywright.mockRejectedValue(new Error("stale ref"));
+
+    await expect(
+      uploadViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        ref: "e12",
+        paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
+      }),
+    ).rejects.toThrow("stale ref");
+
+    page.emitChooser();
+    expect(page.listenerCount()).toBe(0);
+    expect(page.fileChooser.setFiles).not.toHaveBeenCalled();
+  });
+
+  it("propagates strict path revalidation failures", async () => {
+    pathMocks.resolveStrictExistingUploadPaths.mockResolvedValue({
+      ok: false,
+      error: "Invalid path: upload target changed",
+    });
+    const page = createAtomicFileChooserPageMocks();
+    interactionMocks.clickViaPlaywright.mockImplementation(async () => page.emitChooser());
+
+    await expect(
+      uploadViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        ref: "e12",
+        paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
+      }),
+    ).rejects.toThrow("Invalid path: upload target changed");
+    expect(page.press).not.toHaveBeenCalled();
+    expect(page.fileChooser.setFiles).not.toHaveBeenCalled();
+    expect(page.listenerCount()).toBe(0);
+  });
+
+  it("propagates file assignment failures", async () => {
+    const page = createAtomicFileChooserPageMocks();
+    page.fileChooser.setFiles.mockRejectedValue(new Error("setFiles failed"));
+    interactionMocks.clickViaPlaywright.mockImplementation(async () => page.emitChooser());
+
+    await expect(
+      uploadViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        ref: "e12",
+        paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
+      }),
+    ).rejects.toThrow("setFiles failed");
+    expect(page.listenerCount()).toBe(0);
+  });
+
+  it("times out without leaving a chooser listener", async () => {
+    vi.useFakeTimers();
+    try {
+      const page = createAtomicFileChooserPageMocks();
+      const upload = uploadViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        ref: "e12",
+        paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
+        timeoutMs: 500,
+      });
+      const rejection = expect(upload).rejects.toThrow(
+        "Timeout 500ms exceeded while completing file upload",
+      );
+
+      await vi.advanceTimersByTimeAsync(500);
+      await rejection;
+      page.emitChooser();
+      expect(page.listenerCount()).toBe(0);
+      expect(page.fileChooser.setFiles).not.toHaveBeenCalled();
+      expect(sessionMocks.forceDisconnectPlaywrightForTarget).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds file assignment by the same request deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const page = createAtomicFileChooserPageMocks();
+      page.fileChooser.setFiles.mockImplementation(
+        async (_paths, options) =>
+          await new Promise<void>((_resolve, reject) => {
+            setTimeout(() => reject(new Error("setFiles timed out")), options?.timeout ?? 0);
+          }),
+      );
+      interactionMocks.clickViaPlaywright.mockImplementation(async () => page.emitChooser());
+      const upload = uploadViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        ref: "e12",
+        paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
+        timeoutMs: 500,
+      });
+      const rejection = expect(upload).rejects.toThrow(
+        "Timeout 500ms exceeded while completing file upload",
+      );
+
+      await vi.advanceTimersByTimeAsync(500);
+      await rejection;
+      expect(page.press).not.toHaveBeenCalled();
+      expect(page.listenerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds strict path revalidation by the same request deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const page = createAtomicFileChooserPageMocks();
+      pathMocks.resolveStrictExistingUploadPaths.mockImplementation(
+        async () => await new Promise(() => {}),
+      );
+      interactionMocks.clickViaPlaywright.mockImplementation(async () => page.emitChooser());
+      const upload = uploadViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        ref: "e12",
+        paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
+        timeoutMs: 500,
+      });
+      const rejection = expect(upload).rejects.toThrow(
+        "Timeout 500ms exceeded while completing file upload",
+      );
+
+      await vi.advanceTimersByTimeAsync(500);
+      await rejection;
+      expect(page.listenerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("settles connection cleanup before an upload on another target starts", async () => {
+    const page = createAtomicFileChooserPageMocks();
+    let rejectFirstAssignment!: (reason: unknown) => void;
+    page.fileChooser.setFiles
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<void>((_resolve, reject) => {
+            rejectFirstAssignment = reject;
+          }),
+      )
+      .mockResolvedValueOnce(undefined);
+    let finishDisconnect!: () => void;
+    sessionMocks.forceDisconnectPlaywrightForTarget.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          finishDisconnect = () => {
+            rejectFirstAssignment(new Error("Playwright disconnected"));
+            resolve();
+          };
+        }),
+    );
+    interactionMocks.clickViaPlaywright
+      .mockImplementationOnce(async () => page.emitChooser())
+      .mockImplementationOnce(async () => page.emitChooser());
+
+    const first = uploadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      ref: "e1",
+      paths: ["/home/user/.openclaw/media/inbound/first.pdf"],
+    });
+    await vi.waitFor(() => expect(page.fileChooser.setFiles).toHaveBeenCalledTimes(1));
+    const second = uploadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T2",
+      ref: "e2",
+      paths: ["/home/user/.openclaw/media/inbound/second.pdf"],
+    });
+
+    const firstRejection = expect(first).rejects.toThrow("superseded by another waiter");
+    await vi.waitFor(() =>
+      expect(sessionMocks.forceDisconnectPlaywrightForTarget).toHaveBeenCalledTimes(1),
+    );
+    expect(interactionMocks.clickViaPlaywright).toHaveBeenCalledTimes(1);
+    finishDisconnect();
+    await firstRejection;
+    await second;
+    expect(page.fileChooser.setFiles).toHaveBeenCalledTimes(2);
+    expect(page.listenerCount()).toBe(0);
+  });
+
+  it("preserves the cleanup tail when a queued owner aborts", async () => {
+    const page = createAtomicFileChooserPageMocks();
+    let rejectFirstAssignment!: (reason: unknown) => void;
+    page.fileChooser.setFiles
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<void>((_resolve, reject) => {
+            rejectFirstAssignment = reject;
+          }),
+      )
+      .mockResolvedValueOnce(undefined);
+    let finishDisconnect!: () => void;
+    sessionMocks.forceDisconnectPlaywrightForTarget.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          finishDisconnect = () => {
+            rejectFirstAssignment(new Error("Playwright disconnected"));
+            resolve();
+          };
+        }),
+    );
+    interactionMocks.clickViaPlaywright
+      .mockImplementationOnce(async () => page.emitChooser())
+      .mockImplementationOnce(async () => page.emitChooser());
+
+    const first = uploadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      ref: "e1",
+      paths: ["/home/user/.openclaw/media/inbound/first.pdf"],
+    });
+    const firstRejection = expect(first).rejects.toThrow("superseded by another waiter");
+    await vi.waitFor(() => expect(page.fileChooser.setFiles).toHaveBeenCalledTimes(1));
+
+    const secondController = new AbortController();
+    const second = uploadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      ref: "e2",
+      paths: ["/home/user/.openclaw/media/inbound/second.pdf"],
+      signal: secondController.signal,
+    });
+    await vi.waitFor(() =>
+      expect(sessionMocks.forceDisconnectPlaywrightForTarget).toHaveBeenCalledTimes(1),
+    );
+    secondController.abort(new Error("queued upload aborted"));
+    await expect(second).rejects.toThrow("queued upload aborted");
+
+    const third = uploadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      ref: "e3",
+      paths: ["/home/user/.openclaw/media/inbound/third.pdf"],
+    });
+    await Promise.resolve();
+    expect(interactionMocks.clickViaPlaywright).toHaveBeenCalledTimes(1);
+
+    finishDisconnect();
+    await firstRejection;
+    await third;
+    expect(interactionMocks.clickViaPlaywright).toHaveBeenCalledTimes(2);
+    expect(page.fileChooser.setFiles).toHaveBeenCalledTimes(2);
+    expect(page.listenerCount()).toBe(0);
+  });
+
+  it("waits for a superseded click to settle before arming the next chooser", async () => {
+    const page = createAtomicFileChooserPageMocks();
+    let finishFirstClick!: () => void;
+    interactionMocks.clickViaPlaywright
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<void>((resolve) => {
+            finishFirstClick = () => {
+              page.emitChooser();
+              resolve();
+            };
+          }),
+      )
+      .mockImplementationOnce(async () => page.emitChooser());
+
+    const first = uploadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      ref: "e1",
+      paths: ["/home/user/.openclaw/media/inbound/first.pdf"],
+    });
+    await vi.waitFor(() => expect(interactionMocks.clickViaPlaywright).toHaveBeenCalledTimes(1));
+    const second = uploadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      ref: "e2",
+      paths: ["/home/user/.openclaw/media/inbound/second.pdf"],
+    });
+    await Promise.resolve();
+    expect(interactionMocks.clickViaPlaywright).toHaveBeenCalledTimes(1);
+
+    finishFirstClick();
+    await expect(first).rejects.toThrow("superseded by another waiter");
+    await second;
+    expect(page.fileChooser.setFiles).toHaveBeenCalledTimes(1);
+    expect(page.press).not.toHaveBeenCalled();
+    expect(page.listenerCount()).toBe(0);
+  });
+
+  it("aborts without leaving a chooser listener", async () => {
+    const page = createAtomicFileChooserPageMocks();
+    const controller = new AbortController();
+    const upload = uploadViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      ref: "e12",
+      paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
+      signal: controller.signal,
+    });
+
+    await vi.waitFor(() => expect(interactionMocks.clickViaPlaywright).toHaveBeenCalledTimes(1));
+    controller.abort(new Error("request aborted"));
+    await expect(upload).rejects.toThrow("request aborted");
+    page.emitChooser();
+    expect(page.listenerCount()).toBe(0);
+    expect(page.fileChooser.setFiles).not.toHaveBeenCalled();
+    expect(sessionMocks.forceDisconnectPlaywrightForTarget).not.toHaveBeenCalled();
   });
 });

--- a/extensions/browser/src/browser/routes/agent.act.hooks.current-url-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.hooks.current-url-guard.test.ts
@@ -18,6 +18,7 @@ const pathMocks = vi.hoisted(() => ({
 const pwMocks = vi.hoisted(() => ({
   armDialogViaPlaywright: vi.fn(async () => {}),
   armFileUploadViaPlaywright: vi.fn(async () => {}),
+  uploadViaPlaywright: vi.fn(async () => {}),
   clickViaPlaywright: vi.fn(async () => {}),
   setInputFilesViaPlaywright: vi.fn(async () => {}),
 }));
@@ -98,6 +99,7 @@ const blockedHookCases = [
       pathMocks.resolveExistingUploadPaths,
       chromeMcpMocks.uploadChromeMcpFile,
       pwMocks.armFileUploadViaPlaywright,
+      pwMocks.uploadViaPlaywright,
       pwMocks.clickViaPlaywright,
       pwMocks.setInputFilesViaPlaywright,
     ],

--- a/extensions/browser/src/browser/routes/agent.act.hooks.ts
+++ b/extensions/browser/src/browser/routes/agent.act.hooks.ts
@@ -102,6 +102,17 @@ export function registerBrowserAgentActHookRoutes(
               inputRef,
               element,
               paths: resolvedPaths,
+              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+            });
+          } else if (ref) {
+            await pw.uploadViaPlaywright({
+              cdpUrl,
+              targetId: tab.targetId,
+              paths: resolvedPaths,
+              timeoutMs: timeoutMs ?? undefined,
+              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+              ref,
+              signal,
             });
           } else {
             await pw.armFileUploadViaPlaywright({
@@ -110,14 +121,6 @@ export function registerBrowserAgentActHookRoutes(
               paths: resolvedPaths,
               timeoutMs: timeoutMs ?? undefined,
             });
-            if (ref) {
-              await pw.clickViaPlaywright({
-                cdpUrl,
-                targetId: tab.targetId,
-                ssrfPolicy: ctx.state().resolved.ssrfPolicy,
-                ref,
-              });
-            }
           }
           res.json({ ok: true });
         },

--- a/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -490,6 +490,7 @@ describe("browser control server", () => {
   it("rejects loose hook and download timeout options before dispatch", async () => {
     const base = await startServerAndBase();
     const uploadCalls = pwMocks.armFileUploadViaPlaywright.mock.calls.length;
+    const atomicUploadCalls = pwMocks.uploadViaPlaywright.mock.calls.length;
     const dialogCalls = pwMocks.armDialogViaPlaywright.mock.calls.length;
     const waitCalls = pwMocks.waitForDownloadViaPlaywright.mock.calls.length;
     const downloadCalls = pwMocks.downloadViaPlaywright.mock.calls.length;
@@ -520,6 +521,7 @@ describe("browser control server", () => {
     expect(downloadRes.error).toContain("timeoutMs must be a positive integer.");
 
     expect(pwMocks.armFileUploadViaPlaywright).toHaveBeenCalledTimes(uploadCalls);
+    expect(pwMocks.uploadViaPlaywright).toHaveBeenCalledTimes(atomicUploadCalls);
     expect(pwMocks.armDialogViaPlaywright).toHaveBeenCalledTimes(dialogCalls);
     expect(pwMocks.waitForDownloadViaPlaywright).toHaveBeenCalledTimes(waitCalls);
     expect(pwMocks.downloadViaPlaywright).toHaveBeenCalledTimes(downloadCalls);
@@ -545,6 +547,12 @@ describe("browser control server", () => {
       ref: "e12",
     });
     expectOkResult(uploadWithRef);
+    expectBrowserCallFields(pwMocks.uploadViaPlaywright, {
+      targetId: "abcd1234",
+      paths: [path.resolve(DEFAULT_UPLOAD_DIR, "b.txt")],
+      ref: "e12",
+      signal: expect.any(AbortSignal),
+    });
 
     const uploadWithInputRef = await postJson(`${base}/hooks/file-chooser`, {
       paths: ["c.txt"],

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -186,6 +186,7 @@ const pwMocks = vi.hoisted(() => {
   return {
     armDialogViaPlaywright: vi.fn(async () => {}),
     armFileUploadViaPlaywright: vi.fn(async () => {}),
+    uploadViaPlaywright: vi.fn(async () => {}),
     batchViaPlaywright: vi.fn(async (_opts?: unknown) => ({ results: [] })),
     clickCoordsViaPlaywright: vi.fn(async (_opts?: unknown) => {}),
     clickViaPlaywright: vi.fn(async (_opts?: unknown) => {}),


### PR DESCRIPTION
Closes #38844

## What Problem This Solves

Managed Browser `upload` requests that supplied both `paths` and a trigger `ref` returned before Playwright captured the chooser and assigned the files. Failures were detached and suppressed, and a stale waiter could consume a later unrelated chooser.

## Why This Change Was Made

The ref form now has one request-owned Playwright lifecycle: resolve one page, attach one chooser listener, guarded click, strict use-time path revalidation, guarded file assignment, and deterministic cleanup under one deadline and request signal. Ownership is connection-scoped because abort cleanup disconnects the shared Playwright connection.

The paths-only delayed-arm API remains detached. Direct `inputRef` and `element` uploads, Chrome MCP routing, and managed upload-root validation remain supported.

## User Impact

- `paths + ref` waits until exactly one chooser receives the validated files or returns the specific failure.
- Timeout, abort, stale-click, validation, and assignment failures remove their listener.
- Superseding uploads wait for connection cleanup before a successor reconnects.
- Direct input assignment now uses the same navigation policy guard as other interactions.

## Evidence

- Fresh autoreview: clean, 0.86 confidence after the connection-scoped ownership correction.
- Blacksmith Testbox: 6 Browser files / 65 tests passed: https://github.com/openclaw/openclaw/actions/runs/29185303822
- Local focused fallback: the same 6 files / 65 tests passed.
- Real Gateway + managed Chrome + OpenAI agent: the agent issued `upload` with both paths and the current ref, the page observed `selected:report.json`, the agent returned the required pass token, and the Gateway remained alive.
- `git diff --check`: passed.

Exact-head CI is pending. The final live proof needs a fresh credential because the prior OpenAI service-account key was exposed in an internal process-inspection transcript and will not be reused.
