### PR TITLE
fix(release): package unreleased ref candidates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,7 @@ Skills own workflows; root owns hard policy and routing.
 - PR refs: `gh pr view/diff` or `gh api`, not web search. Prefer `gitcrawl` for maintainer discovery; missing/stale `gitcrawl` falls through to live `gh`, not contributor setup. Verify live with `gh` before mutation.
 - zsh: quote `gh api` endpoints containing `?` or brackets; otherwise glob expansion corrupts the invocation.
 - zsh: quote command globs; unmatched patterns abort before the tool runs.
+- `scripts/pr` artifacts: preserve template enum values; validate before prepare.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.
 - No unsolicited PR labels/retitles/rebases/fixups/landing. Comments/reviews ok only for reviewable findings, pre-merge proof, or close/duplicate reason after explicit close/sweep/landing request.
 - Maintainer decision closes the cluster: if deciding reported behavior/proposed fix is not planned, comment+close all directly associated open issues/PRs unless explicitly told to keep one open. Associated means linked PRs/issues, duplicates, companion workaround PRs, and the canonical issue for the rejected behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ Skills own workflows; root owns hard policy and routing.
 - Issue/PR start: `git status -sb`; if clean, `git pull --ff-only`; if dirty, yell before pull/rebase.
 - PR refs: `gh pr view/diff` or `gh api`, not web search. Prefer `gitcrawl` for maintainer discovery; missing/stale `gitcrawl` falls through to live `gh`, not contributor setup. Verify live with `gh` before mutation.
 - zsh: quote `gh api` endpoints containing `?` or brackets; otherwise glob expansion corrupts the invocation.
+- zsh: quote command globs; unmatched patterns abort before the tool runs.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.
 - No unsolicited PR labels/retitles/rebases/fixups/landing. Comments/reviews ok only for reviewable findings, pre-merge proof, or close/duplicate reason after explicit close/sweep/landing request.
 - Maintainer decision closes the cluster: if deciding reported behavior/proposed fix is not planned, comment+close all directly associated open issues/PRs unless explicitly told to keep one open. Associated means linked PRs/issues, duplicates, companion workaround PRs, and the canonical issue for the rejected behavior.

--- a/scripts/resolve-openclaw-package-candidate.mjs
+++ b/scripts/resolve-openclaw-package-candidate.mjs
@@ -1476,6 +1476,7 @@ async function resolveCandidate(options) {
       await installPackageSourceDeps(packageSource.sourceDir);
       await run("node", [
         "scripts/package-openclaw-for-docker.mjs",
+        "--allow-unreleased-changelog",
         "--source-dir",
         packageSource.sourceDir,
         "--output-dir",

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -109,6 +109,17 @@ afterEach(async () => {
 });
 
 describe("resolve-openclaw-package-candidate", () => {
+  it("allows Unreleased notes when packaging an exact ref candidate", () => {
+    const script = readFileSync("scripts/resolve-openclaw-package-candidate.mjs", "utf8");
+    const refPackageBuild = script.slice(
+      script.indexOf('if (options.source === "ref")'),
+      script.indexOf('} else if (options.source === "npm")'),
+    );
+
+    expect(refPackageBuild).toContain('"scripts/package-openclaw-for-docker.mjs"');
+    expect(refPackageBuild).toContain('"--allow-unreleased-changelog"');
+  });
+
   it("accepts only OpenClaw release package specs for npm candidates", () => {
     for (const spec of [
       "openclaw@beta",


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation could not prepare a package artifact from exact main SHA `0350b87f069beffc709080a19f6f5b2f81ef7584`. The build completed, but the ref candidate failed because `package.json` was already `2026.7.2` while `CHANGELOG.md` correctly still used `## Unreleased`.

## Why This Change Was Made

Exact-ref package candidates are non-published validation artifacts. Route that existing ref-only builder through `--allow-unreleased-changelog`; versioned release notes remain preferred when present, while npm/package-publish candidate paths stay strict. Add a focused regression guard and a terse zsh invocation note requested during release prep.

## User Impact

Main and release-branch exact-SHA validation can build the package under test before release notes are finalized. Published package validation remains unchanged.

## Evidence

- Primary failure: https://github.com/openclaw/openclaw/actions/runs/29188817355/job/86639915483
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29189238930
- `pnpm test test/scripts/resolve-openclaw-package-candidate.test.ts test/scripts/package-changelog.test.ts`: 59 passed
- `pnpm check:changed`: formatting, test typecheck, script lint, and guards passed
- Fresh autoreview: clean, no accepted/actionable findings

Provenance: the ref-package call path was introduced by commit `02d266c6c4be828d08a469b54ce66514e3a9e51e` on 2026-04-27; the later explicit Unreleased allowance did not wire this caller.
