### PR TITLE
fix(extensions): prevent source-transform loader native retry

### DIFF
--- a/src/agents/sessions/extensions/loader.native-js.test.ts
+++ b/src/agents/sessions/extensions/loader.native-js.test.ts
@@ -187,7 +187,7 @@ export default async function extension(api) {
     expect(jitiCalls.imports).toEqual([extensionPath]);
   });
 
-  it("keeps SDK-alias JavaScript extensions on one shared jiti loader", async () => {
+  it("uses one source-transform-only jiti loader for SDK-alias JavaScript extensions", async () => {
     // SDK aliases need jiti's virtual resolution, but one shared loader keeps
     // multi-extension imports consistent and cheap.
     const { loadExtensions } = await import("./loader.js");
@@ -212,6 +212,7 @@ module.exports = async function(api) {
     expect(result.errors).toEqual([]);
     expect(result.extensions).toHaveLength(2);
     expect(jitiCalls.options).toHaveLength(1);
+    expect(jitiCalls.options[0]).toMatchObject({ tryNative: false });
     expect(jitiCalls.imports).toEqual([firstPath, secondPath]);
   });
 

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -438,11 +438,13 @@ async function loadExtensionSourceTransformModule(
             ...buildPluginLoaderJitiOptions({}),
             // Bun binaries need virtual modules because extension SDK files are
             // bundled into the executable rather than present on disk.
-            tryNative: false,
             virtualModules: VIRTUAL_MODULES,
           }
         : buildPluginLoaderJitiOptions(getExtensionLoaderAliases())),
       moduleCache: false,
+      // The explicit native fast path already declined this entry; retrying through jiti can
+      // overlap its ESM evaluation. Source-transform fallback must stay transform-only.
+      tryNative: false,
     });
   }
 


### PR DESCRIPTION
Closes #105110

## What Problem This Solves

Fixes an issue where users running an installed extension that requires source transformation would see a native ESM loader diagnostic when the extension loader retried native loading after its fast path had already declined the entry.

## Why This Change Was Made

The explicit native fast path remains available for eligible compiled JavaScript extensions. When an entry instead needs jiti source transformation, its shared loader now disables `tryNative` so it does not retry that path while preserving the existing alias resolution and Bun virtual-module behavior.

## User Impact

Installed extensions that require source transformation, including managed Codex plugin paths with aliased imports, no longer re-enter native ESM loading and emit the associated loader diagnostic during normal agent planning.

## Evidence

- `node scripts/run-vitest.mjs src/agents/sessions/extensions/loader.native-js.test.ts` (10 tests passed)
- `node scripts/run-vitest.mjs src/agents/sessions/extensions/loader.test.ts` (1 test passed)
- `pnpm format:check -- src/agents/sessions/extensions/loader.ts src/agents/sessions/extensions/loader.native-js.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean; no accepted/actionable findings)
- Blacksmith Testbox-through-Crabbox pre-warm could not start because this environment is not authenticated to the `openclaw` organization; remote build and GitHub CI remain pending.
