### PR TITLE
test(telegram): align prerelease contracts

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -5910,7 +5910,13 @@ describe("createTelegramBot", () => {
     await runMiddlewareChain(ctx);
 
     expect(resolveExecApprovalSpy).toHaveBeenCalledTimes(2);
-    expect(editMessageReplyMarkupSpy).toHaveBeenCalledTimes(1);
+    expect(editMessageTextSpy).toHaveBeenCalledWith(
+      1234,
+      231,
+      expect.stringContaining("Result: Allowed once"),
+      { reply_markup: { inline_keyboard: [] } },
+    );
+    expect(editMessageReplyMarkupSpy).not.toHaveBeenCalled();
     expect(sendMessageSpy).not.toHaveBeenCalled();
   });
 

--- a/extensions/telegram/src/channel.message-adapter.test.ts
+++ b/extensions/telegram/src/channel.message-adapter.test.ts
@@ -9,9 +9,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageTelegramMock = vi.fn();
 const reactMessageTelegramMock = vi.fn();
+const sendLocationTelegramMock = vi.fn();
 
 vi.mock("./send.js", () => ({
   reactMessageTelegram: (...args: unknown[]) => reactMessageTelegramMock(...args),
+  sendLocationTelegram: (...args: unknown[]) => sendLocationTelegramMock(...args),
   sendMessageTelegram: (...args: unknown[]) => sendMessageTelegramMock(...args),
 }));
 
@@ -29,6 +31,7 @@ function requireTelegramMessageAdapter(): TelegramMessageAdapter {
 describe("telegram channel message adapter", () => {
   beforeEach(() => {
     reactMessageTelegramMock.mockReset();
+    sendLocationTelegramMock.mockReset();
     sendMessageTelegramMock.mockReset();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Plugin Prerelease run 29187455327 failed Telegram's extension shard because two test contracts lagged recently landed behavior: the full send-module mock omitted `sendLocationTelegram`, and the retry test still expected button-only cleanup after approval receipts moved to a terminal text edit.

## Why This Change Was Made

- Complete the Telegram send-module mock with the location export used by payload sends.
- Assert the successful retried approval renders the visible legacy terminal receipt and clears inline controls through `editMessageText`.

## User Impact

No runtime behavior change. Plugin prerelease validation now exercises the current Telegram contracts without failing on stale mocks or stale receipt assertions.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/29187455327/job/86636055756
- Blacksmith Testbox `tbx_01kxatwx6079g4ywq70r3cng2b`: 124/124 focused Telegram tests passed.
- `git diff --check`
- Fresh autoreview: clean, no accepted/actionable findings.
