### PR TITLE
fix(discord): keep slash commands deployed at the application limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Discord command reconciliation:** fall back to Discord's complete command-set replacement when an application at the 100-command cap cannot create a replacement before deleting stale commands, preventing startup deployment failures without an unsafe delete gap.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Discord command reconciliation:** fall back to Discord's complete command-set replacement when an application at the 100-command cap cannot create a replacement before deleting stale commands, preventing startup deployment failures without an unsafe delete gap.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.

--- a/extensions/discord/src/internal/client.test.ts
+++ b/extensions/discord/src/internal/client.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { Client, ComponentRegistry, type AnyListener } from "./client.js";
 import { BaseCommand } from "./commands.js";
 import { Button, StringSelectMenu, parseCustomId } from "./components.js";
+import { DiscordError } from "./rest.js";
 import { attachRestMock, createInternalTestClient } from "./test-builders.test-support.js";
 
 function createDeferred<T = void>(): {
@@ -236,6 +237,78 @@ describe("Client.deployCommands", () => {
 
     expect(patch).not.toHaveBeenCalled();
     expect(post).not.toHaveBeenCalled();
+    expect(deleteRequest).not.toHaveBeenCalled();
+  });
+
+  it("bulk overwrites when a capped application cannot create a replacement", async () => {
+    const retainedCommands = Array.from({ length: 99 }, (_, index) =>
+      createTestCommand({ name: `retained-${index}` }),
+    );
+    const replacement = createTestCommand({ name: "replacement" });
+    const client = createInternalTestClient([...retainedCommands, replacement]);
+    const existing = [
+      ...retainedCommands.map((command, index) =>
+        Object.assign(command.serialize(), {
+          id: `retained-id-${index}`,
+          application_id: "app1",
+        }),
+      ),
+      Object.assign(createTestCommand({ name: "stale" }).serialize(), {
+        id: "stale-id",
+        application_id: "app1",
+      }),
+    ];
+    let deployedCount = existing.length;
+    const operations: string[] = [];
+    const get = vi.fn(async () => existing);
+    const post = vi.fn(async () => {
+      if (deployedCount >= 100) {
+        throw new DiscordError(new Response(null, { status: 400 }), {
+          message: "Maximum number of application commands reached (100).",
+          code: 30032,
+        });
+      }
+      deployedCount += 1;
+      operations.push("post");
+    });
+    const put = vi.fn(async () => {
+      deployedCount = 100;
+      operations.push("put");
+    });
+    const deleteRequest = vi.fn(async () => undefined);
+    attachRestMock(client, { get, post, put, delete: deleteRequest });
+
+    await client.deployCommands({ mode: "reconcile" });
+
+    expect(deleteRequest).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledWith(Routes.applicationCommands("app1"), {
+      body: replacement.serialize(),
+    });
+    expect(put).toHaveBeenCalledWith(Routes.applicationCommands("app1"), {
+      body: [...retainedCommands, replacement].map((command) => command.serialize()),
+    });
+    expect(operations).toEqual(["put"]);
+    expect(deployedCount).toBe(100);
+  });
+
+  it("keeps stale commands when a replacement create fails below the cap", async () => {
+    const client = createInternalTestClient([createTestCommand({ name: "replacement" })]);
+    const get = vi.fn(async () => [
+      Object.assign(createTestCommand({ name: "stale" }).serialize(), {
+        id: "stale-id",
+        application_id: "app1",
+      }),
+    ]);
+    const post = vi.fn(async () => {
+      throw new Error("Discord unavailable");
+    });
+    const deleteRequest = vi.fn(async () => undefined);
+    attachRestMock(client, { get, post, delete: deleteRequest });
+
+    await expect(client.deployCommands({ mode: "reconcile" })).rejects.toThrow(
+      "Discord unavailable",
+    );
+
     expect(deleteRequest).not.toHaveBeenCalled();
   });
 

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -22,6 +22,8 @@ export type DeployCommandOptions = {
 
 type SerializedCommand = ReturnType<BaseCommand["serialize"]>;
 
+const DISCORD_APPLICATION_COMMAND_LIMIT_REACHED = 30032;
+
 /**
  * Per-`command-deploy-cache.json` path async mutex. `server-channels.ts` can
  * start several Discord deployers concurrently in the same Node.js process;
@@ -133,17 +135,31 @@ export class DiscordCommandDeployer {
   private async reconcileGlobalCommands(desired: SerializedCommand[]) {
     const existing = await this.getCommands();
     const existingByKey = new Map(existing.map((command) => [stableCommandKey(command), command]));
-    const desiredKeys = new Set<string>();
-    for (const command of desired) {
-      const key = stableCommandKey(command as APIApplicationCommand);
-      desiredKeys.add(key);
+    const desiredCommands = desired.map((command) => ({
+      command,
+      key: stableCommandKey(command as APIApplicationCommand),
+    }));
+    const desiredKeys = new Set(desiredCommands.map(({ key }) => key));
+    for (const { command, key } of desiredCommands) {
       const current = existingByKey.get(key);
-      if (!current) {
-        await createApplicationCommand(this.rest, this.params.clientId, command);
+      if (current && !commandsEqual(current, command)) {
+        await editApplicationCommand(this.rest, this.params.clientId, current.id, command);
+      }
+    }
+    for (const { command, key } of desiredCommands) {
+      if (existingByKey.has(key)) {
         continue;
       }
-      if (!commandsEqual(current, command)) {
-        await editApplicationCommand(this.rest, this.params.clientId, current.id, command);
+      try {
+        await createApplicationCommand(this.rest, this.params.clientId, command);
+      } catch (error) {
+        if (!isApplicationCommandLimitError(error)) {
+          throw error;
+        }
+        // Reconcile cannot create before deleting at Discord's hard cap. Bulk
+        // overwrite replaces the complete set without an unsafe delete gap.
+        await overwriteApplicationCommands(this.rest, this.params.clientId, desired);
+        return;
       }
     }
     for (const command of existing) {
@@ -281,6 +297,15 @@ function groupGuildCommands(commands: BaseCommand[]): Map<string, SerializedComm
 
 function stableCommandKey(command: Pick<APIApplicationCommand, "name" | "type">) {
   return `${command.type ?? ApplicationCommandType.ChatInput}:${command.name}`;
+}
+
+function isApplicationCommandLimitError(error: unknown): boolean {
+  return (
+    Boolean(error) &&
+    typeof error === "object" &&
+    "discordCode" in error &&
+    error.discordCode === DISCORD_APPLICATION_COMMAND_LIMIT_REACHED
+  );
 }
 
 function comparableCommand(value: unknown): unknown {

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -301,7 +301,7 @@ function stableCommandKey(command: Pick<APIApplicationCommand, "name" | "type">)
 
 function isApplicationCommandLimitError(error: unknown): boolean {
   return (
-    Boolean(error) &&
+    error !== null &&
     typeof error === "object" &&
     "discordCode" in error &&
     error.discordCode === DISCORD_APPLICATION_COMMAND_LIMIT_REACHED


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord operators with 100 registered application commands would see slash-command deployment fail during Gateway startup when OpenClaw needed to replace a stale command.

## Why This Change Was Made

Reconciliation still edits retained commands and creates replacements normally. If Discord returns its documented application-command limit error, OpenClaw now uses Discord's complete command-set replacement endpoint with the desired set, avoiding both the create-before-delete deadlock and an unsafe delete gap.

## User Impact

Discord slash commands remain deployable when an application is already at Discord's 100-command cap. Other creation failures still preserve the existing command set and propagate normally.

## Evidence

- Before fix: focused Testbox regression failed with Discord error `30032` while trying to create the replacement at 100 commands.
- After fix: Blacksmith Testbox `tbx_01kxaxa8q603rgnnzjwabbw2ca`, focused Discord suite: 19/19 passed.
- Changed-lane gate: format and focused extension checks passed; the global gate then stopped on pre-existing Plugin SDK baseline drift unrelated to these Discord files.
- Fresh Codex autoreview: clean, confidence 0.94.
- Contract: https://docs.discord.com/developers/interactions/application-commands#registering-a-command
