### PR TITLE
fix: clear transcript search data when sessions are deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Session transcript search deletion:** remove FTS rows and index watermarks in the same lifecycle transaction as deleted session transcripts, preventing stale searchable content and index metadata from remaining in the agent database. (#105225)
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Session transcript search deletion:** remove FTS rows and index watermarks in the same lifecycle transaction as deleted session transcripts, preventing stale searchable content and index metadata from remaining in the agent database. (#105225)
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -3866,6 +3866,9 @@ function emitArchivedSqliteTranscriptUpdates(
 
 function deleteSqliteSessionStateRows(database: OpenClawAgentDatabase, sessionId: string): void {
   const db = getSessionKysely(database.db);
+  // The sessions row cascades canonical transcript tables, but FTS is virtual
+  // and its watermark has no cascade; clear both before dropping the owner row.
+  deleteSessionTranscriptIndexInTransaction(database.db, sessionId);
   executeSqliteQuerySync(
     database.db,
     db.deleteFrom("sessions").where("session_id", "=", sessionId),

--- a/src/config/sessions/store.session-lifecycle-mutation.test.ts
+++ b/src/config/sessions/store.session-lifecycle-mutation.test.ts
@@ -261,6 +261,64 @@ describe("session store lifecycle mutations", () => {
     );
   });
 
+  it("deletes transcript search state with archived session rows", async () => {
+    const sessionId = "delete-indexed-session";
+    await replaceSessionEntry(
+      { sessionKey: "agent:main:delete-indexed", storePath },
+      { sessionId, updatedAt: Date.now() },
+    );
+    await replaceSqliteTranscriptEvents(
+      { sessionKey: "agent:main:delete-indexed", sessionId, storePath },
+      [
+        {
+          type: "message",
+          id: "delete-indexed-message",
+          parentId: null,
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "remove this searchable transcript" }],
+          },
+          timestamp: Date.now(),
+        } as unknown as TestTranscriptEvent,
+      ],
+    );
+    const database = openLifecycleTestDatabase(storePath);
+    const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
+    const readSearchState = () => ({
+      fts: executeSqliteQuerySync(
+        database.db,
+        db
+          .selectFrom("session_transcript_fts")
+          .select("session_id")
+          .where("session_id", "=", sessionId),
+      ).rows,
+      watermarks: executeSqliteQuerySync(
+        database.db,
+        db
+          .selectFrom("session_transcript_index_state")
+          .select("session_id")
+          .where("session_id", "=", sessionId),
+      ).rows,
+    });
+
+    expect(readSearchState()).toEqual({
+      fts: [{ session_id: sessionId }],
+      watermarks: [{ session_id: sessionId }],
+    });
+
+    const result = await deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      storePath,
+      target: {
+        canonicalKey: "agent:main:delete-indexed",
+        storeKeys: ["agent:main:delete-indexed"],
+      },
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(readSearchState()).toEqual({ fts: [], watermarks: [] });
+  });
+
   it("durably writes SQLite transcript archives before deleting entry rows", async () => {
     const now = Date.now();
     await replaceSessionEntry(


### PR DESCRIPTION
Closes #105225

## What Problem This Solves

Fixes an issue where users deleting or resetting an indexed session would leave the retired transcript's FTS rows and search watermark in the per-agent database after the canonical session and transcript rows were gone.

## Why This Change Was Made

The lifecycle delete path now clears transcript-search rows inside the same SQLite transaction before dropping the owning session row. A focused regression covers the real archive-and-delete lifecycle rather than only the direct transcript-delete helper.

This PR is AI-assisted. I reviewed the changed lifecycle path, callers, sibling reset path, index helper, and adjacent tests.

## User Impact

Deleted and reset session content no longer remains in transcript-search storage. Search RPC and tool behavior, schema, configuration, and archives are otherwise unchanged.

## Evidence

- Live pre-fix reproduction on isolated `main@18eb472f82668cfcf9464033a92d92c1264f817b`: successful `sessions.delete` left `session_rows=0`, `transcript_rows=0`, `fts_rows=2`, `watermark_rows=1`.
- Live patched Crabbox run `run_fb607374320f`: indexed delete fixture changed from `1/4/3/1` session/transcript/FTS/watermark rows before deletion to `0/0/0/0` after the successful gateway RPC; scoped search returned no deleted hit.
- Same live run: reset retired ID ended at `0/0/0/0`; old phrase returned no scoped hit, new phrase returned both user and assistant hits.
- Final health run `run_23bb64d8633d`: `PRAGMA integrity_check = ok`; every clean watermark equaled `MAX(transcript_events.seq)`; zero FTS sessions without watermarks; zero watermarks without transcripts; no search-index gateway errors.
- Blacksmith Testbox: `src/config/sessions/store.session-lifecycle-mutation.test.ts` and `src/config/sessions/session-transcript-search.test.ts` — 25/25 tests passed; targeted `oxfmt --check` passed.
- Patched source build: Crabbox run `run_98957f0df9cd` passed, including the Plugin SDK declaration budget and Control UI build.
- `check:changed` scoped conflict, attribution, dependency, duplicate, wildcard-export, and format checks passed. Its Plugin SDK API baseline check also fails unchanged on clean base `18eb472f82668cfcf9464033a92d92c1264f817b`; this patch does not touch an exported surface.
- Fresh autoreview: no accepted/actionable findings; overall verdict `patch is correct` (0.90 confidence).

Non-visual storage fix; screenshots are not applicable.
