### PR TITLE
refactor(channels): remove unused token prompt helper

### DIFF
--- a/src/channels/plugins/setup-wizard-helpers.test.ts
+++ b/src/channels/plugins/setup-wizard-helpers.test.ts
@@ -12,7 +12,6 @@ import {
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
 import {
-  applySingleTokenPromptResult,
   buildSingleChannelSecretPromptState,
   createAccountScopedAllowFromSection,
   createAccountScopedGroupAccessSection,
@@ -595,35 +594,6 @@ describe("promptSingleChannelSecretInput", () => {
 
     expect(result).toEqual({ action: "keep" });
     expect(prompter.text).not.toHaveBeenCalled();
-  });
-});
-
-describe("applySingleTokenPromptResult", () => {
-  it("writes env selection as an empty patch on target account", () => {
-    const next = applySingleTokenPromptResult({
-      cfg: {},
-      channel: "discord",
-      accountId: "work",
-      tokenPatchKey: "token",
-      tokenResult: { useEnv: true, token: null },
-    });
-
-    expect(next.channels?.discord?.enabled).toBe(true);
-    expect(next.channels?.discord?.accounts?.work?.enabled).toBe(true);
-    expect(next.channels?.discord?.accounts?.work?.token).toBeUndefined();
-  });
-
-  it("writes provided token under requested key", () => {
-    const next = applySingleTokenPromptResult({
-      cfg: {},
-      channel: "telegram",
-      accountId: DEFAULT_ACCOUNT_ID,
-      tokenPatchKey: "botToken",
-      tokenResult: { useEnv: false, token: "abc" },
-    });
-
-    expect(next.channels?.telegram?.enabled).toBe(true);
-    expect(next.channels?.telegram?.botToken).toBe("abc");
   });
 });
 

--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -922,36 +922,6 @@ export function patchChannelConfigForAccount(params: {
   });
 }
 
-export function applySingleTokenPromptResult(params: {
-  cfg: OpenClawConfig;
-  channel: string;
-  accountId: string;
-  tokenPatchKey: string;
-  tokenResult: {
-    useEnv: boolean;
-    token: SecretInput | null;
-  };
-}): OpenClawConfig {
-  let next = params.cfg;
-  if (params.tokenResult.useEnv) {
-    next = patchChannelConfigForAccount({
-      cfg: next,
-      channel: params.channel,
-      accountId: params.accountId,
-      patch: {},
-    });
-  }
-  if (params.tokenResult.token) {
-    next = patchChannelConfigForAccount({
-      cfg: next,
-      channel: params.channel,
-      accountId: params.accountId,
-      patch: { [params.tokenPatchKey]: params.tokenResult.token },
-    });
-  }
-  return next;
-}
-
 export function buildSingleChannelSecretPromptState(params: {
   accountConfigured: boolean;
   hasConfigToken: boolean;


### PR DESCRIPTION
## What Problem This Solves

Removes an obsolete channel setup helper that remained exported and tested despite having no production, Plugin SDK, or extension caller.

## Why This Change Was Made

The live credential path uses `runSingleChannelSecretStep` with channel-owned `applyUseEnv` and `applySet` callbacks. Exact graph, repository, barrel, and history checks showed `applySingleTokenPromptResult` was a closed island reachable only from its two direct tests.

## User Impact

No user-visible behavior changes. Channel setup keeps the current credential flow with 60 fewer dead lines.

## Evidence

- Exact graph and repository-wide symbol searches found no caller outside the helper's direct tests.
- Full helper-module, `setup-wizard.ts`, Plugin SDK barrel, and extension caller audit confirmed `runSingleChannelSecretStep` remains the canonical live path.
- `node scripts/run-vitest.mjs src/channels/plugins/setup-wizard-helpers.test.ts` - 87 tests passed.
- Targeted channel oxlint passed.
- Targeted oxfmt check passed.
- `git diff --check` passed.
- Fresh autoreview with `gpt-5.6-sol` at medium reasoning found no actionable issues (`0.98` confidence).
- Blacksmith Testbox lease `tbx_01kxapd758whb566q7frzwfy44` was stopped after delegated checkout sync stalled; hosted exact-head CI will supply the broad remote gate.

AI-assisted; the implementation, caller audit, owner boundary, and verification evidence were reviewed against the exact diff.
