### PR TITLE
fix(sqlite): repair canonical unique index drift

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -36,6 +36,7 @@ const rawSqliteAllowPathGroups = {
   ],
   "SQLite database lifecycle, schema, transactions, and pragmas": [
     "src/infra/node-sqlite.ts",
+    "src/infra/sqlite-index-schema.ts",
     "src/infra/sqlite-integrity.ts",
     "src/infra/sqlite-pragma.test-support.ts",
     "src/infra/sqlite-transaction.ts",

--- a/src/infra/sqlite-index-schema.test.ts
+++ b/src/infra/sqlite-index-schema.test.ts
@@ -1,0 +1,153 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import {
+  repairCanonicalSqliteUniqueIndexes,
+  type CanonicalSqliteUniqueIndex,
+} from "./sqlite-index-schema.js";
+
+const CANONICAL_INDEX: CanonicalSqliteUniqueIndex = {
+  name: "idx_records_identity",
+  definition: `
+    ON records(
+      tenant_id COLLATE NOCASE,
+      IFNULL(external_id, '')
+    )
+    WHERE active = 1
+  `,
+};
+
+function createDatabase(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE records (
+      id INTEGER PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      external_id TEXT,
+      active INTEGER NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_records_identity
+      ON records(
+        tenant_id COLLATE NOCASE,
+        IFNULL(external_id, '')
+      )
+      WHERE active = 1;
+  `);
+  return db;
+}
+
+describe("repairCanonicalSqliteUniqueIndexes", () => {
+  it("does not rewrite an already canonical index", () => {
+    const db = createDatabase();
+    try {
+      const before = db.prepare("PRAGMA schema_version").get();
+
+      repairCanonicalSqliteUniqueIndexes(db, "test database", [CANONICAL_INDEX]);
+
+      expect(db.prepare("PRAGMA schema_version").get()).toEqual(before);
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each([
+    [
+      "column order",
+      "CREATE UNIQUE INDEX idx_records_identity ON records(external_id, tenant_id) WHERE active = 1",
+    ],
+    [
+      "collation",
+      "CREATE UNIQUE INDEX idx_records_identity ON records(tenant_id, IFNULL(external_id, '')) WHERE active = 1",
+    ],
+    [
+      "expression",
+      "CREATE UNIQUE INDEX idx_records_identity ON records(tenant_id COLLATE NOCASE, external_id) WHERE active = 1",
+    ],
+    [
+      "partial predicate",
+      "CREATE UNIQUE INDEX idx_records_identity ON records(tenant_id COLLATE NOCASE, IFNULL(external_id, '')) WHERE active = 0",
+    ],
+    ["uniqueness", "CREATE INDEX idx_records_identity ON records(tenant_id, external_id)"],
+  ])("repairs same-name %s drift", (_name, driftedSql) => {
+    const db = createDatabase();
+    try {
+      db.exec(`DROP INDEX idx_records_identity; ${driftedSql};`);
+
+      repairCanonicalSqliteUniqueIndexes(db, "test database", [CANONICAL_INDEX]);
+
+      const row = db
+        .prepare("SELECT sql FROM sqlite_schema WHERE name = 'idx_records_identity'")
+        .get() as { sql?: unknown };
+      expect(row.sql).toContain("tenant_id COLLATE NOCASE");
+      expect(row.sql).toContain("IFNULL(external_id, '')");
+      expect(row.sql).toContain("WHERE active = 1");
+      expect(() =>
+        db.exec(`
+          INSERT INTO records VALUES (1, 'Tenant', NULL, 1);
+          INSERT INTO records VALUES (2, 'tenant', NULL, 1);
+        `),
+      ).toThrow(/UNIQUE constraint failed/iu);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rolls back without dropping the drifted index when canonical rows conflict", () => {
+    const db = createDatabase();
+    try {
+      db.exec(`
+        DROP INDEX idx_records_identity;
+        CREATE UNIQUE INDEX idx_records_identity ON records(id);
+        INSERT INTO records VALUES
+          (1, 'Tenant', NULL, 1),
+          (2, 'tenant', NULL, 1);
+      `);
+
+      expect(() =>
+        repairCanonicalSqliteUniqueIndexes(db, "test database", [CANONICAL_INDEX]),
+      ).toThrow(/canonical unique index idx_records_identity failed.*UNIQUE constraint failed/iu);
+
+      expect(
+        db.prepare("SELECT sql FROM sqlite_schema WHERE name = 'idx_records_identity'").get(),
+      ).toEqual({
+        sql: "CREATE UNIQUE INDEX idx_records_identity ON records(id)",
+      });
+      expect(
+        db
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'index' AND name LIKE 'openclaw_probe_%'",
+          )
+          .all(),
+      ).toEqual([]);
+      expect(db.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("repairs only the main schema when a temporary index has the same name", () => {
+    const db = createDatabase();
+    try {
+      db.exec(`
+        CREATE TEMP TABLE temp_records (id INTEGER PRIMARY KEY);
+        CREATE UNIQUE INDEX temp.idx_records_identity ON temp_records(id);
+        DROP INDEX main.idx_records_identity;
+        CREATE UNIQUE INDEX main.idx_records_identity ON records(id);
+      `);
+
+      repairCanonicalSqliteUniqueIndexes(db, "test database", [CANONICAL_INDEX]);
+
+      expect(
+        db.prepare("SELECT sql FROM main.sqlite_schema WHERE name = 'idx_records_identity'").get(),
+      ).toEqual({
+        sql: expect.stringContaining("tenant_id COLLATE NOCASE"),
+      });
+      expect(
+        db.prepare("SELECT sql FROM temp.sqlite_schema WHERE name = 'idx_records_identity'").get(),
+      ).toEqual({
+        sql: "CREATE UNIQUE INDEX idx_records_identity ON temp_records(id)",
+      });
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/infra/sqlite-index-schema.ts
+++ b/src/infra/sqlite-index-schema.ts
@@ -1,0 +1,103 @@
+import type { DatabaseSync } from "node:sqlite";
+
+export type CanonicalSqliteUniqueIndex = {
+  name: string;
+  definition: string;
+};
+
+type SqliteSchemaRow = {
+  sql?: unknown;
+};
+
+const SQLITE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+
+/**
+ * Restore named unique indexes when SQLite's IF NOT EXISTS semantics preserve
+ * a same-name definition that no longer enforces the canonical constraint.
+ */
+export function repairCanonicalSqliteUniqueIndexes(
+  db: DatabaseSync,
+  databaseLabel: string,
+  indexes: readonly CanonicalSqliteUniqueIndex[],
+): void {
+  const drifted = indexes.filter((index) => {
+    assertSqliteIdentifier(index.name);
+    const row = db
+      .prepare("SELECT sql FROM main.sqlite_schema WHERE type = 'index' AND name = ?")
+      .get(index.name) as SqliteSchemaRow | undefined;
+    return (
+      typeof row?.sql !== "string" ||
+      normalizeCreateIndexSql(row.sql) !==
+        normalizeCreateIndexSql(createIndexSql(index, index.name, false))
+    );
+  });
+  if (drifted.length === 0) {
+    return;
+  }
+
+  const savepoint = "repair_canonical_unique_indexes";
+  let activeIndex: CanonicalSqliteUniqueIndex | undefined;
+  db.exec(`SAVEPOINT ${savepoint};`);
+  try {
+    for (const index of drifted) {
+      activeIndex = index;
+      const probeName = findUnusedProbeIndexName(db, index.name);
+      // Build the canonical constraint first. If existing rows conflict, the
+      // wrong same-name index remains in place and the whole repair rolls back.
+      db.exec(createIndexSql(index, probeName, true));
+      db.exec(`DROP INDEX main.${index.name};`);
+      db.exec(createIndexSql(index, index.name, true));
+      db.exec(`DROP INDEX main.${probeName};`);
+    }
+    db.exec(`RELEASE SAVEPOINT ${savepoint};`);
+  } catch (error) {
+    try {
+      db.exec(`ROLLBACK TO SAVEPOINT ${savepoint};`);
+    } finally {
+      db.exec(`RELEASE SAVEPOINT ${savepoint};`);
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `SQLite canonical unique index ${activeIndex?.name ?? "repair"} failed for ${databaseLabel}: ${detail}`,
+      { cause: error },
+    );
+  }
+}
+
+function createIndexSql(
+  index: CanonicalSqliteUniqueIndex,
+  name: string,
+  qualifyMain: boolean,
+): string {
+  assertSqliteIdentifier(name);
+  return `CREATE UNIQUE INDEX ${qualifyMain ? `main.${name}` : name} ${index.definition};`;
+}
+
+function findUnusedProbeIndexName(db: DatabaseSync, canonicalName: string): string {
+  const prefix = `openclaw_probe_${canonicalName}`;
+  for (let suffix = 0; suffix < 100; suffix += 1) {
+    const candidate = suffix === 0 ? prefix : `${prefix}_${suffix}`;
+    const row = db
+      .prepare("SELECT 1 AS found FROM main.sqlite_schema WHERE name = ?")
+      .get(candidate);
+    if (!row) {
+      return candidate;
+    }
+  }
+  throw new Error(`could not allocate a probe index name for ${canonicalName}`);
+}
+
+function assertSqliteIdentifier(identifier: string): void {
+  if (!SQLITE_IDENTIFIER_PATTERN.test(identifier)) {
+    throw new Error(`invalid SQLite identifier: ${identifier}`);
+  }
+}
+
+function normalizeCreateIndexSql(sql: string): string {
+  return sql
+    .trim()
+    .replace(/;\s*$/u, "")
+    .replace(/^CREATE\s+UNIQUE\s+INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?/iu, "CREATE UNIQUE INDEX ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -185,6 +185,50 @@ function createUnsafeIndexDrift(databasePath: string): void {
   }
 }
 
+function createTranscriptIdempotencyIndexDrift(
+  databasePath: string,
+  options: { duplicateRows?: boolean } = {},
+): void {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(`
+      DROP INDEX idx_agent_transcript_message_idempotency;
+      CREATE UNIQUE INDEX idx_agent_transcript_message_idempotency
+        ON transcript_event_identities(session_id, event_id);
+      INSERT INTO sessions (
+        session_id, session_key, session_scope, created_at, updated_at
+      ) VALUES (
+        'session-1', 'agent:worker-1:session-1', 'conversation', 1, 1
+      );
+      INSERT INTO transcript_events (session_id, seq, event_json, created_at)
+      VALUES
+        ('session-1', 1, '{}', 1),
+        ('session-1', 2, '{}', 2);
+      INSERT INTO transcript_event_identities (
+        session_id, event_id, seq, message_idempotency_key, created_at
+      ) VALUES (
+        'session-1', 'event-1', 1, 'message-1', 1
+      );
+    `);
+    if (options.duplicateRows) {
+      database.exec(`
+        INSERT INTO transcript_event_identities (
+          session_id, event_id, seq, message_idempotency_key, created_at
+        ) VALUES (
+          'session-1', 'event-2', 2, 'message-1', 2
+        );
+      `);
+    }
+    expect(database.prepare("PRAGMA integrity_check").get()).toEqual({
+      integrity_check: "ok",
+    });
+    expect(database.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+  } finally {
+    database.close();
+  }
+}
+
 type AgentSchemaOpenerResult = { agentId: string; ok: boolean; error?: string };
 
 function launchAgentSchemaOpener(params: {
@@ -1110,6 +1154,81 @@ describe("openclaw agent database", () => {
         : transcriptIndex?.sql,
     ).toContain("ON transcript_event_identities(session_id, event_type, seq DESC)");
     expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+  });
+
+  it("repairs a same-name transcript uniqueness index before accepting writes", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const created = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const databasePath = created.path;
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    createTranscriptIdempotencyIndexDrift(databasePath);
+
+    const reopened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const index = reopened.db
+      .prepare(
+        "SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = 'idx_agent_transcript_message_idempotency'",
+      )
+      .get() as { sql?: unknown };
+    expect(index.sql).toContain(
+      "ON transcript_event_identities(session_id, message_idempotency_key)",
+    );
+    expect(index.sql).toContain("WHERE message_idempotency_key IS NOT NULL");
+
+    expect(() =>
+      reopened.db
+        .prepare(
+          `INSERT INTO transcript_event_identities (
+             session_id, event_id, seq, message_idempotency_key, created_at
+           ) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run("session-1", "event-2", 2, "message-1", 2),
+    ).toThrow(/UNIQUE constraint failed/iu);
+  });
+
+  it("rejects same-name transcript index drift when duplicate rows block repair", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const created = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const databasePath = created.path;
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    createTranscriptIdempotencyIndexDrift(databasePath, { duplicateRows: true });
+
+    expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow(
+      /canonical unique index idx_agent_transcript_message_idempotency failed.*UNIQUE constraint failed/iu,
+    );
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const after = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        after
+          .prepare(
+            "SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = 'idx_agent_transcript_message_idempotency'",
+          )
+          .get(),
+      ).toEqual({
+        sql: expect.stringContaining("ON transcript_event_identities(session_id, event_id)"),
+      });
+      expect(
+        after
+          .prepare(
+            "SELECT COUNT(*) AS count FROM transcript_event_identities WHERE message_idempotency_key = 'message-1'",
+          )
+          .get(),
+      ).toEqual({ count: 2 });
+      expect(
+        after
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'index' AND name LIKE 'openclaw_probe_%'",
+          )
+          .all(),
+      ).toEqual([]);
+    } finally {
+      after.close();
+    }
   });
 
   it("records durable per-agent schema metadata", () => {

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -10,6 +10,10 @@ import {
 } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
+import {
+  repairCanonicalSqliteUniqueIndexes,
+  type CanonicalSqliteUniqueIndex,
+} from "../infra/sqlite-index-schema.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import {
   runSqliteImmediateTransactionSync,
@@ -56,6 +60,35 @@ export const OPENCLAW_AGENT_SCHEMA_VERSION = 6;
 const OPENCLAW_AGENT_DB_DIR_MODE = 0o700;
 const OPENCLAW_AGENT_DB_FILE_MODE = 0o600;
 const OPENCLAW_AGENT_DB_SLOW_OPEN_MS = 1_000;
+const OPENCLAW_AGENT_CANONICAL_UNIQUE_INDEXES = [
+  {
+    name: "idx_agent_conversations_identity",
+    definition: `
+      ON conversations(
+        channel,
+        account_id,
+        kind,
+        peer_id,
+        IFNULL(parent_conversation_id, ''),
+        IFNULL(thread_id, '')
+      )
+    `,
+  },
+  {
+    name: "idx_agent_session_conversations_primary",
+    definition: `
+      ON session_conversations(session_id)
+      WHERE role = 'primary'
+    `,
+  },
+  {
+    name: "idx_agent_transcript_message_idempotency",
+    definition: `
+      ON transcript_event_identities(session_id, message_idempotency_key)
+      WHERE message_idempotency_key IS NOT NULL
+    `,
+  },
+] as const satisfies readonly CanonicalSqliteUniqueIndex[];
 const agentDbLog = createSubsystemLogger("state/agent-db");
 
 /** Open per-agent SQLite database handle plus lifecycle maintenance. */
@@ -567,6 +600,7 @@ function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string):
       migrateMemoryIndexSourcesIdentity(db);
       migrateOpenClawAgentSchema(db);
       db.exec(OPENCLAW_AGENT_SCHEMA_SQL);
+      repairCanonicalSqliteUniqueIndexes(db, pathname, OPENCLAW_AGENT_CANONICAL_UNIQUE_INDEXES);
       backfillOpenClawAgentSchema(db, previousVersion);
       const kysely = getNodeSqliteKysely<OpenClawAgentMetadataDatabase>(db);
       db.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION};`);

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -656,6 +656,40 @@ describe("openclaw state database", () => {
     expect(database.path).toBe(path.join(stateDir, "state", "openclaw.sqlite"));
   });
 
+  it("repairs a same-name shared-state uniqueness index", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const created = openOpenClawStateDatabase({ env });
+    const databasePath = created.path;
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const drifted = new DatabaseSync(databasePath);
+    try {
+      drifted.exec(`
+        DROP INDEX idx_operator_approvals_resolution_ref;
+        CREATE UNIQUE INDEX idx_operator_approvals_resolution_ref
+          ON operator_approvals(approval_id);
+      `);
+      expect(drifted.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+    } finally {
+      drifted.close();
+    }
+
+    const reopened = openOpenClawStateDatabase({ env });
+    expect(
+      reopened.db
+        .prepare(
+          "SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = 'idx_operator_approvals_resolution_ref'",
+        )
+        .get(),
+    ).toEqual({
+      sql: "CREATE UNIQUE INDEX idx_operator_approvals_resolution_ref ON operator_approvals(resolution_ref)",
+    });
+  });
+
   it("migrates the released audit ledger to message-compatible attribution exactly once", () => {
     const stateDir = createTempStateDir();
     const databasePath = createLegacyAuditStateDatabase(stateDir);

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -11,6 +11,10 @@ import {
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { applyPrivateModeSync } from "../infra/private-mode.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
+import {
+  repairCanonicalSqliteUniqueIndexes,
+  type CanonicalSqliteUniqueIndex,
+} from "../infra/sqlite-index-schema.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
 import {
@@ -42,6 +46,19 @@ export const OPENCLAW_STATE_SCHEMA_VERSION = 2;
 export const OPENCLAW_SQLITE_BUSY_TIMEOUT_MS = 5_000;
 const OPENCLAW_STATE_DIR_MODE = 0o700;
 const OPENCLAW_STATE_FILE_MODE = 0o600;
+const OPENCLAW_STATE_CANONICAL_UNIQUE_INDEXES = [
+  {
+    name: "idx_operator_approvals_resolution_ref",
+    definition: "ON operator_approvals(resolution_ref)",
+  },
+  {
+    name: "idx_worker_environments_provider_lease",
+    definition: `
+      ON worker_environments(provider_id, lease_id)
+      WHERE lease_id IS NOT NULL
+    `,
+  },
+] as const satisfies readonly CanonicalSqliteUniqueIndex[];
 
 /** Open shared SQLite database handle plus WAL maintenance lifecycle. */
 export type OpenClawStateDatabase = {
@@ -1459,6 +1476,7 @@ function ensureSchema(db: DatabaseSync, pathname: string): void {
       ensureAdditiveStateColumns(db);
       assertCanonicalStateSchemaShape(db, pathname);
       db.exec(OPENCLAW_STATE_SCHEMA_SQL);
+      repairCanonicalSqliteUniqueIndexes(db, pathname, OPENCLAW_STATE_CANONICAL_UNIQUE_INDEXES);
       // Retired node_pairing_* tables were created by earlier schema revisions but
       // never had a shipped writer (the node surface lives on device_pairing_paired
       // records), so dropping the always-empty tables is safe, not destructive.

--- a/src/state/sqlite-schema-shape.test-support.ts
+++ b/src/state/sqlite-schema-shape.test-support.ts
@@ -5,8 +5,8 @@ import { DatabaseSync } from "node:sqlite";
 /**
  * Test helpers for comparing SQLite schema shape.
  *
- * The collected shape intentionally ignores SQLite autoindex suffixes so
- * generated schema tests assert contract-relevant table, column, and index data.
+ * The collected shape intentionally ignores SQLite autoindex suffixes while
+ * preserving named index terms, ordering, collation, expressions, and predicates.
  */
 type ColumnShape = {
   name: string;
@@ -21,6 +21,15 @@ type IndexShape = {
   unique: number;
   origin: string;
   partial: number;
+  sql: string | null;
+  terms: IndexTermShape[];
+};
+
+type IndexTermShape = {
+  kind: "column" | "expression" | "rowid";
+  name: string | null;
+  coll: string;
+  desc: number;
 };
 
 /** Comparable SQLite schema summary used by generated-schema tests. */
@@ -36,12 +45,28 @@ type TableInfoRow = ColumnShape & {
   cid: number;
 };
 
-type IndexListRow = IndexShape & {
+type IndexListRow = {
   seq: number;
+  name: string;
+  unique: number;
+  origin: string;
+  partial: number;
 };
 
 type SqliteMasterRow = {
   name: string;
+};
+
+type IndexSqlRow = {
+  sql?: unknown;
+};
+
+type IndexXInfoRow = {
+  cid: number;
+  name: string | null;
+  coll: string;
+  desc: number;
+  key: number;
 };
 
 /** Execute schema SQL in memory and return its comparable shape. */
@@ -98,13 +123,38 @@ function collectIndexes(db: DatabaseSync, tableName: string): IndexShape[] {
   return (
     db.prepare(`PRAGMA index_list(${quoteSqliteIdentifier(tableName)})`).all() as IndexListRow[]
   )
-    .map(({ name, unique, origin, partial }) => ({
-      name: normalizeAutoIndexName(name),
-      unique,
-      origin,
-      partial,
-    }))
-    .toSorted((left, right) => left.name.localeCompare(right.name));
+    .map(({ name, unique, origin, partial }) => {
+      const row = db
+        .prepare("SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = ?")
+        .get(name) as IndexSqlRow | undefined;
+      return {
+        name: normalizeAutoIndexName(name),
+        unique,
+        origin,
+        partial,
+        sql: typeof row?.sql === "string" ? row.sql : null,
+        terms: collectIndexTerms(db, name),
+      };
+    })
+    .toSorted((left, right) => {
+      const nameOrder = left.name.localeCompare(right.name);
+      return nameOrder !== 0
+        ? nameOrder
+        : JSON.stringify(left).localeCompare(JSON.stringify(right));
+    });
+}
+
+function collectIndexTerms(db: DatabaseSync, indexName: string): IndexTermShape[] {
+  return (
+    db.prepare(`PRAGMA index_xinfo(${quoteSqliteIdentifier(indexName)})`).all() as IndexXInfoRow[]
+  )
+    .filter((term) => term.key === 1)
+    .map(({ cid, name, coll, desc }) => ({
+      kind: cid === -2 ? "expression" : cid === -1 ? "rowid" : "column",
+      name,
+      coll,
+      desc,
+    }));
 }
 
 function normalizeAutoIndexName(name: string): string {


### PR DESCRIPTION
Related: #101290

## What Problem This Solves

Fixes an issue where a same-name SQLite unique index with the wrong columns, expression, collation, order, or partial predicate could survive database initialization. SQLite's integrity checks still report that database as healthy, while `CREATE UNIQUE INDEX IF NOT EXISTS` leaves the weaker definition in place and can allow duplicate durable state.

## Why This Change Was Made

Shared and per-agent schema initialization now validates every OpenClaw-owned named unique-index definition. Drift is repaired inside the existing schema transaction by first building a temporary canonical unique index, then replacing the wrong same-name index only after SQLite proves all existing rows satisfy the intended constraint.

If duplicate rows prevent the canonical constraint, the savepoint restores the prior schema and startup fails without rewriting or deleting user data. Repair DDL is explicitly scoped to the main schema so temporary objects cannot intercept an index name.

Schema-shape tests now compare index terms, ordering, collations, expressions, and partial predicates instead of only index names and flags.

The shared schema helper is explicitly registered in the repository's raw SQLite lifecycle/schema allowlist because this low-level DDL cannot use Kysely.

## User Impact

Valid databases open as before. Databases with repairable same-name index drift recover automatically before accepting writes. Databases whose rows already violate the intended uniqueness contract fail closed with the conflicting index named and retain their original rows and schema for operator recovery.

AI-assisted: yes. The implementation and tests were reviewed with the repository autoreview workflow.

## Evidence

- Blacksmith Testbox through Crabbox `tbx_01kxavks7p2x7j04q9zvfx7cz5`, Actions run https://github.com/openclaw/openclaw/actions/runs/29188072434: 84 focused tests passed across the shared helper, shared-state schema, per-agent schema, duplicate-data rollback, temporary-schema isolation, and concurrent initialization.
- The same Testbox passed targeted oxlint on all seven changed TypeScript files with zero warnings or errors.
- `node scripts/check-kysely-guardrails.mjs` passed after registering the low-level schema helper.
- `git diff --check` passed on the exact PR head.
- Structured autoreview: clean, 0.91 confidence, no accepted or actionable findings.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29188444296.
