### PR TITLE
fix(secrets): preserve partial gateway assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
+- **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -1342,6 +1342,52 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     });
   });
 
+  it("preserves gateway assignments while resolving only missing paths locally", async () => {
+    const localEnvKey = "TALK_API_KEY_PARTIAL_LOCAL";
+    callGateway.mockResolvedValueOnce({
+      assignments: [
+        {
+          path: "talk.providers.gateway.apiKey",
+          pathSegments: ["talk", "providers", "gateway", "apiKey"],
+          value: "gateway-owned-key",
+        },
+      ],
+      diagnostics: [],
+    });
+    await withEnvAsync({ [localEnvKey]: "local-fallback-key" }, async () => {
+      const result = await resolveCommandSecretRefsViaGateway({
+        config: {
+          talk: {
+            providers: {
+              gateway: {
+                apiKey: {
+                  source: "env",
+                  provider: "default",
+                  id: "GATEWAY_ONLY_TALK_KEY",
+                },
+              },
+              local: {
+                apiKey: { source: "env", provider: "default", id: localEnvKey },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        commandName: "reply",
+        targetIds: new Set(["talk.providers.*.apiKey"]),
+      });
+
+      expect(result.resolvedConfig.talk?.providers?.gateway?.apiKey).toBe("gateway-owned-key");
+      expect(result.resolvedConfig.talk?.providers?.local?.apiKey).toBe("local-fallback-key");
+      expect(result.targetStatesByPath).toMatchObject({
+        "talk.providers.gateway.apiKey": "resolved_gateway",
+        "talk.providers.local.apiKey": "resolved_local",
+      });
+      expect(
+        result.diagnostics.some((entry) => entry.includes("gateway secrets.resolve unavailable")),
+      ).toBe(false);
+    });
+  });
+
   it("limits local fallback to targeted refs in read-only modes", async () => {
     const talkEnvKey = "TALK_API_KEY_TARGET_ONLY";
     const gatewayEnvKey = "GATEWAY_PASSWORD_UNRELATED";

--- a/src/secrets/runtime-command-secrets.test.ts
+++ b/src/secrets/runtime-command-secrets.test.ts
@@ -1,10 +1,14 @@
 /** Tests command-scoped secret resolution from active runtime snapshots. */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveCommandSecretsFromActiveRuntimeSnapshot } from "./runtime-command-secrets.js";
 import { createEmptyRuntimeWebToolsMetadata } from "./runtime-fast-path.js";
 import { activateSecretsRuntimeSnapshotState } from "./runtime-state.js";
-import { clearSecretsRuntimeSnapshot } from "./runtime.js";
+import { activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } from "./runtime.js";
+import { asConfig, setupSecretsRuntimeSnapshotTestHooks } from "./runtime.test-support.ts";
 import { discoverConfigSecretTargetsByIds } from "./target-registry.js";
 
 const firecrawlPath = "plugins.entries.firecrawl.config.webSearch.apiKey";
@@ -60,11 +64,12 @@ discoverConfigSecretTargetsByIds(forcedFallbackConfig, new Set([firecrawlPath]))
 
 function activateMinimalSecretsRuntimeSnapshot(params: {
   config: OpenClawConfig;
+  resolvedConfig?: OpenClawConfig;
   env: Record<string, string | undefined>;
 }) {
   const snapshot = {
     sourceConfig: structuredClone(params.config),
-    config: structuredClone(params.config),
+    config: structuredClone(params.resolvedConfig ?? params.config),
     authStores: [],
     warnings: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
@@ -80,6 +85,8 @@ function activateMinimalSecretsRuntimeSnapshot(params: {
     refreshHandler: null,
   });
 }
+
+const { prepareSecretsRuntimeSnapshot } = setupSecretsRuntimeSnapshotTestHooks();
 
 describe("runtime command secrets", () => {
   const previousBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
@@ -157,4 +164,93 @@ describe("runtime command secrets", () => {
     expect(resolved.diagnostics).toEqual([]);
     expect(resolved.inactiveRefPaths).toEqual([]);
   });
+
+  it("returns authoritative assignments from an incomplete runtime snapshot", async () => {
+    const sourceConfig = asConfig({
+      talk: {
+        providers: {
+          gateway: {
+            apiKey: { source: "env", provider: "default", id: "GATEWAY_TALK_KEY" },
+          },
+          local: {
+            apiKey: { source: "env", provider: "default", id: "LOCAL_TALK_KEY" },
+          },
+        },
+      },
+    });
+    const resolvedConfig = structuredClone(sourceConfig);
+    resolvedConfig.talk!.providers!.gateway!.apiKey = "gateway-owned-key";
+    activateMinimalSecretsRuntimeSnapshot({
+      config: sourceConfig,
+      resolvedConfig,
+      env: {},
+    });
+
+    const resolved = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+      commandName: "reply",
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+    });
+
+    expect(resolved.assignments).toEqual([
+      {
+        path: "talk.providers.gateway.apiKey",
+        pathSegments: ["talk", "providers", "gateway", "apiKey"],
+        value: "gateway-owned-key",
+      },
+    ]);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "serves an exec SecretRef materialized during runtime preparation",
+    async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-command-secret-exec-"));
+      try {
+        const resolverPath = path.join(root, "resolver.sh");
+        await fs.writeFile(
+          resolverPath,
+          [
+            "#!/bin/sh",
+            "cat >/dev/null",
+            'printf \'{"protocolVersion":1,"values":{"talk/key":"gateway-exec-key"}}\'',
+          ].join("\n"),
+          { mode: 0o700 },
+        );
+        const config = asConfig({
+          secrets: {
+            providers: {
+              command: {
+                source: "exec",
+                command: resolverPath,
+                jsonOnly: true,
+              },
+            },
+          },
+          talk: {
+            providers: {
+              acme: {
+                apiKey: { source: "exec", provider: "command", id: "talk/key" },
+              },
+            },
+          },
+        });
+        const snapshot = await prepareSecretsRuntimeSnapshot({
+          config,
+          agentDirs: [path.join(root, "agent")],
+          loadAuthStore: () => ({ version: 1, profiles: {} }),
+        });
+        activateSecretsRuntimeSnapshot(snapshot);
+
+        const resolved = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+          commandName: "reply",
+          targetIds: new Set(["talk.providers.*.apiKey"]),
+        });
+
+        expect(resolved.assignments).toMatchObject([
+          { path: "talk.providers.acme.apiKey", value: "gateway-exec-key" },
+        ]);
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/secrets/runtime-command-secrets.ts
+++ b/src/secrets/runtime-command-secrets.ts
@@ -7,7 +7,6 @@ import { resolveManifestContractOwnerPluginId } from "../plugins/plugin-registry
 import { resolveBundledExplicitWebSearchProvidersFromPublicArtifacts } from "../plugins/web-provider-public-artifacts.explicit.js";
 import {
   analyzeCommandSecretAssignmentsFromSnapshot,
-  collectCommandSecretAssignmentsFromSnapshot,
   type CommandSecretAssignment,
 } from "./command-config.js";
 import { getPath, setPathExistingStrict } from "./path-utils.js";
@@ -558,34 +557,11 @@ async function resolveCommandSecretsFromSnapshot(params: {
       ...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
     });
   }
-  const selectedProviderUnresolved = analyzed.unresolved.filter((entry) =>
-    isProviderOverridePath({
-      config: sourceConfig,
-      path: entry.path,
-      providerOverrides: params.providerOverrides,
-    }),
-  );
-  const forcedActiveUnresolved = analyzed.unresolved.filter((entry) =>
-    params.forcedActivePaths?.has(entry.path),
-  );
-  if (selectedProviderUnresolved.length > 0 || forcedActiveUnresolved.length > 0) {
-    return {
-      assignments: analyzed.assignments,
-      diagnostics: analyzed.diagnostics,
-      inactiveRefPaths,
-    };
-  }
-  const resolved = collectCommandSecretAssignmentsFromSnapshot({
-    sourceConfig,
-    resolvedConfig,
-    commandName: params.commandName,
-    targetIds: params.targetIds,
-    inactiveRefPaths: new Set(inactiveRefPaths),
-    ...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
-  });
   return {
-    assignments: resolved.assignments,
-    diagnostics: resolved.diagnostics,
+    // A runtime snapshot can be authoritative for only part of a command's target set.
+    // Preserve those values so the caller falls back locally only for unresolved paths.
+    assignments: analyzed.assignments,
+    diagnostics: analyzed.diagnostics,
     inactiveRefPaths,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

An active Gateway secrets snapshot can resolve some command SecretRefs while leaving an exec-backed target unresolved. The previous all-or-nothing result converted that partial snapshot into `secrets.resolve` failure noise, after which the CLI repeated resolution locally. PR #96661 identified the user-visible failure, but its client-side bypass could discard authoritative Gateway-only values.

Fixes #96653. Supersedes #96661 while preserving @SunnyShu0925's contribution and co-author credit.

## Why This Change Was Made

Keep resolution at the existing owner boundary: the Gateway returns every assignment its active snapshot resolved, even when another target remains unresolved. The existing caller then retains those authoritative values and performs local fallback only for missing paths.

This avoids a second resolution policy, preserves remote/service-only env and file values, and removes the noisy failing RPC without hiding genuine Gateway failures.

## User Impact

- Reply-time command SecretRefs no longer emit an expected `secrets.resolve` unavailable error merely because one exec-backed target needs local fallback.
- Values already materialized by the Gateway remain authoritative.
- Mixed target sets resolve locally only where the Gateway returned no assignment.

## Evidence

- Blacksmith Testbox `tbx_01kxapky9sr42z94nrxr4hnnjs`: 60 focused Gateway, runtime-secret, CLI, and auto-reply tests passed on the current-main replacement.
- The same Testbox passed `tsgo:core` and `tsgo:test:src`.
- Regression coverage includes a real exec provider prepared into the runtime snapshot, an incomplete snapshot with an authoritative assignment, and a mixed Gateway/local target set.
- Two fresh structured reviews of the original final patch reported no actionable findings; the current-main replacement preserves that patch and deletes the unsafe client-side bypass.

Known broad-gate context: the stale fork's delegated full-suite workspace mixed current-main tooling tests with the old fork tree, producing unrelated missing `extensions/crabbox` and shard-inventory failures. Recreating the patch on current `main` removes that workspace mismatch; hosted exact-head CI remains the landing gate.
