### PR TITLE
perf(agents): reduce repeated turn setup latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Agent turn startup:** carry prepared provider route models into auth initialization so repeated Gateway turns avoid duplicate model discovery while preserving independent profile and fallback routes. (#105207)
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent turn startup:** carry prepared provider route models into auth initialization so repeated Gateway turns avoid duplicate model discovery while preserving independent profile and fallback routes. (#105207)
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -1922,6 +1922,7 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     }
 
     expect(mockedGetApiKeyForModel).toHaveBeenCalledTimes(1);
+    expect(mockedResolveModelAsync).toHaveBeenCalledTimes(1);
     expect(mockedBuildAgentRuntimePlan).toHaveBeenCalledTimes(1);
     expect(authStorage.setRuntimeApiKey).toHaveBeenCalledTimes(1);
     const pluginParams = expectMockCallFields(pluginRunAttempt, {
@@ -2841,11 +2842,6 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       authStorage,
     });
     queueOpenAIResolvedModel({
-      api: "openai-responses",
-      baseUrl: "https://api.openai.com/v1",
-      authStorage,
-    });
-    queueOpenAIResolvedModel({
       api: "openai-chatgpt-responses",
       baseUrl: "https://chatgpt.com/backend-api/codex",
       authStorage,
@@ -2906,6 +2902,7 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     }
 
     expect(mockedGetApiKeyForModel).toHaveBeenCalledOnce();
+    expect(mockedResolveModelAsync).toHaveBeenCalledTimes(3);
     expect(pluginRunAttempt).toHaveBeenCalledTimes(2);
     const firstAttempt = mockCallArg(pluginRunAttempt) as EmbeddedRunAttemptParams;
     const secondAttempt = mockCallArg(pluginRunAttempt, 1) as EmbeddedRunAttemptParams;

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1495,6 +1495,7 @@ async function runEmbeddedAgentInternal(
       agentHarness = selectHarnessForModel(effectiveModel);
       pluginHarnessOwnsTransport = agentHarness.id !== "openclaw";
 
+      const authStages = log.isEnabled("trace") ? createEmbeddedRunStageTracker() : undefined;
       const usesOpenAIAuthRouting = provider === OPENAI_PROVIDER_ID;
       const openClawNativeCodexResponsesNeedsAuthBootstrap =
         !pluginHarnessOwnsTransport &&
@@ -1532,6 +1533,7 @@ async function runEmbeddedAgentInternal(
             params.authProfileIdSource === "user" ? params.authProfileId : undefined,
         });
       }
+      authStages?.mark("scope");
       const attemptAuthProfileStore = usesOpenAIAuthRouting
         ? ensureAuthProfileStore(agentDir, {
             externalCliProviderIds: [OPENAI_PROVIDER_ID],
@@ -1550,6 +1552,7 @@ async function runEmbeddedAgentInternal(
               ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
                 allowKeychainPrompt: false,
               }));
+      authStages?.mark("store");
       const requestedProfileId = params.authProfileId?.trim() || undefined;
       const lockedProfileId =
         params.authProfileIdSource === "user" ? requestedProfileId : undefined;
@@ -1586,12 +1589,19 @@ async function runEmbeddedAgentInternal(
             }),
         });
 
-      const materializeAuthPlan = async (plan: AgentRuntimeAuthPlan) => {
+      const materializedRouteModels = new WeakMap<
+        AgentRuntimeAuthPlan,
+        Promise<typeof runtimeModel>
+      >();
+      const materializeAuthPlanUncached = async (plan: AgentRuntimeAuthPlan) => {
         // Native harness sessions own their model tuple. Route preparation may
         // attest auth/transport, but must not rediscover or replace that model.
         if (nativeModelOwned) {
           return runtimeModel;
         }
+        const requiresCredentialScopedResolve = Boolean(
+          plan.modelRoute && (plan.forwardedAuthProfileId || params.authProfileId),
+        );
         return (
           (await materializePreparedRuntimeModel({
             plan,
@@ -1599,7 +1609,9 @@ async function runEmbeddedAgentInternal(
             modelId,
             config: params.config,
             model: runtimeModel,
-            forceResolve: Boolean(plan.modelRoute),
+            // Unscoped direct auth cannot change credential-scoped metadata.
+            // Reuse an already matching tuple; route mismatches still resolve.
+            forceResolve: requiresCredentialScopedResolve,
             resolveModel: ({ config, authProfileId, authProfileMode }) =>
               resolveModelAsync(provider, modelId, agentDir, config, {
                 authStorage,
@@ -1614,10 +1626,25 @@ async function runEmbeddedAgentInternal(
           })) ?? runtimeModel
         );
       };
+      const materializeAuthPlan = (plan: AgentRuntimeAuthPlan) => {
+        if (!plan.modelRoute) {
+          return materializeAuthPlanUncached(plan);
+        }
+        const cached = materializedRouteModels.get(plan);
+        if (cached) {
+          return cached;
+        }
+        // Prepared plans are immutable within one run. Carry their exact model
+        // tuple into auth initialization instead of repeating provider discovery.
+        const materialized = materializeAuthPlanUncached(plan);
+        materializedRouteModels.set(plan, materialized);
+        return materialized;
+      };
       let resolvedAuthPreparation = createAuthPreparation();
       let preparedAuthAttempts = resolvedAuthPreparation.attempts;
       let activePreparedAuthPlan = resolvedAuthPreparation.plan;
       applyResolvedRuntimeModel(await materializeAuthPlan(activePreparedAuthPlan));
+      authStages?.mark("prepare-plan");
 
       const finalizedHarness = selectHarnessForPreparedAttempts(
         effectiveModel,
@@ -1640,6 +1667,7 @@ async function runEmbeddedAgentInternal(
           );
         }
       }
+      authStages?.mark("harness");
       // A selected plugin harness owns context pressure with its native transcript,
       // even if it cannot expose manual compaction. Generic recovery is OpenClaw-only.
       const genericCompactionRecoveryAllowed = !pluginHarnessOwnsTransport;
@@ -1851,6 +1879,7 @@ async function runEmbeddedAgentInternal(
         },
         log,
       });
+      authStages?.mark("controller");
       const advancePluginHarnessAuthAttempt = async (): Promise<boolean> => {
         if (!pluginHarnessOwnsTransport || lockedProfileId) {
           return false;
@@ -1950,6 +1979,15 @@ async function runEmbeddedAgentInternal(
           preparedProfileAttempted = initialAttempt?.kind === "profile";
           lastProfileId = forwardedPluginHarnessProfileId;
         }
+      }
+      authStages?.mark("initialize");
+      if (authStages) {
+        log.trace(
+          formatEmbeddedRunStageSummary(
+            `[trace:embedded-run] auth stages: runId=${params.runId} sessionId=${params.sessionId} phase=auth`,
+            authStages.snapshot(),
+          ),
+        );
       }
       startupStages.mark("auth");
       notifyExecutionPhase("auth", { provider, model: modelId });


### PR DESCRIPTION
Closes #105207

## What Problem This Solves

Repeated Gateway agent turns materialized the same prepared OpenAI route twice during auth setup. On a warm process, duplicate provider/model discovery accounted for roughly half of the local pre-model latency measured in the live path.

## Why This Change Was Made

The runner now carries the exact materialized model forward for the same immutable auth-plan object. Unscoped direct-auth routes also reuse an already matching runtime model tuple, while credential-scoped, profile, mismatch, and fallback routes continue to resolve independently. Trace-only auth substages make future regressions attributable without adding normal-path logging.

AI-assisted: yes. The implementation, route invariants, tests, live provider runs, and benchmark measurements were reviewed and verified by the maintainer agent.

## User Impact

In repeated live `openai/gpt-5.6` Gateway turns, warm median local pre-model setup fell from 441.5 ms to 206.5 ms (53.2%). Warm auth setup fell from 236 ms to 8 ms, and cold pre-model setup fell from 1169 ms to 983 ms. Provider response and tool execution time are unchanged.

## Evidence

- Live baseline: `run_05d253dc5e45`; warm pre-model 455 ms / 428 ms, auth 235 ms / 237 ms.
- Live final: `run_68ba04715c1a`; warm pre-model 187 ms / 226 ms, auth 7 ms / 9 ms.
- Live Node CPU profile: `run_0eae5386bbe1`; local samples identified repeated module/package resolution in the duplicated materialization path.
- Live build: `run_86d623a9d822` passed on fresh AWS Crabbox.
- Focused Testbox proof: 67/67 tests passed on the rebased patch.
- `check:changed` passed formatting, lint, typecheck, cycle, and guard lanes before the final clean rebase.
- Fresh autoreview: clean, no accepted or actionable findings.

