### PR TITLE
fix(sandbox): handle missing stat paths across locales

### DIFF
--- a/src/agents/sandbox/fs-bridge-shell-command-plans.ts
+++ b/src/agents/sandbox/fs-bridge-shell-command-plans.ts
@@ -22,7 +22,7 @@ export function buildStatPlan(
 ): SandboxFsCommandPlan {
   return {
     checks: [{ target, options: { action: "stat files" } }],
-    script: 'set -eu\ncd -- "$1"\nstat -c "%F|%s|%y" -- "$2"',
+    script: 'set -eu\ncd -- "$1"\nLC_ALL=C stat -c "%F|%s|%y" -- "$2"',
     args: [anchoredTarget.canonicalParentPath, anchoredTarget.basename],
     allowFailure: true,
   };

--- a/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
+++ b/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
@@ -223,6 +223,74 @@ describe("sandbox fs bridge anchored ops", () => {
     });
   });
 
+  it("runs stat under the C locale so missing-file errors return null", async () => {
+    await withTempDir("openclaw-fs-bridge-stat-missing-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      mockedExecDockerRaw.mockImplementation(async (args) => {
+        const script = getDockerScript(args);
+        if (script.includes('readlink -f -- "$cursor"')) {
+          return dockerExecResult(`${getDockerArg(args, 1)}\n`);
+        }
+        if (script.includes('stat -c "%F|%s|%y"')) {
+          return {
+            stdout: Buffer.alloc(0),
+            stderr: Buffer.from("stat: cannot stat 'note.txt': No such file or directory\n"),
+            code: 1,
+          };
+        }
+        return dockerExecResult("");
+      });
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.stat({ filePath: "note.txt" })).resolves.toBeNull();
+
+      const statCall = requireDockerCall(
+        findCallByScriptFragment('stat -c "%F|%s|%y" -- "$2"'),
+        "stat",
+      );
+      expect(getDockerScript(statCall[0])).toContain('LC_ALL=C stat -c "%F|%s|%y" -- "$2"');
+    });
+  });
+
+  it("keeps non-missing stat failures as errors", async () => {
+    await withTempDir("openclaw-fs-bridge-stat-error-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      mockedExecDockerRaw.mockImplementation(async (args) => {
+        const script = getDockerScript(args);
+        if (script.includes('readlink -f -- "$cursor"')) {
+          return dockerExecResult(`${getDockerArg(args, 1)}\n`);
+        }
+        if (script.includes('stat -c "%F|%s|%y"')) {
+          return {
+            stdout: Buffer.alloc(0),
+            stderr: Buffer.from("stat: cannot stat 'note.txt': Permission denied\n"),
+            code: 1,
+          };
+        }
+        return dockerExecResult("");
+      });
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.stat({ filePath: "note.txt" })).rejects.toThrow("Permission denied");
+    });
+  });
+
   it("saturates unsafe stat size output", async () => {
     await withTempDir("openclaw-fs-bridge-stat-parse-", async (stateDir) => {
       const workspaceDir = path.join(stateDir, "workspace");

--- a/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
+++ b/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
@@ -234,9 +234,12 @@ describe("sandbox fs bridge anchored ops", () => {
           return dockerExecResult(`${getDockerArg(args, 1)}\n`);
         }
         if (script.includes('stat -c "%F|%s|%y"')) {
+          const stderr = script.includes('LC_ALL=C stat -c "%F|%s|%y"')
+            ? "stat: cannot stat 'note.txt': No such file or directory\n"
+            : "stat: der Aufruf von statx für 'note.txt' ist nicht möglich: Datei oder Verzeichnis nicht gefunden\n";
           return {
             stdout: Buffer.alloc(0),
-            stderr: Buffer.from("stat: cannot stat 'note.txt': No such file or directory\n"),
+            stderr: Buffer.from(stderr),
             code: 1,
           };
         }

--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -188,7 +188,7 @@ describe("remote sandbox fs bridge", () => {
     },
   );
 
-  it("saturates unsafe stat size output without returning NaN", async () => {
+  it("normalizes stat output locale and saturates unsafe sizes", async () => {
     // Remote stat output is untrusted shell text; unsafe numeric fields should
     // clamp to deterministic values instead of leaking NaN into callers.
     await withTempDir("openclaw-remote-fs-bridge-stat-", async (stateDir) => {
@@ -216,8 +216,11 @@ describe("remote sandbox fs bridge", () => {
             };
           }
           if (command.script.includes('stat -c "%F|%s|%y"')) {
+            const kind = command.script.includes('LC_ALL=C stat -c "%F|%s|%y"')
+              ? "regular file"
+              : "reguläre Datei";
             return {
-              stdout: Buffer.from("regular file|9007199254740992|8640000000001\n"),
+              stdout: Buffer.from(`${kind}|9007199254740992|8640000000001\n`),
               stderr: Buffer.alloc(0),
               code: 0,
             };

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -255,7 +255,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       signal: params.signal,
     });
     const result = await this.runRemoteScript({
-      script: 'set -eu\nstat -c "%F|%s|%y" -- "$1"',
+      script: 'set -eu\nLC_ALL=C stat -c "%F|%s|%y" -- "$1"',
       args: [canonical],
       signal: params.signal,
     });


### PR DESCRIPTION
Fixes #105187

## What Problem This Solves

Fixes an issue where users running sandbox containers with a non-English locale could receive a stat error for a missing file instead of OpenClaw treating the file as absent. The same locale sensitivity could make the SSH-backed sandbox bridge misclassify successful file and directory metadata.

## Why This Change Was Made

Sandbox stat commands now run with `LC_ALL=C`, making GNU coreutils diagnostics and `%F` file-type output deterministic before either bridge parses them. Other stat failures continue to surface as errors, and the change preserves existing command, path-safety, and hardlink boundaries.

## User Impact

Sandbox-backed file checks now return the expected missing-file result and file type regardless of container or remote-host locale. Permission and other filesystem failures remain visible to users and operators.

## Evidence

- Real Docker A/B with `golang:1.26.5-bookworm` and generated `de_DE.UTF-8`: the current-main command produced `Datei oder Verzeichnis nicht gefunden` and the existing parser classified it as an error; the fixed `LC_ALL=C stat` command produced `No such file or directory` and the parser classified it as missing.
- Locale-aware regressions now return German diagnostics or `%F` text unless the command pins `LC_ALL=C`, so they fail against current main and pass against this head.
- `pnpm test src/agents/sandbox/fs-bridge.anchored-ops.test.ts src/agents/sandbox/fs-bridge.shell.test.ts src/agents/sandbox/remote-fs-bridge.test.ts` on Testbox: 3 files, 27 tests passed.
- `pnpm check:changed -- src/agents/sandbox/fs-bridge-shell-command-plans.ts src/agents/sandbox/fs-bridge.anchored-ops.test.ts src/agents/sandbox/remote-fs-bridge.ts src/agents/sandbox/remote-fs-bridge.test.ts` on Testbox: all selected core/coreTests gates passed.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29480931490
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean, no accepted/actionable findings.
- GNU coreutils stat contract: https://www.gnu.org/software/coreutils/manual/html_node/stat-invocation.html

AI-assisted: yes.
