### PR TITLE
fix(sqlite): reject orphaned database state before mutation

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -224,13 +224,14 @@ The command:
    process and retry if the checkpoint is busy.
 4. Sets `auto_vacuum` to `INCREMENTAL`, runs a full `VACUUM`, and checkpoints
    again.
-5. Runs both `quick_check` and `integrity_check`, then reapplies owner-only
-   permissions to the database and SQLite sidecar files.
+5. Runs `quick_check`, `integrity_check`, and `foreign_key_check`, then
+   reapplies owner-only permissions to the database and SQLite sidecar files.
 
 JSON output reports the database and WAL sizes, freelist pages, page size, and
-`auto_vacuum` value before and after compaction, plus reclaimed bytes and both
-verification results. SQLite reports `auto_vacuum` as `0` for none, `1` for
-full, and `2` for incremental.
+`auto_vacuum` value before and after compaction, plus reclaimed bytes and the
+`quick_check` and `integrity_check` results. `foreign_key_check` is enforced
+fail-closed and has no separate success field. SQLite reports `auto_vacuum` as
+`0` for none, `1` for full, and `2` for incremental.
 
 Compaction fails without mutation when the schema is old, newer than the
 running OpenClaw build, or belongs to an agent database. Run

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -275,6 +275,47 @@ describe("backupVerifyCommand", () => {
     );
   });
 
+  it("rejects canonical SQLite snapshots with foreign-key violations", async () => {
+    const stateAssetArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw`;
+    const sqliteArchivePath = `${stateAssetArchivePath}/state/openclaw.sqlite`;
+    const sqlitePayload = await createSqlitePayload((database) => {
+      database.exec(`
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE schema_meta (
+          meta_key TEXT NOT NULL PRIMARY KEY,
+          role TEXT NOT NULL
+        );
+        INSERT INTO schema_meta (meta_key, role) VALUES ('primary', 'global');
+        CREATE TABLE parents (id INTEGER PRIMARY KEY);
+        CREATE TABLE children (
+          id INTEGER PRIMARY KEY,
+          parent_id INTEGER NOT NULL REFERENCES parents(id)
+        );
+        INSERT INTO children (id, parent_id) VALUES (1, 99);
+      `);
+    });
+
+    await withBrokenArchiveFixture(
+      {
+        tempPrefix: "openclaw-backup-foreign-key-",
+        manifestAssetArchivePath: stateAssetArchivePath,
+        payloads: [
+          {
+            fileName: "openclaw.sqlite",
+            contents: sqlitePayload,
+            archivePath: sqliteArchivePath,
+          },
+        ],
+      },
+      async (archivePath) => {
+        const runtime = createBackupVerifyRuntime();
+        await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+          /Backup SQLite snapshot failed verification.*foreign_key_check failed.*children row 1 references parents \(foreign key 0\)/iu,
+        );
+      },
+    );
+  });
+
   it("does not interpret plugin-owned SQLite schemas without their owner runtime", async () => {
     const stateAssetArchivePath = `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw`;
     const sqliteArchivePath = `${stateAssetArchivePath}/plugins/dedicated/custom.sqlite`;

--- a/src/commands/doctor-state-sqlite-compact.test.ts
+++ b/src/commands/doctor-state-sqlite-compact.test.ts
@@ -284,4 +284,52 @@ describe("runDoctorStateSqliteCompact", () => {
       after.close();
     }
   });
+
+  it("rejects foreign-key violations before mutating the database", () => {
+    const env = createStateEnv();
+    const sqlitePath = seedStateDatabase({ env, withBloat: true });
+    const sqlite = requireNodeSqlite();
+    const corrupted = new sqlite.DatabaseSync(sqlitePath);
+    try {
+      corrupted.exec(`
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE compact_parents (id INTEGER PRIMARY KEY);
+        CREATE TABLE compact_children (
+          id INTEGER PRIMARY KEY,
+          parent_id INTEGER NOT NULL REFERENCES compact_parents(id)
+        );
+        INSERT INTO compact_children (id, parent_id) VALUES (1, 99);
+      `);
+      expect(corrupted.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
+      expect(corrupted.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+      expect(corrupted.prepare("PRAGMA foreign_key_check").get()).toEqual({
+        table: "compact_children",
+        rowid: 1,
+        parent: "compact_parents",
+        fkid: 0,
+      });
+    } finally {
+      corrupted.close();
+    }
+
+    expect(() => runDoctorStateSqliteCompact({ env })).toThrow(
+      /foreign_key_check failed.*compact_children row 1 references compact_parents \(foreign key 0\)/iu,
+    );
+
+    const after = new sqlite.DatabaseSync(sqlitePath, { readOnly: true });
+    try {
+      expect(readPragma(after, "auto_vacuum")).toBe(0);
+      expect(readPragma(after, "freelist_count")).toBeGreaterThan(0);
+      expect(after.prepare("PRAGMA foreign_key_check").get()).toEqual({
+        table: "compact_children",
+        rowid: 1,
+        parent: "compact_parents",
+        fkid: 0,
+      });
+    } finally {
+      after.close();
+    }
+  });
 });

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -670,6 +670,48 @@ describe("createBackupArchive", () => {
     );
   });
 
+  it("rejects foreign-key violations before creating a backup archive", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-foreign-key-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+        openOpenClawStateDatabase({ env: state.env });
+        closeOpenClawStateDatabase();
+
+        const sqlite = requireNodeSqlite();
+        const database = new sqlite.DatabaseSync(resolveOpenClawStateSqlitePath(state.env));
+        try {
+          database.exec("PRAGMA foreign_keys = OFF;");
+          database
+            .prepare("INSERT INTO task_delivery_state (task_id) VALUES (?)")
+            .run("missing-task");
+          expect(database.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
+          expect(database.prepare("PRAGMA integrity_check").get()).toEqual({
+            integrity_check: "ok",
+          });
+        } finally {
+          database.close();
+        }
+
+        await expect(
+          createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: Date.UTC(2026, 4, 9, 8, 30, 30),
+          }),
+        ).rejects.toThrow(
+          /foreign_key_check failed.*task_delivery_state row 1 references task_runs \(foreign key 0\)/iu,
+        );
+        expect(await fs.readdir(outputDir)).toEqual([]);
+      },
+    );
+  });
+
   it("snapshots per-agent SQLite auth stores without deleted secret pages", async () => {
     await withOpenClawTestState(
       {

--- a/src/infra/sqlite-integrity.test.ts
+++ b/src/infra/sqlite-integrity.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { assertSqliteIntegrity } from "./sqlite-integrity.js";
+
+describe("assertSqliteIntegrity", () => {
+  it("accepts structurally and referentially consistent databases", () => {
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(":memory:");
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE parents (id INTEGER PRIMARY KEY);
+        CREATE TABLE children (
+          id INTEGER PRIMARY KEY,
+          parent_id INTEGER NOT NULL REFERENCES parents(id)
+        );
+        INSERT INTO parents (id) VALUES (1);
+        INSERT INTO children (id, parent_id) VALUES (1, 1);
+      `);
+
+      expect(assertSqliteIntegrity(database, "test database")).toEqual({
+        integrityCheck: "ok",
+        quickCheck: "ok",
+      });
+    } finally {
+      database.close();
+    }
+  });
+
+  it("rejects foreign-key violations that structural checks do not detect", () => {
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(":memory:");
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE parents (id INTEGER PRIMARY KEY);
+        CREATE TABLE children (
+          id INTEGER PRIMARY KEY,
+          parent_id INTEGER NOT NULL REFERENCES parents(id)
+        );
+        INSERT INTO children (id, parent_id) VALUES (1, 99);
+      `);
+      expect(database.prepare("PRAGMA quick_check;").get()).toEqual({ quick_check: "ok" });
+      expect(database.prepare("PRAGMA integrity_check;").get()).toEqual({
+        integrity_check: "ok",
+      });
+
+      expect(() => assertSqliteIntegrity(database, "test database")).toThrow(
+        /foreign_key_check failed for test database: children row 1 references parents \(foreign key 0\)/u,
+      );
+    } finally {
+      database.close();
+    }
+  });
+
+  it("reports violations deterministically without truncating 64-bit rowids", () => {
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(":memory:");
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE parents (id INTEGER PRIMARY KEY);
+        CREATE TABLE children (
+          id INTEGER PRIMARY KEY,
+          parent_id INTEGER NOT NULL REFERENCES parents(id)
+        );
+        INSERT INTO children (id, parent_id)
+        VALUES (9007199254740993, 99), (1, 99);
+      `);
+
+      expect(() => assertSqliteIntegrity(database, "test database")).toThrow(
+        /children row 1 references parents \(foreign key 0\); children row 9007199254740993 references parents \(foreign key 0\)/u,
+      );
+    } finally {
+      database.close();
+    }
+  });
+
+  it("bounds foreign-key violation diagnostics", () => {
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(":memory:");
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE parents (id INTEGER PRIMARY KEY);
+        CREATE TABLE children (
+          id INTEGER PRIMARY KEY,
+          parent_id INTEGER NOT NULL REFERENCES parents(id)
+        );
+        INSERT INTO children (id, parent_id)
+        VALUES (1, 99), (2, 99), (3, 99), (4, 99), (5, 99), (6, 99);
+      `);
+
+      expect(() => assertSqliteIntegrity(database, "test database")).toThrow(
+        /children row 5 references parents \(foreign key 0\); additional violations omitted$/u,
+      );
+    } finally {
+      database.close();
+    }
+  });
+
+  it("identifies violations in WITHOUT ROWID tables", () => {
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(":memory:");
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE parents (id TEXT PRIMARY KEY);
+        CREATE TABLE children (
+          id TEXT PRIMARY KEY,
+          parent_id TEXT NOT NULL REFERENCES parents(id)
+        ) WITHOUT ROWID;
+        INSERT INTO children (id, parent_id) VALUES ('child-1', 'missing-parent');
+      `);
+
+      expect(() => assertSqliteIntegrity(database, "test database")).toThrow(
+        /foreign_key_check failed for test database: children row without rowid references parents \(foreign key 0\)/u,
+      );
+    } finally {
+      database.close();
+    }
+  });
+});

--- a/src/infra/sqlite-integrity.test.ts
+++ b/src/infra/sqlite-integrity.test.ts
@@ -99,6 +99,37 @@ describe("assertSqliteIntegrity", () => {
     }
   });
 
+  it("cannot be bypassed by a schema object shadowing the table-valued pragma", () => {
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(":memory:");
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE parents (id INTEGER PRIMARY KEY);
+        CREATE TABLE children (
+          id INTEGER PRIMARY KEY,
+          parent_id INTEGER NOT NULL REFERENCES parents(id)
+        );
+        INSERT INTO children (id, parent_id) VALUES (1, 99);
+        CREATE TABLE pragma_foreign_key_check (
+          "table" TEXT NOT NULL,
+          rowid INTEGER,
+          parent TEXT NOT NULL,
+          fkid INTEGER NOT NULL
+        );
+      `);
+      expect(
+        database.prepare('SELECT "table", rowid, parent, fkid FROM pragma_foreign_key_check').all(),
+      ).toEqual([]);
+
+      expect(() => assertSqliteIntegrity(database, "test database")).toThrow(
+        /foreign_key_check failed for test database: children row 1 references parents \(foreign key 0\)/u,
+      );
+    } finally {
+      database.close();
+    }
+  });
+
   it("identifies violations in WITHOUT ROWID tables", () => {
     const sqlite = requireNodeSqlite();
     const database = new sqlite.DatabaseSync(":memory:");

--- a/src/infra/sqlite-integrity.ts
+++ b/src/infra/sqlite-integrity.ts
@@ -6,16 +6,24 @@ export type SqliteIntegrityChecks = {
 };
 
 type SqliteCheckPragma = "integrity_check" | "quick_check";
+type SqliteForeignKeyViolation = {
+  fkid: bigint;
+  parent: string;
+  rowid: bigint | null;
+  table: string;
+};
 
-/** Require both structural and table/index consistency before trusting a database. */
+const MAX_REPORTED_FOREIGN_KEY_VIOLATIONS = 5;
+
+/** Require structural, table/index, and referential consistency before trusting a database. */
 export function assertSqliteIntegrity(
   database: DatabaseSync,
   databaseLabel: string,
 ): SqliteIntegrityChecks {
-  return {
-    quickCheck: runSqliteCheck(database, databaseLabel, "quick_check"),
-    integrityCheck: runSqliteCheck(database, databaseLabel, "integrity_check"),
-  };
+  const quickCheck = runSqliteCheck(database, databaseLabel, "quick_check");
+  const integrityCheck = runSqliteCheck(database, databaseLabel, "integrity_check");
+  runSqliteForeignKeyCheck(database, databaseLabel);
+  return { integrityCheck, quickCheck };
 }
 
 /** Require table and associated index consistency before trusting indexed reads. */
@@ -43,4 +51,46 @@ function runSqliteCheck(
   }
   const details = results.map((result) => String(result)).join("; ") || "no result";
   throw new Error(`SQLite ${pragma} failed for ${databaseLabel}: ${details}`);
+}
+
+function runSqliteForeignKeyCheck(database: DatabaseSync, databaseLabel: string): void {
+  let violations: SqliteForeignKeyViolation[];
+  try {
+    const statement = database.prepare(`
+      SELECT "table", rowid, parent, fkid
+      FROM pragma_foreign_key_check
+      ORDER BY
+        "table" COLLATE BINARY,
+        rowid IS NOT NULL,
+        rowid,
+        parent COLLATE BINARY,
+        fkid
+      LIMIT ?
+    `);
+    statement.setReadBigInts(true);
+    violations = statement.all(
+      MAX_REPORTED_FOREIGN_KEY_VIOLATIONS + 1,
+    ) as SqliteForeignKeyViolation[];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`SQLite foreign_key_check failed for ${databaseLabel}: ${message}`, {
+      cause: error,
+    });
+  }
+  if (violations.length === 0) {
+    return;
+  }
+
+  const details = violations
+    .slice(0, MAX_REPORTED_FOREIGN_KEY_VIOLATIONS)
+    .map(formatSqliteForeignKeyViolation);
+  if (violations.length > MAX_REPORTED_FOREIGN_KEY_VIOLATIONS) {
+    details.push("additional violations omitted");
+  }
+  throw new Error(`SQLite foreign_key_check failed for ${databaseLabel}: ${details.join("; ")}`);
+}
+
+function formatSqliteForeignKeyViolation(violation: SqliteForeignKeyViolation): string {
+  const row = violation.rowid === null ? "row without rowid" : `row ${violation.rowid.toString()}`;
+  return `${violation.table} ${row} references ${violation.parent} (foreign key ${violation.fkid.toString()})`;
 }

--- a/src/infra/sqlite-integrity.ts
+++ b/src/infra/sqlite-integrity.ts
@@ -54,23 +54,18 @@ function runSqliteCheck(
 }
 
 function runSqliteForeignKeyCheck(database: DatabaseSync, databaseLabel: string): void {
-  let violations: SqliteForeignKeyViolation[];
+  let violationCount = 0;
+  const violations: SqliteForeignKeyViolation[] = [];
   try {
-    const statement = database.prepare(`
-      SELECT "table", rowid, parent, fkid
-      FROM pragma_foreign_key_check
-      ORDER BY
-        "table" COLLATE BINARY,
-        rowid IS NOT NULL,
-        rowid,
-        parent COLLATE BINARY,
-        fkid
-      LIMIT ?
-    `);
+    // Use direct PRAGMA syntax because a real schema object can shadow the
+    // table-valued pragma name and make a corrupt database appear clean.
+    const statement = database.prepare("PRAGMA foreign_key_check;");
     statement.setReadBigInts(true);
-    violations = statement.all(
-      MAX_REPORTED_FOREIGN_KEY_VIOLATIONS + 1,
-    ) as SqliteForeignKeyViolation[];
+    // OpenClaw's Node >=22.19 floor includes iterate(), added in Node 22.13.
+    for (const violation of statement.iterate() as Iterable<SqliteForeignKeyViolation>) {
+      violationCount += 1;
+      retainSortedForeignKeyViolation(violations, violation);
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`SQLite foreign_key_check failed for ${databaseLabel}: ${message}`, {
@@ -81,13 +76,47 @@ function runSqliteForeignKeyCheck(database: DatabaseSync, databaseLabel: string)
     return;
   }
 
-  const details = violations
-    .slice(0, MAX_REPORTED_FOREIGN_KEY_VIOLATIONS)
-    .map(formatSqliteForeignKeyViolation);
-  if (violations.length > MAX_REPORTED_FOREIGN_KEY_VIOLATIONS) {
+  const details = violations.map(formatSqliteForeignKeyViolation);
+  if (violationCount > MAX_REPORTED_FOREIGN_KEY_VIOLATIONS) {
     details.push("additional violations omitted");
   }
   throw new Error(`SQLite foreign_key_check failed for ${databaseLabel}: ${details.join("; ")}`);
+}
+
+function retainSortedForeignKeyViolation(
+  retained: SqliteForeignKeyViolation[],
+  violation: SqliteForeignKeyViolation,
+): void {
+  retained.push(violation);
+  retained.sort(compareSqliteForeignKeyViolations);
+  if (retained.length > MAX_REPORTED_FOREIGN_KEY_VIOLATIONS) {
+    retained.pop();
+  }
+}
+
+function compareSqliteForeignKeyViolations(
+  left: SqliteForeignKeyViolation,
+  right: SqliteForeignKeyViolation,
+): number {
+  const tableOrder = Buffer.compare(Buffer.from(left.table), Buffer.from(right.table));
+  if (tableOrder !== 0) {
+    return tableOrder;
+  }
+  if (left.rowid === null || right.rowid === null) {
+    if (left.rowid !== right.rowid) {
+      return left.rowid === null ? -1 : 1;
+    }
+  } else if (left.rowid !== right.rowid) {
+    return left.rowid < right.rowid ? -1 : 1;
+  }
+  const parentOrder = Buffer.compare(Buffer.from(left.parent), Buffer.from(right.parent));
+  if (parentOrder !== 0) {
+    return parentOrder;
+  }
+  if (left.fkid === right.fkid) {
+    return 0;
+  }
+  return left.fkid < right.fkid ? -1 : 1;
 }
 
 function formatSqliteForeignKeyViolation(violation: SqliteForeignKeyViolation): string {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -1450,6 +1450,84 @@ describe("openclaw agent database", () => {
     }
   });
 
+  it("rejects foreign-key violations before writable initialization", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const created = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const databasePath = created.path;
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const corrupted = new DatabaseSync(databasePath);
+    try {
+      corrupted.exec("PRAGMA foreign_keys = OFF;");
+      corrupted
+        .prepare(
+          "INSERT INTO session_entries (session_key, session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
+        )
+        .run("orphan", "missing-session", "{}", 1);
+      expect(corrupted.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
+      expect(corrupted.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+      expect(corrupted.prepare("PRAGMA foreign_key_check").get()).toEqual({
+        table: "session_entries",
+        rowid: 1,
+        parent: "sessions",
+        fkid: 0,
+      });
+    } finally {
+      corrupted.close();
+    }
+
+    const before = new DatabaseSync(databasePath, { readOnly: true });
+    let metadataBefore: unknown;
+    try {
+      metadataBefore = before
+        .prepare(
+          "SELECT schema_version, updated_at FROM schema_meta WHERE meta_key = 'primary' LIMIT 1",
+        )
+        .get();
+    } finally {
+      before.close();
+    }
+
+    const failure =
+      /foreign_key_check failed.*session_entries row 1 references sessions \(foreign key 0\)/iu;
+    expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow(failure);
+    const independentlyManaged = new DatabaseSync(databasePath);
+    try {
+      expect(() =>
+        ensureOpenClawAgentDatabaseSchema(independentlyManaged, {
+          agentId: "worker-1",
+          env,
+        }),
+      ).toThrow(failure);
+    } finally {
+      independentlyManaged.close();
+    }
+
+    const after = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        after
+          .prepare(
+            "SELECT schema_version, updated_at FROM schema_meta WHERE meta_key = 'primary' LIMIT 1",
+          )
+          .get(),
+      ).toEqual(metadataBefore);
+      expect(after.prepare("PRAGMA foreign_key_check").get()).toEqual({
+        table: "session_entries",
+        rowid: 1,
+        parent: "sessions",
+        fkid: 0,
+      });
+    } finally {
+      after.close();
+    }
+  });
+
   it("refuses to open newer per-agent schema versions", () => {
     const stateDir = createTempStateDir();
     const databasePath = path.join(

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1228,6 +1228,74 @@ describe("openclaw state database", () => {
     }
   });
 
+  it("rejects foreign-key violations before writable initialization", () => {
+    const stateDir = createTempStateDir();
+    const databasePath = createCanonicalAuditStateDatabase(stateDir);
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const { DatabaseSync } = requireNodeSqlite();
+    const corrupted = new DatabaseSync(databasePath);
+    try {
+      corrupted.exec("PRAGMA foreign_keys = OFF;");
+      corrupted.prepare("INSERT INTO task_delivery_state (task_id) VALUES (?)").run("missing-task");
+      expect(corrupted.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
+      expect(corrupted.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+      expect(corrupted.prepare("PRAGMA foreign_key_check").get()).toEqual({
+        table: "task_delivery_state",
+        rowid: 1,
+        parent: "task_runs",
+        fkid: 0,
+      });
+    } finally {
+      corrupted.close();
+    }
+
+    const before = new DatabaseSync(databasePath, { readOnly: true });
+    let metadataBefore: unknown;
+    try {
+      metadataBefore = before
+        .prepare(
+          "SELECT schema_version, updated_at FROM schema_meta WHERE meta_key = 'primary' LIMIT 1",
+        )
+        .get();
+    } finally {
+      before.close();
+    }
+
+    const failure =
+      /foreign_key_check failed.*task_delivery_state row 1 references task_runs \(foreign key 0\)/iu;
+    expect(() => openOpenClawStateDatabase(options)).toThrow(failure);
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: [],
+      warnings: [expect.stringMatching(failure)],
+    });
+    const checkpointCallback = vi.fn();
+    expect(() =>
+      withOpenClawStateStartupMigrationCheckpointDatabase(checkpointCallback, options),
+    ).toThrow(failure);
+    expect(checkpointCallback).not.toHaveBeenCalled();
+
+    const after = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        after
+          .prepare(
+            "SELECT schema_version, updated_at FROM schema_meta WHERE meta_key = 'primary' LIMIT 1",
+          )
+          .get(),
+      ).toEqual(metadataBefore);
+      expect(after.prepare("PRAGMA foreign_key_check").get()).toEqual({
+        table: "task_delivery_state",
+        rowid: 1,
+        parent: "task_runs",
+        fkid: 0,
+      });
+    } finally {
+      after.close();
+    }
+  });
+
   it.skipIf(process.platform === "win32")(
     "recovers a hot rollback journal before checking integrity",
     () => {


### PR DESCRIPTION
Related: #101290

## What Problem This Solves

Fixes an issue where users opening, backing up, verifying, or vacuuming an OpenClaw SQLite database could have orphaned foreign-key rows accepted as healthy because SQLite's `quick_check` and `integrity_check` do not validate foreign keys.

## Why This Change Was Made

The shared fail-closed integrity gate now also runs `foreign_key_check` before any writable initialization, checkpoint, `VACUUM`, `VACUUM INTO`, or canonical backup verification. Diagnostics are deterministic and bounded, preserve 64-bit rowids, and identify the child table, row, parent table, and foreign-key id without changing the existing doctor report contract.

This intentionally detects and rejects inconsistent state; it does not guess at an automatic repair for orphaned user data.

## User Impact

Corrupt databases with orphaned references are rejected before OpenClaw mutates or snapshots them. Valid databases behave as before. Operators receive a specific error that identifies the violated relationship instead of a misleading healthy result.

AI-assisted: yes. The implementation and tests were reviewed with the repository autoreview workflow.

## Evidence

- Blacksmith Testbox through Crabbox `tbx_01kxasf4b71wbmwahctjrbrxn6`, Actions run https://github.com/openclaw/openclaw/actions/runs/29187032505: 166 focused tests passed across the shared integrity helper, pragma-shadow bypass, shared-state open/repair/startup, per-agent open/schema setup, backup creation, backup verification, and doctor compaction.
- Patch-identical Testbox `tbx_01kxarrf09rdv1qczgbq92be9d`: `tsgo:core`, `tsgo:core:test`, and targeted oxlint passed.
- Structured autoreview: clean, 0.96 confidence, no accepted or actionable findings.
- `pnpm check:changed` reaches formatting and repository guards, then is blocked by the existing `docs/.generated/plugin-sdk-api-baseline.sha256` drift. The same baseline check was reproduced on a pristine `origin/main` worktree; this PR does not touch plugin SDK surfaces.
