### PR TITLE
fix(memory-wiki): honor memory_search deadline during wiki exhaustive scan

### DIFF
--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -210,7 +210,10 @@ advertised node command.
 
 Memory prompt supplement builders receive optional `agentId`,
 `agentSessionKey`, and `sandboxed` context. Memory corpus supplement `search`
-and `get` calls receive optional `agentId` and `sandboxed` context. Plugins with
+and `get` calls receive optional `agentId`, `agentSessionKey`, and `sandboxed`
+context. Search calls may also receive an optional caller-owned `signal`.
+Supplements should check that signal before and during large I/O, stop new work
+after cancellation, and return any completed partial results. Plugins with
 agent-owned storage should resolve that storage for each call instead of
 capturing one global path during registration. If an agent id is required but
 missing in a multi-agent operation, fail closed rather than choosing an

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -448,6 +448,7 @@ describe("memory tools", () => {
         agentSessionKey: "agent:marketing-agent:main",
         sandboxed: true,
         corpus,
+        signal: expect.any(AbortSignal),
       });
     },
   );

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -453,6 +453,55 @@ describe("memory tools", () => {
     },
   );
 
+  it("returns partial wiki hits when the supplement settles after the soft deadline (#104719)", async () => {
+    // Soft deadline aborts before the hard 15s timeout so abort-aware supplements
+    // can deliver completed-partial results instead of only the timeout error.
+    vi.useFakeTimers();
+    try {
+      registerMemoryCorpusSupplement("memory-wiki", {
+        search: async ({ signal }) => {
+          await new Promise<void>((resolve) => {
+            if (signal?.aborted) {
+              resolve();
+              return;
+            }
+            signal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+          return [
+            {
+              corpus: "wiki" as const,
+              path: "entities/partial-deadline.md",
+              title: "Partial Deadline",
+              kind: "entity",
+              score: 4,
+              snippet: "partial wiki hit after soft deadline",
+            },
+          ];
+        },
+        get: async () => null,
+      });
+
+      const tool = createMemorySearchToolOrThrow();
+      const resultPromise = tool.execute("call_wiki_soft_deadline_partial", {
+        query: "partial",
+        corpus: "wiki",
+      });
+      await vi.advanceTimersByTimeAsync(15_000);
+      const result = await resultPromise;
+      const details = result.details as {
+        results?: Array<{ corpus: string; path: string }>;
+        error?: string;
+      };
+
+      expect(details.error).toBeUndefined();
+      expect(details.results?.map((entry) => [entry.corpus, entry.path])).toEqual([
+        ["wiki", "entities/partial-deadline.md"],
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("includes memory results in corpus=all even when wiki scores are numerically higher (#77337)", async () => {
     // Wiki uses integer point scores (up to ~100+); memory uses cosine similarity (0-1).
     // Raw-score sort would starve memory hits when maxResults <= number of wiki hits.

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -163,6 +163,7 @@ export async function searchMemoryCorpusSupplements(params: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   corpus?: "memory" | "wiki" | "all" | "sessions";
+  signal?: AbortSignal;
 }): Promise<MemoryCorpusSearchResult[]> {
   if (params.corpus === "memory" || params.corpus === "sessions") {
     return [];

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -724,6 +724,7 @@ export function createMemorySearchTool(options: {
                         agentSessionKey: options.agentSessionKey,
                         sandboxed: options.sandboxed,
                         corpus: requestedCorpus,
+                        signal: deadlineSignal,
                       }),
                   )
                 : [];

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -51,6 +51,9 @@ type ActiveMemoryManagerContext = Extract<MemoryManagerContext, { manager: unkno
 type QmdRuntimeDebug = NonNullable<MemorySearchRuntimeDebug["qmd"]>;
 
 const MEMORY_SEARCH_TOOL_TIMEOUT_MS = 15_000;
+// Soft-abort before the hard deadline so abort-aware supplement/wiki I/O can
+// return partial results and win the race instead of the stable timeout error.
+const MEMORY_SEARCH_DEADLINE_PARTIAL_BUDGET_MS = 1_000;
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
 
 const memorySearchToolCooldowns = new Map<string, { until: number; error: string }>();
@@ -133,38 +136,64 @@ async function runMemorySearchToolWithDeadline<T>(params: {
 }): Promise<{ status: "ok"; value: T } | { status: "unavailable"; error: string }> {
   const timeoutError = () =>
     new Error(`memory_search timed out after ${Math.round(params.timeoutMs / 1000)}s`);
-  // Abort the losing task when the deadline fires so in-flight embedding work
-  // is cancelled instead of retrying orphaned for minutes after the tool
-  // already returned "timed out" to the agent.
+  // Soft-abort leaves a short budget for abort-aware wiki/supplement work to
+  // settle partial results before the hard timeout commits. Hard timeout still
+  // wins for non-cooperative hung work; abort rejections keep the stable
+  // timeout message instead of provider-wrapped abort noise.
   const controller = new AbortController();
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<"timeout">((resolve) => {
-    timer = setTimeout(() => {
-      // Resolve before aborting: abort listeners run synchronously and an
-      // abort-aware search could reject the task first, replacing the stable
-      // timeout result with a provider-wrapped abort error.
-      resolve("timeout");
+  const softMs = Math.max(0, params.timeoutMs - MEMORY_SEARCH_DEADLINE_PARTIAL_BUDGET_MS);
+  const softTimer = setTimeout(() => {
+    if (!controller.signal.aborted) {
       controller.abort(timeoutError());
+    }
+  }, softMs);
+  softTimer.unref?.();
+  let hardTimer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    hardTimer = setTimeout(() => {
+      if (!controller.signal.aborted) {
+        controller.abort(timeoutError());
+      }
+      resolve("timeout");
     }, params.timeoutMs);
-    timer.unref?.();
+    hardTimer.unref?.();
   });
   const task = params.run(controller.signal);
   task.catch(() => undefined);
 
   try {
-    const result = await Promise.race([task, timeoutPromise]);
-    if (result === "timeout") {
+    const raced = await Promise.race([
+      task.then(
+        (value) => ({ kind: "ok" as const, value }),
+        (error) => ({ kind: "error" as const, error }),
+      ),
+      timeoutPromise.then(() => ({ kind: "timeout" as const })),
+    ]);
+    if (raced.kind === "ok") {
+      return { status: "ok", value: raced.value };
+    }
+    // Prefer the stable timeout copy when the soft/hard deadline aborted the
+    // run (including abort-aware providers that reject on signal). Real errors
+    // before the deadline still surface their message.
+    if (raced.kind === "timeout" || controller.signal.aborted) {
       return {
         status: "unavailable",
         error: timeoutError().message,
       };
     }
-    return { status: "ok", value: result as T };
+    return { status: "unavailable", error: formatErrorMessage(raced.error) };
   } catch (error) {
+    if (controller.signal.aborted) {
+      return {
+        status: "unavailable",
+        error: timeoutError().message,
+      };
+    }
     return { status: "unavailable", error: formatErrorMessage(error) };
   } finally {
-    if (timer) {
-      clearTimeout(timer);
+    clearTimeout(softTimer);
+    if (hardTimer) {
+      clearTimeout(hardTimer);
     }
   }
 }

--- a/extensions/memory-wiki/src/corpus-supplement.test.ts
+++ b/extensions/memory-wiki/src/corpus-supplement.test.ts
@@ -39,12 +39,14 @@ describe("memory-wiki corpus supplement", () => {
     const getAppConfig = vi.fn(() => appConfig);
     const supplement = createWikiCorpusSupplement({ resolveConfig, getAppConfig });
 
+    const deadline = new AbortController();
     await supplement.search({
       query: "support handbook",
       maxResults: 4,
       agentId: "support",
       agentSessionKey: "agent:support:main",
       sandboxed: true,
+      signal: deadline.signal,
     });
     await supplement.get({
       lookup: "marketing-plan",
@@ -72,6 +74,7 @@ describe("memory-wiki corpus supplement", () => {
       maxResults: 4,
       searchBackend: "local",
       searchCorpus: "wiki",
+      signal: deadline.signal,
     });
     expect(queryMocks.getMemoryWikiPage).toHaveBeenCalledWith({
       config: expect.objectContaining({

--- a/extensions/memory-wiki/src/corpus-supplement.ts
+++ b/extensions/memory-wiki/src/corpus-supplement.ts
@@ -14,6 +14,7 @@ export function createWikiCorpusSupplement(params: {
       agentId?: string;
       agentSessionKey?: string;
       sandboxed?: boolean;
+      signal?: AbortSignal;
     }) => {
       const appConfig = params.getAppConfig();
       const config = params.resolveConfig(input.agentId, appConfig);
@@ -27,6 +28,10 @@ export function createWikiCorpusSupplement(params: {
         maxResults: input.maxResults,
         searchBackend: "local",
         searchCorpus: "wiki",
+        // Forward the memory_search deadline so exhaustive underfill scans stop
+        // when the tool has already timed out (do not change completeness when
+        // the search finishes within budget).
+        signal: input.signal,
       });
     },
     get: async (input: {

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -215,15 +215,7 @@ describe("searchMemoryWiki", () => {
   });
 
   it("returns no wiki hits when the caller deadline is already aborted (#104719)", async () => {
-    const { rootDir, config } = await createQueryVault({ initialize: true });
-    await fs.writeFile(
-      path.join(rootDir, "sources", "alpha.md"),
-      renderWikiMarkdown({
-        frontmatter: { pageType: "source", id: "source.alpha", title: "Alpha Source" },
-        body: "# Alpha Source\n\nalpha body text\n",
-      }),
-      "utf8",
-    );
+    const { rootDir, config } = await createQueryVault();
     const controller = new AbortController();
     controller.abort();
 
@@ -234,6 +226,7 @@ describe("searchMemoryWiki", () => {
     });
 
     expect(results).toEqual([]);
+    await expect(fs.access(rootDir)).rejects.toThrow();
   });
 
   it("still exhaustively finds body-only hits when the deadline is not aborted (#104719)", async () => {
@@ -360,7 +353,7 @@ describe("searchMemoryWiki", () => {
       .spyOn(fs, "readFile")
       .mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
         const result = await originalReadFile(...args);
-        const absolutePath = String(args[0] ?? "");
+        const absolutePath = typeof args[0] === "string" ? args[0] : "";
         if (
           absolutePath.endsWith(".md") &&
           absolutePath.includes(`${path.sep}sources${path.sep}`)

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -209,6 +209,115 @@ describe("searchMemoryWiki", () => {
     expect(getActiveMemorySearchManagerMock).not.toHaveBeenCalled();
   });
 
+  it("returns no wiki hits when the caller deadline is already aborted (#104719)", async () => {
+    const { rootDir, config } = await createQueryVault({ initialize: true });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.alpha", title: "Alpha Source" },
+        body: "# Alpha Source\n\nalpha body text\n",
+      }),
+      "utf8",
+    );
+    const controller = new AbortController();
+    controller.abort();
+
+    const results = await searchMemoryWiki({
+      config,
+      query: "alpha",
+      signal: controller.signal,
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it("still exhaustively finds body-only hits when the deadline is not aborted (#104719)", async () => {
+    // Digest-selected candidates underfill maxResults; without abort the vault
+    // must still scan remaining pages so direct and on-budget supplement search
+    // keep complete recall (unlike permanently disabling exhaustive fallback).
+    const { rootDir, config } = await createQueryVault({ initialize: true });
+    await fs.writeFile(
+      path.join(rootDir, "entities", "digest-only.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.digest-only",
+          title: "Digest Only Router",
+          bestUsedFor: ["deadline-token-alpha"],
+        },
+        body: "# Digest Only Router\n\nNo unique body needle here.\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "body-only-needle.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.body-only-needle",
+          title: "Unrelated Title",
+        },
+        body: "# Unrelated Title\n\ndeadline-token-omega unique body only hit\n",
+      }),
+      "utf8",
+    );
+    await compileMemoryWikiVault(config);
+
+    const results = await searchMemoryWiki({
+      config,
+      query: "deadline-token-omega",
+      maxResults: 5,
+    });
+
+    expect(collectWikiResultPaths(results)).toContain("sources/body-only-needle.md");
+  });
+
+  it("stops mid-scan when the deadline aborts during exhaustive page reads (#104719)", async () => {
+    const { rootDir, config } = await createQueryVault({ initialize: true });
+    // Enough files to force more than one read batch (batch size 16).
+    for (let i = 0; i < 40; i += 1) {
+      await fs.writeFile(
+        path.join(rootDir, "sources", `pad-${String(i).padStart(2, "0")}.md`),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "source",
+            id: `source.pad-${i}`,
+            title: `Pad ${i}`,
+          },
+          body: `# Pad ${i}\n\npad body ${i}\n`,
+        }),
+        "utf8",
+      );
+    }
+    await fs.writeFile(
+      path.join(rootDir, "sources", "zzz-late-needle.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.late-needle",
+          title: "Late Needle",
+        },
+        body: "# Late Needle\n\nabort-scan-unique-needle\n",
+      }),
+      "utf8",
+    );
+
+    const controller = new AbortController();
+    const searchPromise = searchMemoryWiki({
+      config,
+      query: "abort-scan-unique-needle",
+      maxResults: 10,
+      signal: controller.signal,
+    });
+    // Yield once so page reads start, then abort mid-scan.
+    await Promise.resolve();
+    controller.abort();
+    const results = await searchPromise;
+
+    // Must not hang / throw; may be empty or partial once the signal fires.
+    expect(Array.isArray(results)).toBe(true);
+  });
+
   it("skips malformed pages while searching the rest of the vault (#96125)", async () => {
     const { rootDir, config } = await createQueryVault({ initialize: true });
     await fs.writeFile(

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -7,7 +7,12 @@ import type { OpenClawConfig } from "../api.js";
 import { compileMemoryWikiVault } from "./compile.js";
 import type { MemoryWikiPluginConfig } from "./config.js";
 import { renderWikiMarkdown } from "./markdown.js";
-import { getMemoryWikiPage, isSessionMemoryPath, searchMemoryWiki } from "./query.js";
+import {
+  getMemoryWikiPage,
+  isSessionMemoryPath,
+  readQueryableWikiPages,
+  searchMemoryWiki,
+} from "./query.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const {
@@ -274,8 +279,10 @@ describe("searchMemoryWiki", () => {
 
   it("stops mid-scan when the deadline aborts during exhaustive page reads (#104719)", async () => {
     const { rootDir, config } = await createQueryVault({ initialize: true });
-    // Enough files to force more than one read batch (batch size 16).
-    for (let i = 0; i < 40; i += 1) {
+    // Representative underfill vault: many padding pages so exhaustive scan needs
+    // multiple 16-file batches (issue-scale proof without a 77 MB live Gateway vault).
+    const padCount = 96;
+    for (let i = 0; i < padCount; i += 1) {
       await fs.writeFile(
         path.join(rootDir, "sources", `pad-${String(i).padStart(2, "0")}.md`),
         renderWikiMarkdown({
@@ -303,19 +310,77 @@ describe("searchMemoryWiki", () => {
     );
 
     const controller = new AbortController();
-    const searchPromise = searchMemoryWiki({
+    // Abort on a microtask so the first batch can start, then stop further batches.
+    queueMicrotask(() => {
+      controller.abort();
+    });
+    const results = await searchMemoryWiki({
       config,
       query: "abort-scan-unique-needle",
       maxResults: 10,
       signal: controller.signal,
     });
-    // Yield once so page reads start, then abort mid-scan.
-    await Promise.resolve();
-    controller.abort();
-    const results = await searchPromise;
 
     // Must not hang / throw; may be empty or partial once the signal fires.
     expect(Array.isArray(results)).toBe(true);
+    // Late needle is sorted after pads; abort during batching must not require a
+    // full remaining-vault completion to return (no orphan full-scan contract).
+    // Partial or empty is fine; hanging or throwing is not.
+  });
+
+  it("returns partial pages and stops further batch reads after abort (#104719)", async () => {
+    const { rootDir } = await createQueryVault({ initialize: true });
+    const padCount = 80;
+    for (let i = 0; i < padCount; i += 1) {
+      await fs.writeFile(
+        path.join(rootDir, "sources", `batch-pad-${String(i).padStart(2, "0")}.md`),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "source",
+            id: `source.batch-pad-${i}`,
+            title: `Batch Pad ${i}`,
+          },
+          body: `# Batch Pad ${i}\n\nbatch pad body ${i}\n`,
+        }),
+        "utf8",
+      );
+    }
+
+    const preAborted = new AbortController();
+    preAborted.abort();
+    // Pre-aborted: no page reads (empty partial result, not a full vault load).
+    expect(await readQueryableWikiPages(rootDir, preAborted.signal)).toEqual([]);
+
+    // Representative vault: abort after the first full batch of page reads so the
+    // remaining batches never start (proves deadline stops further host I/O).
+    const mid = new AbortController();
+    let mdReads = 0;
+    const originalReadFile = fs.readFile.bind(fs);
+    const readFileSpy = vi
+      .spyOn(fs, "readFile")
+      .mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
+        const result = await originalReadFile(...args);
+        const absolutePath = String(args[0] ?? "");
+        if (
+          absolutePath.endsWith(".md") &&
+          absolutePath.includes(`${path.sep}sources${path.sep}`)
+        ) {
+          mdReads += 1;
+          if (mdReads >= 16) {
+            mid.abort();
+          }
+        }
+        return result;
+      });
+    try {
+      const partial = await readQueryableWikiPages(rootDir, mid.signal);
+      expect(partial.length).toBeGreaterThan(0);
+      expect(partial.length).toBeLessThan(padCount);
+      // At most one in-flight batch after the abort trips at the 16th page read.
+      expect(mdReads).toBeLessThan(padCount);
+    } finally {
+      readFileSpy.mockRestore();
+    }
   });
 
   it("skips malformed pages while searching the rest of the vault (#96125)", async () => {

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -376,6 +376,51 @@ describe("searchMemoryWiki", () => {
     }
   });
 
+  it("stops vault directory enumeration after abort (#104719)", async () => {
+    // Recursive readdir could finish the whole tree after cancel; walk with
+    // per-entry checks so enumeration itself is deadline-aware.
+    const { rootDir } = await createQueryVault({ initialize: true });
+    const nestCount = 40;
+    for (let i = 0; i < nestCount; i += 1) {
+      const dir = path.join(rootDir, "sources", `enum-nest-${String(i).padStart(2, "0")}`);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(dir, "page.md"),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "source",
+            id: `source.enum-nest-${i}`,
+            title: `Enum Nest ${i}`,
+          },
+          body: `# Enum Nest ${i}\n\nenum pad ${i}\n`,
+        }),
+        "utf8",
+      );
+    }
+
+    const controller = new AbortController();
+    let readdirCalls = 0;
+    const originalReaddir = fs.readdir.bind(fs);
+    const readdirSpy = vi
+      .spyOn(fs, "readdir")
+      .mockImplementation(async (...args: Parameters<typeof fs.readdir>) => {
+        readdirCalls += 1;
+        // Abort after the walk has entered a few nested source dirs.
+        if (readdirCalls >= 8) {
+          controller.abort();
+        }
+        return await originalReaddir(...args);
+      });
+    try {
+      const pages = await readQueryableWikiPages(rootDir, controller.signal);
+      expect(pages.length).toBeLessThan(nestCount);
+      // Enumeration must stop scheduling further directory reads after abort.
+      expect(readdirCalls).toBeLessThan(nestCount + 10);
+    } finally {
+      readdirSpy.mockRestore();
+    }
+  });
+
   it("skips malformed pages while searching the rest of the vault (#96125)", async () => {
     const { rootDir, config } = await createQueryVault({ initialize: true });
     await fs.writeFile(

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -293,7 +293,8 @@ async function readQueryableWikiPagesByPaths(
         const absolutePath = path.join(rootDir, relativePath);
         const raw = await fs.readFile(absolutePath, "utf8");
         const summary = toWikiPageSummary({ absolutePath, relativePath, raw });
-        return summary ? { ...summary, raw } : null;
+        // Avoid object spread in map (oxc/no-map-spread); keep partial-result shape.
+        return summary ? Object.assign({}, summary, { raw }) : null;
       }),
     );
     for (const page of batchPages) {

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -1528,6 +1528,11 @@ export async function searchMemoryWiki(params: {
     sandboxed: params.sandboxed,
     operation: "wiki_search",
   });
+  // A caller-owned deadline may already have expired before this search starts.
+  // Return before vault initialization so cancelled reads cannot mutate storage.
+  if (params.signal?.aborted) {
+    return [];
+  }
   await initializeMemoryWikiVault(effectiveConfig);
   const maxResults = normalizePositiveInteger(params.maxResults, 10);
   const mode = params.mode ?? "auto";

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -262,24 +262,47 @@ async function listWikiMarkdownFiles(rootDir: string): Promise<string[]> {
   return files.toSorted((left, right) => left.localeCompare(right));
 }
 
-export async function readQueryableWikiPages(rootDir: string): Promise<QueryableWikiPage[]> {
+export async function readQueryableWikiPages(
+  rootDir: string,
+  signal?: AbortSignal,
+): Promise<QueryableWikiPage[]> {
+  if (signal?.aborted) {
+    return [];
+  }
   const files = await listWikiMarkdownFiles(rootDir);
-  return readQueryableWikiPagesByPaths(rootDir, files);
+  return readQueryableWikiPagesByPaths(rootDir, files, signal);
 }
+
+/** Read wiki pages in small batches so a caller deadline can stop mid-scan. */
+const QUERYABLE_PAGE_READ_BATCH_SIZE = 16;
 
 async function readQueryableWikiPagesByPaths(
   rootDir: string,
   files: string[],
+  signal?: AbortSignal,
 ): Promise<QueryableWikiPage[]> {
-  const pages = await Promise.all(
-    files.map(async (relativePath) => {
-      const absolutePath = path.join(rootDir, relativePath);
-      const raw = await fs.readFile(absolutePath, "utf8");
-      const summary = toWikiPageSummary({ absolutePath, relativePath, raw });
-      return summary ? { ...summary, raw } : null;
-    }),
-  );
-  return pages.flatMap((page) => (page ? [page] : []));
+  const pages: QueryableWikiPage[] = [];
+  for (let offset = 0; offset < files.length; offset += QUERYABLE_PAGE_READ_BATCH_SIZE) {
+    if (signal?.aborted) {
+      // Return partial pages already read — caller may still rank what we have.
+      break;
+    }
+    const batch = files.slice(offset, offset + QUERYABLE_PAGE_READ_BATCH_SIZE);
+    const batchPages = await Promise.all(
+      batch.map(async (relativePath) => {
+        const absolutePath = path.join(rootDir, relativePath);
+        const raw = await fs.readFile(absolutePath, "utf8");
+        const summary = toWikiPageSummary({ absolutePath, relativePath, raw });
+        return summary ? { ...summary, raw } : null;
+      }),
+    );
+    for (const page of batchPages) {
+      if (page) {
+        pages.push(page);
+      }
+    }
+  }
+  return pages;
 }
 
 function parseClaimsDigest(raw: string): QueryDigestClaim[] {
@@ -1406,7 +1429,11 @@ async function searchWikiCorpus(params: {
   query: string;
   maxResults: number;
   mode: WikiSearchMode;
+  signal?: AbortSignal;
 }): Promise<WikiSearchResult[]> {
+  if (params.signal?.aborted) {
+    return [];
+  }
   const digest = await readQueryDigestBundle(params.rootDir);
   const candidatePaths = digest
     ? buildDigestCandidatePaths({
@@ -1419,8 +1446,8 @@ async function searchWikiCorpus(params: {
   const seenPaths = new Set<string>();
   const candidatePages =
     candidatePaths.length > 0
-      ? await readQueryableWikiPagesByPaths(params.rootDir, candidatePaths)
-      : await readQueryableWikiPages(params.rootDir);
+      ? await readQueryableWikiPagesByPaths(params.rootDir, candidatePaths, params.signal)
+      : await readQueryableWikiPages(params.rootDir, params.signal);
   for (const page of candidatePages) {
     seenPaths.add(page.relativePath);
   }
@@ -1428,14 +1455,25 @@ async function searchWikiCorpus(params: {
   const results = candidatePages
     .map((page) => toWikiSearchResult(page, params.query, params.mode))
     .filter((page) => page.score > 0);
-  if (candidatePaths.length === 0 || results.length >= params.maxResults) {
+  // Digest underfill previously scanned every remaining Markdown file with no
+  // deadline checks; honor the caller's signal so memory_search timeouts stop
+  // orphan host work while keeping exhaustive recall when still within budget.
+  if (
+    candidatePaths.length === 0 ||
+    results.length >= params.maxResults ||
+    params.signal?.aborted
+  ) {
     return results;
   }
 
   const remainingPaths = (await listWikiMarkdownFiles(params.rootDir)).filter(
     (relativePath) => !seenPaths.has(relativePath),
   );
-  const remainingPages = await readQueryableWikiPagesByPaths(params.rootDir, remainingPaths);
+  const remainingPages = await readQueryableWikiPagesByPaths(
+    params.rootDir,
+    remainingPaths,
+    params.signal,
+  );
   return [
     ...results,
     ...remainingPages
@@ -1478,6 +1516,7 @@ export async function searchMemoryWiki(params: {
   searchBackend?: WikiSearchBackend;
   searchCorpus?: WikiSearchCorpus;
   mode?: WikiSearchMode;
+  signal?: AbortSignal;
 }): Promise<WikiSearchResult[]> {
   const effectiveConfig = applySearchOverrides(params.config, params);
   assertSessionVisibilityAppConfig({
@@ -1498,6 +1537,7 @@ export async function searchMemoryWiki(params: {
         query: params.query,
         maxResults,
         mode,
+        signal: params.signal,
       })
     : [];
 

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -240,25 +240,53 @@ function mergeWikiSearchCorpusResults(params: {
   return sortWikiSearchResults(selected).slice(0, params.maxResults);
 }
 
-async function listWikiMarkdownFiles(rootDir: string): Promise<string[]> {
-  const files = (
-    await Promise.all(
-      QUERY_DIRS.map(async (relativeDir) => {
-        const dirPath = path.join(rootDir, relativeDir);
-        const entries = await fs
-          .readdir(dirPath, { withFileTypes: true, recursive: true })
-          .catch(() => []);
-        return entries
-          .filter(
-            (entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "index.md",
-          )
-          .map((entry) => {
-            const absPath = path.join(entry.parentPath ?? dirPath, entry.name);
-            return path.relative(rootDir, absPath).split(path.sep).join("/");
-          });
-      }),
-    )
-  ).flat();
+/** Walk one vault subdir with abort checks between entries (not one recursive readdir). */
+async function collectWikiMarkdownFilesFromDir(params: {
+  rootDir: string;
+  dirPath: string;
+  files: string[];
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (params.signal?.aborted) {
+    return;
+  }
+  const entries = await fs.readdir(params.dirPath, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (params.signal?.aborted) {
+      return;
+    }
+    const absolutePath = path.join(params.dirPath, entry.name);
+    if (entry.isDirectory()) {
+      await collectWikiMarkdownFilesFromDir({
+        rootDir: params.rootDir,
+        dirPath: absolutePath,
+        files: params.files,
+        signal: params.signal,
+      });
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md") && entry.name !== "index.md") {
+      params.files.push(path.relative(params.rootDir, absolutePath).split(path.sep).join("/"));
+    }
+  }
+}
+
+async function listWikiMarkdownFiles(rootDir: string, signal?: AbortSignal): Promise<string[]> {
+  if (signal?.aborted) {
+    return [];
+  }
+  const files: string[] = [];
+  for (const relativeDir of QUERY_DIRS) {
+    if (signal?.aborted) {
+      break;
+    }
+    await collectWikiMarkdownFilesFromDir({
+      rootDir,
+      dirPath: path.join(rootDir, relativeDir),
+      files,
+      signal,
+    });
+  }
   return files.toSorted((left, right) => left.localeCompare(right));
 }
 
@@ -269,7 +297,7 @@ export async function readQueryableWikiPages(
   if (signal?.aborted) {
     return [];
   }
-  const files = await listWikiMarkdownFiles(rootDir);
+  const files = await listWikiMarkdownFiles(rootDir, signal);
   return readQueryableWikiPagesByPaths(rootDir, files, signal);
 }
 
@@ -1467,7 +1495,10 @@ async function searchWikiCorpus(params: {
     return results;
   }
 
-  const remainingPaths = (await listWikiMarkdownFiles(params.rootDir)).filter(
+  if (params.signal?.aborted) {
+    return results;
+  }
+  const remainingPaths = (await listWikiMarkdownFiles(params.rootDir, params.signal)).filter(
     (relativePath) => !seenPaths.has(relativePath),
   );
   const remainingPages = await readQueryableWikiPagesByPaths(

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -54,6 +54,14 @@ export type MemoryCorpusSupplement = {
     agentId?: string;
     agentSessionKey?: string;
     sandboxed?: boolean;
+    /**
+     * Optional abort signal from the caller's deadline (e.g. memory_search).
+     * When provided, the supplement should check the signal at cancellation
+     * points (before or during large I/O) and return partial results if the
+     * signal fires before search completes — so host work stops when the tool
+     * already timed out.
+     */
+    signal?: AbortSignal;
   }): Promise<MemoryCorpusSearchResult[]>;
   get(params: {
     lookup: string;


### PR DESCRIPTION
Closes #104719

## What Problem This Solves

Fixes an issue where users running `memory_search` with `corpus="wiki"` or `corpus="all"` against a large compiled-wiki vault would hit `memory_search timed out after 15s` when digest-selected candidates underfilled `maxResults`. The wiki supplement then continued a full remaining-vault Markdown scan after the tool had already timed out, so agents lost wiki recall and the host kept doing orphan I/O.

## Why This Change Was Made

The memory tool already owns a fixed deadline (`AbortSignal`), but the corpus-supplement bridge never forwarded it into memory-wiki search. Exhaustive underfill scanning then read remaining pages with no cancellation points. Even after signal threading, resolving the hard timeout *before* abort meant completed-partial wiki results could never surface to the agent.

This PR:

1. Threads an optional `signal` through `MemoryCorpusSupplement.search` → wiki corpus supplement → `searchMemoryWiki` / `searchWikiCorpus`.
2. Soft-aborts ~1s before the hard 15s deadline so abort-aware work can return partial results and win the race (hard timeout still covers non-cooperative hangs; abort rejections keep the stable timeout message).
3. Makes vault directory enumeration walk AbortSignal-aware (per-entry checks instead of one uncancellable recursive `readdir`).
4. Batches page reads so mid-scan abort returns partial pages and stops further I/O.

Unlike approaches that permanently disable exhaustive backfill for supplements (which need a feature-owner completeness tradeoff), exhaustive recall remains the default when the search is still within budget. Direct `wiki_search` is unchanged except that it can also honor an optional signal if a caller provides one.

## User Impact

Agents using compiled-wiki supplements through `memory_search` can receive partial wiki hits within the tool budget instead of only a timeout error when digest underfill starts a large scan. Orphan post-timeout vault I/O stops. On-budget multi-result wiki recall still gets exhaustive underfill when needed.

## Evidence

Verification host: local macOS (agent review follow-up)

ClawSweeper rank-up items addressed on head `9d455619e`:

- **[P1] partial before hard timeout:** soft deadline (`MEMORY_SEARCH_DEADLINE_PARTIAL_BUDGET_MS = 1000`) aborts before hard 15s; cooperative supplement returns hits → tool returns results (not timeout).
- **[P2] cancellable enumeration:** `listWikiMarkdownFiles` walks dirs with abort checks between entries/QUERY_DIRS.

Focused tests (all pass):

```text
node scripts/run-vitest.mjs extensions/memory-wiki/src/query.test.ts -t "104719"
# Tests  5 passed | 41 skipped (46)
# includes: partial batch stop, enum stop after abort, exhaustive when not aborted

node scripts/run-vitest.mjs extensions/memory-core/src/tools.citations.test.ts -t "soft deadline|stalled|forwards effective"
# Tests include:
# ✓ returns partial wiki hits when the supplement settles after the soft deadline (#104719)
# ✓ stalled wiki / memory paths still return stable timeout when non-cooperative

node scripts/run-vitest.mjs extensions/memory-core/src/tools.test.ts -t "does not settle|abort-aware"
# ✓ timeout metadata + abort-aware reject still yield stable timeout message

node scripts/run-vitest.mjs extensions/memory-wiki/src/corpus-supplement.test.ts
# Tests  2 passed

pnpm exec oxlint --config .oxlintrc.json \
  extensions/memory-core/src/tools.ts \
  extensions/memory-core/src/tools.citations.test.ts \
  extensions/memory-wiki/src/query.ts \
  extensions/memory-wiki/src/query.test.ts
# Found 0 warnings and 0 errors

pnpm exec oxfmt --check <same files>
git diff --check
```

## Real behavior proof

- Behavior addressed: (1) soft deadline delivers completed-partial wiki hits before hard timeout wins; (2) vault enumeration + page batches stop after abort; (3) on-budget exhaustive underfill retained; (4) non-cooperative hangs still get stable `memory_search timed out after 15s`.
- Environment: local macOS arm64, openclaw at `9d455619e`, Node via `node scripts/run-vitest.mjs`.
- Current-main contrast: no supplement signal; hard timeout resolved before abort so partials never surfaced; recursive `readdir` uncancellable; full remaining-vault reads after digest underfill.
- Exact steps after this patch:
  1. Soft-deadline unit: supplement waits for abort then returns one wiki hit → `corpus=wiki` result has that path, no timeout error.
  2. Enum cancel: nested sources dirs, abort mid-walk → fewer pages than full nest count and readdir stops scheduling.
  3. Batch cancel: 80-page vault, abort after 16 reads → partial pages, `mdReads < padCount`.
  4. On-budget exhaustive still finds body-only needle outside digest candidates.
  5. Abort-aware reject / hung manager / hung search still report stable 15s timeout (not provider abort noise).
- Evidence after fix (redacted transcript):
  ```text
  ✓ returns partial wiki hits when the supplement settles after the soft deadline (#104719)
  ✓ stops vault directory enumeration after abort (#104719)
  ✓ returns partial pages and stops further batch reads after abort (#104719)
  ✓ still exhaustively finds body-only hits when the deadline is not aborted (#104719)
  ✓ returns no wiki hits when the caller deadline is already aborted (#104719)
  ✓ keeps the timeout result when an abort-aware search rejects on abort
  ✓ does not cooldown primary memory when a corpus=all wiki supplement stalls
  oxlint: 0 warnings 0 errors
  ```
- Control check: non-aborted exhaustive underfill still finds body-only pages; pre-aborted search returns `[]` without vault init; hung paths still timeout.
- Observed result after fix: soft-aborted cooperative wiki search returns partial hits inside the tool budget; hard timeout remains for non-cooperative work; enumeration and page batches honor AbortSignal.
- What was not tested: live 77–180 MB Gateway vault re-proof on this exact head (prior head showed orphan I/O stop; soft-deadline partial delivery is covered by the new unit regression). Permanent digest-only supplement mode intentionally not chosen.

## Linked PR context

Open PRs #104793 and #105098 target the same issue with deadline propagation **plus** `exhaustiveFallback: false` for supplements. This PR keeps on-budget exhaustive recall and instead makes partial delivery win before the hard timeout, with abort-aware enumeration + batched reads.

## AI disclosure

This fix was authored with AI assistance (Grok / xAI contributor agent). Human operator requested raise-merge-probability repairs against ClawSweeper P1/P2 guidance; proof is local Vitest transcripts above.
