### PR TITLE
fix(macos): node invokes no longer time out during reconnect

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -965,10 +965,25 @@ extension GatewayNodeSession {
         channel: GatewayChannelActor,
         socketGeneration: UInt64) async
     {
-        guard await self.awaitLifecycleCallbacks(ifCurrentRoute: route) else { return }
         guard self.isCurrentRoute(route),
               self.channel === channel
         else { return }
+        // Lifecycle cleanup gates owner readiness. Reject while it is suspended instead of
+        // holding the Gateway request until timeout; the replacement route stays fail-closed.
+        if self.lifecycleCallbackBarrier != nil {
+            self.logger.info("node invoke rejected during lifecycle transition id=\(request.id, privacy: .public)")
+            await self.sendInvokeResult(
+                request: request,
+                response: BridgeInvokeResponse(
+                    id: request.id,
+                    ok: false,
+                    error: OpenClawNodeError(
+                        code: .unavailable,
+                        message: "UNAVAILABLE: node lifecycle transition in progress")),
+                channel: channel,
+                socketGeneration: socketGeneration)
+            return
+        }
         self.logger.info("node invoke executing id=\(request.id, privacy: .public)")
         let bridgeRequest = BridgeInvokeRequest(
             id: request.id,
@@ -1002,14 +1017,6 @@ extension GatewayNodeSession {
             response: response,
             channel: channel,
             socketGeneration: socketGeneration)
-    }
-
-    private func awaitLifecycleCallbacks(ifCurrentRoute route: GatewayNodeSessionRoute) async -> Bool {
-        while let lifecycleCallback = self.lifecycleCallbackBarrier {
-            await lifecycleCallback.task.value
-            guard self.isCurrentRoute(route), self.channel != nil else { return false }
-        }
-        return self.isCurrentRoute(route) && self.channel != nil
     }
 
     func invokeIfCurrentRoute(

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -1146,6 +1146,71 @@ struct GatewayNodeSessionTests {
     }
 
     @Test
+    func `replacement invoke fails promptly while disconnect lifecycle is blocked`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let invalidationGate = AsyncGate()
+        let invocations = DisconnectProbe()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: [],
+            commands: ["system.which"],
+            permissions: [:],
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            clientDisplayName: "macOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://first.example.invalid")),
+            token: nil,
+            bootstrapToken: nil,
+            password: nil,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { request in
+                await invocations.record(request.id)
+                return BridgeInvokeResponse(id: request.id, ok: true, payloadJSON: nil, error: nil)
+            },
+            onRouteInvalidated: { await invalidationGate.wait() })
+        let firstTask = try #require(session.latestTask())
+        try await waitUntil("receive loop armed before disconnect") {
+            firstTask.hasPendingReceiveHandler()
+        }
+
+        firstTask.emitReceiveFailure()
+        try await waitUntil("disconnect lifecycle blocked") {
+            await invalidationGate.hasStarted()
+        }
+        try await waitUntil("replacement transport connected") {
+            session.snapshotMakeCount() == 2
+        }
+        let replacementTask = try #require(session.latestTask())
+        try await waitUntil("replacement socket receiving") {
+            replacementTask.hasPendingReceiveHandler()
+        }
+        replacementTask.emitInvokeRequest(id: "during-lifecycle", command: "system.which")
+
+        try await waitUntil("lifecycle unavailable result") {
+            replacementTask.sentRequestCount(method: "node.invoke.result") == 1
+        }
+        let result = try #require(replacementTask.sentRequests(method: "node.invoke.result").first)
+        let params = try #require(result["params"] as? [String: Any])
+        let error = try #require(params["error"] as? [String: Any])
+        #expect(params["id"] as? String == "during-lifecycle")
+        #expect(params["ok"] as? Bool == false)
+        #expect(error["code"] as? String == OpenClawNodeErrorCode.unavailable.rawValue)
+        #expect(error["message"] as? String == "UNAVAILABLE: node lifecycle transition in progress")
+        #expect(await invocations.values() == [])
+
+        await invalidationGate.release()
+        await gateway.disconnect()
+    }
+
+    @Test
     func `disconnect cleanup finishes after an in flight connected callback`() async throws {
         let session = FakeGatewayWebSocketSession()
         let gateway = GatewayNodeSession()


### PR DESCRIPTION
Closes #105281

## What Problem This Solves

Fixes an issue where users invoking a macOS App node would receive a Gateway timeout when a replacement node transport connected before the previous route's lifecycle cleanup finished. The node appeared connected, but commands remained suspended until the deadline.

## Why This Change Was Made

The replacement route remains fail-closed while owner lifecycle cleanup is in progress, but now returns a typed unavailable result immediately instead of awaiting the cleanup task inside request handling. This completes the reconnect behavior introduced in #105091 without allowing native commands to run during an incomplete lifecycle transition.

## User Impact

Agents and operators get an immediate retryable failure during the narrow reconnect transition instead of waiting 30 seconds for a misleading timeout. Once cleanup finishes, the current route continues handling node commands normally.

## Evidence

- `swiftformat --lint apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift --config config/swiftformat` — clean.
- `swift test --package-path apps/shared/OpenClawKit --filter GatewayNodeSessionTests` — 54 tests passed, 0 failures.
- Regression scenario blocks route invalidation, connects the replacement transport, sends `system.which`, and proves the result is immediately `unavailable` while the native invoke handler remains untouched.
- Structured autoreview — clean; no accepted or actionable findings.
- Live before/after: the affected connected Mac node repeatedly timed out before app restart; the same direct `system.which` returned `/bin/hostname` after lifecycle recovery.
