### PR TITLE
feat(tooling): enforce noUncheckedIndexedAccess from the base tsconfig (NUIA endgame)

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -880,7 +880,7 @@ describe("memory index", () => {
 
       expect(providerRuntimeBatchCalls).toHaveLength(3);
       expect(providerRuntimeBatchCalls.every((call) => call.length === 1)).toBe(true);
-      expect(providerRuntimeBatchCalls.map((call) => call[0]).toSorted()).toEqual(
+      expect(providerRuntimeBatchCalls.map((call) => call[0] ?? "").toSorted()).toEqual(
         [
           "# Log\nAlpha memory line.\nZebra memory line.",
           "# Log\nBeta memory line.",

--- a/test/tsconfig/tsconfig.test.json
+++ b/test/tsconfig/tsconfig.test.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // Test lanes opt out of noUncheckedIndexedAccess for now (~4,400 fixture
+    // indexing sites); tracked as a lane-by-lane follow-up to #104600.
+    "noUncheckedIndexedAccess": false,
     "rootDir": "../.."
   },
   "include": [

--- a/tsconfig.core.json
+++ b/tsconfig.core.json
@@ -4,7 +4,6 @@
     // Node-side production code must not see browser globals; ui/ owns DOM via tsconfig.ui.json.
     "lib": ["ES2023"],
     // Production indexed reads must account for missing entries.
-    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "tsBuildInfoFile": ".artifacts/tsgo-cache/core.tsbuildinfo"

--- a/tsconfig.extensions.json
+++ b/tsconfig.extensions.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     // Plugin production indexed reads must account for missing entries.
-    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "tsBuildInfoFile": ".artifacts/tsgo-cache/extensions.tsbuildinfo"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "moduleResolution": "NodeNext",
     "noImplicitOverride": true,
     "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "noEmitOnError": true,
     "noUncheckedSideEffectImports": true,

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "tsBuildInfoFile": ".artifacts/tsgo-cache/scripts.tsbuildinfo"

--- a/tsconfig.ui.json
+++ b/tsconfig.ui.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     // Control UI indexed reads must account for missing entries.
-    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "tsBuildInfoFile": ".artifacts/tsgo-cache/ui.tsbuildinfo"


### PR DESCRIPTION
Closes #104600

## What Problem This Solves

The endgame of the `noUncheckedIndexedAccess` adoption: after phases 1–5 (#104577, #104626, #104670, #104773, #104981, #105132, #105180) burned down ~2,000 production errors and flipped five lanes individually, enforcement now belongs in one place.

## Why This Change Was Made

- `"noUncheckedIndexedAccess": true` moves to the base `tsconfig.json`; the five per-lane copies are deleted. **Any future lane inherits index safety by default.**
- Test lanes carry a single documented opt-out at their shared parent (`test/tsconfig/tsconfig.test.json`): ~4,400 fixture-indexing sites remain there, tracked as a lane-by-lane follow-up with per-lane counts (root 330 → ui-test 255 → extensions-test 1,126 → core-test 2,685).
- Six-line diff, net zero.

## User Impact

None at runtime. The migration's contract is now structural: unchecked index reads in any production code — including code written years from now in lanes that don't exist yet — fail at check time.

## Evidence

- All nine sanctioned lane commands green (`tsgo:core/ui/extensions/scripts`, all five test lanes).
- Synthetic probes: an unchecked read appended to `src/version.ts` fails the core lane; the same read in a test file compiles under the opt-out (both probes removed).
- The 48 raw-invocation diagnostics in the root test lane are declaration-portability issues reproduced identically on clean `origin/main` (pre-existing; the sanctioned lane command passes).
- Structured review clean (0.96).
