### PR TITLE
refactor(sessions): remove unused transcript helpers

### DIFF
--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -47,8 +47,6 @@ import {
   updateSqliteSessionLastRoute,
   loadExactSqliteSessionEntry,
   loadLatestSqliteAssistantText,
-  loadLatestSqliteAssistantMessage,
-  loadLatestSqliteMessage,
   loadSqliteSessionEntry,
   loadSqliteTranscriptEvents,
   loadSqliteTranscriptEventsSync,
@@ -327,16 +325,6 @@ export type LatestTranscriptAssistantText = {
   id?: string;
   text: string;
   timestamp?: number;
-};
-
-export type LatestTranscriptAssistantMessage = {
-  id?: string;
-  message: unknown;
-};
-
-export type LatestTranscriptMessage = {
-  id?: string;
-  message: unknown;
 };
 
 export type SessionTranscriptWriteLockAccessorContext = {
@@ -2368,22 +2356,6 @@ export function readLatestTranscriptAssistantText(
   options: { includeTranscriptOnlyOpenClawAssistant?: boolean } = {},
 ): LatestTranscriptAssistantText | undefined {
   return loadLatestSqliteAssistantText(scope, options);
-}
-
-/** Reads the latest assistant message payload without materializing the whole transcript. */
-export function readLatestTranscriptAssistantMessage(
-  scope: SessionTranscriptReadScope,
-  options: { includeTranscriptOnlyOpenClawAssistant?: boolean } = {},
-): LatestTranscriptAssistantMessage | undefined {
-  return loadLatestSqliteAssistantMessage(scope, options);
-}
-
-/** Reads the latest transcript message payload without materializing the whole transcript. */
-export function readLatestTranscriptMessage(
-  scope: SessionTranscriptReadScope,
-  options: { includeTranscriptOnlyOpenClawAssistant?: boolean } = {},
-): LatestTranscriptMessage | undefined {
-  return loadLatestSqliteMessage(scope, options);
 }
 
 /**

--- a/src/config/sessions/transcript-append.test-support.ts
+++ b/src/config/sessions/transcript-append.test-support.ts
@@ -27,10 +27,7 @@ import {
   streamSessionTranscriptLinesReverse,
 } from "./transcript-stream.js";
 import { isCanonicalSessionTranscriptEntry } from "./transcript-tree.js";
-import {
-  resolveOwnedSessionTranscriptWriteLockRunner,
-  type OwnedSessionTranscriptPublishedEntry,
-} from "./transcript-write-context.js";
+import { resolveOwnedSessionTranscriptWriteLockRunner } from "./transcript-write-context.js";
 import { CURRENT_SESSION_VERSION } from "./version.js";
 
 const SESSION_MANAGER_APPEND_MAX_BYTES = 8 * 1024 * 1024;
@@ -425,13 +422,6 @@ export type AppendSessionTranscriptMessageResult<TMessage> = {
   appended: boolean;
 };
 
-export type SessionTranscriptAppendTransactionContext = {
-  appendEvent: (event: unknown) => Promise<void>;
-  appendMessage: <TMessage>(
-    params: Omit<AppendSessionTranscriptMessageParams<TMessage>, "config" | "transcriptPath">,
-  ) => Promise<AppendSessionTranscriptMessageResult<TMessage> | undefined>;
-};
-
 function isTranscriptAgentMessage(value: unknown): value is AgentMessage {
   return (
     typeof value === "object" &&
@@ -509,57 +499,6 @@ export async function appendSessionTranscriptMessageWithOwnedWriteLock<TMessage>
     throw new Error("Owned transcript write lock is required for batch transcript append");
   }
   return await activeLockRunner(() => appendSessionTranscriptMessageLocked(params));
-}
-
-/**
- * Runs a group of transcript appends through one append queue and write lock.
- */
-export async function runSessionTranscriptAppendTransaction<T>(
-  params: Pick<AppendSessionTranscriptMessageParams, "config" | "transcriptPath">,
-  run: (context: SessionTranscriptAppendTransactionContext) => Promise<T> | T,
-): Promise<T> {
-  const publishedEntries: OwnedSessionTranscriptPublishedEntry[] = [];
-  const runTransaction = async (): Promise<T> =>
-    await run({
-      appendEvent: async (event) => {
-        const result = await appendSessionTranscriptEventLocked({
-          config: params.config,
-          event,
-          transcriptPath: params.transcriptPath,
-        });
-        publishedEntries.push({ kind: "serialized", serialized: result.serializedEntry });
-      },
-      appendMessage: async (messageParams) => {
-        const result = await appendSessionTranscriptMessageLocked({
-          ...messageParams,
-          config: params.config,
-          onHeaderCreated: (header) => {
-            publishedEntries.push({ kind: "header", serialized: header });
-          },
-          transcriptPath: params.transcriptPath,
-        });
-        if (result?.appended === true) {
-          publishedEntries.push({ kind: "id", id: result.messageId });
-        }
-        return result;
-      },
-    });
-  const activeLockRunner = resolveOwnedSessionTranscriptWriteLockRunner({
-    sessionFile: params.transcriptPath,
-  });
-  if (activeLockRunner) {
-    return await activeLockRunner(
-      () => withSessionTranscriptAppendQueue(params.transcriptPath, runTransaction),
-      {
-        publishOwnedWrite: true,
-        resolvePublishedEntries: () => publishedEntries,
-        resolvePublishedEntriesAfterFailure: () => publishedEntries,
-      },
-    );
-  }
-  return await withSessionTranscriptAppendQueue(params.transcriptPath, () =>
-    withSessionTranscriptWriteLock(params, runTransaction),
-  );
 }
 
 type AppendSessionTranscriptEventParams = {


### PR DESCRIPTION
## What Problem This Solves

The session subsystem retained three zero-caller helper surfaces after the SQLite transcript cutover: two duplicate latest-message facade reads and one legacy file-backed append transaction helper. Keeping them preserved duplicate types and queue/lock code that no runtime, test, SDK, or public barrel consumes.

## Why This Change Was Made

Remove the unused helpers, their private result/context types, and imports that become unnecessary. The active SQLite accessors, transcript append path, and Plugin SDK exports are unchanged.

## User Impact

No user-visible behavior changes. The sessions owner has 90 fewer lines of obsolete API and transaction code to maintain.

## Evidence

- Fresh codebase-memory graph: 304,219 nodes / 1,257,278 edges; all three functions reported zero callers.
- Repository-wide exact-symbol search found only the declarations before removal and no references afterward.
- Blacksmith Testbox `tbx_01kxat3k60033eaajaesr2m2kt`: 176/176 focused tests passed across `session-accessor.test.ts`, `session-accessor.conformance.test.ts`, and `transcript.test.ts`.
- Path-scoped `pnpm check:changed` passed core/coreTests typecheck, lint, import-cycle, database-first, formatter, dependency, and repository guards.
- The pre-existing Plugin SDK hash drift was isolated: generated JSON, JSONL, and SHA-256 outputs were byte-identical between clean `main` and this patch; the gate passed with the generated hash supplied temporarily and cleaned afterward.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, no accepted/actionable findings (0.87 confidence).

AI-assisted: yes. No transcript attached per operator preference.
