### PR TITLE
fix(channels): tombstone corrupt ingress rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.
 - **Cron delivery status:** keep successful isolated agent turns at `status=ok` when downstream delivery fails, while preserving the send failure separately in delivery state and run logs. (#95419) Thanks @Alix-007.
+- **Channel ingress recovery:** tombstone and scrub malformed durable ingress payloads without letting corrupt rows hide or starve later valid messages. (#98402) Thanks @Pick-cat.
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -675,7 +675,7 @@ two-party event loops that do not go through the shared inbound reply runner.
 
     `openSyncKeyedStore<T>(...)` returns the same store shape with synchronous methods (`register`, `registerIfAbsent`, `lookup`, `consume`, `clear` all return values directly instead of promises) for callers that cannot await.
 
-    `openChannelIngressQueue<TPayload>(...)` opens a persisted ingress queue scoped to the calling plugin, for buffering inbound events that need at-least-once processing across restarts.
+    `openChannelIngressQueue<TPayload>(...)` opens a persisted ingress queue scoped to the calling plugin, for buffering inbound events that need at-least-once processing across restarts. When stale-claim recovery uses `shouldRecover`, also provide `shouldRecoverCorrupt` if corrupt claimed payloads should be quarantined: its payload-independent claim identity lets the plugin preserve live owner and lane policy before the queue tombstones the row.
 
     <Warning>
     `openKeyedStore`, `openSyncKeyedStore`, and `openChannelIngressQueue` are available only to bundled plugins and trusted official plugin installations in this release.

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -41,6 +41,7 @@ import {
   claimNextTelegramSpooledUpdate,
   completeTelegramSpooledUpdateWithRetry,
   failTelegramSpooledUpdateClaim,
+  isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess,
   isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
   listTelegramSpooledUpdateClaims,
   listTelegramSpooledUpdates,
@@ -948,6 +949,11 @@ export class TelegramPollingSession {
         !this.#isDeferredSpooledUpdateClaim(claim) &&
         !activeLaneKeys.has(this.#spooledUpdateLaneKey(claim)) &&
         !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim, {
+          maxAgeMs: TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
+        }),
+      shouldRecoverCorrupt: (claim) =>
+        !(claim.laneKey && activeLaneKeys.has(claim.laneKey)) &&
+        !isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess(claim, {
           maxAgeMs: TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
         }),
     });

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -245,8 +245,8 @@ export function isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess(
   if (processId === TELEGRAM_SPOOLED_UPDATE_PROCESS_ID) {
     return isFreshClaimOwner(owner, options);
   }
-  return Boolean(
-    processPid !== process.pid && isFreshClaimOwner(owner, options) && processExists(processPid),
+  return (
+    processPid !== process.pid && isFreshClaimOwner(owner, options) && processExists(processPid)
   );
 }
 

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -6,6 +6,7 @@ import type {
   ChannelIngressQueue,
   ChannelIngressQueueClaim,
   ChannelIngressQueueClaimRef,
+  ChannelIngressQueueCorruptClaim,
   ChannelIngressQueueRecord,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
@@ -234,6 +235,21 @@ export function isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
   );
 }
 
+export function isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess(
+  claim: ChannelIngressQueueCorruptClaim,
+  options?: { maxAgeMs?: number; now?: number },
+): boolean {
+  const processId = claim.claim.ownerId;
+  const processPid = processPidFromOwnerId(processId);
+  const owner = { processId, processPid, claimedAt: claim.claim.claimedAt };
+  if (processId === TELEGRAM_SPOOLED_UPDATE_PROCESS_ID) {
+    return isFreshClaimOwner(owner, options);
+  }
+  return Boolean(
+    processPid !== process.pid && isFreshClaimOwner(owner, options) && processExists(processPid),
+  );
+}
+
 export async function writeTelegramSpooledUpdate(params: {
   spoolDir: string;
   update: unknown;
@@ -430,8 +446,10 @@ export async function recoverStaleTelegramSpooledUpdateClaims(params: {
   staleMs?: number;
   now?: number;
   shouldRecover?: (claim: ClaimedTelegramSpooledUpdate) => boolean | Promise<boolean>;
+  shouldRecoverCorrupt?: (claim: ChannelIngressQueueCorruptClaim) => boolean | Promise<boolean>;
 }): Promise<number> {
   const shouldRecover = params.shouldRecover;
+  const shouldRecoverCorrupt = params.shouldRecoverCorrupt;
   return await createTelegramIngressQueue(params.spoolDir).recoverStaleClaims({
     staleMs: params.staleMs ?? TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS,
     ...(params.now === undefined ? {} : { now: params.now }),
@@ -443,5 +461,6 @@ export async function recoverStaleTelegramSpooledUpdateClaims(params: {
           },
         }
       : {}),
+    ...(shouldRecoverCorrupt ? { shouldRecoverCorrupt } : {}),
   });
 }

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -53,6 +53,7 @@ import {
   claimNextTelegramSpooledUpdate,
   completeTelegramSpooledUpdateWithRetry,
   failTelegramSpooledUpdateClaim,
+  isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess,
   isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
   listTelegramSpooledUpdateClaims,
   listTelegramSpooledUpdates,
@@ -771,6 +772,11 @@ export async function startTelegramWebhook(opts: {
         shouldRecover: (claim) =>
           !activeWebhookSpooledLaneKeys.has(resolveWebhookSpooledUpdateLaneKey(claim.update)) &&
           !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim, {
+            maxAgeMs: TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
+          }),
+        shouldRecoverCorrupt: (claim) =>
+          !(claim.laneKey && activeWebhookSpooledLaneKeys.has(claim.laneKey)) &&
+          !isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess(claim, {
             maxAgeMs: TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
           }),
       });

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -199,7 +199,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10627,
+      10630,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/channels/message/index.ts
+++ b/src/channels/message/index.ts
@@ -61,6 +61,7 @@ export type {
   ChannelIngressQueue,
   ChannelIngressQueueClaim,
   ChannelIngressQueueClaimRef,
+  ChannelIngressQueueCorruptClaim,
   ChannelIngressQueueCompletedRecord,
   ChannelIngressQueueEnqueueResult,
   ChannelIngressQueueFailedRecord,

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -777,5 +777,80 @@ describe("channel ingress queue", () => {
         expect(pending[0].payload).toBeNull();
       });
     });
+
+    it("tombstones a corrupt pending row on duplicate enqueue", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+
+        insertCorruptRow(stateDir, '["test","account"]', "dup-bad", {
+          payload_json: "{corrupt",
+        });
+
+        const result = await queue.enqueue("dup-bad", { text: "late" });
+        expect(result.kind).toBe("failed");
+        if (result.kind === "failed") {
+          expect(result.duplicate).toBe(true);
+          expect(result.record.reason).toBe("corrupt_payload");
+        }
+
+        // Verify the corrupt row was actually tombstoned in the DB.
+        const { db } = openOpenClawStateDatabase({
+          env: createStateDirEnv(stateDir),
+        });
+        const row = executeSqliteQuerySync(
+          db,
+          getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
+            .selectFrom("channel_ingress_events")
+            .select(["status", "failed_reason"])
+            .where("queue_name", "=", '["test","account"]')
+            .where("event_id", "=", "dup-bad"),
+        ).rows[0];
+        expect(row?.status).toBe("failed");
+        expect(row?.failed_reason).toBe("corrupt_payload");
+      });
+    });
+
+    it("tombstones corrupt claimed rows during stale recovery", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+
+        const oldTime = 10;
+        insertCorruptRow(stateDir, '["test","account"]', "stale-bad", {
+          payload_json: "{corrupt",
+          status: "claimed",
+          claim_token: "tok-1",
+          claim_owner: "worker",
+          claimed_at: oldTime,
+        });
+
+        const recovered = await queue.recoverStaleClaims({
+          staleMs: Date.now() - oldTime,
+        });
+        expect(recovered).toBe(1);
+
+        // The corrupt claimed row should now be tombstoned as failed.
+        const { db } = openOpenClawStateDatabase({
+          env: createStateDirEnv(stateDir),
+        });
+        const row = executeSqliteQuerySync(
+          db,
+          getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
+            .selectFrom("channel_ingress_events")
+            .select(["status", "failed_reason"])
+            .where("queue_name", "=", '["test","account"]')
+            .where("event_id", "=", "stale-bad"),
+        ).rows[0];
+        expect(row?.status).toBe("failed");
+        expect(row?.failed_reason).toBe("corrupt_payload");
+      });
+    });
   });
 });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -627,6 +631,24 @@ describe("channel ingress queue", () => {
       });
     });
 
+    it("applies listPending limits after excluding corrupt payloads", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+        insertCorruptRow(stateDir, '["test","account"]', "bad-first", {
+          payload_json: "{corrupt",
+        });
+        await queue.enqueue("good-second", { text: "visible" }, { receivedAt: 300 });
+
+        const pending = await queue.listPending({ limit: 1 });
+
+        expect(pending.map((record) => record.id)).toEqual(["good-second"]);
+      });
+    });
+
     it("skips corrupt metadata_json in listPending", async () => {
       await withTempState(async (stateDir) => {
         const queue = createChannelIngressQueue<{ text: string }, { source: string }>({
@@ -735,6 +757,41 @@ describe("channel ingress queue", () => {
         const claimed = await queue.claimNext();
         expect(claimed).not.toBeNull();
         expect(claimed!.id).toBe("good-1");
+
+        const database = openOpenClawStateDatabase({ env: createStateDirEnv(stateDir) });
+        const failed = executeSqliteQueryTakeFirstSync(
+          database.db,
+          getNodeSqliteKysely<ChannelIngressTestDatabase>(database.db)
+            .selectFrom("channel_ingress_events")
+            .select(["status", "failed_reason", "payload_json"])
+            .where("queue_name", "=", '["test","account"]')
+            .where("event_id", "=", "bad-claim"),
+        );
+        expect(failed).toEqual({
+          status: "failed",
+          failed_reason: "corrupt_payload",
+          payload_json: "null",
+        });
+      });
+    });
+
+    it("makes durable progress when a corrupt prefix fills the claim scan limit", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+        insertCorruptRow(stateDir, '["test","account"]', "bad-first", {
+          payload_json: "{corrupt",
+        });
+        await queue.enqueue("good-second", { text: "claimable" }, { receivedAt: 300 });
+
+        await expect(queue.claimNext({ scanLimit: 1 })).resolves.toBeNull();
+        await expect(queue.claimNext({ scanLimit: 1 })).resolves.toMatchObject({
+          id: "good-second",
+          payload: { text: "claimable" },
+        });
       });
     });
 
@@ -759,6 +816,17 @@ describe("channel ingress queue", () => {
         const goodClaim = await queue.claim("good-1");
         expect(goodClaim).not.toBeNull();
         expect(goodClaim!.payload.text).toBe("hello");
+
+        const database = openOpenClawStateDatabase({ env: createStateDirEnv(stateDir) });
+        const failed = executeSqliteQueryTakeFirstSync(
+          database.db,
+          getNodeSqliteKysely<ChannelIngressTestDatabase>(database.db)
+            .selectFrom("channel_ingress_events")
+            .select(["status", "failed_reason"])
+            .where("queue_name", "=", '["test","account"]')
+            .where("event_id", "=", "bad-direct"),
+        );
+        expect(failed).toEqual({ status: "failed", failed_reason: "corrupt_payload" });
       });
     });
 
@@ -805,12 +873,15 @@ describe("channel ingress queue", () => {
           db,
           getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
             .selectFrom("channel_ingress_events")
-            .select(["status", "failed_reason"])
+            .select(["status", "failed_reason", "payload_json", "claim_token", "claimed_at"])
             .where("queue_name", "=", '["test","account"]')
             .where("event_id", "=", "dup-bad"),
         ).rows[0];
         expect(row?.status).toBe("failed");
         expect(row?.failed_reason).toBe("corrupt_payload");
+        expect(row?.payload_json).toBe("null");
+        expect(row?.claim_token).toBeNull();
+        expect(row?.claimed_at).toBeNull();
       });
     });
 
@@ -844,12 +915,16 @@ describe("channel ingress queue", () => {
           db,
           getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
             .selectFrom("channel_ingress_events")
-            .select(["status", "failed_reason"])
+            .select(["status", "failed_reason", "payload_json", "claim_token", "claimed_at"])
             .where("queue_name", "=", '["test","account"]')
             .where("event_id", "=", "stale-bad"),
         ).rows[0];
         expect(row?.status).toBe("failed");
         expect(row?.failed_reason).toBe("corrupt_payload");
+        expect(row?.payload_json).toBe("null");
+        expect(row?.claim_token).toBeNull();
+        expect(row?.claimed_at).toBeNull();
+        await expect(queue.recoverStaleClaims({ staleMs: Date.now() - oldTime })).resolves.toBe(0);
       });
     });
   });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -708,7 +708,7 @@ describe("channel ingress queue", () => {
       });
     });
 
-    it("claimNext skips a corrupt pending row and claims the next valid one", async () => {
+    it("claimNext skips a corrupt first pending row without lane derivation", async () => {
       await withTempState(async (stateDir) => {
         const queue = createChannelIngressQueue<{ text: string }>({
           channelId: "test",
@@ -732,11 +732,7 @@ describe("channel ingress queue", () => {
         }
         await queue.enqueue("good-1", { text: "hello" }, { receivedAt: earlyTime + 10 });
 
-        // claimNext with scanLimit > 1 to scan past the corrupt row.
-        const claimed = await queue.claimNext({
-          scanLimit: 5,
-          deriveLaneKey: () => undefined,
-        });
+        const claimed = await queue.claimNext();
         expect(claimed).not.toBeNull();
         expect(claimed!.id).toBe("good-1");
       });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -707,5 +707,79 @@ describe("channel ingress queue", () => {
         }
       });
     });
+
+    it("claimNext skips a corrupt pending row and claims the next valid one", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+
+        // Insert the bad row first so it sorts before the good row.
+        const earlyTime = 10;
+        insertCorruptRow(stateDir, '["test","account"]', "bad-claim", {
+          payload_json: "{corrupt",
+        });
+        // Override the bad row's received_at to be earlier.
+        {
+          const { db } = openOpenClawStateDatabase({
+            env: createStateDirEnv(stateDir),
+          });
+          db.prepare(
+            `UPDATE channel_ingress_events SET received_at = ? WHERE queue_name = ? AND event_id = ?`,
+          ).run(earlyTime, '["test","account"]', "bad-claim");
+        }
+        await queue.enqueue("good-1", { text: "hello" }, { receivedAt: earlyTime + 10 });
+
+        // claimNext with scanLimit > 1 to scan past the corrupt row.
+        const claimed = await queue.claimNext({
+          scanLimit: 5,
+          deriveLaneKey: () => undefined,
+        });
+        expect(claimed).not.toBeNull();
+        expect(claimed!.id).toBe("good-1");
+      });
+    });
+
+    it("claim returns null for a corrupt pending row", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+
+        await queue.enqueue("good-1", { text: "hello" });
+        insertCorruptRow(stateDir, '["test","account"]', "bad-direct", {
+          payload_json: "{corrupt",
+        });
+
+        // The corrupt row should not be claimable.
+        const badClaim = await queue.claim("bad-direct");
+        expect(badClaim).toBeNull();
+
+        // The good row should still be claimable.
+        const goodClaim = await queue.claim("good-1");
+        expect(goodClaim).not.toBeNull();
+        expect(goodClaim!.payload.text).toBe("hello");
+      });
+    });
+
+    it("handles valid JSON null payload correctly", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<null>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+
+        // Valid JSON null should parse as null, not be treated as corrupt.
+        await queue.enqueue("null-ok", null);
+        const pending = await queue.listPending();
+        expect(pending).toHaveLength(1);
+        expect(pending[0]!.payload).toBeNull();
+      });
+    });
   });
 });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -588,6 +588,7 @@ describe("channel ingress queue", () => {
         env: createStateDirEnv(stateDir),
       });
       const kysely = getNodeSqliteKysely<ChannelIngressTestDatabase>(db);
+      const claimValue = overrides.claim_token ?? null;
       executeSqliteQuerySync(
         db,
         kysely.insertInto("channel_ingress_events").values({
@@ -603,7 +604,7 @@ describe("channel ingress queue", () => {
           received_at: 100,
           updated_at: 200,
           attempts: 0,
-          claim_token: overrides.claim_token ?? null,
+          claim_token: claimValue,
           claim_owner: overrides.claim_owner ?? null,
           claimed_at: overrides.claimed_at ?? null,
           completed_at: overrides.completed_at ?? null,

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -886,6 +886,46 @@ describe("channel ingress queue", () => {
       });
     });
 
+    it("does not tombstone a corrupt actively claimed row on duplicate enqueue", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+        insertCorruptRow(stateDir, '["test","account"]', "dup-claimed-bad", {
+          payload_json: "{corrupt",
+          status: "claimed",
+          claim_token: "test-token-placeholder",
+          claim_owner: "active-worker",
+          claimed_at: 200,
+        });
+
+        await expect(queue.enqueue("dup-claimed-bad", { text: "late" })).rejects.toThrow(
+          "Corrupt payload_json in claimed channel ingress event",
+        );
+
+        const { db } = openOpenClawStateDatabase({
+          env: createStateDirEnv(stateDir),
+        });
+        const row = executeSqliteQueryTakeFirstSync(
+          db,
+          getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
+            .selectFrom("channel_ingress_events")
+            .select(["status", "payload_json", "claim_token", "claim_owner", "claimed_at"])
+            .where("queue_name", "=", '["test","account"]')
+            .where("event_id", "=", "dup-claimed-bad"),
+        );
+        expect(row).toEqual({
+          status: "claimed",
+          payload_json: "{corrupt",
+          claim_token: "test-token-placeholder",
+          claim_owner: "active-worker",
+          claimed_at: 200,
+        });
+      });
+    });
+
     it("tombstones corrupt claimed rows during stale recovery", async () => {
       await withTempState(async (stateDir) => {
         const queue = createChannelIngressQueue<{ text: string }>({
@@ -926,6 +966,48 @@ describe("channel ingress queue", () => {
         expect(row?.claim_token).toBeNull();
         expect(row?.claimed_at).toBeNull();
         await expect(queue.recoverStaleClaims({ staleMs: Date.now() - oldTime })).resolves.toBe(0);
+      });
+    });
+
+    it("does not bypass recovery policy for a corrupt stale claim", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+        insertCorruptRow(stateDir, '["test","account"]', "stale-policy-bad", {
+          payload_json: "{corrupt",
+          status: "claimed",
+          claim_token: "test-token-placeholder",
+          claim_owner: "active-worker",
+          claimed_at: 10,
+        });
+        const shouldRecover = vi.fn(() => true);
+
+        await expect(
+          queue.recoverStaleClaims({ staleMs: 10, now: 20, shouldRecover }),
+        ).resolves.toBe(0);
+        expect(shouldRecover).not.toHaveBeenCalled();
+
+        const { db } = openOpenClawStateDatabase({
+          env: createStateDirEnv(stateDir),
+        });
+        const row = executeSqliteQueryTakeFirstSync(
+          db,
+          getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
+            .selectFrom("channel_ingress_events")
+            .select(["status", "payload_json", "claim_token", "claim_owner", "claimed_at"])
+            .where("queue_name", "=", '["test","account"]')
+            .where("event_id", "=", "stale-policy-bad"),
+        );
+        expect(row).toEqual({
+          status: "claimed",
+          payload_json: "{corrupt",
+          claim_token: "test-token-placeholder",
+          claim_owner: "active-worker",
+          claimed_at: 10,
+        });
       });
     });
   });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -788,7 +788,6 @@ describe("channel ingress queue", () => {
         });
         await queue.enqueue("good-second", { text: "claimable" }, { receivedAt: 300 });
 
-        await expect(queue.claimNext({ scanLimit: 1 })).resolves.toBeNull();
         await expect(queue.claimNext({ scanLimit: 1 })).resolves.toMatchObject({
           id: "good-second",
           payload: { text: "claimable" },
@@ -984,11 +983,29 @@ describe("channel ingress queue", () => {
           claimed_at: 10,
         });
         const shouldRecover = vi.fn(() => true);
+        const shouldRecoverCorrupt = vi.fn(() => false);
 
         await expect(
-          queue.recoverStaleClaims({ staleMs: 10, now: 20, shouldRecover }),
+          queue.recoverStaleClaims({
+            staleMs: 10,
+            now: 20,
+            shouldRecover,
+            shouldRecoverCorrupt,
+          }),
         ).resolves.toBe(0);
         expect(shouldRecover).not.toHaveBeenCalled();
+        expect(shouldRecoverCorrupt).toHaveBeenCalledWith({
+          id: "stale-policy-bad",
+          channelId: "test",
+          accountId: "account",
+          queueName: '["test","account"]',
+          reason: "corrupt_payload",
+          claim: {
+            token: "test-token-placeholder",
+            ownerId: "active-worker",
+            claimedAt: 10,
+          },
+        });
 
         const { db } = openOpenClawStateDatabase({
           env: createStateDirEnv(stateDir),
@@ -1008,6 +1025,24 @@ describe("channel ingress queue", () => {
           claim_owner: "active-worker",
           claimed_at: 10,
         });
+
+        await expect(
+          queue.recoverStaleClaims({
+            staleMs: 10,
+            now: 20,
+            shouldRecover,
+            shouldRecoverCorrupt: () => true,
+          }),
+        ).resolves.toBe(1);
+        const failed = executeSqliteQueryTakeFirstSync(
+          db,
+          getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
+            .selectFrom("channel_ingress_events")
+            .select(["status", "failed_reason"])
+            .where("queue_name", "=", '["test","account"]')
+            .where("event_id", "=", "stale-policy-bad"),
+        );
+        expect(failed).toEqual({ status: "failed", failed_reason: "corrupt_payload" });
       });
     });
   });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -778,7 +778,7 @@ describe("channel ingress queue", () => {
         await queue.enqueue("null-ok", null);
         const pending = await queue.listPending();
         expect(pending).toHaveLength(1);
-        expect(pending[0]!.payload).toBeNull();
+        expect(pending[0].payload).toBeNull();
       });
     });
   });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -682,7 +682,7 @@ describe("channel ingress queue", () => {
         insertCorruptRow(stateDir, '["test","account"]', "claim-bad", {
           payload_json: "{{{broken",
           status: "claimed",
-          claim_token: "tok-1",
+          claim_token: "test-token-placeholder",
           claim_owner: "worker",
           claimed_at: 200,
         });
@@ -897,7 +897,7 @@ describe("channel ingress queue", () => {
         insertCorruptRow(stateDir, '["test","account"]', "stale-bad", {
           payload_json: "{corrupt",
           status: "claimed",
-          claim_token: "tok-1",
+          claim_token: "test-token-placeholder",
           claim_owner: "worker",
           claimed_at: oldTime,
         });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -639,9 +639,14 @@ describe("channel ingress queue", () => {
           accountId: "account",
           stateDir,
         });
-        insertCorruptRow(stateDir, '["test","account"]', "bad-first", {
-          payload_json: "{corrupt",
-        });
+        for (let index = 0; index < 100; index += 1) {
+          insertCorruptRow(
+            stateDir,
+            '["test","account"]',
+            `bad-${index.toString().padStart(3, "0")}`,
+            { payload_json: "{corrupt" },
+          );
+        }
         await queue.enqueue("good-second", { text: "visible" }, { receivedAt: 300 });
 
         const pending = await queue.listPending({ limit: 1 });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -563,4 +563,149 @@ describe("channel ingress queue", () => {
       expect(await queue.listClaims()).toEqual([]);
     });
   });
+
+  describe("corrupt JSON resilience", () => {
+    function insertCorruptRow(
+      stateDir: string,
+      queueName: string,
+      eventId: string,
+      overrides: Partial<{
+        payload_json: string;
+        metadata_json: string | null;
+        completed_metadata_json: string | null;
+        status: string;
+        claim_token: string;
+        claim_owner: string;
+        claimed_at: number;
+        completed_at: number;
+      }>,
+    ) {
+      const { db } = openOpenClawStateDatabase({
+        env: createStateDirEnv(stateDir),
+      });
+      const kysely = getNodeSqliteKysely<ChannelIngressTestDatabase>(db);
+      executeSqliteQuerySync(
+        db,
+        kysely.insertInto("channel_ingress_events").values({
+          queue_name: queueName,
+          event_id: eventId,
+          channel_id: "test",
+          account_id: "account",
+          status: overrides.status ?? "pending",
+          lane_key: null,
+          payload_json: overrides.payload_json ?? "null",
+          metadata_json: overrides.metadata_json ?? null,
+          completed_metadata_json: overrides.completed_metadata_json ?? null,
+          received_at: 100,
+          updated_at: 200,
+          attempts: 0,
+          claim_token: overrides.claim_token ?? null,
+          claim_owner: overrides.claim_owner ?? null,
+          claimed_at: overrides.claimed_at ?? null,
+          completed_at: overrides.completed_at ?? null,
+        } as Record<string, unknown>),
+      );
+    }
+
+    it("skips a pending row with corrupt payload_json in listPending", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+
+        await queue.enqueue("good-1", { text: "hello" });
+        insertCorruptRow(stateDir, '["test","account"]', "bad-1", {
+          payload_json: "{corrupt: true, >>>NOT JSON<<<",
+        });
+        await queue.enqueue("good-2", { text: "world" });
+
+        const pending = await queue.listPending();
+        expect(pending).toHaveLength(2);
+        expect(pending.map((r) => r.id).toSorted()).toEqual(["good-1", "good-2"]);
+      });
+    });
+
+    it("skips corrupt metadata_json in listPending", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }, { source: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+
+        await queue.enqueue("ev-1", { text: "ok" }, { metadata: { source: "good" } });
+        insertCorruptRow(stateDir, '["test","account"]', "ev-bad-meta", {
+          payload_json: JSON.stringify({ text: "has corrupt metadata" }),
+          metadata_json: "{broken",
+        });
+
+        const pending = await queue.listPending();
+        const bad = pending.find((r) => r.id === "ev-bad-meta");
+        expect(bad).not.toBeNull();
+        expect(bad!.metadata).toBeUndefined();
+      });
+    });
+
+    it("skips a claimed row with corrupt payload_json in listClaims", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+
+        await queue.enqueue("claim-ok", { text: "ok" });
+        insertCorruptRow(stateDir, '["test","account"]', "claim-bad", {
+          payload_json: "{{{broken",
+          status: "claimed",
+          claim_token: "tok-1",
+          claim_owner: "worker",
+          claimed_at: 200,
+        });
+
+        // Verify that listClaims skips the corrupt claimed row.
+        const initialClaims = await queue.listClaims();
+        expect(initialClaims.some((c) => c.id === "claim-bad")).toBe(false);
+
+        // The valid enqueued row can still be claimed.
+        const claimResult = await queue.claim("claim-ok");
+        expect(claimResult).not.toBeNull();
+
+        const allClaims = await queue.listClaims();
+        expect(allClaims.some((c) => c.id === "claim-bad")).toBe(false);
+      });
+    });
+
+    it("skips corrupt completed_metadata_json during duplicate detection", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<{ text: string }, unknown, { handler: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+
+        await queue.enqueue("comp-1", { text: "first" });
+        await queue.complete("comp-1", { metadata: { handler: "worker" }, completedAt: 150 });
+
+        // Corrupt the completed_metadata_json
+        const { db } = openOpenClawStateDatabase({
+          env: createStateDirEnv(stateDir),
+        });
+        db.prepare(
+          `UPDATE channel_ingress_events
+             SET completed_metadata_json = ?
+           WHERE queue_name = ? AND event_id = ?`,
+        ).run("not valid json", '["test","account"]', "comp-1");
+
+        // Duplicate detection should still work (metadata just omitted)
+        const dup = await queue.enqueue("comp-1", { text: "late" });
+        expect(dup.kind).toBe("completed");
+        if (dup.kind === "completed") {
+          expect(dup.record.metadata).toBeUndefined();
+        }
+      });
+    });
+  });
 });

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -650,6 +650,22 @@ describe("channel ingress queue", () => {
       });
     });
 
+    it("uses the queue JSON contract when listing deeply nested payloads", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createChannelIngressQueue<unknown>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+        const nestedJson = `${"[".repeat(1001)}0${"]".repeat(1001)}`;
+        const payload = JSON.parse(nestedJson);
+
+        await queue.enqueue("deep", payload);
+
+        await expect(queue.listPending({ limit: 1 })).resolves.toMatchObject([{ id: "deep" }]);
+      });
+    });
+
     it("skips corrupt metadata_json in listPending", async () => {
       await withTempState(async (stateDir) => {
         const queue = createChannelIngressQueue<{ text: string }, { source: string }>({
@@ -792,6 +808,38 @@ describe("channel ingress queue", () => {
           id: "good-second",
           payload: { text: "claimable" },
         });
+      });
+    });
+
+    it("bounds corrupt reconciliation work per claimNext call", async () => {
+      await withTempState(async (stateDir) => {
+        const queueName = '["test","account"]';
+        const queue = createChannelIngressQueue<{ text: string }>({
+          channelId: "test",
+          accountId: "account",
+          stateDir,
+        });
+        for (let index = 0; index < 101; index += 1) {
+          insertCorruptRow(stateDir, queueName, `bad-${index.toString().padStart(3, "0")}`, {
+            payload_json: "{corrupt",
+          });
+        }
+
+        await expect(queue.claimNext({ scanLimit: 200 })).resolves.toBeNull();
+
+        const database = openOpenClawStateDatabase({ env: createStateDirEnv(stateDir) });
+        const counts = executeSqliteQuerySync(
+          database.db,
+          getNodeSqliteKysely<ChannelIngressTestDatabase>(database.db)
+            .selectFrom("channel_ingress_events")
+            .select(["status"])
+            .where("queue_name", "=", queueName),
+        ).rows;
+        expect(counts.filter((row) => row.status === "failed")).toHaveLength(100);
+        expect(counts.filter((row) => row.status === "pending")).toHaveLength(1);
+
+        await expect(queue.claimNext({ scanLimit: 200 })).resolves.toBeNull();
+        expect(await queue.listPending({ limit: "all" })).toEqual([]);
       });
     });
 

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -603,7 +603,7 @@ describe("channel ingress queue", () => {
           claim_owner: overrides.claim_owner ?? null,
           claimed_at: overrides.claimed_at ?? null,
           completed_at: overrides.completed_at ?? null,
-        } as Record<string, unknown>),
+        } as any),
       );
     }
 

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -762,9 +762,9 @@ export function createChannelIngressQueue<
     ).rows;
     let recovered = 0;
     for (const row of claimedRows) {
-      const claim = claimedRecord<TPayload, TMetadata>(row);
-      if (claim === null) {
-        await runOpenClawStateWriteTransaction(
+      const claimRec = claimedRecord<TPayload, TMetadata>(row);
+      if (claimRec === null) {
+        runOpenClawStateWriteTransaction(
           (tx) => {
             executeSqliteQuerySync(
               tx.db,
@@ -786,10 +786,10 @@ export function createChannelIngressQueue<
         recovered += 1;
         continue;
       }
-      if (recoverOptions?.shouldRecover && !(await recoverOptions.shouldRecover(claim))) {
+      if (recoverOptions?.shouldRecover && !(await recoverOptions.shouldRecover(claimRec))) {
         continue;
       }
-      if (await releaseClaimIfStillStale(claim, { cutoff, releasedAt: current })) {
+      if (await releaseClaimIfStillStale(claimRec, { cutoff, releasedAt: current })) {
         recovered += 1;
       }
     }

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -56,6 +56,21 @@ export type ChannelIngressQueueClaimRef = {
   };
 };
 
+/** Claim identity available when a stale row's payload cannot be decoded. */
+export type ChannelIngressQueueCorruptClaim = {
+  id: string;
+  channelId: string;
+  accountId: string;
+  queueName: string;
+  laneKey?: string;
+  reason: "corrupt_payload";
+  claim: {
+    token: string;
+    ownerId: string;
+    claimedAt: number;
+  };
+};
+
 /** Completed ingress event tombstone retained for duplicate detection. */
 export type ChannelIngressQueueCompletedRecord<TCompletedMetadata = unknown> = {
   id: string;
@@ -174,6 +189,7 @@ export type ChannelIngressQueue<TPayload, TMetadata = unknown, TCompletedMetadat
     shouldRecover?: (
       claim: ChannelIngressQueueClaim<TPayload, TMetadata>,
     ) => boolean | Promise<boolean>;
+    shouldRecoverCorrupt?: (claim: ChannelIngressQueueCorruptClaim) => boolean | Promise<boolean>;
   }): Promise<number>;
   prune(options?: ChannelIngressQueuePruneOptions): Promise<number>;
 };
@@ -261,6 +277,22 @@ function claimedRecord<TPayload, TMetadata>(
   }
   return {
     ...base,
+    claim: {
+      token: row.claim_token ?? "",
+      ownerId: row.claim_owner ?? "",
+      claimedAt: row.claimed_at ?? 0,
+    },
+  };
+}
+
+function corruptClaimRecord(row: ChannelIngressRow): ChannelIngressQueueCorruptClaim {
+  return {
+    id: row.event_id,
+    channelId: row.channel_id,
+    accountId: row.account_id,
+    queueName: row.queue_name,
+    ...(row.lane_key === null ? {} : { laneKey: row.lane_key }),
+    reason: "corrupt_payload",
     claim: {
       token: row.claim_token ?? "",
       ownerId: row.claim_owner ?? "",
@@ -626,27 +658,34 @@ export function createChannelIngressQueue<
             ? select.orderBy("event_id", "asc")
             : select.orderBy("received_at", "asc").orderBy("event_id", "asc");
         orderedSelect = orderedSelect.limit(normalizeScanLimit(claimOptions?.scanLimit));
-        const rows = executeSqliteQuerySync(tx.db, orderedSelect).rows;
         const transitionAt = now();
         let selected:
           | { row: ChannelIngressRow; record: ChannelIngressQueueRecord<TPayload, TMetadata> }
           | undefined;
-        for (const row of rows) {
-          const rec = baseRecord<TPayload, TMetadata>(row);
-          if (rec === null) {
-            tombstoneCorruptPayloadRow({
-              db: tx.db,
-              row,
-              expectedStatus: "pending",
-              failedAt: transitionAt,
-            });
-            continue;
+        while (!selected) {
+          const rows = executeSqliteQuerySync(tx.db, orderedSelect).rows;
+          let tombstonedCorruptRow = false;
+          for (const row of rows) {
+            const rec = baseRecord<TPayload, TMetadata>(row);
+            if (rec === null) {
+              tombstonedCorruptRow =
+                tombstoneCorruptPayloadRow({
+                  db: tx.db,
+                  row,
+                  expectedStatus: "pending",
+                  failedAt: transitionAt,
+                }) || tombstonedCorruptRow;
+              continue;
+            }
+            const laneKey =
+              row.lane_key ??
+              (claimOptions?.deriveLaneKey ? claimOptions.deriveLaneKey(rec) : undefined);
+            if (!laneKey || !effectiveBlocked.has(laneKey)) {
+              selected = { row, record: rec };
+              break;
+            }
           }
-          const laneKey =
-            row.lane_key ??
-            (claimOptions?.deriveLaneKey ? claimOptions.deriveLaneKey(rec) : undefined);
-          if (!laneKey || !effectiveBlocked.has(laneKey)) {
-            selected = { row, record: rec };
+          if (selected || !tombstonedCorruptRow) {
             break;
           }
         }
@@ -821,10 +860,15 @@ export function createChannelIngressQueue<
     for (const row of claimedRows) {
       const claimRec = claimedRecord<TPayload, TMetadata>(row);
       if (claimRec === null) {
-        // The recovery predicate owns liveness decisions, but a corrupt payload
-        // cannot be materialized into its callback contract. Preserve the claim
-        // instead of bypassing caller policy and racing an active worker.
-        if (recoverOptions?.shouldRecover) {
+        const shouldRecoverCorrupt = recoverOptions?.shouldRecoverCorrupt;
+        if (shouldRecoverCorrupt) {
+          if (!(await shouldRecoverCorrupt(corruptClaimRecord(row)))) {
+            continue;
+          }
+        } else if (recoverOptions?.shouldRecover) {
+          // Existing payload-aware policies cannot safely decide on corrupt
+          // data. Preserve ownership unless the caller opts into the raw claim
+          // identity contract above.
           continue;
         }
         const tombstoned = runOpenClawStateWriteTransaction(

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -555,10 +555,7 @@ export function createChannelIngressQueue<
           claimOptions?.orderBy === "id"
             ? select.orderBy("event_id", "asc")
             : select.orderBy("received_at", "asc").orderBy("event_id", "asc");
-        orderedSelect =
-          claimOptions?.deriveLaneKey === undefined
-            ? orderedSelect.limit(1)
-            : orderedSelect.limit(normalizeScanLimit(claimOptions.scanLimit));
+        orderedSelect = orderedSelect.limit(normalizeScanLimit(claimOptions?.scanLimit));
         const rows = executeSqliteQuerySync(tx.db, orderedSelect).rows;
         const selected = rows.find((row) => {
           const rec = baseRecord<TPayload, TMetadata>(row);
@@ -580,11 +577,7 @@ export function createChannelIngressQueue<
         }
         const derivedLaneKey =
           selected.lane_key ??
-          (claimOptions?.deriveLaneKey
-            ? (() => {
-                return claimOptions.deriveLaneKey(selectedBase);
-              })()
-            : undefined);
+          (claimOptions?.deriveLaneKey ? claimOptions.deriveLaneKey(selectedBase) : undefined);
         const token = randomUUID();
         const claimedAt = now();
         const ownerId = normalizePart(claimOptions?.ownerId, `${process.pid}`);

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -474,12 +474,19 @@ export function createChannelIngressQueue<
         }
         const dup = rowToEnqueueResult<TPayload, TMetadata, TCompletedMetadata>(row);
         if (dup === null) {
-          const expectedStatus = row.status === "claimed" ? "claimed" : "pending";
+          // A live claimant may already be producing external side effects.
+          // Duplicate enqueue cannot prove ownership is stale, so leave claimed
+          // corruption for the ownership-aware recovery path.
+          if (row.status === "claimed") {
+            throw new Error(
+              `Corrupt payload_json in claimed channel ingress event ${queueName}/${eventId}`,
+            );
+          }
           if (
             !tombstoneCorruptPayloadRow({
               db: tx.db,
               row,
-              expectedStatus,
+              expectedStatus: "pending",
               failedAt: updatedAt,
             })
           ) {
@@ -814,6 +821,12 @@ export function createChannelIngressQueue<
     for (const row of claimedRows) {
       const claimRec = claimedRecord<TPayload, TMetadata>(row);
       if (claimRec === null) {
+        // The recovery predicate owns liveness decisions, but a corrupt payload
+        // cannot be materialized into its callback contract. Preserve the claim
+        // instead of bypassing caller policy and racing an active worker.
+        if (recoverOptions?.shouldRecover) {
+          continue;
+        }
         const tombstoned = runOpenClawStateWriteTransaction(
           (tx) =>
             tombstoneCorruptPayloadRow({

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -5,7 +5,7 @@
  */
 import { randomUUID } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
-import type { Selectable } from "kysely";
+import { sql, type Selectable } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -310,6 +310,45 @@ function selectRow(db: DatabaseSync, queueName: string, id: string) {
   );
 }
 
+function tombstoneCorruptPayloadRow(params: {
+  db: DatabaseSync;
+  row: ChannelIngressRow;
+  expectedStatus: "pending" | "claimed";
+  failedAt: number;
+  staleCutoff?: number;
+}): boolean {
+  const kysely = getChannelIngressKysely(params.db);
+  const baseUpdate = kysely
+    .updateTable("channel_ingress_events")
+    .set({
+      status: "failed",
+      failed_at: params.failedAt,
+      failed_reason: "corrupt_payload",
+      last_error: null,
+      payload_json: "null",
+      metadata_json: null,
+      claim_token: null,
+      claim_owner: null,
+      claimed_at: null,
+      updated_at: params.failedAt,
+    })
+    .where("queue_name", "=", params.row.queue_name)
+    .where("event_id", "=", params.row.event_id)
+    .where("status", "=", params.expectedStatus);
+  if (params.expectedStatus === "pending") {
+    return affectedRows(executeSqliteQuerySync(params.db, baseUpdate)) > 0;
+  }
+  const claimGuardedUpdate =
+    params.row.claim_token === null
+      ? baseUpdate.where("claim_token", "is", null)
+      : baseUpdate.where("claim_token", "=", params.row.claim_token);
+  const staleGuardedUpdate =
+    params.staleCutoff === undefined
+      ? claimGuardedUpdate
+      : claimGuardedUpdate.where("claimed_at", "<=", params.staleCutoff);
+  return affectedRows(executeSqliteQuerySync(params.db, staleGuardedUpdate)) > 0;
+}
+
 function idFrom(idOrRecord: string | { id: string }): string {
   const id = normalizePart(typeof idOrRecord === "string" ? idOrRecord : idOrRecord.id, "");
   if (!id) {
@@ -435,19 +474,17 @@ export function createChannelIngressQueue<
         }
         const dup = rowToEnqueueResult<TPayload, TMetadata, TCompletedMetadata>(row);
         if (dup === null) {
-          executeSqliteQuerySync(
-            tx.db,
-            kysely
-              .updateTable("channel_ingress_events")
-              .set({
-                status: "failed",
-                failed_at: updatedAt,
-                failed_reason: "corrupt_payload",
-                updated_at: updatedAt,
-              })
-              .where("queue_name", "=", queueName)
-              .where("event_id", "=", eventId),
-          );
+          const expectedStatus = row.status === "claimed" ? "claimed" : "pending";
+          if (
+            !tombstoneCorruptPayloadRow({
+              db: tx.db,
+              row,
+              expectedStatus,
+              failedAt: updatedAt,
+            })
+          ) {
+            throw new Error(`Failed to tombstone corrupt ingress event ${queueName}/${eventId}`);
+          }
           return {
             kind: "failed",
             duplicate: true,
@@ -479,6 +516,8 @@ export function createChannelIngressQueue<
       .selectAll()
       .where("queue_name", "=", queueName)
       .where("status", "=", "pending")
+      // Apply the caller's limit to usable work, not a corrupt prefix that materialization skips.
+      .where(sql<boolean>`json_valid(${sql.ref("payload_json")})`)
       .limit(normalizeLimit(listOptions?.limit));
     const query =
       listOptions?.orderBy === "id"
@@ -581,29 +620,36 @@ export function createChannelIngressQueue<
             : select.orderBy("received_at", "asc").orderBy("event_id", "asc");
         orderedSelect = orderedSelect.limit(normalizeScanLimit(claimOptions?.scanLimit));
         const rows = executeSqliteQuerySync(tx.db, orderedSelect).rows;
-        const selected = rows.find((row) => {
+        const transitionAt = now();
+        let selected:
+          | { row: ChannelIngressRow; record: ChannelIngressQueueRecord<TPayload, TMetadata> }
+          | undefined;
+        for (const row of rows) {
           const rec = baseRecord<TPayload, TMetadata>(row);
           if (rec === null) {
-            return false;
+            tombstoneCorruptPayloadRow({
+              db: tx.db,
+              row,
+              expectedStatus: "pending",
+              failedAt: transitionAt,
+            });
+            continue;
           }
           const laneKey =
             row.lane_key ??
             (claimOptions?.deriveLaneKey ? claimOptions.deriveLaneKey(rec) : undefined);
-          return !laneKey || !effectiveBlocked.has(laneKey);
-        });
+          if (!laneKey || !effectiveBlocked.has(laneKey)) {
+            selected = { row, record: rec };
+            break;
+          }
+        }
         if (!selected) {
           return null;
         }
-        // Validate the payload can be decoded before mutating row state.
-        const selectedBase = baseRecord<TPayload, TMetadata>(selected);
-        if (selectedBase === null) {
-          return null;
-        }
         const derivedLaneKey =
-          selected.lane_key ??
-          (claimOptions?.deriveLaneKey ? claimOptions.deriveLaneKey(selectedBase) : undefined);
+          selected.row.lane_key ??
+          (claimOptions?.deriveLaneKey ? claimOptions.deriveLaneKey(selected.record) : undefined);
         const token = randomUUID();
-        const claimedAt = now();
         const ownerId = normalizePart(claimOptions?.ownerId, `${process.pid}`);
         const result = executeSqliteQuerySync(
           tx.db,
@@ -613,18 +659,18 @@ export function createChannelIngressQueue<
               status: "claimed",
               claim_token: token,
               claim_owner: ownerId,
-              claimed_at: claimedAt,
+              claimed_at: transitionAt,
               ...(derivedLaneKey ? { lane_key: derivedLaneKey } : {}),
-              updated_at: claimedAt,
+              updated_at: transitionAt,
             })
             .where("queue_name", "=", queueName)
-            .where("event_id", "=", selected.event_id)
+            .where("event_id", "=", selected.row.event_id)
             .where("status", "=", "pending"),
         );
         if (affectedRows(result) === 0) {
           return null;
         }
-        const row = selectRow(tx.db, queueName, selected.event_id);
+        const row = selectRow(tx.db, queueName, selected.row.event_id);
         return row ? claimedRecord<TPayload, TMetadata>(row) : null;
       },
       { path: database.path },
@@ -643,17 +689,21 @@ export function createChannelIngressQueue<
     return runOpenClawStateWriteTransaction(
       (tx) => {
         const kysely = getChannelIngressKysely(tx.db);
-        // Validate the payload can be decoded before mutating row state.
+        const transitionAt = now();
         const pendingRow = selectRow(tx.db, queueName, eventId);
-        if (
-          !pendingRow ||
-          pendingRow.status !== "pending" ||
-          baseRecord<TPayload, TMetadata>(pendingRow) === null
-        ) {
+        if (!pendingRow || pendingRow.status !== "pending") {
+          return null;
+        }
+        if (baseRecord<TPayload, TMetadata>(pendingRow) === null) {
+          tombstoneCorruptPayloadRow({
+            db: tx.db,
+            row: pendingRow,
+            expectedStatus: "pending",
+            failedAt: transitionAt,
+          });
           return null;
         }
         const token = randomUUID();
-        const claimedAt = now();
         const ownerId = normalizePart(claimOptions?.ownerId, `${process.pid}`);
         const result = executeSqliteQuerySync(
           tx.db,
@@ -663,8 +713,8 @@ export function createChannelIngressQueue<
               status: "claimed",
               claim_token: token,
               claim_owner: ownerId,
-              claimed_at: claimedAt,
-              updated_at: claimedAt,
+              claimed_at: transitionAt,
+              updated_at: transitionAt,
             })
             .where("queue_name", "=", queueName)
             .where("event_id", "=", eventId)
@@ -764,26 +814,20 @@ export function createChannelIngressQueue<
     for (const row of claimedRows) {
       const claimRec = claimedRecord<TPayload, TMetadata>(row);
       if (claimRec === null) {
-        runOpenClawStateWriteTransaction(
-          (tx) => {
-            executeSqliteQuerySync(
-              tx.db,
-              getChannelIngressKysely(tx.db)
-                .updateTable("channel_ingress_events")
-                .set({
-                  status: "failed",
-                  failed_at: current,
-                  failed_reason: "corrupt_payload",
-                  updated_at: current,
-                })
-                .where("queue_name", "=", queueName)
-                .where("event_id", "=", row.event_id)
-                .where("status", "=", "claimed"),
-            );
-          },
+        const tombstoned = runOpenClawStateWriteTransaction(
+          (tx) =>
+            tombstoneCorruptPayloadRow({
+              db: tx.db,
+              row,
+              expectedStatus: "claimed",
+              failedAt: current,
+              staleCutoff: cutoff,
+            }),
           { path: database.path },
         );
-        recovered += 1;
+        if (tombstoned) {
+          recovered += 1;
+        }
         continue;
       }
       if (recoverOptions?.shouldRecover && !(await recoverOptions.shouldRecover(claimRec))) {

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -286,6 +286,7 @@ function claimedRecord<TPayload, TMetadata>(
 }
 
 function corruptClaimRecord(row: ChannelIngressRow): ChannelIngressQueueCorruptClaim {
+  const claimValue = row.claim_token ?? "";
   return {
     id: row.event_id,
     channelId: row.channel_id,
@@ -294,7 +295,7 @@ function corruptClaimRecord(row: ChannelIngressRow): ChannelIngressQueueCorruptC
     ...(row.lane_key === null ? {} : { laneKey: row.lane_key }),
     reason: "corrupt_payload",
     claim: {
-      token: row.claim_token ?? "",
+      token: claimValue,
       ownerId: row.claim_owner ?? "",
       claimedAt: row.claimed_at ?? 0,
     },

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -218,29 +218,31 @@ function affectedRows(result: { numAffectedRows?: bigint }): number {
   return Number(result.numAffectedRows ?? 0n);
 }
 
-function parseJson(value: string): unknown | null {
+type ParseJsonResult = { ok: true; value: unknown } | { ok: false };
+
+function parseJson(value: string): ParseJsonResult {
   try {
-    return JSON.parse(value);
+    return { ok: true, value: JSON.parse(value) };
   } catch {
-    return null;
+    return { ok: false };
   }
 }
 
 function baseRecord<TPayload, TMetadata>(
   row: ChannelIngressRow,
 ): ChannelIngressQueueRecord<TPayload, TMetadata> | null {
-  const payload = parseJson(row.payload_json);
-  if (payload === null) {
+  const payloadResult = parseJson(row.payload_json);
+  if (!payloadResult.ok) {
     return null;
   }
-  const parsedMeta = row.metadata_json === null ? null : parseJson(row.metadata_json);
+  const metaResult = row.metadata_json === null ? null : parseJson(row.metadata_json);
   return {
     id: row.event_id,
     channelId: row.channel_id,
     accountId: row.account_id,
     queueName: row.queue_name,
-    payload: payload as TPayload,
-    ...(parsedMeta === null ? {} : { metadata: parsedMeta as TMetadata }),
+    payload: payloadResult.value as TPayload,
+    ...(metaResult === null || !metaResult.ok ? {} : { metadata: metaResult.value as TMetadata }),
     receivedAt: row.received_at,
     updatedAt: row.updated_at,
     ...(row.lane_key === null ? {} : { laneKey: row.lane_key }),
@@ -270,7 +272,7 @@ function claimedRecord<TPayload, TMetadata>(
 function completedRecord<TCompletedMetadata>(
   row: ChannelIngressRow,
 ): ChannelIngressQueueCompletedRecord<TCompletedMetadata> {
-  const parsedMeta =
+  const metaResult =
     row.completed_metadata_json === null ? null : parseJson(row.completed_metadata_json);
   return {
     id: row.event_id,
@@ -278,7 +280,9 @@ function completedRecord<TCompletedMetadata>(
     accountId: row.account_id,
     queueName: row.queue_name,
     completedAt: row.completed_at ?? row.updated_at,
-    ...(parsedMeta === null ? {} : { metadata: parsedMeta as TCompletedMetadata }),
+    ...(metaResult === null || !metaResult.ok
+      ? {}
+      : { metadata: metaResult.value as TCompletedMetadata }),
   };
 }
 
@@ -557,25 +561,28 @@ export function createChannelIngressQueue<
             : orderedSelect.limit(normalizeScanLimit(claimOptions.scanLimit));
         const rows = executeSqliteQuerySync(tx.db, orderedSelect).rows;
         const selected = rows.find((row) => {
+          const rec = baseRecord<TPayload, TMetadata>(row);
+          if (rec === null) {
+            return false;
+          }
           const laneKey =
             row.lane_key ??
-            (claimOptions?.deriveLaneKey
-              ? (() => {
-                  const rec = baseRecord<TPayload, TMetadata>(row);
-                  return rec ? claimOptions.deriveLaneKey(rec) : undefined;
-                })()
-              : undefined);
+            (claimOptions?.deriveLaneKey ? claimOptions.deriveLaneKey(rec) : undefined);
           return !laneKey || !effectiveBlocked.has(laneKey);
         });
         if (!selected) {
+          return null;
+        }
+        // Validate the payload can be decoded before mutating row state.
+        const selectedBase = baseRecord<TPayload, TMetadata>(selected);
+        if (selectedBase === null) {
           return null;
         }
         const derivedLaneKey =
           selected.lane_key ??
           (claimOptions?.deriveLaneKey
             ? (() => {
-                const rec = baseRecord<TPayload, TMetadata>(selected);
-                return rec ? claimOptions.deriveLaneKey(rec) : undefined;
+                return claimOptions.deriveLaneKey(selectedBase);
               })()
             : undefined);
         const token = randomUUID();
@@ -619,6 +626,15 @@ export function createChannelIngressQueue<
     return runOpenClawStateWriteTransaction(
       (tx) => {
         const kysely = getChannelIngressKysely(tx.db);
+        // Validate the payload can be decoded before mutating row state.
+        const pendingRow = selectRow(tx.db, queueName, eventId);
+        if (
+          !pendingRow ||
+          pendingRow.status !== "pending" ||
+          baseRecord<TPayload, TMetadata>(pendingRow) === null
+        ) {
+          return null;
+        }
         const token = randomUUID();
         const claimedAt = now();
         const ownerId = normalizePart(claimOptions?.ownerId, `${process.pid}`);

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -435,7 +435,31 @@ export function createChannelIngressQueue<
         }
         const dup = rowToEnqueueResult<TPayload, TMetadata, TCompletedMetadata>(row);
         if (dup === null) {
-          throw new Error(`Corrupt channel ingress event ${queueName}/${eventId}`);
+          executeSqliteQuerySync(
+            tx.db,
+            kysely
+              .updateTable("channel_ingress_events")
+              .set({
+                status: "failed",
+                failed_at: updatedAt,
+                failed_reason: "corrupt_payload",
+                updated_at: updatedAt,
+              })
+              .where("queue_name", "=", queueName)
+              .where("event_id", "=", eventId),
+          );
+          return {
+            kind: "failed",
+            duplicate: true,
+            record: {
+              id: row.event_id,
+              channelId: row.channel_id,
+              accountId: row.account_id,
+              queueName: row.queue_name,
+              failedAt: updatedAt,
+              reason: "corrupt_payload",
+            },
+          };
         }
         return dup;
       },
@@ -726,13 +750,46 @@ export function createChannelIngressQueue<
     const current = recoverOptions?.now ?? now();
     const staleMs = Math.max(0, Math.floor(recoverOptions?.staleMs ?? 0));
     const cutoff = current - staleMs;
-    const staleClaims = (await listClaims()).filter((claimed) => claimed.claim.claimedAt <= cutoff);
+    const database = openStateDatabase(options.stateDir);
+    const claimedRows = executeSqliteQuerySync(
+      database.db,
+      getChannelIngressKysely(database.db)
+        .selectFrom("channel_ingress_events")
+        .selectAll()
+        .where("queue_name", "=", queueName)
+        .where("status", "=", "claimed")
+        .where("claimed_at", "<=", cutoff),
+    ).rows;
     let recovered = 0;
-    for (const staleClaim of staleClaims) {
-      if (recoverOptions?.shouldRecover && !(await recoverOptions.shouldRecover(staleClaim))) {
+    for (const row of claimedRows) {
+      const claim = claimedRecord<TPayload, TMetadata>(row);
+      if (claim === null) {
+        await runOpenClawStateWriteTransaction(
+          (tx) => {
+            executeSqliteQuerySync(
+              tx.db,
+              getChannelIngressKysely(tx.db)
+                .updateTable("channel_ingress_events")
+                .set({
+                  status: "failed",
+                  failed_at: current,
+                  failed_reason: "corrupt_payload",
+                  updated_at: current,
+                })
+                .where("queue_name", "=", queueName)
+                .where("event_id", "=", row.event_id)
+                .where("status", "=", "claimed"),
+            );
+          },
+          { path: database.path },
+        );
+        recovered += 1;
         continue;
       }
-      if (await releaseClaimIfStillStale(staleClaim, { cutoff, releasedAt: current })) {
+      if (recoverOptions?.shouldRecover && !(await recoverOptions.shouldRecover(claim))) {
+        continue;
+      }
+      if (await releaseClaimIfStillStale(claim, { cutoff, releasedAt: current })) {
         recovered += 1;
       }
     }

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -259,10 +259,11 @@ function claimedRecord<TPayload, TMetadata>(
   if (base === null) {
     return null;
   }
+  const claimValue = row.claim_token ?? "";
   return {
     ...base,
     claim: {
-      token: row.claim_token ?? "",
+      token: claimValue,
       ownerId: row.claim_owner ?? "",
       claimedAt: row.claimed_at ?? 0,
     },

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -560,21 +560,33 @@ export function createChannelIngressQueue<
     const kysely = getChannelIngressKysely(db);
     const limit = normalizeLimit(listOptions?.limit);
     const records: Array<ChannelIngressQueueRecord<TPayload, TMetadata>> = [];
-    let offset = 0;
+    let lastRow: ChannelIngressRow | undefined;
     while (records.length < limit) {
-      const baseQuery = kysely
+      let pageQuery = kysely
         .selectFrom("channel_ingress_events")
         .selectAll()
         .where("queue_name", "=", queueName)
         .where("status", "=", "pending");
+      if (lastRow) {
+        const cursor = lastRow;
+        pageQuery =
+          listOptions?.orderBy === "id"
+            ? pageQuery.where("event_id", ">", cursor.event_id)
+            : pageQuery.where((eb) =>
+                eb.or([
+                  eb("received_at", ">", cursor.received_at),
+                  eb.and([
+                    eb("received_at", "=", cursor.received_at),
+                    eb("event_id", ">", cursor.event_id),
+                  ]),
+                ]),
+              );
+      }
       const orderedQuery =
         listOptions?.orderBy === "id"
-          ? baseQuery.orderBy("event_id", "asc")
-          : baseQuery.orderBy("received_at", "asc").orderBy("event_id", "asc");
-      const rows = executeSqliteQuerySync(
-        db,
-        orderedQuery.limit(LIST_PENDING_BATCH_SIZE).offset(offset),
-      ).rows;
+          ? pageQuery.orderBy("event_id", "asc")
+          : pageQuery.orderBy("received_at", "asc").orderBy("event_id", "asc");
+      const rows = executeSqliteQuerySync(db, orderedQuery.limit(LIST_PENDING_BATCH_SIZE)).rows;
       for (const row of rows) {
         const record = baseRecord<TPayload, TMetadata>(row);
         if (record) {
@@ -587,7 +599,7 @@ export function createChannelIngressQueue<
       if (rows.length < LIST_PENDING_BATCH_SIZE) {
         break;
       }
-      offset += rows.length;
+      lastRow = rows.at(-1);
     }
     return records;
   };

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -259,11 +259,10 @@ function claimedRecord<TPayload, TMetadata>(
   if (base === null) {
     return null;
   }
-  const claimValue = row.claim_token ?? "";
   return {
     ...base,
     claim: {
-      token: claimValue,
+      token: row.claim_token ?? "",
       ownerId: row.claim_owner ?? "",
       claimedAt: row.claimed_at ?? 0,
     },

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -218,20 +218,29 @@ function affectedRows(result: { numAffectedRows?: bigint }): number {
   return Number(result.numAffectedRows ?? 0n);
 }
 
-function parseJson(value: string): unknown {
-  return JSON.parse(value);
+function parseJson(value: string): unknown | null {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
 }
 
 function baseRecord<TPayload, TMetadata>(
   row: ChannelIngressRow,
-): ChannelIngressQueueRecord<TPayload, TMetadata> {
+): ChannelIngressQueueRecord<TPayload, TMetadata> | null {
+  const payload = parseJson(row.payload_json);
+  if (payload === null) {
+    return null;
+  }
+  const parsedMeta = row.metadata_json === null ? null : parseJson(row.metadata_json);
   return {
     id: row.event_id,
     channelId: row.channel_id,
     accountId: row.account_id,
     queueName: row.queue_name,
-    payload: parseJson(row.payload_json) as TPayload,
-    ...(row.metadata_json === null ? {} : { metadata: parseJson(row.metadata_json) as TMetadata }),
+    payload: payload as TPayload,
+    ...(parsedMeta === null ? {} : { metadata: parsedMeta as TMetadata }),
     receivedAt: row.received_at,
     updatedAt: row.updated_at,
     ...(row.lane_key === null ? {} : { laneKey: row.lane_key }),
@@ -243,9 +252,13 @@ function baseRecord<TPayload, TMetadata>(
 
 function claimedRecord<TPayload, TMetadata>(
   row: ChannelIngressRow,
-): ChannelIngressQueueClaim<TPayload, TMetadata> {
+): ChannelIngressQueueClaim<TPayload, TMetadata> | null {
+  const base = baseRecord<TPayload, TMetadata>(row);
+  if (base === null) {
+    return null;
+  }
   return {
-    ...baseRecord<TPayload, TMetadata>(row),
+    ...base,
     claim: {
       token: row.claim_token ?? "",
       ownerId: row.claim_owner ?? "",
@@ -257,15 +270,15 @@ function claimedRecord<TPayload, TMetadata>(
 function completedRecord<TCompletedMetadata>(
   row: ChannelIngressRow,
 ): ChannelIngressQueueCompletedRecord<TCompletedMetadata> {
+  const parsedMeta =
+    row.completed_metadata_json === null ? null : parseJson(row.completed_metadata_json);
   return {
     id: row.event_id,
     channelId: row.channel_id,
     accountId: row.account_id,
     queueName: row.queue_name,
     completedAt: row.completed_at ?? row.updated_at,
-    ...(row.completed_metadata_json === null
-      ? {}
-      : { metadata: parseJson(row.completed_metadata_json) as TCompletedMetadata }),
+    ...(parsedMeta === null ? {} : { metadata: parsedMeta as TCompletedMetadata }),
   };
 }
 
@@ -309,7 +322,7 @@ function claimTokenFrom(
 
 function rowToEnqueueResult<TPayload, TMetadata, TCompletedMetadata>(
   row: ChannelIngressRow,
-): ChannelIngressQueueEnqueueResult<TPayload, TMetadata, TCompletedMetadata> {
+): ChannelIngressQueueEnqueueResult<TPayload, TMetadata, TCompletedMetadata> | null {
   if (row.status === "completed") {
     return { kind: "completed", duplicate: true, record: completedRecord(row) };
   }
@@ -317,9 +330,11 @@ function rowToEnqueueResult<TPayload, TMetadata, TCompletedMetadata>(
     return { kind: "failed", duplicate: true, record: failedRecord(row) };
   }
   if (row.status === "claimed") {
-    return { kind: "claimed", duplicate: true, record: claimedRecord(row) };
+    const rec = claimedRecord<TPayload, TMetadata>(row);
+    return rec ? { kind: "claimed", duplicate: true, record: rec } : null;
   }
-  return { kind: "pending", duplicate: true, record: baseRecord(row) };
+  const rec = baseRecord<TPayload, TMetadata>(row);
+  return rec ? { kind: "pending", duplicate: true, record: rec } : null;
 }
 
 function normalizeLimit(limit: number | "all" | undefined): number {
@@ -402,13 +417,23 @@ export function createChannelIngressQueue<
           throw new Error(`Failed to read channel ingress event ${queueName}/${eventId}`);
         }
         if (affectedRows(insert) > 0) {
+          const fresh = baseRecord<TPayload, TMetadata>(row);
+          if (fresh === null) {
+            throw new Error(
+              `Corrupt payload_json in channel ingress event ${queueName}/${eventId}`,
+            );
+          }
           return {
             kind: "accepted",
             duplicate: false,
-            record: baseRecord<TPayload, TMetadata>(row),
+            record: fresh,
           };
         }
-        return rowToEnqueueResult<TPayload, TMetadata, TCompletedMetadata>(row);
+        const dup = rowToEnqueueResult<TPayload, TMetadata, TCompletedMetadata>(row);
+        if (dup === null) {
+          throw new Error(`Corrupt channel ingress event ${queueName}/${eventId}`);
+        }
+        return dup;
       },
       { path: database.path },
     );
@@ -432,7 +457,9 @@ export function createChannelIngressQueue<
         ? baseQuery.orderBy("event_id", "asc")
         : baseQuery.orderBy("received_at", "asc").orderBy("event_id", "asc");
     const rows = executeSqliteQuerySync(db, query).rows;
-    return rows.map((row) => baseRecord<TPayload, TMetadata>(row));
+    return rows
+      .map((row) => baseRecord<TPayload, TMetadata>(row))
+      .filter((rec): rec is ChannelIngressQueueRecord<TPayload, TMetadata> => rec !== null);
   };
 
   const listClaims: ChannelIngressQueue<
@@ -453,7 +480,9 @@ export function createChannelIngressQueue<
         .orderBy("received_at", "asc")
         .orderBy("event_id", "asc"),
     ).rows;
-    return rows.map((row) => claimedRecord<TPayload, TMetadata>(row));
+    return rows
+      .map((row) => claimedRecord<TPayload, TMetadata>(row))
+      .filter((rec): rec is ChannelIngressQueueClaim<TPayload, TMetadata> => rec !== null);
   };
 
   const claimNext: ChannelIngressQueue<
@@ -489,7 +518,16 @@ export function createChannelIngressQueue<
               .where("event_id", "in", candidateIds),
           ).rows;
           const claimedCandidateLaneKeys = claimedCandidateRows
-            .map((row) => row.lane_key ?? claimOptions?.deriveLaneKey?.(baseRecord(row)))
+            .map((row) => {
+              if (row.lane_key) {
+                return row.lane_key;
+              }
+              if (!claimOptions?.deriveLaneKey) {
+                return undefined;
+              }
+              const rec = baseRecord<TPayload, TMetadata>(row);
+              return rec ? claimOptions.deriveLaneKey(rec) : undefined;
+            })
             .filter((laneKey): laneKey is string => Boolean(laneKey));
           if (claimedCandidateLaneKeys.length > 0) {
             effectiveBlocked = new Set([...blocked, ...claimedCandidateLaneKeys]);
@@ -519,14 +557,27 @@ export function createChannelIngressQueue<
             : orderedSelect.limit(normalizeScanLimit(claimOptions.scanLimit));
         const rows = executeSqliteQuerySync(tx.db, orderedSelect).rows;
         const selected = rows.find((row) => {
-          const laneKey = row.lane_key ?? claimOptions?.deriveLaneKey?.(baseRecord(row));
+          const laneKey =
+            row.lane_key ??
+            (claimOptions?.deriveLaneKey
+              ? (() => {
+                  const rec = baseRecord<TPayload, TMetadata>(row);
+                  return rec ? claimOptions.deriveLaneKey(rec) : undefined;
+                })()
+              : undefined);
           return !laneKey || !effectiveBlocked.has(laneKey);
         });
         if (!selected) {
           return null;
         }
         const derivedLaneKey =
-          selected.lane_key ?? claimOptions?.deriveLaneKey?.(baseRecord(selected));
+          selected.lane_key ??
+          (claimOptions?.deriveLaneKey
+            ? (() => {
+                const rec = baseRecord<TPayload, TMetadata>(selected);
+                return rec ? claimOptions.deriveLaneKey(rec) : undefined;
+              })()
+            : undefined);
         const token = randomUUID();
         const claimedAt = now();
         const ownerId = normalizePart(claimOptions?.ownerId, `${process.pid}`);

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -5,7 +5,7 @@
  */
 import { randomUUID } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
-import { sql, type Selectable } from "kysely";
+import type { Selectable } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -421,6 +421,13 @@ function normalizeScanLimit(limit: number | undefined): number {
   return Math.max(1, Math.floor(limit ?? 100));
 }
 
+// Materialize pending rows in bounded chunks because SQLite's json_valid()
+// rejects some payloads accepted by the queue's JSON.stringify/JSON.parse contract.
+const LIST_PENDING_BATCH_SIZE = 100;
+// Keep repair work bounded under one SQLite write lock; later calls continue
+// from the durable failed tombstones left by this call.
+const MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM = 100;
+
 function normalizeMaxEntries(value: number | undefined): number | null {
   return value === undefined ? null : Math.max(0, Math.floor(value));
 }
@@ -551,22 +558,38 @@ export function createChannelIngressQueue<
   >["listPending"] = async (listOptions) => {
     const { db } = openStateDatabase(options.stateDir);
     const kysely = getChannelIngressKysely(db);
-    const baseQuery = kysely
-      .selectFrom("channel_ingress_events")
-      .selectAll()
-      .where("queue_name", "=", queueName)
-      .where("status", "=", "pending")
-      // Apply the caller's limit to usable work, not a corrupt prefix that materialization skips.
-      .where(sql<boolean>`json_valid(${sql.ref("payload_json")})`)
-      .limit(normalizeLimit(listOptions?.limit));
-    const query =
-      listOptions?.orderBy === "id"
-        ? baseQuery.orderBy("event_id", "asc")
-        : baseQuery.orderBy("received_at", "asc").orderBy("event_id", "asc");
-    const rows = executeSqliteQuerySync(db, query).rows;
-    return rows
-      .map((row) => baseRecord<TPayload, TMetadata>(row))
-      .filter((rec): rec is ChannelIngressQueueRecord<TPayload, TMetadata> => rec !== null);
+    const limit = normalizeLimit(listOptions?.limit);
+    const records: Array<ChannelIngressQueueRecord<TPayload, TMetadata>> = [];
+    let offset = 0;
+    while (records.length < limit) {
+      const baseQuery = kysely
+        .selectFrom("channel_ingress_events")
+        .selectAll()
+        .where("queue_name", "=", queueName)
+        .where("status", "=", "pending");
+      const orderedQuery =
+        listOptions?.orderBy === "id"
+          ? baseQuery.orderBy("event_id", "asc")
+          : baseQuery.orderBy("received_at", "asc").orderBy("event_id", "asc");
+      const rows = executeSqliteQuerySync(
+        db,
+        orderedQuery.limit(LIST_PENDING_BATCH_SIZE).offset(offset),
+      ).rows;
+      for (const row of rows) {
+        const record = baseRecord<TPayload, TMetadata>(row);
+        if (record) {
+          records.push(record);
+          if (records.length === limit) {
+            break;
+          }
+        }
+      }
+      if (rows.length < LIST_PENDING_BATCH_SIZE) {
+        break;
+      }
+      offset += rows.length;
+    }
+    return records;
   };
 
   const listClaims: ChannelIngressQueue<
@@ -660,6 +683,7 @@ export function createChannelIngressQueue<
             : select.orderBy("received_at", "asc").orderBy("event_id", "asc");
         orderedSelect = orderedSelect.limit(normalizeScanLimit(claimOptions?.scanLimit));
         const transitionAt = now();
+        let corruptReconciliations = 0;
         let selected:
           | { row: ChannelIngressRow; record: ChannelIngressQueueRecord<TPayload, TMetadata> }
           | undefined;
@@ -669,13 +693,19 @@ export function createChannelIngressQueue<
           for (const row of rows) {
             const rec = baseRecord<TPayload, TMetadata>(row);
             if (rec === null) {
-              tombstonedCorruptRow =
-                tombstoneCorruptPayloadRow({
-                  db: tx.db,
-                  row,
-                  expectedStatus: "pending",
-                  failedAt: transitionAt,
-                }) || tombstonedCorruptRow;
+              if (corruptReconciliations >= MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
+                continue;
+              }
+              const didTombstone = tombstoneCorruptPayloadRow({
+                db: tx.db,
+                row,
+                expectedStatus: "pending",
+                failedAt: transitionAt,
+              });
+              tombstonedCorruptRow = didTombstone || tombstonedCorruptRow;
+              if (didTombstone) {
+                corruptReconciliations += 1;
+              }
               continue;
             }
             const laneKey =
@@ -686,7 +716,11 @@ export function createChannelIngressQueue<
               break;
             }
           }
-          if (selected || !tombstonedCorruptRow) {
+          if (
+            selected ||
+            !tombstonedCorruptRow ||
+            corruptReconciliations >= MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM
+          ) {
             break;
           }
         }

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -42,27 +42,12 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function callArg(
-  mock: { mock: { calls: Array<Array<unknown>> } },
-  callIndex: number,
-  argIndex: number,
-  label: string,
-) {
-  const call = mock.mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`Expected mock call: ${label}`);
-  }
-  if (argIndex >= call.length) {
-    throw new Error(`Expected mock call argument ${argIndex}: ${label}`);
-  }
-  return call[argIndex];
-}
-
 function webhookRequestBody() {
-  const request = requireRecord(
-    callArg(mocks.fetchWithSsrFGuard, 0, 0, "webhook request"),
-    "webhook request",
-  );
+  const call = (mocks.fetchWithSsrFGuard.mock.calls as unknown[][])[0];
+  if (!call) {
+    throw new Error("expected webhook request call");
+  }
+  const request = requireRecord(call[0], "webhook request");
   const init = requireRecord(request.init, "webhook request init");
   if (typeof init.body !== "string") {
     throw new Error("expected webhook request body");

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -42,12 +42,27 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function webhookRequestBody() {
-  const call = (mocks.fetchWithSsrFGuard.mock.calls as unknown[][])[0];
+function callArg(
+  mock: { mock: { calls: Array<Array<unknown>> } },
+  callIndex: number,
+  argIndex: number,
+  label: string,
+) {
+  const call = mock.mock.calls[callIndex];
   if (!call) {
-    throw new Error("expected webhook request call");
+    throw new Error(`Expected mock call: ${label}`);
   }
-  const request = requireRecord(call[0], "webhook request");
+  if (argIndex >= call.length) {
+    throw new Error(`Expected mock call argument ${argIndex}: ${label}`);
+  }
+  return call[argIndex];
+}
+
+function webhookRequestBody() {
+  const request = requireRecord(
+    callArg(mocks.fetchWithSsrFGuard, 0, 0, "webhook request"),
+    "webhook request",
+  );
   const init = requireRecord(request.init, "webhook request init");
   if (typeof init.body !== "string") {
     throw new Error("expected webhook request body");

--- a/src/plugin-sdk/channel-outbound.ts
+++ b/src/plugin-sdk/channel-outbound.ts
@@ -149,6 +149,7 @@ export type {
   ChannelIngressQueue,
   ChannelIngressQueueClaim,
   ChannelIngressQueueClaimRef,
+  ChannelIngressQueueCorruptClaim,
   ChannelIngressQueueCompletedRecord,
   ChannelIngressQueueEnqueueResult,
   ChannelIngressQueueFailedRecord,


### PR DESCRIPTION
## What Problem This Solves

Replaces #98402 on current main. A malformed durable channel-ingress payload could throw during JSON parsing, hide later valid rows behind list limits, and repeatedly starve `claimNext` without making durable progress.

## Why This Change Was Made

The replacement centralizes a Kysely compare-and-set tombstone operation for corrupt pending and claimed rows. It scrubs payload, metadata, and claim fields; validates JSON before limited pending selection; makes `claimNext` durably advance past corrupt rows; and reuses the same guarded cleanup during stale-claim recovery. Recovery counts only rows actually changed, preventing an older worker from clearing a newer claim generation.

This preserves @Pick-cat's contributor commits while removing the unrelated gateway test edit and consolidating the final repair at the ingress-queue owner boundary.

## User Impact

One corrupt durable ingress row no longer blocks later valid channel messages. Corrupt data is retained only as a failed tombstone with a bounded reason, while valid queued work remains listable and claimable.

## Evidence

- Blacksmith Testboxes `tbx_01kxarzhjkg0ypn8ttfx5smybz` and `tbx_01kxat2vsnk60cwbghnym4j6py`: 163 focused core queue, Telegram spool, polling, and webhook tests passed.
- Four type lanes passed: `tsgo:core`, `tsgo:test:src`, `tsgo:extensions`, and `tsgo:extensions:test`.
- Full `pnpm build` passed, including the public Plugin SDK declaration graph check (`5,057,529 / 5,100,000` bytes).
- The pinned Plugin SDK surface test passed at `10,630` public exports, including the three additive corrupt-claim re-exports.
- Regression coverage includes limited-list visibility, `scanLimit: 1` convergence, direct claim cleanup, pending duplicate cleanup, active-claim preservation, stale-claim compare-and-set races, and recovery-predicate ownership.
- The additive `shouldRecoverCorrupt` SDK contract is documented in `docs/plugins/sdk-runtime.md`.
- Fresh final autoreview is clean with no accepted or actionable findings (confidence 0.86).

Supersedes #98402.
