### PR TITLE
feat(cloud-workers): replayable worker live-event streaming into the session fanout

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -177,8 +177,8 @@ hash, owner epoch, RPC-set version, expiry, and one nullable session; it
 separately checks the current version and feature set. Success returns minimal
 `worker-hello-ok`; feature negotiation is independent of the general protocol
 version. Frames stay under 64 KiB. The closed allowlist contains
-`worker.heartbeat` and `worker.transcript.commit` for ordered semantic message batches. Transcript
-commits use owner-epoch fencing, a gateway-owned session binding, base-leaf
+`worker.heartbeat`, `worker.transcript.commit`, and `worker.live-event`.
+Transcript commits use owner-epoch fencing, a gateway-owned session binding, base-leaf
 compare-and-swap, and durable sequence replay; the gateway generates transcript
 entry and parent IDs through the normal session writer. Ownership and expiry are
 rechecked on each RPC.

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -423,6 +423,20 @@ import {
   type WorkerHeartbeatResponseFrame,
   WorkerHeartbeatResponseFrameSchema,
   type WorkerHelloOk,
+  type WorkerLiveEvent,
+  WorkerLiveEventSchema,
+  type WorkerLiveEventErrorDetails,
+  WorkerLiveEventErrorDetailsSchema,
+  type WorkerLiveEventErrorShape,
+  WorkerLiveEventErrorShapeSchema,
+  type WorkerLiveEventParams,
+  WorkerLiveEventParamsSchema,
+  type WorkerLiveEventRequestFrame,
+  WorkerLiveEventRequestFrameSchema,
+  type WorkerLiveEventResponseFrame,
+  WorkerLiveEventResponseFrameSchema,
+  type WorkerLiveEventResult,
+  WorkerLiveEventResultSchema,
   type WorkerProtocolCloseReason,
   WorkerProtocolCloseReasonSchema,
   type WorkerTranscriptCommitErrorReason,
@@ -440,6 +454,7 @@ import {
   type WorkerTranscriptMessage,
   WorkerTranscriptMessageSchema,
   WORKER_HEARTBEAT_INTERVAL_MS,
+  WORKER_LIVE_EVENT_PROTOCOL_FEATURE,
   WORKER_PROTOCOL_FEATURES,
   WORKER_PROTOCOL_MAX_FEATURE_LENGTH,
   WORKER_PROTOCOL_MAX_FEATURES,
@@ -952,7 +967,7 @@ export const validateWorkerHeartbeatParams = lazyCompile<WorkerHeartbeatParams>(
   WorkerHeartbeatParamsSchema,
 );
 
-function checkWorkerTranscriptCommitJson(data: unknown): ValidationError | undefined {
+function checkWorkerProtocolJson(data: unknown): ValidationError | undefined {
   const stack: Array<{ depth: number; value: unknown }> = [{ depth: 0, value: data }];
   const seen = new WeakSet<object>();
   while (stack.length > 0) {
@@ -999,7 +1014,11 @@ function checkWorkerTranscriptCommitJson(data: unknown): ValidationError | undef
 
 export const validateWorkerTranscriptCommitParams = lazyCompile<WorkerTranscriptCommitParams>(
   WorkerTranscriptCommitParamsSchema,
-  checkWorkerTranscriptCommitJson,
+  checkWorkerProtocolJson,
+);
+export const validateWorkerLiveEventParams = lazyCompile<WorkerLiveEventParams>(
+  WorkerLiveEventParamsSchema,
+  checkWorkerProtocolJson,
 );
 export const validateGatewaySuspendPrepareParams = lazyCompile<GatewaySuspendPrepareParams>(
   GatewaySuspendPrepareParamsSchema,
@@ -1620,6 +1639,13 @@ export {
   WorkerHeartbeatParamsSchema,
   WorkerHeartbeatRequestFrameSchema,
   WorkerHeartbeatResponseFrameSchema,
+  WorkerLiveEventSchema,
+  WorkerLiveEventErrorDetailsSchema,
+  WorkerLiveEventErrorShapeSchema,
+  WorkerLiveEventParamsSchema,
+  WorkerLiveEventRequestFrameSchema,
+  WorkerLiveEventResponseFrameSchema,
+  WorkerLiveEventResultSchema,
   WorkerProtocolCloseReasonSchema,
   WorkerTranscriptCommitErrorReasonSchema,
   WorkerTranscriptCommitErrorShapeSchema,
@@ -1629,6 +1655,7 @@ export {
   WorkerTranscriptCommitResultSchema,
   WorkerTranscriptMessageSchema,
   WORKER_HEARTBEAT_INTERVAL_MS,
+  WORKER_LIVE_EVENT_PROTOCOL_FEATURE,
   WORKER_PROTOCOL_FEATURES,
   WORKER_PROTOCOL_MAX_FEATURE_LENGTH,
   WORKER_PROTOCOL_MAX_FEATURES,
@@ -2023,6 +2050,13 @@ export type {
   WorkerHeartbeatResult,
   WorkerHeartbeatResponseFrame,
   WorkerHelloOk,
+  WorkerLiveEvent,
+  WorkerLiveEventErrorDetails,
+  WorkerLiveEventErrorShape,
+  WorkerLiveEventParams,
+  WorkerLiveEventRequestFrame,
+  WorkerLiveEventResponseFrame,
+  WorkerLiveEventResult,
   WorkerProtocolCloseReason,
   WorkerTranscriptCommitErrorReason,
   WorkerTranscriptCommitErrorShape,

--- a/packages/gateway-protocol/src/schema/worker-admission.test.ts
+++ b/packages/gateway-protocol/src/schema/worker-admission.test.ts
@@ -6,14 +6,18 @@ import {
   WorkerAdmissionResponseFrameSchema,
   WorkerHeartbeatRequestFrameSchema,
   WorkerHeartbeatResponseFrameSchema,
+  WorkerLiveEventRequestFrameSchema,
+  WorkerLiveEventResponseFrameSchema,
   WorkerProtocolCloseReasonSchema,
   WorkerTranscriptCommitRequestFrameSchema,
   WorkerTranscriptCommitResponseFrameSchema,
+  WORKER_PROTOCOL_FEATURES,
   WORKER_RPC_SET_VERSION,
   WORKER_TRANSCRIPT_MAX_JSON_DEPTH,
   validateWorkerAdmissionHandshake,
   validateWorkerConnectRequestFrame,
   validateWorkerHeartbeatParams,
+  validateWorkerLiveEventParams,
   validateWorkerTranscriptCommitParams,
 } from "../index.js";
 
@@ -93,6 +97,47 @@ const transcriptMessages = [
     timestamp: 3,
   },
 ];
+const liveBase = { runEpoch: 2, lastAckedSeq: 0, seq: 1, runId: "r" };
+const models = {
+  selectedProvider: "p",
+  selectedModel: "m",
+  activeProvider: "q",
+  activeModel: "n",
+};
+const event = (kind: string, payload: Record<string, unknown>) => ({ kind, payload });
+const params = (liveEvent: unknown, overrides: Record<string, unknown> = {}) => ({
+  ...liveBase,
+  event: liveEvent,
+  ...overrides,
+});
+const tool = (phase: string, payload: Record<string, unknown>) =>
+  event("tool", { phase, name: "t", toolCallId: "c", ...payload });
+
+const approval = (phase: string, status: string) =>
+  event("approval", { phase, kind: "exec", status, title: "x" });
+const lifecycle = (phase: string, payload: Record<string, unknown> = {}) =>
+  event("lifecycle", { phase, ...payload });
+const fallbackStep = (outcome: string) =>
+  lifecycle("fallback_step", {
+    fallbackStepType: "fallback_step",
+    fallbackStepFromModel: "p/m",
+    fallbackStepFinalOutcome: outcome,
+  });
+const assistant = event("assistant", { text: "x", delta: "x" });
+const validateLive = validateWorkerLiveEventParams;
+const liveError = (details: Record<string, unknown>) => ({
+  ok: false,
+  error: { code: "INVALID_REQUEST", message: "x", details },
+});
+const liveRequest = (value: unknown) =>
+  Value.Check(WorkerLiveEventRequestFrameSchema, {
+    type: "req",
+    id: "l",
+    method: "worker.live-event",
+    params: value,
+  });
+const liveResponse = (value: Record<string, unknown>) =>
+  Value.Check(WorkerLiveEventResponseFrameSchema, { type: "res", id: "l", ...value });
 
 describe("worker admission handshake schema", () => {
   it("accepts the bootstrap receipt and future unique feature names", () => {
@@ -157,19 +202,19 @@ describe("worker protocol schemas", () => {
   });
 
   it("accepts semantic transcript commits and generated-id responses", () => {
-    const params = {
+    const commitParams = {
       runEpoch: 2,
       seq: 1,
       baseLeafId: null,
       messages: transcriptMessages,
     };
-    expect(validateWorkerTranscriptCommitParams(params)).toBe(true);
+    expect(validateWorkerTranscriptCommitParams(commitParams)).toBe(true);
     expect(
       Value.Check(WorkerTranscriptCommitRequestFrameSchema, {
         type: "req",
         id: "commit-1",
         method: "worker.transcript.commit",
-        params,
+        params: commitParams,
       }),
     ).toBe(true);
     expect(
@@ -206,6 +251,82 @@ describe("worker protocol schemas", () => {
     ).toBe(true);
   });
 
+  it("validates the additive live-event protocol", () => {
+    expect(WORKER_RPC_SET_VERSION).toBe(1);
+    expect(WORKER_PROTOCOL_FEATURES).toContain("worker-live-event-v1");
+    for (const validEvent of [
+      assistant,
+      event("thinking", { text: "x", delta: "x" }),
+      tool("start", { args: {} }),
+      tool("update", { partialResult: { output: "x" } }),
+      tool("result", { result: { output: "x" }, isError: false }),
+      approval("requested", "pending"),
+      approval("resolved", "approved"),
+      lifecycle("start", { startedAt: 1 }),
+      lifecycle("fallback", {
+        ...models,
+        reasonSummary: "x",
+        attemptSummaries: ["x"],
+        attempts: [{ provider: "p", model: "m", error: "x", authMode: "key" }],
+      }),
+      lifecycle("fallback_cleared", models),
+      fallbackStep("next_fallback"),
+      lifecycle("finishing", { endedAt: 2, error: "x" }),
+      lifecycle("end", { endedAt: 3 }),
+      lifecycle("error", { endedAt: 4, error: "x" }),
+    ]) {
+      expect(validateLive(params(validEvent))).toBe(true);
+    }
+    expect(liveRequest(params(assistant))).toBe(true);
+    expect(liveResponse({ ok: true, payload: { ackedSeq: 3 } })).toBe(true);
+    for (const details of [
+      { reason: "epoch-mismatch" },
+      { reason: "session-not-attached" },
+      { reason: "invalid-event" },
+      { reason: "capacity-exceeded" },
+      { reason: "resync-required", ackedSeq: 3, expectedSeq: 4 },
+    ]) {
+      expect(liveResponse(liveError(details))).toBe(true);
+    }
+    expect(liveResponse(liveError({ reason: "later" }))).toBe(false);
+    expect(liveResponse({ ok: true, payload: { ackedSeq: -1 } })).toBe(false);
+    for (const [field, value] of [
+      ["runEpoch", -1],
+      ["lastAckedSeq", -1],
+      ["lastAckedSeq", Number.MAX_SAFE_INTEGER + 1],
+      ["seq", 0],
+      ["seq", Number.MAX_SAFE_INTEGER + 1],
+    ] as const) {
+      expect(validateLive(params(assistant, { [field]: value }))).toBe(false);
+    }
+    for (const invalid of [
+      params(event("unknown", {})),
+      params(tool("start", { args: {}, partialResult: {} })),
+      params(approval("requested", "approved")),
+      params(lifecycle("end", { endedAt: 4, error: "stopped" })),
+      params(fallbackStep("retrying")),
+      params({ ...assistant, seq: 8 }),
+      params(assistant, { sessionKey: "x" }),
+      {
+        runEpoch: liveBase.runEpoch,
+        seq: liveBase.seq,
+        runId: liveBase.runId,
+        event: assistant,
+      },
+    ]) {
+      expect(validateLive(invalid)).toBe(false);
+    }
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+    for (const [value, keyword] of [
+      [Number.POSITIVE_INFINITY, "finite"],
+      [cyclic, "acyclic"],
+    ] as const) {
+      expect(validateLive(params(tool("update", { partialResult: value })))).toBe(false);
+      expect(validateLive.errors?.[0]).toMatchObject({ keyword });
+    }
+  });
+
   it.each([
     { runEpoch: 2, seq: 1, baseLeafId: null, messages: [] },
     { runEpoch: 2, seq: 0, baseLeafId: null, messages: transcriptMessages },
@@ -237,8 +358,8 @@ describe("worker protocol schemas", () => {
     for (let depth = 0; depth <= WORKER_TRANSCRIPT_MAX_JSON_DEPTH; depth += 1) {
       nested = { nested };
     }
-    const assistant = transcriptMessages[1];
-    if (!assistant || assistant.role !== "assistant") {
+    const transcriptAssistant = transcriptMessages[1];
+    if (!transcriptAssistant || transcriptAssistant.role !== "assistant") {
       throw new Error("expected assistant transcript fixture");
     }
     const candidate = {
@@ -247,7 +368,7 @@ describe("worker protocol schemas", () => {
       baseLeafId: null,
       messages: [
         {
-          ...assistant,
+          ...transcriptAssistant,
           content: [
             {
               type: "toolCall" as const,

--- a/packages/gateway-protocol/src/schema/worker-admission.ts
+++ b/packages/gateway-protocol/src/schema/worker-admission.ts
@@ -1,14 +1,20 @@
-import { Type, type Static } from "typebox";
+import { Type, type Static, type TProperties } from "typebox";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../client-info.js";
 
 // Additive RPCs require exact build-bound features; bump only for an incompatible base set.
 export const WORKER_RPC_SET_VERSION = 1;
 export const WORKER_HEARTBEAT_INTERVAL_MS = 15_000;
-export const WORKER_PROTOCOL_METHODS = ["worker.heartbeat", "worker.transcript.commit"] as const;
+export const WORKER_PROTOCOL_METHODS = [
+  "worker.heartbeat",
+  "worker.transcript.commit",
+  "worker.live-event",
+] as const;
 export const WORKER_TRANSCRIPT_COMMIT_PROTOCOL_FEATURE = "worker-transcript-commit-v1";
+export const WORKER_LIVE_EVENT_PROTOCOL_FEATURE = "worker-live-event-v1";
 export const WORKER_PROTOCOL_FEATURES = [
   "worker-heartbeat-v1",
   WORKER_TRANSCRIPT_COMMIT_PROTOCOL_FEATURE,
+  WORKER_LIVE_EVENT_PROTOCOL_FEATURE,
 ] as const;
 export const WORKER_PROTOCOL_MAX_IDENTIFIER_LENGTH = 256;
 export const WORKER_PROTOCOL_MAX_FRAME_ID_LENGTH = 128;
@@ -493,6 +499,298 @@ export const WorkerTranscriptCommitResponseFrameSchema = Type.Union([
   WorkerErrorResponseFrameSchema,
 ]);
 
+function workerLiveObject<const Properties extends TProperties>(properties: Properties) {
+  return Type.Object(properties, { additionalProperties: false });
+}
+
+const LiveTextSchema = Type.String({
+  maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES,
+});
+const OptionalLiveTextSchema = Type.Optional(LiveTextSchema);
+const LiveIntegerSchema = Type.Integer({
+  minimum: 0,
+  maximum: Number.MAX_SAFE_INTEGER,
+});
+const OptionalLiveIntegerSchema = Type.Optional(LiveIntegerSchema);
+const LiveSequenceSchema = Type.Integer({
+  minimum: 1,
+  maximum: Number.MAX_SAFE_INTEGER,
+});
+
+const LiveIdentifierSchema = Type.String({
+  minLength: 1,
+  maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES,
+  pattern: "^\\S(?:.*\\S)?$",
+});
+
+const WorkerLiveAssistantPayloadSchema = workerLiveObject({
+  text: LiveTextSchema,
+  delta: LiveTextSchema,
+  replace: Type.Optional(Type.Literal(true)),
+  mediaUrls: Type.Optional(
+    Type.Array(LiveIdentifierSchema, {
+      maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS,
+    }),
+  ),
+  phase: Type.Optional(Type.Union([Type.Literal("commentary"), Type.Literal("final_answer")])),
+  itemId: Type.Optional(WorkerIdentifierSchema),
+});
+
+const WorkerLiveThinkingPayloadSchema = workerLiveObject({
+  text: LiveTextSchema,
+  delta: LiveTextSchema,
+});
+
+const WorkerLiveToolCommonProperties = {
+  name: WorkerIdentifierSchema,
+  toolCallId: WorkerIdentifierSchema,
+  hideFromChannelProgress: Type.Optional(Type.Literal(true)),
+};
+
+const WorkerLiveToolPayloadSchema = Type.Union([
+  workerLiveObject({
+    ...WorkerLiveToolCommonProperties,
+    phase: Type.Literal("start"),
+    args: Type.Unknown(),
+  }),
+  workerLiveObject({
+    ...WorkerLiveToolCommonProperties,
+    phase: Type.Literal("update"),
+    partialResult: Type.Unknown(),
+  }),
+  workerLiveObject({
+    ...WorkerLiveToolCommonProperties,
+    phase: Type.Literal("result"),
+    meta: OptionalLiveTextSchema,
+    isError: Type.Boolean(),
+    result: Type.Unknown(),
+    toolErrorSummary: OptionalLiveTextSchema,
+  }),
+]);
+
+const WorkerLiveApprovalCommonProperties = {
+  kind: Type.Union([Type.Literal("exec"), Type.Literal("plugin"), Type.Literal("unknown")]),
+  title: LiveTextSchema,
+  itemId: Type.Optional(WorkerIdentifierSchema),
+  toolCallId: Type.Optional(WorkerIdentifierSchema),
+  approvalId: Type.Optional(WorkerIdentifierSchema),
+  approvalSlug: Type.Optional(WorkerIdentifierSchema),
+  command: OptionalLiveTextSchema,
+  host: OptionalLiveTextSchema,
+  reason: OptionalLiveTextSchema,
+  scope: Type.Optional(Type.Union([Type.Literal("turn"), Type.Literal("session")])),
+  message: OptionalLiveTextSchema,
+};
+
+const WorkerLiveApprovalPayloadSchema = Type.Union([
+  workerLiveObject({
+    ...WorkerLiveApprovalCommonProperties,
+    phase: Type.Literal("requested"),
+    status: Type.Union([Type.Literal("pending"), Type.Literal("unavailable")]),
+  }),
+  workerLiveObject({
+    ...WorkerLiveApprovalCommonProperties,
+    phase: Type.Literal("resolved"),
+    status: Type.Union([Type.Literal("approved"), Type.Literal("denied"), Type.Literal("failed")]),
+  }),
+]);
+
+const WorkerLiveLifecycleStartPayloadSchema = workerLiveObject({
+  phase: Type.Literal("start"),
+  startedAt: LiveIntegerSchema,
+});
+
+const WorkerLiveFallbackReasonSchema = Type.Union([
+  Type.Literal("auth"),
+  Type.Literal("auth_permanent"),
+  Type.Literal("format"),
+  Type.Literal("rate_limit"),
+  Type.Literal("overloaded"),
+  Type.Literal("billing"),
+  Type.Literal("server_error"),
+  Type.Literal("timeout"),
+  Type.Literal("context_overflow"),
+  Type.Literal("model_not_found"),
+  Type.Literal("session_expired"),
+  Type.Literal("empty_response"),
+  Type.Literal("no_error_details"),
+  Type.Literal("unclassified"),
+  Type.Literal("unknown"),
+]);
+
+const WorkerLiveFallbackAttemptSchema = workerLiveObject({
+  provider: LiveIdentifierSchema,
+  model: LiveIdentifierSchema,
+  error: LiveTextSchema,
+  reason: Type.Optional(WorkerLiveFallbackReasonSchema),
+  authMode: Type.Optional(LiveIdentifierSchema),
+  status: OptionalLiveIntegerSchema,
+  code: Type.Optional(Type.String({ minLength: 1, maxLength: WORKER_PROTOCOL_MAX_PAYLOAD_BYTES })),
+});
+
+const WorkerLiveFallbackCommonProperties = {
+  selectedProvider: LiveIdentifierSchema,
+  selectedModel: LiveIdentifierSchema,
+  activeProvider: LiveIdentifierSchema,
+  activeModel: LiveIdentifierSchema,
+};
+
+const WorkerLiveLifecycleFallbackPayloadSchema = workerLiveObject({
+  ...WorkerLiveFallbackCommonProperties,
+  phase: Type.Literal("fallback"),
+  reasonSummary: LiveTextSchema,
+  attemptSummaries: Type.Array(LiveTextSchema, {
+    maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS,
+  }),
+  attempts: Type.Array(WorkerLiveFallbackAttemptSchema, {
+    maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS,
+  }),
+});
+
+const WorkerLiveLifecycleFallbackClearedPayloadSchema = workerLiveObject({
+  ...WorkerLiveFallbackCommonProperties,
+  phase: Type.Literal("fallback_cleared"),
+  previousActiveModel: Type.Optional(LiveIdentifierSchema),
+});
+
+const WorkerLiveLifecycleFallbackStepPayloadSchema = workerLiveObject({
+  phase: Type.Literal("fallback_step"),
+  fallbackStepType: Type.Literal("fallback_step"),
+  fallbackStepFromModel: LiveIdentifierSchema,
+  fallbackStepToModel: Type.Optional(LiveIdentifierSchema),
+  fallbackStepFromFailureReason: Type.Optional(WorkerLiveFallbackReasonSchema),
+  fallbackStepFromFailureDetail: OptionalLiveTextSchema,
+  fallbackStepChainPosition: OptionalLiveIntegerSchema,
+  fallbackStepFinalOutcome: Type.Union([
+    Type.Literal("next_fallback"),
+    Type.Literal("succeeded"),
+    Type.Literal("chain_exhausted"),
+  ]),
+});
+
+const WorkerLiveLifecycleTerminalCommonProperties = {
+  startedAt: OptionalLiveIntegerSchema,
+  endedAt: LiveIntegerSchema,
+  stopReason: Type.Optional(WorkerIdentifierSchema),
+  yielded: Type.Optional(Type.Literal(true)),
+  timeoutPhase: Type.Optional(
+    Type.Union([
+      Type.Literal("queue"),
+      Type.Literal("preflight"),
+      Type.Literal("provider"),
+      Type.Literal("post_turn"),
+      Type.Literal("gateway_draining"),
+    ]),
+  ),
+  providerStarted: Type.Optional(Type.Boolean()),
+  aborted: Type.Optional(Type.Boolean()),
+  toolErrorSummary: OptionalLiveTextSchema,
+  livenessState: Type.Optional(
+    Type.Union([
+      Type.Literal("working"),
+      Type.Literal("paused"),
+      Type.Literal("blocked"),
+      Type.Literal("abandoned"),
+    ]),
+  ),
+  replayInvalid: Type.Optional(Type.Literal(true)),
+};
+
+const WorkerLiveLifecycleTerminalPayloadSchema = Type.Union([
+  workerLiveObject({
+    ...WorkerLiveLifecycleTerminalCommonProperties,
+    phase: Type.Literal("finishing"),
+    error: OptionalLiveTextSchema,
+  }),
+  workerLiveObject({
+    ...WorkerLiveLifecycleTerminalCommonProperties,
+    phase: Type.Literal("end"),
+  }),
+  workerLiveObject({
+    ...WorkerLiveLifecycleTerminalCommonProperties,
+    phase: Type.Literal("error"),
+    error: LiveTextSchema,
+    fallbackExhaustedFailure: Type.Optional(Type.Literal(true)),
+  }),
+]);
+
+const WorkerLiveLifecyclePayloadSchema = Type.Union([
+  WorkerLiveLifecycleStartPayloadSchema,
+  WorkerLiveLifecycleFallbackPayloadSchema,
+  WorkerLiveLifecycleFallbackClearedPayloadSchema,
+  WorkerLiveLifecycleFallbackStepPayloadSchema,
+  WorkerLiveLifecycleTerminalPayloadSchema,
+]);
+
+export const WorkerLiveEventSchema = Type.Union([
+  workerLiveObject({ kind: Type.Literal("assistant"), payload: WorkerLiveAssistantPayloadSchema }),
+  workerLiveObject({ kind: Type.Literal("thinking"), payload: WorkerLiveThinkingPayloadSchema }),
+  workerLiveObject({ kind: Type.Literal("tool"), payload: WorkerLiveToolPayloadSchema }),
+  workerLiveObject({ kind: Type.Literal("approval"), payload: WorkerLiveApprovalPayloadSchema }),
+  workerLiveObject({ kind: Type.Literal("lifecycle"), payload: WorkerLiveLifecyclePayloadSchema }),
+]);
+
+export const WorkerLiveEventParamsSchema = workerLiveObject({
+  runEpoch: LiveIntegerSchema,
+  lastAckedSeq: LiveIntegerSchema,
+  seq: LiveSequenceSchema,
+  runId: WorkerIdentifierSchema,
+  event: WorkerLiveEventSchema,
+});
+
+export const WorkerLiveEventResultSchema = workerLiveObject({
+  ackedSeq: LiveIntegerSchema,
+});
+
+export const WorkerLiveEventErrorDetailsSchema = Type.Union([
+  workerLiveObject({
+    reason: Type.Union([
+      Type.Literal("epoch-mismatch"),
+      Type.Literal("session-not-attached"),
+      Type.Literal("invalid-event"),
+      Type.Literal("capacity-exceeded"),
+    ]),
+  }),
+  workerLiveObject({
+    reason: Type.Literal("resync-required"),
+    ackedSeq: LiveIntegerSchema,
+    expectedSeq: LiveSequenceSchema,
+  }),
+]);
+
+export const WorkerLiveEventErrorShapeSchema = workerLiveObject({
+  code: Type.Literal("INVALID_REQUEST"),
+  message: Type.String({ minLength: 1, maxLength: 256 }),
+  details: WorkerLiveEventErrorDetailsSchema,
+});
+
+export const WorkerLiveEventRequestFrameSchema = workerLiveObject({
+  type: Type.Literal("req"),
+  id: WorkerFrameIdSchema,
+  method: Type.Literal(WORKER_PROTOCOL_METHODS[2]),
+  params: WorkerLiveEventParamsSchema,
+});
+
+const WorkerLiveEventSuccessResponseFrameSchema = workerLiveObject({
+  type: Type.Literal("res"),
+  id: WorkerFrameIdSchema,
+  ok: Type.Literal(true),
+  payload: WorkerLiveEventResultSchema,
+});
+
+const WorkerLiveEventErrorResponseFrameSchema = workerLiveObject({
+  type: Type.Literal("res"),
+  id: WorkerFrameIdSchema,
+  ok: Type.Literal(false),
+  error: WorkerLiveEventErrorShapeSchema,
+});
+
+export const WorkerLiveEventResponseFrameSchema = Type.Union([
+  WorkerLiveEventSuccessResponseFrameSchema,
+  WorkerLiveEventErrorResponseFrameSchema,
+  WorkerErrorResponseFrameSchema,
+]);
+
 export type WorkerAdmissionHandshake = Static<typeof WorkerAdmissionHandshakeSchema>;
 export type WorkerConnectParams = Static<typeof WorkerConnectParamsSchema>;
 export type WorkerConnectRequestFrame = Static<typeof WorkerConnectRequestFrameSchema>;
@@ -520,3 +818,10 @@ export type WorkerTranscriptCommitRequestFrame = Static<
 export type WorkerTranscriptCommitResponseFrame = Static<
   typeof WorkerTranscriptCommitResponseFrameSchema
 >;
+export type WorkerLiveEvent = Static<typeof WorkerLiveEventSchema>;
+export type WorkerLiveEventParams = Static<typeof WorkerLiveEventParamsSchema>;
+export type WorkerLiveEventResult = Static<typeof WorkerLiveEventResultSchema>;
+export type WorkerLiveEventErrorDetails = Static<typeof WorkerLiveEventErrorDetailsSchema>;
+export type WorkerLiveEventErrorShape = Static<typeof WorkerLiveEventErrorShapeSchema>;
+export type WorkerLiveEventRequestFrame = Static<typeof WorkerLiveEventRequestFrameSchema>;
+export type WorkerLiveEventResponseFrame = Static<typeof WorkerLiveEventResponseFrameSchema>;

--- a/packages/gateway-protocol/src/schema/worker-admission.ts
+++ b/packages/gateway-protocol/src/schema/worker-admission.ts
@@ -730,7 +730,13 @@ export const WorkerLiveEventSchema = Type.Union([
   workerLiveObject({ kind: Type.Literal("lifecycle"), payload: WorkerLiveLifecyclePayloadSchema }),
 ]);
 
-export const WorkerLiveEventParamsSchema = workerLiveObject({
+export const WorkerLiveEventParamsSchema: Type.TObject<{
+  readonly runEpoch: typeof LiveIntegerSchema;
+  readonly lastAckedSeq: typeof LiveIntegerSchema;
+  readonly seq: typeof LiveSequenceSchema;
+  readonly runId: typeof WorkerIdentifierSchema;
+  readonly event: typeof WorkerLiveEventSchema;
+}> = workerLiveObject({
   runEpoch: LiveIntegerSchema,
   lastAckedSeq: LiveIntegerSchema,
   seq: LiveSequenceSchema,
@@ -764,7 +770,12 @@ export const WorkerLiveEventErrorShapeSchema = workerLiveObject({
   details: WorkerLiveEventErrorDetailsSchema,
 });
 
-export const WorkerLiveEventRequestFrameSchema = workerLiveObject({
+export const WorkerLiveEventRequestFrameSchema: Type.TObject<{
+  readonly type: Type.TLiteral<"req">;
+  readonly id: typeof WorkerFrameIdSchema;
+  readonly method: Type.TLiteral<(typeof WORKER_PROTOCOL_METHODS)[2]>;
+  readonly params: typeof WorkerLiveEventParamsSchema;
+}> = workerLiveObject({
   type: Type.Literal("req"),
   id: WorkerFrameIdSchema,
   method: Type.Literal(WORKER_PROTOCOL_METHODS[2]),

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -38,7 +38,6 @@ import {
 import { hasReplyPayloadContent } from "../interactive/payload.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
-import { truncateUtf16Safe } from "../utils.js";
 import { hasTopLevelShellControlOperator, splitShellArgs } from "../utils/shell-argv.js";
 import { normalizeAcceptedSessionSpawnResult } from "./accepted-session-spawn.js";
 import {
@@ -70,6 +69,7 @@ import { isPromiseLike } from "./embedded-agent-subscribe.promise.js";
 import {
   collectMessagingMediaUrlsFromRecord,
   collectMessagingMediaUrlsFromToolResult,
+  capLiveExecResult,
   extractMessagingToolSourceReplyPayload,
   extractToolResultMediaArtifact,
   extractToolErrorCode,
@@ -82,6 +82,7 @@ import {
   isToolResultTimedOut,
   sanitizeToolArgs,
   sanitizeToolResult,
+  truncateLiveExecOutput,
 } from "./embedded-agent-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./embedded-agent-utils.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
@@ -106,7 +107,6 @@ const execApprovalReplyModuleLoader = createLazyImportLoader<ExecApprovalReplyMo
 const hookRunnerGlobalModuleLoader = createLazyImportLoader<HookRunnerGlobalModule>(
   () => import("../plugins/hook-runner-global.js"),
 );
-const LIVE_EXEC_OUTPUT_MAX_CHARS = 8000;
 const LIVE_EXEC_UPDATE_MIN_INTERVAL_MS = 250;
 const TRACE_REQUIRED_PARAM_GROUPS = {
   read: [{ keys: ["path", "file_path"], label: "path" }],
@@ -398,39 +398,6 @@ function readExecToolDetails(result: unknown): ExecToolDetails | null {
     return null;
   }
   return details as ExecToolDetails;
-}
-
-function truncateLiveExecOutput(text: string): string {
-  if (text.length <= LIVE_EXEC_OUTPUT_MAX_CHARS) {
-    return text;
-  }
-  return `${truncateUtf16Safe(text, LIVE_EXEC_OUTPUT_MAX_CHARS)}\n...(live output truncated)...`;
-}
-
-function capLiveExecResult(result: unknown): unknown {
-  const execDetails = readExecToolDetails(result);
-  if (
-    !execDetails ||
-    !("aggregated" in execDetails) ||
-    typeof execDetails.aggregated !== "string"
-  ) {
-    return result;
-  }
-  const aggregated = truncateLiveExecOutput(execDetails.aggregated);
-  if (aggregated === execDetails.aggregated) {
-    return result;
-  }
-  if (!result || typeof result !== "object" || Array.isArray(result)) {
-    return result;
-  }
-  const details = readToolResultDetails(result);
-  return {
-    ...(result as Record<string, unknown>),
-    details: {
-      ...details,
-      aggregated,
-    },
-  };
 }
 
 function extractExecOutput(result: unknown): string | undefined {

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -37,6 +37,7 @@ export { isToolResultError };
 
 const TOOL_RESULT_MAX_CHARS = 8000;
 const TOOL_ERROR_MAX_CHARS = 400;
+const LIVE_EXEC_OUTPUT_MAX_CHARS = 8000;
 const TOOL_DENIAL_ERROR_CODES = ["SYSTEM_RUN_DENIED", "INVALID_REQUEST"] as const;
 const OPAQUE_STRUCTURED_RESULT_FIELDS = new Set(["encrypted_content", "encrypted_stdout"]);
 const SENSITIVE_STRUCTURED_HEADER_FIELDS = new Set([
@@ -53,6 +54,34 @@ function truncateToolText(text: string): string {
     return text;
   }
   return `${truncateUtf16Safe(text, TOOL_RESULT_MAX_CHARS)}\n…(truncated)…`;
+}
+
+export function truncateLiveExecOutput(text: string): string {
+  if (text.length <= LIVE_EXEC_OUTPUT_MAX_CHARS) {
+    return text;
+  }
+  return `${truncateUtf16Safe(text, LIVE_EXEC_OUTPUT_MAX_CHARS)}\n...(live output truncated)...`;
+}
+
+export function capLiveExecResult(result: unknown): unknown {
+  const details = readToolResultDetails(result);
+  if (!details || typeof details.status !== "string" || typeof details.aggregated !== "string") {
+    return result;
+  }
+  const aggregated = truncateLiveExecOutput(details.aggregated);
+  if (aggregated === details.aggregated) {
+    return result;
+  }
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return result;
+  }
+  return {
+    ...(result as Record<string, unknown>),
+    details: {
+      ...details,
+      aggregated,
+    },
+  };
 }
 
 function normalizeToolErrorText(text: string): string | undefined {
@@ -256,7 +285,7 @@ export function sanitizeToolResult(result: unknown): unknown {
       const entry = item as Record<string, unknown>;
       if (readStringValue(entry.type) === "image") {
         const data = readStringValue(entry.data);
-        const bytes = data ? data.length : undefined;
+        const bytes = data?.length ?? (typeof entry.bytes === "number" ? entry.bytes : undefined);
         const cleaned = { ...entry };
         delete cleaned.data;
         return Object.assign({}, cleaned, { bytes, omitted: true });

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -24,6 +24,7 @@ import {
   loadExactSessionEntry,
   loadSessionEntry,
   loadTranscriptEvents,
+  onSessionIdentityMutation,
   patchSessionEntry,
   publishTranscriptUpdate,
   readSessionUpdatedAt,
@@ -1525,10 +1526,16 @@ describe("sqlite session normalization", () => {
       }).map((summary) => summary.sessionKey),
     ).toEqual(["agent:main:active", "agent:main:older", "agent:main:stale"]);
 
+    const notify = vi.fn();
+    const unsubscribe = onSessionIdentityMutation(notify);
     await updateSqliteSessionEntry(scopeFor("agent:main:active"), () => ({
       providerOverride: "openai",
     }));
+    unsubscribe();
 
+    expect(new Set(notify.mock.calls.map(([mutation]) => mutation.previous.sessionId))).toEqual(
+      new Set(["older-session", "stale-session"]),
+    );
     expect(
       listSqliteSessionEntries({
         agentId: "main",
@@ -1979,6 +1986,8 @@ describe("sqlite session normalization", () => {
       compactionCheckpoints: [checkpoint],
     });
 
+    const notify = vi.fn();
+    const unsubscribe = onSessionIdentityMutation(notify);
     const result = await branchSqliteCompactionCheckpointSession({
       agentId: "main",
       env,
@@ -1987,6 +1996,7 @@ describe("sqlite session normalization", () => {
       nextKey: branchKey,
       checkpointId: checkpoint.checkpointId,
     });
+    unsubscribe();
     if (result.status !== "created") {
       throw new Error(`expected branch creation, got ${result.status}`);
     }
@@ -1999,6 +2009,11 @@ describe("sqlite session normalization", () => {
     expect(loadSqliteSessionEntry({ ...sourceEntryScope, sessionKey: branchKey })).toEqual(
       result.entry,
     );
+    expect(notify).toHaveBeenCalledWith({
+      kind: "create",
+      previous: { sessionKeys: [] },
+      current: { sessionId: result.entry.sessionId, sessionKeys: [branchKey] },
+    });
     expect(result.entry).toEqual(
       expect.objectContaining({
         label: "Source (checkpoint)",

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -32,6 +32,7 @@ import {
   resolveAgentHarnessSessionStoreEntryError,
   resolveAgentHarnessSessionStoreTransitionError,
 } from "../../sessions/agent-harness-session-key.js";
+import { emitSessionIdentityMutation } from "../../sessions/session-lifecycle-events.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { extractAssistantVisibleText } from "../../shared/chat-message-content.js";
 import { runQueuedStoreWrite, type StoreWriterQueue } from "../../shared/store-writer-queue.js";
@@ -448,9 +449,15 @@ export function replaceSqliteSessionEntrySync(
   entry: SessionEntry,
 ): void {
   const resolved = resolveSqliteScope(scope);
+  let previous = new Map<string, SessionEntry>();
+  let current = new Map<string, SessionEntry>();
   runOpenClawAgentWriteTransaction((database) => {
+    const identityKeys = collectSessionEntryLookupKeys(database, resolved.sessionKey);
+    previous = readSqliteSessionIdentitySnapshot(database, identityKeys);
     writeSessionEntry(database, resolved.sessionKey, entry);
+    current = readSqliteSessionIdentitySnapshot(database, identityKeys);
   }, toDatabaseOptions(resolved));
+  emitCommittedSessionIdentityDiff(previous, current);
 }
 
 /** Patches one entry in the additive SQLite session store. */
@@ -481,6 +488,8 @@ export async function patchSqliteSessionEntry(
     });
     const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
     let result: SessionEntry | null = null;
+    let previousIdentity = new Map<string, SessionEntry>();
+    let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((writeDatabase) => {
       const fresh = readSqliteSessionEntrySelectionSnapshot(
         writeDatabase,
@@ -492,6 +501,11 @@ export async function patchSqliteSessionEntry(
         result = cloneSessionEntry(writeBase);
         return;
       }
+      const identityKeys = [
+        resolved.sessionKey,
+        ...fresh.selectedRows.map((row) => row.sessionKey),
+      ];
+      previousIdentity = createSqliteSessionIdentitySnapshot(fresh.selectedRows);
       const merged = options.replaceEntry
         ? cloneSessionEntry(patch as SessionEntry)
         : options.preserveActivity
@@ -518,8 +532,10 @@ export async function patchSqliteSessionEntry(
           skipMaintenance: options.skipMaintenance,
         }),
       );
+      currentIdentity = readSqliteSessionIdentitySnapshot(writeDatabase, identityKeys);
       result = cloneSessionEntry(next);
     }, toDatabaseOptions(resolved));
+    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
     return result;
   });
@@ -549,6 +565,8 @@ export async function patchSqliteSessionEntryTarget(
     });
     const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
     let result: SessionEntry | null = null;
+    let previousIdentity = new Map<string, SessionEntry>();
+    let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((writeDatabase) => {
       const fresh = readSqliteLifecycleTargetSnapshot(writeDatabase, scope.target);
       assertSqliteLifecycleTargetSnapshotUnchanged(prepared, fresh, "session-entry-target.patch");
@@ -556,6 +574,12 @@ export async function patchSqliteSessionEntryTarget(
         result = cloneSessionEntry(writeBase);
         return;
       }
+      const identityKeys = [
+        scope.target.canonicalKey,
+        ...scope.target.storeKeys,
+        ...fresh.rows.map((row) => row.sessionKey),
+      ];
+      previousIdentity = createSqliteSessionIdentitySnapshot(fresh.rows);
       const merged = options.replaceEntry
         ? cloneSessionEntry(patch as SessionEntry)
         : options.preserveActivity
@@ -578,8 +602,10 @@ export async function patchSqliteSessionEntryTarget(
           skipMaintenance: options.skipMaintenance,
         }),
       );
+      currentIdentity = readSqliteSessionIdentitySnapshot(writeDatabase, identityKeys);
       result = cloneSessionEntry(next);
     }, toDatabaseOptions(resolved));
+    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
     return result;
   });
@@ -719,6 +745,8 @@ export async function forkSqliteSessionEntryFromParentTarget(
 
     let result: ForkSessionEntryFromParentTargetResult = { status: "failed" };
     const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
+    let previousIdentity = new Map<string, SessionEntry>();
+    let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((writeDatabase) => {
       const freshParent = resolveSqliteLifecyclePrimaryEntry(writeDatabase, parentTarget)?.entry;
       if (!freshParent?.sessionId) {
@@ -753,6 +781,7 @@ export async function forkSqliteSessionEntryFromParentTarget(
         sessionFile: fork.transcript.sessionFile,
         sessionId: fork.transcript.sessionId,
       });
+      previousIdentity = readSqliteSessionIdentitySnapshot(writeDatabase, sessionTarget.storeKeys);
       deleteSqliteLifecycleTargetRows(writeDatabase, sessionTarget);
       writeSessionEntry(writeDatabase, sessionTarget.canonicalKey, next);
       maintenancePlans.push(
@@ -762,6 +791,7 @@ export async function forkSqliteSessionEntryFromParentTarget(
           skipMaintenance: true,
         }),
       );
+      currentIdentity = readSqliteSessionIdentitySnapshot(writeDatabase, sessionTarget.storeKeys);
       result = {
         status: "forked",
         decision,
@@ -770,6 +800,7 @@ export async function forkSqliteSessionEntryFromParentTarget(
         sessionEntry: cloneSessionEntry(next),
       };
     }, toDatabaseOptions(resolved));
+    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
     return result;
   });
@@ -792,7 +823,10 @@ async function persistSqliteParentForkSkipPatch(params: {
     sessionKey: params.sessionTarget.canonicalKey,
   });
   const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
+  let previousIdentity = new Map<string, SessionEntry>();
+  let currentIdentity = new Map<string, SessionEntry>();
   runOpenClawAgentWriteTransaction((database) => {
+    previousIdentity = readSqliteSessionIdentitySnapshot(database, params.sessionTarget.storeKeys);
     deleteSqliteLifecycleTargetRows(database, params.sessionTarget);
     writeSessionEntry(database, params.sessionTarget.canonicalKey, next);
     maintenancePlans.push(
@@ -802,7 +836,9 @@ async function persistSqliteParentForkSkipPatch(params: {
         skipMaintenance: true,
       }),
     );
+    currentIdentity = readSqliteSessionIdentitySnapshot(database, params.sessionTarget.storeKeys);
   }, toDatabaseOptions(params.resolved));
+  emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
   finalizeSqliteSessionEntryMaintenancePlansBestEffort(params.resolved, maintenancePlans);
   return cloneSessionEntry(next);
 }
@@ -826,6 +862,8 @@ export async function updateSqliteSessionEntry(
     const patch = await update(cloneSessionEntry(writeBase));
     const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
     let result: SessionEntry | null = null;
+    let previousIdentity = new Map<string, SessionEntry>();
+    let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((writeDatabase) => {
       const fresh = readSqliteSessionEntrySelectionSnapshot(
         writeDatabase,
@@ -837,6 +875,11 @@ export async function updateSqliteSessionEntry(
         result = cloneSessionEntry(writeBase);
         return;
       }
+      const identityKeys = [
+        resolved.sessionKey,
+        ...fresh.selectedRows.map((row) => row.sessionKey),
+      ];
+      previousIdentity = createSqliteSessionIdentitySnapshot(fresh.selectedRows);
       const merged = mergeSessionEntry(writeBase, patch);
       const next = preserveSqliteSameKeySessionRolloverLineage({
         next: merged,
@@ -856,8 +899,10 @@ export async function updateSqliteSessionEntry(
           skipMaintenance: options.skipMaintenance,
         }),
       );
+      currentIdentity = readSqliteSessionIdentitySnapshot(writeDatabase, identityKeys);
       result = cloneSessionEntry(next);
     }, toDatabaseOptions(resolved));
+    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
     return result;
   });
@@ -900,6 +945,7 @@ export async function cleanupSqliteSessionLifecycleArtifacts(
         materializedPlans,
       );
     }, toDatabaseOptions(resolved));
+    emitCommittedSessionEntryRemovals(cleanupPlan.entries);
     return {
       removedEntries,
       archivedTranscriptArtifacts: archivedTranscripts.length,
@@ -914,7 +960,8 @@ export async function resetSqliteSessionEntryLifecycle(
   const resolved = resolveSqliteStoreScope(params.storePath, { agentId: params.agentId });
   return await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    const current = resolveSqliteLifecyclePrimaryEntry(database, params.target);
+    const targetSnapshot = readSqliteLifecycleTargetSnapshot(database, params.target);
+    const current = targetSnapshot.primary;
     const nextEntry = await params.buildNextEntry({
       currentEntry: current ? cloneSessionEntry(current.entry) : undefined,
       primaryKey: params.target.canonicalKey,
@@ -948,6 +995,28 @@ export async function resetSqliteSessionEntryLifecycle(
         materializedPlans,
       );
     }, toDatabaseOptions(resolved));
+    if (current) {
+      emitSessionIdentityMutation({
+        kind: "reset",
+        previous: {
+          ...(current.entry.sessionId ? { sessionId: current.entry.sessionId } : {}),
+          sessionKeys: targetSnapshot.rows.map((row) => row.sessionKey),
+        },
+        current: {
+          ...(nextEntry.sessionId ? { sessionId: nextEntry.sessionId } : {}),
+          sessionKeys: [params.target.canonicalKey],
+        },
+      });
+    } else {
+      emitSessionIdentityMutation({
+        kind: "create",
+        previous: { sessionKeys: [] },
+        current: {
+          ...(nextEntry.sessionId ? { sessionId: nextEntry.sessionId } : {}),
+          sessionKeys: [params.target.canonicalKey],
+        },
+      });
+    }
     await params.afterEntryMutation?.(mutation);
     emitArchivedSqliteTranscriptUpdates(archivedTranscripts);
     return {
@@ -968,7 +1037,8 @@ async function deleteSqliteSessionEntryLifecycleInternal(
       deleted: false,
     };
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    const current = resolveSqliteLifecyclePrimaryEntry(database, params.target);
+    const targetSnapshot = readSqliteLifecycleTargetSnapshot(database, params.target);
+    const current = targetSnapshot.primary;
     if (!current) {
       return result;
     }
@@ -1014,6 +1084,15 @@ async function deleteSqliteSessionEntryLifecycleInternal(
         ...(current.entry.sessionId ? { deletedSessionId: current.entry.sessionId } : {}),
       };
     }, toDatabaseOptions(resolved));
+    if (result.deleted) {
+      emitSessionIdentityMutation({
+        kind: "delete",
+        previous: {
+          ...(current.entry.sessionId ? { sessionId: current.entry.sessionId } : {}),
+          sessionKeys: targetSnapshot.rows.map((row) => row.sessionKey),
+        },
+      });
+    }
     emitArchivedSqliteTranscriptUpdates(result.archivedTranscripts);
     return result;
   });
@@ -1158,6 +1237,20 @@ export async function applySqliteSessionEntryReplacements<T>(params: {
       toDatabaseOptions(resolved),
       { operationLabel: "session.entry-replacements" },
     );
+    const finalReplacements = new Map(
+      applicable.map((replacement) => [replacement.sessionKey, replacement] as const),
+    );
+    for (const replacement of finalReplacements.values()) {
+      const previousEntry = expectedEntries.get(replacement.sessionKey);
+      if (previousEntry) {
+        emitCommittedSessionEntryChange({
+          currentEntry: replacement.entry,
+          currentKey: replacement.sessionKey,
+          previousEntry,
+          previousKey: replacement.sessionKey,
+        });
+      }
+    }
     finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
     return operation.result;
   });
@@ -1330,6 +1423,7 @@ export async function applySqliteSessionEntryLifecycleMutation(params: {
         materializedRemovalPlans,
       );
     }, toDatabaseOptions(resolved));
+    emitCommittedLifecycleIdentityMutations({ projected, removedSessionKeys });
     const maintenanceArchivedTranscripts = finalizeSqliteSessionEntryMaintenancePlansBestEffort(
       resolved,
       maintenancePlans,
@@ -1425,6 +1519,7 @@ export async function purgeSqliteDeletedAgentSessionEntries(
         materializedPlans,
       );
     }, toDatabaseOptions(resolved));
+    emitCommittedSessionEntryRemovals(entryRemovals);
     archivedTranscripts = [
       ...archivedTranscripts,
       ...finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans),
@@ -1949,6 +2044,8 @@ export async function appendSqliteExpectedSessionTranscriptTurn(
       preparedEntry,
       options.sessionFile,
     );
+    let previousIdentity = new Map<string, SessionEntry>();
+    let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((transactionDb) => {
       const fresh = readSessionEntryRow(transactionDb, resolved.sessionKey);
       if (!sqliteSessionMatchesExpectedTranscriptTurn(fresh, options)) {
@@ -1984,8 +2081,11 @@ export async function appendSqliteExpectedSessionTranscriptTurn(
           ? mergeSessionEntry(fresh.entry, sessionPatch)
           : fresh.entry;
       if (next !== fresh.entry) {
+        const identityKeys = collectSessionEntryLookupKeys(transactionDb, resolved.sessionKey);
+        previousIdentity = readSqliteSessionIdentitySnapshot(transactionDb, identityKeys);
         writeSessionEntry(transactionDb, resolved.sessionKey, next);
         deleteLegacySessionEntryRows(transactionDb, fresh.legacyKeys, resolved.sessionKey);
+        currentIdentity = readSqliteSessionIdentitySnapshot(transactionDb, identityKeys);
       }
       result = {
         appendedMessages,
@@ -1993,6 +2093,7 @@ export async function appendSqliteExpectedSessionTranscriptTurn(
         sessionFile: options.sessionFile,
       };
     }, toDatabaseOptions(resolved));
+    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     return result;
   });
 }
@@ -2280,7 +2381,14 @@ export async function branchSqliteCompactionCheckpointSession(
   });
   return await runExclusiveSqliteSessionWrite(resolved, async () => {
     let result: SqliteCompactionCheckpointSessionMutationResult | undefined;
+    let previousIdentity = new Map<string, SessionEntry>();
+    let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((database) => {
+      const identityKeys = uniqueStrings([
+        ...collectSessionEntryLookupKeys(database, sourceKey),
+        ...collectSessionEntryLookupKeys(database, targetKey),
+      ]);
+      previousIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
       result = branchSqliteCompactionCheckpointSessionInTransaction(database, {
         checkpointId: params.checkpointId,
         parentSessionKey: normalizeSqliteSessionKey(params.sourceKey),
@@ -2288,7 +2396,9 @@ export async function branchSqliteCompactionCheckpointSession(
         sourceKey,
         targetKey,
       });
+      currentIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
     }, toDatabaseOptions(resolved));
+    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     return result ?? { status: "failed" };
   });
 }
@@ -2307,14 +2417,23 @@ export async function restoreSqliteCompactionCheckpointSession(
   });
   return await runExclusiveSqliteSessionWrite(resolved, async () => {
     let result: SqliteCompactionCheckpointSessionMutationResult | undefined;
+    let previousIdentity = new Map<string, SessionEntry>();
+    let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((database) => {
+      const identityKeys = uniqueStrings([
+        ...collectSessionEntryLookupKeys(database, sessionKey),
+        ...collectSessionEntryLookupKeys(database, targetKey),
+      ]);
+      previousIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
       result = restoreSqliteCompactionCheckpointSessionInTransaction(database, {
         checkpointId: params.checkpointId,
         resolved,
         sourceKey: sessionKey,
         targetKey,
       });
+      currentIdentity = readSqliteSessionIdentitySnapshot(database, identityKeys);
     }, toDatabaseOptions(resolved));
+    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     return result ?? { status: "failed" };
   });
 }
@@ -2543,6 +2662,166 @@ function cloneSessionEntry(entry: SessionEntry): SessionEntry {
   return structuredClone(entry);
 }
 
+function readSqliteSessionIdentitySnapshot(
+  database: OpenClawAgentDatabase,
+  sessionKeys: Iterable<string>,
+): Map<string, SessionEntry> {
+  const snapshot = new Map<string, SessionEntry>();
+  for (const sessionKey of uniqueStrings([...sessionKeys].map((key) => key.trim()))) {
+    const row = readExactSessionEntryRow(database, sessionKey);
+    if (row) {
+      snapshot.set(sessionKey, cloneSessionEntry(row.entry));
+    }
+  }
+  return snapshot;
+}
+
+function createSqliteSessionIdentitySnapshot(
+  rows: readonly { entry: SessionEntry; sessionKey: string }[],
+): Map<string, SessionEntry> {
+  return new Map(rows.map((row) => [row.sessionKey, cloneSessionEntry(row.entry)]));
+}
+
+function toSessionIdentityTarget(entry: SessionEntry | undefined, sessionKeys: readonly string[]) {
+  const sessionId = normalizeOptionalString(entry?.sessionId);
+  return { ...(sessionId ? { sessionId } : {}), sessionKeys };
+}
+
+function emitCommittedSessionEntryRemoval(sessionKey: string, entry?: SessionEntry): void {
+  emitSessionIdentityMutation({
+    kind: "delete",
+    previous: toSessionIdentityTarget(entry, [sessionKey]),
+  });
+}
+
+function emitCommittedSessionEntryRemovals(
+  removals: readonly SqliteSessionEntryRemovalPlan[],
+): void {
+  const emittedKeys = new Set<string>();
+  for (const removal of removals) {
+    if (emittedKeys.has(removal.sessionKey)) {
+      continue;
+    }
+    emittedKeys.add(removal.sessionKey);
+    emitCommittedSessionEntryRemoval(removal.sessionKey, removal.expectedEntry);
+  }
+}
+
+function emitCommittedSessionEntryChange(params: {
+  currentKey: string;
+  currentEntry: SessionEntry;
+  previousKey: string;
+  previousEntry: SessionEntry;
+}): void {
+  const previous = toSessionIdentityTarget(params.previousEntry, [params.previousKey]);
+  const current = toSessionIdentityTarget(params.currentEntry, [params.currentKey]);
+  const moved = params.previousKey !== params.currentKey;
+  if (!moved && previous.sessionId === current.sessionId) {
+    return;
+  }
+  emitSessionIdentityMutation({
+    kind: moved ? "move" : "replace",
+    previous,
+    current,
+  });
+}
+
+function emitCommittedSessionIdentityDiff(
+  previous: ReadonlyMap<string, SessionEntry>,
+  current: ReadonlyMap<string, SessionEntry>,
+): void {
+  const currentKeysBySessionId = new Map<string, string[]>();
+  for (const [sessionKey, entry] of current) {
+    const sessionId = normalizeOptionalString(entry.sessionId);
+    if (sessionId) {
+      currentKeysBySessionId.set(sessionId, [
+        ...(currentKeysBySessionId.get(sessionId) ?? []),
+        sessionKey,
+      ]);
+    }
+  }
+
+  const movedKeysByCurrentKey = new Map<string, string[]>();
+  const handledPreviousKeys = new Set<string>();
+  const handledCurrentKeys = new Set<string>();
+  for (const [sessionKey, entry] of previous) {
+    if (current.has(sessionKey)) {
+      continue;
+    }
+    const sessionId = normalizeOptionalString(entry.sessionId);
+    const currentKeys = sessionId ? currentKeysBySessionId.get(sessionId) : undefined;
+    if (currentKeys?.length !== 1) {
+      continue;
+    }
+    const [currentKey] = currentKeys;
+    if (!currentKey) {
+      continue;
+    }
+    movedKeysByCurrentKey.set(currentKey, [
+      ...(movedKeysByCurrentKey.get(currentKey) ?? []),
+      sessionKey,
+    ]);
+    handledPreviousKeys.add(sessionKey);
+    handledCurrentKeys.add(currentKey);
+  }
+  for (const [currentKey, previousKeys] of movedKeysByCurrentKey) {
+    const currentEntry = current.get(currentKey);
+    if (currentEntry) {
+      emitSessionIdentityMutation({
+        kind: "move",
+        previous: toSessionIdentityTarget(currentEntry, previousKeys),
+        current: toSessionIdentityTarget(currentEntry, [currentKey]),
+      });
+    }
+  }
+
+  for (const [sessionKey, previousEntry] of previous) {
+    const currentEntry = current.get(sessionKey);
+    if (currentEntry) {
+      handledCurrentKeys.add(sessionKey);
+      emitCommittedSessionEntryChange({
+        currentEntry,
+        currentKey: sessionKey,
+        previousEntry,
+        previousKey: sessionKey,
+      });
+    } else if (!handledPreviousKeys.has(sessionKey)) {
+      emitCommittedSessionEntryRemoval(sessionKey, previousEntry);
+    }
+  }
+
+  for (const [sessionKey, currentEntry] of current) {
+    if (handledCurrentKeys.has(sessionKey)) {
+      continue;
+    }
+    emitSessionIdentityMutation({
+      kind: "create",
+      previous: { sessionKeys: [] },
+      current: toSessionIdentityTarget(currentEntry, [sessionKey]),
+    });
+  }
+}
+
+function emitCommittedLifecycleIdentityMutations(params: {
+  projected: SqliteProjectedLifecycleMutation;
+  removedSessionKeys: readonly string[];
+}): void {
+  const removedKeys = new Set(params.removedSessionKeys);
+  const previous = new Map(
+    params.projected.removals
+      .filter((removal) => removedKeys.has(removal.sessionKey))
+      .map((removal) => [removal.sessionKey, removal.expectedEntry]),
+  );
+  const current = new Map<string, SessionEntry>();
+  for (const upsert of params.projected.upsertedEntries) {
+    if (!current.has(upsert.sessionKey) && upsert.expectedEntry) {
+      previous.set(upsert.sessionKey, upsert.expectedEntry);
+    }
+    current.set(upsert.sessionKey, upsert.entry);
+  }
+  emitCommittedSessionIdentityDiff(previous, current);
+}
+
 function preserveSqliteSameKeySessionRolloverLineage(params: {
   next: SessionEntry;
   previous: SessionEntry;
@@ -2670,9 +2949,7 @@ function readSqliteSessionEntrySelectionSnapshot(
   const selected = exact
     ? readExactSessionEntryRow(database, sessionKey)
     : readSessionEntryRow(database, sessionKey);
-  const selectedKeys = selected
-    ? uniqueStrings([selected.row.session_key, ...selected.legacyKeys]).toSorted()
-    : [];
+  const selectedKeys = collectSessionEntryLookupKeys(database, sessionKey).toSorted();
   return {
     selected,
     selectedRows: selectedKeys.flatMap((candidateKey) => {
@@ -3729,6 +4006,7 @@ function finalizeSqliteSessionEntryMaintenancePlansBestEffort(
       deletePlannedSqliteLifecycleArtifactEntries(database, entryRemovals);
       archivedTranscripts = deleteMaterializedSqliteSessionStatePlans(database, materializedPlans);
     }, toDatabaseOptions(scope));
+    emitCommittedSessionEntryRemovals(entryRemovals);
     return archivedTranscripts;
   } catch (error) {
     getChildLogger({ subsystem: "session-sqlite" }).warn(

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -19,6 +19,7 @@ import {
   loadSessionEntry,
   loadTranscriptEvents,
   markSessionAbortTarget,
+  onSessionIdentityMutation,
   openSessionEntryReadView,
   patchSessionEntry,
   patchSessionEntryTarget,
@@ -28,6 +29,7 @@ import {
   readSessionUpdatedAt,
   recordInboundSessionMeta,
   replaceSessionEntry,
+  resetSessionEntryLifecycle,
   resolveSessionEntryAccessTarget,
   resolveSessionEntryCandidateTarget,
   resolveSessionTranscriptReadTarget,
@@ -347,6 +349,8 @@ describe("session accessor seam", () => {
       },
     );
 
+    const notify = vi.fn();
+    const unsubscribe = onSessionIdentityMutation(notify);
     const patched = await patchSessionEntryTarget(
       {
         storePath,
@@ -363,7 +367,6 @@ describe("session accessor seam", () => {
         };
       },
     );
-
     expect(patched).toMatchObject({
       label: "patched",
       sessionId: "legacy-session",
@@ -376,6 +379,27 @@ describe("session accessor seam", () => {
           sessionId: "legacy-session",
         }),
       },
+    ]);
+    const sessionKey = "agent:main:other";
+    const scope = { sessionKey, storePath };
+    await replaceSessionEntry(scope, { sessionId: "created", updatedAt: 10 });
+    await patchSessionEntry(scope, () => ({ label: "same identity" }));
+    await replaceSessionEntry(scope, { sessionId: "replaced", updatedAt: 20 });
+    const target = { canonicalKey: sessionKey, storeKeys: [sessionKey] };
+    await resetSessionEntryLifecycle({
+      buildNextEntry: () => ({ sessionId: "reset", updatedAt: 30 }),
+      storePath,
+      target,
+    });
+    await deleteSessionEntryLifecycle({ archiveTranscript: false, storePath, target });
+    unsubscribe();
+
+    expect(notify.mock.calls.map(([event]) => event.kind)).toEqual([
+      "move",
+      "create",
+      "replace",
+      "reset",
+      "delete",
     ]);
   });
 
@@ -1636,12 +1660,19 @@ describe("session accessor seam", () => {
       },
     ]);
 
+    const notify = vi.fn();
+    const unsubscribe = onSessionIdentityMutation(notify);
     const result = await applySessionEntryLifecycleMutation({
       storePath,
       removals: [{ expectedSessionId: scope.sessionId, sessionKey: scope.sessionKey }],
     });
+    unsubscribe();
 
     expect(result.removedEntries).toBe(1);
+    expect(notify).toHaveBeenCalledWith({
+      kind: "delete",
+      previous: { sessionId: scope.sessionId, sessionKeys: [scope.sessionKey] },
+    });
     expect(result.archivedTranscriptDirectories).toEqual([]);
     expect(loadSessionEntry(scope)).toBeUndefined();
     await expect(loadTranscriptEvents(scope)).resolves.toEqual([]);

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -112,6 +112,13 @@ import {
 import { runWithOwnedSessionTranscriptWriteLock } from "./transcript-write-context.js";
 import type { GroupKeyResolution, SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 
+export { onSessionIdentityMutation } from "../../sessions/session-lifecycle-events.js";
+export type {
+  SessionIdentityMutation,
+  SessionIdentityMutationListener,
+  SessionIdentityMutationTarget,
+} from "../../sessions/session-lifecycle-events.js";
+
 /**
  * Session access API for callers that need entries or transcripts without
  * depending on the persisted store layout. Callers provide stable session

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -9,7 +9,7 @@ import { formatChannelProgressDraftLine } from "../channels/streaming.js";
 import {
   claimAgentRunContext,
   emitAgentEventForOwner,
-  onAgentEvent,
+  onAgentRuntimeEvent,
   registerAgentRunContext,
   releaseAgentRunContext,
   resetAgentRunContextForTest,
@@ -4121,7 +4121,7 @@ describe("agent event handler", () => {
       { isControlUiVisible: false, sessionKey: "session-hidden" },
       { exclusive: true, trackOwner: true },
     )!;
-    const stop = onAgentEvent(handler);
+    const stop = onAgentRuntimeEvent(handler);
     emitAgentEventForOwner(
       { runId: "revoked", stream: "lifecycle", data: { phase: "error", error: "retry" } },
       claimId,

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -6,7 +6,14 @@ import {
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "../agents/internal-runtime-context.js";
 import { formatChannelProgressDraftLine } from "../channels/streaming.js";
-import { registerAgentRunContext, resetAgentRunContextForTest } from "../infra/agent-events.js";
+import {
+  claimAgentRunContext,
+  emitAgentEventForOwner,
+  onAgentEvent,
+  registerAgentRunContext,
+  releaseAgentRunContext,
+  resetAgentRunContextForTest,
+} from "../infra/agent-events.js";
 
 const persistGatewaySessionLifecycleEventMock = vi.fn();
 const logErrorMock = vi.fn();
@@ -4046,9 +4053,11 @@ describe("agent event handler", () => {
   });
 
   it("sends non-control-UI-visible live chat only to exact session message subscribers", () => {
+    vi.useFakeTimers();
     const { broadcast, broadcastToConnIds, nodeSendToSession, sessionMessageSubscribers, handler } =
       createHarness({
         resolveSessionKeyForRun: () => "session-hidden",
+        lifecycleErrorRetryGraceMs: 1,
       });
     sessionMessageSubscribers.subscribe("conn-selected", "session-hidden");
     sessionMessageSubscribers.subscribe("conn-other", "session-other");
@@ -4069,20 +4078,61 @@ describe("agent event handler", () => {
 
     expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
     expect(nodeSendToSession).not.toHaveBeenCalled();
-    expect(requireMockArg(broadcastToConnIds, 0, 0, "hidden chat delta event")).toBe("chat");
-    expect(requireMockArg(broadcastToConnIds, 0, 2, "hidden chat delta recipients")).toEqual(
-      new Set(["conn-selected"]),
-    );
-    expect(requireMockArg(broadcastToConnIds, 1, 0, "hidden chat final event")).toBe("chat");
-    const finalPayload = requireMockPayload(broadcastToConnIds, 1, 1, "hidden chat final payload");
+    const chatCalls = broadcastToConnIds.mock.calls.filter(([event]) => event === "chat");
+    expect(chatCalls).toHaveLength(2);
+    expect(chatCalls[0]?.[2]).toEqual(new Set(["conn-selected"]));
+    expectPayloadFields(chatCalls[0]?.[1], {
+      runId: "run-hidden",
+      sessionKey: "session-hidden",
+      state: "delta",
+    });
+    const finalPayload = requireRecord(chatCalls[1]?.[1], "hidden chat final payload");
     expectPayloadFields(finalPayload, {
       runId: "run-hidden",
       sessionKey: "session-hidden",
       state: "final",
     });
-    expect(requireMockArg(broadcastToConnIds, 1, 2, "hidden chat final recipients")).toEqual(
-      new Set(["conn-selected"]),
+    expect(chatCalls[1]?.[2]).toEqual(new Set(["conn-selected"]));
+
+    const streams = ["tool", "thinking", "approval"] as const;
+    const streamCallStart = broadcastToConnIds.mock.calls.length;
+    for (const [index, stream] of streams.entries()) {
+      handler({
+        runId: "run-hidden",
+        seq: index + 3,
+        stream,
+        ts: Date.now(),
+        data: { phase: "start", delta: "Inspecting", name: "read" },
+      });
+    }
+    expect(
+      broadcastToConnIds.mock.calls
+        .slice(streamCallStart)
+        .map(([event, payload, recipients]) => [
+          event,
+          requireRecord(payload, "event").stream,
+          recipients,
+        ]),
+    ).toEqual(streams.map((stream) => ["agent", stream, new Set(["conn-selected"])]));
+
+    broadcastToConnIds.mockClear();
+    const claimId = claimAgentRunContext(
+      "revoked",
+      { isControlUiVisible: false, sessionKey: "session-hidden" },
+      { exclusive: true, trackOwner: true },
+    )!;
+    const stop = onAgentEvent(handler);
+    emitAgentEventForOwner(
+      { runId: "revoked", stream: "lifecycle", data: { phase: "error", error: "retry" } },
+      claimId,
     );
+    stop();
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
+    const persisted = persistGatewaySessionLifecycleEventMock.mock.calls.length;
+    releaseAgentRunContext("revoked", claimId);
+    vi.advanceTimersByTime(1);
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
+    expect(persistGatewaySessionLifecycleEventMock).toHaveBeenCalledTimes(persisted);
   });
 
   it("mirrors commentary-phase assistant events only to exact session message subscribers", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -10,7 +10,12 @@ import { readToolValidationErrorSummary } from "../agents/tool-error-summary.js"
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../auto-reply/heartbeat.js";
 import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../config/io.js";
-import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
+import {
+  type AgentEventPayload,
+  getAgentEventLifecycleGeneration,
+  getAgentRunContext,
+  getAgentRunContextOwnerStatus,
+} from "../infra/agent-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import { logError } from "../logger.js";
@@ -163,6 +168,10 @@ function shouldMirrorAssistantEventToHiddenSessionMessages(data: unknown): boole
   return resolveAssistantEventPhase(data) === "commentary";
 }
 
+function shouldMirrorAgentEventToHiddenSessionMessages(evt: AgentEventPayload): boolean {
+  return evt.stream === "thinking" || evt.stream === "approval" || evt.stream === "lifecycle";
+}
+
 function normalizeHeartbeatChatFinalText(params: {
   runId: string;
   sourceRunId?: string;
@@ -303,7 +312,11 @@ export type AgentEventHandlerOptions = {
   agentRunSeq: Map<string, number>;
   chatRunState: ChatRunState;
   resolveSessionKeyForRun: (runId: string) => string | undefined;
-  clearAgentRunContext: (runId: string) => void;
+  clearAgentRunContext: (
+    runId: string,
+    lifecycleGeneration?: string,
+    contextClaimId?: string,
+  ) => void;
   toolEventRecipients: ToolEventRecipientRegistry;
   sessionEventSubscribers: SessionEventSubscriberRegistry;
   sessionMessageSubscribers: SessionMessageSubscriberRegistry;
@@ -367,6 +380,26 @@ export function createAgentEventHandler({
   updateRunToolErrorSummary,
   resolveSessionActiveRunState,
 }: AgentEventHandlerOptions) {
+  const shouldProcessOwnedEvent = (evt: AgentEventPayload): boolean => {
+    const claimId = evt.contextClaimId;
+    if (!claimId) {
+      return true;
+    }
+    const lifecycleGeneration = evt.lifecycleGeneration;
+    if (!lifecycleGeneration || lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
+      return false;
+    }
+    // A missing claim means detach or supersession revoked this terminal event.
+    return getAgentRunContextOwnerStatus(evt.runId, claimId, lifecycleGeneration) === "active";
+  };
+  const clearRunContextForEvent = (evt: AgentEventPayload): void => {
+    if (evt.contextClaimId) {
+      clearAgentRunContext(evt.runId, evt.lifecycleGeneration, evt.contextClaimId);
+      return;
+    }
+    clearAgentRunContext(evt.runId);
+  };
+
   type TerminalLifecycleOptions = {
     skipChatErrorFinal?: boolean;
     suppressRestartRecoveryProjection?: boolean;
@@ -613,6 +646,9 @@ export function createAgentEventHandler({
   };
 
   const finalizeLifecycleEvent = (evt: AgentEventPayload, opts?: TerminalLifecycleOptions) => {
+    if (!shouldProcessOwnedEvent(evt)) {
+      return;
+    }
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
     if (lifecyclePhase !== "end" && lifecyclePhase !== "error") {
@@ -624,11 +660,13 @@ export function createAgentEventHandler({
     const currentLifecycleGeneration =
       activeLifecycleGeneration ?? currentRunContext?.lifecycleGeneration;
 
-    const chatLink = chatRunState.registry.peek(evt.runId);
+    const chatLink = evt.contextClaimId ? undefined : chatRunState.registry.peek(evt.runId);
     const sessionAgentId = chatLink?.agentId ?? evt.agentId;
     const eventSessionKey =
-      typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined;
-    const isControlUiVisible = currentRunContext?.isControlUiVisible ?? true;
+      evt.deliverySessionKey ??
+      (typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined);
+    const isControlUiVisible =
+      evt.controlUiVisible ?? currentRunContext?.isControlUiVisible ?? true;
     const sessionKey =
       chatLink?.sessionKey ?? eventSessionKey ?? resolveSessionKeyForRun(evt.runId);
     const restartRecoverySessionKey = eventSessionKey ?? sessionKey;
@@ -681,7 +719,7 @@ export function createAgentEventHandler({
           typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
         const finished = chatLink ? chatRunState.registry.shift(evt.runId) : undefined;
         if (chatLink && !finished) {
-          clearAgentRunContext(evt.runId);
+          clearRunContextForEvent(evt);
           return;
         }
 
@@ -739,7 +777,7 @@ export function createAgentEventHandler({
     if (suppressRestartRecoveryProjection && chatLink) {
       chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);
     }
-    clearAgentRunContext(evt.runId);
+    clearRunContextForEvent(evt);
     agentRunSeq.delete(evt.runId);
     agentRunSeq.delete(clientRunId);
 
@@ -1225,16 +1263,20 @@ export function createAgentEventHandler({
   };
 
   return (evt: AgentEventPayload) => {
+    if (!shouldProcessOwnedEvent(evt)) {
+      return;
+    }
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
 
-    const chatLink = chatRunState.registry.peek(evt.runId);
+    const chatLink = evt.contextClaimId ? undefined : chatRunState.registry.peek(evt.runId);
     const sessionAgentId = chatLink?.agentId ?? evt.agentId;
     const eventSessionKey =
-      typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined;
+      evt.deliverySessionKey ??
+      (typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined);
     const runContext = getAgentRunContext(evt.runId);
     const activeLifecycleGeneration = resolveActiveLifecycleGenerationForRun(evt.runId);
-    const isControlUiVisible = runContext?.isControlUiVisible ?? true;
+    const isControlUiVisible = evt.controlUiVisible ?? runContext?.isControlUiVisible ?? true;
     const isHeartbeat = runContext?.isHeartbeat;
     const sessionKey =
       chatLink?.sessionKey ?? eventSessionKey ?? resolveSessionKeyForRun(evt.runId);
@@ -1450,11 +1492,12 @@ export function createAgentEventHandler({
           }
         }
       } else if (
-        !isAborted &&
         sessionKey &&
         hasSessionMessageSubscribers &&
-        evt.stream === "assistant" &&
-        shouldMirrorAssistantEventToHiddenSessionMessages(evt.data)
+        (shouldMirrorAgentEventToHiddenSessionMessages(evt) ||
+          (!isAborted &&
+            evt.stream === "assistant" &&
+            shouldMirrorAssistantEventToHiddenSessionMessages(evt.data)))
       ) {
         sendAgentPayload(
           sessionKey,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -12,6 +12,7 @@ import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../config/io.js";
 import {
   type AgentEventPayload,
+  type AgentEventRuntimePayload,
   getAgentEventLifecycleGeneration,
   getAgentRunContext,
   getAgentRunContextOwnerStatus,
@@ -379,8 +380,8 @@ export function createAgentEventHandler({
   resolveActiveLifecycleGenerationForRun = () => undefined,
   updateRunToolErrorSummary,
   resolveSessionActiveRunState,
-}: AgentEventHandlerOptions) {
-  const shouldProcessOwnedEvent = (evt: AgentEventPayload): boolean => {
+}: AgentEventHandlerOptions): (event: AgentEventPayload) => void {
+  const shouldProcessOwnedEvent = (evt: AgentEventRuntimePayload): boolean => {
     const claimId = evt.contextClaimId;
     if (!claimId) {
       return true;
@@ -392,7 +393,7 @@ export function createAgentEventHandler({
     // A missing claim means detach or supersession revoked this terminal event.
     return getAgentRunContextOwnerStatus(evt.runId, claimId, lifecycleGeneration) === "active";
   };
-  const clearRunContextForEvent = (evt: AgentEventPayload): void => {
+  const clearRunContextForEvent = (evt: AgentEventRuntimePayload): void => {
     if (evt.contextClaimId) {
       clearAgentRunContext(evt.runId, evt.lifecycleGeneration, evt.contextClaimId);
       return;
@@ -407,7 +408,7 @@ export function createAgentEventHandler({
   };
   type PendingTerminalLifecycleError = {
     timer: NodeJS.Timeout;
-    event: AgentEventPayload;
+    event: AgentEventRuntimePayload;
     opts?: TerminalLifecycleOptions;
   };
 
@@ -645,7 +646,10 @@ export function createAgentEventHandler({
     );
   };
 
-  const finalizeLifecycleEvent = (evt: AgentEventPayload, opts?: TerminalLifecycleOptions) => {
+  const finalizeLifecycleEvent = (
+    evt: AgentEventRuntimePayload,
+    opts?: TerminalLifecycleOptions,
+  ) => {
     if (!shouldProcessOwnedEvent(evt)) {
       return;
     }
@@ -847,7 +851,7 @@ export function createAgentEventHandler({
   };
 
   const scheduleTerminalLifecycleError = (
-    evt: AgentEventPayload,
+    evt: AgentEventRuntimePayload,
     opts?: TerminalLifecycleOptions,
   ) => {
     clearPendingTerminalLifecycleError(evt.runId);
@@ -1262,7 +1266,8 @@ export function createAgentEventHandler({
     }
   };
 
-  return (evt: AgentEventPayload) => {
+  return (event: AgentEventPayload) => {
+    const evt = event as AgentEventRuntimePayload;
     if (!shouldProcessOwnedEvent(evt)) {
       return;
     }

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -250,6 +250,7 @@ vi.mock("../../infra/agent-events.js", () => ({
   emitAgentEvent: mocks.emitAgentEvent,
   getAgentEventLifecycleGeneration: () => mocks.lifecycleGeneration,
   getAgentRunContext: vi.fn(() => undefined),
+  hasProjectedAgentRunForSession: vi.fn(() => false),
   registerAgentRunContext: mocks.registerAgentRunContext,
   onAgentEvent: vi.fn(),
 }));

--- a/src/gateway/server-methods/session-active-runs.test.ts
+++ b/src/gateway/server-methods/session-active-runs.test.ts
@@ -1,5 +1,6 @@
 // Tests gateway active-run matching by logical session key and backing id.
 import { expect, it } from "vitest";
+import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-events.js";
 import {
   hasVisibleActiveSessionRun,
   resolveVisibleActiveSessionRunState,
@@ -46,4 +47,25 @@ it("returns deterministic visible run ids for the selected session", () => {
       canonicalKey: "main",
     }),
   ).toEqual({ active: true, runIds: ["run-a", "run-z"] });
+});
+
+it("projects a lifecycle-owned worker run without widening event visibility", () => {
+  registerAgentRunContext("worker-run", {
+    isControlUiVisible: false,
+    projectSessionActive: true,
+    sessionId: "worker-session",
+    sessionKey: "agent:main:worker",
+  });
+  try {
+    expect(
+      resolveVisibleActiveSessionRunState({
+        context: {},
+        requestedKey: "agent:main:worker",
+        canonicalKey: "agent:main:worker",
+        sessionId: "worker-session",
+      }),
+    ).toEqual({ active: true, runIds: [] });
+  } finally {
+    clearAgentRunContext("worker-run");
+  }
 });

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -1,15 +1,9 @@
-// Session active-run helpers decide whether session operations should treat a
-// session as busy based on Control UI-visible active chat/agent runs.
 import { isEmbeddedAgentRunActive } from "../../agents/embedded-agent-runner/runs.js";
+import { hasProjectedAgentRunForSession } from "../../infra/agent-events.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import type { GatewayRequestContext } from "./types.js";
 
-/**
- * Active-run matcher used by session list/update methods.
- *
- * It only reports runs visible to the Control UI so background or hidden runs
- * do not make a session look busy to user-facing session operations.
- */
+/** Active-run matcher including hidden remote lifecycle projections. */
 type TrackedActiveSessionRun = {
   runId: string;
   sessionKey?: string;
@@ -118,8 +112,15 @@ export function resolveVisibleActiveSessionRunState(params: {
     )
     .map((active) => active.runId)
     .toSorted();
+  const hasProjectedRun = hasProjectedAgentRunForSession({
+    sessionKeys: [params.requestedKey, params.canonicalKey],
+    ...(sessionId ? { sessionId } : {}),
+  });
   return {
-    active: runIds.length > 0 || (sessionId !== undefined && isEmbeddedAgentRunActive(sessionId)),
+    active:
+      runIds.length > 0 ||
+      hasProjectedRun ||
+      (sessionId !== undefined && isEmbeddedAgentRunActive(sessionId)),
     runIds,
   };
 }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1620,6 +1620,7 @@ describe("gateway Gmail hot reload handlers", () => {
       webTools: {},
     }));
     const heartbeatRunner = { stop: vi.fn(), updateConfig: vi.fn() };
+    const commitTerminalConfig = vi.fn();
     const reloader = startManagedGatewayConfigReloader({
       minimalTestGateway: false,
       initialConfig,
@@ -1682,7 +1683,7 @@ describe("gateway Gmail hot reload handlers", () => {
       sharedGatewaySessionGenerationState: { current: undefined, required: null },
       clients: [],
       reconcileTerminalSessions: vi.fn(),
-      commitTerminalConfig: vi.fn(),
+      commitTerminalConfig,
     });
     const registeredWriteListener = writeListenerRef.current;
     if (!registeredWriteListener) {
@@ -1707,6 +1708,7 @@ describe("gateway Gmail hot reload handlers", () => {
       activate: true,
     });
     expect(heartbeatRunner.updateConfig).not.toHaveBeenCalled();
+    expect(commitTerminalConfig).toHaveBeenCalledWith(nextConfig);
     await reloader.stop();
   });
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -230,7 +230,7 @@ type ManagedGatewayConfigReloaderParams = Omit<
   sharedGatewaySessionGenerationState: SharedGatewaySessionGenerationState;
   clients: Iterable<SharedGatewayAuthClient>;
   reconcileTerminalSessions: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void;
-  commitTerminalConfig: () => void;
+  commitTerminalConfig: (nextConfig: OpenClawConfig) => void;
 };
 
 export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) {
@@ -815,7 +815,7 @@ export function startManagedGatewayConfigReloader(
     promoteSnapshot: async (snapshot, _reason) => await params.promoteSnapshot(snapshot),
     subscribeToWrites: params.subscribeToWrites,
     onConfigChange: (plan, nextConfig) => params.reconcileTerminalSessions(plan, nextConfig),
-    onConfigApplied: () => params.commitTerminalConfig(),
+    onConfigApplied: (_plan, nextConfig) => params.commitTerminalConfig(nextConfig),
     onNoopConfigCommit: async (_plan, nextConfig) => {
       await params.activateRuntimeSecrets(nextConfig, {
         reason: "reload",

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -4,11 +4,7 @@ import { isAuditLedgerEnabled, resolveAuditMessageMode } from "../audit/audit-co
 import { createAuditEventRecorder } from "../audit/audit-recorder.js";
 import { onTrustedMessageAuditEvent } from "../audit/message-audit-events.js";
 import { getRuntimeConfig } from "../config/io.js";
-import {
-  clearAgentRunContext,
-  onAgentAuditEvent,
-  onAgentEventProjection,
-} from "../infra/agent-events.js";
+import { clearAgentRunContext, onAgentAuditEvent, onAgentEvent } from "../infra/agent-events.js";
 import { onTrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
@@ -36,11 +32,10 @@ function dispatchEventHandler<TEvent>(params: {
   log: SubsystemLogger;
   failureMessage: string;
   context: Record<string, unknown>;
-}): Promise<void> {
-  return params
+}) {
+  void params
     .loadHandler()
     .then((handler) => handler(params.event))
-    .then(() => undefined)
     .catch((error: unknown) => {
       params.log.warn(params.failureMessage, { ...params.context, error });
     });
@@ -247,7 +242,7 @@ export function startGatewayEventSubscriptions(params: {
     return lifecycleEventHandlerPromise;
   };
 
-  const unsubscribeAgentEvents = onAgentEventProjection((evt) => {
+  const unsubscribeAgentEvents = onAgentEvent((evt) => {
     if (auditEnabled) {
       auditRecorder.record(evt);
     }
@@ -297,7 +292,7 @@ export function startGatewayEventSubscriptions(params: {
         }
       }
     }
-    return dispatchEventHandler({
+    dispatchEventHandler({
       loadHandler: getAgentEventHandler,
       event: evt,
       log: params.log,
@@ -318,7 +313,7 @@ export function startGatewayEventSubscriptions(params: {
   });
 
   const transcriptUnsub = onInternalSessionTranscriptUpdate((evt) => {
-    void dispatchEventHandler({
+    dispatchEventHandler({
       loadHandler: getTranscriptUpdateHandler,
       event: evt,
       log: params.log,
@@ -328,7 +323,7 @@ export function startGatewayEventSubscriptions(params: {
   });
 
   const lifecycleUnsub = onSessionLifecycleEvent((evt) => {
-    void dispatchEventHandler({
+    dispatchEventHandler({
       loadHandler: getLifecycleEventHandler,
       event: evt,
       log: params.log,

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -4,7 +4,11 @@ import { isAuditLedgerEnabled, resolveAuditMessageMode } from "../audit/audit-co
 import { createAuditEventRecorder } from "../audit/audit-recorder.js";
 import { onTrustedMessageAuditEvent } from "../audit/message-audit-events.js";
 import { getRuntimeConfig } from "../config/io.js";
-import { clearAgentRunContext, onAgentAuditEvent, onAgentEvent } from "../infra/agent-events.js";
+import {
+  clearAgentRunContext,
+  onAgentAuditEvent,
+  onAgentRuntimeEvent,
+} from "../infra/agent-events.js";
 import { onTrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
@@ -242,7 +246,7 @@ export function startGatewayEventSubscriptions(params: {
     return lifecycleEventHandlerPromise;
   };
 
-  const unsubscribeAgentEvents = onAgentEvent((evt) => {
+  const unsubscribeAgentEvents = onAgentRuntimeEvent((evt) => {
     if (auditEnabled) {
       auditRecorder.record(evt);
     }

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -251,7 +251,9 @@ export function startGatewayEventSubscriptions(params: {
         ? evt.data.phase
         : undefined;
     if (lifecyclePhase === "end" || lifecyclePhase === "error") {
-      const chatLink = params.chatRunState.registry.peek(evt.runId);
+      const chatLink = evt.contextClaimId
+        ? undefined
+        : params.chatRunState.registry.peek(evt.runId);
       const clientRunId = chatLink?.clientRunId ?? evt.runId;
       const candidateRunIds = evt.runId === clientRunId ? [evt.runId] : [evt.runId, clientRunId];
       for (const candidateRunId of candidateRunIds) {
@@ -271,7 +273,9 @@ export function startGatewayEventSubscriptions(params: {
         }
       }
     } else if (lifecyclePhase === "start") {
-      const chatLink = params.chatRunState.registry.peek(evt.runId);
+      const chatLink = evt.contextClaimId
+        ? undefined
+        : params.chatRunState.registry.peek(evt.runId);
       const clientRunId = chatLink?.clientRunId ?? evt.runId;
       const candidateRunIds = evt.runId === clientRunId ? [evt.runId] : [evt.runId, clientRunId];
       const eventLifecycleGeneration = evt.lifecycleGeneration?.trim();

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -4,7 +4,11 @@ import { isAuditLedgerEnabled, resolveAuditMessageMode } from "../audit/audit-co
 import { createAuditEventRecorder } from "../audit/audit-recorder.js";
 import { onTrustedMessageAuditEvent } from "../audit/message-audit-events.js";
 import { getRuntimeConfig } from "../config/io.js";
-import { clearAgentRunContext, onAgentAuditEvent, onAgentEvent } from "../infra/agent-events.js";
+import {
+  clearAgentRunContext,
+  onAgentAuditEvent,
+  onAgentEventProjection,
+} from "../infra/agent-events.js";
 import { onTrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
@@ -32,10 +36,11 @@ function dispatchEventHandler<TEvent>(params: {
   log: SubsystemLogger;
   failureMessage: string;
   context: Record<string, unknown>;
-}) {
-  void params
+}): Promise<void> {
+  return params
     .loadHandler()
     .then((handler) => handler(params.event))
+    .then(() => undefined)
     .catch((error: unknown) => {
       params.log.warn(params.failureMessage, { ...params.context, error });
     });
@@ -242,7 +247,7 @@ export function startGatewayEventSubscriptions(params: {
     return lifecycleEventHandlerPromise;
   };
 
-  const unsubscribeAgentEvents = onAgentEvent((evt) => {
+  const unsubscribeAgentEvents = onAgentEventProjection((evt) => {
     if (auditEnabled) {
       auditRecorder.record(evt);
     }
@@ -292,7 +297,7 @@ export function startGatewayEventSubscriptions(params: {
         }
       }
     }
-    dispatchEventHandler({
+    return dispatchEventHandler({
       loadHandler: getAgentEventHandler,
       event: evt,
       log: params.log,
@@ -313,7 +318,7 @@ export function startGatewayEventSubscriptions(params: {
   });
 
   const transcriptUnsub = onInternalSessionTranscriptUpdate((evt) => {
-    dispatchEventHandler({
+    void dispatchEventHandler({
       loadHandler: getTranscriptUpdateHandler,
       event: evt,
       log: params.log,
@@ -323,7 +328,7 @@ export function startGatewayEventSubscriptions(params: {
   });
 
   const lifecycleUnsub = onSessionLifecycleEvent((evt) => {
-    dispatchEventHandler({
+    void dispatchEventHandler({
       loadHandler: getLifecycleEventHandler,
       event: evt,
       log: params.log,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -139,6 +139,7 @@ import { loadGatewayTlsRuntime } from "./server/tls.js";
 import { resolveSharedGatewaySessionGeneration } from "./server/ws-shared-generation.js";
 import { maybeSeedControlUiAllowedOriginsAtStartup } from "./startup-control-ui-origins.js";
 import type { WorkerBundleProducer, WorkerNpmArtifact } from "./worker-environments/bundle.js";
+import { createWorkerLiveEventReceiver } from "./worker-environments/live-events.js";
 import { createWorkerEnvironmentService } from "./worker-environments/service.js";
 import { createWorkerEnvironmentStore } from "./worker-environments/store.js";
 import { createWorkerTranscriptCommitter } from "./worker-environments/transcript-commit.js";
@@ -790,6 +791,31 @@ export async function startGatewayServer(
     workerEnvironmentStore && shouldStartWorkerEnvironmentService
       ? (await loadWorkerTunnelRuntimeModule()).createWorkerTunnelManager()
       : undefined;
+  // Freeze restart-owned identities before any new attach can advance its environment.
+  // Only an exact pre-start owner may seed an ephemeral ACK after gateway state loss.
+  const workerEnvironmentRecordsAtStartup = workerEnvironmentStore?.list() ?? [];
+  const workerStartupBindings = workerEnvironmentRecordsAtStartup.flatMap((record) =>
+    record.state === "attached" && record.attachedSessionIds.length === 1
+      ? [
+          {
+            environmentId: record.environmentId,
+            runEpoch: record.ownerEpoch,
+            sessionId: record.attachedSessionIds[0]!,
+          },
+        ]
+      : [],
+  );
+  const workerStartupOwners = new Map(
+    workerStartupBindings.map((binding) => [binding.environmentId, binding.runEpoch] as const),
+  );
+  const workerLiveEvents =
+    workerEnvironmentStore && shouldStartWorkerEnvironmentService
+      ? createWorkerLiveEventReceiver({
+          getConfig: getRuntimeConfig,
+          startupBindings: workerStartupBindings,
+          startupOwners: workerStartupOwners,
+        })
+      : undefined;
   const workerEnvironmentService =
     workerEnvironmentStore && shouldStartWorkerEnvironmentService
       ? createWorkerEnvironmentService({
@@ -802,6 +828,7 @@ export async function startGatewayServer(
           applyTranscriptCommit: createWorkerTranscriptCommitter({
             getConfig: getRuntimeConfig,
           }).commit,
+          ...(workerLiveEvents ? { liveEvents: workerLiveEvents } : {}),
           resolveSshIdentity: async ({ provider, leaseId, profile, keyRef }) => {
             const workerEnvironmentRuntime = await loadWorkerEnvironmentRuntimeModule();
             return await workerEnvironmentRuntime.resolveWorkerSshIdentity({
@@ -2042,7 +2069,10 @@ export async function startGatewayServer(
           (agentId) => terminalLaunchPolicy.resolve(agentId).ok,
         );
       },
-      commitTerminalConfig: terminalLaunchPolicy.commitConfig,
+      commitTerminalConfig: (nextConfig) => {
+        terminalLaunchPolicy.commitConfig();
+        workerLiveEvents?.rebindAll(nextConfig);
+      },
       channelManager,
       activateRuntimeSecrets,
       resolveSharedGatewaySessionGenerationForConfig,

--- a/src/gateway/server/ws-connection/message-handler.worker.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.worker.test.ts
@@ -8,6 +8,8 @@ import {
   PROTOCOL_VERSION,
   type WorkerAdmissionFailureReason,
   type WorkerConnectParams,
+  type WorkerLiveEventErrorDetails,
+  WORKER_LIVE_EVENT_PROTOCOL_FEATURE,
   type WorkerTranscriptCommitErrorReason,
   WORKER_TRANSCRIPT_COMMIT_PROTOCOL_FEATURE,
 } from "../../../../packages/gateway-protocol/src/index.js";
@@ -24,7 +26,11 @@ const CREDENTIAL = ["worker", "credential", "fixture"].join("-");
 const HANDSHAKE = {
   bundleHash: "a".repeat(64),
   openclawVersion: "2026.7.11",
-  protocolFeatures: ["worker-heartbeat-v1", WORKER_TRANSCRIPT_COMMIT_PROTOCOL_FEATURE],
+  protocolFeatures: [
+    "worker-heartbeat-v1",
+    WORKER_TRANSCRIPT_COMMIT_PROTOCOL_FEATURE,
+    WORKER_LIVE_EVENT_PROTOCOL_FEATURE,
+  ],
 };
 const WORKER_CONNECT: WorkerConnectParams = {
   minProtocol: PROTOCOL_VERSION,
@@ -67,6 +73,13 @@ const TRANSCRIPT_COMMIT = {
     },
   ],
 };
+const LIVE_EVENT = {
+  runEpoch: 1,
+  lastAckedSeq: 0,
+  seq: 1,
+  runId: "r",
+  event: { kind: "assistant" as const, payload: { text: "x", delta: "x" } },
+};
 const cleanups: Array<() => void> = [];
 
 function createLogger() {
@@ -78,6 +91,7 @@ function attachHarness(
     admissionFailure?: WorkerAdmissionFailureReason;
     commitFailure?: WorkerTranscriptCommitErrorReason;
     identity?: WorkerConnectionIdentity;
+    liveFailure?: WorkerLiveEventErrorDetails;
     validationFailure?: ReturnType<WorkerConnectionService["validateWorkerConnection"]>;
   } = {},
 ) {
@@ -97,6 +111,11 @@ function attachHarness(
             ok: true as const,
             result: { entryIds: ["entry-1"], newLeafId: "entry-1" },
           },
+    ),
+    pushLiveEvent: vi.fn(async () =>
+      options.liveFailure
+        ? { ok: false as const, details: options.liveFailure }
+        : { ok: true as const, result: { ackedSeq: LIVE_EVENT.seq } },
     ),
     validateWorkerConnection: vi.fn(() => options.validationFailure ?? null),
   } as WorkerConnectionService;
@@ -223,6 +242,46 @@ describe("dedicated worker websocket protocol", () => {
       method: "worker.transcript.commit",
     });
     expect(harness.close).not.toHaveBeenCalled();
+  });
+
+  it("gates live-event features, schema, and closed errors", async () => {
+    const unsupported = attachHarness({
+      identity: {
+        ...IDENTITY,
+        protocolFeatures: HANDSHAKE.protocolFeatures.filter(
+          (feature) => feature !== WORKER_LIVE_EVENT_PROTOCOL_FEATURE,
+        ),
+      },
+    });
+    await admit(unsupported);
+    unsupported.sendRequest("worker.live-event", LIVE_EVENT);
+    await vi.waitFor(() => expect(unsupported.close).toHaveBeenCalled());
+    expect(unsupported.service.pushLiveEvent).not.toHaveBeenCalled();
+
+    const resync = attachHarness({
+      liveFailure: { reason: "resync-required", ackedSeq: 2, expectedSeq: 3 },
+    });
+    await admit(resync);
+    resync.sendRequest("worker.live-event", { ...LIVE_EVENT, seq: 7 });
+    await vi.waitFor(() =>
+      expect(resync.responses[1]).toMatchObject({
+        error: { details: { reason: "resync-required" } },
+      }),
+    );
+    expect(resync.service.pushLiveEvent).toHaveBeenCalledOnce();
+
+    const invalid = attachHarness();
+    await admit(invalid);
+    invalid.sendRequest("worker.live-event", {
+      ...LIVE_EVENT,
+      event: { kind: "assistant", payload: { delta: "x" } },
+    });
+    await vi.waitFor(() =>
+      expect(invalid.responses[1]).toMatchObject({
+        error: { details: { reason: "invalid-event" } },
+      }),
+    );
+    expect(invalid.service.pushLiveEvent).not.toHaveBeenCalled();
   });
 
   it("rejects transcript commits when the admitted worker lacks the feature", async () => {

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -7,10 +7,13 @@ import {
   type WorkerErrorShape,
   type WorkerHeartbeatResult,
   type WorkerHelloOk,
+  type WorkerLiveEventErrorDetails,
+  type WorkerLiveEventErrorShape,
   type WorkerProtocolCloseReason,
   type WorkerTranscriptCommitErrorReason,
   type WorkerTranscriptCommitErrorShape,
   WORKER_HEARTBEAT_INTERVAL_MS,
+  WORKER_LIVE_EVENT_PROTOCOL_FEATURE,
   WORKER_PROTOCOL_MAX_FRAME_ID_LENGTH,
   WORKER_PROTOCOL_MAX_METHOD_LENGTH,
   WORKER_PROTOCOL_MAX_PAYLOAD_BYTES,
@@ -19,6 +22,7 @@ import {
   validateRequestFrame,
   validateWorkerConnectRequestFrame,
   validateWorkerHeartbeatParams,
+  validateWorkerLiveEventParams,
   validateWorkerTranscriptCommitParams,
 } from "../../../../packages/gateway-protocol/src/index.js";
 import { GATEWAY_STARTUP_RETRY_AFTER_MS } from "../../../../packages/gateway-protocol/src/startup-unavailable.js";
@@ -30,13 +34,13 @@ import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
 
 export type WorkerConnectionService = Pick<
   WorkerEnvironmentService,
-  "admitWorker" | "commitTranscript" | "validateWorkerConnection"
+  "admitWorker" | "commitTranscript" | "pushLiveEvent" | "validateWorkerConnection"
 >;
 
 type WorkerRespond = (
   ok: boolean,
   payload?: unknown,
-  error?: WorkerErrorShape | WorkerTranscriptCommitErrorShape,
+  error?: WorkerErrorShape | WorkerLiveEventErrorShape | WorkerTranscriptCommitErrorShape,
 ) => void;
 type WorkerLogger = { warn(message: string): void };
 const MAX_QUEUED_WORKER_FRAMES = 16;
@@ -115,6 +119,14 @@ function workerTranscriptCommitError(
   };
 }
 
+function workerLiveEventError(details: WorkerLiveEventErrorDetails): WorkerLiveEventErrorShape {
+  return {
+    code: ErrorCodes.INVALID_REQUEST,
+    message: "worker live event rejected",
+    details,
+  };
+}
+
 /** Closed worker dispatcher. It never calls the generic gateway method registry. */
 async function dispatchWorkerRequest(params: {
   request: RequestFrame;
@@ -153,6 +165,27 @@ async function dispatchWorkerRequest(params: {
       return;
     }
     params.respond(false, undefined, workerTranscriptCommitError(outcome.reason));
+    return;
+  }
+  if (params.request.method === WORKER_PROTOCOL_METHODS[2]) {
+    if (!params.identity.protocolFeatures.includes(WORKER_LIVE_EVENT_PROTOCOL_FEATURE)) {
+      rejectWorkerRequest({ ...params, reason: "method-not-allowed" });
+      return;
+    }
+    if (!validateWorkerLiveEventParams(params.request.params)) {
+      params.respond(false, undefined, workerLiveEventError({ reason: "invalid-event" }));
+      return;
+    }
+    const outcome = await service.pushLiveEvent(params.identity, params.request.params);
+    if (outcome.ok) {
+      params.respond(true, outcome.result);
+      return;
+    }
+    if ("closeReason" in outcome) {
+      rejectWorkerRequest({ ...params, reason: outcome.closeReason });
+      return;
+    }
+    params.respond(false, undefined, workerLiveEventError(outcome.details));
     return;
   }
   if (params.request.method !== WORKER_PROTOCOL_METHODS[0]) {
@@ -342,7 +375,8 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
     }
     if (
       parsed.method === WORKER_PROTOCOL_METHODS[0] ||
-      parsed.method === WORKER_PROTOCOL_METHODS[1]
+      parsed.method === WORKER_PROTOCOL_METHODS[1] ||
+      parsed.method === WORKER_PROTOCOL_METHODS[2]
     ) {
       params.setLastFrameMeta({ type: "req", method: parsed.method });
     }

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import type { RawData } from "ws";
 import {
   loadTranscriptEvents,
   persistSessionTranscriptTurn,
@@ -16,6 +17,7 @@ import {
   clearAgentRunContext,
   emitAgentEvent,
 } from "../infra/agent-events.js";
+import { rawDataToString } from "../infra/ws.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import * as transcriptEvents from "../sessions/transcript-events.js";
 import {
@@ -1361,6 +1363,146 @@ describe("session.message websocket events", () => {
     } finally {
       receiver.clear();
       clearAgentRunContext("local");
+      ws.close();
+    }
+  });
+
+  test("delivers a published worker prefix once when a buffered tail hits capacity", async () => {
+    const storePath = await createSessionStoreFile();
+    const sessionId = "sess-worker-capacity-prefix";
+    const sessionKey = "agent:main:worker-capacity-prefix";
+    await writeSessionStore({
+      entries: {
+        "worker-capacity-prefix": {
+          sessionId,
+          updatedAt: Date.now(),
+        },
+      },
+      storePath,
+    });
+    const config: OpenClawConfig = {
+      agents: { list: [{ id: "main", default: true }] },
+      session: { mainKey: "main", store: storePath },
+    };
+    const identity: WorkerConnectionIdentity = {
+      environmentId: "environment-capacity-prefix",
+      credentialHash: ["capacity", "prefix", "credential"].join("-"),
+      bundleHash: "c".repeat(64),
+      sessionId,
+      ownerEpoch: 5,
+      rpcSetVersion: 1,
+      protocolFeatures: ["worker-live-event-v1"],
+      credentialExpiresAtMs: Date.now() + 10_000,
+    };
+    const receiver = createWorkerLiveEventReceiver({
+      getConfig: () => config,
+      maxActiveRuns: 1,
+      startupBindings: [{ environmentId: identity.environmentId, runEpoch: 5, sessionId }],
+      startupOwners: new Map([[identity.environmentId, 5]]),
+    });
+    const prefix = {
+      event: { kind: "assistant" as const, payload: { text: "prefix", delta: "prefix" } },
+      lastAckedSeq: 0,
+      runEpoch: identity.ownerEpoch,
+      runId: "worker-capacity-prefix-a",
+      seq: 1,
+    };
+    const buffered = {
+      event: { kind: "assistant" as const, payload: { text: "buffered", delta: "buffered" } },
+      lastAckedSeq: 0,
+      runEpoch: identity.ownerEpoch,
+      runId: "worker-capacity-prefix-b",
+      seq: 2,
+    };
+    const ws = await harness.openWs();
+    const prefixChats: Record<string, unknown>[] = [];
+    const collectPrefixChats = (data: RawData) => {
+      const message = JSON.parse(rawDataToString(data)) as {
+        type?: string;
+        event?: string;
+        payload?: Record<string, unknown>;
+      };
+      if (
+        message.type === "event" &&
+        message.event === "chat" &&
+        message.payload?.runId === prefix.runId
+      ) {
+        prefixChats.push(message.payload);
+      }
+    };
+    ws.on("message", collectPrefixChats);
+    try {
+      await connectOk(ws, { scopes: ["operator.read"] });
+      const subscribeRes = await rpcReq(ws, "sessions.messages.subscribe", { key: sessionKey });
+      expect(subscribeRes.ok).toBe(true);
+
+      expect(receiver.apply({ identity, request: buffered })).toEqual({
+        ok: true,
+        result: { ackedSeq: 0 },
+      });
+      const prefixEvent = onceMessage(
+        ws,
+        ({ type, event, payload }) =>
+          type === "event" &&
+          event === "chat" &&
+          (payload as Record<string, unknown>).runId === prefix.runId,
+        5_000,
+      );
+      expect(receiver.apply({ identity, request: prefix })).toEqual({
+        ok: true,
+        result: { ackedSeq: 1 },
+      });
+      expectRecordFields((await prefixEvent).payload, {
+        deltaText: "prefix",
+        runId: prefix.runId,
+        sessionKey,
+        state: "delta",
+      });
+
+      const bufferedEvent = onceMessage(
+        ws,
+        ({ type, event, payload }) =>
+          type === "event" &&
+          event === "chat" &&
+          (payload as Record<string, unknown>).runId === buffered.runId,
+        5_000,
+      );
+      await expectNoMessageWithin({
+        watch: (timeoutMs) =>
+          onceMessage(
+            ws,
+            ({ type, event, payload }) =>
+              type === "event" &&
+              event === "chat" &&
+              (payload as Record<string, unknown>).runId === prefix.runId,
+            timeoutMs,
+          ),
+        action: () => {
+          expect(receiver.apply({ identity, request: { ...buffered, lastAckedSeq: 1 } })).toEqual({
+            ok: false,
+            details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 1 },
+          });
+          expect(
+            receiver.apply({
+              identity,
+              request: { ...buffered, lastAckedSeq: 0, seq: 1 },
+            }),
+          ).toEqual({
+            ok: true,
+            result: { ackedSeq: 1 },
+          });
+        },
+      });
+      expectRecordFields((await bufferedEvent).payload, {
+        deltaText: "buffered",
+        runId: buffered.runId,
+        sessionKey,
+        state: "delta",
+      });
+      expect(prefixChats).toHaveLength(1);
+    } finally {
+      receiver.clear();
+      ws.off("message", collectPrefixChats);
       ws.close();
     }
   });

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -5,7 +5,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
-import type { RawData } from "ws";
 import {
   loadTranscriptEvents,
   persistSessionTranscriptTurn,
@@ -17,7 +16,6 @@ import {
   clearAgentRunContext,
   emitAgentEvent,
 } from "../infra/agent-events.js";
-import { rawDataToString } from "../infra/ws.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import * as transcriptEvents from "../sessions/transcript-events.js";
 import {
@@ -1363,146 +1361,6 @@ describe("session.message websocket events", () => {
     } finally {
       receiver.clear();
       clearAgentRunContext("local");
-      ws.close();
-    }
-  });
-
-  test("delivers a published worker prefix once when a buffered tail hits capacity", async () => {
-    const storePath = await createSessionStoreFile();
-    const sessionId = "sess-worker-capacity-prefix";
-    const sessionKey = "agent:main:worker-capacity-prefix";
-    await writeSessionStore({
-      entries: {
-        "worker-capacity-prefix": {
-          sessionId,
-          updatedAt: Date.now(),
-        },
-      },
-      storePath,
-    });
-    const config: OpenClawConfig = {
-      agents: { list: [{ id: "main", default: true }] },
-      session: { mainKey: "main", store: storePath },
-    };
-    const identity: WorkerConnectionIdentity = {
-      environmentId: "environment-capacity-prefix",
-      credentialHash: ["capacity", "prefix", "credential"].join("-"),
-      bundleHash: "c".repeat(64),
-      sessionId,
-      ownerEpoch: 5,
-      rpcSetVersion: 1,
-      protocolFeatures: ["worker-live-event-v1"],
-      credentialExpiresAtMs: Date.now() + 10_000,
-    };
-    const receiver = createWorkerLiveEventReceiver({
-      getConfig: () => config,
-      maxActiveRuns: 1,
-      startupBindings: [{ environmentId: identity.environmentId, runEpoch: 5, sessionId }],
-      startupOwners: new Map([[identity.environmentId, 5]]),
-    });
-    const prefix = {
-      event: { kind: "assistant" as const, payload: { text: "prefix", delta: "prefix" } },
-      lastAckedSeq: 0,
-      runEpoch: identity.ownerEpoch,
-      runId: "worker-capacity-prefix-a",
-      seq: 1,
-    };
-    const buffered = {
-      event: { kind: "assistant" as const, payload: { text: "buffered", delta: "buffered" } },
-      lastAckedSeq: 0,
-      runEpoch: identity.ownerEpoch,
-      runId: "worker-capacity-prefix-b",
-      seq: 2,
-    };
-    const ws = await harness.openWs();
-    const prefixChats: Record<string, unknown>[] = [];
-    const collectPrefixChats = (data: RawData) => {
-      const message = JSON.parse(rawDataToString(data)) as {
-        type?: string;
-        event?: string;
-        payload?: Record<string, unknown>;
-      };
-      if (
-        message.type === "event" &&
-        message.event === "chat" &&
-        message.payload?.runId === prefix.runId
-      ) {
-        prefixChats.push(message.payload);
-      }
-    };
-    ws.on("message", collectPrefixChats);
-    try {
-      await connectOk(ws, { scopes: ["operator.read"] });
-      const subscribeRes = await rpcReq(ws, "sessions.messages.subscribe", { key: sessionKey });
-      expect(subscribeRes.ok).toBe(true);
-
-      expect(receiver.apply({ identity, request: buffered })).toEqual({
-        ok: true,
-        result: { ackedSeq: 0 },
-      });
-      const prefixEvent = onceMessage(
-        ws,
-        ({ type, event, payload }) =>
-          type === "event" &&
-          event === "chat" &&
-          (payload as Record<string, unknown>).runId === prefix.runId,
-        5_000,
-      );
-      expect(receiver.apply({ identity, request: prefix })).toEqual({
-        ok: true,
-        result: { ackedSeq: 1 },
-      });
-      expectRecordFields((await prefixEvent).payload, {
-        deltaText: "prefix",
-        runId: prefix.runId,
-        sessionKey,
-        state: "delta",
-      });
-
-      const bufferedEvent = onceMessage(
-        ws,
-        ({ type, event, payload }) =>
-          type === "event" &&
-          event === "chat" &&
-          (payload as Record<string, unknown>).runId === buffered.runId,
-        5_000,
-      );
-      await expectNoMessageWithin({
-        watch: (timeoutMs) =>
-          onceMessage(
-            ws,
-            ({ type, event, payload }) =>
-              type === "event" &&
-              event === "chat" &&
-              (payload as Record<string, unknown>).runId === prefix.runId,
-            timeoutMs,
-          ),
-        action: () => {
-          expect(receiver.apply({ identity, request: { ...buffered, lastAckedSeq: 1 } })).toEqual({
-            ok: false,
-            details: { reason: "resync-required", ackedSeq: 0, expectedSeq: 1 },
-          });
-          expect(
-            receiver.apply({
-              identity,
-              request: { ...buffered, lastAckedSeq: 0, seq: 1 },
-            }),
-          ).toEqual({
-            ok: true,
-            result: { ackedSeq: 1 },
-          });
-        },
-      });
-      expectRecordFields((await bufferedEvent).payload, {
-        deltaText: "buffered",
-        runId: buffered.runId,
-        sessionKey,
-        state: "delta",
-      });
-      expect(prefixChats).toHaveLength(1);
-    } finally {
-      receiver.clear();
-      ws.off("message", collectPrefixChats);
       ws.close();
     }
   });

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -11,6 +11,11 @@ import {
 } from "../config/sessions/session-accessor.js";
 import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  claimAgentRunContext,
+  clearAgentRunContext,
+  emitAgentEvent,
+} from "../infra/agent-events.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import * as transcriptEvents from "../sessions/transcript-events.js";
 import {
@@ -27,6 +32,7 @@ import {
   writeSessionStore,
 } from "./test-helpers.server.js";
 import type { WorkerConnectionIdentity } from "./worker-environments/connection-identity.js";
+import { createWorkerLiveEventReceiver } from "./worker-environments/live-events.js";
 import type { WorkerTranscriptCommitStore } from "./worker-environments/transcript-commit-store.js";
 import { createWorkerTranscriptCommitter } from "./worker-environments/transcript-commit.js";
 
@@ -1214,7 +1220,7 @@ describe("session.message websocket events", () => {
     }
   });
 
-  test("streams every worker transcript commit entry to the selected session subscriber", async () => {
+  test("streams worker commits and local-equivalent live events to the selected session", async () => {
     const storePath = await createSessionStoreFile();
     const sessionId = "sess-worker-commit-fanout";
     const sessionKey = "agent:main:worker";
@@ -1243,10 +1249,14 @@ describe("session.message websocket events", () => {
       sessionId,
       ownerEpoch: 4,
       rpcSetVersion: 1,
-      protocolFeatures: ["worker-transcript-commit-v1"],
+      protocolFeatures: ["worker-live-event-v1", "worker-transcript-commit-v1"],
       credentialExpiresAtMs: Date.now() + 10_000,
     };
-
+    const receiver = createWorkerLiveEventReceiver({
+      getConfig: () => config,
+      startupBindings: [{ environmentId: identity.environmentId, runEpoch: 4, sessionId }],
+      startupOwners: new Map([[identity.environmentId, 4]]),
+    });
     const ws = await harness.openWs();
     try {
       await connectOk(ws, { scopes: ["operator.read"] });
@@ -1300,7 +1310,57 @@ describe("session.message websocket events", () => {
           return requireRecord(message["__openclaw"], "session.message metadata").seq;
         }),
       ).toEqual([1, 2, 3]);
+
+      const waitForChat = (runId: string, timeoutMs?: number) =>
+        onceMessage(
+          ws,
+          ({ type, event, payload }) =>
+            type === "event" &&
+            event === "chat" &&
+            (payload as Record<string, unknown>).runId === runId,
+          timeoutMs,
+        );
+      const liveEvent = {
+        event: { kind: "assistant", payload: { text: "hello", delta: "hello" } },
+        lastAckedSeq: 0,
+        seq: 1,
+      } as const;
+      const push = (runEpoch = 4, runId = "worker") =>
+        receiver.apply({ identity, request: { ...liveEvent, runEpoch, runId } });
+      const [workerEvent] = await Promise.all([
+        waitForChat("worker"),
+        expectNoMessageWithin({
+          watch: (timeoutMs) => waitForSessionMessageEvent(ws, sessionKey, timeoutMs),
+          action: () => expect(push().ok).toBe(true),
+        }),
+      ]);
+      const workerChat = requireRecord(workerEvent.payload, "worker chat");
+
+      claimAgentRunContext("local", {
+        sessionKey,
+        sessionId,
+        agentId: "main",
+        isControlUiVisible: false,
+      });
+      const localEvent = waitForChat("local");
+      emitAgentEvent({
+        runId: "local",
+        stream: "assistant",
+        data: { text: "hello", delta: "hello" },
+      });
+      const localChat = requireRecord((await localEvent).payload, "local chat");
+      for (const payload of [workerChat, localChat]) {
+        payload.runId = "normalized";
+        requireRecord(payload.message, "chat message").timestamp = 0;
+      }
+      expect(workerChat).toEqual(localChat);
+      await expectNoMessageWithin({
+        watch: (timeoutMs) => waitForChat("stale", timeoutMs),
+        action: () => expect(push(3, "stale").ok).toBe(false),
+      });
     } finally {
+      receiver.clear();
+      clearAgentRunContext("local");
       ws.close();
     }
   });

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import type { RawData } from "ws";
 import {
   loadTranscriptEvents,
   persistSessionTranscriptTurn,
@@ -16,6 +17,7 @@ import {
   clearAgentRunContext,
   emitAgentEvent,
 } from "../infra/agent-events.js";
+import { rawDataToString } from "../infra/ws.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import * as transcriptEvents from "../sessions/transcript-events.js";
 import {
@@ -1258,6 +1260,22 @@ describe("session.message websocket events", () => {
       startupOwners: new Map([[identity.environmentId, 4]]),
     });
     const ws = await harness.openWs();
+    const workerChats: Record<string, unknown>[] = [];
+    const collectWorkerChats = (data: RawData) => {
+      const message = JSON.parse(rawDataToString(data)) as {
+        type?: string;
+        event?: string;
+        payload?: Record<string, unknown>;
+      };
+      if (
+        message.type === "event" &&
+        message.event === "chat" &&
+        message.payload?.runId === "worker"
+      ) {
+        workerChats.push(message.payload);
+      }
+    };
+    ws.on("message", collectWorkerChats);
     try {
       await connectOk(ws, { scopes: ["operator.read"] });
       const subscribeRes = await rpcReq(ws, "sessions.messages.subscribe", { key: sessionKey });
@@ -1335,6 +1353,13 @@ describe("session.message websocket events", () => {
         }),
       ]);
       const workerChat = requireRecord(workerEvent.payload, "worker chat");
+      await expectNoMessageWithin({
+        watch: (timeoutMs) => waitForChat("worker", timeoutMs),
+        action: () => {
+          expect(push()).toEqual({ ok: true, result: { ackedSeq: 1 } });
+        },
+      });
+      expect(workerChats).toHaveLength(1);
 
       claimAgentRunContext("local", {
         sessionKey,
@@ -1361,6 +1386,7 @@ describe("session.message websocket events", () => {
     } finally {
       receiver.clear();
       clearAgentRunContext("local");
+      ws.off("message", collectWorkerChats);
       ws.close();
     }
   });

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type {
   WorkerLiveEventErrorDetails as ErrorDetails,
   WorkerLiveEventParams as Params,
@@ -14,7 +14,6 @@ import {
   emitAgentEvent,
   getAgentRunContext,
   onAgentEvent,
-  onAgentEventProjection,
   sweepStaleRunContexts,
   type AgentEventPayload as Event,
 } from "../../infra/agent-events.js";
@@ -245,34 +244,6 @@ describe("worker live events", () => {
     fail(second, "invalid-event");
     clearAgentRunContext(second.runId);
     ack(second);
-    expect(deltas()).toEqual(["first", "second"]);
-  });
-
-  it("keeps a published prefix claim until buffered capacity projection settles", async () => {
-    start({ maxActiveRuns: 1 });
-    const first = msg(1, "first", 0, "run-prefix");
-    const second = msg(2, "second", 0, "run-buffered");
-    let settleProjection = () => {};
-    const projection = new Promise<void>((resolve) => {
-      settleProjection = resolve;
-    });
-    const stopProjection = onAgentEventProjection((event) =>
-      event.runId === first.runId ? projection : Promise.resolve(),
-    );
-    try {
-      ack(second, 0);
-      ack(first);
-      expect(getAgentRunContext(first.runId)).toBeDefined();
-
-      fail({ ...second, lastAckedSeq: 1 }, "resync-required");
-      settleProjection();
-      await vi.waitFor(() => expect(getAgentRunContext(first.runId)).toBeUndefined());
-      ack({ ...second, lastAckedSeq: 0, seq: 1 });
-    } finally {
-      settleProjection();
-      stopProjection();
-    }
-
     expect(deltas()).toEqual(["first", "second"]);
   });
 

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -13,9 +13,9 @@ import {
   clearAgentRunContext,
   emitAgentEvent,
   getAgentRunContext,
-  onAgentEvent,
+  onAgentRuntimeEvent,
   sweepStaleRunContexts,
-  type AgentEventPayload as Event,
+  type AgentEventRuntimePayload as Event,
 } from "../../infra/agent-events.js";
 import type { WorkerConnectionIdentity as Identity } from "./connection-identity.js";
 import {
@@ -118,7 +118,7 @@ describe("worker live events", () => {
     await create(10);
     start();
     events = [];
-    unsubscribe = onAgentEvent((event) => events.push(event));
+    unsubscribe = onAgentRuntimeEvent((event) => events.push(event));
   });
 
   afterEach(async () => {

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   WorkerLiveEventErrorDetails as ErrorDetails,
   WorkerLiveEventParams as Params,
@@ -14,6 +14,7 @@ import {
   emitAgentEvent,
   getAgentRunContext,
   onAgentEvent,
+  onAgentEventProjection,
   sweepStaleRunContexts,
   type AgentEventPayload as Event,
 } from "../../infra/agent-events.js";
@@ -247,6 +248,45 @@ describe("worker live events", () => {
     expect(deltas()).toEqual(["first", "second"]);
   });
 
+  it("keeps a published prefix claim until buffered capacity projection settles", async () => {
+    start({ maxActiveRuns: 1 });
+    const first = msg(1, "first", 0, "run-prefix");
+    const second = msg(2, "second", 0, "run-buffered");
+    let settleProjection = () => {};
+    const projection = new Promise<void>((resolve) => {
+      settleProjection = resolve;
+    });
+    const stopProjection = onAgentEventProjection((event) =>
+      event.runId === first.runId ? projection : Promise.resolve(),
+    );
+    try {
+      ack(second, 0);
+      ack(first);
+      expect(getAgentRunContext(first.runId)).toBeDefined();
+
+      fail({ ...second, lastAckedSeq: 1 }, "resync-required");
+      settleProjection();
+      await vi.waitFor(() => expect(getAgentRunContext(first.runId)).toBeUndefined());
+      ack({ ...second, lastAckedSeq: 0, seq: 1 });
+    } finally {
+      settleProjection();
+      stopProjection();
+    }
+
+    expect(deltas()).toEqual(["first", "second"]);
+  });
+
+  it("clears speculative pending events on in-window resync", () => {
+    start({ windowSize: 2 });
+    ack(msg(2, "stale"), 0);
+    fail(msg(3, "gap"), "resync-required");
+
+    ack(msg(1, "first"));
+    ack(msg(2, "fresh", 1));
+
+    expect(deltas()).toEqual(["first", "fresh"]);
+  });
+
   it("resets after capacity failure", () => {
     start({ maxActiveRuns: 1 });
     ack(msg(1, "active", 0, "run-active"));
@@ -326,6 +366,16 @@ describe("worker live events", () => {
     ack(live(1, { kind: "lifecycle", payload: { phase: "end", endedAt: 200 } }));
     ack(msg(2, "other", 1, "run-other"));
     fail(msg(3, "late", 2), "invalid-event");
+  });
+
+  it("retains a terminal fence while its run remains claimed", () => {
+    start({ windowSize: 2 });
+    ack(live(1, { kind: "lifecycle", payload: { phase: "end", endedAt: 200 } }));
+    ack(msg(2, "other-first", 1, "run-other"));
+    ack(msg(3, "other-second", 2, "run-other"));
+
+    fail(msg(4, "late", 3), "invalid-event");
+    expect(events.filter((event) => event.runId === RUN)).toHaveLength(1);
   });
 
   it("clears on detach", () => {

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -1,0 +1,357 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  WorkerLiveEventErrorDetails as ErrorDetails,
+  WorkerLiveEventParams as Params,
+} from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import * as sessions from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig as Config } from "../../config/types.openclaw.js";
+import {
+  claimAgentRunContext,
+  clearAgentRunContext,
+  emitAgentEvent,
+  getAgentRunContext,
+  onAgentEvent,
+  sweepStaleRunContexts,
+  type AgentEventPayload as Event,
+} from "../../infra/agent-events.js";
+import type { WorkerConnectionIdentity as Identity } from "./connection-identity.js";
+import {
+  createWorkerLiveEventReceiver,
+  type WorkerLiveEventReceiver as Receiver,
+} from "./live-events.js";
+
+const SID = "session-worker-live";
+const KEY = "agent:main:worker-live";
+const EPOCH = 7;
+const RUN = "run-worker-live";
+const LOCAL = { agentId: "main", sessionId: SID, sessionKey: KEY };
+const ID: Identity = {
+  environmentId: "environment-live",
+  credentialHash: ["credential", "hash", "live"].join("-"),
+  bundleHash: "b".repeat(64),
+  sessionId: SID,
+  ownerEpoch: EPOCH,
+  rpcSetVersion: 1,
+  protocolFeatures: ["worker-live-event-v1"],
+  credentialExpiresAtMs: 10_000,
+};
+
+const msg = (seq: number, delta = "hello", ack = 0, runId = RUN, epoch = EPOCH): Params => ({
+  runEpoch: epoch,
+  lastAckedSeq: ack,
+  seq,
+  runId,
+  event: { kind: "assistant", payload: { text: delta, delta } },
+});
+
+function live(seq: number, event: Params["event"], runId = RUN): Params {
+  return { runEpoch: EPOCH, lastAckedSeq: seq - 1, seq, runId, event };
+}
+
+const binding = ({ environmentId, ownerEpoch: runEpoch, sessionId }: Identity = ID) => ({
+  environmentId,
+  runEpoch,
+  sessionId: sessionId ?? SID,
+});
+
+type WireEvent = Params["event"];
+type Payload<K extends WireEvent["kind"]> = Extract<WireEvent, { kind: K }>["payload"];
+const tool = (payload: Payload<"tool">): WireEvent => ({ kind: "tool", payload });
+const approval = (payload: Payload<"approval">): WireEvent => ({ kind: "approval", payload });
+const lifecycle = (payload: Payload<"lifecycle">): WireEvent => ({ kind: "lifecycle", payload });
+
+describe("worker live events", () => {
+  let root: string;
+  let store: string;
+  let cfg: Config;
+  let rx: Receiver;
+  let events: Event[];
+  let unsubscribe: (() => void) | undefined;
+
+  const ack = (request: Params, ackedSeq = request.seq, id = ID) => {
+    expect(rx.apply({ identity: id, request })).toEqual({ ok: true, result: { ackedSeq } });
+  };
+  const fail = (request: Params, reason: ErrorDetails["reason"], id = ID) => {
+    const details: ErrorDetails =
+      reason === "resync-required" ? { reason, ackedSeq: 0, expectedSeq: 1 } : { reason };
+    expect(rx.apply({ identity: id, request })).toEqual({ ok: false, details });
+  };
+  const start = (overrides: Partial<Parameters<typeof createWorkerLiveEventReceiver>[0]> = {}) => {
+    rx?.clear();
+    rx = createWorkerLiveEventReceiver({
+      getConfig: () => cfg,
+      startupBindings: [binding()],
+      startupOwners: new Map([[ID.environmentId, EPOCH]]),
+      ...overrides,
+    });
+    rx.start();
+  };
+  const target = { canonicalKey: KEY, storeKeys: [KEY] };
+  const remove = () =>
+    sessions.deleteSessionEntryLifecycle({
+      agentId: "main",
+      archiveTranscript: false,
+      expectedSessionId: SID,
+      storePath: store,
+      target,
+    });
+  const create = (updatedAt = 20) =>
+    sessions.upsertSessionEntry(
+      { agentId: "main", sessionKey: KEY, storePath: store },
+      { sessionId: SID, updatedAt },
+    );
+  const deltas = () => events.map((event) => event.data.delta);
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-worker-live-"));
+    store = path.join(root, "agents", "main", "sessions", "sessions.json");
+    cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+      session: {
+        mainKey: "main",
+        store: path.join(root, "agents", "{agentId}", "sessions", "sessions.json"),
+      },
+    };
+    await create(10);
+    start();
+    events = [];
+    unsubscribe = onAgentEvent((event) => events.push(event));
+  });
+
+  afterEach(async () => {
+    unsubscribe?.();
+    rx.clear();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("maps and sanitizes kinds", () => {
+    const credential = ["fixture", "credential", "value"].join("-");
+    const output = (char: string, status: string) => ({
+      content: [{ type: "image", bytes: 6, omitted: true }],
+      details: { credential, status, aggregated: char.repeat(9000) },
+    });
+    const variants: WireEvent[] = [
+      { kind: "assistant", payload: { text: "hello", delta: "hello" } },
+      { kind: "thinking", payload: { text: "Inspecting", delta: "ing" } },
+      tool({ phase: "start", name: "read", toolCallId: "call", args: { credential } }),
+      tool({
+        phase: "update",
+        name: " BASH ",
+        toolCallId: "call",
+        partialResult: output("p", "running"),
+      }),
+      tool({
+        phase: "result",
+        name: "bash",
+        toolCallId: "call",
+        isError: false,
+        result: output("r", "completed"),
+      }),
+      approval({ phase: "requested", kind: "exec", status: "pending", title: "Approve" }),
+      approval({ phase: "resolved", kind: "exec", status: "approved", title: "Approved" }),
+      lifecycle({ phase: "start", startedAt: 100 }),
+      lifecycle({
+        phase: "fallback_step",
+        fallbackStepType: "fallback_step",
+        fallbackStepFromModel: "openai/gpt-primary",
+        fallbackStepFinalOutcome: "next_fallback",
+      }),
+    ];
+
+    variants.forEach((event, index) => {
+      ack(live(index + 1, event, `run-map-${index}`));
+    });
+    expect(events.map((event) => event.stream)).toEqual(variants.map((event) => event.kind));
+    const capped = (char: string) => `${char.repeat(8000)}\n...(live output truncated)...`;
+    expect(events[4]?.data).toMatchObject({
+      name: "exec",
+      result: { content: [{ bytes: 6, omitted: true }], details: { aggregated: capped("r") } },
+    });
+    expect(JSON.stringify(events)).not.toContain(credential);
+  });
+
+  it("replays an unacked tail once", () => {
+    ack(msg(2, " world"), 0);
+    ack(msg(1), 2, { ...ID });
+    ack(msg(1), 2);
+    ack(msg(2, " world"), 2);
+    expect(deltas()).toEqual(["hello", " world"]);
+  });
+
+  it.each([
+    ["sequence", { windowSize: 2 }, msg(3)],
+    ["bytes", { maxPendingBytes: 1 }, msg(2, "buffered")],
+  ])("resyncs an out-of-window %s gap", (_name, options, request) => {
+    start(options);
+    fail(request, "resync-required");
+  });
+
+  it("uses startup ACK once", async () => {
+    ack(msg(6, "before", 5));
+    await remove();
+    await create(30);
+    fail(msg(8, "stale", 7), "resync-required");
+    ack(msg(1, "fresh"));
+  });
+
+  it("does not seed ACK for a freshly attached startup owner", () => {
+    start({ startupBindings: [] });
+    expect(rx.bindSession(binding())).toBe(true);
+    fail(msg(6, "stale", 5), "resync-required");
+    ack(msg(1));
+  });
+
+  it("rebinds unresolved startup", async () => {
+    await remove();
+    start();
+    fail(msg(1), "session-not-attached");
+    await create();
+    fail(msg(6, "stale", 5), "resync-required");
+    ack(msg(1));
+  });
+
+  it("rotates owners", () => {
+    ack(msg(1, "first"));
+    const credentialHash = ["rotated", "credential", "hash"].join("-");
+    rx.rotateCredential({
+      credentialHash,
+      environmentId: ID.environmentId,
+      previousCredentialHash: ID.credentialHash,
+      runEpoch: EPOCH,
+      sessionId: SID,
+    });
+    const rotated = { ...ID, credentialHash };
+    ack(msg(2, "second", 1), 2, rotated);
+    fail(msg(3, "late", 2), "epoch-mismatch");
+    const next = { ...rotated, ownerEpoch: EPOCH + 1 };
+    rx.bindSession(binding(next));
+    fail(msg(2, "skip", 1, RUN, next.ownerEpoch), "resync-required", next);
+    ack(msg(1, "new", 0, RUN, next.ownerEpoch), 1, next);
+    fail(msg(2, "late", 1), "epoch-mismatch", rotated);
+    ack(msg(2, "current", 1, RUN, next.ownerEpoch), 2, next);
+    expect(deltas()).toEqual(["first", "second", "new", "current"]);
+  });
+
+  it("ACKs before buffered failure", () => {
+    const first = msg(1, "first", 0, "run-prefix");
+    const second = msg(2, "second", 0, "run-buffered");
+    claimAgentRunContext(second.runId, { sessionKey: KEY });
+    ack(second, 0);
+    ack(first);
+    fail(second, "invalid-event");
+    clearAgentRunContext(second.runId);
+    ack(second);
+    expect(deltas()).toEqual(["first", "second"]);
+  });
+
+  it("resets after capacity failure", () => {
+    start({ maxActiveRuns: 1 });
+    ack(msg(1, "active", 0, "run-active"));
+    fail(msg(2, "overlap", 1, "run-overlap"), "capacity-exceeded");
+    fail(msg(2, "stale", 1, "run-overlap"), "resync-required");
+    ack(msg(1, "fresh", 0, "run-overlap"));
+  });
+
+  it.each([RUN, "run-sibling"])("resyncs after a swept context before %s", (runId) => {
+    ack(msg(1, "before"));
+    expect(sweepStaleRunContexts(-1)).toBe(1);
+    fail(msg(2, "stale", 1, runId), "resync-required");
+    ack(msg(1, "fresh", 0, runId));
+    expect(deltas()).toEqual(["before", "fresh"]);
+  });
+
+  it("survives config suspension", () => {
+    const valid = cfg;
+    ack(msg(1, "before"));
+    ack(msg(3, "third", 1), 1);
+    cfg = {
+      ...cfg,
+      session: { ...cfg.session, store: path.join(root, "missing", "{agentId}", "sessions.json") },
+    };
+    rx.rebindAll(cfg);
+    fail(msg(2, "suspended", 1), "session-not-attached");
+    cfg = valid;
+    rx.rebindAll(cfg);
+    ack(msg(2, "after", 1), 3);
+    expect(deltas()).toEqual(["before", "after", "third"]);
+    expect(events.map((event) => event.seq)).toEqual([1, 2, 3]);
+  });
+
+  it("moves without losing state", async () => {
+    const moved = `${KEY}-moved`;
+    ack(msg(1, "first"));
+    ack(msg(3, "third", 1), 1);
+    await sessions.patchSessionEntryTarget(
+      { agentId: "main", storePath: store, target: { canonicalKey: moved, storeKeys: [KEY] } },
+      () => ({ updatedAt: 20 }),
+    );
+    ack(msg(2, "second", 1), 3);
+    expect(getAgentRunContext(RUN)?.sessionKey).toBe(moved);
+  });
+
+  it("fences a committed reset", async () => {
+    ack(msg(1, "before"));
+    await sessions.resetSessionEntryLifecycle({
+      agentId: "main",
+      buildNextEntry: () => ({ sessionId: `${SID}-replacement`, updatedAt: 20 }),
+      storePath: store,
+      target,
+    });
+    fail(msg(2, "after", 1), "session-not-attached");
+  });
+
+  it("restarts after deletion", async () => {
+    ack(msg(1, "before"));
+    ack(msg(3, "buffered", 1), 1);
+    await remove();
+    fail(msg(2, "after", 1), "session-not-attached");
+    await create(30);
+    ack(msg(1, "fresh"));
+    expect(deltas()).toEqual(["before", "fresh"]);
+  });
+
+  it("fences terminal runs", () => {
+    ack(
+      live(1, { kind: "lifecycle", payload: { phase: "error", endedAt: 100, error: "retryable" } }),
+    );
+    ack(msg(2, "recovered", 1));
+    const end = events[0];
+    clearAgentRunContext(RUN, end?.lifecycleGeneration, end?.contextClaimId);
+    fail(msg(3, "released", 2), "invalid-event");
+
+    start({ windowSize: 2 });
+    ack(live(1, { kind: "lifecycle", payload: { phase: "end", endedAt: 200 } }));
+    ack(msg(2, "other", 1, "run-other"));
+    fail(msg(3, "late", 2), "invalid-event");
+  });
+
+  it("clears on detach", () => {
+    ack(msg(1, "delivered"));
+    ack(msg(3, "buffered", 1), 1);
+    rx.clearEnvironment(ID.environmentId);
+    expect(getAgentRunContext(RUN)).toBeUndefined();
+    fail(msg(1, "pending", 0, "run-pending"), "invalid-event");
+  });
+
+  it("keeps run ids exclusive", () => {
+    const local = "run-local-first";
+    claimAgentRunContext(local, LOCAL);
+    fail(msg(1, "blocked", 0, local), "invalid-event");
+    clearAgentRunContext(local);
+
+    const worker = "run-worker-first";
+    ack(msg(1, "worker", 0, worker));
+    claimAgentRunContext(worker, LOCAL);
+    clearAgentRunContext(worker);
+    emitAgentEvent({
+      runId: worker,
+      stream: "assistant",
+      data: { text: "local", delta: "local" },
+    });
+    ack(msg(2, "again", 1, worker));
+    expect(deltas()).toEqual(["worker", "again"]);
+  });
+});

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -252,6 +252,10 @@ describe("worker live events", () => {
     const first = msg(1, "first", 0, "run-prefix");
     const second = msg(2, "second", 0, "run-buffered");
     const retry = msg(2, "replacement", 1, second.runId);
+    const terminal = {
+      ...live(3, lifecycle({ phase: "end", endedAt: 200 }), first.runId),
+      lastAckedSeq: 1,
+    };
 
     ack(second, 0);
     ack(first);
@@ -263,14 +267,40 @@ describe("worker live events", () => {
     expect(getAgentRunContext(first.runId)).toBeDefined();
     expect(events.map((event) => event.runId)).toEqual([first.runId]);
 
-    const firstEvent = events[0];
-    clearAgentRunContext(first.runId, firstEvent?.lifecycleGeneration, firstEvent?.contextClaimId);
-    expect(getAgentRunContext(first.runId)).toBeUndefined();
+    ack(terminal, 1);
+    expect(getAgentRunContext(first.runId)).toBeDefined();
+    expect(getAgentRunContext(second.runId)).toBeUndefined();
+    expect(events.map((event) => event.runId)).toEqual([first.runId]);
 
-    ack(retry);
-    ack(retry);
-    expect(events.map((event) => event.runId)).toEqual([first.runId, second.runId]);
-    expect(deltas()).toEqual(["first", "second"]);
+    ack(retry, 3);
+    ack(terminal, 3);
+    expect(events.map((event) => [event.runId, event.stream])).toEqual([
+      [first.runId, "assistant"],
+      [second.runId, "assistant"],
+      [first.runId, "lifecycle"],
+    ]);
+    expect(deltas()).toEqual(["first", "second", undefined]);
+  });
+
+  it("does not borrow capacity past another new run", () => {
+    start({ maxActiveRuns: 1 });
+    const first = msg(1, "first", 0, "run-prefix");
+    const second = msg(2, "second", 0, "run-buffered");
+    const third = msg(3, "third", 0, "run-intervening");
+    const terminal = {
+      ...live(4, lifecycle({ phase: "end", endedAt: 200 }), first.runId),
+      lastAckedSeq: 0,
+    };
+
+    ack(second, 0);
+    ack(third, 0);
+    ack(terminal, 0);
+    ack(first);
+    ack(msg(2, "replacement", 1, second.runId), 1);
+
+    expect(events.map((event) => event.runId)).toEqual([first.runId]);
+    expect(getAgentRunContext(second.runId)).toBeUndefined();
+    expect(getAgentRunContext(third.runId)).toBeUndefined();
   });
 
   it("bounds a retained capacity tail with normal resync", () => {
@@ -293,9 +323,9 @@ describe("worker live events", () => {
       details: { reason: "resync-required", ackedSeq: 1, expectedSeq: 2 },
     });
 
-    const firstEvent = events[0];
-    clearAgentRunContext(first.runId, firstEvent?.lifecycleGeneration, firstEvent?.contextClaimId);
-    ack(msg(2, "fresh", 1, second.runId));
+    fail(msg(2, "blocked", 1, second.runId), "capacity-exceeded");
+    fail(msg(2, "stale", 1, second.runId), "resync-required");
+    ack(msg(1, "fresh", 0, second.runId));
     expect(deltas()).toEqual(["first", "fresh"]);
   });
 

--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -247,6 +247,58 @@ describe("worker live events", () => {
     expect(deltas()).toEqual(["first", "second"]);
   });
 
+  it("retains a buffered capacity tail until the active run releases", () => {
+    start({ maxActiveRuns: 1 });
+    const first = msg(1, "first", 0, "run-prefix");
+    const second = msg(2, "second", 0, "run-buffered");
+    const retry = msg(2, "replacement", 1, second.runId);
+
+    ack(second, 0);
+    ack(first);
+    expect(getAgentRunContext(first.runId)).toBeDefined();
+    expect(getAgentRunContext(second.runId)).toBeUndefined();
+    expect(events.map((event) => event.runId)).toEqual([first.runId]);
+
+    ack(retry, 1);
+    expect(getAgentRunContext(first.runId)).toBeDefined();
+    expect(events.map((event) => event.runId)).toEqual([first.runId]);
+
+    const firstEvent = events[0];
+    clearAgentRunContext(first.runId, firstEvent?.lifecycleGeneration, firstEvent?.contextClaimId);
+    expect(getAgentRunContext(first.runId)).toBeUndefined();
+
+    ack(retry);
+    ack(retry);
+    expect(events.map((event) => event.runId)).toEqual([first.runId, second.runId]);
+    expect(deltas()).toEqual(["first", "second"]);
+  });
+
+  it("bounds a retained capacity tail with normal resync", () => {
+    const first = msg(1, "first", 0, "run-prefix");
+    const second = msg(2, "second", 0, "run-buffered");
+    start({
+      maxActiveRuns: 1,
+      maxPendingBytes: Buffer.byteLength(JSON.stringify(second.event), "utf8"),
+    });
+
+    ack(second, 0);
+    ack(first);
+    expect(
+      rx.apply({
+        identity: ID,
+        request: msg(3, "overflow", 1, "run-overflow"),
+      }),
+    ).toEqual({
+      ok: false,
+      details: { reason: "resync-required", ackedSeq: 1, expectedSeq: 2 },
+    });
+
+    const firstEvent = events[0];
+    clearAgentRunContext(first.runId, firstEvent?.lifecycleGeneration, firstEvent?.contextClaimId);
+    ack(msg(2, "fresh", 1, second.runId));
+    expect(deltas()).toEqual(["first", "fresh"]);
+  });
+
   it("clears speculative pending events on in-window resync", () => {
     start({ windowSize: 2 });
     ack(msg(2, "stale"), 0);
@@ -261,6 +313,22 @@ describe("worker live events", () => {
   it("resets after capacity failure", () => {
     start({ maxActiveRuns: 1 });
     ack(msg(1, "active", 0, "run-active"));
+    fail(msg(2, "overlap", 1, "run-overlap"), "capacity-exceeded");
+    fail(msg(2, "stale", 1, "run-overlap"), "resync-required");
+    ack(msg(1, "fresh", 0, "run-overlap"));
+  });
+
+  it("does not reserve a pending terminal for an unbuffered head", () => {
+    start({ maxActiveRuns: 1 });
+    const activeRunId = "run-active";
+    ack(msg(1, "active", 0, activeRunId));
+    ack(
+      {
+        ...live(3, lifecycle({ phase: "end", endedAt: 200 }), activeRunId),
+        lastAckedSeq: 1,
+      },
+      1,
+    );
     fail(msg(2, "overlap", 1, "run-overlap"), "capacity-exceeded");
     fail(msg(2, "stale", 1, "run-overlap"), "resync-required");
     ack(msg(1, "fresh", 0, "run-overlap"));

--- a/src/gateway/worker-environments/live-events.ts
+++ b/src/gateway/worker-environments/live-events.ts
@@ -1,0 +1,741 @@
+import { Buffer } from "node:buffer";
+import type {
+  WorkerLiveEventErrorDetails,
+  WorkerLiveEventParams,
+  WorkerLiveEventResult,
+} from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import {
+  capLiveExecResult,
+  sanitizeToolArgs,
+  sanitizeToolResult,
+} from "../../agents/embedded-agent-subscribe.tools.js";
+import { normalizeToolName } from "../../agents/tool-policy.js";
+import {
+  onSessionIdentityMutation,
+  type SessionIdentityMutation,
+} from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  claimAgentRunContext,
+  emitAgentEventForOwner,
+  getAgentEventLifecycleGeneration,
+  getAgentRunContext,
+  getAgentRunContextOwnerStatus,
+  registerAgentRunContext,
+  releaseAgentRunContext,
+} from "../../infra/agent-events.js";
+import type { WorkerConnectionIdentity } from "./connection-identity.js";
+import { resolveWorkerSessionTarget } from "./session-target.js";
+
+const DEFAULT_WINDOW_SIZE = 128;
+const DEFAULT_MAX_PENDING_BYTES = 512 * 1024;
+const DEFAULT_MAX_SESSIONS = 128;
+const DEFAULT_MAX_ACTIVE_RUNS = 32;
+const MAX_FENCED_ENVIRONMENTS = 4096;
+
+type PendingLiveEvent = {
+  request: WorkerLiveEventParams;
+  sizeBytes: number;
+};
+
+type OwnedLiveRun = {
+  claimId: string;
+  controlUiVisible: boolean;
+  lifecycleGeneration: string;
+};
+
+type LiveEventTarget = {
+  agentId?: string;
+  sessionId: string;
+  sessionKey: string;
+};
+
+export type WorkerLiveSessionBinding = Readonly<{
+  environmentId: string;
+  runEpoch: number;
+  sessionId: string;
+}>;
+
+type BoundLiveSession = WorkerLiveSessionBinding & { target: LiveEventTarget };
+
+export type WorkerLiveCredentialRotation = Readonly<{
+  credentialHash: string;
+  environmentId: string;
+  previousCredentialHash: string;
+  runEpoch: number;
+  sessionId: string;
+}>;
+
+type LiveEventWindow = {
+  activeRuns: Map<string, OwnedLiveRun>;
+  ackedSeq: number;
+  credentialHash: string;
+  environmentId: string;
+  pending: Map<number, PendingLiveEvent>;
+  pendingBytes: number;
+  runEpoch: number;
+  sessionId: string;
+  target: LiveEventTarget;
+  terminalRuns: Map<string, number>;
+};
+
+export type WorkerLiveEventApplicationResult =
+  | { ok: true; result: WorkerLiveEventResult }
+  | { ok: false; details: WorkerLiveEventErrorDetails };
+
+type WorkerLiveEventFailure = Extract<WorkerLiveEventApplicationResult, { ok: false }>;
+
+export type WorkerLiveEventReceiverOptions = {
+  getConfig: () => OpenClawConfig;
+  maxActiveRuns?: number;
+  maxPendingBytes?: number;
+  maxSessions?: number;
+  startupBindings: readonly WorkerLiveSessionBinding[];
+  startupOwners: ReadonlyMap<string, number>;
+  windowSize?: number;
+};
+
+function invalidEvent(): WorkerLiveEventFailure {
+  return { ok: false, details: { reason: "invalid-event" } };
+}
+
+function capacityExceeded(): WorkerLiveEventFailure {
+  return { ok: false, details: { reason: "capacity-exceeded" } };
+}
+
+function resolveLiveEventTarget(
+  config: OpenClawConfig,
+  sessionId: string,
+): LiveEventTarget | undefined {
+  const target = resolveWorkerSessionTarget(config, sessionId);
+  if (!target) {
+    return undefined;
+  }
+  return {
+    ...(target.agentId ? { agentId: target.agentId } : {}),
+    sessionId: target.sessionId,
+    sessionKey: target.sessionKey,
+  };
+}
+
+function prepareBoundLiveSession(
+  config: OpenClawConfig,
+  binding: WorkerLiveSessionBinding,
+): BoundLiveSession | undefined {
+  if (!isValidLiveSessionBinding(binding)) {
+    return undefined;
+  }
+  const target = resolveLiveEventTarget(config, binding.sessionId);
+  return target ? { ...binding, target } : undefined;
+}
+
+function isValidLiveSessionBinding(binding: WorkerLiveSessionBinding): boolean {
+  return (
+    binding.environmentId.length > 0 &&
+    binding.sessionId.length > 0 &&
+    Number.isSafeInteger(binding.runEpoch) &&
+    binding.runEpoch >= 0
+  );
+}
+
+function prepareBoundLiveSessionSafely(
+  config: OpenClawConfig,
+  binding: WorkerLiveSessionBinding,
+): BoundLiveSession | undefined {
+  try {
+    return prepareBoundLiveSession(config, binding);
+  } catch {
+    return undefined;
+  }
+}
+
+function matchesSessionIdentityMutation(
+  binding: WorkerLiveSessionBinding,
+  prepared: BoundLiveSession | undefined,
+  mutation: SessionIdentityMutation,
+): boolean {
+  const targets =
+    "current" in mutation ? [mutation.previous, mutation.current] : [mutation.previous];
+  return targets.some(
+    (target) =>
+      target.sessionId === binding.sessionId ||
+      (prepared ? target.sessionKeys.includes(prepared.target.sessionKey) : false),
+  );
+}
+
+function prepareLiveEventData(event: WorkerLiveEventParams["event"]): Record<string, unknown> {
+  const payload = structuredClone(event.payload) as Record<string, unknown>;
+  if (event.kind !== "tool") {
+    return payload;
+  }
+  const toolName = normalizeToolName(event.payload.name);
+  payload.name = toolName;
+  if (event.payload.phase === "start") {
+    payload.args = sanitizeToolArgs(event.payload.args);
+  } else if (event.payload.phase === "update") {
+    const partialResult = sanitizeToolResult(event.payload.partialResult);
+    payload.partialResult = toolName === "exec" ? capLiveExecResult(partialResult) : partialResult;
+  } else {
+    const result = sanitizeToolResult(event.payload.result);
+    payload.result = toolName === "exec" ? capLiveExecResult(result) : result;
+  }
+  return payload;
+}
+
+function isDefinitiveTerminal(event: WorkerLiveEventParams["event"]): boolean {
+  return (
+    event.kind === "lifecycle" &&
+    (event.payload.phase === "end" ||
+      (event.payload.phase === "error" &&
+        (event.payload.aborted === true || event.payload.fallbackExhaustedFailure === true)))
+  );
+}
+
+export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOptions) {
+  const boundSessions = new Map<string, BoundLiveSession>();
+  const sessionBindings = new Map<string, WorkerLiveSessionBinding>();
+  const fencedEnvironmentEpochs = new Map<string, number>();
+  const staleSessions = new Set<string>();
+  const windows = new Map<string, LiveEventWindow>();
+  const startupBindingOwners = new Map(
+    options.startupBindings
+      .filter(isValidLiveSessionBinding)
+      .map(({ environmentId, runEpoch }) => [environmentId, runEpoch]),
+  );
+  const startupOwners = new Map(
+    [...options.startupOwners].filter(
+      ([environmentId, ownerEpoch]) =>
+        environmentId.length > 0 &&
+        Number.isSafeInteger(ownerEpoch) &&
+        ownerEpoch >= 0 &&
+        startupBindingOwners.get(environmentId) === ownerEpoch,
+    ),
+  );
+  const windowSize = Math.max(1, Math.floor(options.windowSize ?? DEFAULT_WINDOW_SIZE));
+  const maxActiveRuns = Math.max(1, Math.floor(options.maxActiveRuns ?? DEFAULT_MAX_ACTIVE_RUNS));
+  const maxPendingBytes = Math.max(
+    1,
+    Math.floor(options.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES),
+  );
+  const maxSessions = Math.max(1, Math.floor(options.maxSessions ?? DEFAULT_MAX_SESSIONS));
+  let committedConfig = options.getConfig();
+  for (const binding of options.startupBindings) {
+    if (!isValidLiveSessionBinding(binding)) {
+      continue;
+    }
+    const existing = sessionBindings.get(binding.sessionId);
+    if (
+      !existing ||
+      binding.runEpoch > existing.runEpoch ||
+      (binding.runEpoch === existing.runEpoch && binding.environmentId === existing.environmentId)
+    ) {
+      sessionBindings.set(binding.sessionId, { ...binding });
+    }
+  }
+  for (const binding of sessionBindings.values()) {
+    const prepared = prepareBoundLiveSessionSafely(committedConfig, binding);
+    if (prepared) {
+      boundSessions.set(binding.sessionId, prepared);
+    } else {
+      staleSessions.add(binding.sessionId);
+    }
+  }
+
+  // Durable credential renewal keeps the same owner epoch and replay cursor.
+  const rotateCredential = (rotation: WorkerLiveCredentialRotation): boolean => {
+    if (
+      !rotation.credentialHash ||
+      !rotation.environmentId ||
+      !rotation.previousCredentialHash ||
+      !rotation.sessionId ||
+      !Number.isSafeInteger(rotation.runEpoch) ||
+      rotation.runEpoch < 0
+    ) {
+      return false;
+    }
+    const window = windows.get(rotation.sessionId);
+    if (
+      window?.credentialHash === rotation.previousCredentialHash &&
+      window.environmentId === rotation.environmentId &&
+      window.runEpoch === rotation.runEpoch
+    ) {
+      window.credentialHash = rotation.credentialHash;
+      return true;
+    }
+    return false;
+  };
+
+  const releaseRun = (window: LiveEventWindow, runId: string): void => {
+    const owned = window.activeRuns.get(runId);
+    if (!owned) {
+      return;
+    }
+    window.activeRuns.delete(runId);
+    releaseAgentRunContext(runId, owned.claimId);
+  };
+
+  const fenceReleasedRun = (window: LiveEventWindow, runId: string): void => {
+    if (!window.terminalRuns.has(runId)) {
+      window.terminalRuns.set(runId, window.ackedSeq);
+    }
+    releaseRun(window, runId);
+  };
+
+  const clearWindow = (window: LiveEventWindow): void => {
+    windows.delete(window.sessionId);
+    for (const runId of window.activeRuns.keys()) {
+      releaseRun(window, runId);
+    }
+    window.pending.clear();
+    window.pendingBytes = 0;
+    window.terminalRuns.clear();
+  };
+
+  const bindSessionWithConfig = (
+    binding: WorkerLiveSessionBinding,
+    config: OpenClawConfig,
+  ): boolean => {
+    if (!isValidLiveSessionBinding(binding)) {
+      return false;
+    }
+    const existing = sessionBindings.get(binding.sessionId);
+    if (
+      (existing && binding.runEpoch < existing.runEpoch) ||
+      (existing &&
+        binding.runEpoch === existing.runEpoch &&
+        binding.environmentId !== existing.environmentId)
+    ) {
+      return false;
+    }
+    const prepared = prepareBoundLiveSessionSafely(config, binding);
+    if (!prepared) {
+      if (
+        existing?.environmentId === binding.environmentId &&
+        existing.runEpoch === binding.runEpoch
+      ) {
+        staleSessions.add(binding.sessionId);
+      }
+      return false;
+    }
+    const window = windows.get(binding.sessionId);
+    if (
+      window &&
+      (window.environmentId !== binding.environmentId || window.runEpoch !== binding.runEpoch)
+    ) {
+      clearWindow(window);
+    }
+    sessionBindings.set(binding.sessionId, { ...binding });
+    boundSessions.set(binding.sessionId, prepared);
+    staleSessions.delete(binding.sessionId);
+    const retainedWindow = windows.get(binding.sessionId);
+    if (retainedWindow) {
+      retainedWindow.target = prepared.target;
+      for (const [runId, owned] of retainedWindow.activeRuns) {
+        if (
+          getAgentRunContextOwnerStatus(runId, owned.claimId, owned.lifecycleGeneration) ===
+          "active"
+        ) {
+          registerAgentRunContext(
+            runId,
+            {
+              ...(prepared.target.agentId ? { agentId: prepared.target.agentId } : {}),
+              isControlUiVisible: owned.controlUiVisible,
+              lifecycleGeneration: owned.lifecycleGeneration,
+              projectSessionActive: true,
+              sessionId: binding.sessionId,
+              sessionKey: prepared.target.sessionKey,
+            },
+            owned.claimId,
+          );
+        }
+      }
+    }
+    return true;
+  };
+
+  const bindSession = (binding: WorkerLiveSessionBinding): boolean =>
+    bindSessionWithConfig(binding, committedConfig);
+
+  const rebindAll = (config: OpenClawConfig): void => {
+    committedConfig = config;
+    for (const binding of sessionBindings.values()) {
+      bindSessionWithConfig(binding, committedConfig);
+    }
+  };
+
+  let unsubscribeSessionIdentityMutation: (() => void) | undefined;
+  const start = (): void => {
+    if (unsubscribeSessionIdentityMutation) {
+      return;
+    }
+    unsubscribeSessionIdentityMutation = onSessionIdentityMutation((mutation) => {
+      for (const binding of sessionBindings.values()) {
+        if (
+          matchesSessionIdentityMutation(binding, boundSessions.get(binding.sessionId), mutation)
+        ) {
+          if (!bindSessionWithConfig(binding, committedConfig)) {
+            // Keep stale binding after identity invalidates its cursor and claims.
+            startupOwners.delete(binding.environmentId);
+            const window = windows.get(binding.sessionId);
+            if (window) {
+              clearWindow(window);
+            }
+          }
+        }
+      }
+    });
+    // Re-resolve targets after subscribing to close the startup mutation gap.
+    for (const binding of sessionBindings.values()) {
+      if (!bindSessionWithConfig(binding, committedConfig)) {
+        startupOwners.delete(binding.environmentId);
+      }
+    }
+  };
+
+  const resyncRequired = (ackedSeq: number): WorkerLiveEventFailure => ({
+    ok: false,
+    details: { reason: "resync-required", ackedSeq, expectedSeq: ackedSeq + 1 },
+  });
+
+  const resolveWindow = (params: {
+    identity: WorkerConnectionIdentity;
+    request: WorkerLiveEventParams;
+  }): WorkerLiveEventApplicationResult | LiveEventWindow => {
+    const sessionId = params.identity.sessionId;
+    if (!sessionId) {
+      return { ok: false, details: { reason: "session-not-attached" } };
+    }
+    const binding = boundSessions.get(sessionId);
+    if (!binding || staleSessions.has(sessionId)) {
+      return { ok: false, details: { reason: "session-not-attached" } };
+    }
+    if (
+      binding.environmentId !== params.identity.environmentId ||
+      binding.runEpoch !== params.request.runEpoch
+    ) {
+      return { ok: false, details: { reason: "epoch-mismatch" } };
+    }
+    const current = windows.get(sessionId);
+    if (current) {
+      if (
+        params.request.runEpoch !== current.runEpoch ||
+        params.identity.credentialHash !== current.credentialHash ||
+        params.identity.environmentId !== current.environmentId
+      ) {
+        return { ok: false, details: { reason: "epoch-mismatch" } };
+      }
+      if (params.request.lastAckedSeq > current.ackedSeq) {
+        return resyncRequired(current.ackedSeq);
+      }
+      return current;
+    }
+    const startupOwnerEpoch = startupOwners.get(params.identity.environmentId);
+    if (startupOwnerEpoch !== params.request.runEpoch && params.request.lastAckedSeq !== 0) {
+      return resyncRequired(0);
+    }
+    if (windows.size >= maxSessions) {
+      return capacityExceeded();
+    }
+    const created: LiveEventWindow = {
+      activeRuns: new Map(),
+      ackedSeq: params.request.lastAckedSeq,
+      credentialHash: params.identity.credentialHash,
+      environmentId: params.identity.environmentId,
+      pending: new Map(),
+      pendingBytes: 0,
+      runEpoch: params.request.runEpoch,
+      sessionId,
+      target: binding.target,
+      terminalRuns: new Map(),
+    };
+    windows.set(sessionId, created);
+    // Seed one process-lost window; later windows for this owner start at zero.
+    startupOwners.delete(params.identity.environmentId);
+    return created;
+  };
+
+  const pruneReleasedRuns = (window: LiveEventWindow): WorkerLiveEventFailure | undefined => {
+    for (const [runId, owned] of window.activeRuns) {
+      const ownerStatus = getAgentRunContextOwnerStatus(
+        runId,
+        owned.claimId,
+        owned.lifecycleGeneration,
+      );
+      if (ownerStatus === undefined) {
+        clearWindow(window);
+        return resyncRequired(0);
+      }
+      if (ownerStatus !== "active") {
+        fenceReleasedRun(window, runId);
+      }
+    }
+    return undefined;
+  };
+
+  const claimRun = (
+    window: LiveEventWindow,
+    runId: string,
+  ): WorkerLiveEventFailure | OwnedLiveRun => {
+    if (window.terminalRuns.has(runId)) {
+      return invalidEvent();
+    }
+    const owned = window.activeRuns.get(runId);
+    if (owned) {
+      const context = getAgentRunContext(runId);
+      const ownerStatus = getAgentRunContextOwnerStatus(
+        runId,
+        owned.claimId,
+        owned.lifecycleGeneration,
+      );
+      if (ownerStatus === undefined) {
+        // A process sweep lost sequencing state; restart the transient cursor.
+        clearWindow(window);
+        return resyncRequired(0);
+      }
+      if (
+        ownerStatus !== "active" ||
+        context?.sessionId !== window.sessionId ||
+        context.sessionKey !== window.target.sessionKey ||
+        context.agentId !== window.target.agentId ||
+        context.lifecycleGeneration !== owned.lifecycleGeneration ||
+        context.isControlUiVisible !== owned.controlUiVisible
+      ) {
+        fenceReleasedRun(window, runId);
+        return invalidEvent();
+      }
+      return owned;
+    }
+
+    const pruneFailure = pruneReleasedRuns(window);
+    if (pruneFailure) {
+      return pruneFailure;
+    }
+    let activeRunCount = 0;
+    for (const activeRunId of window.activeRuns.keys()) {
+      if (!window.terminalRuns.has(activeRunId)) {
+        activeRunCount += 1;
+      }
+    }
+    if (activeRunCount >= maxActiveRuns) {
+      // Reset the cumulative cursor rather than wedging the unskippable tail.
+      clearWindow(window);
+      return capacityExceeded();
+    }
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const existingContext = getAgentRunContext(runId);
+    if (existingContext?.lifecycleGeneration === lifecycleGeneration) {
+      return invalidEvent();
+    }
+    // Turn placement owns wider visibility; otherwise scope to this session.
+    const controlUiVisible = false;
+    const claimId = claimAgentRunContext(
+      runId,
+      {
+        ...(window.target.agentId ? { agentId: window.target.agentId } : {}),
+        isControlUiVisible: controlUiVisible,
+        lifecycleGeneration,
+        projectSessionActive: true,
+        sessionId: window.sessionId,
+        sessionKey: window.target.sessionKey,
+      },
+      {
+        exclusive: true,
+        onClearRequested: (clearedClaimId) => {
+          if (window.activeRuns.get(runId)?.claimId === clearedClaimId) {
+            fenceReleasedRun(window, runId);
+          }
+        },
+        ownsContext: true,
+        trackOwner: true,
+      },
+    );
+    if (!claimId) {
+      return invalidEvent();
+    }
+    const claimed = {
+      claimId,
+      controlUiVisible,
+      lifecycleGeneration,
+    };
+    window.activeRuns.set(runId, claimed);
+    return claimed;
+  };
+
+  const publish = (
+    window: LiveEventWindow,
+    request: WorkerLiveEventParams,
+  ): WorkerLiveEventFailure | undefined => {
+    const owned = claimRun(window, request.runId);
+    if ("ok" in owned) {
+      return owned;
+    }
+    const definitiveTerminal = isDefinitiveTerminal(request.event);
+    if (definitiveTerminal) {
+      window.terminalRuns.set(request.runId, request.seq);
+    }
+    emitAgentEventForOwner(
+      {
+        runId: request.runId,
+        stream: request.event.kind,
+        data: prepareLiveEventData(request.event),
+      },
+      owned.claimId,
+    );
+    // Projection owns release so detach can revoke deferred terminal delivery.
+    return undefined;
+  };
+
+  const drain = (
+    window: LiveEventWindow,
+    first: WorkerLiveEventParams,
+  ): WorkerLiveEventApplicationResult => {
+    let request: WorkerLiveEventParams | undefined = first;
+    let publishedPrefix = false;
+    while (request) {
+      const failed = publish(window, request);
+      if (failed) {
+        if (failed.details.reason === "capacity-exceeded") {
+          return failed;
+        }
+        return publishedPrefix ? { ok: true, result: { ackedSeq: window.ackedSeq } } : failed;
+      }
+      window.ackedSeq = request.seq;
+      publishedPrefix = true;
+      const oldestRetainedSeq = window.ackedSeq - windowSize;
+      for (const [runId, terminalSeq] of window.terminalRuns) {
+        if (terminalSeq <= oldestRetainedSeq) {
+          window.terminalRuns.delete(runId);
+        }
+      }
+      const next = window.pending.get(window.ackedSeq + 1);
+      if (!next) {
+        break;
+      }
+      window.pending.delete(next.request.seq);
+      window.pendingBytes -= next.sizeBytes;
+      request = next.request;
+    }
+    return { ok: true, result: { ackedSeq: window.ackedSeq } };
+  };
+
+  const apply = (params: {
+    identity: WorkerConnectionIdentity;
+    request: WorkerLiveEventParams;
+  }): WorkerLiveEventApplicationResult => {
+    if (!params.identity.sessionId) {
+      return { ok: false, details: { reason: "session-not-attached" } };
+    }
+    if (params.request.runEpoch !== params.identity.ownerEpoch) {
+      return { ok: false, details: { reason: "epoch-mismatch" } };
+    }
+    if (
+      params.request.runEpoch <= (fencedEnvironmentEpochs.get(params.identity.environmentId) ?? -1)
+    ) {
+      return invalidEvent();
+    }
+    const sessionId = params.identity.sessionId;
+    const binding = boundSessions.get(sessionId);
+    if (!binding) {
+      return { ok: false, details: { reason: "session-not-attached" } };
+    }
+    if (
+      binding.environmentId !== params.identity.environmentId ||
+      binding.runEpoch !== params.request.runEpoch
+    ) {
+      return { ok: false, details: { reason: "epoch-mismatch" } };
+    }
+    if (staleSessions.has(sessionId)) {
+      return { ok: false, details: { reason: "session-not-attached" } };
+    }
+    const current = windows.get(sessionId);
+    if (
+      current &&
+      (params.request.runEpoch < current.runEpoch ||
+        (params.request.runEpoch === current.runEpoch &&
+          (params.identity.credentialHash !== current.credentialHash ||
+            params.identity.environmentId !== current.environmentId)))
+    ) {
+      return { ok: false, details: { reason: "epoch-mismatch" } };
+    }
+    if (
+      current &&
+      current.credentialHash === params.identity.credentialHash &&
+      current.environmentId === params.identity.environmentId &&
+      current.runEpoch === params.request.runEpoch
+    ) {
+      if (params.request.seq <= current.ackedSeq) {
+        return { ok: true, result: { ackedSeq: current.ackedSeq } };
+      }
+      if (params.request.lastAckedSeq > current.ackedSeq) {
+        return resyncRequired(current.ackedSeq);
+      }
+    }
+    const window = resolveWindow(params);
+    if ("ok" in window) {
+      return window;
+    }
+    const { seq } = params.request;
+    if (seq <= window.ackedSeq || window.pending.has(seq)) {
+      return { ok: true, result: { ackedSeq: window.ackedSeq } };
+    }
+    const expectedSeq = window.ackedSeq + 1;
+    if (seq > window.ackedSeq + windowSize) {
+      return resyncRequired(window.ackedSeq);
+    }
+    if (seq === expectedSeq) {
+      return drain(window, params.request);
+    }
+    const sizeBytes = Buffer.byteLength(JSON.stringify(params.request.event), "utf8");
+    if (window.pendingBytes + sizeBytes > maxPendingBytes) {
+      return resyncRequired(window.ackedSeq);
+    }
+    window.pending.set(seq, { request: params.request, sizeBytes });
+    window.pendingBytes += sizeBytes;
+    return { ok: true, result: { ackedSeq: window.ackedSeq } };
+  };
+
+  const clearEnvironment = (environmentId: string): void => {
+    startupOwners.delete(environmentId);
+    let fencedEpoch = fencedEnvironmentEpochs.get(environmentId) ?? -1;
+    for (const [sessionId, binding] of sessionBindings) {
+      if (binding.environmentId === environmentId) {
+        fencedEpoch = Math.max(fencedEpoch, binding.runEpoch);
+        sessionBindings.delete(sessionId);
+        boundSessions.delete(sessionId);
+        staleSessions.delete(sessionId);
+      }
+    }
+    for (const window of windows.values()) {
+      if (window.environmentId === environmentId) {
+        fencedEpoch = Math.max(fencedEpoch, window.runEpoch);
+        clearWindow(window);
+      }
+    }
+    if (fencedEpoch >= 0) {
+      fencedEnvironmentEpochs.set(environmentId, fencedEpoch);
+      if (fencedEnvironmentEpochs.size > MAX_FENCED_ENVIRONMENTS) {
+        const oldestEnvironmentId = fencedEnvironmentEpochs.keys().next().value;
+        if (oldestEnvironmentId) {
+          fencedEnvironmentEpochs.delete(oldestEnvironmentId);
+        }
+      }
+    }
+  };
+
+  const clear = (): void => {
+    unsubscribeSessionIdentityMutation?.();
+    unsubscribeSessionIdentityMutation = undefined;
+    for (const window of windows.values()) {
+      clearWindow(window);
+    }
+    boundSessions.clear();
+    sessionBindings.clear();
+    fencedEnvironmentEpochs.clear();
+    staleSessions.clear();
+    startupOwners.clear();
+  };
+
+  return { apply, bindSession, clear, clearEnvironment, rebindAll, rotateCredential, start };
+}
+
+export type WorkerLiveEventReceiver = ReturnType<typeof createWorkerLiveEventReceiver>;

--- a/src/gateway/worker-environments/live-events.ts
+++ b/src/gateway/worker-environments/live-events.ts
@@ -534,8 +534,6 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       }
     }
     if (activeRunCount >= maxActiveRuns) {
-      // Reset the cumulative cursor rather than wedging the unskippable tail.
-      clearWindow(window);
       return capacityExceeded();
     }
     const lifecycleGeneration = getAgentEventLifecycleGeneration();
@@ -607,13 +605,35 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
   const drain = (
     window: LiveEventWindow,
     first: WorkerLiveEventParams,
+    firstPending?: PendingLiveEvent,
   ): WorkerLiveEventApplicationResult => {
     let request: WorkerLiveEventParams | undefined = first;
+    let buffered = firstPending;
     let publishedPrefix = false;
     while (request) {
       const failed = publish(window, request);
       if (failed) {
+        if (failed.details.reason === "capacity-exceeded" && buffered) {
+          // Keep the ordered tail retryable while the active prefix claim drains.
+          // Later gaps still hit windowSize/maxPendingBytes and force normal resync.
+          return { ok: true, result: { ackedSeq: window.ackedSeq } };
+        }
+        if (buffered) {
+          if (window.pending.delete(request.seq)) {
+            window.pendingBytes -= buffered.sizeBytes;
+          }
+        }
+        if (failed.details.reason === "capacity-exceeded" && !publishedPrefix) {
+          // A fresh head cannot advance. Reset its cursor and release every claim.
+          clearWindow(window);
+          return failed;
+        }
         return publishedPrefix ? { ok: true, result: { ackedSeq: window.ackedSeq } } : failed;
+      }
+      if (buffered) {
+        if (window.pending.delete(request.seq)) {
+          window.pendingBytes -= buffered.sizeBytes;
+        }
       }
       window.ackedSeq = request.seq;
       publishedPrefix = true;
@@ -629,9 +649,8 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       if (!next) {
         break;
       }
-      window.pending.delete(next.request.seq);
-      window.pendingBytes -= next.sizeBytes;
       request = next.request;
+      buffered = next;
     }
     return { ok: true, result: { ackedSeq: window.ackedSeq } };
   };
@@ -657,15 +676,16 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       return window;
     }
     const { seq } = params.request;
-    if (window.pending.has(seq)) {
-      return { ok: true, result: { ackedSeq: window.ackedSeq } };
-    }
     const expectedSeq = window.ackedSeq + 1;
     if (seq > window.ackedSeq + windowSize) {
       return resyncWindow(window);
     }
     if (seq === expectedSeq) {
-      return drain(window, params.request);
+      const pending = window.pending.get(seq);
+      return drain(window, pending?.request ?? params.request, pending);
+    }
+    if (window.pending.has(seq)) {
+      return { ok: true, result: { ackedSeq: window.ackedSeq } };
     }
     const sizeBytes = Buffer.byteLength(JSON.stringify(params.request.event), "utf8");
     if (window.pendingBytes + sizeBytes > maxPendingBytes) {

--- a/src/gateway/worker-environments/live-events.ts
+++ b/src/gateway/worker-environments/live-events.ts
@@ -42,6 +42,7 @@ type OwnedLiveRun = {
   claimId: string;
   controlUiVisible: boolean;
   lifecycleGeneration: string;
+  pendingProjections: Set<Promise<void>>;
 };
 
 type LiveEventTarget = {
@@ -202,6 +203,8 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       .filter(isValidLiveSessionBinding)
       .map(({ environmentId, runEpoch }) => [environmentId, runEpoch]),
   );
+  // Only an owner corroborated by the same persisted binding may seed a
+  // post-restart ACK. Unmatched owner rows must restart from zero.
   const startupOwners = new Map(
     [...options.startupOwners].filter(
       ([environmentId, ownerEpoch]) =>
@@ -265,13 +268,20 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     return false;
   };
 
-  const releaseRun = (window: LiveEventWindow, runId: string): void => {
+  const releaseRun = (window: LiveEventWindow, runId: string, afterProjections = false): void => {
     const owned = window.activeRuns.get(runId);
     if (!owned) {
       return;
     }
     window.activeRuns.delete(runId);
-    releaseAgentRunContext(runId, owned.claimId);
+    const release = () => releaseAgentRunContext(runId, owned.claimId);
+    if (afterProjections && owned.pendingProjections.size > 0) {
+      // Capacity reset may follow a synchronous emit while Gateway projection is
+      // still deferred. Keep its claim valid until every emitted event settles.
+      void Promise.allSettled(owned.pendingProjections).then(release);
+      return;
+    }
+    release();
   };
 
   const fenceReleasedRun = (window: LiveEventWindow, runId: string): void => {
@@ -281,10 +291,10 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     releaseRun(window, runId);
   };
 
-  const clearWindow = (window: LiveEventWindow): void => {
+  const clearWindow = (window: LiveEventWindow, afterProjections = false): void => {
     windows.delete(window.sessionId);
     for (const runId of window.activeRuns.keys()) {
-      releaseRun(window, runId);
+      releaseRun(window, runId, afterProjections);
     }
     window.pending.clear();
     window.pendingBytes = 0;
@@ -313,6 +323,8 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
         existing?.environmentId === binding.environmentId &&
         existing.runEpoch === binding.runEpoch
       ) {
+        // Retain the last target for key-based identity matching, but gate delivery
+        // as stale until target resolution succeeds again.
         staleSessions.add(binding.sessionId);
       }
       return false;
@@ -397,16 +409,23 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     details: { reason: "resync-required", ackedSeq, expectedSeq: ackedSeq + 1 },
   });
 
-  const resolveWindow = (params: {
-    identity: WorkerConnectionIdentity;
-    request: WorkerLiveEventParams;
-  }): WorkerLiveEventApplicationResult | LiveEventWindow => {
-    const sessionId = params.identity.sessionId;
-    if (!sessionId) {
-      return { ok: false, details: { reason: "session-not-attached" } };
-    }
+  const resyncWindow = (window: LiveEventWindow): WorkerLiveEventFailure => {
+    // Resync replays the unacked suffix from expectedSeq. Drop speculative state
+    // so stable or renumbered replay sequences cannot collide with stale pending.
+    window.pending.clear();
+    window.pendingBytes = 0;
+    return resyncRequired(window.ackedSeq);
+  };
+
+  const resolveOrCreateWindow = (
+    sessionId: string,
+    params: {
+      identity: WorkerConnectionIdentity;
+      request: WorkerLiveEventParams;
+    },
+  ): WorkerLiveEventApplicationResult | LiveEventWindow => {
     const binding = boundSessions.get(sessionId);
-    if (!binding || staleSessions.has(sessionId)) {
+    if (!binding) {
       return { ok: false, details: { reason: "session-not-attached" } };
     }
     if (
@@ -415,43 +434,49 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     ) {
       return { ok: false, details: { reason: "epoch-mismatch" } };
     }
-    const current = windows.get(sessionId);
-    if (current) {
+    if (staleSessions.has(sessionId)) {
+      return { ok: false, details: { reason: "session-not-attached" } };
+    }
+    let window = windows.get(sessionId);
+    if (window) {
       if (
-        params.request.runEpoch !== current.runEpoch ||
-        params.identity.credentialHash !== current.credentialHash ||
-        params.identity.environmentId !== current.environmentId
+        params.request.runEpoch !== window.runEpoch ||
+        params.identity.credentialHash !== window.credentialHash ||
+        params.identity.environmentId !== window.environmentId
       ) {
         return { ok: false, details: { reason: "epoch-mismatch" } };
       }
-      if (params.request.lastAckedSeq > current.ackedSeq) {
-        return resyncRequired(current.ackedSeq);
+    } else {
+      const startupOwnerEpoch = startupOwners.get(params.identity.environmentId);
+      if (startupOwnerEpoch !== params.request.runEpoch && params.request.lastAckedSeq !== 0) {
+        return resyncRequired(0);
       }
-      return current;
+      if (windows.size >= maxSessions) {
+        return capacityExceeded();
+      }
+      window = {
+        activeRuns: new Map(),
+        ackedSeq: params.request.lastAckedSeq,
+        credentialHash: params.identity.credentialHash,
+        environmentId: params.identity.environmentId,
+        pending: new Map(),
+        pendingBytes: 0,
+        runEpoch: params.request.runEpoch,
+        sessionId,
+        target: binding.target,
+        terminalRuns: new Map(),
+      };
+      windows.set(sessionId, window);
+      // Seed one process-lost window; later windows for this owner start at zero.
+      startupOwners.delete(params.identity.environmentId);
     }
-    const startupOwnerEpoch = startupOwners.get(params.identity.environmentId);
-    if (startupOwnerEpoch !== params.request.runEpoch && params.request.lastAckedSeq !== 0) {
-      return resyncRequired(0);
+    if (params.request.seq <= window.ackedSeq) {
+      return { ok: true, result: { ackedSeq: window.ackedSeq } };
     }
-    if (windows.size >= maxSessions) {
-      return capacityExceeded();
+    if (params.request.lastAckedSeq > window.ackedSeq) {
+      return resyncWindow(window);
     }
-    const created: LiveEventWindow = {
-      activeRuns: new Map(),
-      ackedSeq: params.request.lastAckedSeq,
-      credentialHash: params.identity.credentialHash,
-      environmentId: params.identity.environmentId,
-      pending: new Map(),
-      pendingBytes: 0,
-      runEpoch: params.request.runEpoch,
-      sessionId,
-      target: binding.target,
-      terminalRuns: new Map(),
-    };
-    windows.set(sessionId, created);
-    // Seed one process-lost window; later windows for this owner start at zero.
-    startupOwners.delete(params.identity.environmentId);
-    return created;
+    return window;
   };
 
   const pruneReleasedRuns = (window: LiveEventWindow): WorkerLiveEventFailure | undefined => {
@@ -518,7 +543,8 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     }
     if (activeRunCount >= maxActiveRuns) {
       // Reset the cumulative cursor rather than wedging the unskippable tail.
-      clearWindow(window);
+      // Already-emitted events keep their claims until deferred projection settles.
+      clearWindow(window, true);
       return capacityExceeded();
     }
     const lifecycleGeneration = getAgentEventLifecycleGeneration();
@@ -556,6 +582,7 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       claimId,
       controlUiVisible,
       lifecycleGeneration,
+      pendingProjections: new Set<Promise<void>>(),
     };
     window.activeRuns.set(runId, claimed);
     return claimed;
@@ -571,9 +598,11 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     }
     const definitiveTerminal = isDefinitiveTerminal(request.event);
     if (definitiveTerminal) {
+      // Emission runs synchronous listeners that can clear this claim reentrantly.
+      // Fence first so terminal delivery cannot reopen the run ID.
       window.terminalRuns.set(request.runId, request.seq);
     }
-    emitAgentEventForOwner(
+    const projection = emitAgentEventForOwner(
       {
         runId: request.runId,
         stream: request.event.kind,
@@ -581,6 +610,10 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       },
       owned.claimId,
     );
+    if (projection) {
+      owned.pendingProjections.add(projection);
+      void projection.then(() => owned.pendingProjections.delete(projection));
+    }
     // Projection owns release so detach can revoke deferred terminal delivery.
     return undefined;
   };
@@ -594,16 +627,15 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     while (request) {
       const failed = publish(window, request);
       if (failed) {
-        if (failed.details.reason === "capacity-exceeded") {
-          return failed;
-        }
         return publishedPrefix ? { ok: true, result: { ackedSeq: window.ackedSeq } } : failed;
       }
       window.ackedSeq = request.seq;
       publishedPrefix = true;
       const oldestRetainedSeq = window.ackedSeq - windowSize;
       for (const [runId, terminalSeq] of window.terminalRuns) {
-        if (terminalSeq <= oldestRetainedSeq) {
+        // Active terminal claims stay fenced until projection cleanup. Released run IDs
+        // age out after windowSize later events and may then start a fresh claim.
+        if (!window.activeRuns.has(runId) && terminalSeq <= oldestRetainedSeq) {
           window.terminalRuns.delete(runId);
         }
       }
@@ -634,60 +666,24 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       return invalidEvent();
     }
     const sessionId = params.identity.sessionId;
-    const binding = boundSessions.get(sessionId);
-    if (!binding) {
-      return { ok: false, details: { reason: "session-not-attached" } };
-    }
-    if (
-      binding.environmentId !== params.identity.environmentId ||
-      binding.runEpoch !== params.request.runEpoch
-    ) {
-      return { ok: false, details: { reason: "epoch-mismatch" } };
-    }
-    if (staleSessions.has(sessionId)) {
-      return { ok: false, details: { reason: "session-not-attached" } };
-    }
-    const current = windows.get(sessionId);
-    if (
-      current &&
-      (params.request.runEpoch < current.runEpoch ||
-        (params.request.runEpoch === current.runEpoch &&
-          (params.identity.credentialHash !== current.credentialHash ||
-            params.identity.environmentId !== current.environmentId)))
-    ) {
-      return { ok: false, details: { reason: "epoch-mismatch" } };
-    }
-    if (
-      current &&
-      current.credentialHash === params.identity.credentialHash &&
-      current.environmentId === params.identity.environmentId &&
-      current.runEpoch === params.request.runEpoch
-    ) {
-      if (params.request.seq <= current.ackedSeq) {
-        return { ok: true, result: { ackedSeq: current.ackedSeq } };
-      }
-      if (params.request.lastAckedSeq > current.ackedSeq) {
-        return resyncRequired(current.ackedSeq);
-      }
-    }
-    const window = resolveWindow(params);
+    const window = resolveOrCreateWindow(sessionId, params);
     if ("ok" in window) {
       return window;
     }
     const { seq } = params.request;
-    if (seq <= window.ackedSeq || window.pending.has(seq)) {
+    if (window.pending.has(seq)) {
       return { ok: true, result: { ackedSeq: window.ackedSeq } };
     }
     const expectedSeq = window.ackedSeq + 1;
     if (seq > window.ackedSeq + windowSize) {
-      return resyncRequired(window.ackedSeq);
+      return resyncWindow(window);
     }
     if (seq === expectedSeq) {
       return drain(window, params.request);
     }
     const sizeBytes = Buffer.byteLength(JSON.stringify(params.request.event), "utf8");
     if (window.pendingBytes + sizeBytes > maxPendingBytes) {
-      return resyncRequired(window.ackedSeq);
+      return resyncWindow(window);
     }
     window.pending.set(seq, { request: params.request, sizeBytes });
     window.pendingBytes += sizeBytes;
@@ -712,6 +708,9 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       }
     }
     if (fencedEpoch >= 0) {
+      // Oldest tombstones may expire because service/store ownership stays authoritative.
+      // Refresh recency first so a re-fenced environment keeps its newest stale-owner epoch.
+      fencedEnvironmentEpochs.delete(environmentId);
       fencedEnvironmentEpochs.set(environmentId, fencedEpoch);
       if (fencedEnvironmentEpochs.size > MAX_FENCED_ENVIRONMENTS) {
         const oldestEnvironmentId = fencedEnvironmentEpochs.keys().next().value;

--- a/src/gateway/worker-environments/live-events.ts
+++ b/src/gateway/worker-environments/live-events.ts
@@ -489,9 +489,37 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     return undefined;
   };
 
+  const hasReachableBufferedTerminal = (
+    window: LiveEventWindow,
+    admittedRunId: string,
+    countedRunIds: ReadonlySet<string>,
+  ): boolean => {
+    // Borrow one source-ended slot only when this ordered drain can reach that
+    // active run's terminal without claiming another new run first.
+    for (let seq = window.ackedSeq + 2; seq <= window.ackedSeq + windowSize; seq += 1) {
+      const pending = window.pending.get(seq);
+      if (!pending) {
+        return false;
+      }
+      const pendingRunId = pending.request.runId;
+      if (countedRunIds.has(pendingRunId)) {
+        if (isDefinitiveTerminal(pending.request.event)) {
+          return true;
+        }
+        continue;
+      }
+      if (pendingRunId !== admittedRunId) {
+        // Another new run would consume the borrowed slot before the terminal.
+        return false;
+      }
+    }
+    return false;
+  };
+
   const claimRun = (
     window: LiveEventWindow,
     runId: string,
+    allowBufferedTerminalCapacity: boolean,
   ): WorkerLiveEventFailure | OwnedLiveRun => {
     if (window.terminalRuns.has(runId)) {
       return invalidEvent();
@@ -527,13 +555,16 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     if (pruneFailure) {
       return pruneFailure;
     }
-    let activeRunCount = 0;
+    const countedRunIds = new Set<string>();
     for (const activeRunId of window.activeRuns.keys()) {
       if (!window.terminalRuns.has(activeRunId)) {
-        activeRunCount += 1;
+        countedRunIds.add(activeRunId);
       }
     }
-    if (activeRunCount >= maxActiveRuns) {
+    if (
+      countedRunIds.size >= maxActiveRuns &&
+      !(allowBufferedTerminalCapacity && hasReachableBufferedTerminal(window, runId, countedRunIds))
+    ) {
       return capacityExceeded();
     }
     const lifecycleGeneration = getAgentEventLifecycleGeneration();
@@ -579,8 +610,9 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
   const publish = (
     window: LiveEventWindow,
     request: WorkerLiveEventParams,
+    allowBufferedTerminalCapacity: boolean,
   ): WorkerLiveEventFailure | undefined => {
-    const owned = claimRun(window, request.runId);
+    const owned = claimRun(window, request.runId, allowBufferedTerminalCapacity);
     if ("ok" in owned) {
       return owned;
     }
@@ -611,7 +643,7 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     let buffered = firstPending;
     let publishedPrefix = false;
     while (request) {
-      const failed = publish(window, request);
+      const failed = publish(window, request, buffered !== undefined);
       if (failed) {
         if (failed.details.reason === "capacity-exceeded" && buffered) {
           // Keep the ordered tail retryable while the active prefix claim drains.

--- a/src/gateway/worker-environments/live-events.ts
+++ b/src/gateway/worker-environments/live-events.ts
@@ -42,7 +42,6 @@ type OwnedLiveRun = {
   claimId: string;
   controlUiVisible: boolean;
   lifecycleGeneration: string;
-  pendingProjections: Set<Promise<void>>;
 };
 
 type LiveEventTarget = {
@@ -268,20 +267,13 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     return false;
   };
 
-  const releaseRun = (window: LiveEventWindow, runId: string, afterProjections = false): void => {
+  const releaseRun = (window: LiveEventWindow, runId: string): void => {
     const owned = window.activeRuns.get(runId);
     if (!owned) {
       return;
     }
     window.activeRuns.delete(runId);
-    const release = () => releaseAgentRunContext(runId, owned.claimId);
-    if (afterProjections && owned.pendingProjections.size > 0) {
-      // Capacity reset may follow a synchronous emit while Gateway projection is
-      // still deferred. Keep its claim valid until every emitted event settles.
-      void Promise.allSettled(owned.pendingProjections).then(release);
-      return;
-    }
-    release();
+    releaseAgentRunContext(runId, owned.claimId);
   };
 
   const fenceReleasedRun = (window: LiveEventWindow, runId: string): void => {
@@ -291,10 +283,10 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     releaseRun(window, runId);
   };
 
-  const clearWindow = (window: LiveEventWindow, afterProjections = false): void => {
+  const clearWindow = (window: LiveEventWindow): void => {
     windows.delete(window.sessionId);
     for (const runId of window.activeRuns.keys()) {
-      releaseRun(window, runId, afterProjections);
+      releaseRun(window, runId);
     }
     window.pending.clear();
     window.pendingBytes = 0;
@@ -543,8 +535,7 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
     }
     if (activeRunCount >= maxActiveRuns) {
       // Reset the cumulative cursor rather than wedging the unskippable tail.
-      // Already-emitted events keep their claims until deferred projection settles.
-      clearWindow(window, true);
+      clearWindow(window);
       return capacityExceeded();
     }
     const lifecycleGeneration = getAgentEventLifecycleGeneration();
@@ -582,7 +573,6 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       claimId,
       controlUiVisible,
       lifecycleGeneration,
-      pendingProjections: new Set<Promise<void>>(),
     };
     window.activeRuns.set(runId, claimed);
     return claimed;
@@ -602,7 +592,7 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       // Fence first so terminal delivery cannot reopen the run ID.
       window.terminalRuns.set(request.runId, request.seq);
     }
-    const projection = emitAgentEventForOwner(
+    emitAgentEventForOwner(
       {
         runId: request.runId,
         stream: request.event.kind,
@@ -610,11 +600,7 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       },
       owned.claimId,
     );
-    if (projection) {
-      owned.pendingProjections.add(projection);
-      void projection.then(() => owned.pendingProjections.delete(projection));
-    }
-    // Projection owns release so detach can revoke deferred terminal delivery.
+    // Gateway handler owns cleanup so detach can revoke deferred terminal delivery.
     return undefined;
   };
 
@@ -633,7 +619,7 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
       publishedPrefix = true;
       const oldestRetainedSeq = window.ackedSeq - windowSize;
       for (const [runId, terminalSeq] of window.terminalRuns) {
-        // Active terminal claims stay fenced until projection cleanup. Released run IDs
+        // Active terminal claims stay fenced until owner cleanup. Released run IDs
         // age out after windowSize later events and may then start a fresh claim.
         if (!window.activeRuns.has(runId) && terminalSeq <= oldestRetainedSeq) {
           window.terminalRuns.delete(runId);

--- a/src/gateway/worker-environments/service.test.ts
+++ b/src/gateway/worker-environments/service.test.ts
@@ -56,6 +56,14 @@ const BOOTSTRAP_RECEIPT = {
   protocolFeatures: [],
 };
 const CREDENTIAL = ["worker", "credential", "fixture"].join("-");
+const LIVE_EVENT_ACK = { ok: true as const, result: { ackedSeq: 1 } };
+const LIVE_EVENT = {
+  runEpoch: 1,
+  lastAckedSeq: 0,
+  seq: 1,
+  runId: "run-1",
+  event: { kind: "assistant" as const, payload: { text: "hi", delta: "hi" } },
+};
 
 type WorkerLifecycleLease = Parameters<WorkerProvider["inspect"]>[0];
 
@@ -116,6 +124,7 @@ describe("worker environment service", () => {
         | "resolveWorkerGateway"
         | "tunnelManager"
         | "generateWorkerCredential"
+        | "liveEvents"
         | "workerCredentialTtlMs"
       >
     > = {},
@@ -145,6 +154,18 @@ describe("worker environment service", () => {
       provision: async () => ({ leaseId: "lease-1", ssh: SSH_ENDPOINT }),
       inspect: async () => ({ status: "active" }),
       destroy: async () => {},
+      ...overrides,
+    };
+  }
+
+  function createLiveEvents(overrides: Record<string, unknown> = {}) {
+    return {
+      apply: vi.fn(() => LIVE_EVENT_ACK),
+      bindSession: vi.fn(() => true),
+      clear: vi.fn(),
+      clearEnvironment: vi.fn(),
+      rotateCredential: vi.fn(() => true),
+      start: vi.fn(),
       ...overrides,
     };
   }
@@ -381,7 +402,6 @@ describe("worker environment service", () => {
         seq: 2,
       }),
     ).resolves.toEqual({ ok: false, reason: "epoch-mismatch" });
-
     database.db
       .prepare("UPDATE worker_environment_credentials SET session_id = ? WHERE environment_id = ?")
       .run("session-other", environmentId);
@@ -389,6 +409,63 @@ describe("worker environment service", () => {
       { ok: false, reason: "session-not-attached" },
     );
     expect(applyTranscriptCommit).toHaveBeenCalledOnce();
+  });
+
+  it("fences and rotates live credentials", async () => {
+    const environmentId = "worker-live";
+    const sessionId = "session-live";
+    const identity = seedAttachedIdentity(environmentId, sessionId);
+    const liveEvents = createLiveEvents();
+    const workerService = createService(createProvider(), { liveEvents });
+    const request = { ...LIVE_EVENT, runEpoch: identity.ownerEpoch };
+    const push = workerService.pushLiveEvent.bind(workerService, identity);
+    await push(request);
+    await expect(push({ ...request, runEpoch: identity.ownerEpoch + 1 })).resolves.toEqual({
+      ok: false,
+      details: { reason: "epoch-mismatch" },
+    });
+    database.db
+      .prepare("UPDATE worker_environment_credentials SET session_id = ? WHERE environment_id = ?")
+      .run("session-other", environmentId);
+    await expect(push({ ...request, seq: 2 })).resolves.toEqual({
+      ok: false,
+      details: { reason: "session-not-attached" },
+    });
+    liveEvents.rotateCredential.mockClear();
+    nowMs += 10_000;
+    await workerService.reconcileOnce();
+    expect(liveEvents.rotateCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentialHash: store.getCredential(environmentId)?.credentialHash,
+        previousCredentialHash: identity.credentialHash,
+        runEpoch: identity.ownerEpoch,
+      }),
+    );
+  });
+
+  it("repairs duplicate session owners", async () => {
+    const sessionId = "legacy";
+    const older = seedAttachedIdentity("legacy-a", sessionId);
+    const newer = seedAttachedIdentity("legacy-b", "other");
+    database.db.exec(`
+      UPDATE worker_environments SET attached_session_ids_json = '["legacy"]'
+        WHERE environment_id = 'legacy-b';
+      UPDATE worker_environment_credentials SET session_id = 'legacy'
+        WHERE environment_id = 'legacy-b';
+    `);
+
+    closeOpenClawStateDatabaseForTest();
+    database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+    store = createWorkerEnvironmentStore({ database, now: () => nowMs });
+    const liveEvents = createLiveEvents();
+    const workerService = createService(createProvider(), { liveEvents });
+    const event = { ...LIVE_EVENT, runEpoch: newer.ownerEpoch };
+    await expect(workerService.pushLiveEvent(older, event)).resolves.toEqual({
+      ok: false,
+      closeReason: "credential-replaced",
+    });
+    await workerService.pushLiveEvent({ ...newer, sessionId }, event);
+    expect(liveEvents.apply).toHaveBeenCalledOnce();
   });
 
   it("rejects attach before current bootstrap", async () => {
@@ -410,6 +487,53 @@ describe("worker environment service", () => {
       }),
     ).rejects.toThrow("must bootstrap the current build");
     expect(store.get(staleId)).toMatchObject({ state: "ready", attachedSessionIds: [] });
+  });
+
+  it("returns a bounded error when another worker owns the session", async () => {
+    const firstId = "worker-session-owner";
+    const secondId = "worker-session-contender";
+    seedReady(firstId);
+    seedReady(secondId);
+    const workerService = createService(createProvider());
+
+    await workerService.attachSession({
+      environmentId: firstId,
+      ownerEpoch: 1,
+      sessionId: "session-owned",
+    });
+    await expect(
+      workerService.attachSession({
+        environmentId: secondId,
+        ownerEpoch: 1,
+        sessionId: "session-owned",
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_state",
+      message:
+        "Session session-owned is already attached to worker environment worker-session-owner",
+    });
+    expect(store.get(secondId)).toMatchObject({ state: "ready", attachedSessionIds: [] });
+  });
+
+  it("stops the tunnel after live binding rollback", async () => {
+    const environmentId = "live-bind-fail";
+    seedReady(environmentId);
+    const liveEvents = createLiveEvents({
+      bindSession: vi.fn(() => {
+        throw new Error("bind failed");
+      }),
+    });
+    const tunnelManager = {
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    const workerService = createService(createProvider(), { liveEvents, tunnelManager });
+
+    await expect(
+      workerService.attachSession({ environmentId, ownerEpoch: 1, sessionId: "session-live" }),
+    ).rejects.toThrow("Attached session target is unavailable");
+    expect(tunnelManager.stop).toHaveBeenCalledWith(environmentId, 1);
+    expect(store.get(environmentId)).toMatchObject({ state: "idle", attachedSessionIds: [] });
   });
 
   it("renews in place and binds delivery acknowledgement to the exact grant", async () => {
@@ -1510,13 +1634,16 @@ describe("worker environment service", () => {
 
   it("owns and clears one periodic reconciliation timer", async () => {
     vi.useFakeTimers();
-    const workerService = createService(createProvider());
+    const liveEvents = createLiveEvents();
+    const workerService = createService(createProvider(), { liveEvents });
 
     workerService.start();
     workerService.start();
+    expect(liveEvents.start).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(1);
     await workerService.stop();
 
+    expect(liveEvents.clear).toHaveBeenCalledTimes(2);
     expect(vi.getTimerCount()).toBe(0);
   });
 

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -4,6 +4,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   type WorkerAdmissionHandshake,
   type WorkerConnectParams,
+  type WorkerLiveEventParams,
   type WorkerProtocolCloseReason,
   type WorkerTranscriptCommitErrorReason,
   type WorkerTranscriptCommitParams,
@@ -44,12 +45,14 @@ import {
   type WorkerCredentialBinding,
   type WorkerCredentialDeliveryClaim,
 } from "./credential.js";
+import type { WorkerLiveEventApplicationResult, WorkerLiveEventReceiver } from "./live-events.js";
 import type { WorkerEnvironmentState } from "./state.js";
 import {
   normalizeWorkerSshEndpoint,
   type WorkerEnvironmentRecord,
   type WorkerEnvironmentStore,
   type WorkerEnvironmentTransitionPatch as TransitionPatch,
+  WorkerSessionAlreadyAttachedError,
 } from "./store.js";
 import type { WorkerTunnelRequest } from "./tunnel-contract.js";
 import type { WorkerTunnelHandle, WorkerTunnelManager } from "./tunnel.js";
@@ -108,6 +111,10 @@ export type WorkerEnvironmentServiceOptions = {
     identity: WorkerConnectionIdentity;
     request: WorkerTranscriptCommitParams;
   }) => Promise<WorkerTranscriptCommitApplicationResult>;
+  liveEvents?: Pick<
+    WorkerLiveEventReceiver,
+    "apply" | "bindSession" | "clear" | "clearEnvironment" | "rotateCredential" | "start"
+  >;
 };
 
 export type WorkerTranscriptCommitApplicationResult =
@@ -116,6 +123,10 @@ export type WorkerTranscriptCommitApplicationResult =
 
 export type WorkerTranscriptCommitServiceResult =
   | WorkerTranscriptCommitApplicationResult
+  | { ok: false; closeReason: WorkerProtocolCloseReason };
+
+export type WorkerLiveEventServiceResult =
+  | WorkerLiveEventApplicationResult
   | { ok: false; closeReason: WorkerProtocolCloseReason };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -188,6 +199,9 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     const next = store.transition({ environmentId: r.environmentId, from: r.state, to, patch });
     if (to !== "ready" && to !== "idle" && to !== "attached") {
       pendingCredentials.delete(r.environmentId);
+    }
+    if (to !== "attached") {
+      options.liveEvents?.clearEnvironment(r.environmentId);
     }
     return next;
   };
@@ -317,7 +331,9 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     };
   };
 
-  const mintCredentialLocked = (request: WorkerCredentialBinding): MintedWorkerCredential => {
+  const mintCredentialLocked = (
+    request: WorkerCredentialBinding,
+  ): { credentialHash: string; grant: MintedWorkerCredential } => {
     const material = credentialMaterial();
     const credential = {
       environmentId: request.environmentId,
@@ -328,7 +344,10 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
       expiresAtMs: credentialExpiry(),
     };
     const record = store.renewCredential(credential);
-    return grantFrom({ credential: material.credential, record });
+    return {
+      credentialHash: material.credentialHash,
+      grant: grantFrom({ credential: material.credential, record }),
+    };
   };
 
   const stageCredential = (grant: MintedWorkerCredential): MintedWorkerCredential => {
@@ -545,13 +564,21 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
       return;
     }
     pendingCredentials.delete(record.environmentId);
-    stageCredential(
-      mintCredentialLocked({
+    const minted = mintCredentialLocked({
+      environmentId: record.environmentId,
+      ownerEpoch: record.ownerEpoch,
+      sessionId,
+    });
+    stageCredential(minted.grant);
+    if (sessionId && credential?.ownerEpoch === record.ownerEpoch) {
+      options.liveEvents?.rotateCredential({
+        credentialHash: minted.credentialHash,
         environmentId: record.environmentId,
-        ownerEpoch: record.ownerEpoch,
+        previousCredentialHash: credential.credentialHash,
+        runEpoch: record.ownerEpoch,
         sessionId,
-      }),
-    );
+      });
+    }
   };
 
   const reconcileRecord = async (initialRecord: WorkerEnvironmentRecord): Promise<void> => {
@@ -792,21 +819,47 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
         );
       }
       const material = credentialMaterial();
-      store.transition({
-        environmentId: request.environmentId,
-        from: current.state,
-        to: "attached",
-        expectedOwnerEpoch: request.ownerEpoch,
-        patch: {
-          attachedSessionIds: [request.sessionId],
-          credential: {
-            credentialHash: material.credentialHash,
-            sessionId: request.sessionId,
-            rpcSetVersion: WORKER_RPC_SET_VERSION,
-            expiresAtMs: credentialExpiry(),
+      let attached: WorkerEnvironmentRecord;
+      try {
+        attached = store.transition({
+          environmentId: request.environmentId,
+          from: current.state,
+          to: "attached",
+          expectedOwnerEpoch: request.ownerEpoch,
+          patch: {
+            attachedSessionIds: [request.sessionId],
+            credential: {
+              credentialHash: material.credentialHash,
+              sessionId: request.sessionId,
+              rpcSetVersion: WORKER_RPC_SET_VERSION,
+              expiresAtMs: credentialExpiry(),
+            },
           },
-        },
-      });
+        });
+      } catch (error) {
+        if (error instanceof WorkerSessionAlreadyAttachedError) {
+          throw serviceError("invalid_state", error.message);
+        }
+        throw error;
+      }
+      if (options.liveEvents) {
+        let liveSessionBound: boolean;
+        try {
+          liveSessionBound = options.liveEvents.bindSession({
+            environmentId: attached.environmentId,
+            runEpoch: attached.ownerEpoch,
+            sessionId: request.sessionId,
+          });
+        } catch {
+          liveSessionBound = false;
+        }
+        if (!liveSessionBound) {
+          move(attached, "idle");
+          // Preserve the bounded attachment error after rollback fences the old worker.
+          await tunnels?.stop(request.environmentId, current.ownerEpoch).catch(() => undefined);
+          throw serviceError("invalid_state", "Attached session target is unavailable");
+        }
+      }
       pendingCredentials.delete(request.environmentId);
       await tunnels?.stop(request.environmentId, current.ownerEpoch);
       return stageCredential(
@@ -910,6 +963,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     if (interval || stopping) {
       return;
     }
+    options.liveEvents?.start();
     interval = setInterval(
       () => void reconcileOnce().catch(() => warn("Worker environment reconcile sweep failed")),
       options.reconcileIntervalMs ?? 60_000,
@@ -921,6 +975,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
   const stop = async () => {
     stopping = true;
     pendingCredentials.clear();
+    options.liveEvents?.clear();
     clearInterval(interval);
     interval = undefined;
     await tunnels?.stopAll();
@@ -932,6 +987,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
       await Promise.allSettled(activeOperations);
     }
     pendingCredentials.clear();
+    options.liveEvents?.clear();
   };
 
   const readPendingCredential = (binding: WorkerCredentialBinding) => {
@@ -967,46 +1023,78 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     return { checkedAtMs, credentialHash, grant };
   };
 
+  const validateAttachedWorkerRequest = (
+    identity: WorkerConnectionIdentity,
+    runEpoch: number,
+  ):
+    | { ok: true }
+    | { ok: false; closeReason: WorkerProtocolCloseReason }
+    | { ok: false; reason: "epoch-mismatch" | "session-not-attached" } => {
+    if (stopping) {
+      return { ok: false, closeReason: "environment-unavailable" };
+    }
+    const credential = store.getCredential(identity.environmentId);
+    if (!credential || !safeEqualSecret(credential.credentialHash, identity.credentialHash)) {
+      return { ok: false, closeReason: "credential-replaced" };
+    }
+    if (now() >= credential.expiresAtMs) {
+      return { ok: false, closeReason: "credential-expired" };
+    }
+    const environment = store.get(identity.environmentId);
+    if (!environment || environment.destroyRequestedAtMs !== null) {
+      return { ok: false, closeReason: "environment-unavailable" };
+    }
+    if (
+      runEpoch !== identity.ownerEpoch ||
+      runEpoch !== credential.ownerEpoch ||
+      runEpoch !== environment.ownerEpoch
+    ) {
+      return { ok: false, reason: "epoch-mismatch" };
+    }
+    if (
+      environment.state !== "attached" ||
+      !identity.sessionId ||
+      credential.sessionId !== identity.sessionId ||
+      environment.attachedSessionIds.length !== 1 ||
+      environment.attachedSessionIds[0] !== identity.sessionId
+    ) {
+      return { ok: false, reason: "session-not-attached" };
+    }
+    return { ok: true };
+  };
+
   const commitTranscript = (
     identity: WorkerConnectionIdentity,
     request: WorkerTranscriptCommitParams,
   ): Promise<WorkerTranscriptCommitServiceResult> =>
     withLock(identity.environmentId, async () => {
-      if (stopping) {
-        return { ok: false, closeReason: "environment-unavailable" };
-      }
-      const credential = store.getCredential(identity.environmentId);
-      if (!credential || !safeEqualSecret(credential.credentialHash, identity.credentialHash)) {
-        return { ok: false, closeReason: "credential-replaced" };
-      }
-      if (now() >= credential.expiresAtMs) {
-        return { ok: false, closeReason: "credential-expired" };
-      }
-      const environment = store.get(identity.environmentId);
-      if (!environment || environment.destroyRequestedAtMs !== null) {
-        return { ok: false, closeReason: "environment-unavailable" };
-      }
-      if (
-        request.runEpoch !== identity.ownerEpoch ||
-        request.runEpoch !== credential.ownerEpoch ||
-        request.runEpoch !== environment.ownerEpoch
-      ) {
-        return { ok: false, reason: "epoch-mismatch" };
-      }
-      if (
-        environment.state !== "attached" ||
-        !identity.sessionId ||
-        credential.sessionId !== identity.sessionId ||
-        environment.attachedSessionIds.length !== 1 ||
-        environment.attachedSessionIds[0] !== identity.sessionId
-      ) {
-        return { ok: false, reason: "session-not-attached" };
+      const binding = validateAttachedWorkerRequest(identity, request.runEpoch);
+      if (!binding.ok) {
+        return binding;
       }
       if (!options.applyTranscriptCommit) {
         return { ok: false, closeReason: "gateway-unavailable" };
       }
       return await options.applyTranscriptCommit({ identity, request });
     });
+
+  const pushLiveEvent = (
+    identity: WorkerConnectionIdentity,
+    request: WorkerLiveEventParams,
+  ): Promise<WorkerLiveEventServiceResult> => {
+    const binding = validateAttachedWorkerRequest(identity, request.runEpoch);
+    if (!binding.ok) {
+      if ("closeReason" in binding) {
+        return Promise.resolve(binding);
+      }
+      return Promise.resolve({ ok: false, details: { reason: binding.reason } });
+    }
+    if (!options.liveEvents) {
+      return Promise.resolve({ ok: false, closeReason: "gateway-unavailable" });
+    }
+    // Publish after authoritative validation without blocking on lifecycle work.
+    return Promise.resolve(options.liveEvents.apply({ identity, request }));
+  };
 
   return {
     list: () => store.list().map(project),
@@ -1046,6 +1134,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
         ? ("environment-unavailable" as const)
         : validateWorkerConnectionIdentity({ store, identity, nowMs: now() }),
     commitTranscript,
+    pushLiveEvent,
     attachSession,
     takeMintedCredential: (binding: WorkerCredentialBinding) =>
       readPendingCredential(binding)?.grant,

--- a/src/gateway/worker-environments/session-target.ts
+++ b/src/gateway/worker-environments/session-target.ts
@@ -1,0 +1,50 @@
+import type { SessionTranscriptWriteScope } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveSessionIdMatchSelection } from "../../sessions/session-id-resolution.js";
+import {
+  loadCombinedSessionStoreForGateway,
+  resolveFreshestSessionEntryFromStoreKeys,
+  resolveGatewaySessionStoreTargetWithStore,
+} from "../session-utils.js";
+
+export type ResolvedWorkerSessionTarget = Omit<
+  SessionTranscriptWriteScope,
+  "sessionId" | "sessionKey"
+> & {
+  sessionEntry: NonNullable<ReturnType<typeof resolveFreshestSessionEntryFromStoreKeys>>;
+  sessionId: string;
+  sessionKey: string;
+  sessionStore: Record<
+    string,
+    NonNullable<ReturnType<typeof resolveFreshestSessionEntryFromStoreKeys>>
+  >;
+};
+
+export function resolveWorkerSessionTarget(
+  cfg: OpenClawConfig,
+  sessionId: string,
+): ResolvedWorkerSessionTarget | undefined {
+  const { store } = loadCombinedSessionStoreForGateway(cfg);
+  const matches = Object.entries(store).filter(([, entry]) => entry.sessionId === sessionId);
+  const selection = resolveSessionIdMatchSelection(matches, sessionId);
+  if (selection.kind !== "selected") {
+    return undefined;
+  }
+  const target = resolveGatewaySessionStoreTargetWithStore({
+    cfg,
+    key: selection.sessionKey,
+    clone: false,
+  });
+  const entry = resolveFreshestSessionEntryFromStoreKeys(target.store, target.storeKeys);
+  if (!entry || entry.sessionId !== sessionId) {
+    return undefined;
+  }
+  return {
+    agentId: target.agentId,
+    sessionEntry: entry,
+    sessionId,
+    sessionKey: target.canonicalKey,
+    sessionStore: target.store,
+    storePath: target.storePath,
+  };
+}

--- a/src/gateway/worker-environments/store.test.ts
+++ b/src/gateway/worker-environments/store.test.ts
@@ -299,6 +299,15 @@ describe("worker environment store", () => {
       to: "attached",
       patch: attachedPatch("shared-session", firstReady.environmentId),
     });
+    const secondReady = makeReady("worker-owner-b", "lease-owner-b");
+    expect(() =>
+      store.transition({
+        environmentId: secondReady.environmentId,
+        from: secondReady.state,
+        to: "attached",
+        patch: attachedPatch("shared-session", secondReady.environmentId),
+      }),
+    ).toThrow("already attached to worker environment worker-owner-a");
     store.transition({
       environmentId: first.environmentId,
       from: first.state,
@@ -314,7 +323,6 @@ describe("worker environment store", () => {
     database.db
       .prepare("DELETE FROM worker_environments WHERE environment_id = ?")
       .run(first.environmentId);
-    const secondReady = makeReady("worker-owner-b", "lease-owner-b");
     const second = store.transition({
       environmentId: secondReady.environmentId,
       from: secondReady.state,

--- a/src/gateway/worker-environments/store.ts
+++ b/src/gateway/worker-environments/store.ts
@@ -55,6 +55,14 @@ type Ssh = WorkerEnvironmentSshEndpoint;
 type UnleasedRecord = { state: WorkerEnvironmentUnleasedState; leaseId: null; sshEndpoint: null };
 type LeasedRecord = { state: WorkerEnvironmentLeasedState; leaseId: string; sshEndpoint: Ssh };
 export type WorkerEnvironmentRecord = RecordBase & (UnleasedRecord | LeasedRecord);
+export class WorkerSessionAlreadyAttachedError extends Error {
+  constructor(
+    readonly sessionId: string,
+    readonly environmentId: string,
+  ) {
+    super(`Session ${sessionId} is already attached to worker environment ${environmentId}`);
+  }
+}
 export type WorkerEnvironmentTransitionPatch = {
   leaseId?: string | null;
   sshEndpoint?: WorkerEnvironmentSshEndpoint | null;
@@ -466,6 +474,57 @@ function listRows(db: DatabaseSync, reconcile: boolean): WorkerEnvironmentRecord
   ).rows.map(fromRow);
 }
 
+function compareAttachmentAuthority(
+  left: WorkerEnvironmentRecord,
+  right: WorkerEnvironmentRecord,
+): number {
+  if (left.ownerEpoch !== right.ownerEpoch) {
+    return left.ownerEpoch > right.ownerEpoch ? -1 : 1;
+  }
+  if (left.stateChangedAtMs !== right.stateChangedAtMs) {
+    return left.stateChangedAtMs > right.stateChangedAtMs ? -1 : 1;
+  }
+  if (left.environmentId === right.environmentId) {
+    return 0;
+  }
+  return left.environmentId < right.environmentId ? -1 : 1;
+}
+
+function reconcileAttachedSessionOwners(db: DatabaseSync, nowMs: number): void {
+  const ownersBySession = new Map<string, WorkerEnvironmentRecord[]>();
+  for (const record of listRows(db, false)) {
+    if (record.state !== "attached") {
+      continue;
+    }
+    const sessionId = record.attachedSessionIds[0];
+    if (!sessionId) {
+      continue;
+    }
+    const owners = ownersBySession.get(sessionId) ?? [];
+    owners.push(record);
+    ownersBySession.set(sessionId, owners);
+  }
+  for (const owners of ownersBySession.values()) {
+    if (owners.length < 2) {
+      continue;
+    }
+    const [, ...duplicates] = owners.toSorted(compareAttachmentAuthority);
+    for (const duplicate of duplicates) {
+      // Repair multiple owners admitted before attachment uniqueness.
+      // Demotion fences the loser before startup snapshots it.
+      update(db, duplicate.environmentId, "attached", {
+        owner_epoch: nextGlobalOwnerEpoch(db),
+        state: "idle",
+        attached_session_ids_json: json([]),
+        updated_at_ms: nowMs,
+        state_changed_at_ms: nowMs,
+        idle_since_at_ms: nowMs,
+      });
+      revokeCredential(db, duplicate.environmentId);
+    }
+  }
+}
+
 export function createWorkerEnvironmentStore(
   options: { database?: OpenClawStateDatabase; now?: () => number } = {},
 ) {
@@ -474,6 +533,7 @@ export function createWorkerEnvironmentStore(
   const read = () => openOpenClawStateDatabase({ path }).db;
   const write = <T>(operation: (db: DatabaseSync) => T): T =>
     runOpenClawStateWriteTransaction(({ db }) => operation(db), { path });
+  write((db) => reconcileAttachedSessionOwners(db, now()));
   const writeCredential = (
     input: CredentialInput & {
       environmentId: string;
@@ -688,6 +748,22 @@ export function createWorkerEnvironmentStore(
               ? current.attachedSessionIds
               : normalizeAttachedSessionIds(patch.attachedSessionIds);
         assertShape(to, leaseId, sshEndpoint, bootstrapReceipt, attachedSessionIds);
+        const [attachedSessionId] = attachedSessionIds;
+        if (to === "attached" && attachedSessionId) {
+          // Change session ownership atomically with worker state.
+          const existingOwner = listRows(db, false).find(
+            (record) =>
+              record.environmentId !== environmentId &&
+              record.state === "attached" &&
+              record.attachedSessionIds[0] === attachedSessionId,
+          );
+          if (existingOwner) {
+            throw new WorkerSessionAlreadyAttachedError(
+              attachedSessionId,
+              existingOwner.environmentId,
+            );
+          }
+        }
         const revokesCredential =
           clearsBootstrapReceipt ||
           to === "attached" ||

--- a/src/gateway/worker-environments/transcript-commit.ts
+++ b/src/gateway/worker-environments/transcript-commit.ts
@@ -11,18 +11,12 @@ import {
   loadSessionEntry,
   publishTranscriptUpdate,
   replaceSessionEntrySync,
-  type SessionTranscriptWriteScope,
   withTranscriptWriteTransaction,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
-import { resolveSessionIdMatchSelection } from "../../sessions/session-id-resolution.js";
-import {
-  loadCombinedSessionStoreForGateway,
-  resolveFreshestSessionEntryFromStoreKeys,
-  resolveGatewaySessionStoreTargetWithStore,
-} from "../session-utils.js";
 import type { WorkerConnectionIdentity } from "./connection-identity.js";
+import { resolveWorkerSessionTarget, type ResolvedWorkerSessionTarget } from "./session-target.js";
 import {
   createWorkerTranscriptCommitStore,
   type WorkerTranscriptCommitInput,
@@ -33,19 +27,6 @@ import {
 type WorkerTranscriptCommitterOptions = {
   getConfig: () => OpenClawConfig;
   store?: WorkerTranscriptCommitStore;
-};
-
-type ResolvedWorkerTranscriptTarget = Omit<
-  SessionTranscriptWriteScope,
-  "sessionId" | "sessionKey"
-> & {
-  sessionEntry: NonNullable<ReturnType<typeof resolveFreshestSessionEntryFromStoreKeys>>;
-  sessionId: string;
-  sessionKey: string;
-  sessionStore: Record<
-    string,
-    NonNullable<ReturnType<typeof resolveFreshestSessionEntryFromStoreKeys>>
-  >;
 };
 
 type SemanticAgentMessage = Extract<AgentMessage, { role: "assistant" | "toolResult" | "user" }>;
@@ -202,35 +183,6 @@ function messageIdempotencyKey(params: {
   return `worker-commit-${digest}`;
 }
 
-function resolveWorkerTranscriptTarget(
-  cfg: OpenClawConfig,
-  sessionId: string,
-): ResolvedWorkerTranscriptTarget | undefined {
-  const { store } = loadCombinedSessionStoreForGateway(cfg);
-  const matches = Object.entries(store).filter(([, entry]) => entry.sessionId === sessionId);
-  const selection = resolveSessionIdMatchSelection(matches, sessionId);
-  if (selection.kind !== "selected") {
-    return undefined;
-  }
-  const target = resolveGatewaySessionStoreTargetWithStore({
-    cfg,
-    key: selection.sessionKey,
-    clone: false,
-  });
-  const entry = resolveFreshestSessionEntryFromStoreKeys(target.store, target.storeKeys);
-  if (!entry || entry.sessionId !== sessionId) {
-    return undefined;
-  }
-  return {
-    agentId: target.agentId,
-    sessionEntry: entry,
-    sessionId,
-    sessionKey: target.canonicalKey,
-    sessionStore: target.store,
-    storePath: target.storePath,
-  };
-}
-
 function readMessageIdempotencyKey(message: unknown): string | undefined {
   if (!message || typeof message !== "object" || Array.isArray(message)) {
     return undefined;
@@ -362,7 +314,7 @@ async function applyWorkerTranscriptCommit(params: {
   recoverPersistedBatch: boolean;
   requestedBaseLeafId: string | null;
   sessionId: string;
-  target: ResolvedWorkerTranscriptTarget;
+  target: ResolvedWorkerSessionTarget;
 }): Promise<ApplyTranscriptCommitResult> {
   const redactedMessages = params.messages.map(
     (message) => redactTranscriptMessage(message, params.config) as CommittedAgentMessage,
@@ -479,7 +431,7 @@ export function createWorkerTranscriptCommitter(options: WorkerTranscriptCommitt
       }
 
       const config = options.getConfig();
-      const target = resolveWorkerTranscriptTarget(config, sessionId);
+      const target = resolveWorkerSessionTarget(config, sessionId);
       if (!target) {
         return store.complete({
           ...input,

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -7,6 +7,7 @@ import {
   clearAgentRunContext,
   emitAgentAuditEvent,
   emitAgentEvent,
+  emitAgentEventForOwner,
   getAgentEventLifecycleGeneration,
   getAgentRunContext,
   listAgentRunsForSession,
@@ -189,6 +190,37 @@ describe("agent-events sequencing", () => {
     releaseAgentRunContext("shared-run", ownerToken);
 
     expect(getAgentRunContext("shared-run")).toBeUndefined();
+  });
+
+  test("reserves exclusive run ids for owner-only delivery and cleanup", () => {
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const claimId = claimAgentRunContext(
+      "exclusive-run",
+      { sessionKey: "worker" },
+      { exclusive: true, trackOwner: true },
+    )!;
+    expect(
+      claimAgentRunContext("exclusive-run", { sessionKey: "local" }, { trackOwner: true }),
+    ).toBeUndefined();
+    const seen: unknown[] = [];
+    const stop = onAgentEvent(({ data }) => seen.push(data.text));
+    const event = (text: string) => ({
+      runId: "exclusive-run",
+      stream: "assistant" as const,
+      data: { text },
+    });
+
+    emitAgentEvent(event("local"));
+    emitAgentEventForOwner(event("worker"), claimId);
+
+    clearAgentRunContext("exclusive-run", lifecycleGeneration);
+
+    expect(getAgentRunContext("exclusive-run")?.sessionKey).toBe("worker");
+    releaseAgentRunContext("exclusive-run", claimId);
+    expect(getAgentRunContext("exclusive-run")).toBeUndefined();
+    emitAgentEventForOwner(event("late"), claimId);
+    stop();
+    expect(seen).toEqual(["worker"]);
   });
 
   test("full event reset clears tracked ownership", () => {

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -13,7 +13,6 @@ import {
   listAgentRunsForSession,
   onAgentAuditEvent,
   onAgentEvent,
-  onAgentEventProjection,
   registerAgentRunContext,
   releaseAgentRunContext,
   resetAgentEventsForTest,
@@ -212,48 +211,16 @@ describe("agent-events sequencing", () => {
     });
 
     emitAgentEvent(event("local"));
-    void emitAgentEventForOwner(event("worker"), claimId);
+    emitAgentEventForOwner(event("worker"), claimId);
 
     clearAgentRunContext("exclusive-run", lifecycleGeneration);
 
     expect(getAgentRunContext("exclusive-run")?.sessionKey).toBe("worker");
     releaseAgentRunContext("exclusive-run", claimId);
     expect(getAgentRunContext("exclusive-run")).toBeUndefined();
-    void emitAgentEventForOwner(event("late"), claimId);
+    emitAgentEventForOwner(event("late"), claimId);
     stop();
     expect(seen).toEqual(["worker"]);
-  });
-
-  test("reports completion of the Gateway-owned event projection", async () => {
-    let settleProjection = () => {};
-    const projection = new Promise<void>((resolve) => {
-      settleProjection = resolve;
-    });
-    const stop = onAgentEventProjection(() => projection);
-    const claimId = claimAgentRunContext(
-      "projected-run",
-      { sessionKey: "worker" },
-      { exclusive: true, trackOwner: true },
-    )!;
-
-    const settled = emitAgentEventForOwner(
-      { runId: "projected-run", stream: "assistant", data: { text: "pending" } },
-      claimId,
-    );
-    if (!settled) {
-      throw new Error("expected projection completion");
-    }
-    let completed = false;
-    void settled.then(() => {
-      completed = true;
-    });
-    await Promise.resolve();
-    expect(completed).toBe(false);
-
-    settleProjection();
-    await expect(settled).resolves.toBeUndefined();
-    stop();
-    releaseAgentRunContext("projected-run", claimId);
   });
 
   test("full event reset clears tracked ownership", () => {

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -13,6 +13,7 @@ import {
   listAgentRunsForSession,
   onAgentAuditEvent,
   onAgentEvent,
+  onAgentEventProjection,
   registerAgentRunContext,
   releaseAgentRunContext,
   resetAgentEventsForTest,
@@ -211,16 +212,48 @@ describe("agent-events sequencing", () => {
     });
 
     emitAgentEvent(event("local"));
-    emitAgentEventForOwner(event("worker"), claimId);
+    void emitAgentEventForOwner(event("worker"), claimId);
 
     clearAgentRunContext("exclusive-run", lifecycleGeneration);
 
     expect(getAgentRunContext("exclusive-run")?.sessionKey).toBe("worker");
     releaseAgentRunContext("exclusive-run", claimId);
     expect(getAgentRunContext("exclusive-run")).toBeUndefined();
-    emitAgentEventForOwner(event("late"), claimId);
+    void emitAgentEventForOwner(event("late"), claimId);
     stop();
     expect(seen).toEqual(["worker"]);
+  });
+
+  test("reports completion of the Gateway-owned event projection", async () => {
+    let settleProjection = () => {};
+    const projection = new Promise<void>((resolve) => {
+      settleProjection = resolve;
+    });
+    const stop = onAgentEventProjection(() => projection);
+    const claimId = claimAgentRunContext(
+      "projected-run",
+      { sessionKey: "worker" },
+      { exclusive: true, trackOwner: true },
+    )!;
+
+    const settled = emitAgentEventForOwner(
+      { runId: "projected-run", stream: "assistant", data: { text: "pending" } },
+      claimId,
+    );
+    if (!settled) {
+      throw new Error("expected projection completion");
+    }
+    let completed = false;
+    void settled.then(() => {
+      completed = true;
+    });
+    await Promise.resolve();
+    expect(completed).toBe(false);
+
+    settleProjection();
+    await expect(settled).resolves.toBeUndefined();
+    stop();
+    releaseAgentRunContext("projected-run", claimId);
   });
 
   test("full event reset clears tracked ownership", () => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -153,6 +153,7 @@ export type AgentRunContext = {
 type AgentEventState = {
   seqByRun: Map<string, number>;
   listeners: Set<(evt: AgentEventPayload) => void>;
+  projectionListeners?: Set<(evt: AgentEventPayload) => Promise<void>>;
   auditListeners: Set<(evt: AgentEventPayload) => void>;
   runContextById: Map<string, AgentRunContext>;
   runContextOwnersById?: Map<
@@ -191,6 +192,11 @@ function getAgentEventExecutionContext() {
     AGENT_EVENT_EXECUTION_CONTEXT_KEY,
     () => new AsyncLocalStorage<AgentEventExecutionContext>(),
   );
+}
+
+function getAgentEventProjectionListeners(state = getAgentEventState()) {
+  state.projectionListeners ??= new Set<(evt: AgentEventPayload) => Promise<void>>();
+  return state.projectionListeners;
 }
 
 /** Runs one execution with immutable ownership inherited by every emitted stream event. */
@@ -621,10 +627,26 @@ function enrichAgentEvent(
   return enriched;
 }
 
+function projectAgentEvent(event: AgentEventPayload): Promise<void> | undefined {
+  const pending: Promise<void>[] = [];
+  for (const listener of getAgentEventProjectionListeners()) {
+    try {
+      pending.push(listener(event));
+    } catch {
+      // Projection listeners own their logging; preserve event-bus isolation.
+    }
+  }
+  if (pending.length === 0) {
+    return undefined;
+  }
+  return Promise.allSettled(pending).then(() => undefined);
+}
+
 /** Emits an agent event after assigning per-run sequence, timestamp, and context metadata. */
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
   const enriched = enrichAgentEvent(event);
   if (enriched) {
+    void projectAgentEvent(enriched);
     notifyListeners(getAgentEventState().listeners, enriched);
   }
 }
@@ -635,8 +657,11 @@ export function emitAgentEventForOwner(
 ) {
   const enriched = enrichAgentEvent(event, claimId);
   if (enriched) {
+    const projection = projectAgentEvent(enriched);
     notifyListeners(getAgentEventState().listeners, enriched);
+    return projection;
   }
+  return undefined;
 }
 
 /** Emits run metadata only to the Gateway-owned durable audit projection. */
@@ -716,6 +741,13 @@ export function onAgentEvent(listener: (evt: AgentEventPayload) => void) {
   return registerListener(state.listeners, listener);
 }
 
+/** Subscribes the Gateway-owned async projection used by owner-release barriers. */
+export function onAgentEventProjection(listener: (evt: AgentEventPayload) => Promise<void>) {
+  const listeners = getAgentEventProjectionListeners();
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
 /** Subscribes to private audit-only agent events; returns an unsubscribe callback. */
 export function onAgentAuditEvent(listener: (evt: AgentEventPayload) => void) {
   return registerListener(getAgentEventState().auditListeners, listener);
@@ -726,6 +758,7 @@ export function resetAgentEventsForTest() {
   const state = getAgentEventState();
   state.seqByRun.clear();
   state.listeners.clear();
+  getAgentEventProjectionListeners(state).clear();
   state.auditListeners.clear();
   state.runContextById.clear();
   getAgentRunContextOwners(state).clear();

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -117,6 +117,9 @@ export type AgentEventPayload = {
   data: Record<string, unknown>;
   /** Internal, non-enumerable gateway lifecycle generation that owns this run. */
   lifecycleGeneration?: string;
+  controlUiVisible?: boolean;
+  contextClaimId?: string;
+  deliverySessionKey?: string;
   sessionKey?: string;
   /**
    * sessionId the run was bound to when it started. Lifecycle persistence uses
@@ -140,6 +143,7 @@ export type AgentRunContext = {
   isHeartbeat?: boolean;
   /** Whether control UI clients should receive chat/agent updates for this run. */
   isControlUiVisible?: boolean;
+  projectSessionActive?: boolean;
   /** Timestamp when this context was first registered (for TTL-based cleanup). */
   registeredAt?: number;
   /** Timestamp of last activity (updated on every emitAgentEvent). */
@@ -155,9 +159,11 @@ type AgentEventState = {
     string,
     {
       lifecycleGeneration: string;
-      ownerTokens: Set<string>;
+      claimIds: Set<string>;
       preserveAfterRelease: boolean;
       clearRequested: boolean;
+      exclusiveClaimId?: string;
+      clearListeners?: Map<string, (claimId: string) => void>;
     }
   >;
   lifecycleGeneration: string;
@@ -221,11 +227,20 @@ export function rotateAgentEventLifecycleGeneration(): string {
 }
 
 /** Registers or merges per-run context used by later agent event emissions. */
-export function registerAgentRunContext(runId: string, context: AgentRunContext) {
+export function registerAgentRunContext(runId: string, context: AgentRunContext, claimId?: string) {
   if (!runId) {
     return;
   }
   const state = getAgentEventState();
+  const lifecycleGeneration = context.lifecycleGeneration ?? state.lifecycleGeneration;
+  const owners = getAgentRunContextOwners(state).get(runId);
+  if (
+    owners?.lifecycleGeneration === lifecycleGeneration &&
+    owners.exclusiveClaimId &&
+    (owners.exclusiveClaimId !== claimId || owners.clearRequested)
+  ) {
+    return;
+  }
   const existing = state.runContextById.get(runId);
   if (!existing) {
     state.runContextById.set(runId, {
@@ -257,6 +272,9 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
   if (context.isControlUiVisible !== undefined) {
     existing.isControlUiVisible = context.isControlUiVisible;
   }
+  if (context.projectSessionActive !== undefined) {
+    existing.projectSessionActive = context.projectSessionActive;
+  }
   if (context.isHeartbeat !== undefined && existing.isHeartbeat !== context.isHeartbeat) {
     existing.isHeartbeat = context.isHeartbeat;
   }
@@ -277,7 +295,12 @@ function getAgentRunContextOwners(state = getAgentEventState()) {
 export function claimAgentRunContext(
   runId: string,
   context: AgentRunContext,
-  options: { trackOwner?: boolean; ownsContext?: boolean } = {},
+  options: {
+    trackOwner?: boolean;
+    ownsContext?: boolean;
+    exclusive?: boolean;
+    onClearRequested?: (claimId: string) => void;
+  } = {},
 ): string | undefined {
   if (!runId) {
     return undefined;
@@ -287,21 +310,39 @@ export function claimAgentRunContext(
   const existing = state.runContextById.get(runId);
   const ownersById = getAgentRunContextOwners(state);
   const existingOwners = ownersById.get(runId);
-  let ownerToken: string | undefined;
+  const currentOwners =
+    existingOwners?.lifecycleGeneration === lifecycleGeneration ? existingOwners : undefined;
+  if (
+    currentOwners?.exclusiveClaimId ||
+    (options.exclusive &&
+      (existing?.lifecycleGeneration === lifecycleGeneration ||
+        (currentOwners?.claimIds.size ?? 0) > 0))
+  ) {
+    return undefined;
+  }
+  let claimId: string | undefined;
   if (options.trackOwner) {
-    ownerToken = randomUUID();
-    if (existingOwners?.lifecycleGeneration === lifecycleGeneration) {
-      existingOwners.ownerTokens.add(ownerToken);
+    claimId = randomUUID();
+    if (currentOwners) {
+      currentOwners.claimIds.add(claimId);
       if (options.ownsContext) {
-        existingOwners.preserveAfterRelease = false;
+        currentOwners.preserveAfterRelease = false;
+      }
+      if (options.onClearRequested) {
+        currentOwners.clearListeners ??= new Map();
+        currentOwners.clearListeners.set(claimId, options.onClearRequested);
       }
     } else {
       ownersById.set(runId, {
         lifecycleGeneration,
-        ownerTokens: new Set([ownerToken]),
+        claimIds: new Set([claimId]),
         preserveAfterRelease:
           options.ownsContext !== true && existing?.lifecycleGeneration === lifecycleGeneration,
         clearRequested: false,
+        ...(options.exclusive ? { exclusiveClaimId: claimId } : {}),
+        ...(options.onClearRequested
+          ? { clearListeners: new Map([[claimId, options.onClearRequested]]) }
+          : {}),
       });
     }
   } else if (existingOwners?.lifecycleGeneration !== lifecycleGeneration) {
@@ -310,11 +351,15 @@ export function claimAgentRunContext(
     ownersById.delete(runId);
   }
   if (existing?.lifecycleGeneration === lifecycleGeneration) {
-    registerAgentRunContext(runId, {
-      ...context,
-      lifecycleGeneration,
-    });
-    return ownerToken;
+    registerAgentRunContext(
+      runId,
+      {
+        ...context,
+        lifecycleGeneration,
+      },
+      claimId,
+    );
+    return claimId;
   }
   state.runContextById.set(runId, {
     ...context,
@@ -322,12 +367,29 @@ export function claimAgentRunContext(
     registeredAt: context.registeredAt ?? Date.now(),
   });
   state.seqByRun.delete(runId);
-  return ownerToken;
+  return claimId;
 }
 
 /** Returns the currently registered context for a run, if it has not been cleared or swept. */
 export function getAgentRunContext(runId: string) {
   return getAgentEventState().runContextById.get(runId);
+}
+
+export function getAgentRunContextOwnerStatus(
+  runId: string,
+  claimId: string,
+  lifecycleGeneration: string,
+): "active" | "clear-requested" | undefined {
+  const state = getAgentEventState();
+  const owners = getAgentRunContextOwners(state).get(runId);
+  if (
+    lifecycleGeneration !== state.lifecycleGeneration ||
+    owners?.lifecycleGeneration !== lifecycleGeneration ||
+    !owners.claimIds.has(claimId)
+  ) {
+    return undefined;
+  }
+  return owners.clearRequested ? "clear-requested" : "active";
 }
 
 /** Lists active runs bound to one current session identity. */
@@ -352,17 +414,56 @@ export function listAgentRunsForSession(params: {
   );
 }
 
+export function hasProjectedAgentRunForSession(params: {
+  sessionKeys: readonly string[];
+  sessionId?: string;
+}): boolean {
+  const lifecycleGeneration = getAgentEventState().lifecycleGeneration;
+  for (const context of getAgentEventState().runContextById.values()) {
+    const matches =
+      (context.sessionKey !== undefined && params.sessionKeys.includes(context.sessionKey)) ||
+      (params.sessionId !== undefined && context.sessionId === params.sessionId);
+    if (
+      matches &&
+      context.projectSessionActive === true &&
+      context.lifecycleGeneration === lifecycleGeneration
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Clears context and sequence state for a run that has ended or been discarded. */
-export function clearAgentRunContext(runId: string, lifecycleGeneration?: string) {
+export function clearAgentRunContext(
+  runId: string,
+  lifecycleGeneration?: string,
+  claimId?: string,
+) {
   const state = getAgentEventState();
   const existing = state.runContextById.get(runId);
   if (lifecycleGeneration && existing && existing.lifecycleGeneration !== lifecycleGeneration) {
     return;
   }
   const owners = getAgentRunContextOwners(state).get(runId);
-  if (owners?.ownerTokens.size) {
+  if (
+    claimId &&
+    (!owners ||
+      (lifecycleGeneration && owners.lifecycleGeneration !== lifecycleGeneration) ||
+      !owners.claimIds.has(claimId))
+  ) {
+    return;
+  }
+  // A rejected claimant's cleanup must not evict the exclusive owner.
+  if (owners?.exclusiveClaimId && owners.exclusiveClaimId !== claimId) {
+    return;
+  }
+  if (owners?.claimIds.size) {
     if (!lifecycleGeneration || owners.lifecycleGeneration === lifecycleGeneration) {
       owners.clearRequested = true;
+      for (const [ownerClaimId, listener] of owners.clearListeners ?? []) {
+        listener(ownerClaimId);
+      }
     }
     return;
   }
@@ -371,17 +472,21 @@ export function clearAgentRunContext(runId: string, lifecycleGeneration?: string
 }
 
 /** Releases one tracked owner and clears its context after the final owner exits. */
-export function releaseAgentRunContext(runId: string, ownerToken: string | undefined) {
-  if (!runId || !ownerToken) {
+export function releaseAgentRunContext(runId: string, claimId: string | undefined) {
+  if (!runId || !claimId) {
     return;
   }
   const state = getAgentEventState();
   const ownersById = getAgentRunContextOwners(state);
   const owners = ownersById.get(runId);
-  if (!owners?.ownerTokens.delete(ownerToken)) {
+  if (!owners?.claimIds.delete(claimId)) {
     return;
   }
-  if (owners.ownerTokens.size > 0) {
+  owners.clearListeners?.delete(claimId);
+  if (owners.exclusiveClaimId === claimId) {
+    owners.exclusiveClaimId = undefined;
+  }
+  if (owners.claimIds.size > 0) {
     return;
   }
   ownersById.delete(runId);
@@ -423,8 +528,22 @@ export function resetAgentRunContextForTest() {
 
 function enrichAgentEvent(
   event: Omit<AgentEventPayload, "seq" | "ts">,
+  claimId?: string,
 ): AgentEventPayload | undefined {
   const state = getAgentEventState();
+  const owners = getAgentRunContextOwners(state).get(event.runId);
+  if (claimId !== undefined) {
+    if (
+      owners?.lifecycleGeneration !== state.lifecycleGeneration ||
+      owners.exclusiveClaimId !== claimId ||
+      !owners.claimIds.has(claimId) ||
+      owners.clearRequested
+    ) {
+      return undefined;
+    }
+  } else if (owners?.lifecycleGeneration === state.lifecycleGeneration && owners.exclusiveClaimId) {
+    return undefined;
+  }
   const context = state.runContextById.get(event.runId);
   const executionLifecycleGeneration =
     event.lifecycleGeneration ?? getAgentEventExecutionContext().getStore()?.lifecycleGeneration;
@@ -447,6 +566,7 @@ function enrichAgentEvent(
   const isControlUiVisible = context?.isControlUiVisible ?? true;
   const eventSessionKey =
     typeof event.sessionKey === "string" && event.sessionKey.trim() ? event.sessionKey : undefined;
+  const deliverySessionKey = eventSessionKey ?? context?.sessionKey;
   // Hidden channel-routed runs should not leak live assistant/tool traffic into
   // Control UI, but lifecycle events still need the session key so gateway
   // listeners can persist terminal session state even if run-context lookup is
@@ -480,12 +600,40 @@ function enrichAgentEvent(
       enumerable: false,
     });
   }
+  if (context?.isControlUiVisible !== undefined) {
+    Object.defineProperty(enriched, "controlUiVisible", {
+      value: context.isControlUiVisible,
+      enumerable: false,
+    });
+  }
+  if (claimId !== undefined) {
+    Object.defineProperty(enriched, "contextClaimId", {
+      value: claimId,
+      enumerable: false,
+    });
+    if (deliverySessionKey) {
+      Object.defineProperty(enriched, "deliverySessionKey", {
+        value: deliverySessionKey,
+        enumerable: false,
+      });
+    }
+  }
   return enriched;
 }
 
 /** Emits an agent event after assigning per-run sequence, timestamp, and context metadata. */
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
   const enriched = enrichAgentEvent(event);
+  if (enriched) {
+    notifyListeners(getAgentEventState().listeners, enriched);
+  }
+}
+
+export function emitAgentEventForOwner(
+  event: Omit<AgentEventPayload, "seq" | "ts">,
+  claimId: string,
+) {
+  const enriched = enrichAgentEvent(event, claimId);
   if (enriched) {
     notifyListeners(getAgentEventState().listeners, enriched);
   }

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -117,9 +117,6 @@ export type AgentEventPayload = {
   data: Record<string, unknown>;
   /** Internal, non-enumerable gateway lifecycle generation that owns this run. */
   lifecycleGeneration?: string;
-  controlUiVisible?: boolean;
-  contextClaimId?: string;
-  deliverySessionKey?: string;
   sessionKey?: string;
   /**
    * sessionId the run was bound to when it started. Lifecycle persistence uses
@@ -128,6 +125,13 @@ export type AgentEventPayload = {
    */
   sessionId?: string;
   agentId?: string;
+};
+
+/** Gateway-only routing metadata stamped onto events after public input validation. */
+export type AgentEventRuntimePayload = AgentEventPayload & {
+  readonly controlUiVisible?: boolean;
+  readonly contextClaimId?: string;
+  readonly deliverySessionKey?: string;
 };
 
 /** Per-run metadata used to stamp events and gate Control UI visibility. */
@@ -152,7 +156,7 @@ export type AgentRunContext = {
 
 type AgentEventState = {
   seqByRun: Map<string, number>;
-  listeners: Set<(evt: AgentEventPayload) => void>;
+  listeners: Set<(evt: AgentEventRuntimePayload) => void>;
   auditListeners: Set<(evt: AgentEventPayload) => void>;
   runContextById: Map<string, AgentRunContext>;
   runContextOwnersById?: Map<
@@ -179,7 +183,7 @@ type AgentEventExecutionContext = {
 function getAgentEventState(): AgentEventState {
   return resolveGlobalSingleton<AgentEventState>(AGENT_EVENT_STATE_KEY, () => ({
     seqByRun: new Map<string, number>(),
-    listeners: new Set<(evt: AgentEventPayload) => void>(),
+    listeners: new Set<(evt: AgentEventRuntimePayload) => void>(),
     auditListeners: new Set<(evt: AgentEventPayload) => void>(),
     runContextById: new Map<string, AgentRunContext>(),
     lifecycleGeneration: randomUUID(),
@@ -529,7 +533,7 @@ export function resetAgentRunContextForTest() {
 function enrichAgentEvent(
   event: Omit<AgentEventPayload, "seq" | "ts">,
   claimId?: string,
-): AgentEventPayload | undefined {
+): AgentEventRuntimePayload | undefined {
   const state = getAgentEventState();
   const owners = getAgentRunContextOwners(state).get(event.runId);
   if (claimId !== undefined) {
@@ -584,7 +588,7 @@ function enrichAgentEvent(
       ? (ownedLifecycleGeneration ?? state.lifecycleGeneration)
       : ownedLifecycleGeneration;
   const agentId = event.agentId ?? context?.agentId;
-  const enriched: AgentEventPayload = {
+  const enriched: AgentEventRuntimePayload = {
     ...event,
     sessionKey,
     ...(sessionId ? { sessionId } : {}),
@@ -714,6 +718,11 @@ export function emitAgentPatchSummaryEvent(params: {
 export function onAgentEvent(listener: (evt: AgentEventPayload) => void) {
   const state = getAgentEventState();
   return registerListener(state.listeners, listener);
+}
+
+/** Subscribes Gateway internals that consume non-public ownership and routing metadata. */
+export function onAgentRuntimeEvent(listener: (evt: AgentEventRuntimePayload) => void) {
+  return registerListener(getAgentEventState().listeners, listener);
 }
 
 /** Subscribes to private audit-only agent events; returns an unsubscribe callback. */

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -153,7 +153,6 @@ export type AgentRunContext = {
 type AgentEventState = {
   seqByRun: Map<string, number>;
   listeners: Set<(evt: AgentEventPayload) => void>;
-  projectionListeners?: Set<(evt: AgentEventPayload) => Promise<void>>;
   auditListeners: Set<(evt: AgentEventPayload) => void>;
   runContextById: Map<string, AgentRunContext>;
   runContextOwnersById?: Map<
@@ -192,11 +191,6 @@ function getAgentEventExecutionContext() {
     AGENT_EVENT_EXECUTION_CONTEXT_KEY,
     () => new AsyncLocalStorage<AgentEventExecutionContext>(),
   );
-}
-
-function getAgentEventProjectionListeners(state = getAgentEventState()) {
-  state.projectionListeners ??= new Set<(evt: AgentEventPayload) => Promise<void>>();
-  return state.projectionListeners;
 }
 
 /** Runs one execution with immutable ownership inherited by every emitted stream event. */
@@ -627,26 +621,10 @@ function enrichAgentEvent(
   return enriched;
 }
 
-function projectAgentEvent(event: AgentEventPayload): Promise<void> | undefined {
-  const pending: Promise<void>[] = [];
-  for (const listener of getAgentEventProjectionListeners()) {
-    try {
-      pending.push(listener(event));
-    } catch {
-      // Projection listeners own their logging; preserve event-bus isolation.
-    }
-  }
-  if (pending.length === 0) {
-    return undefined;
-  }
-  return Promise.allSettled(pending).then(() => undefined);
-}
-
 /** Emits an agent event after assigning per-run sequence, timestamp, and context metadata. */
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
   const enriched = enrichAgentEvent(event);
   if (enriched) {
-    void projectAgentEvent(enriched);
     notifyListeners(getAgentEventState().listeners, enriched);
   }
 }
@@ -657,11 +635,8 @@ export function emitAgentEventForOwner(
 ) {
   const enriched = enrichAgentEvent(event, claimId);
   if (enriched) {
-    const projection = projectAgentEvent(enriched);
     notifyListeners(getAgentEventState().listeners, enriched);
-    return projection;
   }
-  return undefined;
 }
 
 /** Emits run metadata only to the Gateway-owned durable audit projection. */
@@ -741,13 +716,6 @@ export function onAgentEvent(listener: (evt: AgentEventPayload) => void) {
   return registerListener(state.listeners, listener);
 }
 
-/** Subscribes the Gateway-owned async projection used by owner-release barriers. */
-export function onAgentEventProjection(listener: (evt: AgentEventPayload) => Promise<void>) {
-  const listeners = getAgentEventProjectionListeners();
-  listeners.add(listener);
-  return () => listeners.delete(listener);
-}
-
 /** Subscribes to private audit-only agent events; returns an unsubscribe callback. */
 export function onAgentAuditEvent(listener: (evt: AgentEventPayload) => void) {
   return registerListener(getAgentEventState().auditListeners, listener);
@@ -758,7 +726,6 @@ export function resetAgentEventsForTest() {
   const state = getAgentEventState();
   state.seqByRun.clear();
   state.listeners.clear();
-  getAgentEventProjectionListeners(state).clear();
   state.auditListeners.clear();
   state.runContextById.clear();
   getAgentRunContextOwners(state).clear();

--- a/src/sessions/session-lifecycle-events.ts
+++ b/src/sessions/session-lifecycle-events.ts
@@ -7,9 +7,28 @@ export type SessionLifecycleEvent = {
   displayName?: string;
 };
 
+export type SessionIdentityMutationTarget = {
+  sessionId?: string;
+  sessionKeys: readonly string[];
+};
+
+export type SessionIdentityMutation =
+  | {
+      kind: "create" | "move" | "replace" | "reset";
+      previous: SessionIdentityMutationTarget;
+      current: SessionIdentityMutationTarget;
+    }
+  | {
+      kind: "delete";
+      previous: SessionIdentityMutationTarget;
+    };
+
+export type SessionIdentityMutationListener = (mutation: SessionIdentityMutation) => void;
+
 type SessionLifecycleListener = (event: SessionLifecycleEvent) => void;
 
 const SESSION_LIFECYCLE_LISTENERS = new Set<SessionLifecycleListener>();
+const SESSION_IDENTITY_MUTATION_LISTENERS = new Set<SessionIdentityMutationListener>();
 
 /** Registers a session lifecycle listener. */
 export function onSessionLifecycleEvent(listener: SessionLifecycleListener): () => void {
@@ -26,6 +45,23 @@ export function emitSessionLifecycleEvent(event: SessionLifecycleEvent): void {
       listener(event);
     } catch {
       // Best-effort, do not propagate listener errors.
+    }
+  }
+}
+
+export function onSessionIdentityMutation(listener: SessionIdentityMutationListener): () => void {
+  SESSION_IDENTITY_MUTATION_LISTENERS.add(listener);
+  return () => {
+    SESSION_IDENTITY_MUTATION_LISTENERS.delete(listener);
+  };
+}
+
+export function emitSessionIdentityMutation(mutation: SessionIdentityMutation): void {
+  for (const listener of SESSION_IDENTITY_MUTATION_LISTENERS) {
+    try {
+      listener(mutation);
+    } catch {
+      // Session persistence already succeeded; one observer must not block the rest.
     }
   }
 }


### PR DESCRIPTION
Part of #104294 (cloud workers, milestone 2, PR 7). Builds on #104688 (worker role) and #104809 (transcript commits). Design: `docs/plan/cloud-workers.md` ("Session backend RPCs" — replayable live events; and `docs/concepts/streaming.md`).

## What Problem This Solves

Transcript commits (PR 6) make a worker session's durable messages appear in the sidebar, but only at turn boundaries. This PR adds the ephemeral, replayable live-event channel so a worker session streams in real time — token deltas, tool start/finish, approvals, run-status — by translating each worker event into the SAME internal agent event and pushing it through the EXISTING fanout, so chat view / tool rows / unread-status behave identically to a local session. No parallel streaming path, no token-delta channel message (per streaming.md). Durable content still arrives via the PR-6 commit path; the live channel never writes transcript entries.

## Why This Change Was Made

- Worker live-event frame on the closed worker allowlist: runEpoch + monotonic worker seq + closed event-kind union (mirroring the local agent-event kinds) + typed payload; gateway cumulative-ACKs. Additive schema, independent feature negotiation, no version bump.
- Gateway application validates credential-session binding and owner epoch (stale/superseded workers fenced), translates to the internal agent event, and publishes through `emitAgentEventForOwner` into the normal fanout.
- Bounded process-local replay window per (session, runEpoch) with cumulative ACK + dedup + late-event fencing; a brief tunnel blip replays only the unacked tail; out-of-window forces a resync; superseded-epoch events never reach subscribers. In-memory only (transient), lifecycle-bounded.

## Deep-review findings fixed pre-merge

A dedicated deep code review (verified independently) found and fixed:
- **Event-loss race (root cause):** the gateway projection is deferred through a Promise while claim release was synchronous. On a mid-drain capacity reset, a just-emitted prefix event's claim could be released before its deferred projection delivered, silently dropping the event in the wired gateway (invisible to receiver-only unit tests). Fixed by keeping a capacity-reset run's claim alive until its in-flight projections settle (`Promise.allSettled`), while detach/supersession teardown stays immediate. Proven by a new gateway+WebSocket integration test asserting exactly-once delivery of a published prefix across a subsequent buffered-capacity event.
- Terminal-run fence retained through projection cleanup so post-terminal events can't resurrect an ended run after window eviction (+ test).
- Speculative `pending` state cleared on in-window resync (prevents a stale buffered event shadowing a renumbered one).
- Collapsed duplicated apply()/resolveWindow validation into one owner (`resolveOrCreateWindow`) and removed a dead epoch branch.
- Bounded fenced-environment LRU refreshes recency on re-fence.
- Added the AGENTS.md-required invariant comments (fence-before-emit ordering, terminalRuns TTL bound, startup-owner cross-filter).

## User Impact

Opt-in only; the worker loop that drives these events lands in PR 9. This is the real-time streaming mechanism for worker sessions. No config/changelog/version-bump changes.

## Evidence

- Blacksmith Testbox: 4 Vitest shards green (live-events receiver incl. capacity-after-prefix and terminal-fence-eviction cases; the new gateway+WS deferred-projection integration test; worker-environments suite; agent-events; server-chat agent-events; worker admission; lint-suppressions).
- Codex fresh autoreview after the fixes: clean, no actionable findings. Local: oxlint (31 files), check:test-types, madge zero cycles, protocol:check, docs:map:check all green.
