### PR TITLE
fix(tools): bound release metadata reads when installing helpers

### DIFF
--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -95,6 +95,27 @@ describe("ensureTool", () => {
     expect(downloadRelease).toHaveBeenCalledOnce();
   });
 
+  it("bounds release-check success bodies without using response.json()", async () => {
+    const { ensureTool } = await import("./tools-manager.js");
+    const release = vi.fn(async () => {});
+    const response = new Response("x".repeat(1024 * 1024 + 1), { status: 200 });
+    const json = vi.fn(async () => {
+      throw new Error("response.json() should not be called");
+    });
+    Object.defineProperty(response, "json", { value: json });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response,
+      release,
+      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
+    });
+
+    await expect(ensureTool("fd", true)).resolves.toBeUndefined();
+
+    expect(json).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+  });
+
   it("extracts Windows zip downloads via safe archive API with size limits", async () => {
     vi.doMock("node:os", async (importOriginal) => ({
       ...(await importOriginal<typeof import("node:os")>()),

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -21,12 +21,14 @@ import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import chalk from "chalk";
 import { extractArchive } from "../../infra/archive.js";
+import { readResponseWithLimit } from "../../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import { APP_NAME, getBinDir } from "../config.js";
 
 const TOOLS_DIR = getBinDir();
 const NETWORK_TIMEOUT_MS = 10_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
+const RELEASE_CHECK_RESPONSE_MAX_BYTES = 1024 * 1024;
 const MAX_ARCHIVE_BYTES = 100 * 1024 * 1024;
 const MAX_EXTRACTED_BYTES = 500 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRIES = 1_000;
@@ -156,7 +158,11 @@ async function getLatestVersion(repo: string): Promise<string> {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const data = (await response.json()) as { tag_name: string };
+    const body = await readResponseWithLimit(response, RELEASE_CHECK_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(`GitHub release metadata exceeded ${maxBytes} bytes (${size} bytes received)`),
+    });
+    const data = JSON.parse(body.toString("utf8")) as { tag_name: string };
     return data.tag_name.replace(/^v/, "");
   } finally {
     await guarded.release();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where helper tool installation could buffer an oversized GitHub release metadata response through the convenience JSON reader when checking the latest fd/rg release before downloading a helper binary.

## Why This Change Was Made

The helper installer now reads release metadata through the existing bounded HTTP body reader before parsing the same JSON payload. This keeps the change inside the agent tool installer boundary, preserves the guarded fetch release cleanup, and does not change helper selection, download policy, config, provider behavior, or valid release metadata handling.

## User Impact

Users and operators get the same helper auto-install behavior for normal GitHub release metadata, while unexpectedly large metadata responses are rejected at the bounded read boundary instead of being fully buffered.

## Evidence

- Claim proved: helper release metadata checks use the bounded response reader for real GitHub release metadata and do not call `response.json()` while parsing successful metadata.
- Commands / artifacts:
  - Current-head proof at `ab12af1382608646aae2e8f47d5d61663b195e1f`: `node --import tsx --input-type=module -` imported `fetchWithSsrFGuard` and `readResponseWithLimit`, used `auditContext: "tools-manager-release-check"`, and fetched `https://api.github.com/repos/BurntSushi/ripgrep/releases/latest`.
  - Runtime output: `status: 200`, `ok: true`, `bytes: 50552`, `maxBytes: 1048576`, `tag_name: "15.1.0"`, `parsedVersion: "15.1.0"`, `responseJsonCalled: false`.
  - `node scripts/run-vitest.mjs src/agents/utils/tools-manager.test.ts` passed with 1 file and 9 tests passing.
  - `git diff --check` passed.
- Observed result: the same guarded fetch plus bounded-reader sequence used by `tools-manager.ts` successfully parsed a real ripgrep helper release metadata response below the 1 MiB cap, and the focused regression still verifies an oversized 1 MiB + 1 byte metadata response is rejected without using the convenience JSON reader.

