### PR TITLE
chore(plugin-sdk): refresh node presence API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-64d005f6d5fbbfb9fd2fd33c9e549b480df4d97316eff3d34a62b4025807b28d  plugin-sdk-api-baseline.json
-37a538687a420a8e232dfa45106c106b884299b53d4d96e4e6b789e2a6262465  plugin-sdk-api-baseline.jsonl
+13fd6a689ea1e559f3e5f0b67463d407a8050679c1b50597789dffb4daefa71b  plugin-sdk-api-baseline.json
+e593b1cad8dd37c4349b075c6ca1e4cd0c508933c3cca92c0c672bc2fc65ea66  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Plugin SDK API baseline verification on current `main` reports drift after the active-node presence protocol surface landed in #105083.

## Why This Change Was Made

Regenerates the tracked Plugin SDK API hashes from the current public declarations. This is intentionally limited to the generated hash manifest; the protocol change already lives on `main`.

## User Impact

No user-visible behavior changes. Maintainer changed-file validation can verify the current Plugin SDK contract without a false baseline mismatch.

## Evidence

- Fresh Testbox `tbx_01kxasw089f2r4kp57rj0f28pr`: `pnpm plugin-sdk:api:gen` reproduced the committed hashes from current `main`.
- Same Testbox: `pnpm check:changed` passed, including `plugin-sdk:api:check`.
- Fresh branch autoreview: no accepted or actionable findings.
