### PR TITLE
fix(performance): avoid blocking on absent cleanup spans

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -50,7 +50,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 4dde6b6022d94058abced883343de7ee8ce69917
+        default: 61dad0a08f5eee7c632fb104c15f9b0bb8df7987
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -153,7 +153,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '4dde6b6022d94058abced883343de7ee8ce69917' }}
+      KOVA_REF: ${{ inputs.kova_ref || '61dad0a08f5eee7c632fb104c15f9b0bb8df7987' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ Skills own workflows; root owns hard policy and routing.
 - Use `$openclaw-testing` for test/CI choice and `$crabbox` for remote/full/E2E proof.
 - At task start, if code changes, tests, builds, typechecks, lint fan-out, Docker, packaging, E2E, or live proof are likely, classify source trust and immediately pre-warm the safe Crabbox backend in a background command session. Trusted maintainer code defaults to Blacksmith Testbox; untrusted contributor/fork code uses secretless fork CI or sanitized direct AWS Crabbox under the rule above. Continue inspection/editing while it hydrates; sync the current checkout for every run, reuse the lease, then stop it before handoff.
 - Warm Testbox from the task checkout; ownership is checkout-path scoped; `--reclaim` only for intentional transfer.
+- Testbox `--reclaim` does not retarget the remote checkout; never cross repos.
 - Base/head changed: stop and rewarm Testbox; never override stale lease checks.
 - Compound Testbox commands: `bash -lc`, never `sh -lc`; job env uses Bash `declare`.
 - Testbox cleanup: `blacksmith testbox stop --id <tbx_id>`; id is not positional.

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -83,7 +83,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "4dde6b6022d94058abced883343de7ee8ce69917";
+    const kovaRef = "61dad0a08f5eee7c632fb104c15f9b0bb8df7987";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full release performance validation would mark every `agent-cold-warm-message` repeat `BLOCKED` when OpenClaw did not emit the optional `agent.cleanup` source span.

## Why This Change Was Made

Pins Kova to [openclaw/Kova#53](https://github.com/openclaw/Kova/pull/53), which treats only explicit `null` cleanup evidence as absent while keeping malformed non-null evidence and real cleanup threshold regressions blocking. The workflow default, runtime fallback, and pin contract test move together.

The root agent guidance also records that Testbox `--reclaim` does not retarget the remote checkout, preventing cross-repository commands from running against the wrong tree.

## User Impact

Release performance validation can complete when cleanup source-span evidence is unavailable, without weakening required timing measurements or measured cleanup gates.

## Evidence

- Kova CI: https://github.com/openclaw/Kova/actions/runs/29189231990 (Linux and macOS full suites green)
- Testbox `tbx_01kxayae8yvtnswq3k8b5yef73`: `pnpm test test/scripts/openclaw-performance-workflow.test.ts` — 29 passed
- Same Testbox: `pnpm check:workflows` — passed
- Fresh autoreview — clean, no accepted/actionable findings
