### PR TITLE
refactor(plugins): remove obsolete runtime helpers

### DIFF
--- a/src/agents/model-selection-cli.test.ts
+++ b/src/agents/model-selection-cli.test.ts
@@ -68,13 +68,13 @@ function setCliBackendMetadataSnapshot(cliBackends: string[]) {
 
 describe("isCliProvider", () => {
   beforeEach(() => {
-    setupRegistryRuntimeTesting.resetRuntimeState();
+    setupRegistryRuntimeTesting.resetDescriptorCache();
     setCliBackendMetadataSnapshot(["claude-cli"]);
   });
 
   afterEach(() => {
     clearCurrentPluginMetadataSnapshot();
-    setupRegistryRuntimeTesting.resetRuntimeState();
+    setupRegistryRuntimeTesting.resetDescriptorCache();
   });
 
   it("returns true for setup-registered cli backends", () => {
@@ -83,17 +83,5 @@ describe("isCliProvider", () => {
 
   it("returns false for provider ids", () => {
     expect(isCliProvider("example-cli", {} as OpenClawConfig)).toBe(false);
-  });
-
-  it("does not execute setup runtime when descriptor metadata has no matching backend", () => {
-    // Negative checks should stay metadata-only; loading setup runtime here
-    // would make simple provider visibility queries expensive.
-    setupRegistryRuntimeTesting.setRuntimeModuleForTest({
-      resolvePluginSetupCliBackend: () => {
-        throw new Error("setup runtime should not load for CLI provider checks");
-      },
-    });
-
-    expect(isCliProvider("openai", {} as OpenClawConfig)).toBe(false);
   });
 });

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -124,8 +124,6 @@ vi.mock("./bundled-compat.js", () => ({
 
 let resolvePluginCapabilityProviders: typeof import("./capability-provider-runtime.js").resolvePluginCapabilityProviders;
 let resolvePluginCapabilityProvider: typeof import("./capability-provider-runtime.js").resolvePluginCapabilityProvider;
-let resolveBundledCapabilityProviderIds: typeof import("./capability-provider-runtime.js").resolveBundledCapabilityProviderIds;
-let resolveManifestCapabilityProviderIds: typeof import("./capability-provider-runtime.js").resolveManifestCapabilityProviderIds;
 let clearCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-snapshot.js").clearCurrentPluginMetadataSnapshot;
 let setCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-snapshot.js").setCurrentPluginMetadataSnapshot;
 let clearPluginMetadataLifecycleCaches: typeof import("./plugin-metadata-lifecycle.js").clearPluginMetadataLifecycleCaches;
@@ -284,12 +282,8 @@ function expectCompatChainApplied(params: {
 describe("resolvePluginCapabilityProviders", () => {
   beforeAll(async () => {
     vi.resetModules();
-    ({
-      resolveBundledCapabilityProviderIds,
-      resolveManifestCapabilityProviderIds,
-      resolvePluginCapabilityProvider,
-      resolvePluginCapabilityProviders,
-    } = await import("./capability-provider-runtime.js"));
+    ({ resolvePluginCapabilityProvider, resolvePluginCapabilityProviders } =
+      await import("./capability-provider-runtime.js"));
     ({ clearCurrentPluginMetadataSnapshot, setCurrentPluginMetadataSnapshot } =
       await import("./current-plugin-metadata-snapshot.js"));
     ({ clearPluginMetadataLifecycleCaches } = await import("./plugin-metadata-lifecycle.js"));
@@ -323,10 +317,25 @@ describe("resolvePluginCapabilityProviders", () => {
     clearLoadPluginMetadataSnapshotMemo();
   });
 
-  it("resolves bundled capability ids from the current metadata snapshot", () => {
+  it("resolves bundled capability plugins from the current metadata snapshot", () => {
+    const loaded = createEmptyPluginRegistry();
+    loaded.imageGenerationProviders.push({
+      pluginId: "fal",
+      pluginName: "fal",
+      source: "test",
+      provider: {
+        id: "fal",
+        defaultModel: "fal-ai/flux/dev",
+        models: ["fal-ai/flux/dev"],
+        isConfigured: () => true,
+        generateImage: async () => ({ images: [] }),
+      },
+    } as never);
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? undefined : loaded,
+    );
     setCurrentPluginMetadataSnapshot({
       policyHash: resolveInstalledPluginIndexPolicyHash({}),
-      workspaceDir: "/workspace",
       index: { plugins: [] },
       registryDiagnostics: [],
       manifestRegistry: { plugins: [], diagnostics: [] },
@@ -360,19 +369,35 @@ describe("resolvePluginCapabilityProviders", () => {
       },
     } as never);
 
-    expect(
-      resolveBundledCapabilityProviderIds({
-        key: "imageGenerationProviders",
-        workspaceDir: "/workspace",
-      }),
-    ).toEqual(["fal"]);
+    expectResolvedCapabilityProviderIds(
+      resolvePluginCapabilityProviders({ key: "imageGenerationProviders" }),
+      ["fal"],
+    );
+    expectActiveRegistryLookup(["fal"]);
     expect(mocks.loadPluginManifestRegistry).not.toHaveBeenCalled();
   });
 
-  it("resolves enabled external capability ids from the current metadata snapshot", () => {
+  it("resolves enabled external capability plugins from the current metadata snapshot", () => {
+    const loaded = createEmptyPluginRegistry();
+    loaded.imageGenerationProviders.push({
+      pluginId: "external-image",
+      pluginName: "external-image",
+      source: "test",
+      provider: {
+        id: "external-image",
+        label: "External Image",
+        isConfigured: () => true,
+        generate: async () => ({
+          kind: "image",
+          images: [],
+        }),
+      },
+    } as never);
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? undefined : loaded,
+    );
     setCurrentPluginMetadataSnapshot({
       policyHash: resolveInstalledPluginIndexPolicyHash({}),
-      workspaceDir: "/workspace",
       index: {
         plugins: [
           { pluginId: "external-image", origin: "global", enabled: true },
@@ -416,12 +441,11 @@ describe("resolvePluginCapabilityProviders", () => {
       },
     } as never);
 
-    expect(
-      resolveManifestCapabilityProviderIds({
-        key: "imageGenerationProviders",
-        workspaceDir: "/workspace",
-      }),
-    ).toEqual(["external-image"]);
+    expectResolvedCapabilityProviderIds(
+      resolvePluginCapabilityProviders({ key: "imageGenerationProviders" }),
+      ["external-image"],
+    );
+    expectActiveRegistryLookup(["external-image"]);
     expect(mocks.loadPluginManifestRegistry).not.toHaveBeenCalled();
   });
 

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -17,7 +17,6 @@ import {
   hasManifestContractValue,
   isManifestPluginAvailableForControlPlane,
   loadManifestContractSnapshot,
-  listAvailableManifestContractValues,
 } from "./manifest-contract-eligibility.js";
 import {
   resolveConfigScopedRuntimeCacheValue,
@@ -148,33 +147,6 @@ function resolveBundledCapabilityCompatPluginIds(params: {
   providerId?: string;
 }): string[] {
   return resolveCapabilityPluginIds(params).bundledCompatPluginIds;
-}
-
-export function resolveManifestCapabilityProviderIds(params: {
-  key: CapabilityProviderRegistryKey;
-  cfg?: OpenClawConfig;
-  workspaceDir?: string;
-}): string[] {
-  const contractKey = CAPABILITY_CONTRACT_KEY[params.key];
-  return listAvailableManifestContractValues({
-    snapshot: loadCapabilityManifestSnapshot(params),
-    contract: contractKey,
-    config: params.cfg,
-  });
-}
-
-export function resolveBundledCapabilityProviderIds(params: {
-  key: CapabilityProviderRegistryKey;
-  cfg?: OpenClawConfig;
-  workspaceDir?: string;
-}): string[] {
-  const contractKey = CAPABILITY_CONTRACT_KEY[params.key];
-  const snapshot = loadCapabilityManifestSnapshot(params);
-  return sortUniqueStrings(
-    snapshot.plugins.flatMap((plugin) =>
-      plugin.origin === "bundled" ? (plugin.contracts?.[contractKey] ?? []) : [],
-    ),
-  );
 }
 
 function resolveCapabilityProviderConfig(params: {

--- a/src/plugins/manifest-model-suppression.test.ts
+++ b/src/plugins/manifest-model-suppression.test.ts
@@ -11,10 +11,7 @@ vi.mock("./plugin-metadata-snapshot.js", () => ({
   resolvePluginMetadataSnapshot: mocks.resolvePluginMetadataSnapshot,
 }));
 
-import {
-  buildManifestBuiltInModelSuppressionResolver,
-  resolveManifestBuiltInModelSuppression,
-} from "./manifest-model-suppression.js";
+import { buildManifestBuiltInModelSuppressionResolver } from "./manifest-model-suppression.js";
 
 function createMetadataSnapshot(plugins: Record<string, unknown>[]) {
   return {
@@ -84,11 +81,12 @@ describe("manifest model suppression", () => {
   });
 
   it("resolves manifest suppressions for declared provider aliases", () => {
+    const resolver = buildManifestBuiltInModelSuppressionResolver({ env: process.env });
+
     expect(
-      resolveManifestBuiltInModelSuppression({
+      resolver({
         provider: "azure-openai-responses",
         id: "GPT-5.3-Codex-Spark",
-        env: process.env,
       }),
     ).toEqual({
       suppress: true,
@@ -98,32 +96,14 @@ describe("manifest model suppression", () => {
   });
 
   it("ignores suppressions for providers the plugin does not own", () => {
+    const resolver = buildManifestBuiltInModelSuppressionResolver({ env: process.env });
+
     expect(
-      resolveManifestBuiltInModelSuppression({
+      resolver({
         provider: "openrouter",
         id: "foreign-row",
-        env: process.env,
       }),
     ).toBeUndefined();
-  });
-
-  it("reads planned manifest suppressions fresh per lookup", () => {
-    const config = { plugins: { entries: { openai: { enabled: true } } } };
-
-    resolveManifestBuiltInModelSuppression({
-      provider: "azure-openai-responses",
-      id: "gpt-5.3-codex-spark",
-      config,
-      env: process.env,
-    });
-    resolveManifestBuiltInModelSuppression({
-      provider: "azure-openai-responses",
-      id: "gpt-5.3-codex-spark",
-      config,
-      env: process.env,
-    });
-
-    expect(mocks.loadPluginMetadataSnapshot).toHaveBeenCalledTimes(2);
   });
 
   it("reuses planned manifest suppressions inside a resolver instance", () => {
@@ -174,36 +154,33 @@ describe("manifest model suppression", () => {
         },
       ]),
     );
+    const resolver = buildManifestBuiltInModelSuppressionResolver({ env: process.env });
 
     expect(
-      resolveManifestBuiltInModelSuppression({
+      resolver({
         provider: "qwen",
         id: "qwen3.6-plus",
         baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
-        env: process.env,
       })?.suppress,
     ).toBe(true);
     expect(
-      resolveManifestBuiltInModelSuppression({
+      resolver({
         provider: "qwen",
         id: "qwen3.6-plus",
         baseUrl: " https://coding-intl.dashscope.aliyuncs.com./v1 ",
-        env: process.env,
       })?.suppress,
     ).toBe(true);
     expect(
-      resolveManifestBuiltInModelSuppression({
+      resolver({
         provider: "qwen",
         id: "qwen3.6-plus",
-        env: process.env,
       })?.suppress,
     ).toBe(true);
     expect(
-      resolveManifestBuiltInModelSuppression({
+      resolver({
         provider: "qwen",
         id: "qwen3.6-plus",
         baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-        env: process.env,
       }),
     ).toBeUndefined();
   });
@@ -229,23 +206,25 @@ describe("manifest model suppression", () => {
         },
       ]),
     );
-
-    expect(
-      resolveManifestBuiltInModelSuppression({
-        provider: "modelstudio",
-        id: "qwen3.6-plus",
-        config: {
-          models: {
-            providers: {
-              modelstudio: {
-                api: "openai-completions",
-                baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
-                models: [],
-              },
+    const resolver = buildManifestBuiltInModelSuppressionResolver({
+      config: {
+        models: {
+          providers: {
+            modelstudio: {
+              api: "openai-completions",
+              baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+              models: [],
             },
           },
         },
-        env: process.env,
+      },
+      env: process.env,
+    });
+
+    expect(
+      resolver({
+        provider: "modelstudio",
+        id: "qwen3.6-plus",
       }),
     ).toBeUndefined();
   });
@@ -271,22 +250,24 @@ describe("manifest model suppression", () => {
         },
       ]),
     );
-
-    expect(
-      resolveManifestBuiltInModelSuppression({
-        provider: "modelstudio",
-        id: "qwen3.6-plus",
-        config: {
-          models: {
-            providers: {
-              modelstudio: {
-                baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
-                models: [],
-              },
+    const resolver = buildManifestBuiltInModelSuppressionResolver({
+      config: {
+        models: {
+          providers: {
+            modelstudio: {
+              baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+              models: [],
             },
           },
         },
-        env: process.env,
+      },
+      env: process.env,
+    });
+
+    expect(
+      resolver({
+        provider: "modelstudio",
+        id: "qwen3.6-plus",
       }),
     ).toBeUndefined();
   });

--- a/src/plugins/manifest-model-suppression.ts
+++ b/src/plugins/manifest-model-suppression.ts
@@ -166,32 +166,3 @@ export function buildManifestBuiltInModelSuppressionResolver(params: {
     };
   };
 }
-
-/**
- * Resolves whether a built-in model should be suppressed based on manifest declarations.
- *
- * Note: This function instantiates a fresh resolver on every call, which incurs a full
- * filesystem scan of the manifest registry. For hot paths (like building the model catalog),
- * instantiate and reuse `buildManifestBuiltInModelSuppressionResolver` instead.
- */
-export function resolveManifestBuiltInModelSuppression(params: {
-  provider?: string | null;
-  id?: string | null;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  baseUrl?: string | null;
-  unconditionalOnly?: boolean;
-}) {
-  const resolver = buildManifestBuiltInModelSuppressionResolver({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
-  return resolver({
-    provider: params.provider,
-    id: params.id,
-    baseUrl: params.baseUrl,
-    unconditionalOnly: params.unconditionalOnly,
-  });
-}

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -835,11 +835,6 @@ async function resolveHostedCatalogSnapshotStore(params: {
   });
 }
 
-/** Keep signature verification crypto lazy for ordinary catalog metadata paths. */
-export async function loadOfficialExternalPluginCatalogEnvelopeVerifier() {
-  return await import("./official-external-plugin-catalog-envelope.js");
-}
-
 export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   feedUrl?: string;
   feedProfile?: string;

--- a/src/plugins/provider-auth-choices.test.ts
+++ b/src/plugins/provider-auth-choices.test.ts
@@ -48,7 +48,6 @@ vi.resetModules();
 
 const {
   resolveManifestDeprecatedProviderAuthChoice,
-  resolveManifestProviderApiKeyChoice,
   resolveManifestProviderAuthChoice,
   resolveManifestProviderAuthChoices,
   resolveManifestProviderOnboardAuthFlags,
@@ -697,7 +696,7 @@ describe("provider auth choice manifest helpers", () => {
     ]);
   });
 
-  it("resolves api-key choices through manifest-owned provider auth aliases", () => {
+  it("resolves manifest-owned provider auth aliases", () => {
     setManifestPlugins([
       {
         id: "fixture-provider",
@@ -722,10 +721,5 @@ describe("provider auth choice manifest helpers", () => {
     const resolvedProviderId = resolveProviderIdForAuth("fixture-provider-plan");
     expect(pluginRegistryMocks.loadPluginMetadataSnapshot).toHaveBeenCalled();
     expect(resolvedProviderId).toBe("fixture-provider");
-    expect(
-      resolveManifestProviderApiKeyChoice({
-        providerId: "fixture-provider-plan",
-      })?.choiceId,
-    ).toBe("fixture-provider-api-key");
   });
 });

--- a/src/plugins/provider-auth-choices.ts
+++ b/src/plugins/provider-auth-choices.ts
@@ -1,6 +1,5 @@
 // Builds provider auth choice lists from plugin setup metadata.
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
-import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
@@ -301,25 +300,6 @@ export function resolveManifestProviderAuthChoice(
   return resolvePreferredManifestAuthChoiceMetadata({
     config: params,
     matches: (choice) => choice.choiceId === normalized,
-  });
-}
-
-export function resolveManifestProviderApiKeyChoice(params: {
-  providerId: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  includeUntrustedWorkspacePlugins?: boolean;
-}): ProviderAuthChoiceMetadata | undefined {
-  const normalizedProviderId = resolveProviderIdForAuth(params.providerId, params);
-  if (!normalizedProviderId) {
-    return undefined;
-  }
-  return resolvePreferredManifestAuthChoiceMetadata({
-    config: params,
-    matches: (choice) =>
-      Boolean(choice.optionKey) &&
-      resolveProviderIdForAuth(choice.providerId, params) === normalizedProviderId,
   });
 }
 

--- a/src/plugins/setup-registry.runtime.test.ts
+++ b/src/plugins/setup-registry.runtime.test.ts
@@ -1,4 +1,4 @@
-// Verifies runtime setup registry loading and lazy boundaries.
+// Verifies metadata-backed setup registry descriptor lookup.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearCurrentPluginMetadataSnapshot,
@@ -106,8 +106,8 @@ function createCurrentSnapshot(params: {
   } as unknown as PluginMetadataSnapshot;
 }
 
-describe("setup-registry runtime fallback", () => {
-  it("uses bundled registry cliBackends when the setup-registry runtime is unavailable", async () => {
+describe("setup-registry descriptor lookup", () => {
+  it("uses enabled metadata cliBackends", async () => {
     loadPluginMetadataSnapshotMock.mockReturnValue({
       index: {
         diagnostics: [],
@@ -135,20 +135,32 @@ describe("setup-registry runtime fallback", () => {
           origin: "bundled",
           cliBackends: ["Codex-CLI", "legacy-openai-cli"],
         },
+        {
+          id: "disabled",
+          origin: "bundled",
+          cliBackends: ["disabled-cli"],
+        },
+        {
+          id: "local",
+          origin: "workspace",
+          cliBackends: ["local-cli"],
+        },
       ],
     });
 
-    const { testing, resolvePluginSetupCliBackendRuntime } =
+    const { testing, resolvePluginSetupCliBackendDescriptor } =
       await import("./setup-registry.runtime.js");
-    testing.resetRuntimeState();
-    testing.setRuntimeModuleForTest(null);
+    testing.resetDescriptorCache();
 
-    expect(resolvePluginSetupCliBackendRuntime({ backend: "codex-cli" })).toEqual({
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "codex-cli" })).toEqual({
       pluginId: "openai",
       backend: { id: "Codex-CLI" },
     });
-    expect(resolvePluginSetupCliBackendRuntime({ backend: "local-cli" })).toBeUndefined();
-    expect(resolvePluginSetupCliBackendRuntime({ backend: "disabled-cli" })).toBeUndefined();
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "local-cli" })).toEqual({
+      pluginId: "local",
+      backend: { id: "local-cli" },
+    });
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "disabled-cli" })).toBeUndefined();
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledTimes(3);
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
       config: {},
@@ -156,11 +168,10 @@ describe("setup-registry runtime fallback", () => {
     });
   });
 
-  it("refreshes bundled registry cliBackends when the current metadata snapshot changes", async () => {
-    const { testing, resolvePluginSetupCliBackendRuntime } =
+  it("refreshes cliBackends when the current metadata snapshot changes", async () => {
+    const { testing, resolvePluginSetupCliBackendDescriptor } =
       await import("./setup-registry.runtime.js");
-    testing.resetRuntimeState();
-    testing.setRuntimeModuleForTest(null);
+    testing.resetDescriptorCache();
 
     setCurrentPluginMetadataSnapshot(
       createCurrentSnapshot({
@@ -170,11 +181,11 @@ describe("setup-registry runtime fallback", () => {
       { config: {}, env: process.env },
     );
 
-    expect(resolvePluginSetupCliBackendRuntime({ backend: "codex-cli" })).toEqual({
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "codex-cli" })).toEqual({
       pluginId: "openai",
       backend: { id: "Codex-CLI" },
     });
-    expect(resolvePluginSetupCliBackendRuntime({ backend: "next-cli" })).toBeUndefined();
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "next-cli" })).toBeUndefined();
 
     setCurrentPluginMetadataSnapshot(
       createCurrentSnapshot({
@@ -184,8 +195,8 @@ describe("setup-registry runtime fallback", () => {
       { config: {}, env: process.env },
     );
 
-    expect(resolvePluginSetupCliBackendRuntime({ backend: "codex-cli" })).toBeUndefined();
-    expect(resolvePluginSetupCliBackendRuntime({ backend: "next-cli" })).toEqual({
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "codex-cli" })).toBeUndefined();
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "next-cli" })).toEqual({
       pluginId: "openai",
       backend: { id: "Next-CLI" },
     });
@@ -193,10 +204,9 @@ describe("setup-registry runtime fallback", () => {
   });
 
   it("uses workspace-scoped current metadata through the active plugin runtime", async () => {
-    const { testing, resolvePluginSetupCliBackendRuntime } =
+    const { testing, resolvePluginSetupCliBackendDescriptor } =
       await import("./setup-registry.runtime.js");
-    testing.resetRuntimeState();
-    testing.setRuntimeModuleForTest(null);
+    testing.resetDescriptorCache();
 
     setActivePluginRegistry(
       createEmptyPluginRegistry(),
@@ -213,12 +223,12 @@ describe("setup-registry runtime fallback", () => {
       { config: {}, env: process.env },
     );
 
-    expect(resolvePluginSetupCliBackendRuntime({ backend: "codex-cli", config: {} })).toEqual({
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "codex-cli", config: {} })).toEqual({
       pluginId: "openai",
       backend: { id: "Codex-CLI" },
     });
     expect(
-      resolvePluginSetupCliBackendRuntime({ backend: "next-cli", config: {} }),
+      resolvePluginSetupCliBackendDescriptor({ backend: "next-cli", config: {} }),
     ).toBeUndefined();
 
     setCurrentPluginMetadataSnapshot(
@@ -231,9 +241,9 @@ describe("setup-registry runtime fallback", () => {
     );
 
     expect(
-      resolvePluginSetupCliBackendRuntime({ backend: "codex-cli", config: {} }),
+      resolvePluginSetupCliBackendDescriptor({ backend: "codex-cli", config: {} }),
     ).toBeUndefined();
-    expect(resolvePluginSetupCliBackendRuntime({ backend: "next-cli", config: {} })).toEqual({
+    expect(resolvePluginSetupCliBackendDescriptor({ backend: "next-cli", config: {} })).toEqual({
       pluginId: "openai",
       backend: { id: "Next-CLI" },
     });
@@ -249,10 +259,9 @@ describe("setup-registry runtime fallback", () => {
       plugins: [],
     });
 
-    const { testing, resolvePluginSetupCliBackendRuntime } =
+    const { testing, resolvePluginSetupCliBackendDescriptor } =
       await import("./setup-registry.runtime.js");
-    testing.resetRuntimeState();
-    testing.setRuntimeModuleForTest(null);
+    testing.resetDescriptorCache();
 
     setCurrentPluginMetadataSnapshot(
       createCurrentSnapshot({
@@ -264,37 +273,11 @@ describe("setup-registry runtime fallback", () => {
     );
 
     expect(
-      resolvePluginSetupCliBackendRuntime({ backend: "codex-cli", config: {} }),
+      resolvePluginSetupCliBackendDescriptor({ backend: "codex-cli", config: {} }),
     ).toBeUndefined();
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
       config: {},
       env: process.env,
     });
-  });
-
-  it("preserves fail-closed setup lookup when the runtime module explicitly declines to resolve", async () => {
-    loadPluginMetadataSnapshotMock.mockReturnValue({
-      index: {
-        diagnostics: [],
-        plugins: [
-          {
-            pluginId: "openai",
-            origin: "bundled",
-            enabled: true,
-          },
-        ],
-      },
-      plugins: [],
-    });
-
-    const { testing, resolvePluginSetupCliBackendRuntime } =
-      await import("./setup-registry.runtime.js");
-    testing.resetRuntimeState();
-    testing.setRuntimeModuleForTest({
-      resolvePluginSetupCliBackend: () => undefined,
-    });
-
-    expect(resolvePluginSetupCliBackendRuntime({ backend: "codex-cli" })).toBeUndefined();
-    expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/setup-registry.runtime.ts
+++ b/src/plugins/setup-registry.runtime.ts
@@ -1,5 +1,4 @@
-/** Runtime lookup helpers for plugin setup CLI backend descriptors. */
-import { createRequire } from "node:module";
+/** Metadata lookup helpers for plugin setup CLI backend descriptors. */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
@@ -9,51 +8,36 @@ import {
 } from "./plugin-metadata-snapshot.js";
 import { getActivePluginRegistryWorkspaceDirFromState } from "./runtime-state.js";
 
-type SetupRegistryRuntimeModule = Pick<
-  typeof import("./setup-registry.js"),
-  "resolvePluginSetupCliBackend"
->;
-
-type SetupCliBackendRuntimeEntry = {
+type SetupCliBackendDescriptorEntry = {
   pluginId: string;
   backend: {
     id: string;
   };
 };
 
-type SetupCliBackendRuntimeLookupParams = {
+type SetupCliBackendDescriptorLookupParams = {
   backend: string;
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 };
 
-const require = createRequire(import.meta.url);
-const SETUP_REGISTRY_RUNTIME_CANDIDATES = ["./setup-registry.js", "./setup-registry.ts"] as const;
-
 type SetupCliBackendDescriptorCache = {
   configFingerprint: string;
-  entries: SetupCliBackendRuntimeEntry[];
+  entries: SetupCliBackendDescriptorEntry[];
 };
 
-let setupRegistryRuntimeModule: SetupRegistryRuntimeModule | null | undefined;
 let cachedSetupCliBackendDescriptors: SetupCliBackendDescriptorCache | undefined;
-let cachedBundledSetupCliBackends: SetupCliBackendDescriptorCache | undefined;
 
-/** Test hooks for resetting setup-registry runtime module caches. */
+/** Test hook for resetting the descriptor cache. */
 export const testing = {
-  resetRuntimeState(): void {
-    setupRegistryRuntimeModule = undefined;
+  resetDescriptorCache(): void {
     cachedSetupCliBackendDescriptors = undefined;
-    cachedBundledSetupCliBackends = undefined;
-  },
-  setRuntimeModuleForTest(module: SetupRegistryRuntimeModule | null | undefined): void {
-    setupRegistryRuntimeModule = module;
   },
 };
 
 function resolveMetadataSnapshotForSetupCliBackends(
-  params: Omit<SetupCliBackendRuntimeLookupParams, "backend"> = {},
+  params: Omit<SetupCliBackendDescriptorLookupParams, "backend"> = {},
 ): {
   snapshot: PluginMetadataSnapshot;
   cacheable: boolean;
@@ -76,39 +60,9 @@ function resolveMetadataSnapshotForSetupCliBackends(
   };
 }
 
-function resolveBundledSetupCliBackends(
-  params: Omit<SetupCliBackendRuntimeLookupParams, "backend"> = {},
-): SetupCliBackendRuntimeEntry[] {
-  const { snapshot, cacheable } = resolveMetadataSnapshotForSetupCliBackends(params);
-  const configFingerprint = snapshot.configFingerprint;
-  if (
-    cacheable &&
-    configFingerprint &&
-    cachedBundledSetupCliBackends?.configFingerprint === configFingerprint
-  ) {
-    return cachedBundledSetupCliBackends.entries;
-  }
-  const entries = snapshot.plugins.flatMap((plugin) => {
-    if (plugin.origin !== "bundled" || !isInstalledPluginEnabled(snapshot.index, plugin.id)) {
-      return [];
-    }
-    return [...plugin.cliBackends, ...(plugin.setup?.cliBackends ?? [])].map(
-      (backendId) =>
-        ({
-          pluginId: plugin.id,
-          backend: { id: backendId },
-        }) satisfies SetupCliBackendRuntimeEntry,
-    );
-  });
-  if (cacheable && configFingerprint) {
-    cachedBundledSetupCliBackends = { configFingerprint, entries };
-  }
-  return entries;
-}
-
 function resolveSetupCliBackendDescriptors(
-  params: Omit<SetupCliBackendRuntimeLookupParams, "backend"> = {},
-): SetupCliBackendRuntimeEntry[] {
+  params: Omit<SetupCliBackendDescriptorLookupParams, "backend"> = {},
+): SetupCliBackendDescriptorEntry[] {
   const { snapshot, cacheable } = resolveMetadataSnapshotForSetupCliBackends(params);
   const configFingerprint = snapshot.configFingerprint;
   if (
@@ -127,7 +81,7 @@ function resolveSetupCliBackendDescriptors(
         ({
           pluginId: plugin.id,
           backend: { id: backendId },
-        }) satisfies SetupCliBackendRuntimeEntry,
+        }) satisfies SetupCliBackendDescriptorEntry,
     );
   });
   if (cacheable && configFingerprint) {
@@ -136,37 +90,11 @@ function resolveSetupCliBackendDescriptors(
   return entries;
 }
 
-function loadSetupRegistryRuntime(): SetupRegistryRuntimeModule | null {
-  if (setupRegistryRuntimeModule !== undefined) {
-    return setupRegistryRuntimeModule;
-  }
-  for (const candidate of SETUP_REGISTRY_RUNTIME_CANDIDATES) {
-    try {
-      setupRegistryRuntimeModule = require(candidate) as SetupRegistryRuntimeModule;
-      return setupRegistryRuntimeModule;
-    } catch {
-      // Try source/runtime candidates in order.
-    }
-  }
-  setupRegistryRuntimeModule = null;
-  return null;
-}
-
-export function resolvePluginSetupCliBackendDescriptor(params: SetupCliBackendRuntimeLookupParams) {
+export function resolvePluginSetupCliBackendDescriptor(
+  params: SetupCliBackendDescriptorLookupParams,
+) {
   const normalized = normalizeProviderId(params.backend);
   return resolveSetupCliBackendDescriptors(params).find(
     (entry) => normalizeProviderId(entry.backend.id) === normalized,
   );
 }
-
-export function resolvePluginSetupCliBackendRuntime(params: SetupCliBackendRuntimeLookupParams) {
-  const normalized = normalizeProviderId(params.backend);
-  const runtime = loadSetupRegistryRuntime();
-  if (runtime !== null) {
-    return runtime.resolvePluginSetupCliBackend(params);
-  }
-  return resolveBundledSetupCliBackends(params).find(
-    (entry) => normalizeProviderId(entry.backend.id) === normalized,
-  );
-}
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

The plugin runtime owner still carried an obsolete setup runtime loader, duplicate metadata projections, and helper exports that had no production callers. That duplicated discovery policy, cache state, and test-only API surface around the canonical metadata-backed paths.

## Why This Change Was Made

Remove the unused setup runtime fallback and five orphan helper exports, then retarget coverage to the retained descriptor, suppression-resolver, auth-alias, capability-provider, and hosted-catalog paths. The live metadata snapshot and active registry behavior remain unchanged.

## User Impact

No user-visible behavior changes. Maintainers get a smaller plugin runtime surface with one canonical lookup path and less cache/test scaffolding.

## Evidence

- Codebase-memory full index: 304,219 nodes and 1,255,715 edges; exact symbol searches and caller traces found no production consumers for the removed helpers.
- Blacksmith Testbox `tbx_01kxav8hv7a0hfa3qbr511zm4k`: 137 focused tests passed across the affected agent/plugin suites.
- Same Testbox: path-scoped `pnpm check:changed` passed, including core/core-test typechecks, Plugin SDK API baseline, all core lint shards, import-cycle checks, and architecture guards.
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, clean with no accepted/actionable findings (0.91 confidence).

AI-assisted: yes. The implementation and proof were reviewed before submission; no transcript is attached.
