### PR TITLE
fix(config): mark pre-update snapshot only after a successful write

### DIFF
--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -133,8 +133,6 @@ export async function createPreUpdateConfigSnapshot(params: {
   if (preUpdateConfigSnapshotsWritten.has(snapshotKey)) {
     return;
   }
-  // Mark before I/O so a failed best-effort write cannot loop on every later write.
-  preUpdateConfigSnapshotsWritten.add(snapshotKey);
   const snapshotPath = `${params.configPath}.pre-update`;
   try {
     const content = await params.fs.readFile(params.configPath, "utf-8");
@@ -143,6 +141,12 @@ export async function createPreUpdateConfigSnapshot(params: {
       mode: 0o600,
       flag: "w",
     });
+    // Mark only after a successful write. Marking earlier permanently blocked
+    // future snapshots for the process when the first read/write failed
+    // transiently (e.g. a temporary file lock), silently dropping the operator's
+    // rollback point (#105193). Leaving it unmarked on failure lets the next
+    // update attempt retry; pre-update snapshots are per-update, not per-write.
+    preUpdateConfigSnapshotsWritten.add(snapshotKey);
   } catch {
     // best-effort, do not block update
   }

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -222,6 +222,40 @@ describe("config backup rotation", () => {
     });
   });
 
+  it("createPreUpdateConfigSnapshot retries after a transient first-attempt failure (#105193)", async () => {
+    await withTempHome(async () => {
+      const configPath = resolveConfigPathFromTempState();
+      const content = JSON.stringify({ version: "original" });
+      await fs.writeFile(configPath, content, { mode: 0o600 });
+      const snapshotPath = `${configPath}.pre-update`;
+      const { existsSync } = await import("node:fs");
+
+      // First attempt: the read fails transiently (e.g. a temporary file lock).
+      let failNextRead = true;
+      const flakyReadFile = async (p: string, encoding: "utf-8") => {
+        if (failNextRead) {
+          failNextRead = false;
+          throw Object.assign(new Error("EBUSY: resource busy or locked"), { code: "EBUSY" });
+        }
+        return fs.readFile(p, encoding);
+      };
+
+      await createPreUpdateConfigSnapshot({
+        configPath,
+        fs: { writeFile: fs.writeFile, readFile: flakyReadFile, existsSync },
+      });
+      // No snapshot yet, and the file must not be marked as done.
+      await expect(fs.access(snapshotPath)).rejects.toBeTruthy();
+
+      // A later update attempt succeeds and the snapshot is finally written.
+      await createPreUpdateConfigSnapshot({
+        configPath,
+        fs: { writeFile: fs.writeFile, readFile: flakyReadFile, existsSync },
+      });
+      await expect(fs.readFile(snapshotPath, "utf-8")).resolves.toBe(content);
+    });
+  });
+
   it("createPreUpdateConfigSnapshot is a no-op when config does not exist", async () => {
     await withTempHome(async () => {
       const configPath = resolveConfigPathFromTempState();


### PR DESCRIPTION
## What Problem This Solves

`createPreUpdateConfigSnapshot` records the config path in a process-global "already snapshotted" set **before** it reads and writes the snapshot. If that first attempt fails transiently — a temporary file lock, an `EBUSY`, a momentary permission hiccup — the path is nonetheless marked done, so **no snapshot is ever taken for the rest of the process** and the operator silently loses their pre-update rollback point (#105193).

## Why This Change Was Made

The early mark was a guard against looping "on every later write". But `createPreUpdateConfigSnapshot` is only invoked once per `openclaw update` (`src/cli/update-cli/update-command.ts`), not on ordinary config writes — so the loop it guarded against does not occur, while the cost (dropping the snapshot on a transient first failure) is a real data-integrity gap.

The fix moves the `preUpdateConfigSnapshotsWritten.add(...)` to **after** a successful write. On failure the path stays unmarked, so the next update attempt retries. Successful behavior is unchanged: the first successful call marks the path and later calls in the same process remain no-ops (the existing "once per process" and "survives multiple config writes" tests still pass).

## User Impact

- A transient failure on the first pre-update snapshot attempt no longer permanently disables snapshots; the operator keeps a rollback point on the next update.
- No behavior change on the success path or for the per-update (non-looping) call pattern.

## Evidence

**Regression test** (`node scripts/run-vitest.mjs run src/config/config.backup-rotation.test.ts` → 9/9): `createPreUpdateConfigSnapshot retries after a transient first-attempt failure (#105193)` injects a `readFile` that throws `EBUSY` on the first call; it asserts no snapshot exists and the path is not marked, then a second call (read now succeeds) writes the `.pre-update` snapshot with the original content.

**Discriminator**: reverting only `backup-rotation.ts` (restoring mark-before-I/O) fails the new test — the second attempt is skipped because the path was marked on the failed first attempt, exactly the reported permanent block.

Fixes #105193
