### PR TITLE
docs(agents): clarify Testbox cleanup syntax

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ Skills own workflows; root owns hard policy and routing.
 - Use `$openclaw-testing` for test/CI choice and `$crabbox` for remote/full/E2E proof.
 - At task start, if code changes, tests, builds, typechecks, lint fan-out, Docker, packaging, E2E, or live proof are likely, classify source trust and immediately pre-warm the safe Crabbox backend in a background command session. Trusted maintainer code defaults to Blacksmith Testbox; untrusted contributor/fork code uses secretless fork CI or sanitized direct AWS Crabbox under the rule above. Continue inspection/editing while it hydrates; sync the current checkout for every run, reuse the lease, then stop it before handoff.
 - Warm Testbox from the task checkout; lease ownership is checkout-path scoped.
+- Testbox cleanup: `blacksmith testbox stop --id <tbx_id>`; id is not positional.
 - PR review artifacts: keep template enum values; put evidence detail in summaries.
 - Crabbox request means real scenario proof: install/update/call/repro user path; not just copy tests and run them remotely.
 - Visual proof: use Crabbox, set up like a user, then screenshot-verify. No harness/bypass/shortcut unless explicitly asked.


### PR DESCRIPTION
## What Problem This Solves

The Blacksmith Testbox cleanup command rejects a positional lease ID, which makes an otherwise routine cleanup invocation fail.

## Why This Change Was Made

Record the exact `--id` syntax in the root agent instructions where Testbox lease ownership and cleanup are governed.

## User Impact

No product behavior change. Maintainer automation avoids a repeat cleanup invocation error.

## Evidence

- `blacksmith testbox stop tbx_...` rejected the call with `required flag(s) "id" not set`.
- `blacksmith testbox stop --id tbx_...` completed successfully.
- `git diff --check`.
