### PR TITLE
refactor(agents): remove stale testing aliases

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -1302,4 +1302,3 @@ export const testing = {
   setBundleMcpDisposeTimeoutMsForTest,
   resolveSessionMcpRuntimeIdleTtlMs,
 };
-export { testing as __testing };

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -1362,4 +1362,3 @@ export const testing = {
   MAX_FILE_OPS_LIST_CHARS,
   SUMMARY_TRUNCATED_MARKER,
 } as const;
-export { testing as __testing };

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -2068,7 +2068,6 @@ export const testing = {
   mergeParamsWithApprovalOverrides,
   isPlainObject,
 };
-export { testing as __testing };
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
   if (value instanceof Error) {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -1217,4 +1217,3 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
 export function createOpenClawCodingTools(options?: OpenClawCodingToolsOptions): AnyAgentTool[] {
   return createOpenClawCodingToolsInternal(options);
 }
-export { testing as __testing };

--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -178,5 +178,3 @@ export function syncPersistedExternalCliAuthProfiles(
   }
   return next ?? store;
 }
-
-export { testing as __testing };

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -972,4 +972,3 @@ export async function clearAuthProfileCooldown(params: {
     logDroppedAuthProfileBookkeeping("clear_cooldown", profileId);
   }
 }
-export { testing as __testing };

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -2139,4 +2139,3 @@ export const testing = {
   parseOpenClawChannelsLoginShellCommand,
   validateScriptFileForShellBleed,
 };
-export { testing as __testing };

--- a/src/agents/channel-tools.ts
+++ b/src/agents/channel-tools.ts
@@ -181,4 +181,3 @@ export const testing = {
     messageActionTesting.resetLoggedMessageActionErrors();
   },
 };
-export { testing as __testing };

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -522,4 +522,3 @@ export const testing = {
     };
   },
 } as const;
-export { testing as __testing };

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -1751,4 +1751,3 @@ export const testing = {
     typescriptRuntimeForTest = runtime;
   },
 };
-export { testing as __testing };

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -2019,5 +2019,3 @@ export const testing = {
   runAfterCompactionHooks,
   runPostCompactionSideEffects,
 } as const;
-
-export { testing as __testing };

--- a/src/agents/embedded-agent-runner/run.lane-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run.lane-timeout.test.ts
@@ -1,29 +1,29 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_AGENT_TIMEOUT_MS } from "../timeout.js";
-import { __testing } from "./run.js";
+import { testing } from "./run.js";
 
 describe("resolveEmbeddedRunLaneTimeoutMs", () => {
   it("adds queue grace to explicit run timeouts", () => {
-    expect(__testing.resolveEmbeddedRunLaneTimeoutMs(60_000)).toBe(
-      60_000 + __testing.EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
+    expect(testing.resolveEmbeddedRunLaneTimeoutMs(60_000)).toBe(
+      60_000 + testing.EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
     );
-    expect(__testing.resolveEmbeddedRunLaneTimeoutMs(60_000.9)).toBe(
-      60_000 + __testing.EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
+    expect(testing.resolveEmbeddedRunLaneTimeoutMs(60_000.9)).toBe(
+      60_000 + testing.EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
     );
-    expect(__testing.resolveEmbeddedRunLaneTimeoutMs(DEFAULT_AGENT_TIMEOUT_MS + 60_000)).toBe(
-      DEFAULT_AGENT_TIMEOUT_MS + 60_000 + __testing.EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
+    expect(testing.resolveEmbeddedRunLaneTimeoutMs(DEFAULT_AGENT_TIMEOUT_MS + 60_000)).toBe(
+      DEFAULT_AGENT_TIMEOUT_MS + 60_000 + testing.EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
     );
   });
 
   it("keeps the lane watchdog active when the run timeout is disabled", () => {
     const defaultLaneTimeoutMs =
-      DEFAULT_AGENT_TIMEOUT_MS + __testing.EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS;
+      DEFAULT_AGENT_TIMEOUT_MS + testing.EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS;
 
-    expect(__testing.resolveEmbeddedRunLaneTimeoutMs(0)).toBe(defaultLaneTimeoutMs);
-    expect(__testing.resolveEmbeddedRunLaneTimeoutMs(-1)).toBe(defaultLaneTimeoutMs);
-    expect(__testing.resolveEmbeddedRunLaneTimeoutMs(Number.NaN)).toBe(defaultLaneTimeoutMs);
-    expect(__testing.resolveEmbeddedRunLaneTimeoutMs(MAX_TIMER_TIMEOUT_MS)).toBe(
+    expect(testing.resolveEmbeddedRunLaneTimeoutMs(0)).toBe(defaultLaneTimeoutMs);
+    expect(testing.resolveEmbeddedRunLaneTimeoutMs(-1)).toBe(defaultLaneTimeoutMs);
+    expect(testing.resolveEmbeddedRunLaneTimeoutMs(Number.NaN)).toBe(defaultLaneTimeoutMs);
+    expect(testing.resolveEmbeddedRunLaneTimeoutMs(MAX_TIMER_TIMEOUT_MS)).toBe(
       defaultLaneTimeoutMs,
     );
   });

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -5078,4 +5078,3 @@ export const testing = {
   EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
   resolveEmbeddedRunLaneTimeoutMs,
 };
-export { testing as __testing };

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -948,4 +948,3 @@ export const testing = {
     ABANDONED_EMBEDDED_RUN_SESSION_IDS_BY_FILE.clear();
   },
 };
-export { testing as __testing };

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -2484,4 +2484,3 @@ export const testing = {
     nativeHookRelayDeferredToolApprovalRequester = requester;
   },
 } as const;
-export { testing as __testing };

--- a/src/agents/live-cache-regression-runner.ts
+++ b/src/agents/live-cache-regression-runner.ts
@@ -881,4 +881,3 @@ export async function runLiveCacheRegression(): Promise<LiveCacheRegressionResul
   }
   return { regressions, summary, warnings };
 }
-export { testing as __testing };

--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -8,7 +8,7 @@ import {
   resolveMcpAppSandboxPort,
 } from "./mcp-app-sandbox.js";
 import {
-  __testing,
+  testing as mcpUiResourceTesting,
   acquireMcpAppViewRequest,
   fetchMcpAppView,
   getMcpAppViewLease,
@@ -37,7 +37,7 @@ function runtime(readResource: SessionMcpRuntime["readResource"]): SessionMcpRun
 
 describe("MCP App UI resources", () => {
   beforeEach(() => {
-    __testing.clearViewStore();
+    mcpUiResourceTesting.clearViewStore();
   });
 
   afterEach(() => {

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -304,12 +304,10 @@ export function buildMcpAppCanvasPayload(view: { viewId: string; title: string }
   };
 }
 
-const testing = {
+export const testing = {
   clearViewStore() {
     for (const [viewId, view] of getViewStore()) {
       deleteView(viewId, view);
     }
   },
 };
-
-export { testing as __testing };

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -2072,4 +2072,3 @@ export async function runWithImageModelFallback<T>(params: {
     cfg: params.cfg,
   });
 }
-export { testing as __testing };

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { __testing as externalAuthTesting } from "./auth-profiles/external-auth.js";
+import { testing as externalAuthTesting } from "./auth-profiles/external-auth.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   replaceRuntimeAuthProfileStoreSnapshots,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -710,4 +710,3 @@ export const testing = {
       : defaultOpenClawToolsDeps;
   },
 };
-export { testing as __testing };

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -478,4 +478,3 @@ export const testing = {
       : defaultRunWaitDeps;
   },
 };
-export { testing as __testing };

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -169,4 +169,3 @@ export const testing = {
   resolveLaneResumeConcurrency,
   resolveSessionSuspensionReason,
 } as const;
-export { testing as __testing };

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -1101,4 +1101,3 @@ export function resetSessionWriteLockStateForTest(): void {
   unregisterCleanupHandlers();
   resolveProcessStartTimeForLock = getProcessStartTime;
 }
-export { testing as __testing };

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1980,4 +1980,3 @@ export const testing = {
   hasSessionFileChangedAnnounceError,
   isSessionFileChangedAnnounceError,
 };
-export { testing as __testing };

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -590,4 +590,3 @@ export const testing = {
       : defaultSubagentAnnounceOutputDeps;
   },
 };
-export { testing as __testing };

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -660,4 +660,3 @@ export const testing = {
       : defaultSubagentAnnounceDeps;
   },
 };
-export { testing as __testing };

--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -934,4 +934,3 @@ export const testing = {
       : defaultSubagentControlDeps;
   },
 };
-export { testing as __testing };

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -2049,4 +2049,3 @@ export function initSubagentRegistry() {
 // Importing this module also registers the subagent maintenance preserve-key
 // provider as a side effect (see subagent-registry-maintenance.ts).
 export { listSessionMaintenanceProtectedSubagentSessionKeys } from "./subagent-registry-maintenance.js";
-export { testing as __testing };

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1757,4 +1757,3 @@ export const testing = {
       : defaultSubagentSpawnDeps;
   },
 };
-export { testing as __testing };

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -2418,4 +2418,3 @@ export const testing = {
   appendToolSearchCodeStderrTail,
   runCodeModeChild,
 };
-export { testing as __testing };

--- a/src/agents/tools/agent-step.ts
+++ b/src/agents/tools/agent-step.ts
@@ -152,4 +152,3 @@ export const testing = {
       : defaultAgentStepDeps;
   },
 };
-export { testing as __testing };

--- a/src/agents/tools/computer-tool.ts
+++ b/src/agents/tools/computer-tool.ts
@@ -963,4 +963,3 @@ export const testing = {
     waitForPostActionSettle = override ?? defaultWaitForPostActionSettle;
   },
 };
-export { testing as __testing };

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -1093,4 +1093,3 @@ export function createImageTool(options?: {
     },
   };
 }
-export { testing as __testing };

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -484,4 +484,3 @@ export const testing = {
     );
   },
 };
-export { testing as __testing };

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -268,4 +268,3 @@ export const testing = {
       : defaultSessionsSendA2ADeps;
   },
 };
-export { testing as __testing };

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -125,4 +125,3 @@ export const testing = {
   resolveSearchProvider: (search?: Parameters<typeof resolveWebSearchProviderId>[0]["search"]) =>
     resolveWebSearchProviderId({ search }),
 };
-export { testing as __testing };

--- a/src/agents/worktrees/run-lease.test.ts
+++ b/src/agents/worktrees/run-lease.test.ts
@@ -12,7 +12,7 @@ import {
   releaseWorktreeRunLeaseRow,
 } from "./registry.js";
 import {
-  __testing,
+  testing as runLeaseTesting,
   abortWorktreeRemoval,
   acquireWorktreeRunLease,
   claimWorktreeRemoval,
@@ -55,7 +55,7 @@ describe("worktree run lease", () => {
   });
 
   afterEach(async () => {
-    __testing.resetForTest();
+    runLeaseTesting.resetForTest();
     closeOpenClawStateDatabaseForTest();
     await fs.rm(root, { recursive: true, force: true });
   });
@@ -113,7 +113,7 @@ describe("worktree run lease", () => {
       startTime: 4242,
       now: 1,
     });
-    __testing.setDeadPidResolverForTest((pid) => pid === 987_654);
+    runLeaseTesting.setDeadPidResolverForTest((pid) => pid === 987_654);
 
     expect(hasLiveWorktreeRunLease(env, created.id)).toBe(false);
     expect(() =>
@@ -130,7 +130,7 @@ describe("worktree run lease", () => {
       startTime: 111,
       now: 1,
     });
-    __testing.setProcessStartTimeResolverForTest(() => 222);
+    runLeaseTesting.setProcessStartTimeResolverForTest(() => 222);
 
     expect(hasLiveWorktreeRunLease(env, created.id)).toBe(false);
 
@@ -166,7 +166,7 @@ describe("worktree run lease", () => {
   it("recovers admission when the remover died before finalizing the removal", async () => {
     const created = await createSessionWorktree();
     claimWorktreeRemoval(env, { worktreeId: created.id, token: "remover", force: true });
-    __testing.setDeadPidResolverForTest((pid) => pid === process.pid);
+    runLeaseTesting.setDeadPidResolverForTest((pid) => pid === process.pid);
 
     const lease = await acquireWorktreeRunLease(created.id, { env });
     expect(lease.token).toBeTruthy();
@@ -196,7 +196,7 @@ describe("worktree run lease", () => {
     const record = getRegistryWorktree(env, created.id)!;
 
     let attempts = 0;
-    __testing.setReleaseRowImplForTest((rowEnv, id, token) => {
+    runLeaseTesting.setReleaseRowImplForTest((rowEnv, id, token) => {
       attempts += 1;
       if (attempts === 1) {
         throw new Error("simulated state database failure");
@@ -216,7 +216,7 @@ describe("worktree run lease", () => {
     const record = getRegistryWorktree(env, created.id)!;
 
     let fail = true;
-    __testing.setReleaseRowImplForTest((rowEnv, id, token) => {
+    runLeaseTesting.setReleaseRowImplForTest((rowEnv, id, token) => {
       if (fail) {
         throw new Error("simulated state database failure");
       }
@@ -231,7 +231,7 @@ describe("worktree run lease", () => {
     ).toThrow("worktree is busy");
 
     fail = false;
-    await __testing.drainPendingCleanupsForTest();
+    await runLeaseTesting.drainPendingCleanupsForTest();
     expect(hasLiveWorktreeRunLease(env, created.id)).toBe(false);
     expect(await lockState(record)).toEqual({ kind: "none" });
     expect(() =>
@@ -261,7 +261,7 @@ describe("worktree run lease", () => {
     const record = getRegistryWorktree(env, created.id)!;
 
     let failUnlock = true;
-    __testing.setUnlockImplForTest(async (rec) => {
+    runLeaseTesting.setUnlockImplForTest(async (rec) => {
       if (failUnlock) {
         throw new Error("simulated git unlock failure");
       }
@@ -273,7 +273,7 @@ describe("worktree run lease", () => {
     expect(await lockState(record)).toEqual({ kind: "live", pid: process.pid });
 
     failUnlock = false;
-    await __testing.drainPendingCleanupsForTest();
+    await runLeaseTesting.drainPendingCleanupsForTest();
     expect(await lockState(record)).toEqual({ kind: "none" });
   });
 
@@ -283,7 +283,7 @@ describe("worktree run lease", () => {
     const record = getRegistryWorktree(env, created.id)!;
 
     let failUnlock = true;
-    __testing.setUnlockImplForTest(async (rec) => {
+    runLeaseTesting.setUnlockImplForTest(async (rec) => {
       if (failUnlock) {
         throw new Error("simulated git unlock failure");
       }
@@ -295,7 +295,7 @@ describe("worktree run lease", () => {
 
     const second = await acquireWorktreeRunLease(created.id, { env });
     failUnlock = false;
-    await __testing.drainPendingCleanupsForTest();
+    await runLeaseTesting.drainPendingCleanupsForTest();
     expect(await lockState(record)).toEqual({ kind: "live", pid: process.pid });
 
     await second.release();
@@ -319,9 +319,9 @@ describe("worktree run lease", () => {
     const created = await createSessionWorktree();
     claimWorktreeRemoval(env, { worktreeId: created.id, token: "remover-a", force: false });
 
-    __testing.setDeadPidResolverForTest((pid) => pid === process.pid);
+    runLeaseTesting.setDeadPidResolverForTest((pid) => pid === process.pid);
     claimWorktreeRemoval(env, { worktreeId: created.id, token: "remover-b", force: false });
-    __testing.setDeadPidResolverForTest(null);
+    runLeaseTesting.setDeadPidResolverForTest(null);
 
     abortWorktreeRemoval(env, created.id, "remover-a");
     await expect(acquireWorktreeRunLease(created.id, { env })).rejects.toThrow(

--- a/src/agents/worktrees/run-lease.ts
+++ b/src/agents/worktrees/run-lease.ts
@@ -321,7 +321,7 @@ export function hasLiveWorktreeRunLease(env: NodeJS.ProcessEnv, worktreeId: stri
   return hasLiveWorktreeRunLeaseRow(env, worktreeId, ownerChecks);
 }
 
-const testing = {
+export const testing = {
   setProcessStartTimeResolverForTest(resolver: ((pid: number) => number | null) | null): void {
     resolveSelfStartTime = resolver ?? getFileLockProcessStartTime;
     ownerChecks = { ...ownerChecks, getProcessStartTime: resolver ?? undefined };
@@ -348,5 +348,3 @@ const testing = {
     unlockWorktreeImpl = unlockWorktree;
   },
 };
-
-export { testing as __testing };

--- a/src/agents/worktrees/service.remove-lease.test.ts
+++ b/src/agents/worktrees/service.remove-lease.test.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { getRegistryWorktree } from "./registry.js";
-import { __testing, acquireWorktreeRunLease } from "./run-lease.js";
+import { acquireWorktreeRunLease, testing as runLeaseTesting } from "./run-lease.js";
 import { IDLE_GC_MS, ManagedWorktreeService } from "./service.js";
 
 const execFileAsync = promisify(execFile);
@@ -45,7 +45,7 @@ describe("ManagedWorktreeService removal against a live run lease", () => {
   });
 
   afterEach(async () => {
-    __testing.resetForTest();
+    runLeaseTesting.resetForTest();
     closeOpenClawStateDatabaseForTest();
     await fs.rm(root, { recursive: true, force: true });
   });

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-  __testing as cliBackendsTesting,
+  testing as cliBackendsTesting,
   resolveCliBackendConfig,
   resolveCliBackendLiveTest,
 } from "../agents/cli-backends.js";


### PR DESCRIPTION
## What Problem This Solves

Removes redundant `__testing` aliases across the agent runtime that no longer had consumers. The duplicate names obscured the canonical test seam and added dead exports to internal modules.

## Why This Change Was Made

This maintainer-requested dead-code sweep keeps `testing` as the single internal test API, migrates the six remaining consumers, and excludes two modules already touched by open pull requests. Runtime behavior is unchanged.

## User Impact

No user-visible behavior change. Contributors get a smaller, consistent agent testing surface with 35 stale aliases removed.

## Evidence

- Blacksmith Testbox `tbx_01kxaxjmq1w5gv8m2d0y9vv6e2`: 44 focused tests passed across five affected suites.
- Exact 41-file `pnpm check:changed` scope passed, including Plugin SDK API baseline, core and test typechecks, core lint, import-cycle checks, and repository guards.
- Knip 6.8.0 production export scan reports no remaining `__testing` exports in the target set.
- Fresh `gpt-5.6-sol` autoreview at medium reasoning: no accepted/actionable findings; patch correct with 0.96 confidence.
- `git diff --check` passed.

AI-assisted. I reviewed the implementation and validation output. No transcript attached per operator preference.
