### PR TITLE
fix: deliver completed replies when post-turn compaction fails

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -3282,7 +3282,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/infra/outbound/outbound-policy.ts: CrossContextPresentationBuilder",
   "src/infra/outbound/outbound-send-service.ts: OutboundGatewayContext",
   "src/infra/outbound/outbound-send-service.ts: OutboundSendContext",
-  "src/infra/outbound/payloads.ts: normalizeOutboundPayloads",
   "src/infra/outbound/payloads.ts: OutboundPayloadMirror",
   "src/infra/outbound/session-binding-normalization.ts: ConversationRefShape",
   "src/infra/outbound/session-binding-service.ts: SessionBindingErrorCode",

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -3282,6 +3282,7 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/infra/outbound/outbound-policy.ts: CrossContextPresentationBuilder",
   "src/infra/outbound/outbound-send-service.ts: OutboundGatewayContext",
   "src/infra/outbound/outbound-send-service.ts: OutboundSendContext",
+  "src/infra/outbound/payloads.ts: normalizeOutboundPayloads",
   "src/infra/outbound/payloads.ts: OutboundPayloadMirror",
   "src/infra/outbound/session-binding-normalization.ts: ConversationRefShape",
   "src/infra/outbound/session-binding-service.ts: SessionBindingErrorCode",

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -203,12 +203,12 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10640,
+      10641,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5356,
+      5357,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -489,7 +489,7 @@ describe("agentCommand compaction transcript rotation", () => {
       }),
     );
     state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
-      pendingTextSeenByCompaction = params.sessionEntry?.pendingFinalDeliveryText;
+      pendingTextSeenByCompaction = params.sessionEntry?.pendingFinalDeliveryText ?? undefined;
       throw new Error(COMPACTION_ERROR);
     });
 

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -648,6 +648,42 @@ describe("agentCommand compaction transcript rotation", () => {
     });
   });
 
+  it("does not deliver or clear the pending final when restart wins after successful compaction", async () => {
+    const sessionId = "restart-after-successful-compaction";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const text = "reply owned by restart recovery after compaction";
+    const abortController = new AbortController();
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text }));
+    state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
+      expect(params.sessionEntry).toMatchObject({
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: text,
+      });
+      abortController.abort(createAgentRunRestartAbortError());
+      return params.sessionEntry;
+    });
+
+    await expect(
+      agentCommand({
+        message: "room message",
+        sessionId,
+        sessionKey,
+        cwd: state.workspaceDir,
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        deliver: true,
+        abortSignal: abortController.signal,
+      }),
+    ).rejects.toThrow("agent run aborted for restart");
+
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+    expect(findStoredSessionEntry(sessionKey)).toMatchObject({
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: text,
+    });
+  });
+
   it("does not deliver or clear the pending final after lifecycle ownership turns stale", async () => {
     const sessionId = "stale-during-compaction";
     const sessionKey = `agent:main:explicit:${sessionId}`;

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -831,6 +831,34 @@ describe("agentCommand compaction transcript rotation", () => {
     expect(storedEntry?.pendingFinalDeliveryText).toBeUndefined();
   });
 
+  it("skips post-turn compaction when a recoverable final cannot persist a pending marker", async () => {
+    const sessionId = "subagent-no-pending-marker";
+    const sessionKey = `agent:main:subagent:${sessionId}`;
+    const text = "subagent final must deliver before compaction";
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text }));
+
+    const result = await agentCommand({
+      message: "subagent room message",
+      sessionId,
+      sessionKey,
+      cwd: state.workspaceDir,
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(state.runCliTurnCompactionLifecycleMock).not.toHaveBeenCalled();
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({ payloads: [{ text }] }),
+    );
+    expect(result).toMatchObject({ deliverySucceeded: true });
+    const storedEntry = findStoredSessionEntry(sessionKey);
+    expect(storedEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(storedEntry?.pendingFinalDeliveryText).toBeUndefined();
+  });
+
   it("keeps post-turn compaction for no-delivery runs with unrecoverable sendable finals", async () => {
     const sessionId = "unrecoverable-media-no-delivery";
     const sessionKey = `agent:main:explicit:${sessionId}`;

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -14,13 +14,21 @@ import {
   parseSqliteSessionFileMarker,
 } from "../config/sessions/sqlite-marker.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import type { runAgentAttempt } from "./command/attempt-execution.runtime.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent.js";
 import type { loadManifestModelCatalog } from "./model-catalog.js";
+import { createAgentRunRestartAbortError } from "./run-termination.js";
 
 type ProviderModelNormalizationParams = { provider: string; context: { modelId: string } };
 type LoadManifestModelCatalogParams = Parameters<typeof loadManifestModelCatalog>[0];
 type RunAgentAttempt = typeof runAgentAttempt;
+type CliCompactionParams = {
+  sessionEntry?: SessionEntry;
+  sessionKey: string;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+};
 
 const state = vi.hoisted(() => ({
   cfg: undefined as OpenClawConfig | undefined,
@@ -31,6 +39,11 @@ const state = vi.hoisted(() => ({
   normalizeProviderModelIdWithRuntimeMock: vi.fn(
     (_params: ProviderModelNormalizationParams) => undefined,
   ),
+  runCliTurnCompactionLifecycleMock: vi.fn(
+    async (params: CliCompactionParams) => params.sessionEntry,
+  ),
+  deliverAgentCommandResultMock: vi.fn(),
+  emitAgentEventMock: vi.fn(),
   deliveryFreshEntries: [] as Array<SessionEntry | undefined>,
 }));
 
@@ -152,17 +165,25 @@ vi.mock("./command/attempt-execution.runtime.js", async () => {
 });
 
 vi.mock("./command/cli-compaction.js", () => ({
-  runCliTurnCompactionLifecycle: async (params: { sessionEntry?: SessionEntry }) =>
-    params.sessionEntry,
+  runCliTurnCompactionLifecycle: (params: CliCompactionParams) =>
+    state.runCliTurnCompactionLifecycleMock(params),
 }));
 
+vi.mock("../infra/agent-events.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/agent-events.js")>(
+    "../infra/agent-events.js",
+  );
+  return {
+    ...actual,
+    emitAgentEvent: (...args: Parameters<typeof actual.emitAgentEvent>) => {
+      state.emitAgentEventMock(...args);
+      return actual.emitAgentEvent(...args);
+    },
+  };
+});
+
 vi.mock("./command/delivery.runtime.js", () => ({
-  deliverAgentCommandResult: async (params: {
-    resolveFreshSessionEntryForDelivery?: () => Promise<SessionEntry | undefined>;
-  }) => {
-    state.deliveryFreshEntries.push(await params.resolveFreshSessionEntryForDelivery?.());
-    return { deliverySucceeded: true };
-  },
+  deliverAgentCommandResult: (params: unknown) => state.deliverAgentCommandResultMock(params),
 }));
 
 let agentCommand: typeof import("./agent-command.js").agentCommand;
@@ -175,7 +196,18 @@ beforeEach(async () => {
   vi.clearAllMocks();
   state.loadManifestModelCatalogMock.mockReturnValue([]);
   state.normalizeProviderModelIdWithRuntimeMock.mockImplementation(() => undefined);
+  state.runCliTurnCompactionLifecycleMock.mockImplementation(
+    async (params: CliCompactionParams) => params.sessionEntry,
+  );
   state.deliveryFreshEntries = [];
+  state.deliverAgentCommandResultMock.mockImplementation(
+    async (params: {
+      resolveFreshSessionEntryForDelivery?: () => Promise<SessionEntry | undefined>;
+    }) => {
+      state.deliveryFreshEntries.push(await params.resolveFreshSessionEntryForDelivery?.());
+      return { deliverySucceeded: true };
+    },
+  );
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rotation-e2e-"));
   state.workspaceDir = path.join(tmpDir, "workspace");
   state.agentDir = path.join(tmpDir, "agent");
@@ -210,14 +242,16 @@ function makeResult(params: {
   sessionFile?: string;
   text: string;
   compactionCount?: number;
+  runner?: "cli" | "embedded";
+  payloads?: EmbeddedAgentRunResult["payloads"];
 }): EmbeddedAgentRunResult {
   return {
-    payloads: [{ text: params.text }],
+    payloads: params.payloads ?? [{ text: params.text }],
     meta: {
       durationMs: 1,
       stopReason: "end_turn",
       executionTrace: {
-        runner: "embedded" as const,
+        runner: params.runner ?? "embedded",
         fallbackUsed: false,
         winnerProvider: "openai",
         winnerModel: "gpt-5.5",
@@ -258,6 +292,22 @@ function requireStorePath(): string {
   }
   return storePath;
 }
+
+function findStoredSessionEntry(sessionKey: string): SessionEntry | undefined {
+  return listSessionEntries({ storePath: requireStorePath() }).find(
+    (candidate) => candidate.sessionKey === sessionKey,
+  )?.entry;
+}
+
+function readLifecyclePhases(): Array<string | undefined> {
+  return state.emitAgentEventMock.mock.calls
+    .map(([event]) => event as { stream?: string; data?: { phase?: string } })
+    .filter((event) => event.stream === "lifecycle")
+    .map((event) => event.data?.phase);
+}
+
+const COMPACTION_ERROR =
+  "CLI transcript compaction failed for openai/gpt-5.5: Summarization failed: Connection error.";
 
 describe("agentCommand compaction transcript rotation", () => {
   it("does not re-normalize an exact configured custom provider through plugin runtime", async () => {
@@ -372,6 +422,318 @@ describe("agentCommand compaction transcript rotation", () => {
       readSessionMessages({ agentId: "main", sessionId: "rotated-session", storePath }),
     ).resolves.toContainEqual(expect.objectContaining({ role: "assistant" }));
   });
+
+  it.each(["cli", "embedded"] as const)(
+    "persists the pending final before %s compaction failure and still delivers",
+    async (runner) => {
+      const sessionId = `${runner}-compaction-failure`;
+      const sessionKey = `agent:main:explicit:${sessionId}`;
+      const text = `${runner} reply generated before compaction`;
+      let compactionSessionEntry: SessionEntry | undefined;
+      let storedEntryBeforeCompaction: SessionEntry | undefined;
+      state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text, runner }));
+      state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
+        compactionSessionEntry = params.sessionEntry;
+        storedEntryBeforeCompaction = findStoredSessionEntry(sessionKey);
+        throw new Error(COMPACTION_ERROR);
+      });
+
+      const result = await agentCommand({
+        message: "room message",
+        sessionId,
+        sessionKey,
+        cwd: state.workspaceDir,
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        deliver: true,
+      });
+
+      expect(compactionSessionEntry).toMatchObject({
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: text,
+        pendingFinalDeliveryContext: {
+          channel: "discord",
+          to: "discord:dm:123",
+          accountId: "main",
+        },
+      });
+      expect(storedEntryBeforeCompaction).toMatchObject({
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: text,
+      });
+      expect(result).toMatchObject({ deliverySucceeded: true });
+      expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
+      expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
+        expect.objectContaining({ payloads: [{ text }] }),
+      );
+      expect(readLifecyclePhases()).toContain("end");
+      expect(readLifecyclePhases()).not.toContain("error");
+      const storedEntryAfterDelivery = findStoredSessionEntry(sessionKey);
+      expect(storedEntryAfterDelivery?.pendingFinalDelivery).toBeUndefined();
+      expect(storedEntryAfterDelivery?.pendingFinalDeliveryText).toBeUndefined();
+    },
+  );
+
+  it("excludes hidden reasoning from the pending final persisted before compaction", async () => {
+    const sessionId = "reasoning-filter-compaction-failure";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const hiddenReasoning = "private chain of thought";
+    const visibleFinal = "visible final answer";
+    let pendingTextSeenByCompaction: string | undefined;
+    state.runAgentAttemptMock.mockResolvedValueOnce(
+      makeResult({
+        sessionId,
+        text: visibleFinal,
+        payloads: [{ text: hiddenReasoning, isReasoning: true }, { text: visibleFinal }],
+      }),
+    );
+    state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
+      pendingTextSeenByCompaction = params.sessionEntry?.pendingFinalDeliveryText;
+      throw new Error(COMPACTION_ERROR);
+    });
+
+    const result = await agentCommand({
+      message: "room message",
+      sessionId,
+      sessionKey,
+      cwd: state.workspaceDir,
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(pendingTextSeenByCompaction).toBe(visibleFinal);
+    expect(pendingTextSeenByCompaction).not.toContain(hiddenReasoning);
+    expect(result).toMatchObject({ deliverySucceeded: true });
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
+    const storedEntry = findStoredSessionEntry(sessionKey);
+    expect(storedEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(storedEntry?.pendingFinalDeliveryText).toBeUndefined();
+  });
+
+  it("adopts a successful compaction successor for delivery and marker cleanup", async () => {
+    const sessionId = "pre-compaction-session";
+    const successorSessionId = "post-compaction-session";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const text = "reply carried across successful compaction";
+    const successorSessionFile = formatSqliteSessionFileMarker({
+      agentId: "main",
+      sessionId: successorSessionId,
+      storePath: requireStorePath(),
+    });
+    let successorBeforeCleanup: SessionEntry | undefined;
+    let compactionSetupError: Error | undefined;
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text }));
+    state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
+      if (!params.sessionEntry || !params.sessionStore || !params.storePath) {
+        compactionSetupError = new Error("compaction test requires persisted session state");
+        throw compactionSetupError;
+      }
+      successorBeforeCleanup = {
+        ...params.sessionEntry,
+        sessionId: successorSessionId,
+        sessionFile: successorSessionFile,
+        updatedAt: Date.now(),
+      };
+      await replaceSessionEntry(
+        { sessionKey: params.sessionKey, storePath: params.storePath },
+        successorBeforeCleanup,
+      );
+      params.sessionStore[params.sessionKey] = successorBeforeCleanup;
+      return successorBeforeCleanup;
+    });
+
+    const result = await agentCommand({
+      message: "room message",
+      sessionId,
+      sessionKey,
+      cwd: state.workspaceDir,
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(compactionSetupError).toBeUndefined();
+    expect(successorBeforeCleanup).toMatchObject({
+      sessionId: successorSessionId,
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: text,
+    });
+    expect(result).toMatchObject({ deliverySucceeded: true });
+    expect(state.deliveryFreshEntries.at(-1)).toMatchObject({
+      sessionId: successorSessionId,
+      sessionFile: successorSessionFile,
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: text,
+    });
+    const storedSuccessor = findStoredSessionEntry(sessionKey);
+    expect(storedSuccessor).toMatchObject({
+      sessionId: successorSessionId,
+      sessionFile: successorSessionFile,
+    });
+    expect(storedSuccessor?.pendingFinalDelivery).toBeUndefined();
+    expect(storedSuccessor?.pendingFinalDeliveryText).toBeUndefined();
+    expect(storedSuccessor?.restartRecoveryDeliveryContext).toBeUndefined();
+    expect(storedSuccessor?.restartRecoveryDeliveryRunId).toBeUndefined();
+  });
+
+  it("retains the pending final when delivery fails after compaction failure", async () => {
+    const sessionId = "delivery-failure-after-compaction";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const text = "reply awaiting restart recovery";
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text }));
+    state.runCliTurnCompactionLifecycleMock.mockRejectedValueOnce(new Error(COMPACTION_ERROR));
+    state.deliverAgentCommandResultMock.mockResolvedValueOnce({ deliverySucceeded: false });
+
+    const result = await agentCommand({
+      message: "room message",
+      sessionId,
+      sessionKey,
+      cwd: state.workspaceDir,
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(result).toMatchObject({ deliverySucceeded: false });
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
+    expect(findStoredSessionEntry(sessionKey)).toMatchObject({
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: text,
+      pendingFinalDeliveryContext: {
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+      },
+    });
+  });
+
+  it("does not deliver or clear the pending final when restart aborts compaction", async () => {
+    const sessionId = "restart-during-compaction";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const text = "reply owned by restart recovery";
+    const abortController = new AbortController();
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text }));
+    state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
+      expect(params.sessionEntry).toMatchObject({
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: text,
+      });
+      abortController.abort(createAgentRunRestartAbortError());
+      throw new Error(COMPACTION_ERROR);
+    });
+
+    await expect(
+      agentCommand({
+        message: "room message",
+        sessionId,
+        sessionKey,
+        cwd: state.workspaceDir,
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        deliver: true,
+        abortSignal: abortController.signal,
+      }),
+    ).rejects.toThrow("agent run aborted for restart");
+
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+    expect(findStoredSessionEntry(sessionKey)).toMatchObject({
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: text,
+    });
+  });
+
+  it("does not deliver or clear the pending final after lifecycle ownership turns stale", async () => {
+    const sessionId = "stale-during-compaction";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const text = "reply owned by the next gateway lifecycle";
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text }));
+    state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
+      expect(params.sessionEntry).toMatchObject({
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: text,
+      });
+      rotateAgentEventLifecycleGeneration();
+      throw new Error(COMPACTION_ERROR);
+    });
+
+    await expect(
+      agentCommand({
+        message: "room message",
+        sessionId,
+        sessionKey,
+        cwd: state.workspaceDir,
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        deliver: true,
+      }),
+    ).rejects.toThrow("Agent run belongs to a stale gateway lifecycle");
+
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+    expect(findStoredSessionEntry(sessionKey)).toMatchObject({
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: text,
+    });
+  });
+
+  it.each([
+    ["empty payloads", "empty", []],
+    ["a silent NO_REPLY payload", "silent", [{ text: "NO_REPLY" }]],
+    ["a reasoning-only payload", "reasoning", [{ text: "hidden reasoning", isReasoning: true }]],
+    ["a heartbeat-only payload", "heartbeat", [{ text: "HEARTBEAT_OK" }]],
+    ["an outbound-suppressed relay placeholder", "relay-status", [{ text: "No channel reply." }]],
+  ] as const)(
+    "keeps compaction failure fatal for %s without manufacturing delivery state",
+    async (_label, sessionSuffix, payloads) => {
+      const sessionId = `no-reply-compaction-failure-${sessionSuffix}`;
+      const sessionKey = `agent:main:explicit:${sessionId}`;
+      state.runAgentAttemptMock.mockResolvedValueOnce({
+        payloads: [...payloads],
+        meta: {
+          durationMs: 1,
+          stopReason: "end_turn",
+          executionTrace: {
+            runner: "cli",
+            fallbackUsed: false,
+            winnerProvider: "openai",
+            winnerModel: "gpt-5.5",
+          },
+          agentMeta: {
+            sessionId,
+            provider: "openai",
+            model: "gpt-5.5",
+          },
+        },
+      });
+      state.runCliTurnCompactionLifecycleMock.mockRejectedValueOnce(new Error(COMPACTION_ERROR));
+
+      await expect(
+        agentCommand({
+          message: "prompt with no assistant reply",
+          sessionId,
+          sessionKey,
+          cwd: state.workspaceDir,
+          channel: "discord",
+          to: "discord:dm:123",
+          accountId: "main",
+          deliver: true,
+        }),
+      ).rejects.toThrow("Summarization failed: Connection error");
+
+      expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledOnce();
+      expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+      const storedEntry = findStoredSessionEntry(sessionKey);
+      expect(storedEntry?.pendingFinalDelivery).toBeUndefined();
+      expect(storedEntry?.pendingFinalDeliveryText).toBeUndefined();
+      expect(readLifecyclePhases()).toContain("error");
+    },
+  );
 
   it("resumes the next turn from the rotated successor", async () => {
     const storePath = requireStorePath();

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -513,6 +513,38 @@ describe("agentCommand compaction transcript rotation", () => {
     expect(storedEntry?.pendingFinalDeliveryText).toBeUndefined();
   });
 
+  it("preserves media directives in the pending final persisted before compaction", async () => {
+    const sessionId = "media-directive-compaction-failure";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const text = "Rendered chart\nMEDIA:/tmp/chart.png";
+    let pendingTextSeenByCompaction: string | undefined;
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text }));
+    state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
+      pendingTextSeenByCompaction = params.sessionEntry?.pendingFinalDeliveryText ?? undefined;
+      throw new Error(COMPACTION_ERROR);
+    });
+
+    const result = await agentCommand({
+      message: "room message",
+      sessionId,
+      sessionKey,
+      cwd: state.workspaceDir,
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(pendingTextSeenByCompaction).toBe(text);
+    expect(result).toMatchObject({ deliverySucceeded: true });
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({ payloads: [{ text }] }),
+    );
+    const storedEntry = findStoredSessionEntry(sessionKey);
+    expect(storedEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(storedEntry?.pendingFinalDeliveryText).toBeUndefined();
+  });
+
   it("adopts a successful compaction successor for delivery and marker cleanup", async () => {
     const sessionId = "pre-compaction-session";
     const successorSessionId = "post-compaction-session";
@@ -770,6 +802,77 @@ describe("agentCommand compaction transcript rotation", () => {
       expect(readLifecyclePhases()).toContain("error");
     },
   );
+
+  it("skips post-turn compaction before delivering sendable finals that pending text cannot replay", async () => {
+    const sessionId = "unrecoverable-media-before-compaction";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const payloads = [{ mediaUrl: "/tmp/reply.ogg", audioAsVoice: true }];
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text: "", payloads }));
+
+    const result = await agentCommand({
+      message: "room message",
+      sessionId,
+      sessionKey,
+      cwd: state.workspaceDir,
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: true,
+    });
+
+    expect(state.runCliTurnCompactionLifecycleMock).not.toHaveBeenCalled();
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({ payloads }),
+    );
+    expect(result).toMatchObject({ deliverySucceeded: true });
+    const storedEntry = findStoredSessionEntry(sessionKey);
+    expect(storedEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(storedEntry?.pendingFinalDeliveryText).toBeUndefined();
+  });
+
+  it("keeps post-turn compaction for no-delivery runs with unrecoverable sendable finals", async () => {
+    const sessionId = "unrecoverable-media-no-delivery";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const payloads = [{ mediaUrl: "/tmp/reply.ogg", audioAsVoice: true }];
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text: "", payloads }));
+
+    await agentCommand({
+      message: "local model run",
+      sessionId,
+      sessionKey,
+      cwd: state.workspaceDir,
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
+      deliver: false,
+    });
+
+    expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledOnce();
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps post-turn compaction failures fatal for no-delivery runs", async () => {
+    const sessionId = "no-delivery-compaction-failure";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text: "local final" }));
+    state.runCliTurnCompactionLifecycleMock.mockRejectedValueOnce(new Error(COMPACTION_ERROR));
+
+    await expect(
+      agentCommand({
+        message: "local model run",
+        sessionId,
+        sessionKey,
+        cwd: state.workspaceDir,
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        deliver: false,
+      }),
+    ).rejects.toThrow("Summarization failed: Connection error");
+
+    expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledOnce();
+  });
 
   it("resumes the next turn from the rotated successor", async () => {
     const storePath = requireStorePath();

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -3,8 +3,9 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveInlineAgentImageAttachments } from "../auto-reply/reply/agent-turn-attachments.js";
 import {
-  buildPendingFinalDeliveryText,
+  buildRecoverablePendingFinalDeliveryText,
   normalizePendingFinalDeliveryPayloads,
+  normalizePendingFinalRecoveryPayloads,
 } from "../auto-reply/reply/pending-final-delivery.js";
 import {
   formatThinkingLevels,
@@ -2701,8 +2702,11 @@ async function agentCommandInternal(
         }
 
         const payloads = result.payloads ?? [];
+        const recoveryFinalPayloads = normalizePendingFinalRecoveryPayloads(payloads);
         const sendableFinalPayloads = normalizePendingFinalDeliveryPayloads(payloads);
         const hasSendableFinalPayload = sendableFinalPayloads.length > 0;
+        const recoverableFinalDeliveryText =
+          buildRecoverablePendingFinalDeliveryText(recoveryFinalPayloads);
         let pendingFinalDeliveryTextForThisRun: string | undefined;
 
         // Persist the completed final before optional post-turn compaction. A compaction
@@ -2717,16 +2721,15 @@ async function agentCommandInternal(
           !isSubagentSessionKey(sessionKey)
         ) {
           const now = Date.now();
-          const combinedPayload = buildPendingFinalDeliveryText(sendableFinalPayloads);
-          pendingFinalDeliveryTextForThisRun = combinedPayload || undefined;
 
-          if (combinedPayload) {
+          if (recoverableFinalDeliveryText && hasSendableFinalPayload) {
+            pendingFinalDeliveryTextForThisRun = recoverableFinalDeliveryText;
             const entry = sessionStore[sessionKey] ?? sessionEntry;
             if (entry) {
               const next: SessionEntry = {
                 ...entry,
                 pendingFinalDelivery: true,
-                pendingFinalDeliveryText: combinedPayload,
+                pendingFinalDeliveryText: recoverableFinalDeliveryText,
                 pendingFinalDeliveryContext: currentRunDeliveryContext,
                 pendingFinalDeliveryCreatedAt: now,
                 updatedAt: now,
@@ -2745,7 +2748,16 @@ async function agentCommandInternal(
           }
         }
 
-        if (persistedCliTurnTranscript && !suppressVisibleSessionEffects) {
+        const canSafelyRunPostTurnCompaction =
+          opts.deliver !== true ||
+          !hasSendableFinalPayload ||
+          Boolean(recoverableFinalDeliveryText);
+
+        if (
+          persistedCliTurnTranscript &&
+          !suppressVisibleSessionEffects &&
+          canSafelyRunPostTurnCompaction
+        ) {
           try {
             const compactedSessionEntry = await (
               await loadCliCompactionRuntime()
@@ -2785,7 +2797,11 @@ async function agentCommandInternal(
               throw error;
             }
             assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
-            if (!hasSendableFinalPayload) {
+            if (
+              opts.deliver !== true ||
+              !recoverableFinalDeliveryText ||
+              !hasSendableFinalPayload
+            ) {
               throw error;
             }
             log.warn(

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2,7 +2,8 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveInlineAgentImageAttachments } from "../auto-reply/reply/agent-turn-attachments.js";
-import { sanitizePendingFinalDeliveryText } from "../auto-reply/reply/pending-final-delivery.js";
+import { normalizeReplyPayload } from "../auto-reply/reply/normalize-reply.js";
+import { buildPendingFinalDeliveryText } from "../auto-reply/reply/pending-final-delivery.js";
 import {
   formatThinkingLevels,
   isThinkingLevelSupported,
@@ -34,6 +35,10 @@ import {
   resolveAgentOutboundTarget,
 } from "../infra/outbound/agent-delivery.js";
 import { resolveMessageChannelSelection } from "../infra/outbound/channel-selection.js";
+import {
+  normalizeOutboundPayloads,
+  normalizeReplyPayloadsForDelivery,
+} from "../infra/outbound/payloads.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -1031,6 +1036,7 @@ async function agentCommandInternal(
   let lifecycleGeneration = opts.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(runId);
   const effectiveCwd = cwd ? resolveUserPath(cwd) : workspaceDir;
   let sessionEntry = prepared.sessionEntry;
+  let runOwnedSessionId = sessionId;
   const sessionStateActor = classifySessionStateActor({
     inputProvenance: opts.inputProvenance,
     internalEvents: opts.internalEvents,
@@ -2649,17 +2655,20 @@ async function agentCommandInternal(
           });
           sessionEntry = sessionStore[sessionKey] ?? sessionEntry;
         }
+        // Provider and post-turn compaction rotations transfer this run's delivery cleanup
+        // ownership to a known successor; unrelated later rotations must still fail the CAS guards.
+        runOwnedSessionId = effectiveSessionId;
 
         const transcriptPersistenceRunner = result.meta.executionTrace?.runner;
         const embeddedAssistantGapFill =
           transcriptPersistenceRunner === "embedded" ||
           (transcriptPersistenceRunner === undefined &&
             Boolean(result.meta.finalAssistantVisibleText?.trim()));
+        let persistedCliTurnTranscript = false;
         if (
           !sessionReboundDuringRun &&
           (transcriptPersistenceRunner === "cli" || embeddedAssistantGapFill)
         ) {
-          let persistedCliTurnTranscript = false;
           try {
             const transcriptSessionEntry = internalSessionTarget?.sessionEntry ?? sessionEntry;
             const transcriptResult = await attemptExecutionRuntime.persistCliTurnTranscript({
@@ -2691,8 +2700,59 @@ async function agentCommandInternal(
               `Turn transcript persistence failed for ${sessionKey ?? sessionId}: ${error instanceof Error ? error.message : String(error)}`,
             );
           }
-          if (persistedCliTurnTranscript && !suppressVisibleSessionEffects) {
-            sessionEntry = await (
+        }
+
+        const payloads = result.payloads ?? [];
+        const normalizedFinalPayloads = payloads.flatMap((payload) => {
+          const normalized = normalizeReplyPayload(payload, { applyChannelTransforms: false });
+          return normalized ? [normalized] : [];
+        });
+        const sendableFinalPayloads = normalizeReplyPayloadsForDelivery(normalizedFinalPayloads);
+        let pendingFinalDeliveryTextForThisRun: string | undefined;
+
+        // Persist the completed final before optional post-turn compaction. A compaction
+        // timeout or restart must leave recovery enough state to deliver the visible reply.
+        if (
+          opts.deliver === true &&
+          sessionStore &&
+          sessionKey &&
+          !suppressVisibleSessionEffects &&
+          !sessionReboundDuringRun &&
+          payloads.length > 0 &&
+          !isSubagentSessionKey(sessionKey)
+        ) {
+          const now = Date.now();
+          const combinedPayload = buildPendingFinalDeliveryText(sendableFinalPayloads);
+          pendingFinalDeliveryTextForThisRun = combinedPayload || undefined;
+
+          if (combinedPayload) {
+            const entry = sessionStore[sessionKey] ?? sessionEntry;
+            if (entry) {
+              const next: SessionEntry = {
+                ...entry,
+                pendingFinalDelivery: true,
+                pendingFinalDeliveryText: combinedPayload,
+                pendingFinalDeliveryContext: currentRunDeliveryContext,
+                pendingFinalDeliveryCreatedAt: now,
+                updatedAt: now,
+              };
+              const persisted = await persistSessionEntry({
+                sessionStore,
+                sessionKey,
+                storePath,
+                initialEntry: entry,
+                entry: next,
+                shouldPersist: (current) =>
+                  shouldPersistCurrentRunSessionCleanup(current, runOwnedSessionId),
+              });
+              sessionEntry = persisted;
+            }
+          }
+        }
+
+        if (persistedCliTurnTranscript && !suppressVisibleSessionEffects) {
+          try {
+            const compactedSessionEntry = await (
               await loadCliCompactionRuntime()
             ).runCliTurnCompactionLifecycle({
               cfg,
@@ -2714,54 +2774,23 @@ async function agentCommandInternal(
               thinkLevel: effectiveTurnThinkLevel,
               extraSystemPrompt: opts.extraSystemPrompt,
             });
-          }
-        }
-
-        const payloads = result.payloads ?? [];
-        let pendingFinalDeliveryTextForThisRun: string | undefined;
-
-        // Phase 2: Persist pending final delivery for main sessions before attempting delivery.
-        // This ensures that if the process restarts during delivery, the payload is durable.
-        if (
-          opts.deliver === true &&
-          sessionStore &&
-          sessionKey &&
-          !suppressVisibleSessionEffects &&
-          !sessionReboundDuringRun &&
-          payloads.length > 0 &&
-          !isSubagentSessionKey(sessionKey)
-        ) {
-          const now = Date.now();
-          const combinedPayload = sanitizePendingFinalDeliveryText(
-            payloads
-              .map((p) => (typeof p.text === "string" ? p.text : ""))
-              .filter(Boolean)
-              .join("\n\n"),
-          );
-          pendingFinalDeliveryTextForThisRun = combinedPayload || undefined;
-
-          if (combinedPayload) {
-            const entry = sessionStore[sessionKey] ?? sessionEntry;
-            if (entry) {
-              const next: SessionEntry = {
-                ...entry,
-                pendingFinalDelivery: true,
-                pendingFinalDeliveryText: combinedPayload,
-                pendingFinalDeliveryContext: currentRunDeliveryContext,
-                pendingFinalDeliveryCreatedAt: now,
-                updatedAt: now,
-              };
-              const persisted = await persistSessionEntry({
-                sessionStore,
-                sessionKey,
-                storePath,
-                initialEntry: entry,
-                entry: next,
-                shouldPersist: (current) =>
-                  shouldPersistCurrentRunSessionCleanup(current, sessionId),
-              });
-              sessionEntry = persisted;
+            sessionEntry = compactedSessionEntry;
+            runOwnedSessionId = compactedSessionEntry?.sessionId ?? runOwnedSessionId;
+          } catch (error) {
+            const restartAbortReason = opts.abortSignal?.reason;
+            if (isAgentRunRestartAbortReason(restartAbortReason)) {
+              throw restartAbortReason;
             }
+            if (isAgentRunRestartAbortReason(error)) {
+              throw error;
+            }
+            assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+            if (normalizeOutboundPayloads(sendableFinalPayloads).length === 0) {
+              throw error;
+            }
+            log.warn(
+              `Post-turn transcript compaction failed for ${sessionKey ?? sessionId}; continuing final delivery: ${formatErrorMessage(error)}`,
+            );
           }
         }
 
@@ -2776,7 +2805,7 @@ async function agentCommandInternal(
                   readConsistency: "latest",
                   clone: false,
                 });
-                if (!freshEntry || freshEntry.sessionId !== effectiveSessionId) {
+                if (!freshEntry || freshEntry.sessionId !== runOwnedSessionId) {
                   return undefined;
                 }
                 sessionStore[sessionKey] = freshEntry;
@@ -2799,7 +2828,7 @@ async function agentCommandInternal(
           resolveFreshSessionEntryForDelivery
             ? {
                 ...deliveryParams,
-                expectedSessionIdForFreshDelivery: effectiveSessionId,
+                expectedSessionIdForFreshDelivery: runOwnedSessionId,
                 resolveFreshSessionEntryForDelivery,
               }
             : deliveryParams,
@@ -2830,7 +2859,8 @@ async function agentCommandInternal(
               storePath,
               initialEntry: entry,
               entry: next,
-              shouldPersist: (current) => shouldPersistCurrentRunSessionCleanup(current, sessionId),
+              shouldPersist: (current) =>
+                shouldPersistCurrentRunSessionCleanup(current, runOwnedSessionId),
             });
             sessionEntry = persisted;
           }
@@ -2891,7 +2921,7 @@ async function agentCommandInternal(
             initialEntry: entry,
             entry: next,
             shouldPersist: (current) =>
-              shouldPersistRestartRecoveryCleanup(current, sessionId, runId),
+              shouldPersistRestartRecoveryCleanup(current, runOwnedSessionId, runId),
           });
           sessionEntry = persisted;
         }

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2,8 +2,10 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveInlineAgentImageAttachments } from "../auto-reply/reply/agent-turn-attachments.js";
-import { normalizeReplyPayload } from "../auto-reply/reply/normalize-reply.js";
-import { buildPendingFinalDeliveryText } from "../auto-reply/reply/pending-final-delivery.js";
+import {
+  buildPendingFinalDeliveryText,
+  normalizePendingFinalDeliveryPayloads,
+} from "../auto-reply/reply/pending-final-delivery.js";
 import {
   formatThinkingLevels,
   isThinkingLevelSupported,
@@ -35,10 +37,6 @@ import {
   resolveAgentOutboundTarget,
 } from "../infra/outbound/agent-delivery.js";
 import { resolveMessageChannelSelection } from "../infra/outbound/channel-selection.js";
-import {
-  normalizeOutboundPayloads,
-  normalizeReplyPayloadsForDelivery,
-} from "../infra/outbound/payloads.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -2703,11 +2701,8 @@ async function agentCommandInternal(
         }
 
         const payloads = result.payloads ?? [];
-        const normalizedFinalPayloads = payloads.flatMap((payload) => {
-          const normalized = normalizeReplyPayload(payload, { applyChannelTransforms: false });
-          return normalized ? [normalized] : [];
-        });
-        const sendableFinalPayloads = normalizeReplyPayloadsForDelivery(normalizedFinalPayloads);
+        const sendableFinalPayloads = normalizePendingFinalDeliveryPayloads(payloads);
+        const hasSendableFinalPayload = sendableFinalPayloads.length > 0;
         let pendingFinalDeliveryTextForThisRun: string | undefined;
 
         // Persist the completed final before optional post-turn compaction. A compaction
@@ -2774,6 +2769,11 @@ async function agentCommandInternal(
               thinkLevel: effectiveTurnThinkLevel,
               extraSystemPrompt: opts.extraSystemPrompt,
             });
+            const restartAbortReason = opts.abortSignal?.reason;
+            if (isAgentRunRestartAbortReason(restartAbortReason)) {
+              throw restartAbortReason;
+            }
+            assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
             sessionEntry = compactedSessionEntry;
             runOwnedSessionId = compactedSessionEntry?.sessionId ?? runOwnedSessionId;
           } catch (error) {
@@ -2785,7 +2785,7 @@ async function agentCommandInternal(
               throw error;
             }
             assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
-            if (normalizeOutboundPayloads(sendableFinalPayloads).length === 0) {
+            if (!hasSendableFinalPayload) {
               throw error;
             }
             log.warn(
@@ -2834,7 +2834,7 @@ async function agentCommandInternal(
             : deliveryParams,
         );
 
-        // Phase 2: Clear pending delivery payload after successful delivery.
+        // Clear this run's pending delivery payload after successful delivery.
         if (
           sessionStore &&
           sessionKey &&

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -3,11 +3,6 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveInlineAgentImageAttachments } from "../auto-reply/reply/agent-turn-attachments.js";
 import {
-  buildRecoverablePendingFinalDeliveryText,
-  normalizePendingFinalDeliveryPayloads,
-  normalizePendingFinalRecoveryPayloads,
-} from "../auto-reply/reply/pending-final-delivery.js";
-import {
   formatThinkingLevels,
   isThinkingLevelSupported,
   normalizeThinkLevel,
@@ -164,6 +159,7 @@ import {
   type ModelVisibilityPolicy,
 } from "./model-visibility-policy.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-routing.js";
+import { persistPendingFinalDeliveryMarker } from "./pending-final-delivery-marker.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 import type { AgentRunSessionTarget } from "./run-session-target.js";
 import {
@@ -172,6 +168,7 @@ import {
   isAgentRunRestartAbortReason,
   resolveAgentRunAbortLifecycleFields,
   resolveAgentRunErrorLifecycleFields,
+  throwAgentRunRestartAbortReason,
 } from "./run-termination.js";
 import { resolveSessionRuntimeOverrideForProvider } from "./session-runtime-compat.js";
 import { normalizeSpawnedRunMetadata } from "./spawned-context.js";
@@ -1034,8 +1031,8 @@ async function agentCommandInternal(
   } = prepared;
   let lifecycleGeneration = opts.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(runId);
   const effectiveCwd = cwd ? resolveUserPath(cwd) : workspaceDir;
-  let sessionEntry = prepared.sessionEntry;
-  let runOwnedSessionId = sessionId;
+  let sessionEntry = prepared.sessionEntry,
+    runOwnedSessionId = sessionId;
   const sessionStateActor = classifySessionStateActor({
     inputProvenance: opts.inputProvenance,
     internalEvents: opts.internalEvents,
@@ -2654,8 +2651,6 @@ async function agentCommandInternal(
           });
           sessionEntry = sessionStore[sessionKey] ?? sessionEntry;
         }
-        // Provider and post-turn compaction rotations transfer this run's delivery cleanup
-        // ownership to a known successor; unrelated later rotations must still fail the CAS guards.
         runOwnedSessionId = effectiveSessionId;
 
         const transcriptPersistenceRunner = result.meta.executionTrace?.runner;
@@ -2702,56 +2697,24 @@ async function agentCommandInternal(
         }
 
         const payloads = result.payloads ?? [];
-        const recoveryFinalPayloads = normalizePendingFinalRecoveryPayloads(payloads);
-        const sendableFinalPayloads = normalizePendingFinalDeliveryPayloads(payloads);
-        const hasSendableFinalPayload = sendableFinalPayloads.length > 0;
-        const recoverableFinalDeliveryText =
-          buildRecoverablePendingFinalDeliveryText(recoveryFinalPayloads);
-        let pendingFinalDeliveryTextForThisRun: string | undefined;
-
-        // Persist the completed final before optional post-turn compaction. A compaction
-        // timeout or restart must leave recovery enough state to deliver the visible reply.
-        if (
-          opts.deliver === true &&
-          sessionStore &&
-          sessionKey &&
-          !suppressVisibleSessionEffects &&
-          !sessionReboundDuringRun &&
-          payloads.length > 0 &&
-          !isSubagentSessionKey(sessionKey)
-        ) {
-          const now = Date.now();
-
-          if (recoverableFinalDeliveryText && hasSendableFinalPayload) {
-            pendingFinalDeliveryTextForThisRun = recoverableFinalDeliveryText;
-            const entry = sessionStore[sessionKey] ?? sessionEntry;
-            if (entry) {
-              const next: SessionEntry = {
-                ...entry,
-                pendingFinalDelivery: true,
-                pendingFinalDeliveryText: recoverableFinalDeliveryText,
-                pendingFinalDeliveryContext: currentRunDeliveryContext,
-                pendingFinalDeliveryCreatedAt: now,
-                updatedAt: now,
-              };
-              const persisted = await persistSessionEntry({
-                sessionStore,
-                sessionKey,
-                storePath,
-                initialEntry: entry,
-                entry: next,
-                shouldPersist: (current) =>
-                  shouldPersistCurrentRunSessionCleanup(current, runOwnedSessionId),
-              });
-              sessionEntry = persisted;
-            }
-          }
-        }
+        const pendingFinalDeliveryMarker = await persistPendingFinalDeliveryMarker({
+          deliver: opts.deliver === true,
+          sessionStore,
+          sessionKey,
+          sessionEntry,
+          storePath,
+          suppressVisibleSessionEffects,
+          sessionReboundDuringRun,
+          payloads,
+          deliveryContext: currentRunDeliveryContext,
+          runOwnedSessionId,
+        });
+        sessionEntry = pendingFinalDeliveryMarker.sessionEntry;
 
         const canSafelyRunPostTurnCompaction =
           opts.deliver !== true ||
-          !hasSendableFinalPayload ||
-          Boolean(recoverableFinalDeliveryText);
+          !pendingFinalDeliveryMarker.hasSendableFinalPayload ||
+          pendingFinalDeliveryMarker.pendingFinalDeliveryMarkerPersisted;
 
         if (
           persistedCliTurnTranscript &&
@@ -2781,26 +2744,18 @@ async function agentCommandInternal(
               thinkLevel: effectiveTurnThinkLevel,
               extraSystemPrompt: opts.extraSystemPrompt,
             });
-            const restartAbortReason = opts.abortSignal?.reason;
-            if (isAgentRunRestartAbortReason(restartAbortReason)) {
-              throw restartAbortReason;
-            }
+            throwAgentRunRestartAbortReason(opts.abortSignal?.reason);
             assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
             sessionEntry = compactedSessionEntry;
             runOwnedSessionId = compactedSessionEntry?.sessionId ?? runOwnedSessionId;
           } catch (error) {
-            const restartAbortReason = opts.abortSignal?.reason;
-            if (isAgentRunRestartAbortReason(restartAbortReason)) {
-              throw restartAbortReason;
-            }
-            if (isAgentRunRestartAbortReason(error)) {
-              throw error;
-            }
+            throwAgentRunRestartAbortReason(opts.abortSignal?.reason);
+            throwAgentRunRestartAbortReason(error);
             assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
             if (
               opts.deliver !== true ||
-              !recoverableFinalDeliveryText ||
-              !hasSendableFinalPayload
+              !pendingFinalDeliveryMarker.pendingFinalDeliveryMarkerPersisted ||
+              !pendingFinalDeliveryMarker.hasSendableFinalPayload
             ) {
               throw error;
             }
@@ -2850,7 +2805,6 @@ async function agentCommandInternal(
             : deliveryParams,
         );
 
-        // Clear this run's pending delivery payload after successful delivery.
         if (
           sessionStore &&
           sessionKey &&
@@ -2864,7 +2818,7 @@ async function agentCommandInternal(
           }
           const noPendingTextForThisRun =
             opts.deliver === true &&
-            pendingFinalDeliveryTextForThisRun === undefined &&
+            pendingFinalDeliveryMarker.pendingFinalDeliveryTextForThisRun === undefined &&
             entry?.pendingFinalDelivery === true &&
             !entry.pendingFinalDeliveryText;
           if (entry && (deliveryResult?.deliverySucceeded === true || noPendingTextForThisRun)) {

--- a/src/agents/pending-final-delivery-marker.ts
+++ b/src/agents/pending-final-delivery-marker.ts
@@ -1,0 +1,94 @@
+/** Persists restart-recoverable final delivery markers for agent runs. */
+import type { ReplyPayload } from "../auto-reply/reply-payload.js";
+import {
+  buildRecoverablePendingFinalDeliveryText,
+  normalizePendingFinalDeliveryPayloads,
+  normalizePendingFinalRecoveryPayloads,
+} from "../auto-reply/reply/pending-final-delivery.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import { isSubagentSessionKey } from "../routing/session-key.js";
+import type { DeliveryContext } from "../utils/delivery-context.shared.js";
+import { persistSessionEntry } from "./command/attempt-execution.shared.js";
+
+type PersistPendingFinalDeliveryMarkerParams = {
+  deliver: boolean;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey?: string;
+  sessionEntry?: SessionEntry;
+  storePath: string;
+  suppressVisibleSessionEffects: boolean;
+  sessionReboundDuringRun: boolean;
+  payloads: ReplyPayload[];
+  deliveryContext?: DeliveryContext;
+  runOwnedSessionId: string;
+};
+
+export type PendingFinalDeliveryMarkerResult = {
+  sessionEntry?: SessionEntry;
+  pendingFinalDeliveryTextForThisRun?: string;
+  pendingFinalDeliveryMarkerPersisted: boolean;
+  hasSendableFinalPayload: boolean;
+};
+
+export async function persistPendingFinalDeliveryMarker(
+  params: PersistPendingFinalDeliveryMarkerParams,
+): Promise<PendingFinalDeliveryMarkerResult> {
+  const recoveryPayloads = normalizePendingFinalRecoveryPayloads(params.payloads);
+  const hasSendableFinalPayload = normalizePendingFinalDeliveryPayloads(params.payloads).length > 0;
+  const recoverableText = buildRecoverablePendingFinalDeliveryText(recoveryPayloads);
+
+  if (
+    !params.deliver ||
+    !params.sessionStore ||
+    !params.sessionKey ||
+    params.suppressVisibleSessionEffects ||
+    params.sessionReboundDuringRun ||
+    params.payloads.length === 0 ||
+    isSubagentSessionKey(params.sessionKey) ||
+    !recoverableText ||
+    !hasSendableFinalPayload
+  ) {
+    return {
+      sessionEntry: params.sessionEntry,
+      pendingFinalDeliveryMarkerPersisted: false,
+      hasSendableFinalPayload,
+    };
+  }
+
+  const entry = params.sessionStore[params.sessionKey] ?? params.sessionEntry;
+  if (!entry) {
+    return {
+      sessionEntry: params.sessionEntry,
+      pendingFinalDeliveryMarkerPersisted: false,
+      hasSendableFinalPayload,
+    };
+  }
+
+  const now = Date.now();
+  const persisted = await persistSessionEntry({
+    sessionStore: params.sessionStore,
+    sessionKey: params.sessionKey,
+    storePath: params.storePath,
+    initialEntry: entry,
+    entry: {
+      ...entry,
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: recoverableText,
+      pendingFinalDeliveryContext: params.deliveryContext,
+      pendingFinalDeliveryCreatedAt: now,
+      updatedAt: now,
+    },
+    shouldPersist: (current) =>
+      current?.sessionId === params.runOwnedSessionId && current.abortedLastRun !== true,
+  });
+  const markerPersisted =
+    persisted?.pendingFinalDelivery === true &&
+    persisted.pendingFinalDeliveryText === recoverableText;
+
+  return {
+    sessionEntry: persisted,
+    pendingFinalDeliveryTextForThisRun: markerPersisted ? recoverableText : undefined,
+    pendingFinalDeliveryMarkerPersisted: markerPersisted,
+    hasSendableFinalPayload,
+  };
+}

--- a/src/agents/pending-final-delivery-marker.ts
+++ b/src/agents/pending-final-delivery-marker.ts
@@ -23,7 +23,7 @@ type PersistPendingFinalDeliveryMarkerParams = {
   runOwnedSessionId: string;
 };
 
-export type PendingFinalDeliveryMarkerResult = {
+type PendingFinalDeliveryMarkerResult = {
   sessionEntry?: SessionEntry;
   pendingFinalDeliveryTextForThisRun?: string;
   pendingFinalDeliveryMarkerPersisted: boolean;

--- a/src/agents/run-termination.ts
+++ b/src/agents/run-termination.ts
@@ -46,6 +46,12 @@ export function isAgentRunRestartAbortReason(value: unknown): boolean {
   }
 }
 
+export function throwAgentRunRestartAbortReason(value: unknown): void {
+  if (isAgentRunRestartAbortReason(value)) {
+    throw value;
+  }
+}
+
 function isAgentRunTimeoutAbortReason(value: unknown): boolean {
   if (!value || typeof value !== "object") {
     return false;

--- a/src/auto-reply/reply/pending-final-delivery.test.ts
+++ b/src/auto-reply/reply/pending-final-delivery.test.ts
@@ -4,7 +4,13 @@ import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "../../agents/internal-runtime-context.js";
-import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
+import {
+  buildRecoverablePendingFinalDeliveryText,
+  buildPendingFinalDeliveryText,
+  normalizePendingFinalDeliveryPayloads,
+  normalizePendingFinalRecoveryPayloads,
+  sanitizePendingFinalDeliveryText,
+} from "./pending-final-delivery.js";
 
 describe("sanitizePendingFinalDeliveryText", () => {
   it("strips internal metadata from durable pending delivery text", () => {
@@ -38,5 +44,87 @@ describe("sanitizePendingFinalDeliveryText", () => {
 
   it("preserves heartbeat ack text for ack-aware classification", () => {
     expect(sanitizePendingFinalDeliveryText("HEARTBEAT_OK short")).toBe("HEARTBEAT_OK short");
+  });
+});
+
+describe("normalizePendingFinalRecoveryPayloads", () => {
+  it("keeps media directives in the durable recovery text while sendable delivery parses them", () => {
+    const rawPayloads = [{ text: "Rendered chart\nMEDIA:/tmp/chart.png" }];
+
+    const recoveryPayloads = normalizePendingFinalRecoveryPayloads(rawPayloads);
+    expect(buildPendingFinalDeliveryText(recoveryPayloads)).toBe(
+      "Rendered chart\nMEDIA:/tmp/chart.png",
+    );
+
+    const deliveryPayloads = normalizePendingFinalDeliveryPayloads(rawPayloads);
+    expect(buildPendingFinalDeliveryText(deliveryPayloads)).toBe("Rendered chart");
+  });
+
+  it("keeps media-only directives as durable recovery text", () => {
+    const recoveryPayloads = normalizePendingFinalRecoveryPayloads([
+      { text: "MEDIA:/tmp/chart.png" },
+    ]);
+
+    expect(buildPendingFinalDeliveryText(recoveryPayloads)).toBe("MEDIA:/tmp/chart.png");
+    expect(normalizePendingFinalDeliveryPayloads(recoveryPayloads)).toHaveLength(1);
+  });
+
+  it("encodes structured media URLs as durable media directives", () => {
+    expect(
+      buildRecoverablePendingFinalDeliveryText([
+        { text: "Rendered chart", mediaUrl: "/tmp/chart.png" },
+      ]),
+    ).toBe("Rendered chart\nMEDIA:/tmp/chart.png");
+    expect(
+      buildRecoverablePendingFinalDeliveryText([{ mediaUrls: ["/tmp/a.png", "/tmp/b.png"] }]),
+    ).toBe("MEDIA:/tmp/a.png\nMEDIA:/tmp/b.png");
+  });
+
+  it("refuses payload shapes the text marker cannot replay without loss", () => {
+    expect(
+      buildRecoverablePendingFinalDeliveryText([
+        { text: "Pick one", interactive: { blocks: [{ type: "buttons", buttons: [] }] } },
+      ]),
+    ).toBeUndefined();
+    expect(
+      buildRecoverablePendingFinalDeliveryText([
+        { text: "Secret image", mediaUrl: "/tmp/secret.png", sensitiveMedia: true },
+      ]),
+    ).toBeUndefined();
+    expect(
+      buildRecoverablePendingFinalDeliveryText([{ text: "[[reply_to_current]] visible final" }]),
+    ).toBeUndefined();
+  });
+
+  it("refuses multi-payload media finals because text recovery loses payload boundaries", () => {
+    expect(
+      buildRecoverablePendingFinalDeliveryText([
+        { text: "A", mediaUrl: "/tmp/a.png" },
+        { text: "B", mediaUrl: "/tmp/b.png" },
+      ]),
+    ).toBeUndefined();
+    expect(
+      buildRecoverablePendingFinalDeliveryText([{ text: "A\nMEDIA:/tmp/a.png" }, { text: "B" }]),
+    ).toBeUndefined();
+  });
+
+  it("allows a single structured media payload to recover through media directives", () => {
+    expect(
+      buildRecoverablePendingFinalDeliveryText([
+        { text: "Rendered chart", mediaUrls: ["/tmp/a.png", "/tmp/b.png"] },
+      ]),
+    ).toBe("Rendered chart\nMEDIA:/tmp/a.png\nMEDIA:/tmp/b.png");
+  });
+
+  it("omits payloads that normal delivery suppresses", () => {
+    expect(
+      buildRecoverablePendingFinalDeliveryText([
+        { text: "No channel reply." },
+        { text: "visible final" },
+      ]),
+    ).toBe("visible final");
+    expect(
+      buildRecoverablePendingFinalDeliveryText([{ text: "No channel reply." }]),
+    ).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/pending-final-delivery.ts
+++ b/src/auto-reply/reply/pending-final-delivery.ts
@@ -16,11 +16,65 @@ import { normalizeReplyPayload } from "./normalize-reply.js";
 export function normalizePendingFinalDeliveryPayloads(
   payloads: readonly ReplyPayload[],
 ): ReplyPayload[] {
-  const normalizedPayloads = payloads.flatMap((payload) => {
+  return normalizeReplyPayloadsForDelivery(normalizePendingFinalRecoveryPayloads(payloads));
+}
+
+/** Normalize raw final payloads for durable recovery without stripping delivery directives. */
+export function normalizePendingFinalRecoveryPayloads(
+  payloads: readonly ReplyPayload[],
+): ReplyPayload[] {
+  return payloads.flatMap((payload) => {
     const normalized = normalizeReplyPayload(payload, { applyChannelTransforms: false });
     return normalized ? [normalized] : [];
   });
-  return normalizeReplyPayloadsForDelivery(normalizedPayloads);
+}
+
+/** Build durable recovery text only for payload shapes this marker can replay without loss. */
+export function buildRecoverablePendingFinalDeliveryText(
+  payloads: readonly ReplyPayload[],
+): string | undefined {
+  const sendablePayloads: ReplyPayload[] = [];
+  for (const payload of payloads) {
+    if (payload.isReasoning === true) {
+      continue;
+    }
+    const deliveryPayloads = normalizeReplyPayloadsForDelivery([payload]);
+    if (deliveryPayloads.length === 0) {
+      continue;
+    }
+    if (
+      hasUnsupportedDurableRecoveryShape(payload) ||
+      deliveryPayloads.some(hasUnrecoverableNormalizedDeliveryShape)
+    ) {
+      return undefined;
+    }
+    sendablePayloads.push(...deliveryPayloads);
+  }
+  if (
+    sendablePayloads.length > 1 &&
+    sendablePayloads.some((payload) => hasDurableMedia(payload) || hasMediaDirectiveText(payload))
+  ) {
+    return undefined;
+  }
+
+  const recoveryPayloads: ReplyPayload[] = [];
+  for (const payload of sendablePayloads) {
+    const textAndMedia = [
+      payload.text,
+      ...collectDurableMediaDirectives(payload).map((mediaUrl) => `MEDIA:${mediaUrl}`),
+    ]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .join("\n");
+    if (textAndMedia) {
+      recoveryPayloads.push({
+        ...payload,
+        mediaUrl: undefined,
+        mediaUrls: undefined,
+        text: textAndMedia,
+      });
+    }
+  }
+  return buildPendingFinalDeliveryText(recoveryPayloads) || undefined;
 }
 
 /** Build the restart-recovery text represented by one or more final payloads. */
@@ -31,6 +85,63 @@ export function buildPendingFinalDeliveryText(payloads: ReplyPayload[]): string 
     .filter((textLocal): textLocal is string => Boolean(textLocal))
     .join("\n\n");
   return sanitizePendingFinalDeliveryText(text);
+}
+
+function collectDurableMediaDirectives(payload: ReplyPayload): string[] {
+  if (payload.sensitiveMedia === true) {
+    return [];
+  }
+  const mediaUrls = [...(payload.mediaUrls ?? []), ...(payload.mediaUrl ? [payload.mediaUrl] : [])];
+  const seen = new Set<string>();
+  return mediaUrls
+    .map((mediaUrl) => mediaUrl.trim())
+    .filter((mediaUrl) => {
+      if (!mediaUrl || seen.has(mediaUrl)) {
+        return false;
+      }
+      seen.add(mediaUrl);
+      return true;
+    });
+}
+
+function hasUnsupportedDurableRecoveryShape(payload: ReplyPayload): boolean {
+  const hasMedia = hasDurableMedia(payload);
+  return (
+    payload.sensitiveMedia === true ||
+    payload.trustedLocalMedia === true ||
+    payload.presentation !== undefined ||
+    payload.interactive !== undefined ||
+    payload.btw !== undefined ||
+    payload.delivery !== undefined ||
+    payload.channelData !== undefined ||
+    payload.location !== undefined ||
+    payload.replyToId !== undefined ||
+    payload.replyToTag !== undefined ||
+    payload.replyToCurrent !== undefined ||
+    payload.audioAsVoice === true ||
+    payload.videoAsNote === true ||
+    payload.spokenText !== undefined ||
+    payload.ttsSupplement !== undefined ||
+    (hasMedia && (payload.isCommentary === true || payload.isStatusNotice === true))
+  );
+}
+
+function hasDurableMedia(payload: ReplyPayload): boolean {
+  return Boolean(payload.mediaUrl?.trim() || payload.mediaUrls?.some((url) => url.trim()));
+}
+
+function hasMediaDirectiveText(payload: ReplyPayload): boolean {
+  return /^\s*MEDIA:/imu.test(payload.text ?? "");
+}
+
+function hasUnrecoverableNormalizedDeliveryShape(payload: ReplyPayload): boolean {
+  return (
+    payload.replyToCurrent === true ||
+    payload.replyToTag === true ||
+    payload.replyToId !== undefined ||
+    payload.audioAsVoice === true ||
+    payload.videoAsNote === true
+  );
 }
 
 /** Sanitizes final pending-delivery text and removes silent control tokens. */

--- a/src/auto-reply/reply/pending-final-delivery.ts
+++ b/src/auto-reply/reply/pending-final-delivery.ts
@@ -1,3 +1,4 @@
+import { normalizeReplyPayloadsForDelivery } from "../../infra/outbound/payloads.js";
 import {
   isSilentReplyPayloadText,
   isSilentReplyText,
@@ -9,6 +10,18 @@ import {
 /** Sanitizes pending final delivery text before channel-visible output. */
 import type { ReplyPayload } from "../types.js";
 import { stripInternalMetadataForDisplay } from "./display-text-sanitize.js";
+import { normalizeReplyPayload } from "./normalize-reply.js";
+
+/** Normalize raw final payloads into the channel-agnostic sendable set recovery can mark. */
+export function normalizePendingFinalDeliveryPayloads(
+  payloads: readonly ReplyPayload[],
+): ReplyPayload[] {
+  const normalizedPayloads = payloads.flatMap((payload) => {
+    const normalized = normalizeReplyPayload(payload, { applyChannelTransforms: false });
+    return normalized ? [normalized] : [];
+  });
+  return normalizeReplyPayloadsForDelivery(normalizedPayloads);
+}
 
 /** Build the restart-recovery text represented by one or more final payloads. */
 export function buildPendingFinalDeliveryText(payloads: ReplyPayload[]): string {


### PR DESCRIPTION
Closes #94688

Related: #94928

## What Problem This Solves

Fixes an issue where users could lose a completed channel reply when post-turn transcript compaction failed or the gateway restarted during compaction. The reply could already be present in the local transcript and Control UI while never reaching the originating channel.

## Why This Change Was Made

The turn owner now records the canonical, user-visible pending final before optional post-turn compaction. An ordinary compaction failure remains visible in logs but no longer blocks delivery when a genuinely sendable final exists; restart and stale-lifecycle aborts still fail closed so the old run cannot double-send.

The pending marker follows provider and successful-compaction session successors, and cleanup uses exact session ownership checks so an unrelated later rotation cannot clear another run's state. Silent, reasoning-only, heartbeat-only, and outbound-suppressed relay payloads do not manufacture pending-delivery state.

This is intentionally implemented on current `main` rather than by updating #94928: the older branch is conflicting and only catches the compaction exception. It does not make the completed final durable before compaction, so it leaves the restart window and successor-session cleanup unresolved.

## User Impact

Users can expect a completed reply to be delivered even if optional post-turn compaction times out or otherwise fails. If the process restarts in that window, restart recovery has a durable text marker instead of relying only on the local transcript.

No configuration surface or timeout default changes. Empty or intentionally suppressed replies still treat compaction failure as fatal, and successful compaction behavior is unchanged.

## Evidence

- Validation environment: local macOS using the repository's narrow Codex-worktree fallback; hosted CI is pending on this draft.
- `node scripts/run-vitest.mjs src/agents/agent-command.compaction-rotation.test.ts` — 15/15 passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply/pending-final-delivery.test.ts src/auto-reply/reply/reply-utils.test.ts src/infra/outbound/payloads.test.ts` — 122/122 passed.
- `pnpm tsgo:core` — passed.
- `node scripts/run-oxlint.mjs src/agents/agent-command.ts src/agents/agent-command.compaction-rotation.test.ts` — passed.
- `pnpm exec oxfmt --check src/agents/agent-command.ts src/agents/agent-command.compaction-rotation.test.ts` — passed.
- `git diff --check` — passed.
- Regression coverage verifies CLI and embedded replies, compaction-successor adoption, failed-delivery retention, restart/stale lifecycle ownership, and suppression of empty, `NO_REPLY`, reasoning-only, heartbeat-only, and relay-status payloads.
- No live configuration was changed and no private transcript or deployment log is included in this PR.

## AI Assistance

AI-assisted investigation, implementation, test authoring, and review. I inspected the changed lifecycle, delivery normalization, session-store/restart-recovery paths, and the sibling Codex app-server compaction contract, understand the resulting behavior, and addressed all findings from local `codex review --base origin/main` before opening this draft.

## Real behavior proof (2026-07-12)

The real gateway/Matrix run was performed against pre-refresh head `4a19ebbd4e6d531b8325ca8db226d9b0c539b419`. The runtime change on the refreshed head has the same stable patch ID (`1d111b71aaa68462029bbec3e626dfde5056d3bc`) as that proven head; the only contributor changes added afterward are the test-only nullability normalization and removal of the now-stale dead-code baseline entry, neither of which changes runtime behavior.

- Used an isolated gateway launched from this exact worktree, invoking `openclaw agent --deliver` through that gateway (not `--local`).
- Used a disposable Tuwunel Matrix homeserver, the real bundled Matrix plugin, and a separate observer account to verify outbound delivery.
- Generated the final through a dedicated local Ollama model and the supported generic CLI backend; post-turn compaction used the production context engine.
- After observing the durable pending-final marker with a Matrix route, paused only the dedicated proof model server. This produced a real 3-second compaction watchdog timeout.
- Observed the PR's `Post-turn transcript compaction failed … continuing final delivery` warning, then one exact Matrix reply from the SUT. No duplicate appeared during a 5-second follow-up window, and every pending-final field was cleared after successful delivery.

Redacted live result:

```json
{
  "faultInjectedOnlyAfterDurableMarker": true,
  "realCompactionTimeoutObserved": true,
  "continuationWarningObserved": true,
  "matrixExactReplyMatched": true,
  "matrixSenderMatched": true,
  "matrixEventCount": 1,
  "delayedDuplicateObserved": false,
  "pendingFinalFieldsClearedAfterDelivery": true,
  "durableMarkerObservedMs": 28270,
  "matrixReplyObservedMs": 31878
}
```

The run also passed the Matrix harness, differential probe, channel-ready check, and canary. All account IDs, room IDs, event IDs, access tokens, prompt text, and raw logs were redacted; no private transcript or deployment data is attached.

Scope: this is real gateway/channel proof for the ordinary forced post-turn compaction-timeout path. The existing focused test coverage remains the evidence for the distinct restart/ownership cases; this live pass did not inject a restart.

## Refresh verification (2026-07-12)

- Fixed the nullable test assignment in `src/agents/agent-command.compaction-rotation.test.ts` with `?? undefined`.
- Rebased onto then-current upstream `main` at `5ab07fde4abd8e88e78d3dc6c50efc2794a55269`; the subsequent one-line dead-code baseline correction produced current PR head `ffc16e5700fd9fbb0f8de5853ccb874229fc7faa`.
- `pnpm test src/agents/agent-command.compaction-rotation.test.ts` — 15/15 passed.
- `pnpm check:test-types` — passed.
- `pnpm deadcode:dependencies && pnpm deadcode:unused-files && pnpm deadcode:exports` — passed.
- `pnpm build` — passed, including the plugin-SDK declaration budget check.
- `git diff --check` — passed.
- The refreshed runtime commit and the exact-head live-proof runtime commit have the same stable patch ID, confirming the rebase did not alter the proven runtime design.

