### PR TITLE
test(plugins): align prerelease contracts

### DIFF
--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -1336,7 +1336,7 @@ describe("provider-runtime", () => {
 
     expect(contribution?.stablePrefix).toContain("<persona_latch>");
     expect(contribution?.sectionOverrides?.interaction_style).toContain(
-      "Live chat tone: short, natural, human.",
+      "Live chat: short, natural, human.",
     );
   });
 

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -265,7 +265,7 @@ describe("setup-registry module loader", () => {
 
   it("uses the runtime-supported source-transform boundary on Windows for setup-api modules", () => {
     expect(windowsSourceTransformCase.filename).toBe(windowsSourceTransformCase.expectedFilename);
-    expect(windowsSourceTransformCase.options.tryNative).toBe(true);
+    expect(windowsSourceTransformCase.options.tryNative).toBe(false);
   });
 
   it("passes explicit plugin id scope into setup manifest reads", () => {


### PR DESCRIPTION
## What Problem This Solves

Plugin Prerelease exact-main run 29187455327 failed the agentic-plugin shard because two test expectations no longer matched their owning contracts.

## Why This Change Was Made

The GPT-5 prompt compaction changed the stable interaction-style text, while the native ESM fallback-race fix intentionally makes jiti's source-transform fallback run with native loading disabled. Both affected tests still asserted the previous values.

## User Impact

No runtime behavior change. Restores deterministic Plugin Prerelease coverage for the current prompt and plugin-loader contracts.

## Evidence

- Exact failure: https://github.com/openclaw/openclaw/actions/runs/29187455327/job/86636055681
- Blacksmith Testbox `tbx_01kxatrnp9kjvf4m37mz5zxkrr`: 2 files, 91 tests passed
- `git diff --check`
- Fresh Codex autoreview: clean, no accepted/actionable findings
