### PR TITLE
fix(text): strip MiniMax marker from channel replies

### DIFF
--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -27,6 +27,13 @@ const minimaxProviderPlugin = {
   },
 };
 
+function createEmptyStream(): ReturnType<StreamFn> {
+  return {
+    result: async () => ({}) as never,
+    async *[Symbol.asyncIterator]() {},
+  } as ReturnType<StreamFn>;
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
 });
@@ -69,6 +76,21 @@ describe("minimax provider hooks", () => {
         modelId: "MiniMax-M2.7",
       } as never),
     ).toBe("native");
+  });
+
+  it("owns message-end stream handling in the official MiniMax provider hooks", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: minimaxProviderPlugin,
+      id: "minimax",
+      name: "MiniMax Provider",
+    });
+    const apiProvider = requireRegisteredProvider(providers, "minimax");
+    const portalProvider = requireRegisteredProvider(providers, "minimax-portal");
+
+    expect(apiProvider.textTransforms).toBeUndefined();
+    expect(portalProvider.textTransforms).toBeUndefined();
+    expect(apiProvider.wrapStreamFn).toBeTypeOf("function");
+    expect(portalProvider.wrapStreamFn).toBe(apiProvider.wrapStreamFn);
   });
 
   it("defaults M3 thinking on while keeping M2.x thinking off by default", async () => {
@@ -283,7 +305,7 @@ describe("minimax provider hooks", () => {
     let resolvedApiModelId = "";
     const captureApiModel: StreamFn = (model) => {
       resolvedApiModelId = model.id ?? "";
-      return {} as ReturnType<StreamFn>;
+      return createEmptyStream();
     };
     const wrappedApiStream = apiProvider.wrapStreamFn?.({
       provider: "minimax",
@@ -305,7 +327,7 @@ describe("minimax provider hooks", () => {
     let resolvedPortalModelId = "";
     const capturePortalModel: StreamFn = (model) => {
       resolvedPortalModelId = model.id ?? "";
-      return {} as ReturnType<StreamFn>;
+      return createEmptyStream();
     };
     const wrappedPortalStream = portalProvider.wrapStreamFn?.({
       provider: "minimax-portal",

--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -8,6 +8,7 @@ import type {
   ProviderCatalogContext,
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
+  ProviderWrapStreamFnContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import {
   MINIMAX_OAUTH_MARKER,
@@ -38,6 +39,7 @@ import {
   buildMinimaxProvider,
   resolveMinimaxCatalogBaseUrl,
 } from "./provider-catalog.js";
+import { createMinimaxMessageEndMarkerWrapper } from "./stream.js";
 import { resolveMinimaxThinkingProfile } from "./thinking.js";
 
 const API_PROVIDER_ID = "minimax";
@@ -61,9 +63,18 @@ const HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
   family: "hybrid-anthropic-openai",
   anthropicModelDropThinkingBlocks: true,
 });
+
+function wrapMinimaxProviderStream(
+  ctx: ProviderWrapStreamFnContext,
+): ProviderWrapStreamFnContext["streamFn"] {
+  const fastModeStreamFn = MINIMAX_FAST_MODE_STREAM_HOOKS.wrapStreamFn?.(ctx) ?? ctx.streamFn;
+  return createMinimaxMessageEndMarkerWrapper(fastModeStreamFn);
+}
+
 const MINIMAX_PROVIDER_HOOKS = {
   ...HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS,
   ...MINIMAX_FAST_MODE_STREAM_HOOKS,
+  wrapStreamFn: wrapMinimaxProviderStream,
   resolveReasoningOutputMode: () => "native" as const,
   resolveThinkingProfile: ({ modelId }: { modelId: string }) =>
     resolveMinimaxThinkingProfile(modelId),

--- a/extensions/minimax/stream.test.ts
+++ b/extensions/minimax/stream.test.ts
@@ -9,13 +9,15 @@ import type {
 import { describe, expect, it } from "vitest";
 import { createMinimaxMessageEndMarkerWrapper } from "./stream.js";
 
+const TEST_MODEL_ID = "MiniMax-M3";
+
 function createAssistantMessage(text: string): AssistantMessage {
   return {
     role: "assistant",
     content: [{ type: "text", text }],
     api: "anthropic-messages",
     provider: "minimax",
-    model: "MiniMax-M2.7",
+    model: TEST_MODEL_ID,
     usage: {
       input: 0,
       output: 0,
@@ -106,7 +108,7 @@ function runWrapper(events: AssistantMessageEvent[], onIteratorClose?: () => voi
     {
       api: "anthropic-messages",
       provider: "minimax",
-      id: "MiniMax-M2.7",
+      id: TEST_MODEL_ID,
     } as Model<"anthropic-messages">,
     { messages: [] } as Context,
   );

--- a/extensions/minimax/stream.test.ts
+++ b/extensions/minimax/stream.test.ts
@@ -1,0 +1,392 @@
+// MiniMax tests cover message-end stream handling.
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  Context,
+  Model,
+} from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { createMinimaxMessageEndMarkerWrapper } from "./stream.js";
+
+function createAssistantMessage(text: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "anthropic-messages",
+    provider: "minimax",
+    model: "MiniMax-M2.7",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  };
+}
+
+function createToolUseMessage(text: string): AssistantMessage {
+  return {
+    ...createAssistantMessage(text),
+    content: [
+      { type: "text", text },
+      { type: "toolCall", id: "call_1", name: "test", arguments: {} },
+    ],
+    stopReason: "toolUse",
+  };
+}
+
+function createThinkingAndTextMessage(thinking: string, text: string): AssistantMessage {
+  return {
+    ...createAssistantMessage(text),
+    content: [
+      { type: "thinking", thinking },
+      { type: "text", text },
+    ],
+  };
+}
+
+function createTextPairMessage(first: string, second: string): AssistantMessage {
+  return {
+    ...createAssistantMessage(second),
+    content: [
+      { type: "text", text: first },
+      { type: "text", text: second },
+    ],
+  };
+}
+
+function createEventStream(
+  events: AssistantMessageEvent[],
+  streamError?: Error,
+  onIteratorClose?: () => void,
+): StreamFn {
+  return (() => {
+    const terminal = events.find((event) => event.type === "done" || event.type === "error");
+    const message =
+      terminal?.type === "done"
+        ? terminal.message
+        : terminal?.type === "error"
+          ? terminal.error
+          : createAssistantMessage("");
+    return {
+      result: async () => message,
+      async *[Symbol.asyncIterator]() {
+        try {
+          yield* events;
+          if (streamError) {
+            throw streamError;
+          }
+        } finally {
+          onIteratorClose?.();
+        }
+      },
+    };
+  }) as StreamFn;
+}
+
+async function collectEvents(stream: ReturnType<StreamFn>): Promise<AssistantMessageEvent[]> {
+  const events: AssistantMessageEvent[] = [];
+  for await (const event of stream as AsyncIterable<AssistantMessageEvent>) {
+    events.push(event);
+  }
+  return events;
+}
+
+function runWrapper(
+  events: AssistantMessageEvent[],
+  streamError?: Error,
+  onIteratorClose?: () => void,
+) {
+  const wrapped = createMinimaxMessageEndMarkerWrapper(
+    createEventStream(events, streamError, onIteratorClose),
+  );
+  return wrapped(
+    {
+      api: "anthropic-messages",
+      provider: "minimax",
+      id: "MiniMax-M2.7",
+    } as Model<"anthropic-messages">,
+    { messages: [] } as Context,
+  );
+}
+
+describe("MiniMax message-end stream wrapper", () => {
+  it("withholds a split terminal marker until the text block closes", async () => {
+    const text = "Done[e~[";
+    const events: AssistantMessageEvent[] = [
+      { type: "start", partial: createAssistantMessage("") },
+      { type: "text_start", contentIndex: 0, partial: createAssistantMessage("") },
+      {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "Done[e",
+        partial: createAssistantMessage("Done[e"),
+      },
+      { type: "text_delta", contentIndex: 0, delta: "~[", partial: createAssistantMessage(text) },
+      { type: "text_end", contentIndex: 0, content: text, partial: createAssistantMessage(text) },
+      { type: "done", reason: "stop", message: createAssistantMessage(text) },
+    ];
+
+    const stream = runWrapper(events);
+    const output = await collectEvents(stream);
+    const textDeltas = output.filter((event) => event.type === "text_delta");
+    const textEnd = output.find((event) => event.type === "text_end");
+    const done = output.find((event) => event.type === "done");
+
+    expect(textDeltas.map((event) => event.delta)).toEqual(["Done"]);
+    expect(textDeltas[0]?.partial?.content).toEqual([{ type: "text", text: "Done" }]);
+    expect(textEnd?.type === "text_end" ? textEnd.content : undefined).toBe("Done");
+    expect(done?.type === "done" ? done.message.content : undefined).toEqual([
+      { type: "text", text: "Done" },
+    ]);
+    expect(JSON.stringify(output)).not.toContain("[e~[");
+    expect(JSON.stringify(output)).not.toContain("[e");
+    await expect(
+      (stream as { result(): Promise<AssistantMessage> }).result(),
+    ).resolves.toMatchObject({
+      content: [{ type: "text", text: "Done" }],
+    });
+  });
+
+  it("preserves a literal marker when later text proves it is not terminal", async () => {
+    const text = "The literal [e~[ belongs in this explanation.";
+    const events: AssistantMessageEvent[] = [
+      { type: "start", partial: createAssistantMessage("") },
+      { type: "text_start", contentIndex: 0, partial: createAssistantMessage("") },
+      { type: "text_delta", contentIndex: 0, delta: "The literal [e" },
+      {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "~[ belongs in this explanation.",
+        partial: createAssistantMessage(text),
+      },
+      { type: "text_end", contentIndex: 0, content: text, partial: createAssistantMessage(text) },
+      { type: "done", reason: "stop", message: createAssistantMessage(text) },
+    ];
+
+    const stream = runWrapper(events);
+    const output = await collectEvents(stream);
+    const textDeltas = output.filter((event) => event.type === "text_delta");
+    const lastDelta = textDeltas.at(-1);
+
+    expect(textDeltas.map((event) => event.delta).join("")).toBe(text);
+    expect(lastDelta?.type === "text_delta" ? lastDelta.partial?.content : undefined).toEqual([
+      { type: "text", text },
+    ]);
+    expect(output.find((event) => event.type === "text_end")).toMatchObject({ content: text });
+    await expect(
+      (stream as { result(): Promise<AssistantMessage> }).result(),
+    ).resolves.toMatchObject({
+      content: [{ type: "text", text }],
+    });
+  });
+
+  it("restores a completed marker before a following tool block", async () => {
+    const text = "Call the tool[e~[";
+    const toolUse = createToolUseMessage(text);
+    const events: AssistantMessageEvent[] = [
+      { type: "start", partial: createAssistantMessage("") },
+      { type: "text_start", contentIndex: 0, partial: createAssistantMessage("") },
+      { type: "text_delta", contentIndex: 0, delta: "Call the tool[e" },
+      { type: "text_delta", contentIndex: 0, delta: "~[" },
+      { type: "text_end", contentIndex: 0, content: text, partial: createAssistantMessage(text) },
+      { type: "toolcall_start", contentIndex: 1, partial: toolUse },
+      { type: "done", reason: "toolUse", message: toolUse },
+    ];
+
+    const output = await collectEvents(runWrapper(events));
+    const textDeltas = output.filter((event) => event.type === "text_delta");
+    const textEnd = output.find((event) => event.type === "text_end");
+    const done = output.find((event) => event.type === "done");
+
+    expect(textDeltas.map((event) => event.delta).join("")).toBe(text);
+    expect(textEnd?.type === "text_end" ? textEnd.content : undefined).toBe(text);
+    expect(done?.type === "done" ? done.message.content : undefined).toEqual(toolUse.content);
+  });
+
+  it("holds a split marker across interleaved thinking events", async () => {
+    const text = "Done[e~[";
+    const beforeMarker = createThinkingAndTextMessage("reasoning", "Done[e");
+    const fullMessage = createThinkingAndTextMessage("reasoning", text);
+    const stream = runWrapper([
+      { type: "start", partial: createThinkingAndTextMessage("", "") },
+      { type: "thinking_start", contentIndex: 0, partial: createThinkingAndTextMessage("", "") },
+      { type: "text_start", contentIndex: 1, partial: createThinkingAndTextMessage("", "") },
+      { type: "text_delta", contentIndex: 1, delta: "Done[e", partial: beforeMarker },
+      { type: "thinking_delta", contentIndex: 0, delta: "reasoning", partial: beforeMarker },
+      { type: "text_delta", contentIndex: 1, delta: "~[", partial: fullMessage },
+      { type: "text_end", contentIndex: 1, content: text, partial: fullMessage },
+      { type: "thinking_end", contentIndex: 0, content: "reasoning", partial: fullMessage },
+      { type: "done", reason: "stop", message: fullMessage },
+    ]);
+
+    const output = await collectEvents(stream);
+    const textDeltas = output.filter((event) => event.type === "text_delta");
+    const textEnd = output.find((event) => event.type === "text_end");
+    const done = output.find((event) => event.type === "done");
+
+    expect(textDeltas.map((event) => event.delta)).toEqual(["Done"]);
+    expect(textEnd).toMatchObject({ content: "Done" });
+    expect(done?.type === "done" ? done.message.content : undefined).toEqual([
+      { type: "thinking", thinking: "reasoning" },
+      { type: "text", text: "Done" },
+    ]);
+    expect(JSON.stringify(output)).not.toContain("[e~[");
+    expect(JSON.stringify(output)).not.toContain("[e");
+  });
+
+  it("preserves an earlier text marker while cleaning the terminal text block", async () => {
+    const leadingText = "Leading[e~[";
+    const terminalText = "Final[e~[";
+    const leadingMessage = createTextPairMessage(leadingText, "");
+    const fullMessage = createTextPairMessage(leadingText, terminalText);
+    const output = await collectEvents(
+      runWrapper([
+        { type: "start", partial: createTextPairMessage("", "") },
+        { type: "text_start", contentIndex: 0, partial: createTextPairMessage("", "") },
+        { type: "text_start", contentIndex: 1, partial: createTextPairMessage("", "") },
+        { type: "text_delta", contentIndex: 0, delta: leadingText, partial: leadingMessage },
+        { type: "text_delta", contentIndex: 1, delta: terminalText, partial: fullMessage },
+        { type: "text_end", contentIndex: 1, content: terminalText, partial: fullMessage },
+        { type: "text_end", contentIndex: 0, content: leadingText, partial: fullMessage },
+        { type: "done", reason: "stop", message: fullMessage },
+      ]),
+    );
+
+    const leadingDeltas = output.filter(
+      (event): event is Extract<AssistantMessageEvent, { type: "text_delta" }> =>
+        event.type === "text_delta" && event.contentIndex === 0,
+    );
+    const leadingTextEnd = output.find(
+      (event): event is Extract<AssistantMessageEvent, { type: "text_end" }> =>
+        event.type === "text_end" && event.contentIndex === 0,
+    );
+    const terminalTextEnd = output.find(
+      (event): event is Extract<AssistantMessageEvent, { type: "text_end" }> =>
+        event.type === "text_end" && event.contentIndex === 1,
+    );
+    const done = output.find((event) => event.type === "done");
+
+    expect(leadingDeltas.map((event) => event.delta)).toEqual([leadingText]);
+    expect(leadingTextEnd).toMatchObject({ content: leadingText });
+    expect(terminalTextEnd).toMatchObject({ content: "Final" });
+    for (const event of output) {
+      if (!("partial" in event) || !event.partial) {
+        continue;
+      }
+      const terminalBlock = event.partial.content[1];
+      if (terminalBlock?.type === "text") {
+        expect(terminalBlock.text).not.toBe(terminalText);
+      }
+    }
+    expect(done?.type === "done" ? done.message.content : undefined).toEqual([
+      { type: "text", text: leadingText },
+      { type: "text", text: "Final" },
+    ]);
+  });
+
+  it("cleans a completed marker when the stream terminates with an error", async () => {
+    const text = "Interrupted[e~[";
+    const error = { ...createAssistantMessage(text), stopReason: "error" as const };
+    const stream = runWrapper([
+      { type: "start", partial: createAssistantMessage("") },
+      { type: "text_start", contentIndex: 0, partial: createAssistantMessage("") },
+      { type: "text_delta", contentIndex: 0, delta: "Interrupted[e" },
+      { type: "text_delta", contentIndex: 0, delta: "~[" },
+      { type: "text_end", contentIndex: 0, content: text, partial: createAssistantMessage(text) },
+      { type: "error", reason: "error", error },
+    ]);
+
+    const output = await collectEvents(stream);
+    const terminal = output.find((event) => event.type === "error");
+
+    expect(terminal?.type === "error" ? terminal.error.content : undefined).toEqual([
+      { type: "text", text: "Interrupted" },
+    ]);
+    await expect(
+      (stream as { result(): Promise<AssistantMessage> }).result(),
+    ).resolves.toMatchObject({
+      content: [{ type: "text", text: "Interrupted" }],
+    });
+  });
+
+  it("replays a deferred marker and text end before rethrowing a source error", async () => {
+    const text = "Interrupted[e~[";
+    const sourceError = new Error("transport closed");
+    const stream = runWrapper(
+      [
+        { type: "start", partial: createAssistantMessage("") },
+        { type: "text_start", contentIndex: 0, partial: createAssistantMessage("") },
+        {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: text,
+          partial: createAssistantMessage(text),
+        },
+        { type: "text_end", contentIndex: 0, content: text, partial: createAssistantMessage(text) },
+      ],
+      sourceError,
+    );
+    const output: AssistantMessageEvent[] = [];
+
+    await expect(
+      (async () => {
+        for await (const event of stream as AsyncIterable<AssistantMessageEvent>) {
+          output.push(event);
+        }
+      })(),
+    ).rejects.toBe(sourceError);
+
+    const textDeltas = output.filter((event) => event.type === "text_delta");
+    const textEnd = output.find((event) => event.type === "text_end");
+    expect(textDeltas.map((event) => event.delta).join("")).toBe(text);
+    expect(textEnd).toMatchObject({ content: text });
+  });
+
+  it("forwards early iterator cancellation to the source stream", async () => {
+    let sourceClosed = false;
+    const stream = runWrapper(
+      [
+        { type: "start", partial: createAssistantMessage("") },
+        { type: "text_start", contentIndex: 0, partial: createAssistantMessage("") },
+      ],
+      undefined,
+      () => {
+        sourceClosed = true;
+      },
+    );
+    const iterator = (stream as AsyncIterable<AssistantMessageEvent>)[Symbol.asyncIterator]();
+
+    await iterator.next();
+    await iterator.return?.();
+
+    expect(sourceClosed).toBe(true);
+  });
+
+  it("closes the source iterator after a terminal event", async () => {
+    let sourceClosed = false;
+    const text = "Done[e~[";
+    const stream = runWrapper(
+      [
+        { type: "start", partial: createAssistantMessage("") },
+        { type: "text_start", contentIndex: 0, partial: createAssistantMessage("") },
+        { type: "text_delta", contentIndex: 0, delta: text, partial: createAssistantMessage(text) },
+        { type: "text_end", contentIndex: 0, content: text, partial: createAssistantMessage(text) },
+        { type: "done", reason: "stop", message: createAssistantMessage(text) },
+      ],
+      undefined,
+      () => {
+        sourceClosed = true;
+      },
+    );
+
+    await collectEvents(stream);
+
+    expect(sourceClosed).toBe(true);
+  });
+});

--- a/extensions/minimax/stream.test.ts
+++ b/extensions/minimax/stream.test.ts
@@ -50,6 +50,13 @@ function createThinkingAndTextMessage(thinking: string, text: string): Assistant
   };
 }
 
+function createThinkingMessage(thinking: string): AssistantMessage {
+  return {
+    ...createAssistantMessage(""),
+    content: [{ type: "thinking", thinking }],
+  };
+}
+
 function createTextPairMessage(first: string, second: string): AssistantMessage {
   return {
     ...createAssistantMessage(second),
@@ -62,7 +69,6 @@ function createTextPairMessage(first: string, second: string): AssistantMessage 
 
 function createEventStream(
   events: AssistantMessageEvent[],
-  streamError?: Error,
   onIteratorClose?: () => void,
 ): StreamFn {
   return (() => {
@@ -78,9 +84,6 @@ function createEventStream(
       async *[Symbol.asyncIterator]() {
         try {
           yield* events;
-          if (streamError) {
-            throw streamError;
-          }
         } finally {
           onIteratorClose?.();
         }
@@ -99,11 +102,10 @@ async function collectEvents(stream: ReturnType<StreamFn>): Promise<AssistantMes
 
 function runWrapper(
   events: AssistantMessageEvent[],
-  streamError?: Error,
   onIteratorClose?: () => void,
 ) {
   const wrapped = createMinimaxMessageEndMarkerWrapper(
-    createEventStream(events, streamError, onIteratorClose),
+    createEventStream(events, onIteratorClose),
   );
   return wrapped(
     {
@@ -209,19 +211,33 @@ describe("MiniMax message-end stream wrapper", () => {
     expect(done?.type === "done" ? done.message.content : undefined).toEqual(toolUse.content);
   });
 
-  it("holds a split marker across interleaved thinking events", async () => {
+  it("cleans a terminal marker after a preceding thinking block", async () => {
     const text = "Done[e~[";
     const beforeMarker = createThinkingAndTextMessage("reasoning", "Done[e");
     const fullMessage = createThinkingAndTextMessage("reasoning", text);
     const stream = runWrapper([
-      { type: "start", partial: createThinkingAndTextMessage("", "") },
-      { type: "thinking_start", contentIndex: 0, partial: createThinkingAndTextMessage("", "") },
-      { type: "text_start", contentIndex: 1, partial: createThinkingAndTextMessage("", "") },
+      { type: "start", partial: createAssistantMessage("") },
+      { type: "thinking_start", contentIndex: 0, partial: createThinkingMessage("") },
+      {
+        type: "thinking_delta",
+        contentIndex: 0,
+        delta: "reasoning",
+        partial: createThinkingMessage("reasoning"),
+      },
+      {
+        type: "thinking_end",
+        contentIndex: 0,
+        content: "reasoning",
+        partial: createThinkingMessage("reasoning"),
+      },
+      {
+        type: "text_start",
+        contentIndex: 1,
+        partial: createThinkingAndTextMessage("reasoning", ""),
+      },
       { type: "text_delta", contentIndex: 1, delta: "Done[e", partial: beforeMarker },
-      { type: "thinking_delta", contentIndex: 0, delta: "reasoning", partial: beforeMarker },
       { type: "text_delta", contentIndex: 1, delta: "~[", partial: fullMessage },
       { type: "text_end", contentIndex: 1, content: text, partial: fullMessage },
-      { type: "thinking_end", contentIndex: 0, content: "reasoning", partial: fullMessage },
       { type: "done", reason: "stop", message: fullMessage },
     ]);
 
@@ -243,17 +259,26 @@ describe("MiniMax message-end stream wrapper", () => {
   it("preserves an earlier text marker while cleaning the terminal text block", async () => {
     const leadingText = "Leading[e~[";
     const terminalText = "Final[e~[";
-    const leadingMessage = createTextPairMessage(leadingText, "");
+    const leadingMessage = createAssistantMessage(leadingText);
     const fullMessage = createTextPairMessage(leadingText, terminalText);
     const output = await collectEvents(
       runWrapper([
-        { type: "start", partial: createTextPairMessage("", "") },
-        { type: "text_start", contentIndex: 0, partial: createTextPairMessage("", "") },
-        { type: "text_start", contentIndex: 1, partial: createTextPairMessage("", "") },
+        { type: "start", partial: createAssistantMessage("") },
+        { type: "text_start", contentIndex: 0, partial: createAssistantMessage("") },
         { type: "text_delta", contentIndex: 0, delta: leadingText, partial: leadingMessage },
+        {
+          type: "text_end",
+          contentIndex: 0,
+          content: leadingText,
+          partial: leadingMessage,
+        },
+        {
+          type: "text_start",
+          contentIndex: 1,
+          partial: createTextPairMessage(leadingText, ""),
+        },
         { type: "text_delta", contentIndex: 1, delta: terminalText, partial: fullMessage },
         { type: "text_end", contentIndex: 1, content: terminalText, partial: fullMessage },
-        { type: "text_end", contentIndex: 0, content: leadingText, partial: fullMessage },
         { type: "done", reason: "stop", message: fullMessage },
       ]),
     );
@@ -272,7 +297,7 @@ describe("MiniMax message-end stream wrapper", () => {
     );
     const done = output.find((event) => event.type === "done");
 
-    expect(leadingDeltas.map((event) => event.delta)).toEqual([leadingText]);
+    expect(leadingDeltas.map((event) => event.delta).join("")).toBe(leadingText);
     expect(leadingTextEnd).toMatchObject({ content: leadingText });
     expect(terminalTextEnd).toMatchObject({ content: "Final" });
     for (const event of output) {
@@ -315,39 +340,6 @@ describe("MiniMax message-end stream wrapper", () => {
     });
   });
 
-  it("replays a deferred marker and text end before rethrowing a source error", async () => {
-    const text = "Interrupted[e~[";
-    const sourceError = new Error("transport closed");
-    const stream = runWrapper(
-      [
-        { type: "start", partial: createAssistantMessage("") },
-        { type: "text_start", contentIndex: 0, partial: createAssistantMessage("") },
-        {
-          type: "text_delta",
-          contentIndex: 0,
-          delta: text,
-          partial: createAssistantMessage(text),
-        },
-        { type: "text_end", contentIndex: 0, content: text, partial: createAssistantMessage(text) },
-      ],
-      sourceError,
-    );
-    const output: AssistantMessageEvent[] = [];
-
-    await expect(
-      (async () => {
-        for await (const event of stream as AsyncIterable<AssistantMessageEvent>) {
-          output.push(event);
-        }
-      })(),
-    ).rejects.toBe(sourceError);
-
-    const textDeltas = output.filter((event) => event.type === "text_delta");
-    const textEnd = output.find((event) => event.type === "text_end");
-    expect(textDeltas.map((event) => event.delta).join("")).toBe(text);
-    expect(textEnd).toMatchObject({ content: text });
-  });
-
   it("forwards early iterator cancellation to the source stream", async () => {
     let sourceClosed = false;
     const stream = runWrapper(
@@ -355,7 +347,6 @@ describe("MiniMax message-end stream wrapper", () => {
         { type: "start", partial: createAssistantMessage("") },
         { type: "text_start", contentIndex: 0, partial: createAssistantMessage("") },
       ],
-      undefined,
       () => {
         sourceClosed = true;
       },
@@ -379,7 +370,6 @@ describe("MiniMax message-end stream wrapper", () => {
         { type: "text_end", contentIndex: 0, content: text, partial: createAssistantMessage(text) },
         { type: "done", reason: "stop", message: createAssistantMessage(text) },
       ],
-      undefined,
       () => {
         sourceClosed = true;
       },

--- a/extensions/minimax/stream.test.ts
+++ b/extensions/minimax/stream.test.ts
@@ -100,13 +100,8 @@ async function collectEvents(stream: ReturnType<StreamFn>): Promise<AssistantMes
   return events;
 }
 
-function runWrapper(
-  events: AssistantMessageEvent[],
-  onIteratorClose?: () => void,
-) {
-  const wrapped = createMinimaxMessageEndMarkerWrapper(
-    createEventStream(events, onIteratorClose),
-  );
+function runWrapper(events: AssistantMessageEvent[], onIteratorClose?: () => void) {
+  const wrapped = createMinimaxMessageEndMarkerWrapper(createEventStream(events, onIteratorClose));
   return wrapped(
     {
       api: "anthropic-messages",

--- a/extensions/minimax/stream.ts
+++ b/extensions/minimax/stream.ts
@@ -1,0 +1,275 @@
+// MiniMax provider module implements stream output handling.
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import {
+  streamSimple,
+  type AssistantMessage,
+  type AssistantMessageEvent,
+} from "openclaw/plugin-sdk/llm";
+
+const MESSAGE_END_MARKER = "[e~[";
+
+type TextDeltaEvent = Extract<AssistantMessageEvent, { type: "text_delta" }>;
+type TextEndEvent = Extract<AssistantMessageEvent, { type: "text_end" }>;
+type TerminalEvent = Extract<AssistantMessageEvent, { type: "done" | "error" }>;
+type AssistantStream = Awaited<ReturnType<StreamFn>>;
+type PendingText = {
+  contentIndex: number;
+  value: string;
+  deferredTextEnd?: TextEndEvent;
+};
+
+function replayPendingText(contentIndex: number, delta: string): TextDeltaEvent {
+  // `text_delta.partial` is optional: replay the held tail instead of attaching
+  // a snapshot that may have advanced while this wrapper waited for termination.
+  return { type: "text_delta", contentIndex, delta };
+}
+
+function stripMessageEndMarker(text: string): string {
+  return text.replace(/\[e~\[(\s*)$/, "$1");
+}
+
+function splitTrailingCandidate(text: string): { visible: string; pending: string } {
+  const markerIndex = text.lastIndexOf(MESSAGE_END_MARKER);
+  if (markerIndex >= 0 && /^\s*$/.test(text.slice(markerIndex + MESSAGE_END_MARKER.length))) {
+    return { visible: text.slice(0, markerIndex), pending: text.slice(markerIndex) };
+  }
+  for (let length = Math.min(MESSAGE_END_MARKER.length - 1, text.length); length > 0; length -= 1) {
+    if (MESSAGE_END_MARKER.startsWith(text.slice(-length))) {
+      return { visible: text.slice(0, -length), pending: text.slice(-length) };
+    }
+  }
+  return { visible: text, pending: "" };
+}
+
+function replaceText(
+  message: AssistantMessage,
+  contentIndex: number,
+  text: string,
+): AssistantMessage {
+  const block = message.content[contentIndex];
+  if (block?.type !== "text" || block.text === text) {
+    return message;
+  }
+  return {
+    ...message,
+    content: message.content.map((content, index) =>
+      index === contentIndex ? { ...block, text } : content,
+    ),
+  };
+}
+
+function trimFinalMessage(message: AssistantMessage): AssistantMessage {
+  const contentIndex = message.content.length - 1;
+  const block = message.content[contentIndex];
+  return block?.type === "text"
+    ? replaceText(message, contentIndex, stripMessageEndMarker(block.text))
+    : message;
+}
+
+function replaceTextEnd(event: TextEndEvent, content: string): TextEndEvent {
+  const partial = replaceText(event.partial, event.contentIndex, content);
+  return content === event.content && partial === event.partial
+    ? event
+    : {
+        ...event,
+        content,
+        partial,
+      };
+}
+
+function hidePendingTails(
+  event: AssistantMessageEvent,
+  pending: Iterable<PendingText>,
+): AssistantMessageEvent {
+  if (!("partial" in event) || !event.partial) {
+    return event;
+  }
+  let partial = event.partial;
+  for (const state of pending) {
+    const block = partial.content[state.contentIndex];
+    if (block?.type === "text" && block.text.endsWith(state.value)) {
+      partial = replaceText(partial, state.contentIndex, block.text.slice(0, -state.value.length));
+    }
+  }
+  return partial === event.partial ? event : { ...event, partial };
+}
+
+function terminalTextIndex(event: TerminalEvent): number | undefined {
+  const message = event.type === "done" ? event.message : event.error;
+  const contentIndex = message.content.length - 1;
+  return message.content[contentIndex]?.type === "text" ? contentIndex : undefined;
+}
+
+function eventContentIndex(event: AssistantMessageEvent): number | undefined {
+  return "contentIndex" in event ? event.contentIndex : undefined;
+}
+
+async function* transformEvents(
+  source: AsyncIterable<AssistantMessageEvent>,
+): AsyncGenerator<AssistantMessageEvent> {
+  const pendingByContentIndex = new Map<number, PendingText>();
+  let highestContentIndex = -1;
+
+  const replayLiteral = (state: PendingText): AssistantMessageEvent[] => [
+    replayPendingText(state.contentIndex, state.value),
+    ...(state.deferredTextEnd
+      ? [hidePendingTails(state.deferredTextEnd, pendingByContentIndex.values()) as TextEndEvent]
+      : []),
+  ];
+
+  const flushLiteral = (contentIndex: number): AssistantMessageEvent[] => {
+    const state = pendingByContentIndex.get(contentIndex);
+    if (!state) {
+      return [];
+    }
+    pendingByContentIndex.delete(contentIndex);
+    return replayLiteral(state);
+  };
+  // A later block proves an earlier tail literal; earlier blocks may still end
+  // interleaved while the final text block awaits the terminal event.
+  const flushBefore = (contentIndex: number): AssistantMessageEvent[] =>
+    [...pendingByContentIndex.values()]
+      .filter((state) => state.contentIndex < contentIndex)
+      .sort((left, right) => left.contentIndex - right.contentIndex)
+      .flatMap((state) => flushLiteral(state.contentIndex));
+  const flushAll = (): AssistantMessageEvent[] =>
+    [...pendingByContentIndex.values()]
+      .sort((left, right) => left.contentIndex - right.contentIndex)
+      .flatMap((state) => flushLiteral(state.contentIndex));
+
+  const iterator = source[Symbol.asyncIterator]();
+  let sourceExhausted = false;
+  let sourceFailed = false;
+  try {
+    while (true) {
+      let next: IteratorResult<AssistantMessageEvent>;
+      try {
+        next = await iterator.next();
+      } catch (error) {
+        sourceFailed = true;
+        // A thrown source has no terminal event to classify the held suffix.
+        // Replay it as literal text before preserving the transport error.
+        yield* flushAll();
+        throw error;
+      }
+      if (next.done) {
+        sourceExhausted = true;
+        break;
+      }
+      const event = next.value;
+      if (event.type === "done" || event.type === "error") {
+        const contentIndex = terminalTextIndex(event);
+        const message = event.type === "done" ? event.message : event.error;
+        const cleaned = trimFinalMessage(message);
+        const removesTerminalMarker = cleaned !== message;
+        const terminalBlock =
+          contentIndex === undefined ? undefined : cleaned.content[contentIndex];
+        const terminalText = terminalBlock?.type === "text" ? terminalBlock.text : undefined;
+
+        for (const state of [...pendingByContentIndex.values()].sort(
+          (left, right) => left.contentIndex - right.contentIndex,
+        )) {
+          pendingByContentIndex.delete(state.contentIndex);
+          if (removesTerminalMarker && state.contentIndex === contentIndex) {
+            const whitespace = state.value.slice(MESSAGE_END_MARKER.length);
+            if (whitespace) {
+              yield replayPendingText(state.contentIndex, whitespace);
+            }
+            if (state.deferredTextEnd && terminalText !== undefined) {
+              yield replaceTextEnd(state.deferredTextEnd, terminalText);
+            }
+          } else {
+            yield* replayLiteral(state);
+          }
+        }
+        yield event.type === "done" ? { ...event, message: cleaned } : { ...event, error: cleaned };
+        return;
+      }
+
+      const contentIndex = eventContentIndex(event);
+      const isEarlierContentBlock =
+        contentIndex !== undefined && contentIndex < highestContentIndex;
+      if (contentIndex !== undefined && contentIndex > highestContentIndex) {
+        yield* flushBefore(contentIndex);
+        highestContentIndex = contentIndex;
+      }
+
+      if (event.type === "text_delta") {
+        if (isEarlierContentBlock) {
+          yield hidePendingTails(event, pendingByContentIndex.values());
+          continue;
+        }
+        if (pendingByContentIndex.get(event.contentIndex)?.deferredTextEnd) {
+          yield* flushLiteral(event.contentIndex);
+        }
+        const previous = pendingByContentIndex.get(event.contentIndex);
+        const candidate = splitTrailingCandidate((previous?.value ?? "") + event.delta);
+        if (candidate.pending) {
+          pendingByContentIndex.set(event.contentIndex, {
+            contentIndex: event.contentIndex,
+            value: candidate.pending,
+          });
+        } else {
+          pendingByContentIndex.delete(event.contentIndex);
+        }
+        if (candidate.visible) {
+          yield hidePendingTails(
+            { ...event, delta: candidate.visible },
+            pendingByContentIndex.values(),
+          ) as TextDeltaEvent;
+        }
+        continue;
+      }
+
+      if (event.type === "text_end") {
+        if (isEarlierContentBlock) {
+          yield hidePendingTails(event, pendingByContentIndex.values());
+          continue;
+        }
+        if (pendingByContentIndex.get(event.contentIndex)?.deferredTextEnd) {
+          yield* flushLiteral(event.contentIndex);
+        }
+        const trailing = splitTrailingCandidate(event.content).pending;
+        if (trailing) {
+          pendingByContentIndex.set(event.contentIndex, {
+            contentIndex: event.contentIndex,
+            value: trailing,
+            deferredTextEnd: event,
+          });
+        } else {
+          yield* flushLiteral(event.contentIndex);
+          yield hidePendingTails(event, pendingByContentIndex.values());
+        }
+        continue;
+      }
+
+      yield hidePendingTails(event, pendingByContentIndex.values());
+    }
+  } finally {
+    if (!sourceExhausted && !sourceFailed) {
+      await iterator.return?.();
+    }
+  }
+
+  yield* flushAll();
+}
+
+function wrapStream(stream: AssistantStream): AssistantStream {
+  const readResult = stream.result.bind(stream);
+  stream.result = async () => trimFinalMessage(await readResult());
+
+  const createIterator = stream[Symbol.asyncIterator].bind(stream);
+  stream[Symbol.asyncIterator] = () =>
+    transformEvents({ [Symbol.asyncIterator]: createIterator })[Symbol.asyncIterator]();
+  return stream;
+}
+
+export function createMinimaxMessageEndMarkerWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const maybeStream = underlying(model, context, options);
+    return maybeStream && typeof maybeStream === "object" && "then" in maybeStream
+      ? Promise.resolve(maybeStream).then(wrapStream)
+      : wrapStream(maybeStream);
+  };
+}

--- a/extensions/minimax/stream.ts
+++ b/extensions/minimax/stream.ts
@@ -77,21 +77,25 @@ function replaceTextEnd(event: TextEndEvent, content: string): TextEndEvent {
       };
 }
 
-function hidePendingTails(
+function hidePendingTail(
   event: AssistantMessageEvent,
-  pending: Iterable<PendingText>,
+  pending: PendingText | undefined,
 ): AssistantMessageEvent {
-  if (!("partial" in event) || !event.partial) {
+  if (!pending || !("partial" in event) || !event.partial) {
     return event;
   }
-  let partial = event.partial;
-  for (const state of pending) {
-    const block = partial.content[state.contentIndex];
-    if (block?.type === "text" && block.text.endsWith(state.value)) {
-      partial = replaceText(partial, state.contentIndex, block.text.slice(0, -state.value.length));
-    }
+  const block = event.partial.content[pending.contentIndex];
+  if (block?.type !== "text" || !block.text.endsWith(pending.value)) {
+    return event;
   }
-  return partial === event.partial ? event : { ...event, partial };
+  return {
+    ...event,
+    partial: replaceText(
+      event.partial,
+      pending.contentIndex,
+      block.text.slice(0, -pending.value.length),
+    ),
+  };
 }
 
 function terminalTextIndex(event: TerminalEvent): number | undefined {
@@ -107,151 +111,89 @@ function eventContentIndex(event: AssistantMessageEvent): number | undefined {
 async function* transformEvents(
   source: AsyncIterable<AssistantMessageEvent>,
 ): AsyncGenerator<AssistantMessageEvent> {
-  const pendingByContentIndex = new Map<number, PendingText>();
-  let highestContentIndex = -1;
+  let pending: PendingText | undefined;
 
   const replayLiteral = (state: PendingText): AssistantMessageEvent[] => [
     replayPendingText(state.contentIndex, state.value),
-    ...(state.deferredTextEnd
-      ? [hidePendingTails(state.deferredTextEnd, pendingByContentIndex.values()) as TextEndEvent]
-      : []),
+    ...(state.deferredTextEnd ? [state.deferredTextEnd] : []),
   ];
-
-  const flushLiteral = (contentIndex: number): AssistantMessageEvent[] => {
-    const state = pendingByContentIndex.get(contentIndex);
-    if (!state) {
-      return [];
-    }
-    pendingByContentIndex.delete(contentIndex);
-    return replayLiteral(state);
+  const flushLiteral = (): AssistantMessageEvent[] => {
+    const state = pending;
+    pending = undefined;
+    return state ? replayLiteral(state) : [];
   };
-  // A later block proves an earlier tail literal; earlier blocks may still end
-  // interleaved while the final text block awaits the terminal event.
-  const flushBefore = (contentIndex: number): AssistantMessageEvent[] =>
-    [...pendingByContentIndex.values()]
-      .filter((state) => state.contentIndex < contentIndex)
-      .sort((left, right) => left.contentIndex - right.contentIndex)
-      .flatMap((state) => flushLiteral(state.contentIndex));
-  const flushAll = (): AssistantMessageEvent[] =>
-    [...pendingByContentIndex.values()]
-      .sort((left, right) => left.contentIndex - right.contentIndex)
-      .flatMap((state) => flushLiteral(state.contentIndex));
 
-  const iterator = source[Symbol.asyncIterator]();
-  let sourceExhausted = false;
-  let sourceFailed = false;
-  try {
-    while (true) {
-      let next: IteratorResult<AssistantMessageEvent>;
-      try {
-        next = await iterator.next();
-      } catch (error) {
-        sourceFailed = true;
-        // A thrown source has no terminal event to classify the held suffix.
-        // Replay it as literal text before preserving the transport error.
-        yield* flushAll();
-        throw error;
-      }
-      if (next.done) {
-        sourceExhausted = true;
-        break;
-      }
-      const event = next.value;
-      if (event.type === "done" || event.type === "error") {
-        const contentIndex = terminalTextIndex(event);
-        const message = event.type === "done" ? event.message : event.error;
-        const cleaned = trimFinalMessage(message);
-        const removesTerminalMarker = cleaned !== message;
+  // StreamFn encodes provider failures as terminal error events. A thrown
+  // iterator violates the agent-core contract and is not normalized here.
+  for await (const event of source) {
+    if (event.type === "done" || event.type === "error") {
+      const contentIndex = terminalTextIndex(event);
+      const message = event.type === "done" ? event.message : event.error;
+      const cleaned = trimFinalMessage(message);
+      const state = pending;
+      pending = undefined;
+
+      if (state && cleaned !== message && state.contentIndex === contentIndex) {
+        const whitespace = state.value.slice(MESSAGE_END_MARKER.length);
+        if (whitespace) {
+          yield replayPendingText(state.contentIndex, whitespace);
+        }
         const terminalBlock =
           contentIndex === undefined ? undefined : cleaned.content[contentIndex];
-        const terminalText = terminalBlock?.type === "text" ? terminalBlock.text : undefined;
-
-        for (const state of [...pendingByContentIndex.values()].sort(
-          (left, right) => left.contentIndex - right.contentIndex,
-        )) {
-          pendingByContentIndex.delete(state.contentIndex);
-          if (removesTerminalMarker && state.contentIndex === contentIndex) {
-            const whitespace = state.value.slice(MESSAGE_END_MARKER.length);
-            if (whitespace) {
-              yield replayPendingText(state.contentIndex, whitespace);
-            }
-            if (state.deferredTextEnd && terminalText !== undefined) {
-              yield replaceTextEnd(state.deferredTextEnd, terminalText);
-            }
-          } else {
-            yield* replayLiteral(state);
-          }
+        if (state.deferredTextEnd && terminalBlock?.type === "text") {
+          yield replaceTextEnd(state.deferredTextEnd, terminalBlock.text);
         }
-        yield event.type === "done" ? { ...event, message: cleaned } : { ...event, error: cleaned };
-        return;
+      } else if (state) {
+        yield* replayLiteral(state);
       }
 
-      const contentIndex = eventContentIndex(event);
-      const isEarlierContentBlock =
-        contentIndex !== undefined && contentIndex < highestContentIndex;
-      if (contentIndex !== undefined && contentIndex > highestContentIndex) {
-        yield* flushBefore(contentIndex);
-        highestContentIndex = contentIndex;
-      }
-
-      if (event.type === "text_delta") {
-        if (isEarlierContentBlock) {
-          yield hidePendingTails(event, pendingByContentIndex.values());
-          continue;
-        }
-        if (pendingByContentIndex.get(event.contentIndex)?.deferredTextEnd) {
-          yield* flushLiteral(event.contentIndex);
-        }
-        const previous = pendingByContentIndex.get(event.contentIndex);
-        const candidate = splitTrailingCandidate((previous?.value ?? "") + event.delta);
-        if (candidate.pending) {
-          pendingByContentIndex.set(event.contentIndex, {
-            contentIndex: event.contentIndex,
-            value: candidate.pending,
-          });
-        } else {
-          pendingByContentIndex.delete(event.contentIndex);
-        }
-        if (candidate.visible) {
-          yield hidePendingTails(
-            { ...event, delta: candidate.visible },
-            pendingByContentIndex.values(),
-          ) as TextDeltaEvent;
-        }
-        continue;
-      }
-
-      if (event.type === "text_end") {
-        if (isEarlierContentBlock) {
-          yield hidePendingTails(event, pendingByContentIndex.values());
-          continue;
-        }
-        if (pendingByContentIndex.get(event.contentIndex)?.deferredTextEnd) {
-          yield* flushLiteral(event.contentIndex);
-        }
-        const trailing = splitTrailingCandidate(event.content).pending;
-        if (trailing) {
-          pendingByContentIndex.set(event.contentIndex, {
-            contentIndex: event.contentIndex,
-            value: trailing,
-            deferredTextEnd: event,
-          });
-        } else {
-          yield* flushLiteral(event.contentIndex);
-          yield hidePendingTails(event, pendingByContentIndex.values());
-        }
-        continue;
-      }
-
-      yield hidePendingTails(event, pendingByContentIndex.values());
+      yield event.type === "done" ? { ...event, message: cleaned } : { ...event, error: cleaned };
+      return;
     }
-  } finally {
-    if (!sourceExhausted && !sourceFailed) {
-      await iterator.return?.();
+
+    const contentIndex = eventContentIndex(event);
+    // Anthropic-compatible streams finish one content block before the next.
+    // A different block therefore proves a held marker candidate is literal.
+    if (pending && contentIndex !== undefined && contentIndex !== pending.contentIndex) {
+      yield* flushLiteral();
     }
+
+    if (event.type === "text_delta") {
+      if (pending?.deferredTextEnd) {
+        yield* flushLiteral();
+      }
+      const candidate = splitTrailingCandidate((pending?.value ?? "") + event.delta);
+      pending = candidate.pending
+        ? { contentIndex: event.contentIndex, value: candidate.pending }
+        : undefined;
+      if (candidate.visible) {
+        yield hidePendingTail({ ...event, delta: candidate.visible }, pending) as TextDeltaEvent;
+      }
+      continue;
+    }
+
+    if (event.type === "text_end") {
+      if (pending?.deferredTextEnd) {
+        yield* flushLiteral();
+      }
+      const trailing = splitTrailingCandidate(event.content).pending;
+      if (trailing) {
+        pending = {
+          contentIndex: event.contentIndex,
+          value: trailing,
+          deferredTextEnd: event,
+        };
+      } else {
+        yield* flushLiteral();
+        yield event;
+      }
+      continue;
+    }
+
+    yield hidePendingTail(event, pending);
   }
 
-  yield* flushAll();
+  yield* flushLiteral();
 }
 
 function wrapStream(stream: AssistantStream): AssistantStream {

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -1448,6 +1448,48 @@ describe("ollama plugin", () => {
     expect(auth).toBeUndefined();
   });
 
+  it("does not attach MiniMax marker cleanup to Ollama Cloud MiniMax transports", () => {
+    const provider = registerOllamaCloudProvider();
+    const nativeBaseStreamFn = vi.fn(() => ({}) as never);
+    const openAiBaseStreamFn = vi.fn(() => ({}) as never);
+
+    expect(
+      provider.resolveDynamicModel?.({
+        provider: "ollama-cloud",
+        modelId: "minimax-m2.7:cloud",
+      } as never),
+    ).toMatchObject({
+      provider: "ollama-cloud",
+      id: "minimax-m2.7:cloud",
+    });
+    expect(provider.textTransforms).toBeUndefined();
+    expect(
+      provider.wrapStreamFn?.({
+        provider: "ollama-cloud",
+        modelId: "minimax-m2.7:cloud",
+        model: {
+          api: "ollama",
+          provider: "ollama-cloud",
+          id: "minimax-m2.7:cloud",
+        },
+        streamFn: nativeBaseStreamFn,
+      } as never),
+    ).toBe(nativeBaseStreamFn);
+    expect(
+      provider.wrapStreamFn?.({
+        provider: "ollama-cloud",
+        modelId: "minimax-m2.7:cloud",
+        model: {
+          api: "openai-completions",
+          provider: "ollama-cloud",
+          id: "minimax-m2.7:cloud",
+          baseUrl: "https://ollama.com/v1",
+        },
+        streamFn: openAiBaseStreamFn,
+      } as never),
+    ).toBe(openAiBaseStreamFn);
+  });
+
   it("registers ollama-cloud as a hosted provider", async () => {
     const provider = registerOllamaCloudProvider();
 


### PR DESCRIPTION
Closes #105113

## What Problem This Solves

Official MiniMax Anthropic-compatible streams can append `[e~[` at the end of an assistant message. The earlier shared text sanitizer was too broad: it receives text without provider or transport identity, so it could remove ordinary prose from unrelated hosted MiniMax routes.

## Why This Change Was Made

The cleanup now belongs to `extensions/minimax` and is attached only to the `minimax` and `minimax-portal` provider hooks. The wrapper keeps at most one possible trailing marker for the current sequential text block, hides that candidate from partial snapshots, removes it only at terminal `done` or `error` events (and `result()`), and restores it when later text or another content block proves it is literal. The existing MiniMax fast-mode wrapper remains the inner wrapper.

`StreamFn` reports provider failures as terminal error events, so the wrapper handles that contract directly and preserves iterator cancellation without adding a second non-contract error path.

## User Impact

Official MiniMax and MiniMax Portal streams no longer expose the terminal marker. Literal marker-like prose, preceding thinking blocks, sequential text blocks, and tool-use turns remain intact. Ollama Cloud MiniMax routes are unchanged for both native and OpenAI-compatible transports.

## Evidence

- GitHub CI `checks-node-changed` on `231a63ad793915073806a2e93c006133fc25963e`: 88 tests passed across `extensions/minimax/index.test.ts` (15), `extensions/minimax/provider-discovery.contract.test.ts` (3), `extensions/minimax/stream.test.ts` (8), and `extensions/ollama/index.test.ts` (62).
- The same CI head passed `build-artifacts`, `check-prod-types`, `check-test-types`, and `check-additional-extension-package-boundary`.
- `oxfmt --check` passed for the five changed MiniMax/Ollama files; `git diff --check` is clean.
- Full-branch autoreview against the merge base completed clean with no accepted/actionable findings.
- Earlier review evidence captured raw Ollama Cloud MiniMax M2.7/M3 native and `/v1` streams without the marker; the Ollama regression asserts no MiniMax cleanup wrapper is attached there.
- CI run `29385552030` is not globally green because five underlying checks fail outside this PR's changed surfaces: stale `docs/docs_map.md`, a UI chat import cycle, core embedded-agent lint errors, unused channel message-access exports, and stale bundled-channel metadata. `openclaw/ci-gate` reflects those failures; none names a changed file from this PR.

Remaining proof gap: no live official MiniMax-to-channel round trip has been captured for this exact head.

Tested commit: `231a63ad793915073806a2e93c006133fc25963e`

ScreenSshot

<img width="1440" height="3168" alt="Screenshot_20260715_144822" src="https://github.com/user-attachments/assets/03ed8711-7084-4ddb-bc44-fd1518c14839" />

