### PR TITLE
test(matrix): isolate approval reaction runtime

### DIFF
--- a/extensions/matrix/src/approval-reactions.test.ts
+++ b/extensions/matrix/src/approval-reactions.test.ts
@@ -1,5 +1,5 @@
 // Matrix tests cover approval reactions plugin behavior.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildMatrixApprovalReactionHint,
   clearMatrixApprovalReactionTargetsForTest,
@@ -8,7 +8,7 @@ import {
   resolveMatrixApprovalReactionTargetWithPersistence as resolveMatrixApprovalReactionTargetWithPersistenceRaw,
   unregisterMatrixApprovalReactionTarget as unregisterMatrixApprovalReactionTargetRaw,
 } from "./approval-reactions.js";
-import { setMatrixRuntime } from "./runtime.js";
+import { clearMatrixRuntime, setMatrixRuntime } from "./runtime.js";
 
 type RegisterTargetParams = Parameters<typeof registerMatrixApprovalReactionTargetRaw>[0];
 type ResolveTargetParams = Parameters<
@@ -53,8 +53,13 @@ function createRuntimeLogger(overrides: { warn?: ReturnType<typeof vi.fn> } = {}
   };
 }
 
+beforeEach(() => {
+  clearMatrixRuntime();
+});
+
 afterEach(() => {
   clearMatrixApprovalReactionTargetsForTest();
+  clearMatrixRuntime();
   vi.restoreAllMocks();
 });
 

--- a/extensions/matrix/src/runtime.ts
+++ b/extensions/matrix/src/runtime.ts
@@ -4,6 +4,7 @@ import type { PluginRuntime } from "./runtime-api.js";
 
 const {
   setRuntime: setMatrixRuntime,
+  clearRuntime: clearMatrixRuntime,
   getRuntime: getMatrixRuntime,
   tryGetRuntime: getOptionalMatrixRuntime,
 } = createPluginRuntimeStore<PluginRuntime>({
@@ -11,4 +12,4 @@ const {
   errorMessage: "Matrix runtime not initialized",
 });
 
-export { getMatrixRuntime, getOptionalMatrixRuntime, setMatrixRuntime };
+export { clearMatrixRuntime, getMatrixRuntime, getOptionalMatrixRuntime, setMatrixRuntime };


### PR DESCRIPTION
## Summary

- expose the Matrix plugin runtime store's existing clear operation
- reset Matrix runtime before and after approval-reaction tests
- prevent persisted runtime state from leaking into no-isolate validation

## Verification

- `node scripts/run-vitest.mjs extensions/matrix/src/approval-reactions.test.ts` (9 passed, including post-rebase)
- `git diff --check origin/main...HEAD`
- fresh autoreview: clean, no accepted/actionable findings

Release note: none; test-isolation repair with no runtime behavior change.
