### PR TITLE
test(ci): repair plugin prerelease contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ Skills own workflows; root owns hard policy and routing.
 
 - Use `$openclaw-testing` for test/CI choice and `$crabbox` for remote/full/E2E proof.
 - At task start, if code changes, tests, builds, typechecks, lint fan-out, Docker, packaging, E2E, or live proof are likely, classify source trust and immediately pre-warm the safe Crabbox backend in a background command session. Trusted maintainer code defaults to Blacksmith Testbox; untrusted contributor/fork code uses secretless fork CI or sanitized direct AWS Crabbox under the rule above. Continue inspection/editing while it hydrates; sync the current checkout for every run, reuse the lease, then stop it before handoff.
-- Warm Testbox from the task checkout; lease ownership is checkout-path scoped.
+- Warm Testbox from the task checkout; ownership is checkout-path scoped; `--reclaim` only for intentional transfer.
 - Testbox cleanup: `blacksmith testbox stop --id <tbx_id>`; id is not positional.
 - PR review artifacts: keep template enum values; put evidence detail in summaries.
 - Crabbox request means real scenario proof: install/update/call/repro user path; not just copy tests and run them remotely.
@@ -139,7 +139,7 @@ Skills own workflows; root owns hard policy and routing.
 - Local agent work is limited to lightweight non-test checks such as `git diff --check`, targeted formatting, and cheap static probes. Tests and computationally intensive work default to the selected remote box.
 - In Codex or linked worktrees, direct local `pnpm test*`, `pnpm check*`, `pnpm crabbox:run`, and `scripts/committer` can trigger pnpm dependency reconciliation or install prompts. Prefer `node` wrappers locally and Crabbox/Testbox for pnpm-gated proof.
 - Crabbox wrapper `stop` has no `--timing-json`; use `node scripts/crabbox-wrapper.mjs stop --provider <provider> --id <id>`.
-- Repo-native PR worktree may omit `node_modules`; run dependency-backed formatter/docs scripts via Testbox or hosted CI.
+- Repo-native PR worktree may omit `node_modules`; prove remotely, then use `git commit --no-verify`, not `scripts/committer`.
 - Parallel agents share the checkout; never switch its branch while sibling work runs.
 - Full suites, changed gates, builds, typechecks, lint fan-out, Docker/package/E2E/live/cross-OS proof, or anything computationally intensive: Crabbox/Testbox.
 - If an allowed local fallback fans out or becomes expensive, stop it and move the work to the pre-warmed remote box.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ Skills own workflows; root owns hard policy and routing.
 - Use `$openclaw-testing` for test/CI choice and `$crabbox` for remote/full/E2E proof.
 - At task start, if code changes, tests, builds, typechecks, lint fan-out, Docker, packaging, E2E, or live proof are likely, classify source trust and immediately pre-warm the safe Crabbox backend in a background command session. Trusted maintainer code defaults to Blacksmith Testbox; untrusted contributor/fork code uses secretless fork CI or sanitized direct AWS Crabbox under the rule above. Continue inspection/editing while it hydrates; sync the current checkout for every run, reuse the lease, then stop it before handoff.
 - Warm Testbox from the task checkout; ownership is checkout-path scoped; `--reclaim` only for intentional transfer.
+- Base/head changed: stop and rewarm Testbox; never override stale lease checks.
 - Testbox cleanup: `blacksmith testbox stop --id <tbx_id>`; id is not positional.
 - PR review artifacts: keep template enum values; put evidence detail in summaries.
 - Crabbox request means real scenario proof: install/update/call/repro user path; not just copy tests and run them remotely.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ Skills own workflows; root owns hard policy and routing.
 - At task start, if code changes, tests, builds, typechecks, lint fan-out, Docker, packaging, E2E, or live proof are likely, classify source trust and immediately pre-warm the safe Crabbox backend in a background command session. Trusted maintainer code defaults to Blacksmith Testbox; untrusted contributor/fork code uses secretless fork CI or sanitized direct AWS Crabbox under the rule above. Continue inspection/editing while it hydrates; sync the current checkout for every run, reuse the lease, then stop it before handoff.
 - Warm Testbox from the task checkout; ownership is checkout-path scoped; `--reclaim` only for intentional transfer.
 - Base/head changed: stop and rewarm Testbox; never override stale lease checks.
+- Compound Testbox commands: `bash -lc`, never `sh -lc`; job env uses Bash `declare`.
 - Testbox cleanup: `blacksmith testbox stop --id <tbx_id>`; id is not positional.
 - PR review artifacts: keep template enum values; put evidence detail in summaries.
 - Crabbox request means real scenario proof: install/update/call/repro user path; not just copy tests and run them remotely.

--- a/extensions/codex/prompt-overlay-runtime-contract.test.ts
+++ b/extensions/codex/prompt-overlay-runtime-contract.test.ts
@@ -17,10 +17,10 @@ describe("Codex prompt overlay runtime contract", () => {
 
     expect(contribution?.stablePrefix).toContain("<persona_latch>");
     expect(contribution?.sectionOverrides?.interaction_style).toContain(
-      "Live chat tone: short, natural, human.",
+      "Live chat: short, natural, human.",
     );
     expect(contribution?.sectionOverrides?.interaction_style).not.toContain(
-      "Use heartbeats to create useful proactive progress",
+      "Heartbeat = useful proactive progress",
     );
   });
 

--- a/extensions/codex/provider.test.ts
+++ b/extensions/codex/provider.test.ts
@@ -704,8 +704,8 @@ describe("codex provider", () => {
       stablePrefix: CODEX_GPT5_BEHAVIOR_CONTRACT,
     });
     const interactionStyle = contribution?.sectionOverrides?.interaction_style;
-    expect(interactionStyle).toContain("Live chat tone: short, natural, human.");
-    expect(interactionStyle).not.toContain("Use heartbeats to create useful proactive progress");
+    expect(interactionStyle).toContain("Live chat: short, natural, human.");
+    expect(interactionStyle).not.toContain("Heartbeat = useful proactive progress");
   });
 
   it("does not add the GPT-5 prompt overlay to non-GPT-5 Codex provider runs", () => {

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -16,6 +16,7 @@ import {
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "openclaw/plugin-sdk/message-tool-delivery-hints";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { registerSandboxBackend } from "openclaw/plugin-sdk/sandbox";
+import { formatSqliteSessionFileMarker } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CODEX_TURN_START_TEXT_INPUT_MAX_CHARS } from "./context-engine-projection.js";
 import type { CodexServerNotification } from "./protocol.js";
@@ -84,6 +85,31 @@ function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAtt
     authProfileStore: { version: 1, profiles: {} },
     modelRegistry: {} as never,
   } as EmbeddedRunAttemptParams;
+}
+
+function createSqliteParams(workspaceDir: string, storeName: string): EmbeddedRunAttemptParams {
+  const sessionId = "session-1";
+  const sessionKey = "agent:main:session-1";
+  const storePath = path.join(tempDir, `${storeName}.sqlite`);
+  const sessionFile = formatSqliteSessionFileMarker({
+    agentId: "main",
+    sessionId,
+    storePath,
+  });
+  const params = createParams(sessionFile, workspaceDir);
+  params.sessionTarget = {
+    agentId: "main",
+    sessionId,
+    sessionKey,
+    storePath,
+  };
+  const message = userMessage("hello", Date.now());
+  params.userTurnTranscriptRecorder = {
+    message,
+    resolveMessage: async () => message,
+    markRuntimePersisted() {},
+  } as EmbeddedRunAttemptParams["userTurnTranscriptRecorder"];
+  return params;
 }
 
 const DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
@@ -1929,7 +1955,6 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
   ] as const)(
     "keeps $name turns heartbeat-classified through afterTurn maintenance",
     async (testCase) => {
-      const sessionFile = path.join(tempDir, "session.jsonl");
       const workspaceDir = path.join(tempDir, "workspace");
       const afterTurn = vi.fn(
         async (_params: Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]) => undefined,
@@ -1937,7 +1962,10 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       const maintain = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
       const contextEngine = createContextEngine({ afterTurn, maintain, bootstrap: undefined });
       const harness = createStartedThreadHarness();
-      const params = createParams(sessionFile, workspaceDir);
+      const params = createSqliteParams(
+        workspaceDir,
+        `heartbeat-${testCase.bootstrapContextRunKind}`,
+      );
       params.contextEngine = contextEngine;
       params.trigger = testCase.trigger;
       params.bootstrapContextRunKind = testCase.bootstrapContextRunKind;
@@ -2056,7 +2084,6 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
   });
 
   it("falls back to ingestBatch and skips turn maintenance on prompt failure", async () => {
-    const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const ingestBatch = vi.fn(async () => ({ ingestedCount: 2 }));
     const maintain = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
@@ -2067,7 +2094,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       bootstrap: undefined,
     });
     const harness = createStartedThreadHarness();
-    const params = createParams(sessionFile, workspaceDir);
+    const params = createSqliteParams(workspaceDir, "prompt-failure");
     params.contextEngine = contextEngine;
 
     const run = runCodexAppServerAttempt(params);

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -511,10 +511,10 @@ describe("Codex app-server native code mode config", () => {
     });
 
     expect(instructions).toContain("## Skill Workshop");
-    expect(instructions).toContain("Route durable skill work");
-    expect(instructions).toContain("through the `skill_workshop` tool");
-    expect(instructions).toContain("Generated skills are pending proposals.");
-    expect(instructions).toContain("only when the user explicitly asks");
+    expect(instructions).toContain("Durable reusable skill/playbook/workflow work");
+    expect(instructions).toContain("`skill_workshop`");
+    expect(instructions).toContain("Generated = pending proposal");
+    expect(instructions).toContain("only explicit user ask");
   });
 
   it("keeps developer instructions compact when no dynamic tools are deferred", () => {
@@ -1268,7 +1268,7 @@ describe("Codex app-server turn params", () => {
       "This is an OpenClaw heartbeat turn. Apply these instructions only to this heartbeat wake",
     );
     expect(heartbeatCollaborationMode.settings.developer_instructions).toContain(
-      "Use heartbeats to create useful proactive progress",
+      "Heartbeat = useful proactive progress",
     );
     expect(heartbeatCollaborationMode.settings.developer_instructions).toContain(
       "If `heartbeat_respond` is not already available and `tool_search` is available",

--- a/src/plugin-sdk/plugin-test-api.ts
+++ b/src/plugin-sdk/plugin-test-api.ts
@@ -25,6 +25,7 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     registerHostedMediaResolver() {},
     registerChannel() {},
     registerGatewayMethod() {},
+    registerSessionCatalog() {},
     registerCli() {},
     registerNodeCliFeature() {},
     registerCliBackend() {},
@@ -93,7 +94,7 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     },
     on() {},
     ...flatApi,
-  } as OpenClawPluginApiWithoutFacades;
+  } satisfies OpenClawPluginApiWithoutFacades;
   // Facades derive nested `agent`, `lifecycle`, `runContext`, and `session`
   // views from the flat API; explicit overrides below let tests replace only
   // the nested surface under test without rebuilding every no-op method.


### PR DESCRIPTION
## What Problem This Solves

Plugin Prerelease shard 1 failed deterministically on current main with 21 Codex extension test failures. The test SDK helper omitted the new session-catalog registration method, shared prompt assertions lagged the compressed contract, and three context-engine lifecycle cases still used pre-SQLite transcript fixtures.

## Why This Change Was Made

- Add the missing `registerSessionCatalog` no-op and structurally check the complete test API shape so future SDK additions fail typecheck instead of failing plugin tests at runtime.
- Align Codex prompt assertions with the canonical compressed shared guidance.
- Exercise lifecycle finalization with SQLite markers, runtime session identity, and a user-turn recorder while preserving the user/assistant and ingestion assertions.
- Record the Testbox checkout-ownership and sparse-worktree commit invocation rules.

## User Impact

No production behavior change. Plugin prerelease validation becomes deterministic and the Codex lifecycle tests continue to cover the current SQLite runtime contract.

## Evidence

- Failed lane: https://github.com/openclaw/openclaw/actions/runs/29187455327/job/86636055732
- Blacksmith Testbox `tbx_01kxatrb6e1md5d0frhazrr5gy`: focused Codex tests, 197 passed.
- Same Testbox: exact shard-1 extension batch command, all 257 files passed; Codex 105 files / 2421 tests passed.
- Same Testbox: `pnpm check:changed`, including format, SDK baselines, typechecks, lint, and guards.
- Fresh autoreview: no accepted or actionable findings.
