### PR TITLE
fix(elevenlabs): reject malformed base URL overrides

### DIFF
--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -110,4 +110,18 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
     expect(url).toContain("commit_strategy=vad");
     expect(url).toContain("language_code=en");
   });
+
+  it("preserves an explicit secure WebSocket base URL", () => {
+    const url = testing.toElevenLabsRealtimeWsUrl({
+      apiKey: "eleven-key",
+      baseUrl: "wss://realtime.example.com/",
+      providerConfig: {},
+      modelId: "scribe_v2_realtime",
+      audioFormat: "ulaw_8000",
+      sampleRate: 8000,
+      commitStrategy: "vad",
+    });
+
+    expect(url).toContain("wss://realtime.example.com/v1/speech-to-text/realtime?");
+  });
 });

--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -110,18 +110,4 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
     expect(url).toContain("commit_strategy=vad");
     expect(url).toContain("language_code=en");
   });
-
-  it("preserves an explicit secure WebSocket base URL", () => {
-    const url = testing.toElevenLabsRealtimeWsUrl({
-      apiKey: "eleven-key",
-      baseUrl: "wss://realtime.example.com/",
-      providerConfig: {},
-      modelId: "scribe_v2_realtime",
-      audioFormat: "ulaw_8000",
-      sampleRate: 8000,
-      commitStrategy: "vad",
-    });
-
-    expect(url).toContain("wss://realtime.example.com/v1/speech-to-text/realtime?");
-  });
 });

--- a/extensions/elevenlabs/realtime-transcription-provider.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.ts
@@ -14,7 +14,7 @@ import {
   parseFiniteNumber as readFiniteNumber,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveElevenLabsApiKeyWithProfileFallback } from "./config-api.js";
-import { normalizeElevenLabsBaseUrl } from "./shared.js";
+import { normalizeElevenLabsRealtimeBaseUrl } from "./shared.js";
 
 type ElevenLabsRealtimeTranscriptionProviderConfig = {
   apiKey?: string;
@@ -128,12 +128,6 @@ function normalizeProviderConfig(
       2_000,
     ),
   };
-}
-
-function normalizeElevenLabsRealtimeBaseUrl(value?: string): string {
-  const url = new URL(normalizeElevenLabsBaseUrl(value));
-  url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
-  return url.toString().replace(/\/+$/, "");
 }
 
 function toElevenLabsRealtimeWsUrl(config: ElevenLabsRealtimeTranscriptionSessionConfig): string {
@@ -277,7 +271,7 @@ export function buildElevenLabsRealtimeTranscriptionProvider(): RealtimeTranscri
       return createElevenLabsRealtimeTranscriptionSession({
         ...req,
         apiKey,
-        baseUrl: normalizeElevenLabsBaseUrl(config.baseUrl),
+        baseUrl: normalizeElevenLabsRealtimeBaseUrl(config.baseUrl),
         modelId: config.modelId ?? ELEVENLABS_REALTIME_DEFAULT_MODEL,
         audioFormat: config.audioFormat ?? ELEVENLABS_REALTIME_DEFAULT_AUDIO_FORMAT,
         sampleRate: config.sampleRate ?? ELEVENLABS_REALTIME_DEFAULT_SAMPLE_RATE,

--- a/extensions/elevenlabs/shared.test.ts
+++ b/extensions/elevenlabs/shared.test.ts
@@ -11,19 +11,30 @@ describe("normalizeElevenLabsBaseUrl", () => {
     expect(normalizeElevenLabsBaseUrl("  https://custom.example.com/  ")).toBe(
       "https://custom.example.com",
     );
+    expect(normalizeElevenLabsBaseUrl("http://localhost:8080")).toBe("http://localhost:8080");
   });
 
-  it("falls back to the default for a malformed URL instead of yielding an unparseable value", () => {
-    // Callers feed the result straight into `new URL(...)`; a malformed value
-    // would otherwise throw an uncaught TypeError downstream.
-    const normalized = normalizeElevenLabsBaseUrl("not a url");
-    expect(normalized).toBe(DEFAULT_ELEVENLABS_BASE_URL);
-    expect(() => new URL(normalized)).not.toThrow();
+  it("rejects an explicit malformed override instead of silently retargeting", () => {
+    // An operator's explicit endpoint must not be swapped for the default; fail
+    // actionably here so the request cannot target an unintended host, and so a
+    // downstream `new URL(...)` never throws an opaque TypeError.
+    expect(() => normalizeElevenLabsBaseUrl("not a url")).toThrow(/Invalid ElevenLabs baseUrl/);
   });
 
-  it("keeps every normalized result parseable by new URL", () => {
-    for (const input of ["not a url", "", "://broken", "https://ok.example.com/"]) {
-      expect(() => new URL(normalizeElevenLabsBaseUrl(input))).not.toThrow();
+  it("rejects a parseable but unsupported (non-HTTP(S)) scheme", () => {
+    // `new URL()` accepts ftp:/data:/custom schemes, but downstream fetch and
+    // WebSocket paths only support http(s) ElevenLabs endpoints.
+    expect(() => normalizeElevenLabsBaseUrl("ftp://files.example.com")).toThrow(
+      /expected http\/https/,
+    );
+    expect(() => normalizeElevenLabsBaseUrl("data:text/plain,x")).toThrow(/expected http\/https/);
+  });
+
+  it("keeps every accepted result parseable as an http(s) URL", () => {
+    for (const input of ["https://ok.example.com/", "http://a.b:9000"]) {
+      const normalized = normalizeElevenLabsBaseUrl(input);
+      const url = new URL(normalized);
+      expect(["http:", "https:"]).toContain(url.protocol);
     }
   });
 });

--- a/extensions/elevenlabs/shared.test.ts
+++ b/extensions/elevenlabs/shared.test.ts
@@ -25,9 +25,31 @@ describe("normalizeElevenLabsBaseUrl", () => {
     // `new URL()` accepts ftp:/data:/custom schemes, but downstream fetch and
     // WebSocket paths only support http(s) ElevenLabs endpoints.
     expect(() => normalizeElevenLabsBaseUrl("ftp://files.example.com")).toThrow(
-      /expected http\/https/,
+      /unsupported scheme/,
     );
-    expect(() => normalizeElevenLabsBaseUrl("data:text/plain,x")).toThrow(/expected http\/https/);
+    expect(() => normalizeElevenLabsBaseUrl("data:text/plain,x")).toThrow(/unsupported scheme/);
+  });
+
+  it("does not leak URL credentials or sensitive query values in validation errors", () => {
+    // Rejection errors may reach logs/diagnostics; they must not echo userinfo
+    // or credential-bearing query parameters from the configured baseUrl.
+    const nonHttp = "ftp://user:sup3r-secret@files.example.com/x?api_key=leak-me";
+    expect(() => normalizeElevenLabsBaseUrl(nonHttp)).toThrow(/unsupported scheme/);
+    try {
+      normalizeElevenLabsBaseUrl(nonHttp);
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).not.toContain("sup3r-secret");
+      expect(message).not.toContain("leak-me");
+      expect(message).not.toContain("api_key");
+    }
+    // A malformed value that embeds a token must not be echoed either.
+    const malformed = "http://:not a url token=abcd1234secret";
+    try {
+      normalizeElevenLabsBaseUrl(malformed);
+    } catch (error) {
+      expect((error as Error).message).not.toContain("abcd1234secret");
+    }
   });
 
   it("keeps every accepted result parseable as an http(s) URL", () => {

--- a/extensions/elevenlabs/shared.test.ts
+++ b/extensions/elevenlabs/shared.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_ELEVENLABS_BASE_URL, normalizeElevenLabsBaseUrl } from "./shared.js";
+
+describe("normalizeElevenLabsBaseUrl", () => {
+  it("returns the default when the base URL is missing or blank", () => {
+    expect(normalizeElevenLabsBaseUrl(undefined)).toBe(DEFAULT_ELEVENLABS_BASE_URL);
+    expect(normalizeElevenLabsBaseUrl("   ")).toBe(DEFAULT_ELEVENLABS_BASE_URL);
+  });
+
+  it("trims and strips trailing slashes from a valid URL", () => {
+    expect(normalizeElevenLabsBaseUrl("  https://custom.example.com/  ")).toBe(
+      "https://custom.example.com",
+    );
+  });
+
+  it("falls back to the default for a malformed URL instead of yielding an unparseable value", () => {
+    // Callers feed the result straight into `new URL(...)`; a malformed value
+    // would otherwise throw an uncaught TypeError downstream.
+    const normalized = normalizeElevenLabsBaseUrl("not a url");
+    expect(normalized).toBe(DEFAULT_ELEVENLABS_BASE_URL);
+    expect(() => new URL(normalized)).not.toThrow();
+  });
+
+  it("keeps every normalized result parseable by new URL", () => {
+    for (const input of ["not a url", "", "://broken", "https://ok.example.com/"]) {
+      expect(() => new URL(normalizeElevenLabsBaseUrl(input))).not.toThrow();
+    }
+  });
+});

--- a/extensions/elevenlabs/shared.test.ts
+++ b/extensions/elevenlabs/shared.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_ELEVENLABS_BASE_URL, normalizeElevenLabsBaseUrl } from "./shared.js";
+import {
+  DEFAULT_ELEVENLABS_BASE_URL,
+  normalizeElevenLabsBaseUrl,
+  normalizeElevenLabsRealtimeBaseUrl,
+} from "./shared.js";
 
 describe("normalizeElevenLabsBaseUrl", () => {
   it("returns the default when the base URL is missing or blank", () => {
@@ -59,5 +63,17 @@ describe("normalizeElevenLabsBaseUrl", () => {
       const url = new URL(normalized);
       expect(["http:", "https:"]).toContain(url.protocol);
     }
+  });
+
+  it("maps HTTP endpoints and preserves explicit WebSocket endpoints for realtime", () => {
+    expect(normalizeElevenLabsRealtimeBaseUrl("https://api.example.com/")).toBe(
+      "wss://api.example.com",
+    );
+    expect(normalizeElevenLabsRealtimeBaseUrl("wss://realtime.example.com/")).toBe(
+      "wss://realtime.example.com",
+    );
+    expect(normalizeElevenLabsRealtimeBaseUrl("ws://localhost:8080/")).toBe(
+      "ws://localhost:8080",
+    );
   });
 });

--- a/extensions/elevenlabs/shared.test.ts
+++ b/extensions/elevenlabs/shared.test.ts
@@ -72,8 +72,6 @@ describe("normalizeElevenLabsBaseUrl", () => {
     expect(normalizeElevenLabsRealtimeBaseUrl("wss://realtime.example.com/")).toBe(
       "wss://realtime.example.com",
     );
-    expect(normalizeElevenLabsRealtimeBaseUrl("ws://localhost:8080/")).toBe(
-      "ws://localhost:8080",
-    );
+    expect(normalizeElevenLabsRealtimeBaseUrl("ws://localhost:8080/")).toBe("ws://localhost:8080");
   });
 });

--- a/extensions/elevenlabs/shared.test.ts
+++ b/extensions/elevenlabs/shared.test.ts
@@ -19,6 +19,7 @@ describe("normalizeElevenLabsBaseUrl", () => {
     // actionably here so the request cannot target an unintended host, and so a
     // downstream `new URL(...)` never throws an opaque TypeError.
     expect(() => normalizeElevenLabsBaseUrl("not a url")).toThrow(/Invalid ElevenLabs baseUrl/);
+    expect(() => normalizeElevenLabsBaseUrl("////")).toThrow(/Invalid ElevenLabs baseUrl/);
   });
 
   it("rejects a parseable but unsupported (non-HTTP(S)) scheme", () => {

--- a/extensions/elevenlabs/shared.ts
+++ b/extensions/elevenlabs/shared.ts
@@ -18,10 +18,16 @@ export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
   try {
     parsed = new URL(trimmed);
   } catch {
-    throw new Error(`Invalid ElevenLabs baseUrl: ${trimmed}`);
+    // Do not interpolate the raw value: an explicit baseUrl may embed userinfo
+    // (https://user:token@host) or credential-bearing query params that would
+    // otherwise leak into logs/diagnostics via this error.
+    throw new Error("Invalid ElevenLabs baseUrl: value is not a valid URL");
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`Invalid ElevenLabs baseUrl (expected http/https): ${trimmed}`);
+    // Only the scheme is safe to surface; the rest of the URL may carry secrets.
+    throw new Error(
+      `Invalid ElevenLabs baseUrl: unsupported scheme "${parsed.protocol}" (expected http or https)`,
+    );
   }
   return trimmed;
 }

--- a/extensions/elevenlabs/shared.ts
+++ b/extensions/elevenlabs/shared.ts
@@ -7,16 +7,21 @@ export function isValidElevenLabsVoiceId(voiceId: string): boolean {
 
 export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
   const trimmed = baseUrl?.trim().replace(/\/+$/, "");
+  // Only an absent/blank value falls back to the default endpoint. An explicit
+  // custom endpoint is the operator's intent, so reject it actionably here (at
+  // the shared config boundary) rather than silently retargeting to the default
+  // or letting a downstream `new URL(...)` throw an opaque TypeError.
   if (!trimmed) {
     return DEFAULT_ELEVENLABS_BASE_URL;
   }
-  // Callers pass the result straight into `new URL(...)`; a malformed value
-  // (e.g. "not a url") would otherwise throw an uncaught TypeError downstream.
-  // Fall back to the default endpoint instead of propagating an unparseable URL.
+  let parsed: URL;
   try {
-    void new URL(trimmed);
+    parsed = new URL(trimmed);
   } catch {
-    return DEFAULT_ELEVENLABS_BASE_URL;
+    throw new Error(`Invalid ElevenLabs baseUrl: ${trimmed}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Invalid ElevenLabs baseUrl (expected http/https): ${trimmed}`);
   }
   return trimmed;
 }

--- a/extensions/elevenlabs/shared.ts
+++ b/extensions/elevenlabs/shared.ts
@@ -6,6 +6,17 @@ export function isValidElevenLabsVoiceId(voiceId: string): boolean {
 }
 
 export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
-  const trimmed = baseUrl?.trim();
-  return trimmed?.replace(/\/+$/, "") || DEFAULT_ELEVENLABS_BASE_URL;
+  const trimmed = baseUrl?.trim().replace(/\/+$/, "");
+  if (!trimmed) {
+    return DEFAULT_ELEVENLABS_BASE_URL;
+  }
+  // Callers pass the result straight into `new URL(...)`; a malformed value
+  // (e.g. "not a url") would otherwise throw an uncaught TypeError downstream.
+  // Fall back to the default endpoint instead of propagating an unparseable URL.
+  try {
+    void new URL(trimmed);
+  } catch {
+    return DEFAULT_ELEVENLABS_BASE_URL;
+  }
+  return trimmed;
 }

--- a/extensions/elevenlabs/shared.ts
+++ b/extensions/elevenlabs/shared.ts
@@ -5,29 +5,45 @@ export function isValidElevenLabsVoiceId(voiceId: string): boolean {
   return /^[a-zA-Z0-9]{10,40}$/.test(voiceId);
 }
 
-export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
-  const trimmed = baseUrl?.trim().replace(/\/+$/, "");
+function normalizeElevenLabsBaseUrlWithProtocols(
+  baseUrl: string | undefined,
+  allowedProtocols: readonly string[],
+): string {
+  const trimmed = baseUrl?.trim();
   // Only an absent/blank value falls back to the default endpoint. An explicit
-  // custom endpoint is the operator's intent, so reject it actionably here (at
-  // the shared config boundary) rather than silently retargeting to the default
-  // or letting a downstream `new URL(...)` throw an opaque TypeError.
+  // custom endpoint is operator intent, so never silently retarget it.
   if (!trimmed) {
     return DEFAULT_ELEVENLABS_BASE_URL;
   }
+  const normalized = trimmed.replace(/\/+$/, "");
   let parsed: URL;
   try {
-    parsed = new URL(trimmed);
+    parsed = new URL(normalized);
   } catch {
     // Do not interpolate the raw value: an explicit baseUrl may embed userinfo
     // (https://user:token@host) or credential-bearing query params that would
     // otherwise leak into logs/diagnostics via this error.
     throw new Error("Invalid ElevenLabs baseUrl: value is not a valid URL");
   }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+  if (!allowedProtocols.includes(parsed.protocol)) {
     // Only the scheme is safe to surface; the rest of the URL may carry secrets.
     throw new Error(
-      `Invalid ElevenLabs baseUrl: unsupported scheme "${parsed.protocol}" (expected http or https)`,
+      `Invalid ElevenLabs baseUrl: unsupported scheme "${parsed.protocol}" (expected ${allowedProtocols.join(" or ")})`,
     );
   }
-  return trimmed;
+  return normalized;
+}
+
+export function normalizeElevenLabsBaseUrl(baseUrl?: string): string {
+  return normalizeElevenLabsBaseUrlWithProtocols(baseUrl, ["http:", "https:"]);
+}
+
+export function normalizeElevenLabsRealtimeBaseUrl(baseUrl?: string): string {
+  const url = new URL(
+    normalizeElevenLabsBaseUrlWithProtocols(baseUrl, ["http:", "https:", "ws:", "wss:"]),
+  );
+  if (url.protocol === "http:" || url.protocol === "https:") {
+    url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
+  }
+  return url.toString().replace(/\/+$/, "");
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a malformed or non-HTTP(S) ElevenLabs `baseUrl` in provider config is
either crashed on with an uncaught `TypeError: Invalid URL` or silently accepted, instead of
being rejected with an actionable error.

`normalizeElevenLabsBaseUrl` in `extensions/elevenlabs/shared.ts` only trimmed the value and
stripped trailing slashes — it never confirmed the result was a parseable HTTP(S) URL. Its
callers feed the result straight into `new URL(...)`: `normalizeElevenLabsRealtimeBaseUrl`
(`realtime-transcription-provider.ts:134`) does `new URL(normalizeElevenLabsBaseUrl(value))`,
and TTS/speech/media-understanding consume the same helper.

**Concrete example:** with `baseUrl: "not a url"`, `normalizeElevenLabsBaseUrl` on current `main`
returns `"not a url"` unchanged and the downstream `new URL("not a url")` throws an opaque
`TypeError: Invalid URL`. A value like `ftp://files.example.com` parses but is not a usable
ElevenLabs endpoint, yet is accepted and passed to fetch/WebSocket construction.

## Why This Change Was Made

Validate the base URL at the shared config boundary and **fail actionably**: only an absent/blank
value falls back to `DEFAULT_ELEVENLABS_BASE_URL`; an explicit value that is unparseable, or whose
scheme is not `http:`/`https:`, throws a clear `Invalid ElevenLabs baseUrl` error. This mirrors the
merged `fix(microsoft-foundry): reject malformed endpoints` (#104796) precedent — reject malformed
explicit endpoints rather than silently retargeting them. An operator's explicit custom endpoint is
their intent, so it is never silently swapped for the default (which would change behavior across all
four consumers on upgrade); valid `http(s)` endpoints are trimmed/normalized exactly as before.

## User Impact

**Before:** a mistyped ElevenLabs `baseUrl` surfaces an opaque `TypeError: Invalid URL` at session
setup, and a non-HTTP(S) endpoint is accepted and produces unusable fetch/WebSocket URLs.

**After:** an explicit malformed or non-HTTP(S) `baseUrl` fails fast with an actionable error; absent/blank
config still defaults; valid custom `http(s)` endpoints are unchanged. Validation errors never echo the raw
configured URL, so embedded userinfo or credential-bearing query params are not disclosed to logs/diagnostics.

## Evidence

- `extensions/elevenlabs/shared.ts` — `normalizeElevenLabsBaseUrl` rejects explicit malformed / non-HTTP(S) values (throws) and only defaults absent/blank input. Error messages are redacted: the malformed case says "value is not a valid URL"; the scheme case surfaces only the offending `protocol`, never the raw URL.
- Regression test: `extensions/elevenlabs/shared.test.ts` — asserts absent/blank → default, valid → normalized, explicit malformed → throws, `ftp:`/`data:` → throws `unsupported scheme`, and (disclosure test) a `baseUrl` with userinfo + `api_key` query is rejected **without** its secret/token appearing in the error. The malformed/scheme cases fail on the pre-fix `.trim()`-only version; the disclosure test fails on the earlier raw-value error and passes after redaction.
- Function probe against the real production `normalizeElevenLabsBaseUrl`:

```
$ node --import tsx -e "import('./extensions/elevenlabs/shared.ts').then(m => …)"
undefined -> "https://api.elevenlabs.io"
"https://custom.example.com/" -> "https://custom.example.com"
"not a url" -> THROWS: Invalid ElevenLabs baseUrl: value is not a valid URL
"ftp://user:sup3r-secret@files.example.com?api_key=leak-me" -> THROWS: Invalid ElevenLabs baseUrl: unsupported scheme "ftp:" (expected http or https)
```

(The credential-bearing input above is rejected with no `sup3r-secret` / `leak-me` / `api_key` in the message.)
