### PR TITLE
fix: report unmanaged Gateway restarts truthfully

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -53,6 +53,7 @@ const probeGateway = vi.fn<
 const callGatewayCli = vi.fn();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.hoisted(() => vi.fn(() => ({})));
+const readActiveGatewayLockPort = vi.hoisted(() => vi.fn<() => Promise<number | undefined>>());
 const recoverInstalledLaunchAgent = vi.hoisted(() => vi.fn());
 const repairLoadedGatewayServiceForStart = vi.hoisted(() => vi.fn());
 const findInstalledSystemdGatewayScope = vi.hoisted(() =>
@@ -101,6 +102,10 @@ vi.mock("../../infra/gateway-processes.js", () => ({
   signalVerifiedGatewayPidSync: (pid: number, signal: "SIGTERM" | "SIGUSR1") =>
     signalVerifiedGatewayPidSync(pid, signal),
   formatGatewayPidList: (pids: number[]) => formatGatewayPidList(pids),
+}));
+
+vi.mock("../../infra/gateway-lock.js", () => ({
+  readActiveGatewayLockPort: () => readActiveGatewayLockPort(),
 }));
 
 vi.mock("../../gateway/probe.js", () => ({
@@ -214,6 +219,7 @@ describe("runDaemonRestart health checks", () => {
     callGatewayCli.mockReset();
     isRestartEnabled.mockReset();
     loadConfig.mockReset();
+    readActiveGatewayLockPort.mockReset();
     recoverInstalledLaunchAgent.mockReset();
     repairLoadedGatewayServiceForStart.mockReset();
 
@@ -224,6 +230,7 @@ describe("runDaemonRestart health checks", () => {
     service.restart.mockResolvedValue({ outcome: "completed" });
     runServiceStart.mockResolvedValue(undefined);
     recoverInstalledLaunchAgent.mockResolvedValue(null);
+    readActiveGatewayLockPort.mockResolvedValue(undefined);
     findInstalledSystemdGatewayScope.mockReset();
     findInstalledSystemdGatewayScope.mockResolvedValue(null);
     restartSystemdService.mockReset();
@@ -573,6 +580,26 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("signals and verifies the active unmanaged port despite a config edit", async () => {
+    loadConfig.mockReturnValue({ gateway: { port: 19_001 } });
+    readActiveGatewayLockPort.mockResolvedValue(18_789);
+    findVerifiedGatewayListenerPidsOnPortSync.mockImplementation((port) =>
+      port === 18_789 ? [4200] : [],
+    );
+    mockUnmanagedRestart({ runPostRestartCheck: true });
+
+    await runDaemonRestart({ json: true });
+
+    expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18_789);
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "ws://127.0.0.1:18789" }),
+    );
+    expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGUSR1");
+    expect(waitForGatewayHealthyListener).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 18_789 }),
+    );
   });
 
   it("prefers launchd repair over unmanaged restart when an installed LaunchAgent is unloaded", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -12,6 +12,7 @@ import {
 } from "../../daemon/systemd.js";
 import { callGatewayCli } from "../../gateway/call.js";
 import { probeGateway } from "../../gateway/probe.js";
+import { readActiveGatewayLockPort } from "../../infra/gateway-lock.js";
 import {
   findVerifiedGatewayListenerPidsOnPortSync,
   formatGatewayPidList,
@@ -334,9 +335,14 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   let restartedWithoutServiceManager = false;
   const restartIntent = resolveGatewayRestartIntentOptions(opts);
   const configuredPort = await resolveExplicitGatewayConfigPort();
-  const restartPort =
+  const managedRestartPort =
     configuredPort ??
     (await resolveGatewayLifecyclePort(service).catch(() => resolveGatewayPortFallback()));
+  // An unmanaged run loop keeps its lock port across in-process restarts, even
+  // when config changes underneath it. Use that port for both the signal and
+  // health proof or a valid CLI/env override looks like a failed restart.
+  const unmanagedPort =
+    (await readActiveGatewayLockPort().catch(() => undefined)) ?? managedRestartPort;
   const restartHealthAttempts = postRestartHealthAttempts();
   const restartWaitMs = restartHealthAttempts * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
@@ -369,7 +375,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
           return recovered;
         }
       }
-      const handled = await restartGatewayWithoutServiceManager(restartPort, restartIntent);
+      const handled = await restartGatewayWithoutServiceManager(unmanagedPort, restartIntent);
       if (handled) {
         restartedWithoutServiceManager = true;
         return handled;
@@ -380,7 +386,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       if (restartedWithoutServiceManager) {
         // SIGUSR1 restarts have no service-manager state to watch; use listener health only.
         const health = await waitForGatewayHealthyListener({
-          port: restartPort,
+          port: unmanagedPort,
           attempts: restartHealthAttempts,
           delayMs: POST_RESTART_HEALTH_DELAY_MS,
         });
@@ -389,7 +395,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         }
 
         const diagnostics = renderGatewayPortHealthDiagnostics(health);
-        const timeoutLine = `Timed out after ${restartWaitSeconds}s waiting for gateway port ${restartPort} to become healthy.`;
+        const timeoutLine = `Timed out after ${restartWaitSeconds}s waiting for gateway port ${unmanagedPort} to become healthy.`;
         if (!jsonOutput) {
           defaultRuntime.log(theme.warn(timeoutLine));
           for (const line of diagnostics) {
@@ -409,7 +415,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
 
       let health = await waitForGatewayHealthyRestart({
         service,
-        port: restartPort,
+        port: managedRestartPort,
         attempts: restartHealthAttempts,
         delayMs: POST_RESTART_HEALTH_DELAY_MS,
         includeUnknownListenersAsStale: process.platform === "win32",
@@ -432,7 +438,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         }
         health = await waitForGatewayHealthyRestart({
           service,
-          port: restartPort,
+          port: managedRestartPort,
           attempts: restartHealthAttempts,
           delayMs: POST_RESTART_HEALTH_DELAY_MS,
           includeUnknownListenersAsStale: process.platform === "win32",
@@ -446,12 +452,12 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       const diagnostics = renderRestartDiagnostics(health);
       const failure = formatRestartFailure({
         health,
-        port: restartPort,
+        port: managedRestartPort,
         timeoutSeconds: restartWaitSeconds,
       });
       const runningNoPortLine =
         health.runtime.status === "running" && health.portUsage.status === "free"
-          ? `Gateway process is running but port ${restartPort} is still free (startup hang/crash loop or very slow VM startup).`
+          ? `Gateway process is running but port ${managedRestartPort} is still free (startup hang/crash loop or very slow VM startup).`
           : null;
       if (!jsonOutput) {
         defaultRuntime.log(theme.warn(failure.statusLine));

--- a/src/crestodian/operations.test.ts
+++ b/src/crestodian/operations.test.ts
@@ -559,6 +559,24 @@ describe("parseCrestodianOperation", () => {
     expect(runGatewayRestart).not.toHaveBeenCalled();
   });
 
+  it("does not report or audit a gateway restart that returned false", async () => {
+    const tempDir = opTempDirs.make("crestodian-restart-failed-");
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
+    const { runtime, lines } = createCrestodianTestRuntime();
+    const runGatewayRestart = vi.fn(async () => false);
+
+    await expect(
+      executeCrestodianOperation({ kind: "gateway-restart" }, runtime, {
+        approved: true,
+        deps: { runGatewayRestart },
+      }),
+    ).rejects.toThrow("Gateway restart did not complete");
+
+    expect(lines.join("\n")).toContain("[crestodian] running: gateway.restart");
+    expect(lines.join("\n")).not.toContain("[crestodian] done: gateway.restart");
+    await expect(fs.access(path.join(tempDir, "audit", "crestodian.jsonl"))).rejects.toThrow();
+  });
+
   it("validates missing config without exiting the process", async () => {
     mockConfig.missing("/tmp/openclaw.json");
     const { runtime, lines } = createCrestodianTestRuntime();

--- a/src/crestodian/operations.ts
+++ b/src/crestodian/operations.ts
@@ -114,7 +114,7 @@ export type CrestodianCommandDeps = {
     cliOptions: ConfigSetOptions;
   }) => Promise<void>;
   runDoctor?: (runtime: RuntimeEnv, options: DoctorOptions) => Promise<void>;
-  runGatewayRestart?: () => Promise<void>;
+  runGatewayRestart?: () => Promise<void | boolean>;
   runGatewayStart?: () => Promise<void>;
   runGatewayStop?: () => Promise<void>;
   runPluginInstall?: (spec: string, runtime: RuntimeEnv) => Promise<void>;
@@ -560,7 +560,9 @@ function formatGatewayStatusLine(overview: CrestodianOverview): string {
     .join("\n");
 }
 
-async function runGatewayLifecycle(operation: "start" | "stop" | "restart"): Promise<void> {
+async function runGatewayLifecycle(
+  operation: "start" | "stop" | "restart",
+): Promise<void | boolean> {
   const lifecycle = await import("../cli/daemon-cli/lifecycle.js");
   if (operation === "start") {
     await lifecycle.runDaemonStart();
@@ -570,7 +572,7 @@ async function runGatewayLifecycle(operation: "start" | "stop" | "restart"): Pro
     await lifecycle.runDaemonStop();
     return;
   }
-  await lifecycle.runDaemonRestart();
+  return await lifecycle.runDaemonRestart();
 }
 
 async function readConfigFileSnapshotLazy(): Promise<ConfigFileSnapshot> {
@@ -1493,7 +1495,10 @@ export async function executeCrestodianOperation(
         run: async (ctx) => {
           const runGatewayRestart =
             ctx.deps?.runGatewayRestart ?? (() => runGatewayLifecycle("restart"));
-          await ctx.commit(runGatewayRestart);
+          const restarted = await ctx.commit(runGatewayRestart);
+          if (restarted === false) {
+            throw new Error("Gateway restart did not complete");
+          }
           return { summary: "Restarted Gateway" };
         },
       });


### PR DESCRIPTION
Related: #105109
Follow-up to #105153

## What Problem This Solves

Fixes two issues found during the exact-landed-main macOS CLI soak: restarting an unmanaged Gateway after editing `gateway.port` could miss the still-running process on its active port, and Crestodian could print a successful `done` line and write a success audit when the daemon restart returned `false`.

## Why This Change Was Made

Unmanaged restarts now use the live Gateway lock port for both verified process signaling and the post-restart health proof, preserving intentional CLI/environment port precedence. Managed service restarts retain the existing config-directed repair path. Crestodian treats a `false` lifecycle result as a failed operation, so it neither reports nor audits success.

## User Impact

Foreground Gateways restart reliably even when config changed underneath their fixed runtime port, and Crestodian no longer claims a refused or incomplete restart succeeded. Managed LaunchAgent port repair behavior from #105153 is unchanged.

## Evidence

- Live Golden Gate reproduction on current `main`: after `gateway.port` changed from 18789 to 19001, Crestodian missed the active 18789 process and printed `[crestodian] done: gateway.restart` after `Gateway service not loaded`.
- Blacksmith Testbox `tbx_01kxasbccc25549p43d36qex73`: 107 focused lifecycle and Crestodian operation tests passed.
- Same Testbox: `pnpm check:test-types`, `pnpm lint --threads=8`, and `pnpm format:check` passed.
- Fresh structured autoreview: clean, correctness 0.91.
