### PR TITLE
ci: pin release validation Go toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1424,9 +1424,11 @@ jobs:
 
       - name: Setup Go for docs i18n
         if: matrix.requires_go == true
+        # The current workflow validates frozen targets whose go.mod may predate this patch pin.
+        # Keep the runner toolchain owned by the workflow while using the target only for cache keys.
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version-file: scripts/docs-i18n/go.mod
+          go-version: "1.25.12"
           cache-dependency-path: scripts/docs-i18n/go.sum
 
       - name: Verify docs i18n Go toolchain

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2084,7 +2084,7 @@ describe("ci workflow guards", () => {
     );
   });
 
-  it("keeps docs i18n CI on the patched preferred Go toolchain", () => {
+  it("keeps docs i18n CI on the workflow-owned patched Go toolchain", () => {
     const workflow = readCiWorkflow();
     const nodeTestJob = workflow.jobs["checks-node-core-test-nondist-shard"];
     const setupGoStep = nodeTestJob.steps.find(
@@ -2097,11 +2097,11 @@ describe("ci workflow guards", () => {
       if: "matrix.requires_go == true",
       uses: SETUP_GO_V6,
       with: {
-        "go-version-file": "scripts/docs-i18n/go.mod",
+        "go-version": "1.25.12",
         "cache-dependency-path": "scripts/docs-i18n/go.sum",
       },
     });
-    expect(setupGoStep.with).not.toHaveProperty("go-version");
+    expect(setupGoStep.with).not.toHaveProperty("go-version-file");
     expect(verifyGoStep).toMatchObject({
       if: "matrix.requires_go == true",
       run: 'test "$(go env GOVERSION)" = "go1.25.12"',


### PR DESCRIPTION
## What Problem This Solves

Full release validation runs the current trusted CI workflow against frozen release targets. The docs-i18n shard read its Go version from the target's `go.mod`, so extended-stable selected Go 1.25.0 and then failed the current workflow's required Go 1.25.12 assertion.

## Why This Change Was Made

Make the current workflow own its patched Go 1.25.12 runner pin. Frozen targets still own the module and `go.sum` cache key, but no longer downgrade the workflow's security/toolchain requirement.

## User Impact

Historical and release-branch validation can run the docs-i18n tooling with the current patched Go version. Current-main's 1.25.12 requirement remains strict.

## Evidence

- Failing LTS job: https://github.com/openclaw/openclaw/actions/runs/29187889044/job/86637217098
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29188142537
- `pnpm test test/scripts/ci-workflow-guards.test.ts`: 52 passed
- `node scripts/check-workflows.mjs`: passed
- Fresh autoreview: clean
