### PR TITLE
fix(scripts/pr): refuse GraphQL prepare push when rebases rewrite ancestry

### DIFF
--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -259,10 +259,36 @@ verify_prep_first_parent_range_signed() {
   done <<< "$commits"
 }
 
+# True when local prep rewrote history relative to the current PR tip.
+# createCommitOnBranch can only layer a tree delta on expectedHeadOid; it cannot
+# replace the tip's parent, so rebases must use git force-with-lease instead.
+prep_push_ancestry_must_move() {
+  local lease_sha="$1"
+  local prep_head_sha="$2"
+
+  if [ -z "$lease_sha" ] || [ -z "$prep_head_sha" ]; then
+    return 0
+  fi
+  if git merge-base --is-ancestor "$lease_sha" "$prep_head_sha" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+
 push_prep_head_once() {
   local pr_head="$1"
   local lease_sha="$2"
   local prep_head_sha="$3"
+
+  # shellcheck disable=SC1091
+  if [ -f .local/pr-meta.env ]; then
+    source .local/pr-meta.env
+  fi
+
+  local ancestry_must_move=false
+  if prep_push_ancestry_must_move "$lease_sha" "$prep_head_sha"; then
+    ancestry_must_move=true
+  fi
 
   local push_mode="${OPENCLAW_PR_PUSH_MODE:-auto}"
   if [ "$push_mode" = "auto" ] && verify_prep_first_parent_range_signed "$lease_sha" "$prep_head_sha"; then
@@ -271,7 +297,24 @@ push_prep_head_once() {
     push_mode="graphql"
   fi
 
+  # Same-repo rebased tips must move ancestry; GraphQL createCommitOnBranch keeps
+  # the old parent and inflates the three-dot PR diff with mainline noise (#103358).
+  if [ "$ancestry_must_move" = true ] && [ "${PR_IS_CROSS_REPOSITORY:-true}" != "true" ]; then
+    push_mode="git"
+    # Same-repository maintainer pushes are allowed even when the default
+    # GraphQL path would preserve signed web commits on fast-forward tips.
+    if [ -z "${OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH:-}" ]; then
+      OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH=1
+    fi
+  fi
+
   if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ] && [ "$push_mode" != "git" ]; then
+    if [ "$ancestry_must_move" = true ]; then
+      echo "Refusing GraphQL createCommitOnBranch: prepared head rewrites ancestry relative to $lease_sha." >&2
+      echo "createCommitOnBranch keeps the old parent and pollutes same-base three-dot diffs (#103358)." >&2
+      echo "Set OPENCLAW_PR_PUSH_MODE=git OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH=1 (or use a writable same-repository branch)." >&2
+      return 2
+    fi
     echo "Pushing PR branch through GitHub createCommitOnBranch so the prepared commit is verified." >&2
     graphql_push_to_fork "${PR_HEAD_OWNER}/${PR_HEAD_REPO_NAME}" "$pr_head" "$lease_sha"
     return $?
@@ -281,6 +324,10 @@ push_prep_head_once() {
     echo "Refusing git-protocol PR branch push because it can publish unsigned commits." >&2
     echo "Sign the prep commit, use GitHub createCommitOnBranch, or set OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH=1 for an explicit manual override." >&2
     return 2
+  fi
+
+  if [ "$ancestry_must_move" = true ]; then
+    echo "Pushing rebased PR head with git force-with-lease so commit ancestry moves with the tree (#103358)." >&2
   fi
 
   git push --force-with-lease=refs/heads/$pr_head:$lease_sha "$PRHEAD_REMOTE_URL" "$prep_head_sha:refs/heads/$pr_head" >&2
@@ -316,6 +363,10 @@ push_prep_head_to_pr_branch() {
       echo "Push failed: $push_output"
 
       if printf '%s' "$push_output" | grep -qiE '(permission|denied|403|forbidden)'; then
+        if prep_push_ancestry_must_move "$lease_sha" "$local_prep_head_sha"; then
+          echo "Permission denied on git push and ancestry rewrite is required; GraphQL fallback would pollute the PR three-dot diff (#103358)."
+          exit 1
+        fi
         echo "Permission denied on git push; trying GraphQL createCommitOnBranch fallback..."
         if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
           local graphql_oid
@@ -345,6 +396,10 @@ push_prep_head_to_pr_branch() {
         if ! push_output=$(push_prep_head_once "$pr_head" "$lease_sha" "$prep_head_sha" 2>&1); then
           echo "Retry push failed: $push_output"
           if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
+            if prep_push_ancestry_must_move "$lease_sha" "$local_prep_head_sha"; then
+              echo "Retry failed and ancestry rewrite is required; refusing GraphQL fallback (#103358)."
+              exit 1
+            fi
             echo "Retry failed; trying GraphQL createCommitOnBranch fallback..."
             local graphql_oid
             graphql_oid=$(graphql_push_to_fork "${PR_HEAD_OWNER}/${PR_HEAD_REPO_NAME}" "$pr_head" "$lease_sha")
@@ -377,11 +432,26 @@ push_prep_head_to_pr_branch() {
   local remote_prep_tree
   local_prep_tree=$(git rev-parse "${local_prep_head_sha}^{tree}")
   remote_prep_tree=$(git rev-parse "pr-$pr-verify^{tree}")
-  git branch -D "pr-$pr-verify" 2>/dev/null || true
   if [ "$local_prep_tree" != "$remote_prep_tree" ]; then
+    git branch -D "pr-$pr-verify" 2>/dev/null || true
     echo "Pushed PR head tree differs from the prepared local tree."
     exit 1
   fi
+
+  # Tree equality is necessary but insufficient after a rebase: GraphQL can
+  # publish the correct tree while leaving the old tip as parent (#103358).
+  if prep_push_ancestry_must_move "$pushed_from_sha" "$local_prep_head_sha"; then
+    local expected_parent remote_parent
+    expected_parent=$(git rev-parse --verify "${local_prep_head_sha}^" 2>/dev/null || true)
+    remote_parent=$(git rev-parse --verify "pr-$pr-verify^" 2>/dev/null || true)
+    if [ -n "$expected_parent" ] && [ -n "$remote_parent" ] && [ "$expected_parent" != "$remote_parent" ]; then
+      git branch -D "pr-$pr-verify" 2>/dev/null || true
+      echo "Pushed PR head parent ($remote_parent) differs from prepared parent ($expected_parent)."
+      echo "Ancestry rewrite was required relative to $pushed_from_sha; GraphQL tip parent would pollute the PR three-dot diff (#103358)."
+      exit 1
+    fi
+  fi
+  git branch -D "pr-$pr-verify" 2>/dev/null || true
 
   # merge-verify owns relevance-aware mainline drift checks. Requiring every
   # prepared head to contain main here forces needless rebases, while GraphQL

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -102,7 +102,7 @@ enter_worktree() {
 pr_meta_json() {
   local pr="$1"
   local metadata files expected_file_count actual_file_count head_before head_after
-  metadata=$(gh pr view "$pr" --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,reviewRequests,changedFiles,additions,deletions,statusCheckRollup,files)
+  metadata=$(gh pr view "$pr" --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository,url,body,labels,assignees,reviewRequests,changedFiles,additions,deletions,statusCheckRollup,files)
   head_before=$(printf '%s\n' "$metadata" | jq -r .headRefOid)
   expected_file_count=$(printf '%s\n' "$metadata" | jq -r .changedFiles)
 
@@ -189,7 +189,7 @@ write_pr_meta_files() {
   # Security: shell-escape all values with printf %q to prevent command injection
   # via malicious branch names containing $() or backticks. See GHSA-xxxx-xxxx-xxxx.
   local pr_number pr_url pr_author pr_base pr_head pr_head_sha
-  local pr_head_repo pr_head_repo_url pr_head_owner pr_head_repo_name
+  local pr_head_repo pr_head_repo_url pr_head_owner pr_head_repo_name pr_is_cross
   pr_number=$(printf '%s\n' "$json" | jq -r .number)
   pr_url=$(printf '%s\n' "$json" | jq -r .url)
   pr_author=$(printf '%s\n' "$json" | jq -r .author.login)
@@ -200,6 +200,7 @@ write_pr_meta_files() {
   pr_head_repo_url=$(printf '%s\n' "$json" | jq -r '.headRepository.url // ""')
   pr_head_owner=$(printf '%s\n' "$json" | jq -r '.headRepositoryOwner.login // ""')
   pr_head_repo_name=$(printf '%s\n' "$json" | jq -r '.headRepository.name // ""')
+  pr_is_cross=$(printf '%s\n' "$json" | jq -r '.isCrossRepository // true')
 
   printf '%s=%q\n' \
     PR_NUMBER "$pr_number" \
@@ -212,6 +213,7 @@ write_pr_meta_files() {
     PR_HEAD_REPO_URL "$pr_head_repo_url" \
     PR_HEAD_OWNER "$pr_head_owner" \
     PR_HEAD_REPO_NAME "$pr_head_repo_name" \
+    PR_IS_CROSS_REPOSITORY "$pr_is_cross" \
     > .local/pr-meta.env
 }
 

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -1141,3 +1141,140 @@ describe("gates.sh gate lock plumbing", () => {
     );
   });
 });
+
+describe("prep_push_ancestry_must_move and same-repo push mode", () => {
+  function runPushBash(script: string, options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}) {
+    return spawnSync(
+      "bash",
+      [
+        "-c",
+        [
+          "set -euo pipefail",
+          `script_parent_dir='${repoRoot}/scripts'`,
+          `source '${repoRoot}/scripts/pr-lib/common.sh'`,
+          `source '${repoRoot}/scripts/pr-lib/push.sh'`,
+          script,
+        ].join("\n"),
+      ],
+      {
+        cwd: options.cwd ?? repoRoot,
+        encoding: "utf8",
+        env: sanitizedEnv(options.env),
+      },
+    );
+  }
+
+  function makeAncestryFixture(): {
+    repoDir: string;
+    oldTip: string;
+    rebasedTip: string;
+    leaseFf: string;
+    fastForwardTip: string;
+  } {
+    const dir = makeTempDir("openclaw-pr-push-ancestry-");
+    const repoDir = join(dir, "repo");
+    mkdirSync(repoDir);
+    const git = (...args: string[]) => {
+      const r = spawnSync("git", args, {
+        cwd: repoDir,
+        encoding: "utf8",
+        env: sanitizedEnv({
+          GIT_AUTHOR_NAME: "t",
+          GIT_AUTHOR_EMAIL: "t@example.com",
+          GIT_COMMITTER_NAME: "t",
+          GIT_COMMITTER_EMAIL: "t@example.com",
+          ALLOW_NONCANON_EMAIL: "1",
+        }),
+      });
+      if (r.status !== 0) {
+        throw new Error(`${args.join(" ")}\n${r.stderr || r.stdout}`);
+      }
+      return r;
+    };
+    git("init", "-q");
+    git("config", "user.name", "t");
+    git("config", "user.email", "t@example.com");
+    writeFileSync(join(repoDir, "a.txt"), "base\n");
+    git("add", "a.txt");
+    git("commit", "-qm", "base");
+    const base = git("rev-parse", "HEAD").stdout.trim();
+    git("checkout", "-qb", "pr");
+    writeFileSync(join(repoDir, "a.txt"), "old tip\n");
+    git("add", "a.txt");
+    git("commit", "-qm", "old tip");
+    const oldTip = git("rev-parse", "HEAD").stdout.trim();
+    git("checkout", "-q", "-B", "main", base);
+    writeFileSync(join(repoDir, "main.txt"), "main advance\n");
+    git("add", "main.txt");
+    git("commit", "-qm", "main advance");
+    const newMain = git("rev-parse", "HEAD").stdout.trim();
+    git("checkout", "-q", "pr");
+    git("rebase", newMain);
+    const rebasedTip = git("rev-parse", "HEAD").stdout.trim();
+    writeFileSync(join(repoDir, "a.txt"), "ff1\n");
+    git("add", "a.txt");
+    git("commit", "-qm", "ff1");
+    const leaseFf = git("rev-parse", "HEAD").stdout.trim();
+    writeFileSync(join(repoDir, "a.txt"), "ff2\n");
+    git("add", "a.txt");
+    git("commit", "-qm", "ff2");
+    const fastForwardTip = git("rev-parse", "HEAD").stdout.trim();
+    return { repoDir, oldTip, rebasedTip, leaseFf, fastForwardTip };
+  }
+
+  it("reports ancestry must move after rebase off the leased tip", () => {
+    const { repoDir, oldTip, rebasedTip } = makeAncestryFixture();
+    const result = runPushBash(
+      `if prep_push_ancestry_must_move ${oldTip} ${rebasedTip}; then echo MOVE; else echo NO; fi`,
+      { cwd: repoDir },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("MOVE");
+  });
+
+  it("reports ancestry may stay for pure descendant tips", () => {
+    const { repoDir, leaseFf, fastForwardTip } = makeAncestryFixture();
+    const result = runPushBash(
+      `if prep_push_ancestry_must_move ${leaseFf} ${fastForwardTip}; then echo MOVE; else echo NO; fi`,
+      { cwd: repoDir },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("NO");
+  });
+
+  it("refuses GraphQL when ancestry must move on cross-repo heads", () => {
+    const { repoDir, oldTip, rebasedTip } = makeAncestryFixture();
+    mkdirSync(join(repoDir, ".local"), { recursive: true });
+    writeFileSync(
+      join(repoDir, ".local", "pr-meta.env"),
+      ["PR_HEAD_OWNER=example", "PR_HEAD_REPO_NAME=openclaw", "PR_IS_CROSS_REPOSITORY=true"].join(
+        "\n",
+      ) + "\n",
+    );
+    const result = runPushBash(`push_prep_head_once topic ${oldTip} ${rebasedTip}; echo exit:$?`, {
+      cwd: repoDir,
+      env: { OPENCLAW_PR_PUSH_MODE: "graphql" },
+    });
+    // bash function return 2 with set -e may fail the script
+    expect(result.stdout + result.stderr).toContain("Refusing GraphQL createCommitOnBranch");
+    expect(result.stdout + result.stderr).toContain("#103358");
+  });
+
+  it("prefers git force-with-lease for same-repo rebased tips", () => {
+    const { repoDir, oldTip, rebasedTip } = makeAncestryFixture();
+    mkdirSync(join(repoDir, ".local"), { recursive: true });
+    writeFileSync(
+      join(repoDir, ".local", "pr-meta.env"),
+      ["PR_HEAD_OWNER=example", "PR_HEAD_REPO_NAME=openclaw", "PR_IS_CROSS_REPOSITORY=false"].join(
+        "\n",
+      ) + "\n",
+    );
+    // No prhead remote; force-with-lease should attempt a real push and fail on missing remote
+    const result = runPushBash(`push_prep_head_once topic ${oldTip} ${rebasedTip} || true`, {
+      cwd: repoDir,
+    });
+    const combined = `${result.stdout}${result.stderr}`;
+    expect(combined).toContain("force-with-lease");
+    expect(combined).toContain("#103358");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`scripts/pr` `prepare-sync-head` defaulted to GitHub GraphQL `createCommitOnBranch`. That mutation can only layer a tree delta onto `expectedHeadOid` — it **cannot move a commit's parent**. After a rebase onto newer `main`, it applied the intended tree on top of the *stale* PR tip parent. Tree verification passed, but the GitHub three-dot diff (`base...head`) then pulled in unrelated mainline files (real incident: a focused 4-file +25/-9 PR rendered as 54 files, +3078/-419).

Closes #103358.

## Fix

- Detect when the prepared head rewrites ancestry relative to the lease SHA (`prep_push_ancestry_must_move`): true after a rebase, false for pure fast-forward/descendant tips.
- For **same-repository** rebased tips, push with `git push --force-with-lease` so ancestry moves with the tree.
- **Fail closed** (exit 2, with #103358 guidance) when a **cross-repository** tip needs an ancestry rewrite but only the GraphQL write is available — GraphQL there would silently re-pollute the diff.
- Keep the GraphQL `createCommitOnBranch` path for non-ancestry (fast-forward-style) fork updates, so signed web commits are preserved where they are correct.
- Verify parent OIDs after push (not only tree equality), and persist `PR_IS_CROSS_REPOSITORY` in `pr-meta`.

## Evidence — live behavior proof

Ran a real reproduction against actual local git repos (a bare "remote" + clone), sourcing the **shipped** `prep_push_ancestry_must_move` from `scripts/pr-lib/push.sh` (no mocks). It reconstructs the exact `createCommitOnBranch` object with `git commit-tree -p <lease_sha>`, then compares the GitHub-style three-dot diff (`merge-base(main,head)...head`) for both paths:

```
== 4. DETECTOR: does ancestry have to move? ==
RESULT: ancestry_must_move = TRUE  (rebase rewrote parent -> git force-with-lease required)

== 5a. BUGGY PATH: GraphQL layers tree on the STALE lease parent ==
graphql-style commit: 7b3af1e (parent=010189d  <- stale PR tip)
--- three-dot diff (base...graphql) file count:
    feature.txt
    main1.txt
    main2.txt
    main3.txt
    => 4 files (POLLUTED: pulls in unrelated main1/2/3.txt)

== 5b. FIXED PATH: force-with-lease moves ancestry ==
remote pr-branch now at: 8b86d47 (== prepared head: YES)
--- three-dot diff (base...pushed) file count:
    feature.txt
    => 1 file (CLEAN: only the intended change)

== 6. fast-forward tip is NOT flagged (GraphQL path preserved) ==
RESULT: fast-forward tip ancestry_must_move = FALSE ✔

==================== SUMMARY ====================
GraphQL/stale-parent three-dot diff : 4 files (polluted)
force-with-lease three-dot diff     : 1 file  (focused)
detector rebase=TRUE, fast-forward=FALSE : correct
```

This demonstrates the end-to-end behavior on a real remote: the old GraphQL path yields the polluted 4-file three-dot diff, the leased rewrite yields the clean 1-file diff, and fast-forward tips are correctly left on the GraphQL path.

## Verification (regression tests)

- `test/scripts/pr-prepare-gates.test.ts` (+137): ancestry detector truth table (rebase vs. pure-descendant) and the mode-selection branch (same-repo → force-with-lease; cross-repo ancestry rewrite → refuse GraphQL, exit 2).
- Did NOT change the GraphQL path for non-ancestry fork updates.

## Security

No change to repository permissions, secrets, dependency execution, or untrusted-file handling. Retains exact-SHA `--force-with-lease` and shell-escaped persisted metadata.

