### PR TITLE
test(browser): align snapshot contract fixtures

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
@@ -56,6 +56,16 @@ vi.mock("./pw-session.page-cdp.js", () => pageCdpMocks);
 const interactions = await import("./pw-tools-core.interactions.js");
 const snapshots = await import("./pw-tools-core.snapshot.js");
 
+function createSnapshotPage(overrides: Record<string, unknown>) {
+  const mainFrame = {};
+  return {
+    mainFrame: vi.fn(() => mainFrame),
+    on: vi.fn(),
+    off: vi.fn(),
+    ...overrides,
+  };
+}
+
 describe("pw-tools-core browser SSRF guards", () => {
   beforeEach(() => {
     pageState.page = null;
@@ -1038,10 +1048,10 @@ describe("pw-tools-core browser SSRF guards", () => {
 
   it("re-checks current page URL before snapshotting AI content", async () => {
     const ariaSnapshot = vi.fn(async () => 'button "Save"');
-    pageState.page = {
+    pageState.page = createSnapshotPage({
       ariaSnapshot,
       url: vi.fn(() => "https://example.com"),
-    };
+    });
 
     await snapshots.snapshotAiViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
@@ -1063,10 +1073,10 @@ describe("pw-tools-core browser SSRF guards", () => {
 
   it("re-checks current page URL before role snapshots", async () => {
     const ariaSnapshot = vi.fn(async () => "");
-    pageState.page = {
+    pageState.page = createSnapshotPage({
       locator: vi.fn(() => ({ ariaSnapshot })),
       url: vi.fn(() => "https://example.com"),
-    };
+    });
 
     await snapshots.snapshotRoleViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -497,6 +497,8 @@ describe("browser control server", () => {
     expect(cdpMocks.snapshotRoleViaCdp).toHaveBeenCalledWith({
       wsUrl: "ws://127.0.0.1/devtools/page/abcd1234",
       urls: undefined,
+      maxChars: DEFAULT_AI_SNAPSHOT_MAX_CHARS,
+      timeoutMs: undefined,
       options: {
         interactive: true,
         compact: undefined,


### PR DESCRIPTION
## Summary

- complete the SSRF snapshot Page fake with the Playwright lifecycle methods now used by navigation guards
- assert current CDP fallback forwarding for snapshot output budget and timeout
- restore the exact browser failures from Plugin Prerelease

## Verification

- `node scripts/run-vitest.mjs extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts extensions/browser/src/browser/server.agent-contract-core.test.ts` (59 passed)
- `git diff --check`
- fresh autoreview: clean, no accepted/actionable findings

Release note: none; test-contract-only release-validation repair.
