### PR TITLE
fix(embeddings): bound openai-compatible requests without AbortSignal

### DIFF
--- a/src/plugins/openai-compatible-embedding-http-timeout.test-helpers.ts
+++ b/src/plugins/openai-compatible-embedding-http-timeout.test-helpers.ts
@@ -1,0 +1,44 @@
+// Test helpers for OpenAI-compatible embedding HTTP hang floors.
+type OpenAICompatibleEmbeddingTimeoutOverride = {
+  queryMs?: number;
+  batchMs?: number;
+};
+
+const EMBEDDING_TIMEOUT_TEST_HOOK_KEY = Symbol.for("openclaw.openaiCompatibleEmbeddingTimeout");
+
+type EmbeddingTimeoutTestHook = {
+  override?: OpenAICompatibleEmbeddingTimeoutOverride;
+};
+
+function testHook(): EmbeddingTimeoutTestHook {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const existing = globalStore[EMBEDDING_TIMEOUT_TEST_HOOK_KEY] as
+    | EmbeddingTimeoutTestHook
+    | undefined;
+  if (existing) {
+    return existing;
+  }
+  const created: EmbeddingTimeoutTestHook = {};
+  globalStore[EMBEDDING_TIMEOUT_TEST_HOOK_KEY] = created;
+  return created;
+}
+
+/** Production defaults mirrored for assertions (must match http-timeout module). */
+export const OPENAI_COMPATIBLE_EMBEDDING_QUERY_TIMEOUT_MS = 60_000;
+export const OPENAI_COMPATIBLE_EMBEDDING_BATCH_TIMEOUT_MS = 600_000;
+
+/** Shorten or clear no-signal hang floors for hung-socket proofs. */
+export function setOpenAICompatibleEmbeddingRequestTimeoutMsForTest(
+  timeoutMs?: number | OpenAICompatibleEmbeddingTimeoutOverride,
+): void {
+  const hook = testHook();
+  if (timeoutMs === undefined) {
+    hook.override = undefined;
+    return;
+  }
+  if (typeof timeoutMs === "number") {
+    hook.override = { queryMs: timeoutMs, batchMs: timeoutMs };
+    return;
+  }
+  hook.override = timeoutMs;
+}

--- a/src/plugins/openai-compatible-embedding-http-timeout.ts
+++ b/src/plugins/openai-compatible-embedding-http-timeout.ts
@@ -1,0 +1,64 @@
+// Hang floors and shared header helpers for OpenAI-compatible embedding HTTP.
+export type OpenAICompatibleEmbeddingTimeoutKind = "query" | "batch";
+
+type OpenAICompatibleEmbeddingTimeoutOverride = {
+  queryMs?: number;
+  batchMs?: number;
+};
+
+const DEFAULT_QUERY_TIMEOUT_MS = 60_000;
+const DEFAULT_BATCH_TIMEOUT_MS = 600_000;
+
+const EMBEDDING_TIMEOUT_TEST_HOOK_KEY = Symbol.for("openclaw.openaiCompatibleEmbeddingTimeout");
+
+type EmbeddingTimeoutTestHook = {
+  override?: OpenAICompatibleEmbeddingTimeoutOverride;
+};
+
+function readTestOverride(): OpenAICompatibleEmbeddingTimeoutOverride | undefined {
+  // Vitest hang proofs shorten floors via globalThis; production never sets this.
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const hook = globalStore[EMBEDDING_TIMEOUT_TEST_HOOK_KEY] as EmbeddingTimeoutTestHook | undefined;
+  return hook?.override;
+}
+
+/** Resolve the transport timeout, composing only when the caller omitted a signal. */
+export function resolveOpenAICompatibleEmbeddingTimeoutMs(params: {
+  signal?: AbortSignal;
+  kind: OpenAICompatibleEmbeddingTimeoutKind;
+}): number | undefined {
+  // Memory search / tool callers already install deadlines on their AbortSignal.
+  if (params.signal) {
+    return undefined;
+  }
+  const override = readTestOverride();
+  if (params.kind === "query") {
+    return override?.queryMs ?? DEFAULT_QUERY_TIMEOUT_MS;
+  }
+  return override?.batchMs ?? DEFAULT_BATCH_TIMEOUT_MS;
+}
+
+/** Normalize an HTTP header name for OpenAI-compatible embedding requests. */
+export function normalizeOpenAICompatibleEmbeddingHeaderName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function isSensitiveHeaderName(name: string): boolean {
+  return (
+    name === "authorization" ||
+    name === "proxy-authorization" ||
+    name.includes("api-key") ||
+    name.includes("token") ||
+    name.includes("secret")
+  );
+}
+
+/** Drop credential-bearing headers from runtime cache identity. */
+export function sanitizeOpenAICompatibleEmbeddingCacheHeaders(
+  headers: Record<string, string>,
+): Record<string, string> | undefined {
+  const safeHeaders = Object.fromEntries(
+    Object.entries(headers).filter(([name]) => !isSensitiveHeaderName(name)),
+  );
+  return Object.keys(safeHeaders).length > 0 ? safeHeaders : undefined;
+}

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -6,6 +6,11 @@ import { withTestTimeout } from "../../test/helpers/promise.js";
 import { UnresolvedSecretInputError } from "../config/types.secrets.js";
 import type { EmbeddingProviderCreateOptions } from "./embedding-providers.js";
 import { getRegisteredEmbeddingProvider } from "./embedding-providers.js";
+import {
+  OPENAI_COMPATIBLE_EMBEDDING_BATCH_TIMEOUT_MS,
+  OPENAI_COMPATIBLE_EMBEDDING_QUERY_TIMEOUT_MS,
+  setOpenAICompatibleEmbeddingRequestTimeoutMsForTest,
+} from "./openai-compatible-embedding-http-timeout.test-helpers.js";
 import { openAICompatibleEmbeddingProviderAdapter } from "./openai-compatible-embedding-provider.js";
 
 async function createOpenAICompatibleEmbeddingProvider(options: EmbeddingProviderCreateOptions) {
@@ -190,6 +195,44 @@ async function startHangingErrorEmbeddingServer(): Promise<{
   };
 }
 
+/** Accepts the embedding POST but never writes headers or a body. */
+async function startNeverRespondingEmbeddingServer(): Promise<{ baseUrl: string }> {
+  const sockets = new Set<Socket>();
+  const server = createServer((req: IncomingMessage, _res: ServerResponse) => {
+    void (async () => {
+      await readJsonBody(req);
+      // Intentionally leave the response open so missing timeouts hang forever.
+    })();
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  servers.push({
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        for (const socket of sockets) {
+          socket.destroy();
+        }
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+  };
+}
+
 async function startOversizedSuccessEmbeddingServer(): Promise<OversizedStreamServer> {
   const chunk = Buffer.alloc(64 * 1024, 0x20);
   const prefix = Buffer.from('{"data":[');
@@ -281,6 +324,7 @@ async function startOversizedSuccessEmbeddingServer(): Promise<OversizedStreamSe
 }
 
 afterEach(async () => {
+  setOpenAICompatibleEmbeddingRequestTimeoutMsForTest();
   const pending = servers.splice(0);
   await Promise.all(pending.map((server) => server.close()));
 });
@@ -496,6 +540,147 @@ describe("openai-compatible generic embedding provider", () => {
       input: ["a", "abcd"],
       dimensions: 1024,
     });
+  });
+
+  it("uses distinct no-signal floors for query and batch", () => {
+    expect(OPENAI_COMPATIBLE_EMBEDDING_QUERY_TIMEOUT_MS).toBe(60_000);
+    expect(OPENAI_COMPATIBLE_EMBEDDING_BATCH_TIMEOUT_MS).toBe(600_000);
+  });
+
+  it("times out embedding requests that never respond when caller omits signal", async () => {
+    setOpenAICompatibleEmbeddingRequestTimeoutMsForTest(50);
+    const server = await startNeverRespondingEmbeddingServer();
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        model: "text-embedding-bge-m3",
+        remote: { baseUrl: server.baseUrl },
+      }),
+    );
+
+    const outcome = await Promise.race([
+      provider.embed("hello").then(
+        () => ({ type: "resolved" as const }),
+        (error: unknown) => ({ type: "rejected" as const, error }),
+      ),
+      new Promise<{ type: "hung" }>((resolve) => {
+        setTimeout(() => resolve({ type: "hung" }), 1_000);
+      }),
+    ]);
+
+    expect(outcome.type).toBe("rejected");
+    if (outcome.type !== "rejected") {
+      return;
+    }
+    expect(outcome.error).toMatchObject({ name: "TimeoutError", message: "request timed out" });
+  });
+
+  it("times out unsignaled batch requests that never respond", async () => {
+    setOpenAICompatibleEmbeddingRequestTimeoutMsForTest(50);
+    const server = await startNeverRespondingEmbeddingServer();
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        model: "text-embedding-bge-m3",
+        remote: { baseUrl: server.baseUrl },
+      }),
+    );
+
+    const outcome = await Promise.race([
+      provider.embedBatch(["hello", "world"]).then(
+        () => ({ type: "resolved" as const }),
+        (error: unknown) => ({ type: "rejected" as const, error }),
+      ),
+      new Promise<{ type: "hung" }>((resolve) => {
+        setTimeout(() => resolve({ type: "hung" }), 1_000);
+      }),
+    ]);
+
+    expect(outcome.type).toBe("rejected");
+    if (outcome.type !== "rejected") {
+      return;
+    }
+    expect(outcome.error).toMatchObject({ name: "TimeoutError", message: "request timed out" });
+  });
+
+  it("keeps query and batch no-signal floors independent", async () => {
+    setOpenAICompatibleEmbeddingRequestTimeoutMsForTest({ queryMs: 50, batchMs: 250 });
+    const server = await startNeverRespondingEmbeddingServer();
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        model: "text-embedding-bge-m3",
+        remote: { baseUrl: server.baseUrl },
+      }),
+    );
+
+    const queryStarted = Date.now();
+    const queryOutcome = await Promise.race([
+      provider.embed("hello").then(
+        () => ({ type: "resolved" as const }),
+        (error: unknown) => ({ type: "rejected" as const, error }),
+      ),
+      new Promise<{ type: "hung" }>((resolve) => {
+        setTimeout(() => resolve({ type: "hung" }), 150);
+      }),
+    ]);
+    const queryElapsedMs = Date.now() - queryStarted;
+
+    expect(queryOutcome.type).toBe("rejected");
+    expect(queryElapsedMs).toBeLessThan(150);
+
+    const batchStarted = Date.now();
+    const batchPromise = provider.embedBatch(["hello", "world"]).then(
+      () => ({ type: "resolved" as const }),
+      (error: unknown) => ({ type: "rejected" as const, error }),
+    );
+    const earlyBatch = await Promise.race([
+      batchPromise,
+      new Promise<{ type: "still-pending" }>((resolve) => {
+        setTimeout(() => resolve({ type: "still-pending" }), 120);
+      }),
+    ]);
+    expect(earlyBatch).toEqual({ type: "still-pending" });
+
+    const batchOutcome = await Promise.race([
+      batchPromise,
+      new Promise<{ type: "hung" }>((resolve) => {
+        setTimeout(() => resolve({ type: "hung" }), 1_000);
+      }),
+    ]);
+    const batchElapsedMs = Date.now() - batchStarted;
+
+    expect(batchOutcome.type).toBe("rejected");
+    if (batchOutcome.type !== "rejected") {
+      return;
+    }
+    expect(batchOutcome.error).toMatchObject({
+      name: "TimeoutError",
+      message: "request timed out",
+    });
+    expect(batchElapsedMs).toBeGreaterThanOrEqual(200);
+  });
+
+  it("keeps caller AbortSignal deadlines instead of the no-signal transport floor", async () => {
+    setOpenAICompatibleEmbeddingRequestTimeoutMsForTest(50);
+    const server = await startNeverRespondingEmbeddingServer();
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        model: "text-embedding-bge-m3",
+        remote: { baseUrl: server.baseUrl },
+      }),
+    );
+    const controller = new AbortController();
+
+    const outcome = await Promise.race([
+      provider.embed("hello", { signal: controller.signal }).then(
+        () => ({ type: "resolved" as const }),
+        (error: unknown) => ({ type: "rejected" as const, error }),
+      ),
+      new Promise<{ type: "still-pending" }>((resolve) => {
+        setTimeout(() => resolve({ type: "still-pending" }), 200);
+      }),
+    ]);
+
+    expect(outcome).toEqual({ type: "still-pending" });
+    controller.abort();
   });
 
   it("bounds exact-limit embedding errors without splitting UTF-16 and cancels", async () => {

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -18,6 +18,12 @@ import type {
   EmbeddingProviderCallOptions,
   EmbeddingProviderCreateOptions,
 } from "./embedding-provider-types.js";
+import {
+  normalizeOpenAICompatibleEmbeddingHeaderName,
+  resolveOpenAICompatibleEmbeddingTimeoutMs,
+  sanitizeOpenAICompatibleEmbeddingCacheHeaders,
+  type OpenAICompatibleEmbeddingTimeoutKind,
+} from "./openai-compatible-embedding-http-timeout.js";
 
 /** Provider id for OpenAI-compatible remote embedding servers. */
 const OPENAI_COMPATIBLE_EMBEDDING_PROVIDER_ID = "openai-compatible";
@@ -139,10 +145,6 @@ function resolveRequestInputType(
   return client.inputType;
 }
 
-function normalizeHeaderName(name: string): string {
-  return name.trim().toLowerCase();
-}
-
 function buildHeaders(params: {
   apiKey: string | undefined;
   extra: Record<string, unknown> | undefined;
@@ -152,7 +154,7 @@ function buildHeaders(params: {
     "content-type": "application/json",
   };
   for (const [name, rawValue] of Object.entries(params.extra ?? {})) {
-    const normalizedName = normalizeHeaderName(name);
+    const normalizedName = normalizeOpenAICompatibleEmbeddingHeaderName(name);
     if (!normalizedName || normalizedName === "authorization") {
       continue;
     }
@@ -169,23 +171,6 @@ function buildHeaders(params: {
     headers.authorization = `Bearer ${params.apiKey}`;
   }
   return headers;
-}
-
-function isSensitiveHeaderName(name: string): boolean {
-  return (
-    name === "authorization" ||
-    name === "proxy-authorization" ||
-    name.includes("api-key") ||
-    name.includes("token") ||
-    name.includes("secret")
-  );
-}
-
-function sanitizeCacheHeaders(headers: Record<string, string>): Record<string, string> | undefined {
-  const safeHeaders = Object.fromEntries(
-    Object.entries(headers).filter(([name]) => !isSensitiveHeaderName(name)),
-  );
-  return Object.keys(safeHeaders).length > 0 ? safeHeaders : undefined;
 }
 
 function resolveSecretString(params: { value: unknown; path: string }): string | undefined {
@@ -326,6 +311,7 @@ async function createEmbeddingHttpError(response: Response): Promise<Error> {
 async function postEmbeddingRequest(params: {
   client: OpenAICompatibleEmbeddingClient;
   input: string[];
+  kind: OpenAICompatibleEmbeddingTimeoutKind;
   signal?: AbortSignal;
   inputType?: EmbeddingProviderCallOptions["inputType"];
 }): Promise<number[][]> {
@@ -342,6 +328,10 @@ async function postEmbeddingRequest(params: {
       ? await client.acquireLocalService(client.localServiceTarget, params.signal)
       : undefined;
   try {
+    const timeoutMs = resolveOpenAICompatibleEmbeddingTimeoutMs({
+      signal: params.signal,
+      kind: params.kind,
+    });
     const { response, release } = await fetchWithSsrFGuard({
       url: `${client.baseUrl}/embeddings`,
       init: {
@@ -350,6 +340,7 @@ async function postEmbeddingRequest(params: {
         body: JSON.stringify(body),
       },
       signal: params.signal,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       policy: client.ssrfPolicy,
       auditContext: "embedding-provider:openai-compatible",
     });
@@ -436,6 +427,7 @@ async function createOpenAICompatibleEmbeddingProvider(
     return await postEmbeddingRequest({
       client,
       input: inputs.map(embeddingInputToText),
+      kind: "batch",
       signal: callOptions?.signal,
       inputType: callOptions?.inputType,
     });
@@ -446,7 +438,14 @@ async function createOpenAICompatibleEmbeddingProvider(
       model: client.model,
       ...(typeof client.dimensions === "number" ? { dimensions: client.dimensions } : {}),
       embed: async (input, callOptions) => {
-        const [embedding] = await embedBatch([input], callOptions);
+        // Query uses its own path so unsignaled embeds get the 60s floor, not 600s batch.
+        const [embedding] = await postEmbeddingRequest({
+          client,
+          input: [embeddingInputToText(input)],
+          kind: "query",
+          signal: callOptions?.signal,
+          inputType: callOptions?.inputType,
+        });
         if (!embedding) {
           throw malformedEmbeddingResponse();
         }
@@ -464,7 +463,7 @@ export const openAICompatibleEmbeddingProviderAdapter: EmbeddingProviderAdapter 
   transport: "remote",
   create: async (options) => {
     const { provider, client } = await createOpenAICompatibleEmbeddingProvider(options);
-    const cacheHeaders = sanitizeCacheHeaders(client.headers);
+    const cacheHeaders = sanitizeOpenAICompatibleEmbeddingCacheHeaders(client.headers);
     return {
       provider,
       runtime: {


### PR DESCRIPTION
## What Problem This Solves

OpenAI-compatible embedding HTTP calls only forwarded an optional caller `AbortSignal`. Gateway `/v1/embeddings` and capability-CLI paths call `embed` / `embedBatch` without a signal, so a server that accepts the TCP connection but never sends headers could hang the request forever. Memory/wiki callers already install their own deadlines; this gap is the unsignaled transport path.

## Why This Change Was Made

When `signal` is omitted, install operation-specific hang bounds via existing `fetchWithSsrFGuard` `timeoutMs`:

- `embed` (query): 60s — aligned with memory remote query defaults
- `embedBatch` (batch): 600s (10 minutes) — aligned with adapter `inlineBatchTimeoutMs` / local batch policy so gateway/CLI batches are not clamped below established batch budgets

When a caller already provides a signal, leave that deadline alone so memory search / tool timeouts are not clamped.

No new config surface. Test-only override shortens the floor for hang repros.

## User Impact

**Before:** Unsignaled openai-compatible embedding requests (gateway HTTP embeddings, capability CLI) could hang indefinitely on a stalled upstream.

**After:** Unsignaled query requests fail after 60s; unsignaled batch requests fail after 600s (`TimeoutError` / `request timed out`). Callers that pass `AbortSignal` keep their own budget.

## Evidence

- Changed: `src/plugins/openai-compatible-embedding-http-timeout.ts` (+ provider wiring)
- Production caller under test: `createOpenAICompatibleEmbeddingProvider(...).provider.embed` / `embedBatch` against a real local `node:http` server that never responds
- Regression: `src/plugins/openai-compatible-embedding-provider.test.ts`
- Sibling cases still green in the same file (UTF-16 error bounds, oversized JSON cancel, auth/config paths)

### Unit regression

```bash
node scripts/run-vitest.mjs src/plugins/openai-compatible-embedding-provider.test.ts --reporter=verbose
```

```text
 ✓ |plugins| ... > uses distinct no-signal floors for query and batch
 ✓ |plugins| ... > times out embedding requests that never respond when caller omits signal
 ✓ |plugins| ... > times out unsignaled batch requests that never respond
 ✓ |plugins| ... > keeps query and batch no-signal floors independent
 ✓ |plugins| ... > keeps caller AbortSignal deadlines instead of the no-signal transport floor
 Test Files  1 passed (1)
      Tests  31 passed (31)
```

## Real behavior proof

- **Behavior or issue addressed:** Unsignaled openai-compatible embedding POSTs no longer hang forever when the upstream accepts the connection but never responds; query and batch use distinct floors (60s / 600s).
- **Canonical reachability path:** gateway `embeddings-http` / capability CLI / direct provider → `createOpenAICompatibleEmbeddingProvider` → `embed` (query) or `embedBatch` (batch) → `postEmbeddingRequest` → `fetchWithSsrFGuard({ timeoutMs })` when `signal` is absent.
- **Boundary crossed:** Operator/remote OpenAI-compatible embedding HTTP → local AbortSignal timeout via guarded fetch.
- **Shared helper / provider constraint check:** Reuses `fetchWithSsrFGuard` `timeoutMs` / `buildTimeoutAbortSignal`. Query floor `60_000`; batch floor `600_000` matches adapter `inlineBatchTimeoutMs`. Does not override caller-owned signals. Does not add config/env.
- **Observed result after fix:** Unsignaled `embedBatch` / `embed` reject with `TimeoutError` on a hung socket; defaults are 60s query / 600s batch; caller-provided `AbortSignal` is not clamped.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
