### PR TITLE
refactor(plugins): remove dead contribution owner wrappers

### DIFF
--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -70,18 +70,6 @@ export type ResolveProviderOwnersParams = PluginRegistryContributionOptions & {
   providerId: string;
 };
 
-export type ResolveChannelOwnersParams = PluginRegistryContributionOptions & {
-  channelId: string;
-};
-
-export type ResolveCliBackendOwnersParams = PluginRegistryContributionOptions & {
-  cliBackendId: string;
-};
-
-export type ResolveSetupProviderOwnersParams = PluginRegistryContributionOptions & {
-  setupProviderId: string;
-};
-
 export type ResolveManifestContractPluginIdsParams = LoadPluginRegistryParams & {
   contract: PluginManifestContractListKey;
   origin?: PluginOrigin;
@@ -409,44 +397,6 @@ export function resolveProviderOwners(params: ResolveProviderOwnersParams): read
     ...params,
     contribution: "providers",
     matches: (contributionId) => normalizeProviderId(contributionId) === providerId,
-  });
-}
-
-export function resolveChannelOwners(params: ResolveChannelOwnersParams): readonly string[] {
-  const channelId = normalizeContributionId(params.channelId);
-  if (!channelId) {
-    return [];
-  }
-  return resolvePluginContributionOwners({
-    ...params,
-    contribution: "channels",
-    matches: channelId,
-  });
-}
-
-export function resolveCliBackendOwners(params: ResolveCliBackendOwnersParams): readonly string[] {
-  const cliBackendId = normalizeContributionId(params.cliBackendId);
-  if (!cliBackendId) {
-    return [];
-  }
-  return resolvePluginContributionOwners({
-    ...params,
-    contribution: "cliBackends",
-    matches: cliBackendId,
-  });
-}
-
-export function resolveSetupProviderOwners(
-  params: ResolveSetupProviderOwnersParams,
-): readonly string[] {
-  const setupProviderId = normalizeContributionId(params.setupProviderId);
-  if (!setupProviderId) {
-    return [];
-  }
-  return resolvePluginContributionOwners({
-    ...params,
-    contribution: "setupProviders",
-    matches: setupProviderId,
   });
 }
 

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -30,14 +30,11 @@ import {
   loadPluginRegistrySnapshotWithMetadata,
   normalizePluginsConfigWithRegistry,
   refreshPluginRegistry,
-  resolveChannelOwners,
-  resolveCliBackendOwners,
   resolveManifestContractOwnerPluginId,
   resolveManifestContractPluginIds,
   resolveManifestContractPluginIdsByCompatibilityRuntimePath,
   resolvePluginContributionOwners,
   resolveProviderOwners,
-  resolveSetupProviderOwners,
 } from "./plugin-registry.js";
 import { resolvePluginPath } from "./registry.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
@@ -261,8 +258,20 @@ describe("plugin registry facade", () => {
         matches: "demo-alias",
       }),
     ).toEqual(["demo"]);
-    expect(resolveChannelOwners({ index, channelId: "demo-chat" })).toEqual(["demo"]);
-    expect(resolveCliBackendOwners({ index, cliBackendId: "demo-cli" })).toEqual(["demo"]);
+    expect(
+      resolvePluginContributionOwners({
+        index,
+        contribution: "channels",
+        matches: "demo-chat",
+      }),
+    ).toEqual(["demo"]);
+    expect(
+      resolvePluginContributionOwners({
+        index,
+        contribution: "cliBackends",
+        matches: "demo-cli",
+      }),
+    ).toEqual(["demo"]);
     expect(
       resolvePluginContributionOwners({
         index,
@@ -270,7 +279,13 @@ describe("plugin registry facade", () => {
         matches: (contributionId) => contributionId === "demo-cli",
       }),
     ).toEqual(["demo"]);
-    expect(resolveSetupProviderOwners({ index, setupProviderId: "demo-setup" })).toEqual(["demo"]);
+    expect(
+      resolvePluginContributionOwners({
+        index,
+        contribution: "setupProviders",
+        matches: "demo-setup",
+      }),
+    ).toEqual(["demo"]);
     expect(resolveManifestContractPluginIds({ index, contract: "webSearchProviders" })).toEqual([
       "demo",
     ]);
@@ -346,14 +361,27 @@ describe("plugin registry facade", () => {
 
     expect(listPluginContributionIds({ lookUpTable, contribution: "providers" })).toEqual(["demo"]);
     expect(resolveProviderOwners({ lookUpTable, providerId: "DEMO" })).toEqual(["demo"]);
-    expect(resolveChannelOwners({ lookUpTable, channelId: "demo-chat" })).toEqual(["demo"]);
-    expect(resolveCliBackendOwners({ lookUpTable, cliBackendId: "demo-cli" })).toEqual(["demo"]);
-    expect(resolveCliBackendOwners({ lookUpTable, cliBackendId: "demo-setup-cli" })).toEqual([
-      "demo",
-    ]);
-    expect(resolveSetupProviderOwners({ lookUpTable, setupProviderId: "demo-setup" })).toEqual([
-      "demo",
-    ]);
+    expect(
+      resolvePluginContributionOwners({
+        lookUpTable,
+        contribution: "channels",
+        matches: "demo-chat",
+      }),
+    ).toEqual(["demo"]);
+    expect(
+      resolvePluginContributionOwners({
+        lookUpTable,
+        contribution: "cliBackends",
+        matches: "demo-cli",
+      }),
+    ).toEqual(["demo"]);
+    expect(
+      resolvePluginContributionOwners({
+        lookUpTable,
+        contribution: "setupProviders",
+        matches: "demo-setup",
+      }),
+    ).toEqual(["demo"]);
     expect(
       resolvePluginContributionOwners({
         lookUpTable,


### PR DESCRIPTION
## What Problem This Solves

Removes three plugin contribution-owner helpers that no production code calls. Keeping these wrappers expanded the internal registry surface and preserved wrapper-only tests around behavior already owned by the generic contribution resolver.

## Why This Change Was Made

The channel, CLI-backend, and setup-provider wrappers were deleted after source search, history inspection, and the full code graph showed no production callers. Existing registry tests now exercise the canonical `resolvePluginContributionOwners` path directly; the provider-specific resolver remains because it has live callers and provider normalization behavior.

## User Impact

No user-visible behavior changes. The internal plugin registry API is smaller, with one canonical contribution-owner resolution path.

## Evidence

- Full codebase-memory graph: 304,063 nodes / 1,255,125 edges; all three removed functions had no production callers, and only `src/plugins/plugin-registry.test.ts` called them.
- `blacksmith testbox run --id tbx_01kxarzcbnmwfcdnsggaae3d2q "... pnpm test:serial src/plugins/plugin-registry.test.ts"`: 25/25 tests passed.
- Path-scoped `pnpm check:changed -- src/plugins/plugin-registry-contributions.ts src/plugins/plugin-registry.test.ts`: passed all core/core-test typecheck, lint, import-cycle, formatting, and repository guard lanes.
- Plugin SDK baseline JSON, JSONL, and hash regenerated byte-identically against clean `origin/main`; the tracked baseline mismatch is pre-existing main-branch debt.
- Fresh autoreview with `gpt-5.6-sol`, medium reasoning: clean, no actionable findings, overall confidence 0.9.
