### PR TITLE
refactor(plugins): remove obsolete plain-file installer

### DIFF
--- a/src/plugins/install-security-scan.runtime.test.ts
+++ b/src/plugins/install-security-scan.runtime.test.ts
@@ -41,6 +41,7 @@ const {
   evaluateSkillInstallPolicyRuntime,
   preflightPluginNpmInstallPolicyRuntime,
   scanBundleInstallSourceRuntime,
+  scanFileInstallSourceRuntime,
 } = await import("./install-security-scan.runtime.js");
 
 function expectOnlyOperatorPolicyRan() {
@@ -53,17 +54,17 @@ function expectOnlyOperatorPolicyRan() {
   expect(getGlobalHookRunnerMock).not.toHaveBeenCalled();
 }
 
-describe("install security scan official bypass", () => {
-  beforeEach(() => {
-    runInstallPolicyMock.mockReset();
-    findBlockedManifestDependenciesMock.mockReset();
-    findBlockedNodeModulesDirectoryMock.mockReset();
-    findBlockedNodeModulesFileAliasMock.mockReset();
-    findBlockedPackageDirectoryInPathMock.mockReset();
-    findBlockedPackageFileAliasInPathMock.mockReset();
-    getGlobalHookRunnerMock.mockReset();
-  });
+beforeEach(() => {
+  runInstallPolicyMock.mockReset();
+  findBlockedManifestDependenciesMock.mockReset();
+  findBlockedNodeModulesDirectoryMock.mockReset();
+  findBlockedNodeModulesFileAliasMock.mockReset();
+  findBlockedPackageDirectoryInPathMock.mockReset();
+  findBlockedPackageFileAliasInPathMock.mockReset();
+  getGlobalHookRunnerMock.mockReset();
+});
 
+describe("install security scan official bypass", () => {
   it("bypasses plugin install friction for bundled OpenClaw sources", async () => {
     const result = await scanBundleInstallSourceRuntime({
       logger: {},
@@ -172,5 +173,112 @@ describe("install security scan official bypass", () => {
       },
     });
     expect(runInstallPolicyMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("legacy file install scan compatibility", () => {
+  it("preserves policy and hook metadata for published lazy install chunks", async () => {
+    const warnings: string[] = [];
+    const hasHooks = vi.fn().mockReturnValue(true);
+    const runBeforeInstall = vi.fn().mockResolvedValue(undefined);
+    getGlobalHookRunnerMock.mockReturnValue({ hasHooks, runBeforeInstall });
+    runInstallPolicyMock.mockResolvedValueOnce({
+      findings: [
+        {
+          ruleId: "registry-review",
+          severity: "warn",
+          message: "Registry requires review.",
+        },
+      ],
+    });
+
+    const result = await scanFileInstallSourceRuntime({
+      filePath: "/tmp/payload.js",
+      logger: { warn: (message) => warnings.push(message) },
+      mode: "update",
+      pluginId: "payload",
+      requestedSpecifier: "./payload.js",
+    });
+
+    expect(result).toBeUndefined();
+    expect(warnings).toEqual(["Install policy: Registry requires review."]);
+    expect(runInstallPolicyMock).toHaveBeenCalledWith({
+      config: undefined,
+      logger: expect.any(Object),
+      request: {
+        targetName: "payload",
+        targetType: "plugin",
+        sourcePath: "/tmp/payload.js",
+        sourcePathKind: "file",
+        source: { kind: "file", authority: "user", mutable: true, network: false },
+        origin: { type: "plugin-file" },
+        request: {
+          kind: "plugin-file",
+          mode: "update",
+          requestedSpecifier: "./payload.js",
+        },
+        plugin: {
+          contentType: "file",
+          pluginId: "payload",
+          extensions: ["payload.js"],
+        },
+      },
+    });
+    expect(hasHooks).toHaveBeenCalledWith("before_install");
+    expect(runBeforeInstall).toHaveBeenCalledWith(
+      {
+        targetName: "payload",
+        targetType: "plugin",
+        origin: "plugin-file",
+        sourcePath: "/tmp/payload.js",
+        sourcePathKind: "file",
+        request: {
+          kind: "plugin-file",
+          mode: "update",
+          requestedSpecifier: "./payload.js",
+        },
+        builtinScan: {
+          status: "ok",
+          scannedFiles: 0,
+          critical: 0,
+          warn: 0,
+          info: 0,
+          findings: [],
+        },
+        plugin: {
+          contentType: "file",
+          pluginId: "payload",
+          extensions: ["payload.js"],
+        },
+      },
+      {
+        origin: "plugin-file",
+        targetType: "plugin",
+        requestKind: "plugin-file",
+      },
+    );
+  });
+
+  it("returns operator policy blocks before invoking hooks", async () => {
+    runInstallPolicyMock.mockResolvedValueOnce({
+      blocked: {
+        code: "security_scan_blocked",
+        reason: "blocked by operator policy",
+      },
+    });
+
+    const result = await scanFileInstallSourceRuntime({
+      filePath: "/tmp/payload.js",
+      logger: {},
+      pluginId: "payload",
+    });
+
+    expect(result).toEqual({
+      blocked: {
+        code: "security_scan_blocked",
+        reason: "blocked by operator policy",
+      },
+    });
+    expect(getGlobalHookRunnerMock).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/install-security-scan.ts
+++ b/src/plugins/install-security-scan.ts
@@ -113,7 +113,10 @@ export async function scanInstalledPackageDependencyTree(params: {
   return await scanInstalledPackageDependencyTreeRuntime(params);
 }
 
-/** Scans one file-based plugin install source. */
+/**
+ * Retained for install.runtime compatibility with pre-v2026.6.5 lazy install chunks.
+ * Remove only with the matching runtime-postbuild legacy alias cleanup.
+ */
 export async function scanFileInstallSource(
   params: InstallSafetyOverrides & {
     config?: OpenClawConfig;

--- a/src/plugins/install.path.test.ts
+++ b/src/plugins/install.path.test.ts
@@ -2,15 +2,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { initializeGlobalHookRunner, resetGlobalHookRunner } from "./hook-runner-global.js";
-import { createMockPluginRegistry } from "./hooks.test-helpers.js";
-import {
-  installPluginFromFile,
-  installPluginFromPath,
-  PLUGIN_INSTALL_ERROR_CODE,
-} from "./install.js";
+import { installPluginFromPath, PLUGIN_INSTALL_ERROR_CODE } from "./install.js";
 import { packToArchive } from "./test-helpers/archive-fixtures.js";
 import { createSuiteTempRootTracker } from "./test-helpers/fs-fixtures.js";
 import {
@@ -61,26 +54,6 @@ function setupNativePluginInstallFixture() {
   return { caseDir, pluginDir, extensionsDir: path.join(stateDir, "extensions") };
 }
 
-async function installFromFileWithWarnings(params: {
-  config?: OpenClawConfig;
-  extensionsDir: string;
-  filePath: string;
-  dangerouslyForceUnsafeInstall?: boolean;
-}) {
-  const warnings: string[] = [];
-  const result = await installPluginFromFile({
-    config: params.config,
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-    filePath: params.filePath,
-    extensionsDir: params.extensionsDir,
-    logger: {
-      info: () => {},
-      warn: (msg: string) => warnings.push(msg),
-    },
-  });
-  return { result, warnings };
-}
-
 afterAll(() => {
   suiteTempRootTracker.cleanup();
 });
@@ -120,180 +93,11 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  resetGlobalHookRunner();
   vi.clearAllMocks();
   vi.unstubAllEnvs();
 });
 
 describe("installPluginFromPath", () => {
-  it("runs before_install for plain file plugins with file provenance metadata", async () => {
-    const handler = vi.fn().mockReturnValue({
-      findings: [
-        {
-          ruleId: "manual-review",
-          severity: "warn",
-          file: "payload.js",
-          line: 1,
-          message: "Review single-file plugin before install",
-        },
-      ],
-    });
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    const baseDir = suiteTempRootTracker.makeTempDir();
-    const extensionsDir = path.join(baseDir, "extensions");
-    fs.mkdirSync(extensionsDir, { recursive: true });
-
-    const sourcePath = path.join(baseDir, "payload.js");
-    fs.writeFileSync(sourcePath, "console.log('SAFE');\n", "utf-8");
-
-    const result = await installPluginFromFile({
-      filePath: sourcePath,
-      extensionsDir,
-    });
-
-    expect(result.ok).toBe(true);
-    expect(handler).toHaveBeenCalledTimes(1);
-    const [installContext, installMetadata] = handler.mock.calls[0] ?? [];
-    expect(installContext).toEqual({
-      targetName: "payload",
-      targetType: "plugin",
-      origin: "plugin-file",
-      sourcePath,
-      sourcePathKind: "file",
-      request: {
-        kind: "plugin-file",
-        mode: "install",
-        requestedSpecifier: sourcePath,
-      },
-      builtinScan: {
-        status: "ok",
-        scannedFiles: 0,
-        critical: 0,
-        warn: 0,
-        info: 0,
-        findings: [],
-      },
-      plugin: {
-        contentType: "file",
-        pluginId: "payload",
-        extensions: ["payload.js"],
-      },
-    });
-    expect(installMetadata).toEqual({
-      origin: "plugin-file",
-      targetType: "plugin",
-      requestKind: "plugin-file",
-    });
-  });
-
-  it("allows plain file installs with dangerous code patterns without built-in scanner blocking", async () => {
-    const baseDir = suiteTempRootTracker.makeTempDir();
-    const extensionsDir = path.join(baseDir, "extensions");
-    fs.mkdirSync(extensionsDir, { recursive: true });
-
-    const sourcePath = path.join(baseDir, "payload.js");
-    fs.writeFileSync(sourcePath, "eval('danger');\n", "utf-8");
-
-    const { result, warnings } = await installFromFileWithWarnings({
-      filePath: sourcePath,
-      extensionsDir,
-    });
-
-    expect(result.ok).toBe(true);
-    expect(warnings).toStrictEqual([]);
-  });
-
-  it("runs install policy before dry-run file install returns", async () => {
-    const baseDir = suiteTempRootTracker.makeTempDir();
-    const extensionsDir = path.join(baseDir, "extensions");
-    fs.mkdirSync(extensionsDir, { recursive: true });
-
-    const sourcePath = path.join(baseDir, "payload.js");
-    fs.writeFileSync(sourcePath, "console.log('SAFE');\n", "utf-8");
-    const config = {
-      security: {
-        installPolicy: {
-          enabled: true,
-          exec: {
-            source: "exec",
-            command: process.execPath,
-            args: [
-              "-e",
-              'process.stdin.resume();process.stdin.on("end",()=>{process.stdout.write(JSON.stringify({protocolVersion:1,decision:"block",reason:"blocked file plugin"}));});',
-            ],
-            allowInsecurePath: true,
-          },
-        },
-      },
-    } satisfies OpenClawConfig;
-
-    const result = await installPluginFromFile({
-      config,
-      filePath: sourcePath,
-      extensionsDir,
-      dryRun: true,
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-      expect(result.error).toContain("blocked by install policy: blocked file plugin");
-    }
-  });
-
-  it("logs locationless install policy warnings without undefined locations", async () => {
-    const baseDir = suiteTempRootTracker.makeTempDir();
-    const extensionsDir = path.join(baseDir, "extensions");
-    fs.mkdirSync(extensionsDir, { recursive: true });
-
-    const sourcePath = path.join(baseDir, "payload.js");
-    fs.writeFileSync(sourcePath, "console.log('SAFE');\n", "utf-8");
-    const config = {
-      security: {
-        installPolicy: {
-          enabled: true,
-          exec: {
-            source: "exec",
-            command: process.execPath,
-            args: [
-              "-e",
-              'process.stdin.resume();process.stdin.on("end",()=>{process.stdout.write(JSON.stringify({protocolVersion:1,decision:"allow",findings:[{ruleId:"registry-review",severity:"warn",message:"Registry requires review."}]}));});',
-            ],
-            allowInsecurePath: true,
-          },
-        },
-      },
-    } satisfies OpenClawConfig;
-
-    const { result, warnings } = await installFromFileWithWarnings({
-      config,
-      filePath: sourcePath,
-      extensionsDir,
-    });
-
-    expect(result.ok).toBe(true);
-    expect(warnings).toEqual(["Install policy: Registry requires review."]);
-  });
-
-  it("treats dangerouslyForceUnsafeInstall as a no-op for plain file installs", async () => {
-    const baseDir = suiteTempRootTracker.makeTempDir();
-    const extensionsDir = path.join(baseDir, "extensions");
-    fs.mkdirSync(extensionsDir, { recursive: true });
-
-    const sourcePath = path.join(baseDir, "payload.js");
-    fs.writeFileSync(sourcePath, "eval('danger');\n", "utf-8");
-
-    const { result, warnings } = await installFromFileWithWarnings({
-      filePath: sourcePath,
-      extensionsDir,
-      dangerouslyForceUnsafeInstall: true,
-    });
-
-    expect(result.ok).toBe(true);
-    expect(warnings).toStrictEqual([]);
-  });
-
   it("rejects managed plain file plugin installs through path install", async () => {
     const baseDir = suiteTempRootTracker.makeTempDir();
     const extensionsDir = path.join(baseDir, "extensions");
@@ -315,35 +119,6 @@ describe("installPluginFromPath", () => {
     expect(result.error).toBe(
       "Plain file plugin installs are not supported. Install a plugin directory or archive that contains openclaw.plugin.json, or list standalone plugin files in plugins.load.paths.",
     );
-  });
-
-  it("blocks hardlink alias overwrites when installing a plain file plugin", async () => {
-    const baseDir = suiteTempRootTracker.makeTempDir();
-    const extensionsDir = path.join(baseDir, "extensions");
-    const outsideDir = path.join(baseDir, "outside");
-    fs.mkdirSync(extensionsDir, { recursive: true });
-    fs.mkdirSync(outsideDir, { recursive: true });
-
-    const sourcePath = path.join(baseDir, "payload.js");
-    fs.writeFileSync(sourcePath, "console.log('SAFE');\n", "utf-8");
-    const victimPath = path.join(outsideDir, "victim.js");
-    fs.writeFileSync(victimPath, "ORIGINAL", "utf-8");
-
-    const targetPath = path.join(extensionsDir, "payload.js");
-    fs.linkSync(victimPath, targetPath);
-
-    const result = await installPluginFromFile({
-      filePath: sourcePath,
-      extensionsDir,
-      mode: "update",
-    });
-
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      return;
-    }
-    expect(result.error.toLowerCase()).toMatch(/hardlink|path alias escape/);
-    expect(fs.readFileSync(victimPath, "utf-8")).toBe("ORIGINAL");
   });
 
   it.runIf(process.platform !== "win32")(

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -59,9 +59,6 @@ vi.mock("./install.runtime.js", async () => {
     scanPackageInstallSource: (
       ...args: Parameters<typeof installSecurityScan.scanPackageInstallSource>
     ) => installSecurityScan.scanPackageInstallSource(...args),
-    scanFileInstallSource: (
-      ...args: Parameters<typeof installSecurityScan.scanFileInstallSource>
-    ) => installSecurityScan.scanFileInstallSource(...args),
   };
 });
 

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -259,7 +259,7 @@ export type PluginNpmIntegrityDriftParams = {
 };
 
 type PluginInstallPolicyRequest = {
-  kind: "plugin-dir" | "plugin-archive" | "plugin-file" | "plugin-npm" | "plugin-git";
+  kind: "plugin-dir" | "plugin-archive" | "plugin-npm" | "plugin-git";
   requestedSpecifier?: string;
   source?: InstallPolicySource;
 };
@@ -530,17 +530,6 @@ async function resolveLatestCompatibleNpmResolution(params: {
   }
 
   return null;
-}
-
-function buildFileInstallResult(pluginId: string, targetFile: string): InstallPluginResult {
-  return {
-    ok: true,
-    pluginId,
-    targetDir: targetFile,
-    manifestName: undefined,
-    version: undefined,
-    extensions: [path.basename(targetFile)],
-  };
 }
 
 function buildDirectoryInstallResult(params: {
@@ -1971,9 +1960,6 @@ function localPluginInstallPolicySource(kind: PluginInstallPolicyRequest["kind"]
   if (kind === "plugin-archive") {
     return { kind: "archive", authority: "user", mutable: true, network: false } as const;
   }
-  if (kind === "plugin-file") {
-    return { kind: "file", authority: "user", mutable: true, network: false } as const;
-  }
   if (kind === "plugin-git") {
     return { kind: "git", authority: "third-party", mutable: true, network: true } as const;
   }
@@ -1989,8 +1975,6 @@ function sourceFamilyForInstallPolicyKind(
       return "archive";
     case "plugin-dir":
       return "directory";
-    case "plugin-file":
-      return "file";
     case "plugin-git":
       return "git";
     case "plugin-npm":
@@ -2879,103 +2863,6 @@ export async function installPluginFromDir(
     mode: effectiveMode,
     sourceFamily: sourceFamilyForInstallPolicyKind(installPolicyRequest.kind, "directory"),
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
-  });
-  return result;
-}
-
-export async function installPluginFromFile(params: {
-  config?: OpenClawConfig;
-  filePath: string;
-  dangerouslyForceUnsafeInstall?: boolean;
-  extensionsDir?: string;
-  logger?: PluginInstallLogger;
-  mode?: "install" | "update";
-  dryRun?: boolean;
-  installPolicyRequest?: PluginInstallPolicyRequest;
-}): Promise<InstallPluginResult> {
-  const runtime = await loadPluginInstallRuntime();
-  const { logger, mode, dryRun } = runtime.resolveInstallModeOptions(params, defaultLogger);
-
-  const filePath = resolveUserPath(params.filePath);
-  const installPolicyRequest = params.installPolicyRequest ?? {
-    kind: "plugin-file",
-    requestedSpecifier: params.filePath,
-    source: localPluginInstallPolicySource("plugin-file"),
-  };
-  if (!(await runtime.fileExists(filePath))) {
-    return { ok: false, error: `file not found: ${filePath}` };
-  }
-
-  const extensionsDir = params.extensionsDir
-    ? resolveUserPath(params.extensionsDir)
-    : resolveDefaultPluginExtensionsDir();
-  await fs.mkdir(extensionsDir, { recursive: true });
-
-  const base = path.basename(filePath, path.extname(filePath));
-  const pluginId = base || "plugin";
-  const pluginIdError = validatePluginId(pluginId);
-  if (pluginIdError) {
-    return { ok: false, error: pluginIdError };
-  }
-  const targetFile = path.join(
-    extensionsDir,
-    `${safePluginInstallFileName(pluginId)}${path.extname(filePath)}`,
-  );
-  const preparedTarget: PreparedInstallTarget = {
-    targetPath: targetFile,
-    effectiveMode: await resolveEffectiveInstallMode({
-      runtime,
-      requestedMode: mode,
-      targetPath: targetFile,
-    }),
-  };
-
-  const availability = await ensureInstallTargetAvailableForMode({
-    runtime,
-    targetPath: preparedTarget.targetPath,
-    mode: preparedTarget.effectiveMode,
-  });
-  if (!availability.ok) {
-    return availability;
-  }
-
-  const scanResult = await runInstallSourceScan({
-    subject: `Plugin file "${pluginId}"`,
-    pluginId,
-    mode: preparedTarget.effectiveMode,
-    sourceFamily: "file",
-    scan: async () =>
-      await runtime.scanFileInstallSource({
-        config: params.config,
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-        filePath,
-        logger,
-        mode: preparedTarget.effectiveMode,
-        pluginId,
-        requestedSpecifier: installPolicyRequest.requestedSpecifier,
-      }),
-  });
-  if (scanResult) {
-    return scanResult;
-  }
-
-  if (dryRun) {
-    return buildFileInstallResult(pluginId, preparedTarget.targetPath);
-  }
-
-  logger.info?.(`Installing to ${preparedTarget.targetPath}…`);
-  try {
-    const root = await runtime.root(extensionsDir);
-    await root.copyIn(path.basename(preparedTarget.targetPath), filePath);
-  } catch (err) {
-    return { ok: false, error: String(err) };
-  }
-
-  const result = buildFileInstallResult(pluginId, preparedTarget.targetPath);
-  emitSuccessfulPluginInstallSecurityEvent(result, {
-    dryRun,
-    mode: preparedTarget.effectiveMode,
-    sourceFamily: "file",
   });
   return result;
 }


### PR DESCRIPTION
## What Problem This Solves

Managed plugin installs have rejected standalone plugin files since v2026.6.5, but the old `installPluginFromFile` implementation, its private policy branches, and integration-only tests remained in core.

## Why This Change Was Made

Remove the unreachable installer and its dead helper/type branches. Keep `scanFileInstallSource` and its runtime barrel export because published lazy install chunks can still reach that symbol through the stable `install.runtime.js` hot-update compatibility alias. Move the meaningful file-policy and `before_install` metadata coverage directly onto that retained scanner.

## User Impact

No supported behavior changes. Managed plain-file installs remain rejected with the existing guidance to use `plugins.load.paths`. Older live gateways retain their file-scan compatibility path during package updates. Production code shrinks by roughly 110 lines.

## Evidence

- `pnpm test:serial src/plugins/install.path.test.ts src/plugins/install-security-scan.runtime.test.ts src/plugins/install.test.ts test/scripts/runtime-postbuild.test.ts` on Testbox `tbx_01kxaqfgxzf01re4n5ggc9ezq1`: 147 tests passed.
- `pnpm build` on the same Testbox: passed.
- Built artifact assertion: `dist/install.runtime.js` exists, `scanFileInstallSource` remains in `install.runtime-_zaRutZE.js`, and no built root chunk contains `installPluginFromFile`.
- `pnpm check:changed` on the same Testbox: passed after proving the generated Plugin SDK baseline is byte-identical to clean main; the tracked baseline hash is already stale on main.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, no actionable findings, 0.87 confidence.
- `git diff --check`: passed.

No changelog entry: internal dead-code cleanup with no supported behavior change.
