### PR TITLE
fix(ci): stop legacy QA smoke compatibility timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1197,13 +1197,58 @@ jobs:
           if (typeof smokePlan.createQaSmokeCiPart === "function") {
             runs = smokePlan.createQaSmokeCiPart(partId).runs;
           } else if (typeof smokePlan.createQaSmokeCiMatrix === "function") {
+            // Legacy planners select the entire profile and can mix long-lived
+            // execution kinds. Reuse the current bounded smoke contract and
+            // isolate each kind so frozen targets cannot pin a profile part.
+            const compatibilityScenarioIds = new Set([
+              "control-ui-chat-flow-playwright",
+              "crestodian-ring-zero-setup",
+              "dreaming-shadow-trial-report",
+              "gateway-smoke",
+              "group-visible-reply-tool",
+              "long-running-release-audit",
+              "luna-thinking-visibility-switch",
+              "matrix-restart-resume",
+              "personal-task-followthrough-status",
+              "plugin-lifecycle-hot-reload",
+              "subagent-completion-direct-fallback",
+              "telegram-commands-command",
+            ]);
             const partIndex = partId === "profile-1" ? 0 : partId === "profile-2" ? 1 : -1;
             if (partIndex < 0) {
               throw new Error(`unknown QA smoke CI profile part: ${partId}`);
             }
-            runs = smokePlan
+            const scenarioCatalog = await import("./extensions/qa-lab/src/scenario-catalog.ts");
+            const scenarioKindById = new Map(
+              scenarioCatalog
+                .readQaScenarioPack()
+                .scenarios.map((scenario) => [scenario.id, scenario.execution.kind]),
+            );
+            const legacyRuns = smokePlan
               .createQaSmokeCiMatrix()
               .include.filter((_, index) => index % 2 === partIndex);
+            runs = legacyRuns.flatMap((run) => {
+              const scenarioIdsByKind = new Map();
+              for (const scenarioId of run.scenario_ids) {
+                if (!compatibilityScenarioIds.has(scenarioId)) {
+                  continue;
+                }
+                const kind = scenarioKindById.get(scenarioId);
+                if (!kind) {
+                  throw new Error(`legacy QA smoke scenario not found: ${scenarioId}`);
+                }
+                const scenarioIds = scenarioIdsByKind.get(kind) ?? [];
+                scenarioIds.push(scenarioId);
+                scenarioIdsByKind.set(kind, scenarioIds);
+              }
+              return [...scenarioIdsByKind.entries()]
+                .toSorted(([left], [right]) => left.localeCompare(right))
+                .map(([kind, scenarioIds]) => ({
+                  ...run,
+                  slug: `${run.slug}-${kind}`,
+                  scenario_ids: scenarioIds,
+                }));
+            });
           } else {
             throw new Error("QA smoke plan does not expose a supported CI planner.");
           }

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2675,6 +2675,15 @@ describe("ci workflow guards", () => {
     expect(smokeProfileJob["runs-on"]).toContain("blacksmith-16vcpu-ubuntu-2404");
     expect(smokeRunStep.run).toContain("createQaSmokeCiPart");
     expect(smokeRunStep.run).toContain("createQaSmokeCiMatrix");
+    expect(smokeRunStep.run).toContain("readQaScenarioPack");
+    expect(smokeRunStep.run).toContain("scenarioIdsByKind");
+    const compatibilityScenarioBlock = smokeRunStep.run.match(
+      /const compatibilityScenarioIds = new Set\(\[([\s\S]*?)\]\);/u,
+    )?.[1];
+    expect(compatibilityScenarioBlock?.match(/^\s+"[^"]+",$/gmu)).toHaveLength(12);
+    expect(compatibilityScenarioBlock).toContain('"control-ui-chat-flow-playwright"');
+    expect(compatibilityScenarioBlock).toContain('"gateway-smoke"');
+    expect(compatibilityScenarioBlock).toContain('"matrix-restart-resume"');
     expect(smokeRunStep.run).toContain("No QA smoke runs assigned");
     expect(smokeRunStep.run).toContain("node openclaw.mjs qa run");
     expect(smokeRunStep.run).not.toContain("pnpm openclaw qa run");


### PR DESCRIPTION
Related: #104909

## What Problem This Solves

Fixes an issue where release validation for an older beta target would run the legacy full QA smoke matrix inside one compatibility profile part, finish all visible flow scenarios, then time out after ten minutes without aggregate evidence.

The exact beta failure was run 29186268875, job 86632829560. Its artifact preserved 44 passing flow/script scenarios; the mixed invocation then stopped producing output after the final passing flow at 08:51:30 UTC and exited 124 at 08:54:04 UTC.

## Why This Change Was Made

Current targets keep using their native 12-scenario bounded planner unchanged. For frozen targets that only expose the legacy matrix planner, the compatibility path now selects the same bounded 12-scenario smoke contract and separates runs by execution kind before invoking the old harness. This removes the broad mixed-lifecycle invocation while preserving every selected scenario's original assertions and fail-closed exit handling.

## User Impact

Beta, extended-stable, and historical release validation can complete the QA smoke compatibility lane without spending the entire deadline on the old broad mixed runner. Current main CI behavior is unchanged.

## Evidence

- Failing exact beta run: https://github.com/openclaw/openclaw/actions/runs/29186268875/job/86632829560
- Failure artifact: https://github.com/openclaw/openclaw/actions/runs/29186268875/artifacts/8258193300
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29186855024 — 54 focused tests passed across the QA smoke planner and CI workflow guards.
- `actionlint .github/workflows/ci.yml` passed.
- `git diff --check` passed.
- Fresh autoreview: clean; no accepted or actionable findings.

AI-assisted. No agent transcript attached, per maintainer instruction.
