### PR TITLE
improve(ui): fold the New session target controls into click menus

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -314,6 +314,27 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         .poll(() => folderSelect.locator(".new-session-page__trigger-label").textContent())
         .toBe("Projects");
 
+      // Clearing the path applies the node's default directory (empty folder),
+      // the state the replaced clearable folder textbox could express.
+      await folderSelect.locator("summary").click();
+      await roots.getByRole("button", { name: "MacBook" }).click();
+      await expect.poll(() => pathInput.inputValue()).toBe(NODE_PICKED);
+      await pathInput.fill("");
+      await page.getByRole("button", { name: "Use this folder" }).click();
+      await expect
+        .poll(() => folderSelect.locator(".new-session-page__trigger-label").textContent())
+        .toBe("Agent workspace");
+      await expect.poll(() => whereLabel.textContent()).toBe("MacBook");
+
+      // Browse back to the custom folder for the final create assertion.
+      await folderSelect.locator("summary").click();
+      await roots.getByRole("button", { name: "MacBook" }).click();
+      await roots.getByRole("button", { name: "Projects" }).click();
+      await page.getByRole("button", { name: "Use this folder" }).click();
+      await expect
+        .poll(() => folderSelect.locator(".new-session-page__trigger-label").textContent())
+        .toBe("Projects");
+
       await page.locator(".new-session-page__message").fill("inspect the remote checkout");
       await page.getByRole("button", { name: "Start session" }).click();
       const createRequest = await gateway.waitForRequest("sessions.create");

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -105,41 +105,54 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.getByRole("heading", { name: "Main" }).waitFor();
       await page.locator(".new-session-page__message").waitFor();
 
-      // Unified layout: the draft block (target row above the composer) sits
+      // Unified layout: the trigger row (menus above the composer) sits
       // inside the start-screen welcome, below the hero.
       const heroBox = await page.locator(".agent-chat__welcome h2").boundingBox();
-      const targetsBox = await page.locator(".new-session-page__targets").boundingBox();
+      const triggersBox = await page.locator(".new-session-page__triggers").boundingBox();
       const composerBox = await page.locator(".new-session-page__composer").boundingBox();
       expect(heroBox).not.toBeNull();
-      expect(targetsBox).not.toBeNull();
+      expect(triggersBox).not.toBeNull();
       expect(composerBox).not.toBeNull();
       expect((heroBox?.y ?? 0) + (heroBox?.height ?? 0)).toBeLessThanOrEqual(
-        (targetsBox?.y ?? 0) + 1,
+        (triggersBox?.y ?? 0) + 1,
       );
-      expect((targetsBox?.y ?? 0) + (targetsBox?.height ?? 0)).toBeLessThanOrEqual(
+      expect((triggersBox?.y ?? 0) + (triggersBox?.height ?? 0)).toBeLessThanOrEqual(
         (composerBox?.y ?? 0) + 1,
       );
 
-      const folderInput = page.getByRole("textbox", { name: "Folder", exact: true });
-      await expect.poll(() => folderInput.inputValue()).toBe(WORKSPACE);
+      // The folder trigger labels the workspace and opens the browser menu.
+      const folderSelect = page.locator(".new-session-page__select--folder");
+      await expect
+        .poll(() => folderSelect.locator(".new-session-page__trigger-label").textContent())
+        .toBe("openclaw");
 
       // Browse from the workspace, descend one level, then adopt the folder.
-      await page.getByRole("button", { name: "Browse folders" }).click();
+      await folderSelect.locator("summary").click();
       await page
         .locator(".new-session-page__browser-list")
         .getByRole("button", { name: "Gateway" })
         .click();
       await page.locator(".new-session-page__browser-entry", { hasText: "packages" }).click();
       await expect
-        .poll(() => page.locator(".new-session-page__browser-path").textContent())
-        .toBe(`Gateway · local · ${PICKED}`);
+        .poll(() => page.locator("input.new-session-page__browser-path").inputValue())
+        .toBe(PICKED);
       await page.getByRole("button", { name: "Use this folder" }).click();
 
-      await expect.poll(() => folderInput.inputValue()).toBe(PICKED);
-      // Custom host folders force a managed worktree.
-      const worktreeToggle = page.locator(".new-session-page__target--toggle input");
-      await expect.poll(() => worktreeToggle.isChecked()).toBe(true);
-      expect(await worktreeToggle.isDisabled()).toBe(true);
+      // The adopted folder closes the menu and updates the trigger label.
+      await expect.poll(() => folderSelect.getAttribute("open")).toBeNull();
+      await expect
+        .poll(() => folderSelect.locator(".new-session-page__trigger-label").textContent())
+        .toBe("packages");
+
+      // Custom host folders force a managed worktree (badge on the where
+      // trigger; the menu item is checked and locked).
+      const whereTrigger = page.locator('.new-session-page__trigger[data-worktree="true"]');
+      await whereTrigger.waitFor();
+      await whereTrigger.click();
+      const worktreeItem = page.getByRole("menuitemradio", { name: "Worktree" });
+      await expect.poll(() => worktreeItem.getAttribute("aria-checked")).toBe("true");
+      expect(await worktreeItem.isDisabled()).toBe(true);
+      await page.keyboard.press("Escape");
 
       await page.locator(".new-session-page__message").fill("fix the flaky test");
       await page.getByRole("button", { name: "Start session" }).click();
@@ -244,32 +257,40 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     try {
       await page.goto(`${server.baseUrl}new`);
       await page.locator(".new-session-page__message").waitFor();
-      const where = page.getByRole("combobox", { name: "Where" });
-      const folder = page.getByRole("textbox", { name: "Folder", exact: true });
-      await where.selectOption("macbook");
-      await expect.poll(() => folder.inputValue()).toBe("");
+      const folderSelect = page.locator(".new-session-page__select--folder");
+      const whereSelect = page.locator(
+        ".new-session-page__select:not(.new-session-page__select--folder)",
+      );
+      const whereTrigger = whereSelect.locator("summary");
+      const whereLabel = whereSelect.locator(".new-session-page__trigger-label");
 
-      // Reopening a Windows node browser preserves UNC paths; these cannot be
-      // rediscovered by starting at the node home directory.
-      await folder.fill(NODE_UNC);
-      await folder.press("Tab");
-      await page.getByRole("button", { name: "Browse folders" }).click();
-      await page
-        .locator(".new-session-page__browser-list")
-        .getByRole("button", { name: "MacBook" })
-        .click();
-      await expect
-        .poll(() => page.locator(".new-session-page__browser-path").textContent())
-        .toBe(`MacBook · ${NODE_UNC}`);
-      await page.getByRole("button", { name: "Browse folders" }).click();
-      await folder.fill("");
-      await folder.press("Tab");
+      // Pick the node from the where menu.
+      await whereTrigger.click();
+      await page.getByRole("menuitemradio", { name: "MacBook" }).click();
+      await expect.poll(() => whereLabel.textContent()).toBe("MacBook");
+      // Node sessions cannot use managed worktrees, so the menu drops the item.
+      await whereTrigger.click();
+      expect(await page.getByRole("menuitemradio", { name: "Worktree" }).count()).toBe(0);
+      await page.keyboard.press("Escape");
 
-      await where.selectOption("");
-      await expect.poll(() => folder.inputValue()).toBe(WORKSPACE);
-      await page.getByRole("button", { name: "Browse folders" }).click();
-
+      // Manual path entry in the browser head preserves UNC paths; these
+      // cannot be rediscovered by starting at the node home directory.
+      await folderSelect.locator("summary").click();
       const roots = page.locator(".new-session-page__browser-list");
+      await roots.getByRole("button", { name: "MacBook" }).click();
+      const pathInput = page.locator("input.new-session-page__browser-path");
+      await expect.poll(() => pathInput.inputValue()).toBe(NODE_HOME);
+      await pathInput.fill(NODE_UNC);
+      await pathInput.press("Enter");
+      await expect.poll(() => pathInput.inputValue()).toBe(NODE_UNC);
+      // Close without applying; the draft keeps the node home default.
+      await page.keyboard.press("Escape");
+
+      // Back on the Gateway, the browser super-root lists every node.
+      await whereTrigger.click();
+      await page.getByRole("menuitemradio", { name: "Gateway · local" }).click();
+      await expect.poll(() => whereLabel.textContent()).toBe("Gateway · local");
+      await folderSelect.locator("summary").click();
       await expect
         .poll(() =>
           roots
@@ -287,11 +308,11 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await roots.getByRole("button", { name: "Projects" }).click();
       await page.getByRole("button", { name: "Use this folder" }).click();
 
-      await expect.poll(() => where.inputValue()).toBe("macbook");
-      await expect.poll(() => folder.inputValue()).toBe(NODE_PICKED);
-      const worktreeToggle = page.locator(".new-session-page__target--toggle input");
-      expect(await worktreeToggle.isChecked()).toBe(false);
-      expect(await worktreeToggle.isDisabled()).toBe(true);
+      // Using a node folder retargets the draft to that node.
+      await expect.poll(() => whereLabel.textContent()).toBe("MacBook");
+      await expect
+        .poll(() => folderSelect.locator(".new-session-page__trigger-label").textContent())
+        .toBe("Projects");
 
       await page.locator(".new-session-page__message").fill("inspect the remote checkout");
       await page.getByRole("button", { name: "Start session" }).click();

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -39,6 +39,11 @@ type BrowserTarget = { nodeId: string; label: string };
 
 const WORKTREE_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
+/** Last path segment for the folder trigger label; handles both separators. */
+function folderDisplayName(path: string): string {
+  return path.split(/[\\/]/).findLast((segment) => segment.length > 0) ?? "";
+}
+
 class NewSessionPage extends OpenClawLightDomElement {
   @property({ attribute: false }) data: NewSessionRouteData | undefined;
 
@@ -80,10 +85,46 @@ class NewSessionPage extends OpenClawLightDomElement {
       (sessions, notify) => sessions.subscribe(notify),
     );
 
+  override connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener("pointerdown", this.handleDocumentPointerDown, true);
+    document.addEventListener("keydown", this.handleDocumentKeydown, true);
+  }
+
   override disconnectedCallback() {
+    document.removeEventListener("pointerdown", this.handleDocumentPointerDown, true);
+    document.removeEventListener("keydown", this.handleDocumentKeydown, true);
     this.subscriptions.clear();
     super.disconnectedCallback();
   }
+
+  private openMenus(): HTMLDetailsElement[] {
+    return [...this.querySelectorAll<HTMLDetailsElement>(".new-session-page__select[open]")];
+  }
+
+  // Same central dismissal contract as the chat composer's <details> menus:
+  // pointerdown outside an open menu closes it, Escape closes and restores
+  // trigger focus.
+  private readonly handleDocumentPointerDown = (event: PointerEvent) => {
+    const path = event.composedPath();
+    for (const details of this.openMenus()) {
+      if (!path.includes(details)) {
+        details.open = false;
+      }
+    }
+  };
+
+  private readonly handleDocumentKeydown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape") {
+      return;
+    }
+    const open = this.openMenus().at(-1);
+    if (open) {
+      event.stopPropagation();
+      open.open = false;
+      open.querySelector<HTMLElement>("summary")?.focus();
+    }
+  };
 
   override updated() {
     const agentsReady = this.agents().length > 0;
@@ -354,20 +395,19 @@ class NewSessionPage extends OpenClawLightDomElement {
 
   private closeBrowser() {
     this.browserRequestToken += 1;
+    // Reset state before collapsing the <details> so its toggle handler sees
+    // browserOpen === false and does not re-enter this method.
     this.browserOpen = false;
     this.browserLoading = false;
     this.browserError = null;
     this.browserListing = null;
     this.browserTarget = null;
-  }
-
-  private toggleBrowser() {
-    if (this.browserOpen) {
-      this.closeBrowser();
-      return;
+    const details = this.querySelector<HTMLDetailsElement>(
+      ".new-session-page__select--folder[open]",
+    );
+    if (details) {
+      details.open = false;
     }
-    this.browserOpen = true;
-    this.showBrowserRoot();
   }
 
   private showBrowserRoot() {
@@ -456,13 +496,28 @@ class NewSessionPage extends OpenClawLightDomElement {
           >
             ${icons.arrowLeft}
           </button>
-          <span class="new-session-page__browser-path"
-            >${target
-              ? `${target.label}${listing?.path ? ` · ${listing.path}` : ""}`
-              : t("newSession.where")}${this.browserLoading
-              ? ` · ${t("common.loading")}`
-              : ""}</span
-          >
+          ${target
+            ? html`
+                <input
+                  class="new-session-page__browser-path"
+                  type="text"
+                  aria-label=${t("newSession.folder")}
+                  placeholder=${target.label}
+                  .value=${listing?.path ?? ""}
+                  @keydown=${(event: KeyboardEvent) => {
+                    // Manual path entry browses there; "Use this folder" applies it.
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      const path = (event.target as HTMLInputElement).value.trim();
+                      this.loadBrowser(path || undefined);
+                    }
+                  }}
+                />
+              `
+            : html`<span class="new-session-page__browser-path">${t("newSession.where")}</span>`}
+          ${this.browserLoading
+            ? html`<span class="new-session-page__browser-loading">${t("common.loading")}</span>`
+            : nothing}
           <button
             type="button"
             class="new-session-page__browser-nav"
@@ -554,157 +609,230 @@ class NewSessionPage extends OpenClawLightDomElement {
     `;
   }
 
-  private renderTargetBar() {
-    const agents = this.agents();
+  /** Closes the menu containing the clicked item and hands focus back. */
+  private closeMenuFrom(event: Event) {
+    const details = (event.currentTarget as HTMLElement).closest("details");
+    if (details?.open) {
+      details.open = false;
+      details.querySelector<HTMLElement>("summary")?.focus();
+    }
+  }
+
+  private renderMenuItem(params: {
+    label: string;
+    checked: boolean;
+    disabled?: boolean;
+    title?: string;
+    onSelect: (event: Event) => void;
+  }) {
+    return html`
+      <button
+        type="button"
+        class="session-menu__item"
+        role="menuitemradio"
+        aria-checked=${String(params.checked)}
+        title=${params.title ?? nothing}
+        ?disabled=${params.disabled ?? false}
+        @click=${params.onSelect}
+      >
+        <span class="session-menu__check" aria-hidden="true"
+          >${params.checked ? icons.check : nothing}</span
+        >
+        <span class="session-menu__text">${params.label}</span>
+      </button>
+    `;
+  }
+
+  private renderAgentSelect(agents: ReturnType<NewSessionPage["agents"]>) {
+    const selected = this.selectedAgent();
+    const label = selected?.identity?.name ?? selected?.name ?? selected?.id ?? this.agentId;
+    return html`
+      <details class="new-session-page__select">
+        <summary class="new-session-page__trigger" title=${t("newSession.agent")}>
+          <span class="new-session-page__target-icon" aria-hidden="true">${icons.bot}</span>
+          <span class="new-session-page__trigger-label">${label}</span>
+          <span class="new-session-page__trigger-chevron" aria-hidden="true"
+            >${icons.chevronDown}</span
+          >
+        </summary>
+        <div class="new-session-page__menu" role="menu" aria-label=${t("newSession.agent")}>
+          ${agents.map((option) =>
+            this.renderMenuItem({
+              label: option.identity?.name ?? option.name ?? option.id,
+              checked: normalizeAgentId(option.id) === this.agentId,
+              onSelect: (event) => {
+                this.selectAgentId(option.id);
+                this.closeMenuFrom(event);
+              },
+            }),
+          )}
+        </div>
+      </details>
+    `;
+  }
+
+  /** Where + worktree consolidated into one "run on" menu (Cursor-style). */
+  private renderWhereSelect() {
     const execNodes = this.execNodes();
-    const isAdmin = this.isAdmin();
+    const showNodes = this.isAdmin() && execNodes.length > 0;
+    const activeNode = execNodes.find((node) => node.nodeId === this.execNode);
+    const whereLabel = this.execNode
+      ? (activeNode?.displayName ?? this.execNode)
+      : t("newSession.gateway");
     const customFolder = this.usesCustomFolder();
     const worktreeAvailable = this.worktreeAvailable();
     const branches = this.branches;
     return html`
-      <div class="new-session-page__targets">
-        ${agents.length > 1
-          ? html`
-              <label class="new-session-page__target" title=${t("newSession.agent")}>
-                <span class="new-session-page__target-icon" aria-hidden="true">${icons.bot}</span>
-                <select
-                  aria-label=${t("newSession.agent")}
-                  .value=${this.agentId}
-                  @change=${(event: Event) =>
-                    this.selectAgentId((event.target as HTMLSelectElement).value)}
-                >
-                  ${agents.map(
-                    (option) => html`
-                      <option
-                        value=${option.id}
-                        ?selected=${normalizeAgentId(option.id) === this.agentId}
-                      >
-                        ${option.identity?.name ?? option.name ?? option.id}
-                      </option>
-                    `,
-                  )}
-                </select>
-              </label>
-            `
-          : nothing}
-        ${isAdmin && execNodes.length > 0
-          ? html`
-              <label class="new-session-page__target" title=${t("newSession.where")}>
-                <span class="new-session-page__target-icon" aria-hidden="true"
-                  >${icons.monitor}</span
-                >
-                <select
-                  aria-label=${t("newSession.where")}
-                  .value=${this.execNode}
-                  @change=${(event: Event) => {
-                    this.selectExecNode((event.target as HTMLSelectElement).value);
-                  }}
-                >
-                  <option value="" ?selected=${!this.execNode}>${t("newSession.gateway")}</option>
-                  ${execNodes.map(
-                    (node) => html`
-                      <option value=${node.nodeId} ?selected=${this.execNode === node.nodeId}>
-                        ${node.displayName}
-                      </option>
-                    `,
-                  )}
-                </select>
-              </label>
-            `
-          : nothing}
-        <label
-          class="new-session-page__target new-session-page__target--folder"
-          title=${t("newSession.folder")}
+      <details class="new-session-page__select">
+        <summary
+          class="new-session-page__trigger"
+          title=${t("newSession.where")}
+          data-worktree=${String(this.worktree)}
         >
-          <span class="new-session-page__target-icon" aria-hidden="true">${icons.folder}</span>
-          <input
-            type="text"
-            aria-label=${t("newSession.folder")}
-            placeholder=${this.execNode
-              ? t("newSession.folderPlaceholder")
-              : this.workspacePath() || t("newSession.folderPlaceholder")}
-            .value=${this.folder}
-            ?disabled=${!isAdmin}
-            @input=${(event: Event) => {
-              // Track keystrokes so a re-render (e.g. agent hydration) cannot
-              // overwrite an in-progress edit; side effects wait for change.
-              this.folder = (event.target as HTMLInputElement).value;
-            }}
-            @change=${(event: Event) => this.applyFolder((event.target as HTMLInputElement).value)}
-          />
-          ${this.browseAvailable()
+          <span class="new-session-page__target-icon" aria-hidden="true">${icons.monitor}</span>
+          <span class="new-session-page__trigger-label">${whereLabel}</span>
+          ${this.worktree
+            ? html`<span class="new-session-page__target-icon" aria-hidden="true"
+                >${icons.gitBranch}</span
+              >`
+            : nothing}
+          <span class="new-session-page__trigger-chevron" aria-hidden="true"
+            >${icons.chevronDown}</span
+          >
+        </summary>
+        <div class="new-session-page__menu" role="menu" aria-label=${t("newSession.where")}>
+          ${showNodes
             ? html`
-                <button
-                  type="button"
-                  class="new-session-page__browse"
-                  title=${t("newSession.browse")}
-                  aria-label=${t("newSession.browse")}
-                  aria-expanded=${String(this.browserOpen)}
-                  @click=${() => this.toggleBrowser()}
-                >
-                  ${icons.folderOpen}
-                </button>
+                <div class="new-session-page__menu-title">${t("newSession.where")}</div>
+                ${this.renderMenuItem({
+                  label: t("newSession.gateway"),
+                  checked: !this.execNode,
+                  onSelect: (event) => {
+                    this.selectExecNode("");
+                    this.closeMenuFrom(event);
+                  },
+                })}
+                ${execNodes.map((node) =>
+                  this.renderMenuItem({
+                    label: node.displayName,
+                    checked: this.execNode === node.nodeId,
+                    onSelect: (event) => {
+                      this.selectExecNode(node.nodeId);
+                      this.closeMenuFrom(event);
+                    },
+                  }),
+                )}
               `
             : nothing}
-        </label>
-        <div class="new-session-page__target-group">
-          <label
-            class="new-session-page__target new-session-page__target--toggle"
-            title=${worktreeAvailable
-              ? t("chat.runControls.newSessionWorktree")
-              : t("newSession.worktreeUnavailable")}
-          >
-            <input
-              type="checkbox"
-              .checked=${this.worktree}
-              ?disabled=${!worktreeAvailable || customFolder}
-              @change=${(event: Event) => {
-                this.worktree = (event.target as HTMLInputElement).checked;
-                if (this.worktree) {
-                  this.maybeLoadBranches();
-                }
-              }}
-            />
-            <span class="new-session-page__target-icon" aria-hidden="true">${icons.gitBranch}</span>
-            <span>${t("newSession.worktree")}</span>
-          </label>
-          ${this.worktree
+          ${!this.execNode
             ? html`
-                <label class="new-session-page__target" title=${t("newSession.baseBranch")}>
-                  <input
-                    type="text"
-                    list="new-session-branches"
-                    class="new-session-page__branch"
-                    aria-label=${t("newSession.baseBranch")}
-                    placeholder=${this.branchesLoading
-                      ? t("common.loading")
-                      : (branches?.defaultBranch ?? t("newSession.baseBranch"))}
-                    .value=${this.baseRef}
-                    @input=${(event: Event) => {
-                      this.baseRef = (event.target as HTMLInputElement).value.trim();
-                    }}
-                  />
-                  <datalist id="new-session-branches">
-                    ${(branches?.branches ?? []).map(
-                      (branch) => html`<option value=${branch.name}></option>`,
-                    )}
-                  </datalist>
-                </label>
-                <label class="new-session-page__target" title=${t("newSession.worktreeName")}>
-                  <input
-                    type="text"
-                    class="new-session-page__branch"
-                    aria-label=${t("newSession.worktreeName")}
-                    placeholder=${t("newSession.worktreeNamePlaceholder")}
-                    .value=${this.worktreeName}
-                    @input=${(event: Event) => {
-                      this.worktreeName = (event.target as HTMLInputElement).value.trim();
-                    }}
-                  />
-                </label>
+                ${showNodes
+                  ? html`<div class="session-menu__separator" role="separator"></div>`
+                  : nothing}
+                ${this.renderMenuItem({
+                  label: t("newSession.worktree"),
+                  checked: this.worktree,
+                  disabled: !worktreeAvailable || customFolder,
+                  title: worktreeAvailable
+                    ? t("chat.runControls.newSessionWorktree")
+                    : t("newSession.worktreeUnavailable"),
+                  onSelect: () => {
+                    // Stays open: enabling reveals the branch/name fields below.
+                    this.worktree = !this.worktree;
+                    if (this.worktree) {
+                      this.maybeLoadBranches();
+                    }
+                  },
+                })}
+                ${this.worktree
+                  ? html`
+                      <label class="new-session-page__menu-field">
+                        <span>${t("newSession.baseBranch")}</span>
+                        <input
+                          type="text"
+                          list="new-session-branches"
+                          placeholder=${this.branchesLoading
+                            ? t("common.loading")
+                            : (branches?.defaultBranch ?? t("newSession.baseBranch"))}
+                          .value=${this.baseRef}
+                          @input=${(event: Event) => {
+                            this.baseRef = (event.target as HTMLInputElement).value.trim();
+                          }}
+                        />
+                        <datalist id="new-session-branches">
+                          ${(branches?.branches ?? []).map(
+                            (branch) => html`<option value=${branch.name}></option>`,
+                          )}
+                        </datalist>
+                      </label>
+                      <label class="new-session-page__menu-field">
+                        <span>${t("newSession.worktreeName")}</span>
+                        <input
+                          type="text"
+                          placeholder=${t("newSession.worktreeNamePlaceholder")}
+                          .value=${this.worktreeName}
+                          @input=${(event: Event) => {
+                            this.worktreeName = (event.target as HTMLInputElement).value.trim();
+                          }}
+                        />
+                      </label>
+                    `
+                  : nothing}
               `
             : nothing}
         </div>
+      </details>
+    `;
+  }
+
+  private renderFolderSelect() {
+    const browseAvailable = this.browseAvailable();
+    const folderName = folderDisplayName(this.folder.trim() || this.workspacePath());
+    const label = folderName || t("newSession.folderPlaceholder");
+    return html`
+      <details
+        class="new-session-page__select new-session-page__select--folder"
+        @toggle=${(event: Event) => {
+          const details = event.currentTarget as HTMLDetailsElement;
+          if (details.open) {
+            this.browserOpen = true;
+            this.showBrowserRoot();
+          } else if (this.browserOpen) {
+            this.closeBrowser();
+          }
+        }}
+      >
+        <summary
+          class="new-session-page__trigger ${browseAvailable
+            ? ""
+            : "new-session-page__trigger--disabled"}"
+          title=${browseAvailable ? t("newSession.browse") : t("newSession.folder")}
+          aria-disabled=${String(!browseAvailable)}
+          @click=${(event: Event) => {
+            if (!browseAvailable) {
+              event.preventDefault();
+            }
+          }}
+        >
+          <span class="new-session-page__target-icon" aria-hidden="true">${icons.folder}</span>
+          <span class="new-session-page__trigger-label">${label}</span>
+          <span class="new-session-page__trigger-chevron" aria-hidden="true"
+            >${icons.chevronDown}</span
+          >
+        </summary>
+        <div class="new-session-page__menu new-session-page__menu--browser">
+          ${this.renderBrowser()}
+        </div>
+      </details>
+    `;
+  }
+
+  private renderTargetBar() {
+    const agents = this.agents();
+    return html`
+      <div class="new-session-page__triggers">
+        ${agents.length > 1 ? this.renderAgentSelect(agents) : nothing} ${this.renderFolderSelect()}
+        ${this.renderWhereSelect()}
       </div>
     `;
   }
@@ -717,7 +845,7 @@ class NewSessionPage extends OpenClawLightDomElement {
       !WORKTREE_NAME_PATTERN.test(this.worktreeName.trim());
     return html`
       <div class="new-session-page__draft">
-        ${this.renderTargetBar()} ${this.renderBrowser()}
+        ${this.renderTargetBar()}
         ${worktreeNameInvalid
           ? html`<div class="new-session-page__error">${t("newSession.worktreeNameInvalid")}</div>`
           : nothing}

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -492,13 +492,11 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.browserPathDraft = "";
   }
 
-  /** The listed directory, or a typed absolute path when listing is
-      unavailable (fs.listDir missing/failing must not block manual entry). */
+  /** "Use this folder" applies exactly what the head input shows. The draft
+      syncs to every listed directory, covers hosts that cannot list
+      (fs.listDir missing/failing), and an edited path always wins over a
+      stale listing. */
   private usableBrowserPath(): string | null {
-    const listed = this.browserListing?.path;
-    if (listed) {
-      return listed;
-    }
     const draft = this.browserPathDraft.trim();
     return isAbsolutePath(draft) ? draft : null;
   }

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -49,6 +49,10 @@ function folderDisplayName(path: string): string {
 const MENU_ITEM_SELECTOR =
   ".session-menu__item:not(:disabled), .new-session-page__browser-entry:not(:disabled)";
 
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith("/") || path.startsWith("\\") || /^[A-Za-z]:[\\/]/.test(path);
+}
+
 class NewSessionPage extends OpenClawLightDomElement {
   @property({ attribute: false }) data: NewSessionRouteData | undefined;
 
@@ -72,6 +76,9 @@ class NewSessionPage extends OpenClawLightDomElement {
   @state() private browserError: string | null = null;
   @state() private browserListing: FsListDirResult | null = null;
   @state() private browserTarget: BrowserTarget | null = null;
+  // The head input's live value; a typed absolute path stays applicable via
+  // "Use this folder" even when the host cannot list it (no fs.listDir).
+  @state() private browserPathDraft = "";
 
   private openedFor: string | null = null;
   private agentsHydrated = false;
@@ -467,6 +474,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.browserError = null;
     this.browserListing = null;
     this.browserTarget = null;
+    this.browserPathDraft = "";
     const details = this.querySelector<HTMLDetailsElement>(
       ".new-session-page__select--folder[open]",
     );
@@ -481,17 +489,26 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.browserError = null;
     this.browserListing = null;
     this.browserTarget = null;
+    this.browserPathDraft = "";
+  }
+
+  /** The listed directory, or a typed absolute path when listing is
+      unavailable (fs.listDir missing/failing must not block manual entry). */
+  private usableBrowserPath(): string | null {
+    const listed = this.browserListing?.path;
+    if (listed) {
+      return listed;
+    }
+    const draft = this.browserPathDraft.trim();
+    return isAbsolutePath(draft) ? draft : null;
   }
 
   private selectBrowserTarget(target: BrowserTarget) {
     const folder = this.folder.trim();
     const matchesCurrentTarget = target.nodeId === this.execNode;
-    const path =
-      matchesCurrentTarget &&
-      (folder.startsWith("/") || folder.startsWith("\\") || /^[A-Za-z]:[\\/]/.test(folder))
-        ? folder
-        : undefined;
+    const path = matchesCurrentTarget && isAbsolutePath(folder) ? folder : undefined;
     this.browserTarget = target;
+    this.browserPathDraft = path ?? "";
     this.loadBrowser(path);
   }
 
@@ -517,6 +534,9 @@ class NewSessionPage extends OpenClawLightDomElement {
           return;
         }
         this.browserListing = result ?? null;
+        if (result?.path) {
+          this.browserPathDraft = result.path;
+        }
       })
       .catch(() => {
         if (requestId !== this.browserRequestToken) {
@@ -542,6 +562,9 @@ class NewSessionPage extends OpenClawLightDomElement {
     }
     const listing = this.browserListing;
     const target = this.browserTarget;
+    // Hosts can answer fs.listDir with a shapeless payload; a missing entries
+    // array must read as an empty directory, not crash the render.
+    const entries = listing?.entries ?? [];
     return html`
       <div class="new-session-page__browser">
         <div class="new-session-page__browser-head">
@@ -568,12 +591,16 @@ class NewSessionPage extends OpenClawLightDomElement {
                   type="text"
                   aria-label=${t("newSession.folder")}
                   placeholder=${target.label}
-                  .value=${listing?.path ?? ""}
+                  .value=${this.browserPathDraft}
+                  @input=${(event: Event) => {
+                    this.browserPathDraft = (event.target as HTMLInputElement).value;
+                  }}
                   @keydown=${(event: KeyboardEvent) => {
-                    // Manual path entry browses there; "Use this folder" applies it.
+                    // Manual path entry browses there; "Use this folder" applies
+                    // the typed path even when the host cannot list it.
                     if (event.key === "Enter") {
                       event.preventDefault();
-                      const path = (event.target as HTMLInputElement).value.trim();
+                      const path = this.browserPathDraft.trim();
                       this.loadBrowser(path || undefined);
                     }
                   }}
@@ -631,13 +658,13 @@ class NewSessionPage extends OpenClawLightDomElement {
                 )}
               `
             : nothing}
-          ${listing && listing.entries.length === 0 && !this.browserLoading
+          ${listing && entries.length === 0 && !this.browserLoading
             ? html`<div class="new-session-page__browser-empty">
                 ${t("newSession.browserEmpty")}
               </div>`
             : nothing}
           ${target
-            ? (listing?.entries ?? []).map(
+            ? entries.map(
                 (entry) => html`
                   <button
                     type="button"
@@ -659,10 +686,11 @@ class NewSessionPage extends OpenClawLightDomElement {
           <button
             type="button"
             class="new-session-page__browser-use"
-            ?disabled=${!listing || !target}
+            ?disabled=${!target || !this.usableBrowserPath()}
             @click=${() => {
-              if (listing && target) {
-                this.applyFolder(listing.path, target.nodeId);
+              const path = this.usableBrowserPath();
+              if (target && path) {
+                this.applyFolder(path, target.nodeId);
                 this.closeBrowser();
               }
             }}
@@ -874,7 +902,9 @@ class NewSessionPage extends OpenClawLightDomElement {
       <details
         class="new-session-page__select new-session-page__select--folder"
         @toggle=${(event: Event) => {
-          this.handleMenuToggle(event);
+          // Browser state first: handleMenuToggle captures updateComplete for
+          // its focus hook, which must wait for the render these setters
+          // schedule (a bare details-attribute flip schedules none).
           const details = event.currentTarget as HTMLDetailsElement;
           if (details.open) {
             this.browserOpen = true;
@@ -882,6 +912,7 @@ class NewSessionPage extends OpenClawLightDomElement {
           } else if (this.browserOpen) {
             this.closeBrowser();
           }
+          this.handleMenuToggle(event);
         }}
       >
         <summary

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -495,9 +495,14 @@ class NewSessionPage extends OpenClawLightDomElement {
   /** "Use this folder" applies exactly what the head input shows. The draft
       syncs to every listed directory, covers hosts that cannot list
       (fs.listDir missing/failing), and an edited path always wins over a
-      stale listing. */
+      stale listing. A cleared input applies "" — the host's default
+      directory (workspace on the Gateway, home on a node) — matching the
+      clearable folder textbox this browser replaced. Null disables Use. */
   private usableBrowserPath(): string | null {
     const draft = this.browserPathDraft.trim();
+    if (draft.length === 0) {
+      return "";
+    }
     return isAbsolutePath(draft) ? draft : null;
   }
 
@@ -522,6 +527,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     // Clear the previous directory immediately: keeping it clickable while the
     // request is in flight would let "Use this folder" apply the stale path.
     this.browserListing = null;
+    const draftAtRequest = this.browserPathDraft;
     void client
       .request<FsListDirResult>("fs.listDir", {
         ...(path ? { path } : {}),
@@ -532,7 +538,9 @@ class NewSessionPage extends OpenClawLightDomElement {
           return;
         }
         this.browserListing = result ?? null;
-        if (result?.path) {
+        // Sync the head input to the listed directory unless the user typed
+        // while this request was in flight; their edit wins.
+        if (result?.path && this.browserPathDraft === draftAtRequest) {
           this.browserPathDraft = result.path;
         }
       })
@@ -684,10 +692,10 @@ class NewSessionPage extends OpenClawLightDomElement {
           <button
             type="button"
             class="new-session-page__browser-use"
-            ?disabled=${!target || !this.usableBrowserPath()}
+            ?disabled=${!target || this.usableBrowserPath() === null}
             @click=${() => {
               const path = this.usableBrowserPath();
-              if (target && path) {
+              if (target && path !== null) {
                 this.applyFolder(path, target.nodeId);
                 this.closeBrowser();
               }

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -39,9 +39,10 @@ type BrowserTarget = { nodeId: string; label: string };
 
 const WORKTREE_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
-/** Last path segment for the folder trigger label; handles both separators. */
+/** Last path segment for the folder trigger label; handles both separators.
+    Falls back to the raw path so filesystem roots ("/", "C:\") stay visible. */
 function folderDisplayName(path: string): string {
-  return path.split(/[\\/]/).findLast((segment) => segment.length > 0) ?? "";
+  return path.split(/[\\/]/).findLast((segment) => segment.length > 0) ?? path;
 }
 
 class NewSessionPage extends OpenClawLightDomElement {

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -45,6 +45,10 @@ function folderDisplayName(path: string): string {
   return path.split(/[\\/]/).findLast((segment) => segment.length > 0) ?? path;
 }
 
+/** Focusable rows for the menu keyboard contract (menu items + browser rows). */
+const MENU_ITEM_SELECTOR =
+  ".session-menu__item:not(:disabled), .new-session-page__browser-entry:not(:disabled)";
+
 class NewSessionPage extends OpenClawLightDomElement {
   @property({ attribute: false }) data: NewSessionRouteData | undefined;
 
@@ -140,6 +144,41 @@ class NewSessionPage extends OpenClawLightDomElement {
         other.open = false;
       }
     }
+    // Keyboard contract of the replaced native selects: opening moves focus
+    // into the menu (browser content renders on the next Lit update). The
+    // summary sits outside the menu div, so this only skips when the user
+    // already focused menu content (e.g. a field).
+    void this.updateComplete.then(() => {
+      if (!details.open) {
+        return;
+      }
+      const menu = details.querySelector(".new-session-page__menu");
+      if (menu && !menu.contains(document.activeElement)) {
+        menu.querySelector<HTMLElement>(MENU_ITEM_SELECTOR)?.focus();
+      }
+    });
+  };
+
+  /** ArrowUp/Down wrap through the menu's items; Home/End jump to the edges. */
+  private readonly handleMenuKeydown = (event: KeyboardEvent) => {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+      return;
+    }
+    const items = [
+      ...(event.currentTarget as HTMLElement).querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR),
+    ];
+    if (items.length === 0) {
+      return;
+    }
+    event.preventDefault();
+    const index = items.indexOf(document.activeElement as HTMLElement);
+    const target =
+      event.key === "Home"
+        ? items[0]
+        : event.key === "End"
+          ? items.at(-1)
+          : items[(index + (event.key === "ArrowDown" ? 1 : -1) + items.length) % items.length];
+    target?.focus();
   };
 
   override updated() {
@@ -373,6 +412,11 @@ class NewSessionPage extends OpenClawLightDomElement {
   }
 
   private selectAgentId(agentId: string) {
+    // Re-picking the checked agent must not reset the draft (the native
+    // select never fired change for the same option).
+    if (normalizeAgentId(agentId) === normalizeAgentId(this.agentId)) {
+      return;
+    }
     this.agentId = normalizeAgentId(agentId);
     this.folder = this.execNode ? "" : this.workspacePath();
     this.worktree = false;
@@ -671,7 +715,12 @@ class NewSessionPage extends OpenClawLightDomElement {
             >${icons.chevronDown}</span
           >
         </summary>
-        <div class="new-session-page__menu" role="menu" aria-label=${t("newSession.agent")}>
+        <div
+          class="new-session-page__menu"
+          role="menu"
+          aria-label=${t("newSession.agent")}
+          @keydown=${this.handleMenuKeydown}
+        >
           ${agents.map((option) =>
             this.renderMenuItem({
               label: option.identity?.name ?? option.name ?? option.id,
@@ -716,7 +765,12 @@ class NewSessionPage extends OpenClawLightDomElement {
             >${icons.chevronDown}</span
           >
         </summary>
-        <div class="new-session-page__menu" role="menu" aria-label=${t("newSession.where")}>
+        <div
+          class="new-session-page__menu"
+          role="menu"
+          aria-label=${t("newSession.where")}
+          @keydown=${this.handleMenuKeydown}
+        >
           ${showNodes
             ? html`
                 <div class="new-session-page__menu-title">${t("newSession.where")}</div>
@@ -843,7 +897,10 @@ class NewSessionPage extends OpenClawLightDomElement {
             >${icons.chevronDown}</span
           >
         </summary>
-        <div class="new-session-page__menu new-session-page__menu--browser">
+        <div
+          class="new-session-page__menu new-session-page__menu--browser"
+          @keydown=${this.handleMenuKeydown}
+        >
           ${this.renderBrowser()}
         </div>
       </details>

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -511,7 +511,6 @@ class NewSessionPage extends OpenClawLightDomElement {
     const matchesCurrentTarget = target.nodeId === this.execNode;
     const path = matchesCurrentTarget && isAbsolutePath(folder) ? folder : undefined;
     this.browserTarget = target;
-    this.browserPathDraft = path ?? "";
     this.loadBrowser(path);
   }
 
@@ -527,6 +526,10 @@ class NewSessionPage extends OpenClawLightDomElement {
     // Clear the previous directory immediately: keeping it clickable while the
     // request is in flight would let "Use this folder" apply the stale path.
     this.browserListing = null;
+    // Navigation owns the shown path at once, so a mid-flight "Use this
+    // folder" applies where the user is heading, never the directory they
+    // just left ("" = the host default while heading home).
+    this.browserPathDraft = path ?? "";
     const draftAtRequest = this.browserPathDraft;
     void client
       .request<FsListDirResult>("fs.listDir", {

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -126,6 +126,21 @@ class NewSessionPage extends OpenClawLightDomElement {
     }
   };
 
+  // Mutual exclusion must hook the details toggle, not just pointerdown:
+  // keyboard activation (Enter/Space on a summary) opens without any pointer
+  // event, and two open panels would overlap.
+  private readonly handleMenuToggle = (event: Event) => {
+    const details = event.currentTarget as HTMLDetailsElement;
+    if (!details.open) {
+      return;
+    }
+    for (const other of this.openMenus()) {
+      if (other !== details) {
+        other.open = false;
+      }
+    }
+  };
+
   override updated() {
     const agentsReady = this.agents().length > 0;
     const openKey = this.data?.agentId ?? "";
@@ -647,7 +662,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     const selected = this.selectedAgent();
     const label = selected?.identity?.name ?? selected?.name ?? selected?.id ?? this.agentId;
     return html`
-      <details class="new-session-page__select">
+      <details class="new-session-page__select" @toggle=${this.handleMenuToggle}>
         <summary class="new-session-page__trigger" title=${t("newSession.agent")}>
           <span class="new-session-page__target-icon" aria-hidden="true">${icons.bot}</span>
           <span class="new-session-page__trigger-label">${label}</span>
@@ -683,7 +698,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     const worktreeAvailable = this.worktreeAvailable();
     const branches = this.branches;
     return html`
-      <details class="new-session-page__select">
+      <details class="new-session-page__select" @toggle=${this.handleMenuToggle}>
         <summary
           class="new-session-page__trigger"
           title=${t("newSession.where")}
@@ -787,12 +802,19 @@ class NewSessionPage extends OpenClawLightDomElement {
 
   private renderFolderSelect() {
     const browseAvailable = this.browseAvailable();
-    const folderName = folderDisplayName(this.folder.trim() || this.workspacePath());
-    const label = folderName || t("newSession.folderPlaceholder");
+    const folder = this.folder.trim();
+    // An empty folder on a node session means that node's default directory —
+    // never the Gateway workspace, so no local-workspace fallback there.
+    const label = folder
+      ? folderDisplayName(folder)
+      : this.execNode
+        ? t("newSession.folderPlaceholder")
+        : folderDisplayName(this.workspacePath()) || t("newSession.folderPlaceholder");
     return html`
       <details
         class="new-session-page__select new-session-page__select--folder"
         @toggle=${(event: Event) => {
+          this.handleMenuToggle(event);
           const details = event.currentTarget as HTMLDetailsElement;
           if (details.open) {
             this.browserOpen = true;

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -159,9 +159,14 @@ class NewSessionPage extends OpenClawLightDomElement {
     });
   };
 
-  /** ArrowUp/Down wrap through the menu's items; Home/End jump to the edges. */
+  /** ArrowUp/Down wrap through the menu's items; Home/End jump to the edges.
+      Text fields keep native caret/datalist behavior for these keys. */
   private readonly handleMenuKeydown = (event: KeyboardEvent) => {
     if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+      return;
+    }
+    const origin = event.target as HTMLElement;
+    if (origin instanceof HTMLInputElement || origin instanceof HTMLTextAreaElement) {
       return;
     }
     const items = [

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -320,14 +320,28 @@ openclaw-new-session-page {
   cursor: default;
 }
 
-/* Phones (and short landscape): match the chat thread's mobile inset; the
-   trigger row is already compact, so it needs no further condensing. */
+/* Phones (and short landscape): match the chat thread's mobile inset, and
+   anchor menus to the trigger row instead of their trigger — a near
+   viewport-wide panel under a non-leftmost trigger would otherwise run past
+   the right edge. */
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .new-session-page__scroll {
     padding: 12px 8px;
   }
 
   .new-session-page__triggers {
+    position: relative;
     gap: 4px 12px;
+  }
+
+  .new-session-page__select {
+    position: static;
+  }
+
+  .new-session-page__menu {
+    right: 0;
+    left: 0;
+    width: auto;
+    max-width: none;
   }
 }

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -50,9 +50,9 @@ openclaw-new-session-page {
   text-align: left;
 }
 
-/* Cursor-style quiet target row: plain muted text controls with the native
-   select chevrons, no chip borders; hover/focus restores full contrast. */
-.new-session-page__targets {
+/* Cursor-style quiet trigger row: each control is a <details> whose summary
+   reads as muted text with a chevron; the menu floats below the trigger. */
+.new-session-page__triggers {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -60,61 +60,118 @@ openclaw-new-session-page {
   padding: 0 2px;
 }
 
-/* The worktree toggle and its branch/name fields wrap as one unit so the
-   dependent fields never land on a different line than their toggle. */
-.new-session-page__target-group {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: inherit;
+.new-session-page__select {
+  position: relative;
 }
 
-.new-session-page__target {
+.new-session-page__trigger {
   display: inline-flex;
   align-items: center;
   gap: 5px;
   padding: 2px 0;
-  border: 0;
-  background: none;
+  font-size: 12px;
+  color: var(--muted);
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+}
+
+.new-session-page__trigger::-webkit-details-marker {
+  display: none;
+}
+
+.new-session-page__trigger:hover,
+.new-session-page__select[open] > .new-session-page__trigger {
+  color: var(--text);
+}
+
+.new-session-page__trigger--disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.new-session-page__trigger--disabled:hover {
+  color: var(--muted);
+}
+
+.new-session-page__trigger-label {
+  max-width: min(40vw, 260px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.new-session-page__trigger-chevron {
+  display: inline-flex;
+  color: inherit;
+}
+
+.new-session-page__trigger-chevron svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* Menu panel anchored under its trigger; item rows reuse the shared
+   .session-menu__* styles so every menu in the app reads the same. */
+.new-session-page__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 80;
+  min-width: 224px;
+  max-width: min(320px, calc(100vw - 24px));
+  padding: 6px;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 78%, transparent);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-lg);
+}
+
+.new-session-page__menu-title {
+  padding: 4px 8px 2px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.new-session-page__menu-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  padding: 2px 8px;
   font-size: 12px;
   color: var(--muted);
 }
 
-.new-session-page__target:hover,
-.new-session-page__target:focus-within {
-  color: var(--text);
+.new-session-page__menu-field span {
+  flex: 0 0 auto;
 }
 
-.new-session-page__target select,
-.new-session-page__target input[type="text"] {
-  border: 0;
+.new-session-page__menu-field input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   background: transparent;
-  color: inherit;
+  color: var(--text);
   font-size: 12px;
   outline: none;
-  cursor: pointer;
 }
 
-.new-session-page__target input[type="text"] {
-  cursor: text;
+.new-session-page__menu-field input:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
 }
 
-.new-session-page__target input[type="text"]::placeholder {
-  color: inherit;
-}
-
-/* Compact by default so the browse button hugs the path; grows only as far
-   as a long path needs, then ellipsizes via the input's own scroll. */
-.new-session-page__target--folder {
-  flex: 0 1 auto;
-  min-width: 0;
-}
-
-.new-session-page__target--folder input {
-  width: 150px;
-  max-width: 40vw;
-  min-width: 0;
-  field-sizing: content;
+/* The folder menu hosts the directory browser; wider than the list menus. */
+.new-session-page__menu--browser {
+  width: min(420px, calc(100vw - 24px));
+  max-width: none;
+  padding: 0;
+  overflow: hidden;
 }
 
 .new-session-page__target-icon {
@@ -127,11 +184,6 @@ openclaw-new-session-page {
   height: 14px;
 }
 
-.new-session-page__branch {
-  width: 140px;
-}
-
-.new-session-page__browse,
 .new-session-page__browser-nav {
   display: inline-flex;
   align-items: center;
@@ -145,13 +197,11 @@ openclaw-new-session-page {
   cursor: pointer;
 }
 
-.new-session-page__browse:hover,
 .new-session-page__browser-nav:hover:not(:disabled) {
   background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
   color: var(--text);
 }
 
-.new-session-page__browse svg,
 .new-session-page__browser-nav svg {
   width: 14px;
   height: 14px;
@@ -162,11 +212,9 @@ openclaw-new-session-page {
   cursor: default;
 }
 
+/* The menu panel already draws the border/background chrome. */
 .new-session-page__browser {
   overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--panel);
 }
 
 .new-session-page__browser-head {
@@ -177,14 +225,25 @@ openclaw-new-session-page {
   border-bottom: 1px solid var(--border);
 }
 
+/* Editable path (input) or the pick-a-root hint (span). */
 .new-session-page__browser-path {
   flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding: 0;
+  border: 0;
+  background: transparent;
   font-size: 12px;
   color: var(--text);
+  outline: none;
+}
+
+.new-session-page__browser-loading {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--muted);
 }
 
 .new-session-page__browser-list {
@@ -261,31 +320,14 @@ openclaw-new-session-page {
   cursor: default;
 }
 
-/* Phones (and short landscape): match the chat thread's mobile inset and
-   condense the target rows in DOM order — the folder chip flexes next to
-   Where and the worktree group wraps below as a unit, so visual, reading,
-   and tab order stay aligned at every phone width. */
+/* Phones (and short landscape): match the chat thread's mobile inset; the
+   trigger row is already compact, so it needs no further condensing. */
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .new-session-page__scroll {
     padding: 12px 8px;
   }
 
-  .new-session-page__targets {
+  .new-session-page__triggers {
     gap: 4px 12px;
-  }
-
-  .new-session-page__target--folder {
-    flex: 1 1 140px;
-    min-width: 140px;
-  }
-
-  .new-session-page__target--folder input {
-    flex: 1 1 auto;
-    width: 0;
-    max-width: none;
-  }
-
-  .new-session-page__branch {
-    width: 110px;
   }
 }


### PR DESCRIPTION
Closes #105264

## What Problem This Solves

The `/new` launcher's target controls were inline chips — a folder path input, a where select, and a worktree checkbox expanding into two more inline fields. Even compacted (#105177) they take up to three rows above the composer on phones, and the responsive plumbing existed only to manage that clutter.

## Why This Change Was Made

The controls fold into Cursor-style click menus (the maintainer-suggested concept), so the row is one quiet line at every width:

- **Folder trigger** shows the folder basename and opens the directory browser (#105114's gateway/node roots) as a floating panel; manual path entry moves into the panel's editable path field (Enter browses there, "Use this folder" applies it).
- **Where trigger** shows the execution target and opens one menu with Gateway/node selection plus the worktree toggle and labeled base-branch/name fields; a branch badge appears on the trigger when a worktree is enabled. Node-bound drafts no longer render an inert worktree toggle — the item disappears because managed worktrees are Gateway-only.
- **Agent trigger** becomes a menu when more than one agent exists.

Implementation reuses what the app already has: the chat composer's `details/summary` inline-select idiom (same outside-pointerdown/Escape dismissal contract), and the shared `.session-menu__*` item styles so every menu in the app reads the same. The inline-row CSS (folder flex choreography, worktree group wrapper, phone condensing rules) is deleted; no new i18n keys.

## User Impact

One compact trigger row — `📁 folder ⌄ · 🖥 where ⌄` — on desktop and phones alike, with the full browse/worktree power behind two clicks. Keyboard: Escape closes and restores trigger focus; menu items are radio menuitems.

Desktop:

![desktop](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-target-menus/new-session-menus-desktop.png)

Where menu open (custom folder forcing a worktree, fields inline in the menu):

![desktop open](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-target-menus/new-session-menus-desktop-open.png)

Mobile:

![mobile](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-target-menus/new-session-menus-mobile.png)

![mobile open](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/new-session-target-menus/new-session-menus-mobile-open.png)

## Evidence

- Both mocked-gateway e2e tests rewritten for the menu interactions and passing locally (`pnpm test ui/src/e2e/new-session-page.e2e.test.ts`): the browse→adopt→forced-worktree flow (badge + checked/locked menu item) and the node super-root flow (menu node selection, UNC manual entry in the panel head, retarget-on-use, worktree item absent for node drafts). `sessions.create` payload assertions unchanged.
- Live mock-harness verification on desktop and 375×812: menu open/close, outside-click and Escape dismissal with focus restore, node selection updating the trigger, custom folder forcing the worktree state, browser panel roots/loading states.
- `pnpm test ui/src/pages/new-session/create-params.test.ts ui/src/pages/chat/chat-view.test.ts` passing; `oxfmt` + `scripts/run-oxlint.mjs` clean.
- No i18n changes: all labels reuse existing `newSession.*` keys (`browse` becomes the folder trigger's tooltip, `where` the menu title).
- Net prod LOC grows (+128 TS, +42 CSS) but concepts shrink: the entire inline-row responsive choreography (folder flex sizing, worktree group wrapper, phone condensing media rules) is deleted in favor of one menu idiom shared with the rest of the app.
- Second-model review (Codex gpt-5.6-sol, xhigh) ran nine passes; twelve findings were accepted and fixed before landing, covering menu mutual exclusion for keyboard opens, the full native-select keyboard contract (focus-on-open, wrapping arrows, Home/End with text-field exemption), folder-label correctness for node sessions and filesystem roots, phone viewport clamping (row-anchored full-width menus), and the folder-draft state machine: typed paths win over stale listings, listings cannot erase in-flight typing, a cleared input applies the host-default directory, manual entry works on hosts without fs.listDir, and navigation claims the shown path at request time so mid-latency applies never regress. One recurring claim (re-selecting the checked target discards draft state) was rejected twice with a code citation — selectExecNode's same-value guard sits outside the diff hunks — and the final pass returned clean: "menu state, same-target guards, folder-browser draft handling, request-race protection, worktree constraints, and responsive styling are internally consistent."
