### PR TITLE
fix(tools): bound release metadata reads when installing helpers

### DIFF
--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -95,6 +95,27 @@ describe("ensureTool", () => {
     expect(downloadRelease).toHaveBeenCalledOnce();
   });
 
+  it("bounds release-check success bodies without using response.json()", async () => {
+    const { ensureTool } = await import("./tools-manager.js");
+    const release = vi.fn(async () => {});
+    const response = new Response("x".repeat(1024 * 1024 + 1), { status: 200 });
+    const json = vi.fn(async () => {
+      throw new Error("response.json() should not be called");
+    });
+    Object.defineProperty(response, "json", { value: json });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response,
+      release,
+      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
+    });
+
+    await expect(ensureTool("fd", true)).resolves.toBeUndefined();
+
+    expect(json).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+  });
+
   it("extracts Windows zip downloads via safe archive API with size limits", async () => {
     vi.doMock("node:os", async (importOriginal) => ({
       ...(await importOriginal<typeof import("node:os")>()),

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -21,12 +21,14 @@ import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import chalk from "chalk";
 import { extractArchive } from "../../infra/archive.js";
+import { readResponseWithLimit } from "../../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import { APP_NAME, getBinDir } from "../config.js";
 
 const TOOLS_DIR = getBinDir();
 const NETWORK_TIMEOUT_MS = 10_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
+const RELEASE_CHECK_RESPONSE_MAX_BYTES = 1024 * 1024;
 const MAX_ARCHIVE_BYTES = 100 * 1024 * 1024;
 const MAX_EXTRACTED_BYTES = 500 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRIES = 1_000;
@@ -156,7 +158,11 @@ async function getLatestVersion(repo: string): Promise<string> {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const data = (await response.json()) as { tag_name: string };
+    const body = await readResponseWithLimit(response, RELEASE_CHECK_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(`GitHub release metadata exceeded ${maxBytes} bytes (${size} bytes received)`),
+    });
+    const data = JSON.parse(body.toString("utf8")) as { tag_name: string };
     return data.tag_name.replace(/^v/, "");
   } finally {
     await guarded.release();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running built-in file search helpers could have an oversized GitHub release metadata success response fully buffered when OpenClaw needs to download fd or ripgrep.

## Why This Change Was Made

The helper installer already bounds archive downloads and cancels release-check error bodies. This change applies the existing bounded response reader to the release metadata success body before JSON parsing, keeping the fix local to the tool installer without changing helper selection, archive download limits, or config behavior.

## User Impact

Helper auto-installation now keeps GitHub release metadata reads under a fixed byte cap before parsing, so a bad release metadata response cannot bypass the bounded IO used by the rest of the helper download path.

## Evidence

- Claim proved: current head `876354a6bc69c375b3c751f0bdc4731937a68535` exercises the real fd helper auto-install path after the bounded release metadata read change. In an isolated `OPENCLAW_AGENT_DIR`, `getToolPath("fd")` returned `null`, OpenClaw downloaded fd through `ensureTool("fd")`, installed it under the agent bin directory, and the installed binary ran successfully.
- Commands / artifacts:
  - `node --import <repo>/node_modules/tsx/dist/esm/index.mjs --input-type=module -` with a repo-local proof script importing `src/agents/utils/tools-manager.ts` and calling `ensureTool("fd", false)` after setting an isolated `OPENCLAW_AGENT_DIR` and a `PATH` without fd/fdfind.
  - `git diff --check origin/main..HEAD -- src/agents/utils/tools-manager.ts src/agents/utils/tools-manager.test.ts`
- Observed result:

```text
[proof] head=876354a6bc69c375b3c751f0bdc4731937a68535
[proof] isolated OPENCLAW_AGENT_DIR=<OPENCLAW_AGENT_DIR>
[proof] PATH=D:\soft-programs\nodejs;C:\WINDOWS\System32
[proof] before getToolPath("fd")=null
fd not found. Downloading...
fd installed to <OPENCLAW_AGENT_DIR>\bin\fd.exe
[proof] ensureTool("fd") returned <OPENCLAW_AGENT_DIR>\bin\fd.exe
[proof] installed exists=true
[proof] installed under agent bin=true
[proof] fd --version status=0
[proof] fd --version stdout=fd 10.4.2
```

- `git diff --check origin/main..HEAD -- src/agents/utils/tools-manager.ts src/agents/utils/tools-manager.test.ts` passed with no whitespace errors.