### PR TITLE
improve(ui): compact the New session controls and hero on phones

### DIFF
--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -647,62 +647,64 @@ class NewSessionPage extends OpenClawLightDomElement {
               `
             : nothing}
         </label>
-        <label
-          class="new-session-page__target new-session-page__target--toggle"
-          title=${worktreeAvailable
-            ? t("chat.runControls.newSessionWorktree")
-            : t("newSession.worktreeUnavailable")}
-        >
-          <input
-            type="checkbox"
-            .checked=${this.worktree}
-            ?disabled=${!worktreeAvailable || customFolder}
-            @change=${(event: Event) => {
-              this.worktree = (event.target as HTMLInputElement).checked;
-              if (this.worktree) {
-                this.maybeLoadBranches();
-              }
-            }}
-          />
-          <span class="new-session-page__target-icon" aria-hidden="true">${icons.gitBranch}</span>
-          <span>${t("newSession.worktree")}</span>
-        </label>
-        ${this.worktree
-          ? html`
-              <label class="new-session-page__target" title=${t("newSession.baseBranch")}>
-                <input
-                  type="text"
-                  list="new-session-branches"
-                  class="new-session-page__branch"
-                  aria-label=${t("newSession.baseBranch")}
-                  placeholder=${this.branchesLoading
-                    ? t("common.loading")
-                    : (branches?.defaultBranch ?? t("newSession.baseBranch"))}
-                  .value=${this.baseRef}
-                  @input=${(event: Event) => {
-                    this.baseRef = (event.target as HTMLInputElement).value.trim();
-                  }}
-                />
-                <datalist id="new-session-branches">
-                  ${(branches?.branches ?? []).map(
-                    (branch) => html`<option value=${branch.name}></option>`,
-                  )}
-                </datalist>
-              </label>
-              <label class="new-session-page__target" title=${t("newSession.worktreeName")}>
-                <input
-                  type="text"
-                  class="new-session-page__branch"
-                  aria-label=${t("newSession.worktreeName")}
-                  placeholder=${t("newSession.worktreeNamePlaceholder")}
-                  .value=${this.worktreeName}
-                  @input=${(event: Event) => {
-                    this.worktreeName = (event.target as HTMLInputElement).value.trim();
-                  }}
-                />
-              </label>
-            `
-          : nothing}
+        <div class="new-session-page__target-group">
+          <label
+            class="new-session-page__target new-session-page__target--toggle"
+            title=${worktreeAvailable
+              ? t("chat.runControls.newSessionWorktree")
+              : t("newSession.worktreeUnavailable")}
+          >
+            <input
+              type="checkbox"
+              .checked=${this.worktree}
+              ?disabled=${!worktreeAvailable || customFolder}
+              @change=${(event: Event) => {
+                this.worktree = (event.target as HTMLInputElement).checked;
+                if (this.worktree) {
+                  this.maybeLoadBranches();
+                }
+              }}
+            />
+            <span class="new-session-page__target-icon" aria-hidden="true">${icons.gitBranch}</span>
+            <span>${t("newSession.worktree")}</span>
+          </label>
+          ${this.worktree
+            ? html`
+                <label class="new-session-page__target" title=${t("newSession.baseBranch")}>
+                  <input
+                    type="text"
+                    list="new-session-branches"
+                    class="new-session-page__branch"
+                    aria-label=${t("newSession.baseBranch")}
+                    placeholder=${this.branchesLoading
+                      ? t("common.loading")
+                      : (branches?.defaultBranch ?? t("newSession.baseBranch"))}
+                    .value=${this.baseRef}
+                    @input=${(event: Event) => {
+                      this.baseRef = (event.target as HTMLInputElement).value.trim();
+                    }}
+                  />
+                  <datalist id="new-session-branches">
+                    ${(branches?.branches ?? []).map(
+                      (branch) => html`<option value=${branch.name}></option>`,
+                    )}
+                  </datalist>
+                </label>
+                <label class="new-session-page__target" title=${t("newSession.worktreeName")}>
+                  <input
+                    type="text"
+                    class="new-session-page__branch"
+                    aria-label=${t("newSession.worktreeName")}
+                    placeholder=${t("newSession.worktreeNamePlaceholder")}
+                    .value=${this.worktreeName}
+                    @input=${(event: Event) => {
+                      this.worktreeName = (event.target as HTMLInputElement).value.trim();
+                    }}
+                  />
+                </label>
+              `
+            : nothing}
+        </div>
       </div>
     `;
   }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4206,6 +4206,35 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   }
 }
 
+/* Phones (and short landscape): scale the welcome hero down so the composer
+   and recent chats fit the first screenful on the start screen and /new. */
+@media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .agent-chat__welcome {
+    gap: 8px;
+    padding: 16px 12px;
+  }
+
+  .agent-chat__welcome h2 {
+    font-size: 20px;
+  }
+
+  .agent-chat__welcome-avatar {
+    width: 64px;
+    height: 64px;
+  }
+
+  .agent-chat__welcome-clawd {
+    width: 88px;
+    height: 77px;
+  }
+
+  .agent-chat__welcome .agent-chat__avatar--text {
+    width: 64px;
+    height: 64px;
+    font-size: 22px;
+  }
+}
+
 .agent-chat__avatar--text {
   width: 80px;
   height: 80px;

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -251,3 +251,33 @@ openclaw-new-session-page {
   opacity: 0.5;
   cursor: default;
 }
+
+/* Phones (and short landscape): match the chat thread's mobile inset and
+   condense the target rows — Where and Worktree share one line while the
+   folder picker takes its own full-width line below, so long paths stay
+   readable. The folder chip's visual order moves after the toggle; DOM
+   (and thus reading/tab) order is unchanged. */
+@media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .new-session-page__scroll {
+    padding: 12px 8px;
+  }
+
+  .new-session-page__targets {
+    gap: 4px 12px;
+  }
+
+  .new-session-page__target--folder {
+    order: 2;
+    flex: 1 1 100%;
+  }
+
+  .new-session-page__target--folder input {
+    flex: 1 1 auto;
+    width: 0;
+    max-width: none;
+  }
+
+  .new-session-page__branch {
+    width: 110px;
+  }
+}

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -60,6 +60,15 @@ openclaw-new-session-page {
   padding: 0 2px;
 }
 
+/* The worktree toggle and its branch/name fields wrap as one unit so the
+   dependent fields never land on a different line than their toggle. */
+.new-session-page__target-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: inherit;
+}
+
 .new-session-page__target {
   display: inline-flex;
   align-items: center;
@@ -253,9 +262,9 @@ openclaw-new-session-page {
 }
 
 /* Phones (and short landscape): match the chat thread's mobile inset and
-   condense the target rows in DOM order — the folder chip flexes to fill the
-   first line next to Where (its 140px floor pushes Worktree to the next
-   line), so visual, reading, and tab order stay aligned. */
+   condense the target rows in DOM order — the folder chip flexes next to
+   Where and the worktree group wraps below as a unit, so visual, reading,
+   and tab order stay aligned at every phone width. */
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .new-session-page__scroll {
     padding: 12px 8px;

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -253,10 +253,9 @@ openclaw-new-session-page {
 }
 
 /* Phones (and short landscape): match the chat thread's mobile inset and
-   condense the target rows — Where and Worktree share one line while the
-   folder picker takes its own full-width line below, so long paths stay
-   readable. The folder chip's visual order moves after the toggle; DOM
-   (and thus reading/tab) order is unchanged. */
+   condense the target rows in DOM order — the folder chip flexes to fill the
+   first line next to Where (its 140px floor pushes Worktree to the next
+   line), so visual, reading, and tab order stay aligned. */
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .new-session-page__scroll {
     padding: 12px 8px;
@@ -267,8 +266,8 @@ openclaw-new-session-page {
   }
 
   .new-session-page__target--folder {
-    order: 2;
-    flex: 1 1 100%;
+    flex: 1 1 140px;
+    min-width: 140px;
   }
 
   .new-session-page__target--folder input {


### PR DESCRIPTION
Closes #105176

## What Problem This Solves

On phones the `/new` launcher wasted its first screenful: the target controls (Where, Folder, Worktree) stacked as three loose full-width rows, the welcome hero took a third of the viewport, and the composer plus recent chats sat below the fold.

## Why This Change Was Made

Phone-width rules (matching the repo's existing `max-width: 768px` + short-landscape breakpoint combo):

- **Target rows condense**: the folder picker flexes to fill the first line next to Where (140px floor), and Worktree wraps to the second line — visual, reading, and tab order all follow the DOM (a second-model review pass caught an earlier `order`-based variant whose focus order diverged; fixed before landing). With worktree on, base branch and name join as dense follow-up lines.
- **Shared welcome hero scales down** (mascot 128→88px, avatar 96→64px, title 24→20px, tighter padding) in `ui/src/styles/chat/layout.css` — this benefits the empty-chat start screen and `/new` equally, keeping the two intentionally identical surfaces (#105068) in sync.
- **Scroll inset matches chat**: `/new`'s pane padding drops to the chat thread's compact mobile padding instead of the desktop titlebar band.

CSS-only; no TypeScript, i18n, or behavior changes.

## User Impact

The mobile `/new` screen now fits hero, controls, composer, and five recent chats in one screenful, with the session-start controls reading as a dense launcher instead of a sparse stack. Desktop is unchanged.

Portrait:

![mobile default](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-mobile-compact/new-session-mobile-default.png)

Worktree on with a long custom path (three dense rows, path fully readable):

![mobile worktree](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-mobile-compact/new-session-mobile-worktree.png)

Landscape phone:

![landscape](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-mobile-compact/new-session-mobile-landscape.png)

## Evidence

- Live-verified against the mock dev harness at 375×812 (default + worktree-on + folder browser), 932×430 landscape, and 1280×800 desktop (no change); the empty-chat start screen verified with the smaller hero on mobile. Screenshots above.
- `oxfmt --check` clean on both touched CSS files; `git diff --check` clean.
- The new-session e2e runs at a 1280×900 viewport, above the phone breakpoint, so its layout assertions are unaffected.
