### PR TITLE
ci: isolate frozen Control UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1055,8 +1055,9 @@ jobs:
           if [[ "$COMPATIBILITY_TARGET" == "true" ]]; then
             # Frozen targets can contain timing-sensitive tests fixed on current main.
             # Give legacy browser fixtures enough headroom on shared hosted runners.
+            # Isolate files because older suites can still leak module mocks between tests.
             # Do not retry whole files: several rely on one-shot mocked browser globals.
-            pnpm --dir ui test --testTimeout=30000
+            pnpm --dir ui test --testTimeout=30000 --isolate
           else
             pnpm --dir ui test
           fi

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1894,7 +1894,7 @@ describe("ci workflow guards", () => {
     expect(uiInstall.run).toContain("node scripts/ensure-playwright-chromium.mjs");
     expect(uiInstall.run).not.toContain("OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM");
     expect(uiTest.run).toContain('if [[ "$COMPATIBILITY_TARGET" == "true" ]]');
-    expect(uiTest.run).toContain("pnpm --dir ui test --testTimeout=30000");
+    expect(uiTest.run).toContain("pnpm --dir ui test --testTimeout=30000 --isolate");
     expect(uiTest.run).not.toContain("--retry");
     expect(uiTest.run).toContain("pnpm --dir ui test");
   });


### PR DESCRIPTION
## Summary

- isolate Control UI test files when trusted `main` CI validates a frozen release target
- keep the current-main fast path and its target-owned Vitest configuration unchanged
- guard the compatibility invocation against dropping file isolation

## Verification

- exact LTS target `a62bede54bbb6e66f624812ade28b70f3f0aa57c`: `pnpm --dir ui test --testTimeout=30000 --isolate` — 144 files / 2,129 tests passed ([Testbox](https://github.com/openclaw/openclaw/actions/runs/29186587172))
- `pnpm test test/scripts/ci-workflow-guards.test.ts` — 52 tests passed ([Testbox](https://github.com/openclaw/openclaw/actions/runs/29186709218))
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- fresh autoreview: no accepted/actionable findings

The failed release child ran the same LTS target without file isolation and reported 54 failures across five files. Their missing mocks, timers, and gateway state are cross-file leakage signatures; the isolated exact-target run is green without any LTS product backport.
