### PR TITLE
feat(ui): auto-load older external-session transcript on scroll

### DIFF
--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -30,7 +30,7 @@ suite("Claude native session catalog", () => {
     await server?.close();
   });
 
-  it("uses native sidebar/chat pagination and disables paired-node continuation", async () => {
+  it("auto-loads older chat without moving the viewport and disables paired-node continuation", async () => {
     const page = await browser.newPage();
     await page.clock.install();
     const catalogResponse = (threadId: string, name: string, nextCursor?: string) => ({
@@ -100,7 +100,14 @@ suite("Claude native session catalog", () => {
               response: {
                 hostId: "node:devbox",
                 threadId: "remote-thread",
-                items: [{ id: "a1", type: "agentMessage", text: "newer answer" }],
+                items: Array.from({ length: 40 }, (_, index) => ({
+                  id: `a${index + 1}`,
+                  type: index % 2 === 0 ? "agentMessage" : "userMessage",
+                  text:
+                    index === 0
+                      ? "newer answer"
+                      : `recent transcript message ${index + 1} with enough text to fill the pane`,
+                })),
                 nextCursor: "older",
               },
             },
@@ -123,8 +130,32 @@ suite("Claude native session catalog", () => {
     await page.getByText("Older remote review", { exact: true }).waitFor();
     await page.getByText("Remote architecture review", { exact: true }).click();
     await expect.poll(() => page.getByText("newer answer", { exact: true }).count()).toBe(1);
-    await page.getByRole("button", { name: "Load older" }).click();
+    const thread = page.locator(".chat-thread");
+    await expect
+      .poll(() => thread.evaluate((element) => element.scrollHeight > element.clientHeight + 100))
+      .toBe(true);
+    const initialReadCount = (await gateway.getRequests("sessions.catalog.read")).length;
+    await gateway.deferNext("sessions.catalog.read");
+    const before = await thread.evaluate((element) => {
+      element.scrollTop = 0;
+      return { scrollHeight: element.scrollHeight, scrollTop: element.scrollTop };
+    });
+    await expect
+      .poll(() => gateway.getRequests("sessions.catalog.read").then((requests) => requests.length))
+      .toBe(initialReadCount + 1);
+    await page.locator(".chat-history-loading").waitFor();
+    expect(await page.getByRole("button", { name: "Load older" }).count()).toBe(0);
+    await gateway.resolveDeferred("sessions.catalog.read");
     await expect.poll(() => page.getByText("older question", { exact: true }).count()).toBe(1);
+    const after = await thread.evaluate((element) => ({
+      scrollHeight: element.scrollHeight,
+      scrollTop: element.scrollTop,
+    }));
+    expect(after.scrollTop).toBeGreaterThan(0);
+    expect(after.scrollTop).toBeCloseTo(
+      before.scrollTop + (after.scrollHeight - before.scrollHeight),
+      0,
+    );
     expect(await page.locator(".agent-chat__composer-combobox > textarea").isDisabled()).toBe(true);
     await expect
       .poll(() => page.getByText("This session is on a paired node and is view-only.").count())
@@ -133,6 +164,14 @@ suite("Claude native session catalog", () => {
       catalogId: "claude",
       cursor: "older",
     });
+    const exhaustedReadCount = (await gateway.getRequests("sessions.catalog.read")).length;
+    await thread.evaluate((element) => {
+      element.scrollTop = 0;
+    });
+    await page.clock.runFor(500);
+    expect(await page.locator(".chat-history-loading").count()).toBe(0);
+    expect(await page.getByRole("button", { name: "Load older" }).count()).toBe(0);
+    expect(await gateway.getRequests("sessions.catalog.read")).toHaveLength(exhaustedReadCount);
     await page.close();
   });
 });

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -387,6 +387,24 @@ describe("chat pane catalog session lifecycle", () => {
     expect(message.content[0]?.text).not.toContain("Unsupported external session item");
   });
 
+  it("clamps oversized aggregated tool output before rendering", () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
+
+    const message = pane.catalogItemMessage(
+      {
+        type: "toolResult",
+        raw: { aggregatedOutput: "x".repeat(5000) },
+      } as SessionCatalogTranscriptItem,
+      0,
+    ) as { content: Array<{ text: string }> };
+
+    // The 500-char preview cap keeps a single huge tool result from injecting
+    // megabytes into one chat message; the "Tool result\n\n" prefix adds a bit.
+    expect(message.content[0]?.text.length).toBeLessThan(600);
+    expect(message.content[0]?.text.startsWith("Tool result")).toBe(true);
+  });
+
   it("skips an empty unknown catalog item", () => {
     const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
     const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -126,6 +126,10 @@ function createTestChatPane(params: { client: GatewayBrowserClient; sessions: Se
     sessionsLoading: false,
     sidebarContent: null,
     sidebarOpen: false,
+    // Minimal scroll host so scheduleChatScroll is a no-op instead of throwing.
+    chatScrollGeneration: 0,
+    chatScrollCommitCleanup: null,
+    renderLifecycle: { afterCommit: () => () => {}, invalidate: () => {} },
   } as unknown as ChatPageHost;
   pane.context = createSessionContext(params.client, params.sessions);
   pane.state = state;
@@ -438,6 +442,33 @@ describe("chat pane catalog session lifecycle", () => {
     expect(progressed).toBe(false);
     // Cursor cleared → hasOlderMessages() is false, so the observer will not refire.
     expect(pane.catalogCursor).toBeUndefined();
+  });
+
+  it("keeps paging when an advancing older page renders nothing new", async () => {
+    const readPage: SessionsCatalogReadResult = {
+      hostId: "gateway:local",
+      threadId: "thread-1",
+      // A page of only unsupported/empty items renders nothing but still advances
+      // the cursor: older renderable history may sit behind it, so paging continues.
+      items: [{ id: "x1", type: "other" }],
+      nextCursor: "cursor-2",
+    };
+    const client = {
+      request: vi.fn(async () => readPage),
+    } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const key = "catalog:claude:gateway%3Alocal:thread-1";
+    state.sessionKey = key;
+    pane.sessionKey = key;
+    pane.catalogCursor = "cursor-1";
+
+    const progressed = await pane.loadCatalogSession(
+      { catalogId: "claude", hostId: "gateway:local", threadId: "thread-1" },
+      true,
+    );
+
+    expect(progressed).toBe(true);
+    expect(pane.catalogCursor).toBe("cursor-2");
   });
 
   it("re-arms a failed older-page load only after another user scroll", () => {

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -45,7 +45,9 @@ type TestChatPane = HTMLElement & {
   handleTranscriptScroll: (event: Event) => void;
   historyAutoLoadBlocked: boolean;
   syncHistoryObserver: () => void;
-  loadCatalogSession: (key: CatalogSessionKey, older: boolean) => Promise<void>;
+  loadCatalogSession: (key: CatalogSessionKey, older: boolean) => Promise<boolean>;
+  loadOlderMessages: () => Promise<void>;
+  hasOlderMessages: () => boolean;
 };
 
 const suggestion: TaskSuggestion = {
@@ -405,6 +407,23 @@ describe("chat pane catalog session lifecycle", () => {
     expect(pane.historyAutoLoadBlocked).toBe(false);
     expect(pane.syncHistoryObserver).toHaveBeenCalledOnce();
     expect(state.handleChatScroll).toHaveBeenCalledWith(event);
+  });
+
+  it("re-arms a blocked auto-load when the manual fallback is clicked", async () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    // A short (non-scrollable) thread cannot emit a scroll event, so a blocked
+    // auto-load must be recoverable through the fallback's loadOlderMessages call.
+    state.sessionKey = "catalog:claude:gateway%3Alocal:thread-1";
+    pane.historyAutoLoadBlocked = true;
+    pane.loadCatalogSession = vi.fn(async () => false);
+    pane.hasOlderMessages = vi.fn(() => true);
+
+    await pane.loadOlderMessages();
+
+    // loadOlderMessages clears the block on entry, so the retry is not stranded.
+    expect(pane.loadCatalogSession).toHaveBeenCalledOnce();
+    expect(pane.historyAutoLoadBlocked).toBe(true);
   });
 });
 

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -48,6 +48,7 @@ type TestChatPane = HTMLElement & {
   loadCatalogSession: (key: CatalogSessionKey, older: boolean) => Promise<boolean>;
   loadOlderMessages: () => Promise<void>;
   hasOlderMessages: () => boolean;
+  catalogCursor: string | undefined;
 };
 
 const suggestion: TaskSuggestion = {
@@ -410,6 +411,33 @@ describe("chat pane catalog session lifecycle", () => {
     const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
 
     expect(pane.catalogItemMessage({ type: "other" }, 0)).toBeNull();
+  });
+
+  it("exhausts pagination when an older read does not advance the cursor", async () => {
+    const readPage: SessionsCatalogReadResult = {
+      hostId: "gateway:local",
+      threadId: "thread-1",
+      items: [{ id: "u1", type: "userMessage", text: "hi" }],
+      // Same cursor the request was made with: a stale provider that would loop.
+      nextCursor: "cursor-1",
+    };
+    const client = {
+      request: vi.fn(async () => readPage),
+    } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const key = "catalog:claude:gateway%3Alocal:thread-1";
+    state.sessionKey = key;
+    pane.sessionKey = key;
+    pane.catalogCursor = "cursor-1";
+
+    const progressed = await pane.loadCatalogSession(
+      { catalogId: "claude", hostId: "gateway:local", threadId: "thread-1" },
+      true,
+    );
+
+    expect(progressed).toBe(false);
+    // Cursor cleared → hasOlderMessages() is false, so the observer will not refire.
+    expect(pane.catalogCursor).toBeUndefined();
   });
 
   it("re-arms a failed older-page load only after another user scroll", () => {

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
   SessionCatalogSession,
+  SessionCatalogTranscriptItem,
   SessionsCatalogListResult,
   SessionsCatalogReadResult,
   TaskSuggestion,
@@ -37,6 +38,13 @@ type TestChatPane = HTMLElement & {
   onPaneSessionChange?: (paneId: string, sessionKey: string) => void;
   sessionKey: string;
   catalogSession: SessionCatalogSession | null;
+  catalogItemMessage: (
+    item: SessionCatalogTranscriptItem,
+    index: number,
+  ) => Record<string, unknown> | null;
+  handleTranscriptScroll: (event: Event) => void;
+  historyAutoLoadBlocked: boolean;
+  syncHistoryObserver: () => void;
   loadCatalogSession: (key: CatalogSessionKey, older: boolean) => Promise<void>;
 };
 
@@ -347,6 +355,56 @@ describe("chat pane catalog session lifecycle", () => {
       limit: 50,
     });
     expect(pane.catalogSession).toEqual(selectedSession);
+  });
+
+  it.each([
+    {
+      name: "uses a raw command for an empty tool call",
+      item: { type: "toolCall", raw: { command: "git status --short" } },
+      expected: "Tool call\n\ngit status --short",
+    },
+    {
+      name: "uses aggregated output for an empty tool result",
+      item: { type: "toolResult", raw: { aggregatedOutput: "working tree clean" } },
+      expected: "Tool result\n\nworking tree clean",
+    },
+    {
+      name: "renders an empty reasoning item as its label alone",
+      item: { type: "reasoning" },
+      expected: "Thinking",
+    },
+  ])("$name", ({ item, expected }) => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
+
+    const message = pane.catalogItemMessage(item as SessionCatalogTranscriptItem, 0) as {
+      content: Array<{ text: string }>;
+    };
+
+    expect(message.content[0]?.text).toBe(expected);
+    expect(message.content[0]?.text).not.toContain("Unsupported external session item");
+  });
+
+  it("skips an empty unknown catalog item", () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
+
+    expect(pane.catalogItemMessage({ type: "other" }, 0)).toBeNull();
+  });
+
+  it("re-arms a failed older-page load only after another user scroll", () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    state.handleChatScroll = vi.fn();
+    pane.historyAutoLoadBlocked = true;
+    pane.syncHistoryObserver = vi.fn();
+    const event = new Event("scroll");
+
+    pane.handleTranscriptScroll(event);
+
+    expect(pane.historyAutoLoadBlocked).toBe(false);
+    expect(pane.syncHistoryObserver).toHaveBeenCalledOnce();
+    expect(state.handleChatScroll).toHaveBeenCalledWith(event);
   });
 });
 

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -49,6 +49,7 @@ type TestChatPane = HTMLElement & {
   loadOlderMessages: () => Promise<void>;
   hasOlderMessages: () => boolean;
   catalogCursor: string | undefined;
+  olderCursorsSeen: Set<string>;
 };
 
 const suggestion: TaskSuggestion = {
@@ -469,6 +470,34 @@ describe("chat pane catalog session lifecycle", () => {
 
     expect(progressed).toBe(true);
     expect(pane.catalogCursor).toBe("cursor-2");
+  });
+
+  it("exhausts pagination when an older read cycles back to a visited cursor", async () => {
+    const readPage: SessionsCatalogReadResult = {
+      hostId: "gateway:local",
+      threadId: "thread-1",
+      items: [{ id: "x1", type: "other" }],
+      // Cursor points back to one already visited this session: a c1 -> c2 -> c1
+      // cycle that would otherwise loop forever on empty pages.
+      nextCursor: "cursor-1",
+    };
+    const client = {
+      request: vi.fn(async () => readPage),
+    } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const key = "catalog:claude:gateway%3Alocal:thread-1";
+    state.sessionKey = key;
+    pane.sessionKey = key;
+    pane.catalogCursor = "cursor-2";
+    pane.olderCursorsSeen.add("cursor-1");
+
+    const progressed = await pane.loadCatalogSession(
+      { catalogId: "claude", hostId: "gateway:local", threadId: "thread-1" },
+      true,
+    );
+
+    expect(progressed).toBe(false);
+    expect(pane.catalogCursor).toBeUndefined();
   });
 
   it("re-arms a failed older-page load only after another user scroll", () => {

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -817,6 +817,7 @@ class ChatPane extends OpenClawLightDomElement {
           cursor = nextCursor;
         }
       }
+      const requestedOlderCursor = older ? this.catalogCursor : undefined;
       const page = await client.request<SessionsCatalogReadResult>("sessions.catalog.read", {
         catalogId: key.catalogId,
         hostId: key.hostId,
@@ -832,16 +833,21 @@ class ChatPane extends OpenClawLightDomElement {
         .map((item, index) => this.catalogItemMessage(item, index))
         .filter((message) => message !== null);
       const nextMessages = older ? this.prependUniqueCatalogMessages(messages) : messages;
+      const grew = nextMessages.length > this.catalogMessages.length;
+      // Exhaust pagination when an older read makes no forward progress — no next
+      // cursor, a cursor that does not advance, or no newly rendered messages
+      // (empty/filtered/all-duplicate page). Otherwise the re-armed observer would
+      // re-issue the identical request in an unbounded loop against a stale provider.
+      const olderExhausted =
+        older && (!page.nextCursor || page.nextCursor === requestedOlderCursor || !grew);
       this.pendingHistoryAnchor =
-        older && nextMessages.length > this.catalogMessages.length
-          ? this.currentHistoryAnchor(state.sessionKey)
-          : null;
+        older && grew ? this.currentHistoryAnchor(state.sessionKey) : null;
       this.catalogMessages = nextMessages;
-      this.catalogCursor = page.nextCursor;
+      this.catalogCursor = olderExhausted ? undefined : page.nextCursor;
       const currentState = this.state ?? state;
       currentState.lastError = null;
       scheduleChatScroll(currentState, !older);
-      return true;
+      return older ? !olderExhausted : true;
     } catch (error) {
       if (isCurrent()) {
         (this.state ?? state).lastError = error instanceof Error ? error.message : String(error);

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -286,6 +286,10 @@ class ChatPane extends OpenClawLightDomElement {
   private historyObserverArmed = false;
   private historyAutoLoadBlocked = false;
   private pendingHistoryAnchor: ChatHistoryAnchor | null = null;
+  // Older cursors already requested this session. A provider that cycles cursors
+  // (c1 -> c2 -> c1) on empty/duplicate pages would otherwise loop forever, since
+  // the sentinel never scrolls out of view when nothing new renders.
+  private readonly olderCursorsSeen = new Set<string>();
 
   private captureConnectionScope(): ChatPaneConnectionScope | null {
     const context = this.context;
@@ -782,6 +786,7 @@ class ChatPane extends OpenClawLightDomElement {
     if (!older) {
       this.catalogLoading = true;
       this.catalogCursor = undefined;
+      this.olderCursorsSeen.clear();
       this.historyObserverArmed = false;
       this.historyObserver?.disconnect();
       this.historyObserver = null;
@@ -818,6 +823,9 @@ class ChatPane extends OpenClawLightDomElement {
         }
       }
       const requestedOlderCursor = older ? this.catalogCursor : undefined;
+      if (requestedOlderCursor) {
+        this.olderCursorsSeen.add(requestedOlderCursor);
+      }
       const page = await client.request<SessionsCatalogReadResult>("sessions.catalog.read", {
         catalogId: key.catalogId,
         hostId: key.hostId,
@@ -834,14 +842,16 @@ class ChatPane extends OpenClawLightDomElement {
         .filter((message) => message !== null);
       const nextMessages = older ? this.prependUniqueCatalogMessages(messages) : messages;
       const grew = nextMessages.length > this.catalogMessages.length;
-      // Exhaust only when the cursor cannot advance (absent or unchanged): that is
-      // the sole proof no more history exists, and it stops the re-armed observer
-      // from re-issuing the identical request in an unbounded loop. An advancing
-      // cursor with no newly rendered messages (a page that is entirely filtered
-      // or duplicate) must keep paging — real older history may sit behind it, and
-      // each request advances toward a real end.
+      // Exhaust when the cursor cannot make new forward progress: absent, unchanged,
+      // or already visited this session (a provider cycling c1 -> c2 -> c1). Any of
+      // these stops the re-armed observer from looping. An advancing, never-seen
+      // cursor with no newly rendered messages (an entirely filtered/duplicate page)
+      // must keep paging — real older history may sit behind it.
       const olderExhausted =
-        older && (!page.nextCursor || page.nextCursor === requestedOlderCursor);
+        older &&
+        (!page.nextCursor ||
+          page.nextCursor === requestedOlderCursor ||
+          this.olderCursorsSeen.has(page.nextCursor));
       this.pendingHistoryAnchor =
         older && grew ? this.currentHistoryAnchor(state.sessionKey) : null;
       this.catalogMessages = nextMessages;
@@ -883,6 +893,7 @@ class ChatPane extends OpenClawLightDomElement {
     this.historyObserverArmed = false;
     this.historyAutoLoadBlocked = false;
     this.pendingHistoryAnchor = null;
+    this.olderCursorsSeen.clear();
     this.historyObserver?.disconnect();
     this.historyObserver = null;
   }

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1744,7 +1744,12 @@ class ChatPane extends OpenClawLightDomElement {
       historyPagination: catalogKey
         ? {
             loading: this.loadingOlder,
-            manualFallback: this.hasOlderMessages() && typeof IntersectionObserver !== "function",
+            // Also surface the button when auto-load is blocked after a failure: a
+            // non-scrollable (short) thread can never emit the scroll event that
+            // re-arms the observer, so the button is the only retry path.
+            manualFallback:
+              this.hasOlderMessages() &&
+              (typeof IntersectionObserver !== "function" || this.historyAutoLoadBlocked),
             onLoadOlder: () => void this.loadOlderMessages(),
           }
         : undefined,

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -834,12 +834,14 @@ class ChatPane extends OpenClawLightDomElement {
         .filter((message) => message !== null);
       const nextMessages = older ? this.prependUniqueCatalogMessages(messages) : messages;
       const grew = nextMessages.length > this.catalogMessages.length;
-      // Exhaust pagination when an older read makes no forward progress — no next
-      // cursor, a cursor that does not advance, or no newly rendered messages
-      // (empty/filtered/all-duplicate page). Otherwise the re-armed observer would
-      // re-issue the identical request in an unbounded loop against a stale provider.
+      // Exhaust only when the cursor cannot advance (absent or unchanged): that is
+      // the sole proof no more history exists, and it stops the re-armed observer
+      // from re-issuing the identical request in an unbounded loop. An advancing
+      // cursor with no newly rendered messages (a page that is entirely filtered
+      // or duplicate) must keep paging — real older history may sit behind it, and
+      // each request advances toward a real end.
       const olderExhausted =
-        older && (!page.nextCursor || page.nextCursor === requestedOlderCursor || !grew);
+        older && (!page.nextCursor || page.nextCursor === requestedOlderCursor);
       this.pendingHistoryAnchor =
         older && grew ? this.currentHistoryAnchor(state.sessionKey) : null;
       this.catalogMessages = nextMessages;

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -38,6 +38,7 @@ import { icons } from "../../components/icons.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
 import { retirePendingChatSideQuestion } from "../../lib/chat/side-result.ts";
+import { clampText } from "../../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import {
@@ -136,6 +137,51 @@ import { configureToolTitleFetcher } from "./tool-titles.ts";
 
 type ChatPageContext = ApplicationContext;
 type PaneSessionChangeOptions = { replace?: boolean };
+type ChatHistoryAnchor = {
+  sessionKey: string;
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+const CATALOG_TOOL_RESULT_PREVIEW_MAX_CHARS = 500;
+
+function catalogRawRecord(raw: unknown): Record<string, unknown> | null {
+  return raw && typeof raw === "object" && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : null;
+}
+
+function catalogRawString(raw: unknown, keys: readonly string[]): string | null {
+  const record = catalogRawRecord(raw);
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function catalogRawResult(raw: unknown): string | null {
+  const result = catalogRawRecord(raw)?.result;
+  if (result === undefined) {
+    return null;
+  }
+  try {
+    const text = JSON.stringify(result);
+    return text ? clampText(text, CATALOG_TOOL_RESULT_PREVIEW_MAX_CHARS) : null;
+  } catch {
+    return null;
+  }
+}
+
+function catalogMessageId(message: unknown): string | null {
+  const messageId = catalogRawRecord(message)?.messageId;
+  return typeof messageId === "string" && messageId ? messageId : null;
+}
 type ChatPaneConnectionScope = {
   context: ChatPageContext;
   state: ChatPageHost;
@@ -229,12 +275,17 @@ class ChatPane extends OpenClawLightDomElement {
   private dismissedSessionPullRequestIds: ReadonlySet<string> = new Set();
   @litState() private catalogMessages: unknown[] = [];
   @litState() private catalogLoading = false;
-  @litState() private catalogLoadingOlder = false;
+  @litState() private loadingOlder = false;
   private catalogCursor: string | undefined;
   private catalogSession: SessionCatalogSession | null = null;
   private catalogHost: SessionCatalogHost | null = null;
   private catalogLoadGeneration = 0;
   private catalogRequestedSessionKey: string | null = null;
+  private olderLoadGeneration = 0;
+  private historyObserver: IntersectionObserver | null = null;
+  private historyObserverArmed = false;
+  private historyAutoLoadBlocked = false;
+  private pendingHistoryAnchor: ChatHistoryAnchor | null = null;
 
   private captureConnectionScope(): ChatPaneConnectionScope | null {
     const context = this.context;
@@ -554,6 +605,7 @@ class ChatPane extends OpenClawLightDomElement {
       return;
     }
     const previousSessionKey = state.sessionKey;
+    this.resetOlderMessagesViewport();
     const catalogKey = parseCatalogSessionKey(nextSessionKey);
     const previousSessionsResult = state.sessionsResult;
     const nextSessionRow = state.sessionsResult?.sessions.find((row) => row.key === nextSessionKey);
@@ -662,42 +714,72 @@ class ChatPane extends OpenClawLightDomElement {
     void this.loadCatalogSession(key, false);
   }
 
-  private catalogItemMessage(item: SessionCatalogTranscriptItem, index: number): unknown {
+  private catalogItemMessage(
+    item: SessionCatalogTranscriptItem,
+    index: number,
+  ): Record<string, unknown> | null {
     const timestamp = item.timestamp ? Date.parse(item.timestamp) : Date.now() + index;
-    const text = item.text || "[Unsupported external session item]";
+    const text = item.text?.trim() ? item.text : null;
     if (item.type === "userMessage") {
-      return { role: "user", content: text, timestamp, messageId: item.id };
+      return text ? { role: "user", content: text, timestamp, messageId: item.id } : null;
     }
-    const prefix =
-      item.type === "reasoning"
-        ? "Thinking\n\n"
-        : item.type === "toolCall"
-          ? "Tool call\n\n"
-          : item.type === "toolResult"
-            ? "Tool result\n\n"
-            : "";
+    let content = text;
+    if (item.type === "reasoning") {
+      content = text ? `Thinking\n\n${text}` : "Thinking";
+    } else if (item.type === "toolCall") {
+      const label =
+        text ?? catalogRawString(item.raw, ["command", "name", "tool", "title", "query"]);
+      content = label ? `Tool call\n\n${label}` : "Tool call";
+    } else if (item.type === "toolResult") {
+      const output =
+        text ?? catalogRawString(item.raw, ["aggregatedOutput"]) ?? catalogRawResult(item.raw);
+      content = output ? `Tool result\n\n${output}` : "Tool result";
+    }
+    if (!content) {
+      return null;
+    }
     return {
       role: "assistant",
-      content: [{ type: "text", text: `${prefix}${text}` }],
+      content: [{ type: "text", text: content }],
       timestamp,
       messageId: item.id,
     };
   }
 
-  private async loadCatalogSession(key: CatalogSessionKey, older: boolean) {
+  private prependUniqueCatalogMessages(messages: unknown[]): unknown[] {
+    const seenIds = new Set(this.catalogMessages.map(catalogMessageId).filter(Boolean));
+    const uniqueMessages = messages.filter((message) => {
+      const messageId = catalogMessageId(message);
+      if (!messageId || !seenIds.has(messageId)) {
+        if (messageId) {
+          seenIds.add(messageId);
+        }
+        return true;
+      }
+      return false;
+    });
+    return [...uniqueMessages, ...this.catalogMessages];
+  }
+
+  private async loadCatalogSession(key: CatalogSessionKey, older: boolean): Promise<boolean> {
     const state = this.state;
     const client = state?.client;
     if (!state || !client || !state.connected) {
-      return;
+      return false;
+    }
+    if (older && !this.catalogCursor) {
+      return false;
     }
     const generation = older ? this.catalogLoadGeneration : ++this.catalogLoadGeneration;
     const requestedSessionKey = buildCatalogSessionKey(key);
     const isCurrent = () =>
       generation === this.catalogLoadGeneration && this.sessionKey === requestedSessionKey;
-    if (older) {
-      this.catalogLoadingOlder = true;
-    } else {
+    if (!older) {
       this.catalogLoading = true;
+      this.catalogCursor = undefined;
+      this.historyObserverArmed = false;
+      this.historyObserver?.disconnect();
+      this.historyObserver = null;
     }
     try {
       if (!older) {
@@ -713,7 +795,7 @@ class ChatPane extends OpenClawLightDomElement {
             ...(cursor ? { cursors: { [key.hostId]: cursor } } : {}),
           });
           if (!isCurrent()) {
-            return;
+            return false;
           }
           const catalog = listed.catalogs.find((candidate) => candidate.id === key.catalogId);
           this.catalogHost = catalog?.hosts.find((host) => host.hostId === key.hostId) ?? null;
@@ -738,27 +820,159 @@ class ChatPane extends OpenClawLightDomElement {
         ...(older && this.catalogCursor ? { cursor: this.catalogCursor } : {}),
       });
       if (!isCurrent()) {
-        return;
+        return false;
       }
       const messages = page.items
         .toReversed()
-        .map((item, index) => this.catalogItemMessage(item, index));
-      this.catalogMessages = older ? [...messages, ...this.catalogMessages] : messages;
+        .map((item, index) => this.catalogItemMessage(item, index))
+        .filter((message) => message !== null);
+      const nextMessages = older ? this.prependUniqueCatalogMessages(messages) : messages;
+      this.pendingHistoryAnchor =
+        older && nextMessages.length > this.catalogMessages.length
+          ? this.currentHistoryAnchor(state.sessionKey)
+          : null;
+      this.catalogMessages = nextMessages;
       this.catalogCursor = page.nextCursor;
       const currentState = this.state ?? state;
       currentState.lastError = null;
       scheduleChatScroll(currentState, !older);
+      return true;
     } catch (error) {
       if (isCurrent()) {
         (this.state ?? state).lastError = error instanceof Error ? error.message : String(error);
       }
+      return false;
     } finally {
       if (isCurrent()) {
         const currentState = this.state ?? state;
-        this.catalogLoading = false;
-        this.catalogLoadingOlder = false;
-        currentState.chatLoading = false;
+        if (!older) {
+          this.catalogLoading = false;
+          currentState.chatLoading = false;
+        }
         currentState.requestUpdate();
+      }
+    }
+  }
+
+  private hasOlderMessages(): boolean {
+    const state = this.state;
+    return Boolean(
+      state &&
+      parseCatalogSessionKey(state.sessionKey) &&
+      this.catalogCursor &&
+      !this.catalogLoading,
+    );
+  }
+
+  private resetOlderMessagesViewport(): void {
+    this.olderLoadGeneration += 1;
+    this.loadingOlder = false;
+    this.historyObserverArmed = false;
+    this.historyAutoLoadBlocked = false;
+    this.pendingHistoryAnchor = null;
+    this.historyObserver?.disconnect();
+    this.historyObserver = null;
+  }
+
+  private restoreHistoryAnchor(): void {
+    const anchor = this.pendingHistoryAnchor;
+    if (!anchor) {
+      return;
+    }
+    this.pendingHistoryAnchor = null;
+    const state = this.state;
+    const thread = this.querySelector<HTMLElement>(".chat-thread");
+    if (!state || !thread || state.sessionKey !== anchor.sessionKey) {
+      return;
+    }
+    thread.scrollTop = anchor.scrollTop + (thread.scrollHeight - anchor.scrollHeight);
+  }
+
+  private currentHistoryAnchor(sessionKey: string): ChatHistoryAnchor | null {
+    const thread = this.querySelector<HTMLElement>(".chat-thread");
+    return thread
+      ? { sessionKey, scrollHeight: thread.scrollHeight, scrollTop: thread.scrollTop }
+      : null;
+  }
+
+  private syncHistoryObserver(): void {
+    this.historyObserver?.disconnect();
+    this.historyObserver = null;
+    if (this.catalogLoading) {
+      this.historyObserverArmed = false;
+      if (this.loadingOlder) {
+        this.olderLoadGeneration += 1;
+        this.loadingOlder = false;
+        this.pendingHistoryAnchor = null;
+      }
+    }
+    if (
+      typeof IntersectionObserver !== "function" ||
+      this.historyAutoLoadBlocked ||
+      this.loadingOlder ||
+      !this.hasOlderMessages()
+    ) {
+      return;
+    }
+    const root = this.querySelector<HTMLElement>(".chat-thread");
+    const sentinel = root?.querySelector<HTMLElement>(".chat-history-sentinel") ?? null;
+    if (!root || !sentinel) {
+      return;
+    }
+    if (!this.historyObserverArmed) {
+      this.historyObserverArmed = root.scrollHeight <= root.clientHeight;
+    }
+    if (!this.historyObserverArmed) {
+      return;
+    }
+    this.historyObserver = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          void this.loadOlderMessages();
+        }
+      },
+      { root, rootMargin: "300px 0px 0px", threshold: 0 },
+    );
+    this.historyObserver.observe(sentinel);
+  }
+
+  private handleTranscriptScroll(event: Event): void {
+    // A failed intersecting request stays disarmed until the user scrolls again,
+    // preventing a tight retry loop without permanently stranding older history.
+    if (this.historyAutoLoadBlocked) {
+      this.historyAutoLoadBlocked = false;
+      this.syncHistoryObserver();
+    } else if (!this.historyObserverArmed) {
+      this.historyObserverArmed = true;
+      this.syncHistoryObserver();
+    }
+    this.state?.handleChatScroll(event);
+  }
+
+  private async loadOlderMessages(): Promise<void> {
+    const state = this.state;
+    const catalogKey = state ? parseCatalogSessionKey(state.sessionKey) : null;
+    if (!state || !catalogKey || this.loadingOlder || !this.hasOlderMessages()) {
+      return;
+    }
+    const generation = ++this.olderLoadGeneration;
+    this.historyAutoLoadBlocked = false;
+    this.loadingOlder = true;
+    let prepended = false;
+    try {
+      prepended = await this.loadCatalogSession(catalogKey, true);
+    } catch (error) {
+      if (generation === this.olderLoadGeneration) {
+        state.lastError = error instanceof Error ? error.message : String(error);
+      }
+    } finally {
+      if (generation === this.olderLoadGeneration) {
+        if (!prepended) {
+          this.pendingHistoryAnchor = null;
+          this.historyAutoLoadBlocked = this.hasOlderMessages();
+        }
+        this.loadingOlder = false;
+        state.requestUpdate();
       }
     }
   }
@@ -1168,6 +1382,11 @@ class ChatPane extends OpenClawLightDomElement {
     }
   }
 
+  override updated() {
+    this.restoreHistoryAnchor();
+    this.syncHistoryObserver();
+  }
+
   override disconnectedCallback() {
     this.paneResizeObserver?.disconnect();
     this.paneResizeObserver = null;
@@ -1177,6 +1396,7 @@ class ChatPane extends OpenClawLightDomElement {
     this.taskSuggestionBusyIds.clear();
     this.taskSuggestionOperations.clear();
     this.resetSessionPullRequests();
+    this.resetOlderMessagesViewport();
     this.nativeDraftCleanup?.();
     this.nativeDraftCleanup = null;
     this.announceCommandPaletteTarget(null);
@@ -1287,6 +1507,7 @@ class ChatPane extends OpenClawLightDomElement {
       this.taskSuggestions = [];
       this.taskSuggestionBusyIds.clear();
       this.taskSuggestionOperations.clear();
+      this.resetOlderMessagesViewport();
       state.chatLoading = false;
     }
     state.client = snapshot.client;
@@ -1520,13 +1741,13 @@ class ChatPane extends OpenClawLightDomElement {
       compactionStatus: state.compactionStatus,
       fallbackStatus: state.fallbackStatus,
       messages: catalogKey ? this.catalogMessages : state.chatMessages,
-      historyPagination:
-        catalogKey && this.catalogCursor
-          ? {
-              loading: this.catalogLoadingOlder,
-              onLoadOlder: () => void this.loadCatalogSession(catalogKey, true),
-            }
-          : undefined,
+      historyPagination: catalogKey
+        ? {
+            loading: this.loadingOlder,
+            manualFallback: this.hasOlderMessages() && typeof IntersectionObserver !== "function",
+            onLoadOlder: () => void this.loadOlderMessages(),
+          }
+        : undefined,
       sideChatTurns: catalogKey ? [] : state.chatSideChatTurns,
       sideChatPending: catalogKey ? null : state.chatSideResultPending,
       sideChatHidden: catalogKey ? true : state.chatSideChatHidden,
@@ -1663,7 +1884,9 @@ class ChatPane extends OpenClawLightDomElement {
         state.resetToolStream();
         void refreshPageChat(state, { awaitHistory: true, scheduleScroll: false });
       },
-      onChatScroll: state.handleChatScroll,
+      onChatScroll: catalogKey
+        ? (event) => this.handleTranscriptScroll(event)
+        : state.handleChatScroll,
       getDraft: () => state.chatMessage,
       onDraftChange: state.handleChatDraftChange,
       onRequestUpdate: state.requestUpdate,

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -731,8 +731,13 @@ class ChatPane extends OpenClawLightDomElement {
         text ?? catalogRawString(item.raw, ["command", "name", "tool", "title", "query"]);
       content = label ? `Tool call\n\n${label}` : "Tool call";
     } else if (item.type === "toolResult") {
+      // Raw aggregated output is only bounded by the transcript read's per-item
+      // byte cap (megabytes), so clamp it to the preview size before rendering.
+      const aggregated = catalogRawString(item.raw, ["aggregatedOutput"]);
       const output =
-        text ?? catalogRawString(item.raw, ["aggregatedOutput"]) ?? catalogRawResult(item.raw);
+        text ??
+        (aggregated ? clampText(aggregated, CATALOG_TOOL_RESULT_PREVIEW_MAX_CHARS) : null) ??
+        catalogRawResult(item.raw);
       content = output ? `Tool result\n\n${output}` : "Tool result";
     }
     if (!content) {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -717,6 +717,47 @@ describe("chat conversation width", () => {
   });
 });
 
+describe("chat history pagination", () => {
+  it("renders the auto-load sentinel and a spinner while older history loads", () => {
+    const container = renderChatView({
+      historyPagination: {
+        loading: true,
+        manualFallback: false,
+        onLoadOlder: () => undefined,
+      },
+    });
+    const threadInner = requireElement(container, ".chat-thread-inner", "chat thread inner");
+    const sentinel = requireElement(container, ".chat-history-sentinel", "history sentinel");
+
+    expect(threadInner.firstElementChild).toBe(sentinel);
+    expect(sentinel.querySelector(".session-run-spinner")).not.toBeNull();
+    expect(sentinel.querySelector('[role="status"]')?.textContent?.trim()).toBe(
+      t("common.loading"),
+    );
+    expect(sentinel.querySelector("button")).toBeNull();
+  });
+
+  it("keeps a manual button only when IntersectionObserver is unavailable", () => {
+    const onLoadOlder = vi.fn();
+    const container = renderChatView({
+      historyPagination: {
+        loading: false,
+        manualFallback: true,
+        onLoadOlder,
+      },
+    });
+    const button = requireElement(
+      container,
+      ".chat-history-fallback",
+      "history fallback",
+    ) as HTMLButtonElement;
+
+    expect(button.textContent?.trim()).toBe(t("chat.loadOlder"));
+    button.click();
+    expect(onLoadOlder).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("direct thread avatar mode", () => {
   function sessionsListWithKind(sessionKey: string, kind: "direct" | "group" | "global") {
     return {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -74,7 +74,11 @@ export type ChatProps = {
   compactionStatus?: CompactionStatus | null;
   fallbackStatus?: FallbackStatus | null;
   messages: unknown[];
-  historyPagination?: { loading: boolean; onLoadOlder: () => void };
+  historyPagination?: {
+    loading: boolean;
+    manualFallback: boolean;
+    onLoadOlder: () => void;
+  };
   sideChatTurns?: ChatSideResult[];
   sideChatPending?: ChatSideResultPending | null;
   sideChatHidden?: boolean;
@@ -224,6 +228,7 @@ export function renderChat(props: ChatProps) {
     paneId: props.paneId,
     sessionKey: props.sessionKey,
     loading: props.loading,
+    historyPagination: props.historyPagination,
     messages: props.messages,
     toolMessages: props.toolMessages,
     streamSegments: props.streamSegments,
@@ -418,19 +423,6 @@ export function renderChat(props: ChatProps) {
         },
         requestUpdate,
       )}
-      ${props.historyPagination
-        ? html`<div class="chat-history-pagination">
-            <button
-              class="btn btn--sm"
-              type="button"
-              ?disabled=${props.historyPagination.loading}
-              @click=${props.historyPagination.onLoadOlder}
-            >
-              ${props.historyPagination.loading ? t("common.loading") : t("chat.loadOlder")}
-            </button>
-          </div>`
-        : nothing}
-
       <div
         class="chat-workbench ${props.sessionWorkspace?.collapsed
           ? "chat-workbench--workspace-collapsed"

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -90,6 +90,11 @@ type ChatThreadProps = {
   paneId: string;
   sessionKey: string;
   loading: boolean;
+  historyPagination?: {
+    loading: boolean;
+    manualFallback: boolean;
+    onLoadOlder: () => void;
+  };
   messages: unknown[];
   toolMessages: unknown[];
   streamSegments: ChatStreamSegment[];
@@ -828,6 +833,30 @@ export function renderChatThread(props: ChatThreadProps) {
       @pointerup=${(event: PointerEvent) => handleChatThreadSelectionPointerUp(event, props)}
     >
       <div class="chat-thread-inner">
+        ${props.historyPagination
+          ? html`
+              <div class="chat-history-sentinel">
+                ${props.historyPagination.loading
+                  ? html`
+                      <div class="chat-history-loading" role="status">
+                        <span class="session-run-spinner" aria-hidden="true"></span>
+                        <span>${t("common.loading")}</span>
+                      </div>
+                    `
+                  : props.historyPagination.manualFallback
+                    ? html`
+                        <button
+                          class="btn btn--sm chat-history-fallback"
+                          type="button"
+                          @click=${props.historyPagination.onLoadOlder}
+                        >
+                          ${t("chat.loadOlder")}
+                        </button>
+                      `
+                    : nothing}
+              </div>
+            `
+          : nothing}
         ${showLoadingSkeleton ? renderLoadingSkeleton() : nothing}
         ${isEmpty && !state.searchOpen ? renderWelcomeState(props) : nothing}
         ${isEmpty && state.searchOpen

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -120,6 +120,21 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   margin-inline: auto;
 }
 
+.chat-history-sentinel {
+  display: flex;
+  min-height: 28px;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-history-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
 /* The zero-height anchor keeps the affordance out of the flex flow so showing
    it never shrinks the transcript or moves the composer. */
 .chat-scroll-to-bottom-wrap {


### PR DESCRIPTION
Closes #105165

## What Problem This Solves

Viewing an external Claude Code / Codex catalog session in the Chat pane, older history sat behind a manual **"Load older"** button; scrolling up loaded nothing and there was no loading affordance. Tool-call, tool-result, and reasoning items with no plain-text body rendered as an ugly `[Unsupported external session item]` placeholder.

## Why This Change Was Made

Catalog sessions should browse like native ones — scroll up, older messages appear, viewport stays put. This adds auto-load-on-scroll for external (read-only) catalog transcripts and fixes the placeholder rendering. Native-session scroll-back needs server-side history paging work and is tracked separately in #105127.

## User Impact

- Scrolling a Claude/Codex catalog transcript near the top auto-loads the next older page (IntersectionObserver on a top sentinel), with an inline spinner while it loads. The viewport is anchored — prepended history does not move what you were reading. Loading stops when the cursor is exhausted. The manual button remains only as a fallback (no `IntersectionObserver`, or to retry after a transient failure on a short, non-scrollable thread).
- Tool calls, tool results, and reasoning now render their real content (command, tool name, aggregated output) pulled from the item's structured `raw` data, or are cleanly skipped — no more `[Unsupported external session item]`.
- Native OpenClaw sessions are unchanged (this touches only the catalog transcript path).

## Evidence

- **Live-verified** on a gateway built from this branch against a real `~/.claude`:
  - Older-page load: 49 → 99 messages on trigger; cursor advances for further pages.
  - Viewport anchoring: after prepending 6106px of older content, `scrollTop` auto-shifted 0 → 5890 to keep the same message in view (no jump).
  - Placeholder fix: a catalog transcript that previously showed `[Unsupported external session item]` now renders `Tool call` / `Tool result` with real content and **zero** placeholder nodes.
- **Real-Chromium E2E** (`ui/src/e2e/claude-sessions.e2e.test.ts`): scroll-to-top fires the observer → `.chat-history-loading` spinner appears → older page loads → `after.scrollTop ≈ before.scrollTop + (after.scrollHeight - before.scrollHeight)` (anchoring) → no "Load older" button in auto mode → second scroll-to-top with exhausted cursor triggers no further load.
- **Unit** (`ui/src/pages/chat/chat-pane.test.ts`): raw-derived tool-call/tool-result/reasoning mapping; empty unknown item skipped; failed auto-load re-arms only on user scroll; blocked auto-load is recoverable via the fallback's `loadOlderMessages`.
- `node scripts/run-vitest.mjs ui/src/pages/chat/...` and the catalog e2e pass locally; changed-file oxlint clean; `pnpm build` clean (no `[INEFFECTIVE_DYNAMIC_IMPORT]`); i18n check clean on the rebased branch.
- Structured autoreview run; the one accepted finding (short-thread blocked-fallback retry) is fixed in-branch with a regression test.
- Known gap: native-session scroll-back deferred to #105127 (server paging contract work).
