### PR TITLE
fix(ui): recover worktree creation after reconnect

### DIFF
--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -10,8 +10,11 @@ type WorktreesPageTestElement = HTMLElement & {
   records: WorktreeRecord[];
   error: string | null;
   busyId: string | null;
+  creating: boolean;
+  createRepoRoot: string;
   updateComplete: Promise<boolean>;
   requestUpdate: () => void;
+  createWorktree: () => Promise<void>;
   removeWorktree: (record: WorktreeRecord) => Promise<void>;
   restore: (record: WorktreeRecord) => Promise<void>;
 };
@@ -250,5 +253,37 @@ describe("WorktreesPage lifecycle", () => {
 
     expect(page.error).toBeNull();
     expect(page.busyId).toBeNull();
+  });
+
+  it("clears pending create state across a same-client reconnect", async () => {
+    const pendingCreate = deferred<unknown>();
+    const request = vi.fn((method: string) => {
+      if (method === "worktrees.create") {
+        return pendingCreate.promise;
+      }
+      return Promise.resolve({ worktrees: [] });
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const source = mutableGateway(client);
+    const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
+    page.context = contextWithGateway(source.gateway);
+    page.createRepoRoot = "/tmp/repo";
+    document.body.append(page);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+
+    const creating = page.createWorktree();
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("worktrees.create", { repoRoot: "/tmp/repo" }),
+    );
+    expect(page.creating).toBe(true);
+
+    source.emit(false);
+    source.emit(true);
+    expect(page.creating).toBe(false);
+
+    pendingCreate.reject(new Error("gateway closed"));
+    await creating;
+    expect(page.creating).toBe(false);
+    expect(page.error).toBeNull();
   });
 });

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -102,7 +102,9 @@ class WorktreesPage extends OpenClawLightDomElement {
 
   private invalidateOperations() {
     this.operationEpoch += 1;
+    // Stale operation promises skip their finalizers, so reset every epoch-owned flag here.
     this.busyId = null;
+    this.creating = false;
   }
 
   private captureOperationScope(): WorktreeOperationScope | null {


### PR DESCRIPTION
Closes #105278

## What Problem This Solves

Fixes an issue where users creating a managed worktree in the Control UI would be left with a permanently disabled **Loading…** button when the Gateway disconnected and reconnected while creation was pending. Reloading the page was the only way to use the form again.

## Why This Change Was Made

Gateway identity/connection changes already invalidate every captured Worktrees-page operation epoch. The invalidation helper now resets the later-added create-in-progress flag alongside per-row busy state, because stale promises intentionally suppress their own catch/finally writes. Existing stale-client protections remain unchanged.

## User Impact

After a Gateway reconnect, the New worktree form becomes usable again immediately instead of remaining stuck. Stale create results still cannot write errors or trigger reloads through the replacement Gateway epoch.

## Evidence

- Current-main real browser repro: Playwright drove the source-built Worktrees page, started an actual `worktrees.create` against a five-second failing setup fixture, closed the real Gateway WebSocket, observed disconnected → reconnected, and found Create still disabled after reconnect and after settlement (`true → true → true`).
- Patched real browser proof: the same actual-WebSocket scenario reset Create after reconnect and kept it recovered after settlement (`true → false → false`) with no browser errors.
- The temporary setup failure cleaned up fully in both runs: no linked checkout, `openclaw/*` branch, or matching Worktrees registry record remained.
- Fresh Blacksmith Testbox `tbx_01kxaxe8zfen29sm5j04858wtc`: `corepack pnpm test ui/src/pages/worktrees/worktrees-page.test.ts` passed 6/6 tests. Delegated run: https://github.com/openclaw/openclaw/actions/runs/29188946725
- Local source UI build and remote `corepack pnpm ui:build` passed.
- Remote changed-surface gate passed formatting, core/UI typechecks, lint, and repository guards in 2m06s.
- Fresh structured autoreview: no accepted/actionable findings; patch correct, confidence 0.96.

Before/after screenshots remain local because public image upload has not been authorized.
