### PR TITLE
fix(active-memory): restore SQLite recall sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ Docs: https://docs.openclaw.ai
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.
 - **Cron delivery status:** keep successful isolated agent turns at `status=ok` when downstream delivery fails, while preserving the send failure separately in delivery state and run logs. (#95419) Thanks @Alix-007.
 - **Channel ingress recovery:** tombstone and scrub malformed durable ingress payloads without letting corrupt rows hide or starve later valid messages. (#98402) Thanks @Pick-cat.
-- **Active Memory recall sessions:** initialize embedded recall runs with an exact SQLite session identity and clean up their transient transcript state afterward, restoring pre-prompt recall under strict plugin session ownership.
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.
 - **Cron delivery status:** keep successful isolated agent turns at `status=ok` when downstream delivery fails, while preserving the send failure separately in delivery state and run logs. (#95419) Thanks @Alix-007.
 - **Channel ingress recovery:** tombstone and scrub malformed durable ingress payloads without letting corrupt rows hide or starve later valid messages. (#98402) Thanks @Pick-cat.
+- **Active Memory recall sessions:** initialize embedded recall runs with an exact SQLite session identity and clean up their transient transcript state afterward, restoring pre-prompt recall under strict plugin session ownership.
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -8,6 +8,7 @@ import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { parseSqliteSessionFileMarker } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
@@ -46,6 +47,7 @@ const hoisted = vi.hoisted(() => {
   };
   return {
     closeActiveMemorySearchManager: vi.fn(async () => {}),
+    cleanupSessionLifecycleArtifacts: vi.fn(),
     runtimeTranscriptFiles: {} as Record<string, string>,
     sessionStore,
     updateSessionStore: vi.fn(
@@ -69,6 +71,7 @@ vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
   );
   return {
     ...actual,
+    cleanupSessionLifecycleArtifacts: hoisted.cleanupSessionLifecycleArtifacts,
     updateSessionStore: hoisted.updateSessionStore,
   };
 });
@@ -158,19 +161,6 @@ describe("active-memory plugin", () => {
       },
     };
   });
-  const deleteSession = vi.fn(
-    async (params: { sessionKey: string; deleteTranscript?: boolean }) => {
-      const sessionId = hoisted.sessionStore[params.sessionKey]?.sessionId;
-      if (typeof sessionId === "string") {
-        const testSessionFile = hoisted.runtimeTranscriptFiles[sessionId];
-        if (testSessionFile) {
-          await fs.rm(testSessionFile, { force: true });
-          delete hoisted.runtimeTranscriptFiles[sessionId];
-        }
-      }
-      delete hoisted.sessionStore[params.sessionKey];
-    },
-  );
   let stateDir = "";
   let configFile: Record<string, unknown> = {};
   let pluginConfig: Record<string, unknown> = {
@@ -270,9 +260,6 @@ describe("active-memory plugin", () => {
             },
           ),
         },
-      },
-      subagent: {
-        deleteSession,
       },
       state: {
         resolveStateDir: () => stateDir,
@@ -530,6 +517,28 @@ describe("active-memory plugin", () => {
         payloads: [{ text: "- lemon pepper wings\n- blue cheese" }],
       };
     });
+    hoisted.cleanupSessionLifecycleArtifacts.mockImplementation(
+      async (params: { sessionKeySegmentPrefix: string }) => {
+        const entry = Object.entries(hoisted.sessionStore).find(([sessionKey]) => {
+          const parsed = sessionKey.split(":").slice(2).join(":");
+          return parsed.startsWith(params.sessionKeySegmentPrefix);
+        });
+        if (!entry) {
+          return { archivedTranscriptArtifacts: 0, removedEntries: 0 };
+        }
+        const [sessionKey, sessionEntry] = entry;
+        const sessionId = sessionEntry.sessionId;
+        if (typeof sessionId === "string") {
+          const testSessionFile = hoisted.runtimeTranscriptFiles[sessionId];
+          if (testSessionFile) {
+            await fs.rm(testSessionFile, { force: true });
+            delete hoisted.runtimeTranscriptFiles[sessionId];
+          }
+        }
+        delete hoisted.sessionStore[sessionKey];
+        return { archivedTranscriptArtifacts: 0, removedEntries: 1 };
+      },
+    );
     testing.resetActiveRecallCacheForTests();
     testing.setTimeoutPartialDataGraceMsForTests(5);
     plugin.register(api as unknown as OpenClawPluginApi);
@@ -645,9 +654,13 @@ describe("active-memory plugin", () => {
       sessionId,
       sessionFile: runtimeSessionFile,
     });
-    expect(deleteSession).toHaveBeenCalledWith({
-      sessionKey,
-      deleteTranscript: false,
+    expect(hoisted.cleanupSessionLifecycleArtifacts).toHaveBeenCalledWith({
+      agentId: "main",
+      archiveRemovedEntryTranscripts: false,
+      orphanTranscriptMinAgeMs: 0,
+      sessionKeySegmentPrefix: parseAgentSessionKey(sessionKey)?.rest,
+      storePath: path.join(stateDir, "sessions.json"),
+      transcriptContentMarker: `"runId":"${sessionId}"`,
     });
     expect(hoisted.sessionStore[sessionKey]).toBeUndefined();
     expectPrependContextContains(result, "lemon pepper wings");

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -641,12 +641,13 @@ describe("active-memory plugin", () => {
       storePath: path.join(stateDir, "sessions.json"),
     });
     expect(persistedEntryAtRun).toMatchObject({
+      pluginOwnerId: "active-memory",
       sessionId,
       sessionFile: runtimeSessionFile,
     });
     expect(deleteSession).toHaveBeenCalledWith({
       sessionKey,
-      deleteTranscript: true,
+      deleteTranscript: false,
     });
     expect(hoisted.sessionStore[sessionKey]).toBeUndefined();
     expectPrependContextContains(result, "lemon pepper wings");

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -653,6 +653,30 @@ describe("active-memory plugin", () => {
     expectPrependContextContains(result, "lemon pepper wings");
   });
 
+  it("uses a unique SQLite session key for repeated identical recalls", async () => {
+    const hookParams = {
+      agentId: "main",
+      trigger: "user",
+      sessionKey: "agent:main:main",
+      messageProvider: "webchat",
+    };
+    const event = { prompt: "what wings should i order?", messages: [] };
+
+    await hooks.before_prompt_build(event, hookParams);
+    const firstSessionKey = requireNonEmptyString(
+      lastRuntimeEmbeddedRunParams().sessionKey,
+      "expected first runtime session key",
+    );
+    testing.resetActiveRecallCacheForTests();
+    await hooks.before_prompt_build(event, hookParams);
+    const secondSessionKey = requireNonEmptyString(
+      lastRuntimeEmbeddedRunParams().sessionKey,
+      "expected second runtime session key",
+    );
+
+    expect(secondSessionKey).not.toBe(firstSessionKey);
+  });
+
   it("registers a session-scoped active-memory toggle command", async () => {
     const command = registeredCommands["active-memory"];
     const sessionKey = "agent:main:active-memory-toggle";

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -730,6 +730,28 @@ describe("active-memory plugin", () => {
     expect(secondSessionKey).not.toBe(firstSessionKey);
   });
 
+  it("retries transient SQLite recall cleanup failures", async () => {
+    hoisted.cleanupSessionLifecycleArtifacts.mockRejectedValueOnce(
+      new Error("session store is busy"),
+    );
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order? retry cleanup", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    expectPrependContextContains(result, "lemon pepper wings");
+    expect(hoisted.cleanupSessionLifecycleArtifacts).toHaveBeenCalledTimes(2);
+    expect(api.logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("failed to clean up recall session"),
+    );
+  });
+
   it("registers a session-scoped active-memory toggle command", async () => {
     const command = registeredCommands["active-memory"];
     const sessionKey = "agent:main:active-memory-toggle";

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -48,6 +48,7 @@ const hoisted = vi.hoisted(() => {
   return {
     closeActiveMemorySearchManager: vi.fn(async () => {}),
     cleanupSessionLifecycleArtifacts: vi.fn(),
+    patchSessionEntry: vi.fn(),
     runtimeTranscriptFiles: {} as Record<string, string>,
     sessionStore,
     updateSessionStore: vi.fn(
@@ -72,6 +73,7 @@ vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
   return {
     ...actual,
     cleanupSessionLifecycleArtifacts: hoisted.cleanupSessionLifecycleArtifacts,
+    patchSessionEntry: hoisted.patchSessionEntry,
     updateSessionStore: hoisted.updateSessionStore,
   };
 });
@@ -517,6 +519,31 @@ describe("active-memory plugin", () => {
         payloads: [{ text: "- lemon pepper wings\n- blue cheese" }],
       };
     });
+    hoisted.patchSessionEntry.mockImplementation(
+      async (params: {
+        fallbackEntry?: Record<string, unknown>;
+        replaceEntry?: boolean;
+        sessionKey: string;
+        skipMaintenance?: boolean;
+        update: (
+          entry: Record<string, unknown>,
+          context: { existingEntry?: Record<string, unknown> },
+        ) => Record<string, unknown> | null;
+      }) => {
+        const existingEntry = hoisted.sessionStore[params.sessionKey];
+        const entry = existingEntry ?? params.fallbackEntry;
+        if (!entry) {
+          return null;
+        }
+        const patch = params.update({ ...entry }, { existingEntry });
+        if (!patch) {
+          return existingEntry ?? entry;
+        }
+        const next = params.replaceEntry ? { ...patch } : { ...entry, ...patch };
+        hoisted.sessionStore[params.sessionKey] = next;
+        return next;
+      },
+    );
     hoisted.cleanupSessionLifecycleArtifacts.mockImplementation(
       async (params: { sessionKeySegmentPrefix: string }) => {
         const entry = Object.entries(hoisted.sessionStore).find(([sessionKey]) => {
@@ -654,6 +681,19 @@ describe("active-memory plugin", () => {
       sessionId,
       sessionFile: runtimeSessionFile,
     });
+    expect(hoisted.patchSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fallbackEntry: expect.objectContaining({
+          pluginOwnerId: "active-memory",
+          sessionId,
+          sessionFile: runtimeSessionFile,
+        }),
+        replaceEntry: true,
+        sessionKey,
+        skipMaintenance: true,
+        storePath: path.join(stateDir, "sessions.json"),
+      }),
+    );
     expect(hoisted.cleanupSessionLifecycleArtifacts).toHaveBeenCalledWith({
       agentId: "main",
       archiveRemovedEntryTranscripts: false,
@@ -3468,6 +3508,19 @@ describe("active-memory plugin", () => {
     expect(result).toBeUndefined();
     expectLinesToContain(getActiveMemoryLines(sessionKey), "🧩 Active Memory: status=failed");
     expect(getActiveMemoryLines(sessionKey).join("\n")).not.toContain(
+      "must not be surfaced from generic errors",
+    );
+    const transcriptDir = path.join(
+      stateDir,
+      "plugins",
+      "active-memory",
+      "transcripts",
+      "agents",
+      "main",
+      "active-memory",
+    );
+    const transcriptPath = await expectSingleTranscriptArtifact(transcriptDir);
+    expect(await fs.readFile(transcriptPath, "utf8")).toContain(
       "must not be surfaced from generic errors",
     );
   });

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -752,6 +752,33 @@ describe("active-memory plugin", () => {
     );
   });
 
+  it("cleans the transient workspace when SQLite recall cleanup retries are exhausted", async () => {
+    const rmSpy = vi.spyOn(fs, "rm");
+    hoisted.cleanupSessionLifecycleArtifacts.mockRejectedValue(
+      new Error("session store remains busy"),
+    );
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order? cleanup failure", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(hoisted.cleanupSessionLifecycleArtifacts).toHaveBeenCalledTimes(3);
+    expect(rmSpy).toHaveBeenCalledWith(expect.stringMatching(/openclaw-active-memory-.*/), {
+      recursive: true,
+      force: true,
+    });
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("failed to clean up recall session"),
+    );
+  });
+
   it("registers a session-scoped active-memory toggle command", async () => {
     const command = registeredCommands["active-memory"];
     const sessionKey = "agent:main:active-memory-toggle";

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -8,13 +8,10 @@ import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { parseSqliteSessionFileMarker } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import plugin, { testing } from "./index.js";
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 // Match only lone surrogates so valid supplementary-plane characters remain allowed.
 const UNPAIRED_SURROGATE_RE =
@@ -30,6 +27,16 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   throw new Error(`expected missing path ${targetPath}`);
 }
 
+async function expectSingleTranscriptArtifact(directory: string): Promise<string> {
+  const files = await fs.readdir(directory);
+  expect(files).toEqual([expect.stringMatching(/^active-memory-[a-z0-9]+-[a-f0-9]{8}\.jsonl$/)]);
+  const filename = files[0];
+  if (!filename) {
+    throw new Error(`expected active-memory transcript in ${directory}`);
+  }
+  return path.join(directory, filename);
+}
+
 const hoisted = vi.hoisted(() => {
   const sessionStore: Record<string, Record<string, unknown>> = {
     "agent:main:main": {
@@ -39,6 +46,7 @@ const hoisted = vi.hoisted(() => {
   };
   return {
     closeActiveMemorySearchManager: vi.fn(async () => {}),
+    runtimeTranscriptFiles: {} as Record<string, string>,
     sessionStore,
     updateSessionStore: vi.fn(
       async (
@@ -65,6 +73,41 @@ vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
   };
 });
 
+vi.mock("openclaw/plugin-sdk/session-transcript-runtime", async () => {
+  const actual = await vi.importActual<
+    typeof import("openclaw/plugin-sdk/session-transcript-runtime")
+  >("openclaw/plugin-sdk/session-transcript-runtime");
+  return {
+    ...actual,
+    readSessionTranscriptEvents: async (
+      target: Parameters<typeof actual.readSessionTranscriptEvents>[0],
+    ) => {
+      const testSessionFile = hoisted.runtimeTranscriptFiles[target.sessionId];
+      if (testSessionFile) {
+        try {
+          const content = await fs.readFile(testSessionFile, "utf8");
+          return content
+            .split("\n")
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .flatMap((line) => {
+              try {
+                return [JSON.parse(line) as unknown];
+              } catch {
+                return [];
+              }
+            });
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw error;
+          }
+        }
+      }
+      return await actual.readSessionTranscriptEvents(target);
+    },
+  };
+});
+
 describe("active-memory plugin", () => {
   it("keeps previous-message query context UTF-16 well-formed", () => {
     const query = testing.buildSearchQuery({
@@ -80,6 +123,54 @@ describe("active-memory plugin", () => {
   const hookOptions: Record<string, Record<string, unknown> | undefined> = {};
   const registeredCommands: Record<string, any> = {};
   const runEmbeddedAgent = vi.fn();
+  const runtimeRunEmbeddedAgent = vi.fn(async (params: Record<string, unknown>) => {
+    const sessionId =
+      typeof params.sessionId === "string" && params.sessionId.length > 0
+        ? params.sessionId
+        : "unknown";
+    const testSessionFile = path.join(stateDir, `${sessionId}.jsonl`);
+    hoisted.runtimeTranscriptFiles[sessionId] = testSessionFile;
+    const result = await runEmbeddedAgent({ ...params, sessionFile: testSessionFile });
+    if (typeof result !== "object" || result === null || Array.isArray(result)) {
+      return result;
+    }
+    const resultRecord = result as Record<string, unknown>;
+    const meta =
+      typeof resultRecord.meta === "object" &&
+      resultRecord.meta !== null &&
+      !Array.isArray(resultRecord.meta)
+        ? (resultRecord.meta as Record<string, unknown>)
+        : {};
+    const agentMeta =
+      typeof meta.agentMeta === "object" &&
+      meta.agentMeta !== null &&
+      !Array.isArray(meta.agentMeta)
+        ? (meta.agentMeta as Record<string, unknown>)
+        : {};
+    return {
+      ...resultRecord,
+      meta: {
+        ...meta,
+        agentMeta: {
+          sessionFile: testSessionFile,
+          ...agentMeta,
+        },
+      },
+    };
+  });
+  const deleteSession = vi.fn(
+    async (params: { sessionKey: string; deleteTranscript?: boolean }) => {
+      const sessionId = hoisted.sessionStore[params.sessionKey]?.sessionId;
+      if (typeof sessionId === "string") {
+        const testSessionFile = hoisted.runtimeTranscriptFiles[sessionId];
+        if (testSessionFile) {
+          await fs.rm(testSessionFile, { force: true });
+          delete hoisted.runtimeTranscriptFiles[sessionId];
+        }
+      }
+      delete hoisted.sessionStore[params.sessionKey];
+    },
+  );
   let stateDir = "";
   let configFile: Record<string, unknown> = {};
   let pluginConfig: Record<string, unknown> = {
@@ -132,7 +223,7 @@ describe("active-memory plugin", () => {
     logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
     runtime: {
       agent: {
-        runEmbeddedAgent,
+        runEmbeddedAgent: runtimeRunEmbeddedAgent,
         session: {
           resolveStorePath: vi.fn(() => path.join(stateDir, "sessions.json")),
           loadSessionStore: vi.fn(() => hoisted.sessionStore),
@@ -145,6 +236,11 @@ describe("active-memory plugin", () => {
               sessionKey,
               entry,
             })),
+          ),
+          upsertSessionEntry: vi.fn(
+            async (params: { sessionKey: string; entry: Record<string, unknown> }) => {
+              hoisted.sessionStore[params.sessionKey] = { ...params.entry };
+            },
           ),
           patchSessionEntry: vi.fn(
             async (params: {
@@ -174,6 +270,9 @@ describe("active-memory plugin", () => {
             },
           ),
         },
+      },
+      subagent: {
+        deleteSession,
       },
       state: {
         resolveStateDir: () => stateDir,
@@ -333,12 +432,14 @@ describe("active-memory plugin", () => {
     const calls = runEmbeddedAgent.mock.calls;
     return requireRecord(calls[calls.length - 1]?.[0], "expected embedded run params");
   };
+  const lastRuntimeEmbeddedRunParams = () => {
+    const calls = runtimeRunEmbeddedAgent.mock.calls;
+    return requireRecord(calls[calls.length - 1]?.[0], "expected runtime embedded run params");
+  };
   const lastEmbeddedPrompt = () =>
     requireNonEmptyString(lastEmbeddedRunParams().prompt, "expected embedded prompt");
   const lastEmbeddedSessionKey = () =>
     requireNonEmptyString(lastEmbeddedRunParams().sessionKey, "expected embedded session key");
-  const lastEmbeddedSessionFile = () =>
-    requireNonEmptyString(lastEmbeddedRunParams().sessionFile, "expected embedded session file");
   const lastSessionStoreUpdater = () => {
     const calls = hoisted.updateSessionStore.mock.calls;
     const updater = calls[calls.length - 1]?.[1] as
@@ -406,6 +507,9 @@ describe("active-memory plugin", () => {
     };
     for (const key of Object.keys(hoisted.sessionStore)) {
       delete hoisted.sessionStore[key];
+    }
+    for (const key of Object.keys(hoisted.runtimeTranscriptFiles)) {
+      delete hoisted.runtimeTranscriptFiles[key];
     }
     hoisted.sessionStore["agent:main:main"] = {
       sessionId: "s-main",
@@ -496,6 +600,56 @@ describe("active-memory plugin", () => {
     );
 
     expect(lastEmbeddedRunParams().lane).toBe("active-memory");
+  });
+
+  it("creates and removes the exact SQLite recall session around the embedded run", async () => {
+    let persistedEntryAtRun: Record<string, unknown> | undefined;
+    runEmbeddedAgent.mockImplementationOnce(async (params: Record<string, unknown>) => {
+      const sessionKey = requireNonEmptyString(params.sessionKey, "expected embedded session key");
+      persistedEntryAtRun = structuredClone(hoisted.sessionStore[sessionKey]);
+      const sessionFile = requireNonEmptyString(
+        params.sessionFile,
+        "expected test transcript artifact",
+      );
+      await writeUsableMemoryTranscript(sessionFile, "lemon pepper wings");
+      return { payloads: [{ text: "- lemon pepper wings" }] };
+    });
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    const runtimeParams = lastRuntimeEmbeddedRunParams();
+    const sessionId = requireNonEmptyString(runtimeParams.sessionId, "expected runtime session id");
+    const sessionKey = requireNonEmptyString(
+      runtimeParams.sessionKey,
+      "expected runtime session key",
+    );
+    const runtimeSessionFile = requireNonEmptyString(
+      runtimeParams.sessionFile,
+      "expected runtime session file",
+    );
+    expect(parseSqliteSessionFileMarker(runtimeSessionFile)).toEqual({
+      agentId: "main",
+      sessionId,
+      storePath: path.join(stateDir, "sessions.json"),
+    });
+    expect(persistedEntryAtRun).toMatchObject({
+      sessionId,
+      sessionFile: runtimeSessionFile,
+    });
+    expect(deleteSession).toHaveBeenCalledWith({
+      sessionKey,
+      deleteTranscript: true,
+    });
+    expect(hoisted.sessionStore[sessionKey]).toBeUndefined();
+    expectPrependContextContains(result, "lemon pepper wings");
   });
 
   it("registers a session-scoped active-memory toggle command", async () => {
@@ -5744,9 +5898,7 @@ describe("active-memory plugin", () => {
     );
 
     expect(mkdtempSpy).toHaveBeenCalled();
-    const sessionFile = lastEmbeddedSessionFile();
-    expect(sessionFile).toMatch(/openclaw-active-memory-.*\/session\.jsonl$/);
-    expect(rmSpy).toHaveBeenCalledWith(path.dirname(sessionFile), {
+    expect(rmSpy).toHaveBeenCalledWith(expect.stringMatching(/openclaw-active-memory-.*/), {
       recursive: true,
       force: true,
     });
@@ -5781,11 +5933,8 @@ describe("active-memory plugin", () => {
     );
     expect(mkdirSpy).toHaveBeenCalledWith(expectedDir, { recursive: true, mode: 0o700 });
     expect(mkdtempSpy).not.toHaveBeenCalled();
-    expect(lastEmbeddedSessionFile()).toMatch(
-      new RegExp(
-        `^${escapeRegExp(expectedDir)}${escapeRegExp(path.sep)}active-memory-[a-z0-9]+-[a-f0-9]{8}\\.jsonl$`,
-      ),
-    );
+    const transcriptPath = await expectSingleTranscriptArtifact(expectedDir);
+    expect(await fs.readFile(transcriptPath, "utf8")).toContain("lemon pepper wings");
     const infoLines = vi
       .mocked(api.logger.info)
       .mock.calls.map((call: unknown[]) => String(call[0]));
@@ -5825,11 +5974,13 @@ describe("active-memory plugin", () => {
       "active-memory",
     );
     expect(mkdirSpy).toHaveBeenCalledWith(expectedDir, { recursive: true, mode: 0o700 });
-    expect(lastEmbeddedSessionFile()).toMatch(
-      new RegExp(
-        `^${escapeRegExp(expectedDir)}${escapeRegExp(path.sep)}active-memory-[a-z0-9]+-[a-f0-9]{8}\\.jsonl$`,
-      ),
+    const runtimeSessionFile = requireNonEmptyString(
+      lastRuntimeEmbeddedRunParams().sessionFile,
+      "expected runtime session file",
     );
+    expect(parseSqliteSessionFileMarker(runtimeSessionFile)).toMatchObject({
+      agentId: "main",
+    });
   });
 
   it("scopes persisted subagent transcripts by agent", async () => {
@@ -5862,11 +6013,13 @@ describe("active-memory plugin", () => {
       "active-memory-subagents",
     );
     expect(mkdirSpy).toHaveBeenCalledWith(expectedDir, { recursive: true, mode: 0o700 });
-    expect(lastEmbeddedSessionFile()).toMatch(
-      new RegExp(
-        `^${escapeRegExp(expectedDir)}${escapeRegExp(path.sep)}active-memory-[a-z0-9]+-[a-f0-9]{8}\\.jsonl$`,
-      ),
+    const runtimeSessionFile = requireNonEmptyString(
+      lastRuntimeEmbeddedRunParams().sessionFile,
+      "expected runtime session file",
     );
+    expect(parseSqliteSessionFileMarker(runtimeSessionFile)).toMatchObject({
+      agentId: "support/agent",
+    });
   });
 
   it("sanitizes control characters out of debug lines", async () => {

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1035,9 +1035,9 @@ describe("active-memory plugin", () => {
 
   it.each([
     {
-      label: "a reserved Codex harness key",
+      label: "a missing reserved Codex harness key",
       sessionKey: "agent:main:harness:codex:supervision:thread-1",
-      entry: { sessionId: "codex-1", updatedAt: 1 },
+      entry: undefined,
     },
     {
       label: "a model-locked session",
@@ -1052,7 +1052,9 @@ describe("active-memory plugin", () => {
   ])(
     "skips recall before state or model side effects for $label",
     async ({ sessionKey, entry }) => {
-      hoisted.sessionStore[sessionKey] = entry;
+      if (entry) {
+        hoisted.sessionStore[sessionKey] = entry;
+      }
       const openKeyedStore = vi.spyOn(api.runtime.state, "openKeyedStore");
 
       const result = await hooks.before_prompt_build(

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -3440,36 +3440,39 @@ async function runRecallSubagent(params: {
     }
     throw error;
   } finally {
-    if (runtimeSessionCreated) {
-      if (params.config.persistTranscripts && !transcriptArtifactPersisted) {
-        await persistActiveMemoryTranscriptArtifact({
-          sources: transcriptSources,
-          sessionFile: artifactSessionFile,
+    try {
+      if (runtimeSessionCreated) {
+        if (params.config.persistTranscripts && !transcriptArtifactPersisted) {
+          await persistActiveMemoryTranscriptArtifact({
+            sources: transcriptSources,
+            sessionFile: artifactSessionFile,
+          }).catch((error: unknown) => {
+            const message = toSingleLineLogValue(
+              error instanceof Error ? error.message : String(error),
+            );
+            params.api.logger.debug?.(
+              `active-memory: failed to persist recall transcript ${artifactSessionFile}: ${message}`,
+            );
+          });
+        }
+        await cleanupActiveMemoryRecallSession({
+          agentId: params.agentId,
+          sessionId: subagentSessionId,
+          sessionKey: subagentSessionKey,
+          storePath,
         }).catch((error: unknown) => {
           const message = toSingleLineLogValue(
             error instanceof Error ? error.message : String(error),
           );
-          params.api.logger.debug?.(
-            `active-memory: failed to persist recall transcript ${artifactSessionFile}: ${message}`,
+          params.api.logger.warn?.(
+            `active-memory: failed to clean up recall session ${subagentSessionKey}: ${message}`,
           );
+          throw error;
         });
       }
-      await cleanupActiveMemoryRecallSession({
-        agentId: params.agentId,
-        sessionId: subagentSessionId,
-        sessionKey: subagentSessionKey,
-        storePath,
-      }).catch((error: unknown) => {
-        const message = toSingleLineLogValue(
-          error instanceof Error ? error.message : String(error),
-        );
-        params.api.logger.warn?.(
-          `active-memory: failed to clean up recall session ${subagentSessionKey}: ${message}`,
-        );
-        throw error;
-      });
+    } finally {
+      await transientWorkspace?.cleanup();
     }
-    await transientWorkspace?.cleanup();
   }
 }
 

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -7,6 +7,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import * as readline from "node:readline";
+import { setTimeout as sleep } from "node:timers/promises";
 import {
   DEFAULT_PROVIDER,
   parseModelRef,
@@ -67,6 +68,7 @@ const DEFAULT_QUERY_MODE = "recent" as const;
 const DEFAULT_QMD_SEARCH_MODE = "search" as const;
 const DEFAULT_TRANSCRIPT_DIR = "active-memory";
 const ACTIVE_MEMORY_RECALL_LANE = "active-memory";
+const ACTIVE_MEMORY_CLEANUP_RETRY_DELAYS_MS = [0, 50, 250] as const;
 const DEFAULT_CIRCUIT_BREAKER_MAX_TIMEOUTS = 3;
 const DEFAULT_CIRCUIT_BREAKER_COOLDOWN_MS = 60_000;
 const DEFAULT_ACTIVE_MEMORY_TOOLS_ALLOW = ["memory_search", "memory_get"] as const;
@@ -3148,6 +3150,43 @@ async function persistActiveMemoryTranscriptArtifact(params: {
   );
 }
 
+async function cleanupActiveMemoryRecallSession(params: {
+  agentId: string;
+  sessionId: string;
+  sessionKey: string;
+  storePath: string;
+}): Promise<void> {
+  const sessionKeySegmentPrefix =
+    parseAgentSessionKey(params.sessionKey)?.rest ?? params.sessionKey;
+  let lastError: unknown;
+  for (const delayMs of ACTIVE_MEMORY_CLEANUP_RETRY_DELAYS_MS) {
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+    try {
+      const result = await cleanupSessionLifecycleArtifacts({
+        agentId: params.agentId,
+        archiveRemovedEntryTranscripts: false,
+        orphanTranscriptMinAgeMs: 0,
+        sessionKeySegmentPrefix,
+        storePath: params.storePath,
+        transcriptContentMarker: `"runId":"${params.sessionId}"`,
+      });
+      if (result.removedEntries !== 1) {
+        throw new Error(
+          `active-memory recall cleanup removed ${String(result.removedEntries)} sessions`,
+        );
+      }
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`active-memory recall cleanup failed: ${String(lastError)}`);
+}
+
 async function runRecallSubagent(params: {
   api: OpenClawPluginApi;
   config: ResolvedActiveRecallPluginConfig;
@@ -3415,22 +3454,19 @@ async function runRecallSubagent(params: {
           );
         });
       }
-      const sessionKeySegmentPrefix =
-        parseAgentSessionKey(subagentSessionKey)?.rest ?? subagentSessionKey;
-      await cleanupSessionLifecycleArtifacts({
+      await cleanupActiveMemoryRecallSession({
         agentId: params.agentId,
-        archiveRemovedEntryTranscripts: false,
-        orphanTranscriptMinAgeMs: 0,
-        sessionKeySegmentPrefix,
+        sessionId: subagentSessionId,
+        sessionKey: subagentSessionKey,
         storePath,
-        transcriptContentMarker: `"runId":"${subagentSessionId}"`,
       }).catch((error: unknown) => {
         const message = toSingleLineLogValue(
           error instanceof Error ? error.message : String(error),
         );
-        params.api.logger.debug?.(
+        params.api.logger.warn?.(
           `active-memory: failed to clean up recall session ${subagentSessionKey}: ${message}`,
         );
+        throw error;
       });
     }
     await transientWorkspace?.cleanup();

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -3184,7 +3184,7 @@ async function runRecallSubagent(params: {
   const subagentScope = parentSessionKey ?? params.sessionId ?? crypto.randomUUID();
   const subagentSuffix = `active-memory:${crypto
     .createHash("sha1")
-    .update(`${subagentScope}:${params.query}`)
+    .update(`${subagentScope}:${params.query}:${subagentSessionId}`)
     .digest("hex")
     .slice(0, 12)}`;
   const subagentSessionKey = parentSessionKey

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -32,6 +32,7 @@ import { isPathInside } from "openclaw/plugin-sdk/security-runtime";
 import {
   cleanupSessionLifecycleArtifacts,
   formatSqliteSessionFileMarker,
+  patchSessionEntry,
   parseSqliteSessionFileMarker,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import {
@@ -3236,19 +3237,27 @@ async function runRecallSubagent(params: {
 
   let harnessHasUsableMemoryResult = false;
   let harnessHasUnavailableMemorySearchResult = false;
+  let transcriptArtifactPersisted = false;
   let runtimeSessionCreated = false;
   try {
-    await params.api.runtime.agent.session.upsertSessionEntry({
+    const runtimeEntry = {
+      pluginOwnerId: params.api.id,
+      sessionId: subagentSessionId,
+      sessionFile: runtimeSessionFile,
+      updatedAt: Date.now(),
+    };
+    const createdEntry = await patchSessionEntry({
       agentId: params.agentId,
+      fallbackEntry: runtimeEntry,
+      replaceEntry: true,
       sessionKey: subagentSessionKey,
+      skipMaintenance: true,
       storePath,
-      entry: {
-        pluginOwnerId: params.api.id,
-        sessionId: subagentSessionId,
-        sessionFile: runtimeSessionFile,
-        updatedAt: Date.now(),
-      },
+      update: (_entry, context) => (context.existingEntry ? null : runtimeEntry),
     });
+    if (createdEntry?.sessionId !== subagentSessionId) {
+      throw new Error(`active-memory recall session already exists: ${subagentSessionKey}`);
+    }
     runtimeSessionCreated = true;
     params.onTranscriptSources?.(transcriptSources);
     if (persistedDir) {
@@ -3344,6 +3353,7 @@ async function runRecallSubagent(params: {
         sources: transcriptSources,
         sessionFile: artifactSessionFile,
       });
+      transcriptArtifactPersisted = true;
     }
     const transcriptState = await readMergedActiveMemoryTranscriptState({
       sources: transcriptSources,
@@ -3392,6 +3402,19 @@ async function runRecallSubagent(params: {
     throw error;
   } finally {
     if (runtimeSessionCreated) {
+      if (params.config.persistTranscripts && !transcriptArtifactPersisted) {
+        await persistActiveMemoryTranscriptArtifact({
+          sources: transcriptSources,
+          sessionFile: artifactSessionFile,
+        }).catch((error: unknown) => {
+          const message = toSingleLineLogValue(
+            error instanceof Error ? error.message : String(error),
+          );
+          params.api.logger.debug?.(
+            `active-memory: failed to persist recall transcript ${artifactSessionFile}: ${message}`,
+          );
+        });
+      }
       const sessionKeySegmentPrefix =
         parseAgentSessionKey(subagentSessionKey)?.rest ?? subagentSessionKey;
       await cleanupSessionLifecycleArtifacts({

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -29,7 +29,10 @@ import {
 import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { parseAgentSessionKey, parseThreadSessionSuffix } from "openclaw/plugin-sdk/routing";
 import { isPathInside } from "openclaw/plugin-sdk/security-runtime";
-import { parseSqliteSessionFileMarker } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  formatSqliteSessionFileMarker,
+  parseSqliteSessionFileMarker,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import {
   readSessionTranscriptEvents,
   type SessionTranscriptTargetParams,
@@ -3200,7 +3203,7 @@ async function runRecallSubagent(params: {
         params.config.transcriptDir,
       )
     : undefined;
-  const sessionFile =
+  const artifactSessionFile =
     persistedDir !== undefined
       ? path.join(persistedDir, `${subagentSessionId}.jsonl`)
       : path.join(requireTransientWorkspaceDir(tempDir), "session.jsonl");
@@ -3210,6 +3213,11 @@ async function runRecallSubagent(params: {
       agentId: params.agentId,
     },
   );
+  const runtimeSessionFile = formatSqliteSessionFileMarker({
+    agentId: params.agentId,
+    sessionId: subagentSessionId,
+    storePath,
+  });
   const runtimeSource: ActiveMemoryTranscriptSource = {
     kind: "runtime",
     target: {
@@ -3220,32 +3228,44 @@ async function runRecallSubagent(params: {
     },
   };
   let transcriptSources = collectActiveMemoryTranscriptSources({
-    artifactSessionFile: sessionFile,
+    artifactSessionFile,
     runtimeSource,
     activeSessionKey: subagentSessionKey,
-  });
-  params.onTranscriptSources?.(transcriptSources);
-  if (persistedDir) {
-    await fs.mkdir(persistedDir, { recursive: true, mode: 0o700 });
-    await fs.chmod(persistedDir, 0o700).catch(() => undefined);
-  }
-  const prompt = buildRecallPrompt({
-    config: params.config,
-    query: params.query,
-    searchQuery: params.searchQuery,
-  });
-  const { messageChannel, messageProvider } = resolveRecallRunChannelContext({
-    api: params.api,
-    agentId: params.agentId,
-    sessionKey: parentSessionKey,
-    sessionId: params.sessionId,
-    messageProvider: params.messageProvider,
-    channelId: params.channelId,
   });
 
   let harnessHasUsableMemoryResult = false;
   let harnessHasUnavailableMemorySearchResult = false;
+  let runtimeSessionCreated = false;
   try {
+    await params.api.runtime.agent.session.upsertSessionEntry({
+      agentId: params.agentId,
+      sessionKey: subagentSessionKey,
+      storePath,
+      entry: {
+        sessionId: subagentSessionId,
+        sessionFile: runtimeSessionFile,
+        updatedAt: Date.now(),
+      },
+    });
+    runtimeSessionCreated = true;
+    params.onTranscriptSources?.(transcriptSources);
+    if (persistedDir) {
+      await fs.mkdir(persistedDir, { recursive: true, mode: 0o700 });
+      await fs.chmod(persistedDir, 0o700).catch(() => undefined);
+    }
+    const prompt = buildRecallPrompt({
+      config: params.config,
+      query: params.query,
+      searchQuery: params.searchQuery,
+    });
+    const { messageChannel, messageProvider } = resolveRecallRunChannelContext({
+      api: params.api,
+      agentId: params.agentId,
+      sessionKey: parentSessionKey,
+      sessionId: params.sessionId,
+      messageProvider: params.messageProvider,
+      channelId: params.channelId,
+    });
     const embeddedConfig = applyActiveMemoryRuntimeConfigSnapshot(params.api.config, params.config);
     const embeddedTimeoutMs = params.config.timeoutMs + params.config.setupGraceTimeoutMs;
     const result = await params.api.runtime.agent.runEmbeddedAgent({
@@ -3260,7 +3280,7 @@ async function runRecallSubagent(params: {
       },
       messageChannel,
       messageProvider,
-      sessionFile,
+      sessionFile: runtimeSessionFile,
       workspaceDir,
       agentDir,
       config: embeddedConfig,
@@ -3291,9 +3311,10 @@ async function runRecallSubagent(params: {
         harnessHasUnavailableMemorySearchResult ||= evidence.hasUnavailableMemorySearchResult;
       },
     });
-    const activeSessionFile = readActiveMemorySessionFileFromRunResult(result) ?? sessionFile;
+    const activeSessionFile =
+      readActiveMemorySessionFileFromRunResult(result) ?? runtimeSessionFile;
     transcriptSources = collectActiveMemoryTranscriptSources({
-      artifactSessionFile: sessionFile,
+      artifactSessionFile,
       runtimeSource,
       activeSessionFile,
       activeSessionKey: subagentSessionKey,
@@ -3317,7 +3338,10 @@ async function runRecallSubagent(params: {
       .join("\n")
       .trim();
     if (params.config.persistTranscripts) {
-      await persistActiveMemoryTranscriptArtifact({ sources: transcriptSources, sessionFile });
+      await persistActiveMemoryTranscriptArtifact({
+        sources: transcriptSources,
+        sessionFile: artifactSessionFile,
+      });
     }
     const transcriptState = await readMergedActiveMemoryTranscriptState({
       sources: transcriptSources,
@@ -3327,7 +3351,7 @@ async function runRecallSubagent(params: {
       transcriptState.searchDebug ?? readActiveMemorySearchDebugFromRunResult(result);
     return {
       rawReply: rawReply || "NONE",
-      transcriptPath: params.config.persistTranscripts ? sessionFile : undefined,
+      transcriptPath: params.config.persistTranscripts ? artifactSessionFile : undefined,
       searchDebug,
       hasUsableMemoryResult: transcriptState.hasUsableMemoryResult || harnessHasUsableMemoryResult,
       hasUnavailableMemorySearchResult:
@@ -3365,6 +3389,21 @@ async function runRecallSubagent(params: {
     }
     throw error;
   } finally {
+    if (runtimeSessionCreated) {
+      await params.api.runtime.subagent
+        .deleteSession({
+          sessionKey: subagentSessionKey,
+          deleteTranscript: true,
+        })
+        .catch((error: unknown) => {
+          const message = toSingleLineLogValue(
+            error instanceof Error ? error.message : String(error),
+          );
+          params.api.logger.debug?.(
+            `active-memory: failed to clean up recall session ${subagentSessionKey}: ${message}`,
+          );
+        });
+    }
     await transientWorkspace?.cleanup();
   }
 }

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -3242,6 +3242,7 @@ async function runRecallSubagent(params: {
       sessionKey: subagentSessionKey,
       storePath,
       entry: {
+        pluginOwnerId: params.api.id,
         sessionId: subagentSessionId,
         sessionFile: runtimeSessionFile,
         updatedAt: Date.now(),
@@ -3393,7 +3394,7 @@ async function runRecallSubagent(params: {
       await params.api.runtime.subagent
         .deleteSession({
           sessionKey: subagentSessionKey,
-          deleteTranscript: true,
+          deleteTranscript: false,
         })
         .catch((error: unknown) => {
           const message = toSingleLineLogValue(

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -30,6 +30,7 @@ import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/p
 import { parseAgentSessionKey, parseThreadSessionSuffix } from "openclaw/plugin-sdk/routing";
 import { isPathInside } from "openclaw/plugin-sdk/security-runtime";
 import {
+  cleanupSessionLifecycleArtifacts,
   formatSqliteSessionFileMarker,
   parseSqliteSessionFileMarker,
 } from "openclaw/plugin-sdk/session-store-runtime";
@@ -3391,19 +3392,23 @@ async function runRecallSubagent(params: {
     throw error;
   } finally {
     if (runtimeSessionCreated) {
-      await params.api.runtime.subagent
-        .deleteSession({
-          sessionKey: subagentSessionKey,
-          deleteTranscript: false,
-        })
-        .catch((error: unknown) => {
-          const message = toSingleLineLogValue(
-            error instanceof Error ? error.message : String(error),
-          );
-          params.api.logger.debug?.(
-            `active-memory: failed to clean up recall session ${subagentSessionKey}: ${message}`,
-          );
-        });
+      const sessionKeySegmentPrefix =
+        parseAgentSessionKey(subagentSessionKey)?.rest ?? subagentSessionKey;
+      await cleanupSessionLifecycleArtifacts({
+        agentId: params.agentId,
+        archiveRemovedEntryTranscripts: false,
+        orphanTranscriptMinAgeMs: 0,
+        sessionKeySegmentPrefix,
+        storePath,
+        transcriptContentMarker: `"runId":"${subagentSessionId}"`,
+      }).catch((error: unknown) => {
+        const message = toSingleLineLogValue(
+          error instanceof Error ? error.message : String(error),
+        );
+        params.api.logger.debug?.(
+          `active-memory: failed to clean up recall session ${subagentSessionKey}: ${message}`,
+        );
+      });
     }
     await transientWorkspace?.cleanup();
   }

--- a/extensions/qa-lab/src/scenario-runtime-api.test.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.test.ts
@@ -51,6 +51,7 @@ function createDeps(overrides?: Partial<QaScenarioRuntimeDeps>): QaScenarioRunti
     readEffectiveTools: fn,
     readSkillStatus: fn,
     readRawQaSessionStore: fn,
+    seedQaSessionTranscript: fn,
     readGatewayLogs: fn,
     markGatewayLogCursor: fn,
     scanGatewayLogSentinels: fn,
@@ -194,6 +195,7 @@ describe("createQaScenarioRuntimeApi", () => {
     expect(api.markGatewayLogCursor).toBe(deps.markGatewayLogCursor);
     expect(api.assertNoGatewayLogSentinels).toBe(deps.assertNoGatewayLogSentinels);
     expect(api.readSessionTranscriptSummary).toBe(deps.readSessionTranscriptSummary);
+    expect(api.seedQaSessionTranscript).toBe(deps.seedQaSessionTranscript);
     for (const toolName of browserAndWebRuntimeTools) {
       expect(api[toolName]).toBe(deps[toolName]);
     }

--- a/extensions/qa-lab/src/scenario-runtime-api.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.ts
@@ -63,6 +63,7 @@ export type QaScenarioRuntimeDeps = {
   readEffectiveTools: QaScenarioRuntimeFunction;
   readSkillStatus: QaScenarioRuntimeFunction;
   readRawQaSessionStore: QaScenarioRuntimeFunction;
+  seedQaSessionTranscript: QaScenarioRuntimeFunction;
   readGatewayLogs: QaScenarioRuntimeFunction;
   markGatewayLogCursor: QaScenarioRuntimeFunction;
   scanGatewayLogSentinels: QaScenarioRuntimeFunction;
@@ -159,6 +160,7 @@ type QaScenarioRuntimeApi<
   readEffectiveTools: TDeps["readEffectiveTools"];
   readSkillStatus: TDeps["readSkillStatus"];
   readRawQaSessionStore: TDeps["readRawQaSessionStore"];
+  seedQaSessionTranscript: TDeps["seedQaSessionTranscript"];
   readGatewayLogs: TDeps["readGatewayLogs"];
   markGatewayLogCursor: TDeps["markGatewayLogCursor"];
   scanGatewayLogSentinels: TDeps["scanGatewayLogSentinels"];
@@ -272,6 +274,7 @@ export function createQaScenarioRuntimeApi<
     readEffectiveTools: params.deps.readEffectiveTools,
     readSkillStatus: params.deps.readSkillStatus,
     readRawQaSessionStore: params.deps.readRawQaSessionStore,
+    seedQaSessionTranscript: params.deps.seedQaSessionTranscript,
     readGatewayLogs: params.deps.readGatewayLogs,
     markGatewayLogCursor: params.deps.markGatewayLogCursor,
     scanGatewayLogSentinels: params.deps.scanGatewayLogSentinels,

--- a/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
@@ -1,6 +1,11 @@
 // Qa Lab tests cover suite runtime agent session plugin behavior.
+import fs from "node:fs/promises";
 import path from "node:path";
-import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  loadTranscriptEventsSync,
+  parseSqliteSessionFileMarker,
+  upsertSessionEntry,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -9,6 +14,7 @@ import {
   readRawQaSessionStore,
   readSessionTranscriptSummary,
   readSkillStatus,
+  seedQaSessionTranscript,
   setSessionStoreLockRetryDelaysMsForTests,
 } from "./suite-runtime-agent-session.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
@@ -178,6 +184,95 @@ describe("qa suite runtime agent session helpers", () => {
     ).resolves.toEqual({
       "session-1": { sessionId: "session-1", status: "running", updatedAt: 10 },
     });
+  });
+
+  it("seeds QA session metadata and transcript messages in SQLite", async () => {
+    const tempRoot = await makeTempDir("qa-session-seed-");
+    const sessionId = "seeded-session";
+    const sessionKey = "agent:qa:seeded-session";
+
+    await seedQaSessionTranscript(
+      {
+        gateway: { tempRoot },
+      } as never,
+      {
+        sessionId,
+        sessionKey,
+        updatedAt: 300,
+        label: "Seeded QA transcript",
+        messages: [
+          { role: "user", text: "What is the codename?", timestamp: 100 },
+          { role: "assistant", text: "The codename is ORBIT-10.", timestamp: 200 },
+        ],
+      },
+    );
+
+    const sessionStore = await readRawQaSessionStore({
+      gateway: { tempRoot },
+    } as never);
+    expect(sessionStore).toMatchObject({
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 300,
+        origin: { label: "Seeded QA transcript" },
+      },
+    });
+    expect(parseSqliteSessionFileMarker(sessionStore[sessionKey]?.sessionFile)).toMatchObject({
+      agentId: "qa",
+      sessionId,
+    });
+
+    const transcriptEvents = loadTranscriptEventsSync({
+      agentId: "qa",
+      env: qaSessionEnv(tempRoot),
+      sessionId,
+      sessionKey,
+    });
+    expect(
+      transcriptEvents.flatMap((event) => {
+        const message = (event as { message?: unknown }).message;
+        return message ? [message] : [];
+      }),
+    ).toEqual([
+      {
+        role: "user",
+        timestamp: 100,
+        content: [{ type: "text", text: "What is the codename?" }],
+      },
+      {
+        role: "assistant",
+        timestamp: 200,
+        content: [{ type: "text", text: "The codename is ORBIT-10." }],
+      },
+    ]);
+
+    await expect(
+      fs.stat(path.join(tempRoot, "state", "agents", "qa", "agent", "openclaw-agent.sqlite")),
+    ).resolves.toBeDefined();
+    await expect(
+      fs.stat(path.join(tempRoot, "state", "agents", "qa", "sessions", "sessions.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      fs.stat(path.join(tempRoot, "state", "agents", "qa", "sessions", `${sessionId}.jsonl`)),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects an empty QA session transcript seed", async () => {
+    const tempRoot = await makeTempDir("qa-session-seed-empty-");
+
+    await expect(
+      seedQaSessionTranscript(
+        {
+          gateway: { tempRoot },
+        } as never,
+        {
+          sessionId: "seeded-session",
+          sessionKey: "agent:qa:seeded-session",
+          updatedAt: 100,
+          messages: [],
+        },
+      ),
+    ).rejects.toThrow("requires at least one message");
   });
 
   it("summarizes a QA session transcript by session key", async () => {

--- a/extensions/qa-lab/src/suite-runtime-agent-session.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.ts
@@ -3,9 +3,13 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
+  formatSqliteSessionFileMarker,
   listSessionEntries,
   loadTranscriptEventsSync,
+  resolveStorePath,
+  upsertSessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
+import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import {
   isRecord,
   normalizeOptionalString as readNonEmptyString,
@@ -25,6 +29,18 @@ type QaGatewayCallEnv = Pick<
   QaSuiteRuntimeEnv,
   "gateway" | "primaryModel" | "alternateModel" | "providerMode"
 >;
+
+type QaSessionTranscriptSeedParams = {
+  label?: string;
+  messages: readonly {
+    role: "assistant" | "user";
+    text: string;
+    timestamp: number;
+  }[];
+  sessionId: string;
+  sessionKey: string;
+  updatedAt: number;
+};
 
 const SESSION_STORE_LOCK_RETRY_DELAYS_MS = [1_000, 3_000, 5_000] as const;
 let sessionStoreLockRetryDelaysMsForTests: readonly number[] | undefined;
@@ -220,6 +236,62 @@ function qaSessionRuntimeEnv(tempRoot: string): NodeJS.ProcessEnv {
   };
 }
 
+async function seedQaSessionTranscript(
+  env: Pick<QaSuiteRuntimeEnv, "gateway">,
+  params: QaSessionTranscriptSeedParams,
+): Promise<void> {
+  const sessionId = params.sessionId.trim();
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionId || !sessionKey) {
+    throw new Error("seedQaSessionTranscript requires sessionId and sessionKey");
+  }
+  if (params.messages.length === 0) {
+    throw new Error("seedQaSessionTranscript requires at least one message");
+  }
+
+  const runtimeEnv = qaSessionRuntimeEnv(env.gateway.tempRoot);
+  const storePath = resolveStorePath(undefined, {
+    agentId: "qa",
+    env: runtimeEnv,
+  });
+  const label = params.label?.trim();
+  await upsertSessionEntry({
+    agentId: "qa",
+    env: runtimeEnv,
+    sessionKey,
+    storePath,
+    entry: {
+      sessionFile: formatSqliteSessionFileMarker({
+        agentId: "qa",
+        sessionId,
+        storePath,
+      }),
+      sessionId,
+      updatedAt: params.updatedAt,
+      ...(label ? { origin: { label } } : {}),
+    },
+  });
+
+  for (const seed of params.messages) {
+    const appended = await appendSessionTranscriptMessageByIdentity({
+      agentId: "qa",
+      env: runtimeEnv,
+      sessionId,
+      sessionKey,
+      storePath,
+      now: seed.timestamp,
+      message: {
+        role: seed.role,
+        timestamp: seed.timestamp,
+        content: [{ type: "text", text: seed.text }],
+      },
+    });
+    if (!appended?.appended) {
+      throw new Error(`failed to seed QA session transcript for ${sessionKey}`);
+    }
+  }
+}
+
 async function readRawQaSessionStore(env: Pick<QaSuiteRuntimeEnv, "gateway">) {
   return Object.fromEntries(
     listSessionEntries({ agentId: "qa", env: qaSessionRuntimeEnv(env.gateway.tempRoot) }).map(
@@ -259,6 +331,7 @@ export {
   readRawQaSessionStore,
   readSessionTranscriptSummary,
   readSkillStatus,
+  seedQaSessionTranscript,
   setSessionStoreLockRetryDelaysMsForTests,
 };
 

--- a/extensions/qa-lab/src/suite-runtime-agent.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent.ts
@@ -5,6 +5,7 @@ export {
   readRawQaSessionStore,
   readSessionTranscriptSummary,
   readSkillStatus,
+  seedQaSessionTranscript,
 } from "./suite-runtime-agent-session.js";
 export {
   forceMemoryIndex,

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -24,6 +24,7 @@ const createSession = vi.hoisted(() => vi.fn());
 const readEffectiveTools = vi.hoisted(() => vi.fn());
 const readSkillStatus = vi.hoisted(() => vi.fn());
 const readRawQaSessionStore = vi.hoisted(() => vi.fn());
+const seedQaSessionTranscript = vi.hoisted(() => vi.fn());
 const readSessionTranscriptSummary = vi.hoisted(() => vi.fn());
 const runQaCli = vi.hoisted(() => vi.fn());
 const extractMediaPathFromText = vi.hoisted(() => vi.fn());
@@ -95,6 +96,7 @@ vi.mock("./suite-runtime-agent.js", () => ({
   readEffectiveTools,
   readSkillStatus,
   readRawQaSessionStore,
+  seedQaSessionTranscript,
   readSessionTranscriptSummary,
   runQaCli,
   extractMediaPathFromText,
@@ -252,6 +254,7 @@ describe("qa suite runtime flow", () => {
         markGatewayLogCursor: () => number;
         assertNoGatewayLogSentinels: typeof assertNoGatewayLogSentinels;
         readSessionTranscriptSummary: typeof readSessionTranscriptSummary;
+        seedQaSessionTranscript: typeof seedQaSessionTranscript;
         findManagedDreamingCronJob: typeof findManagedDreamingCronJob;
         forceMemoryIndex: typeof forceMemoryIndex;
         runAgentPrompt: typeof runAgentPrompt;
@@ -277,6 +280,7 @@ describe("qa suite runtime flow", () => {
     expect(call.deps.markGatewayLogCursor()).toBe(0);
     expect(() => call.deps.assertNoGatewayLogSentinels()).not.toThrow();
     expect(call.deps.readSessionTranscriptSummary).toBe(readSessionTranscriptSummary);
+    expect(call.deps.seedQaSessionTranscript).toBe(seedQaSessionTranscript);
     expect(call.deps.findManagedDreamingCronJob).toBe(findManagedDreamingCronJob);
     expect(call.deps.forceMemoryIndex).toBe(forceMemoryIndex);
     expect(call.deps.waitForAgentHistoryReply).toBe(waitForAgentHistoryReply);

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -46,6 +46,7 @@ import {
   resolveGeneratedImagePath,
   runAgentPrompt,
   runQaCli,
+  seedQaSessionTranscript,
   startAgentRun,
   waitForAgentHistoryReply,
   waitForAgentRun,
@@ -204,6 +205,7 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
     readEffectiveTools,
     readSkillStatus,
     readRawQaSessionStore,
+    seedQaSessionTranscript,
     readGatewayLogs: () => params.env.gateway.logs?.() ?? "",
     markGatewayLogCursor: () => (params.env.gateway.logs?.() ?? "").length,
     scanGatewayLogSentinels: (options?: Parameters<typeof scanGatewayLogSentinels>[1]) =>

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -23,10 +23,10 @@ scenario:
             allowedChatTypes:
               - direct
             logging: true
-            persistTranscripts: true
-            transcriptDir: qa-memory-e2e
             queryMode: recent
             maxSummaryChars: 220
+            timeoutMs: 15000
+            setupGraceTimeoutMs: 30000
   successCriteria:
     - With Active Memory off after doctor migrates the legacy session toggle, the session shows no Active Memory plugin activity.
     - With Active Memory on, plugin-owned evidence shows the Active Memory sub-agent searched memory before the main reply.
@@ -51,7 +51,6 @@ scenario:
       expectedNeedle: lemon pepper wings
       prompt: "Silent snack recall check: what snack do I usually want for QA movie night? Reply in one short sentence."
       promptSnippet: "Silent snack recall check"
-      transcriptDir: qa-memory-e2e
 
 flow:
   steps:
@@ -85,17 +84,9 @@ flow:
         - set: activeSessionKey
           value:
             expr: "'agent:qa:qa-channel:direct:active-memory-on'"
-        - set: transcriptRoot
-          value:
-            expr: "path.join(env.gateway.tempRoot, 'state', 'plugins', 'active-memory', 'transcripts', 'agents', 'qa', config.transcriptDir)"
         - set: toggleStorePath
           value:
             expr: "path.join(env.gateway.tempRoot, 'state', 'plugins', 'active-memory', 'session-toggles.json')"
-        - call: fs.rm
-          args:
-            - ref: transcriptRoot
-            - recursive: true
-              force: true
         - call: fs.rm
           args:
             - ref: toggleStorePath
@@ -198,24 +189,6 @@ flow:
                   message:
                     expr: "`active memory reply missed the hidden preference: ${activeOutbound.text}`"
         - call: waitForCondition
-          saveAs: transcriptPath
-          args:
-            - lambda:
-                async: true
-                expr: "await (async () => { const entries = (await fs.readdir(transcriptRoot).catch(() => [])).filter((entry) => entry.endsWith('.jsonl')).toSorted(); return entries.length > 0 ? path.join(transcriptRoot, entries.at(-1)) : undefined; })()"
-            - 10000
-        - call: fs.readFile
-          saveAs: transcriptText
-          args:
-            - ref: transcriptPath
-            - utf8
-        - assert:
-            expr: "transcriptText.includes('memory_search')"
-            message: active memory transcript missing memory_search
-        - assert:
-            expr: "transcriptText.includes('memory_get')"
-            message: active memory transcript missing memory_get
-        - call: waitForCondition
           saveAs: activeSessionEntry
           args:
             - lambda:
@@ -234,4 +207,4 @@ flow:
               - assert:
                   expr: "mockRequests.some((request) => request.allInputText.includes('You are a memory search agent.') && request.plannedToolName === 'memory_get')"
                   message: expected mock Active Memory memory_get request
-      detailsExpr: "`${activeOutbound.text}\\n\\ntranscript=${transcriptPath}`"
+      detailsExpr: activeOutbound.text

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -195,6 +195,13 @@ flow:
                 async: true
                 expr: "await (async () => { const store = await readRawQaSessionStore(env); const entry = store[activeSessionKey]; if (!entry || !Array.isArray(entry.pluginDebugEntries)) return undefined; return entry.pluginDebugEntries.some((pluginEntry) => pluginEntry?.pluginId === 'active-memory' && Array.isArray(pluginEntry.lines) && pluginEntry.lines.some((line) => line.includes('Active Memory: status=ok'))) ? entry : undefined; })()"
             - 10000
+        - call: readRawQaSessionStore
+          saveAs: sessionStoreAfterRecall
+          args:
+            - ref: env
+        - assert:
+            expr: "!Object.keys(sessionStoreAfterRecall).some((sessionKey) => sessionKey.startsWith(`${activeSessionKey}:active-memory:`))"
+            message: active memory recall left a transient SQLite session behind
         - if:
             expr: "Boolean(env.mock)"
             then:

--- a/qa/scenarios/memory/session-memory-ranking.yaml
+++ b/qa/scenarios/memory/session-memory-ranking.yaml
@@ -108,36 +108,29 @@ flow:
                   - ref: staleMemoryPath
                   - ref: staleAt
                   - ref: staleAt
-              - set: transcriptsDir
-                value:
-                  expr: "resolveSessionTranscriptsDirForAgent('qa', env.gateway.runtimeEnv, () => env.gateway.runtimeEnv.HOME ?? path.join(env.gateway.tempRoot, 'home'))"
-              - call: fs.mkdir
-                args:
-                  - ref: transcriptsDir
-                  - recursive: true
-              - set: transcriptPath
-                value:
-                  expr: "path.join(transcriptsDir, `${config.transcriptId}.jsonl`)"
               - set: now
                 value:
                   expr: "Date.now()"
-              - call: fs.writeFile
-                args:
-                  - ref: transcriptPath
-                  - expr: "[JSON.stringify({ type: 'session', id: config.transcriptId, timestamp: new Date(now - 120000).toISOString() }), JSON.stringify({ type: 'message', message: { role: 'user', timestamp: new Date(now - 90000).toISOString(), content: [{ type: 'text', text: config.transcriptQuestion }] } }), JSON.stringify({ type: 'message', message: { role: 'assistant', timestamp: new Date(now - 60000).toISOString(), content: [{ type: 'text', text: config.transcriptAnswer }] } })].join('\\n') + '\\n'"
-                  - utf8
-              - call: readRawQaSessionStore
-                saveAs: sessionStore
+              - call: seedQaSessionTranscript
                 args:
                   - ref: env
-              - set: sessionStorePath
-                value:
-                  expr: "path.join(env.gateway.tempRoot, 'state', 'agents', 'qa', 'sessions', 'sessions.json')"
-              - call: fs.writeFile
-                args:
-                  - ref: sessionStorePath
-                  - expr: "JSON.stringify({ ...sessionStore, ['agent:qa:seed-session-memory-ranking']: { sessionId: config.transcriptId, updatedAt: now, sessionFile: transcriptPath, origin: { label: 'QA seeded session memory ranking transcript' } } }, null, 2)"
-                  - utf8
+                  - sessionId:
+                      expr: config.transcriptId
+                    sessionKey: agent:qa:seed-session-memory-ranking
+                    updatedAt:
+                      ref: now
+                    label: QA seeded session memory ranking transcript
+                    messages:
+                      - role: user
+                        text:
+                          expr: config.transcriptQuestion
+                        timestamp:
+                          expr: now - 90000
+                      - role: assistant
+                        text:
+                          expr: config.transcriptAnswer
+                        timestamp:
+                          expr: now - 60000
               - call: forceMemoryIndex
                 args:
                   - env:


### PR DESCRIPTION
Related: #100167

## What Problem This Solves

Fixes an issue where Active Memory recall stopped producing pre-prompt context after session storage moved to SQLite. Embedded recall runs used a transient session identity that was not present in the canonical registry, so strict plugin session ownership could reject the run; QA memory scenarios also still seeded retired JSONL/session-index state.

## Why This Change Was Made

Creates each recall session through the canonical SQLite session-store API, uses a unique session key per run, preserves configured transcript artifacts, and removes the transient registry/transcript state after completion. QA scenarios now seed transcript events through the same SQLite runtime path. Cleanup retries remain bounded, cleanup failures are surfaced, and temporary workspaces are still removed if registry cleanup fails.

## User Impact

Active Memory can provide pre-prompt recall again under SQLite-backed sessions without leaving transient session rows, transcript artifacts, or temporary workspaces behind. Repeated or overlapping recalls remain isolated.

## Evidence

- Wrapper-owned Testbox `tbx_01kxawxbdj8vb91ne98fq3ecc6`: Active Memory tests `169/169` and QA runtime tests `15/15` passed.
- Same Testbox: `session-memory-ranking` and `active-memory-preprompt-recall` passed in `.artifacts/qa-e2e/memory-final-c9f8f37d3a5/qa-suite-summary.json`.
- Fresh wrapper-owned Testbox `tbx_01kxax74rpm0m0sdtbp7vxrqjg`: scoped `pnpm check:changed` passed for the 12 PR paths, including Plugin SDK baseline, `tsgo` with root-level `noUncheckedIndexedAccess`, all oxlint shards, and runtime import cycles.
- Fresh structured autoreview returned no accepted/actionable findings. The final landing-policy cleanup removed the release-owned changelog entry; the runtime, test, and scenario patch remained unchanged from the reviewed and tested diff.
