### PR TITLE
fix: harden Crestodian maintenance flows

### DIFF
--- a/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts
@@ -25,6 +25,7 @@ function firstBeforeAgentReplyCall() {
 
 function firstAttemptParams(): {
   cleanupBundleMcpOnRunEnd?: boolean;
+  disableTrajectory?: boolean;
   modelRun?: boolean;
   promptMode?: string;
   promptCacheKey?: string;
@@ -34,6 +35,7 @@ function firstAttemptParams(): {
     | [
         {
           cleanupBundleMcpOnRunEnd?: boolean;
+          disableTrajectory?: boolean;
           modelRun?: boolean;
           promptMode?: string;
           promptCacheKey?: string;
@@ -153,19 +155,21 @@ describe("runEmbeddedAgent cron before_agent_reply seam", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards one-shot model-run flags into the embedded attempt", async () => {
-    // Model-run mode is request-scoped; it must pass through to the first
-    // attempt without becoming a persistent session setting.
+  it("forwards one-shot auxiliary-run flags into the embedded attempt", async () => {
+    // Auxiliary-run flags are request-scoped; they must pass through to the
+    // first attempt without becoming persistent session settings.
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
 
     await runEmbeddedAgent({
       ...overflowBaseRunParams,
       trigger: "user",
+      disableTrajectory: true,
       modelRun: true,
       promptMode: "none",
     });
 
     const attemptParams = firstAttemptParams();
+    expect(attemptParams.disableTrajectory).toBe(true);
     expect(attemptParams.modelRun).toBe(true);
     expect(attemptParams.promptMode).toBe("none");
   });

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2556,7 +2556,7 @@ async function runEmbeddedAgentInternal(
             runtimePlan,
           });
           const hostTrajectoryRecorder =
-            agentHarness.id === CODEX_HARNESS_ID
+            agentHarness.id === CODEX_HARNESS_ID && !params.disableTrajectory
               ? createTrajectoryRuntimeRecorder({
                   cfg: params.config,
                   env: process.env,
@@ -2813,6 +2813,7 @@ async function runEmbeddedAgentInternal(
             inputProvenance: params.inputProvenance,
             streamParams: params.streamParams,
             modelRun: params.modelRun,
+            disableTrajectory: params.disableTrajectory,
             promptMode: params.promptMode,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3212,18 +3212,20 @@ export async function runEmbeddedAttempt(
         sessionKey: params.sessionKey,
         sessionTarget: params.sessionTarget,
       });
-      trajectoryRecorder = createTrajectoryRuntimeRecorder({
-        cfg: params.config,
-        env: process.env,
-        runId: params.runId,
-        sessionId: activeSession.sessionId,
-        sessionKey: params.sessionKey,
-        sessionFile: trajectorySessionFile,
-        provider: params.provider,
-        modelId: params.modelId,
-        modelApi: params.model.api,
-        workspaceDir: params.workspaceDir,
-      });
+      trajectoryRecorder = params.disableTrajectory
+        ? null
+        : createTrajectoryRuntimeRecorder({
+            cfg: params.config,
+            env: process.env,
+            runId: params.runId,
+            sessionId: activeSession.sessionId,
+            sessionKey: params.sessionKey,
+            sessionFile: trajectorySessionFile,
+            provider: params.provider,
+            modelId: params.modelId,
+            modelApi: params.model.api,
+            workspaceDir: params.workspaceDir,
+          });
       trajectoryRecorder?.recordEvent("session.started", {
         trigger: params.trigger,
         sessionFile: params.sessionFile,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -135,6 +135,8 @@ export type RunEmbeddedAgentParams = {
   forceRestartSafeTools?: boolean;
   /** Internal one-shot model probe mode: no tools, no workspace/chat prompt policy. */
   modelRun?: boolean;
+  /** Disable trajectory persistence for auxiliary runs with no durable session owner. */
+  disableTrajectory?: boolean;
   /** Explicit system prompt mode override for trusted callers. */
   promptMode?: PromptMode;
   /** Keep the message tool available even when a narrow profile would omit it. */

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -221,6 +221,52 @@ describe("runServiceRestart token drift", () => {
     );
   });
 
+  it("repairs managed port drift before restarting", async () => {
+    service.readRuntime.mockResolvedValue({ status: "running", pid: 1234 });
+    service.readCommand.mockResolvedValue({
+      programArguments: ["openclaw", "gateway", "--port", "18789"],
+      environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+    });
+    type RepairLoadedService = NonNullable<
+      Parameters<typeof runServiceRestart>[0]["repairLoadedService"]
+    >;
+    const repairLoadedService = vi.fn<RepairLoadedService>(async () => ({
+      result: "restarted" as const,
+      message: "Gateway service definition repaired and restarted.",
+      loaded: true,
+    }));
+
+    await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true, restartIntent: { waitMs: 2_500 } },
+      expectedPort: 19_001,
+      repairLoadedService,
+    });
+
+    expect(repairLoadedService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issues: [
+          {
+            code: "port-mismatch",
+            message: "service port 18789 does not match current gateway config port 19001",
+          },
+        ],
+      }),
+    );
+    expect(service.restart).not.toHaveBeenCalled();
+    expect(writeGatewayRestartIntentSync).toHaveBeenCalledWith({
+      targetPid: 1234,
+      reason: "gateway.restart",
+      intent: { waitMs: 2_500 },
+    });
+    expect(readJsonLog<{ result?: string; message?: string }>()).toMatchObject({
+      result: "restarted",
+      message: "Gateway service definition repaired and restarted.",
+    });
+  });
+
   it("emits drift warning when enabled", async () => {
     await runServiceRestart(createServiceRunArgs(true));
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -8,7 +8,11 @@ import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../../confi
 import { checkTokenDrift } from "../../daemon/service-audit.js";
 import type { GatewayServiceRestartResult } from "../../daemon/service-types.js";
 import type { GatewayServiceStartRepairIssue, GatewayServiceState } from "../../daemon/service.js";
-import { describeGatewayServiceRestart, startGatewayService } from "../../daemon/service.js";
+import {
+  describeGatewayServiceRestart,
+  inspectGatewayServiceStartRepair,
+  startGatewayService,
+} from "../../daemon/service.js";
 import type { GatewayService } from "../../daemon/service.js";
 import { renderSystemdUnavailableHints } from "../../daemon/systemd-hints.js";
 import { isSystemdUserServiceAvailable } from "../../daemon/systemd.js";
@@ -257,6 +261,7 @@ export async function runServiceStart(params: {
   opts?: DaemonLifecycleOptions;
   onNotLoaded?: (ctx: ServiceRecoveryContext) => Promise<ServiceRecoveryResult | null>;
   repairLoadedService?: (ctx: ServiceStartRepairContext) => Promise<ServiceRecoveryResult | null>;
+  expectedPort?: number;
 }) {
   const json = Boolean(params.opts?.json);
   const { stdout, warnings, emit, fail } = createDaemonActionContext({ action: "start", json });
@@ -307,11 +312,15 @@ export async function runServiceStart(params: {
     }
   }
   try {
-    const startResult = await startGatewayService(params.service, {
-      env: process.env,
-      stdout,
-      warn,
-    });
+    const startResult = await startGatewayService(
+      params.service,
+      {
+        env: process.env,
+        stdout,
+        warn,
+      },
+      params.expectedPort,
+    );
     if (startResult.outcome === "missing-install") {
       await handleServiceNotLoaded({
         serviceNoun: params.serviceNoun,
@@ -484,6 +493,8 @@ export async function runServiceRestart(params: {
   renderStartHints: () => string[];
   opts?: DaemonLifecycleOptions;
   checkTokenDrift?: boolean;
+  expectedPort?: number;
+  repairLoadedService?: (ctx: ServiceStartRepairContext) => Promise<ServiceRecoveryResult | null>;
   postRestartCheck?: (ctx: RestartPostCheckContext) => Promise<GatewayServiceRestartResult | void>;
   onNotLoaded?: (ctx: ServiceRecoveryContext) => Promise<ServiceRecoveryResult | null>;
 }): Promise<boolean> {
@@ -492,7 +503,26 @@ export async function runServiceRestart(params: {
   const warn = json ? (message: string) => warnings.push(message) : undefined;
   const restartIntent = params.opts?.restartIntent;
   let handledRecovery: ServiceRecoveryResult | null = null;
+  let handledRepair: ServiceRecoveryResult | null = null;
   let recoveredLoadedState: boolean | null = null;
+  let wroteRestartIntent = false;
+  const prepareGatewayRestartIntent = async () => {
+    if (params.serviceNoun !== "Gateway" || wroteRestartIntent) {
+      return;
+    }
+    const runtime = await params.service.readRuntime(process.env).catch(() => null);
+    wroteRestartIntent = writeGatewayRestartIntentSync({
+      targetPid: runtime?.pid,
+      reason: "gateway.restart",
+      ...(restartIntent ? { intent: restartIntent } : {}),
+    });
+  };
+  const clearPreparedRestartIntent = () => {
+    if (wroteRestartIntent) {
+      clearGatewayRestartIntentSync();
+      wroteRestartIntent = false;
+    }
+  };
   const emitScheduledRestart = (
     restartStatus: ReturnType<typeof describeGatewayServiceRestart>,
     serviceLoaded: boolean,
@@ -559,6 +589,45 @@ export async function runServiceRestart(params: {
     recoveredLoadedState = handledRecovery.loaded ?? null;
   }
 
+  if (loaded && params.repairLoadedService) {
+    try {
+      const { state, issues } = await inspectGatewayServiceStartRepair(
+        params.service,
+        { env: process.env },
+        params.expectedPort,
+      );
+      if (issues.length > 0) {
+        await prepareGatewayRestartIntent();
+        handledRepair = await params.repairLoadedService({
+          json,
+          stdout,
+          warn,
+          fail,
+          state,
+          issues,
+        });
+        if (!handledRepair) {
+          clearPreparedRestartIntent();
+          fail(
+            `${params.serviceNoun} service needs repair before restart: ${issues
+              .map((issue) => issue.message)
+              .join("; ")}`,
+            [formatCliCommand("openclaw gateway install --force")],
+          );
+          return false;
+        }
+        if (handledRepair.warnings?.length) {
+          warnings.push(...handledRepair.warnings);
+        }
+      }
+    } catch (err) {
+      clearPreparedRestartIntent();
+      const hints = params.renderStartHints();
+      fail(`${params.serviceNoun} repair failed: ${String(err)}`, hints);
+      return false;
+    }
+  }
+
   if (loaded && params.checkTokenDrift) {
     // Check for token drift before restart (service token vs config token)
     try {
@@ -597,22 +666,12 @@ export async function runServiceRestart(params: {
 
   try {
     let restartResult: GatewayServiceRestartResult = { outcome: "completed" };
-    if (loaded) {
-      let wroteRestartIntent = false;
-      if (params.serviceNoun === "Gateway") {
-        const runtime = await params.service.readRuntime(process.env).catch(() => null);
-        wroteRestartIntent = writeGatewayRestartIntentSync({
-          targetPid: runtime?.pid,
-          reason: "gateway.restart",
-          ...(restartIntent ? { intent: restartIntent } : {}),
-        });
-      }
+    if (loaded && !handledRepair) {
+      await prepareGatewayRestartIntent();
       try {
         restartResult = await params.service.restart({ env: process.env, stdout, warn });
       } catch (err) {
-        if (wroteRestartIntent) {
-          clearGatewayRestartIntentSync();
-        }
+        clearPreparedRestartIntent();
         throw err;
       }
     }
@@ -648,12 +707,13 @@ export async function runServiceRestart(params: {
     emit({
       ok: true,
       result: "restarted",
-      message: handledRecovery?.message,
+      message: handledRecovery?.message ?? handledRepair?.message,
       service: buildDaemonServiceSnapshot(params.service, restarted),
       warnings: warnings.length ? warnings : undefined,
     });
-    if (!json && handledRecovery?.message) {
-      defaultRuntime.log(handledRecovery.message);
+    const actionMessage = handledRecovery?.message ?? handledRepair?.message;
+    if (!json && actionMessage) {
+      defaultRuntime.log(actionMessage);
     }
     return true;
   } catch (err) {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -311,6 +311,25 @@ describe("runDaemonRestart health checks", () => {
     expect(recoverInstalledLaunchAgent).toHaveBeenCalledWith({ result: "started" });
   });
 
+  it("preserves an install-time port override when config does not own the port", async () => {
+    await runDaemonStart({ json: true });
+    await runDaemonRestart({ json: true });
+
+    expect(requireMockCallArg(runServiceStart, "runServiceStart").expectedPort).toBeUndefined();
+    expect(requireMockCallArg(runServiceRestart, "runServiceRestart").expectedPort).toBeUndefined();
+  });
+
+  it("repairs toward an explicitly configured gateway port", async () => {
+    loadConfig.mockReturnValue({ gateway: { port: 19_001 } });
+    resolveGatewayPort.mockReturnValue(19_001);
+
+    await runDaemonStart({ json: true });
+    await runDaemonRestart({ json: true });
+
+    expect(requireMockCallArg(runServiceStart, "runServiceStart").expectedPort).toBe(19_001);
+    expect(requireMockCallArg(runServiceRestart, "runServiceRestart").expectedPort).toBe(19_001);
+  });
+
   it("requests a safe gateway restart over RPC without touching the service manager", async () => {
     await runDaemonRestart({ json: true, safe: true });
 

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -329,7 +329,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   if (opts.safe) {
     return await requestSafeGatewayRestart(opts);
   }
-  const json = Boolean(opts.json);
+  const jsonOutput = Boolean(opts.json);
   const service = resolveGatewayService();
   let restartedWithoutServiceManager = false;
   const restartIntent = resolveGatewayRestartIntentOptions(opts);
@@ -390,7 +390,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
 
         const diagnostics = renderGatewayPortHealthDiagnostics(health);
         const timeoutLine = `Timed out after ${restartWaitSeconds}s waiting for gateway port ${restartPort} to become healthy.`;
-        if (!json) {
+        if (!jsonOutput) {
           defaultRuntime.log(theme.warn(timeoutLine));
           for (const line of diagnostics) {
             defaultRuntime.log(theme.muted(line));
@@ -420,7 +420,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         // Gateway pids once, restart again, then re-run the same health proof.
         const staleMsg = `Found stale gateway process(es): ${health.staleGatewayPids.join(", ")}.`;
         warnings.push(staleMsg);
-        if (!json) {
+        if (!jsonOutput) {
           defaultRuntime.log(theme.warn(staleMsg));
           defaultRuntime.log(theme.muted("Stopping stale process(es) and retrying restart..."));
         }
@@ -453,7 +453,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         health.runtime.status === "running" && health.portUsage.status === "free"
           ? `Gateway process is running but port ${restartPort} is still free (startup hang/crash loop or very slow VM startup).`
           : null;
-      if (!json) {
+      if (!jsonOutput) {
         defaultRuntime.log(theme.warn(failure.statusLine));
         if (runningNoPortLine) {
           defaultRuntime.log(theme.warn(runningNoPortLine));

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -91,6 +91,11 @@ function resolveGatewayPortFallback(): Promise<number> {
     .catch(() => resolveGatewayPort(undefined, process.env));
 }
 
+async function resolveExplicitGatewayConfigPort(): Promise<number | undefined> {
+  const cfg = await readBestEffortConfig().catch(() => undefined);
+  return cfg?.gateway?.port;
+}
+
 async function assertUnmanagedGatewayRestartEnabled(port: number): Promise<void> {
   const cfg = await readBestEffortConfig().catch(() => undefined);
   const tlsEnabled = Boolean(cfg?.gateway?.tls?.enabled);
@@ -274,6 +279,7 @@ export async function runDaemonUninstall(opts: DaemonLifecycleOptions = {}) {
 /** Start the managed Gateway service, repairing stale service definitions when possible. */
 export async function runDaemonStart(opts: DaemonLifecycleOptions = {}) {
   const service = resolveGatewayService();
+  const expectedPort = await resolveExplicitGatewayConfigPort();
   return await runServiceStart({
     serviceNoun: "Gateway",
     service,
@@ -285,12 +291,14 @@ export async function runDaemonStart(opts: DaemonLifecycleOptions = {}) {
     repairLoadedService: async ({ json, stdout, warn, state, issues }) =>
       await repairLoadedGatewayServiceForStart({
         service,
+        port: expectedPort,
         json,
         stdout,
         warn,
         state,
         issues,
       }),
+    expectedPort,
     opts,
   });
 }
@@ -325,9 +333,10 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   const service = resolveGatewayService();
   let restartedWithoutServiceManager = false;
   const restartIntent = resolveGatewayRestartIntentOptions(opts);
-  const restartPort = await resolveGatewayLifecyclePort(service).catch(() =>
-    resolveGatewayPortFallback(),
-  );
+  const configuredPort = await resolveExplicitGatewayConfigPort();
+  const restartPort =
+    configuredPort ??
+    (await resolveGatewayLifecyclePort(service).catch(() => resolveGatewayPortFallback()));
   const restartHealthAttempts = postRestartHealthAttempts();
   const restartWaitMs = restartHealthAttempts * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
@@ -341,6 +350,18 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       ...(restartIntent ? { restartIntent } : {}),
     },
     checkTokenDrift: true,
+    expectedPort: configuredPort,
+    repairLoadedService: async ({ json, stdout, warn, state, issues }) =>
+      await repairLoadedGatewayServiceForStart({
+        action: "restart",
+        service,
+        port: configuredPort,
+        json,
+        stdout,
+        warn,
+        state,
+        issues,
+      }),
     onNotLoaded: async () => {
       if (process.platform === "darwin") {
         const recovered = await recoverInstalledLaunchAgent({ result: "restarted" });

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -12,7 +12,7 @@ import {
   buildPlatformRuntimeLogHints,
   buildPlatformServiceStartHints,
 } from "../../daemon/runtime-hints.js";
-import { parseInlineOptionToken } from "../../infra/inline-option-token.js";
+import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
 import { formatCliCommand } from "../command-format.js";
 import { parsePort } from "../shared/parse-port.js";
 import { createDaemonActionContext } from "./response.js";
@@ -70,27 +70,7 @@ export function resolveRuntimeStatusColor(status: string | undefined): (value: s
 
 /** Extract `--port` from service ProgramArguments. */
 export function parsePortFromArgs(programArguments: string[] | undefined): number | null {
-  if (!programArguments?.length) {
-    return null;
-  }
-  for (let i = 0; i < programArguments.length; i += 1) {
-    const arg = programArguments[i];
-    if (arg === "--port") {
-      const next = programArguments[i + 1];
-      const parsed = parsePort(next);
-      if (parsed) {
-        return parsed;
-      }
-    }
-    if (arg?.startsWith("--port=")) {
-      const option = parseInlineOptionToken(arg);
-      const parsed = parsePort(option.hasInlineValue ? option.inlineValue : undefined);
-      if (parsed) {
-        return parsed;
-      }
-    }
-  }
-  return null;
+  return parseTcpPortFromArgs(programArguments);
 }
 
 /** Pick the best local probe host for a configured Gateway bind mode. */

--- a/src/cli/daemon-cli/start-repair.ts
+++ b/src/cli/daemon-cli/start-repair.ts
@@ -12,18 +12,26 @@ import type {
   GatewayServiceState,
 } from "../../daemon/service.js";
 import { formatGatewayServiceStartRepairIssues } from "../../daemon/service.js";
+import { parseTcpPort, parseTcpPortFromArgs } from "../../infra/tcp-port.js";
 import { defaultRuntime } from "../../runtime.js";
 import { mergeInstallInvocationEnv } from "./install.js";
 
 /** Repair a loaded but stale Gateway service definition and report the start result. */
 export async function repairLoadedGatewayServiceForStart(params: {
+  action?: "restart" | "start";
   service: GatewayService;
+  port?: number;
   state: GatewayServiceState;
   issues: GatewayServiceStartRepairIssue[];
   json: boolean;
   stdout: NodeJS.WritableStream;
   warn?: (message: string) => void;
-}): Promise<{ result: "started"; message: string; warnings?: string[]; loaded: boolean }> {
+}): Promise<{
+  result: "restarted" | "started";
+  message: string;
+  warnings?: string[];
+  loaded: boolean;
+}> {
   const { snapshot: configSnapshot, writeOptions: configWriteOptions } =
     await readConfigFileSnapshotForWrite();
   const cfg = configSnapshot.valid ? configSnapshot.sourceConfig : configSnapshot.config;
@@ -34,7 +42,10 @@ export async function repairLoadedGatewayServiceForStart(params: {
     existingServiceEnv: existingEnvironment,
   });
   const wrapperPath = await resolveOpenClawWrapperPath(installEnv[OPENCLAW_WRAPPER_ENV_KEY]);
-  const port = resolveGatewayPort(cfg);
+  const installedPort =
+    parseTcpPortFromArgs(params.state.command?.programArguments) ??
+    parseTcpPort(params.state.command?.environment?.OPENCLAW_GATEWAY_PORT);
+  const port = params.port ?? installedPort ?? resolveGatewayPort(cfg);
 
   const tokenResolution = await resolveGatewayInstallToken({
     config: cfg,
@@ -94,9 +105,11 @@ export async function repairLoadedGatewayServiceForStart(params: {
   }
 
   return {
-    result: "started",
+    result: params.action === "restart" ? "restarted" : "started",
     message:
-      "Gateway service definition repaired and started. Reopen the Control UI with `openclaw dashboard` or copy a fresh auth URL with `openclaw dashboard --no-open`.",
+      params.action === "restart"
+        ? "Gateway service definition repaired and restarted."
+        : "Gateway service definition repaired and started. Reopen the Control UI with `openclaw dashboard` or copy a fresh auth URL with `openclaw dashboard --no-open`.",
     warnings: warnings.length ? warnings : undefined,
     loaded,
   };

--- a/src/crestodian/assistant.configured.test.ts
+++ b/src/crestodian/assistant.configured.test.ts
@@ -327,6 +327,7 @@ describe("Crestodian configured-model planner", () => {
       }),
     );
     expect(runEmbeddedAgent.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
+    expect(runEmbeddedAgent.mock.calls[0]?.[0]?.disableTrajectory).toBe(true);
   });
 
   it("carries the verified child runtime artifact into planning", async () => {

--- a/src/crestodian/assistant.configured.test.ts
+++ b/src/crestodian/assistant.configured.test.ts
@@ -326,6 +326,7 @@ describe("Crestodian configured-model planner", () => {
         toolsAllow: [],
       }),
     );
+    expect(runEmbeddedAgent.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
   });
 
   it("carries the verified child runtime artifact into planning", async () => {

--- a/src/crestodian/assistant.configured.test.ts
+++ b/src/crestodian/assistant.configured.test.ts
@@ -323,11 +323,13 @@ describe("Crestodian configured-model planner", () => {
         authProfileIdSource: "user",
         agentHarnessRuntimeOverride: "codex",
         disableTools: true,
+        disableTrajectory: true,
         toolsAllow: [],
       }),
     );
-    expect(runEmbeddedAgent.mock.calls[0]?.[0]?.sessionKey).toBeUndefined();
-    expect(runEmbeddedAgent.mock.calls[0]?.[0]?.disableTrajectory).toBe(true);
+    expect(runEmbeddedAgent).toHaveBeenCalledWith(
+      expect.not.objectContaining({ sessionKey: expect.anything() }),
+    );
   });
 
   it("carries the verified child runtime artifact into planning", async () => {

--- a/src/crestodian/assistant.ts
+++ b/src/crestodian/assistant.ts
@@ -92,7 +92,6 @@ export async function planCrestodianCommandWithConfiguredModel(params: {
     const runId = `crestodian-planner-${randomUUID()}`;
     const shared = {
       sessionId: `${runId}-session`,
-      sessionKey: `temp:crestodian-planner:${runId}`,
       agentId: "crestodian",
       trigger: "manual" as const,
       sessionFile: path.join(tempDir, "session.jsonl"),

--- a/src/crestodian/assistant.ts
+++ b/src/crestodian/assistant.ts
@@ -109,6 +109,7 @@ export async function planCrestodianCommandWithConfiguredModel(params: {
       messageChannel: "crestodian",
       messageProvider: "crestodian",
       disableTools: true,
+      disableTrajectory: true,
       ...(route.authProfileId ? { authProfileId: route.authProfileId } : {}),
     };
     const result =

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -69,7 +69,7 @@ export type GatewayServiceState = {
 };
 
 export type GatewayServiceStartRepairIssue = {
-  code: "missing-program" | "temporary-program" | "version-mismatch";
+  code: "missing-program" | "port-mismatch" | "temporary-program" | "version-mismatch";
   message: string;
 };
 

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -222,6 +222,58 @@ describe("startGatewayService", () => {
     expect(service.restart).not.toHaveBeenCalled();
   });
 
+  it("requests repair before start when the managed port differs from config", async () => {
+    const service = createService({
+      readCommand: vi.fn(async () => ({
+        programArguments: ["openclaw", "gateway", "--port", "18789"],
+        environment: { OPENCLAW_GATEWAY_PORT: "19001" },
+      })),
+      isLoaded: vi.fn(async () => true),
+      readRuntime: vi.fn(async () => ({ status: "running" })),
+    });
+
+    const result = await startGatewayService(
+      service,
+      {
+        env: {},
+        stdout: process.stdout,
+      },
+      19_001,
+    );
+
+    expect(result.outcome).toBe("repair-required");
+    if (result.outcome === "repair-required") {
+      expect(result.issues).toContainEqual({
+        code: "port-mismatch",
+        message: "service port 18789 does not match current gateway config port 19001",
+      });
+    }
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("uses the command-line port before a stale managed environment port", async () => {
+    const service = createService({
+      readCommand: vi.fn(async () => ({
+        programArguments: ["openclaw", "gateway", "--port", "19001"],
+        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+      })),
+      isLoaded: vi.fn(async () => true),
+      readRuntime: vi.fn(async () => ({ status: "running" })),
+    });
+
+    const result = await startGatewayService(
+      service,
+      {
+        env: {},
+        stdout: process.stdout,
+      },
+      19_001,
+    );
+
+    expect(result.outcome).toBe("started");
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+
   it("requests repair before start when the loaded service points at temporary install paths", async () => {
     const service = createService({
       readCommand: vi.fn(async () => ({

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { parseTcpPort, parseTcpPortFromArgs } from "../infra/tcp-port.js";
 import { VERSION } from "../version.js";
 import { assertFutureConfigActionAllowed } from "./future-config-guard.js";
 import {
@@ -142,6 +143,7 @@ function isMissingProgramPath(value: string | undefined): boolean {
 
 function collectGatewayServiceStartRepairIssues(
   state: GatewayServiceState,
+  expectedPort?: number,
 ): GatewayServiceStartRepairIssue[] {
   const command = state.command;
   if (!state.loaded || !command) {
@@ -155,6 +157,15 @@ function collectGatewayServiceStartRepairIssues(
     issues.push({
       code: "version-mismatch",
       message: `service was installed by OpenClaw ${serviceVersion}, current CLI is ${VERSION}`,
+    });
+  }
+  const servicePort =
+    parseTcpPortFromArgs(command.programArguments) ??
+    parseTcpPort(command.environment?.OPENCLAW_GATEWAY_PORT ?? "");
+  if (expectedPort !== undefined && servicePort !== null && servicePort !== expectedPort) {
+    issues.push({
+      code: "port-mismatch",
+      message: `service port ${servicePort} does not match current gateway config port ${expectedPort}`,
     });
   }
   for (const candidate of command.programArguments.slice(0, 2)) {
@@ -173,6 +184,19 @@ function collectGatewayServiceStartRepairIssues(
     }
   }
   return issues;
+}
+
+/** Reads the installed service and reports definition drift that must be repaired before launch. */
+export async function inspectGatewayServiceStartRepair(
+  service: GatewayService,
+  args: GatewayServiceEnvArgs,
+  expectedPort?: number,
+): Promise<{ state: GatewayServiceState; issues: GatewayServiceStartRepairIssue[] }> {
+  const state = await readGatewayServiceState(service, args);
+  return {
+    state,
+    issues: collectGatewayServiceStartRepairIssues(state, expectedPort),
+  };
 }
 
 export function formatGatewayServiceStartRepairIssues(
@@ -208,8 +232,13 @@ export async function readGatewayServiceState(
 export async function startGatewayService(
   service: GatewayService,
   args: GatewayServiceControlArgs,
+  expectedPort?: number,
 ): Promise<GatewayServiceStartResult> {
-  const state = await readGatewayServiceState(service, { env: args.env });
+  const { state, issues: repairIssues } = await inspectGatewayServiceStartRepair(
+    service,
+    { env: args.env },
+    expectedPort,
+  );
   if (!state.loaded && !state.installed) {
     return {
       outcome: "missing-install",
@@ -217,7 +246,6 @@ export async function startGatewayService(
     };
   }
 
-  const repairIssues = collectGatewayServiceStartRepairIssues(state);
   if (repairIssues.length > 0) {
     return {
       outcome: "repair-required",

--- a/src/infra/tcp-port.ts
+++ b/src/infra/tcp-port.ts
@@ -15,3 +15,26 @@ export function parseTcpPort(raw: unknown): number | null {
   }
   return parsed;
 }
+
+/** Extract the effective `--port` value from command arguments. */
+export function parseTcpPortFromArgs(programArguments: string[] | undefined): number | null {
+  if (!programArguments?.length) {
+    return null;
+  }
+  for (let index = 0; index < programArguments.length; index += 1) {
+    const argument = programArguments[index];
+    if (argument === "--port") {
+      const parsed = parseTcpPort(programArguments[index + 1]);
+      if (parsed !== null) {
+        return parsed;
+      }
+    }
+    if (argument?.startsWith("--port=")) {
+      const parsed = parseTcpPort(argument.slice("--port=".length));
+      if (parsed !== null) {
+        return parsed;
+      }
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## What Problem This Solves

Closes #105109 and #105111.

- Managed gateway restart could keep the installed LaunchAgent's stale port after `gateway.port` changed, so status targeted the new port while the service still launched on the old port.
- Crestodian's auxiliary configured-model plan persisted trajectory events against a derived session target that has no durable session row, producing `FOREIGN KEY constraint failed` during otherwise successful CLI and TUI requests.

## Why This Change Was Made

- Treat the installed command arguments as the effective managed-service port, detect a config/service port mismatch, and repair the service before restart. Preserve intentional install-time port overrides when config does not explicitly own the port.
- Carry restart intent through repair so the restarted process retains the original restart semantics and does not restart twice.
- Add a request-scoped trajectory opt-out for auxiliary embedded runs with no durable session owner, and enable it for Crestodian planning.

## User Impact

- Changing `gateway.port` and restarting the managed gateway now repairs the LaunchAgent to the configured port instead of leaving the gateway unavailable.
- Crestodian CLI and TUI questions no longer emit trajectory foreign-key cleanup errors.
- Existing install-time gateway port overrides remain authoritative until `gateway.port` is explicitly configured.

## Evidence

- `node scripts/run-vitest.mjs src/crestodian/assistant.configured.test.ts src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts` — 15 tests passed.
- Focused daemon/CLI/plugin regression shards on the rebased branch — 119 tests passed.
- Fresh structured autoreview — clean, no accepted/actionable findings.
- Golden Gate pristine-snapshot package smoke at `8a37459464f`: install/version, gateway RPC, Control UI, and real OpenAI agent turn passed. Artifact: `.artifacts/parallels/openclaw-parallels-macos.iOJf6w`.
- Exact-head Crestodian CLI: fuzzy config inspection, typed config read/write, invalid-value refusal, and live RPC inspection passed without loader or trajectory errors.
- Exact-head Crestodian TUI under `expect`: returned `TUI_CONFIG_OK 18789`; no loader or trajectory errors.
- Current pristine snapshot is at the login window and no approved Golden Gate console credential exists, so this run could not repeat the managed LaunchAgent restart from a real `gui/501` session. The restart behavior is covered by focused service/lifecycle regression tests; the headless foreground-gateway fallback was not misrepresented as LaunchAgent proof.
