### PR TITLE
fix(bedrock-mantle): isolate discovery cache by credential

### DIFF
--- a/extensions/amazon-bedrock-mantle/api.ts
+++ b/extensions/amazon-bedrock-mantle/api.ts
@@ -6,6 +6,7 @@ export {
   discoverMantleModels,
   generateBearerTokenFromIam,
   getCachedIamToken,
+  getMantleDiscoveryCacheSnapshotForTest,
   MANTLE_IAM_TOKEN_MARKER,
   mergeImplicitMantleProvider,
   resetIamTokenCacheForTest,

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -466,6 +466,48 @@ describe("bedrock mantle discovery", () => {
     expect(mockFetch).toHaveBeenCalledTimes(2); // Re-fetched
   });
 
+  it("isolates discovery cache entries by bearer token within a region", async () => {
+    let now = 1000000;
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        modelDiscoveryResponse({
+          data: [{ id: "model-from-token-a", object: "model" }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        modelDiscoveryResponse({
+          data: [{ id: "model-from-token-b", object: "model" }],
+        }),
+      );
+
+    const tokenA = "mantle-token-account-a"; // pragma: allowlist secret
+    const tokenB = "mantle-token-account-b"; // pragma: allowlist secret
+
+    const first = await discoverMantleModels({
+      region: "us-east-1",
+      bearerToken: tokenA,
+      fetchFn: mockFetch as unknown as typeof fetch,
+      now: () => now,
+    });
+    expect(first.map((model) => model.id)).toEqual(["model-from-token-a"]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    now += 60_000;
+    const second = await discoverMantleModels({
+      region: "us-east-1",
+      bearerToken: tokenB,
+      fetchFn: mockFetch as unknown as typeof fetch,
+      now: () => now,
+    });
+    expect(second.map((model) => model.id)).toEqual(["model-from-token-b"]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    const serialized = JSON.stringify({ first, second });
+    expect(serialized).not.toContain(tokenA);
+    expect(serialized).not.toContain(tokenB);
+  });
+
   it("returns stale cache on fetch failure", async () => {
     let now = 1000000;
     const mockFetch = vi

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -9,6 +9,7 @@ const {
   mergeImplicitMantleProvider,
   resetIamTokenCacheForTest,
   resetMantleDiscoveryCacheForTest,
+  getMantleDiscoveryCacheSnapshotForTest,
   resolveImplicitMantleProvider,
   resolveMantleBearerToken,
   resolveMantleRuntimeBearerToken,
@@ -506,6 +507,74 @@ describe("bedrock mantle discovery", () => {
     const serialized = JSON.stringify({ first, second });
     expect(serialized).not.toContain(tokenA);
     expect(serialized).not.toContain(tokenB);
+  });
+
+  it("bounds discovery cache growth under token rotation and purges expired entries", async () => {
+    let now = 1_000_000;
+    const mockFetch = vi.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      const auth = String(
+        (init?.headers as Record<string, string> | undefined)?.Authorization ?? "",
+      );
+      const token = auth.replace(/^Bearer\s+/i, "");
+      return modelDiscoveryResponse({
+        data: [{ id: `model-for-${token}`, object: "model" }],
+      });
+    });
+
+    const tokens: string[] = [];
+    for (let i = 0; i < 70; i += 1) {
+      const token = `mantle-rotating-token-${String(i).padStart(3, "0")}`; // pragma: allowlist secret
+      tokens.push(token);
+      await discoverMantleModels({
+        region: "us-east-1",
+        bearerToken: token,
+        fetchFn: mockFetch as unknown as typeof fetch,
+        now: () => now,
+      });
+      now += 1_000;
+    }
+
+    const snapshot = getMantleDiscoveryCacheSnapshotForTest();
+    expect(snapshot.size).toBe(64);
+    expect(snapshot.keys.every((key) => key.startsWith("us-east-1:"))).toBe(true);
+    for (const token of tokens) {
+      expect(snapshot.keys.join("\n")).not.toContain(token);
+    }
+
+    // Expire us-east rows, then insert eu-west + a fresh us-east; eu must survive.
+    now += 3_600_000;
+    await discoverMantleModels({
+      region: "eu-west-1",
+      bearerToken: "mantle-eu-token", // pragma: allowlist secret
+      fetchFn: mockFetch as unknown as typeof fetch,
+      now: () => now,
+    });
+    await discoverMantleModels({
+      region: "us-east-1",
+      bearerToken: "mantle-after-expiry", // pragma: allowlist secret
+      fetchFn: mockFetch as unknown as typeof fetch,
+      now: () => now,
+    });
+    const afterExpiry = getMantleDiscoveryCacheSnapshotForTest();
+    expect(afterExpiry.keys.some((key) => key.startsWith("eu-west-1:"))).toBe(true);
+    expect(afterExpiry.keys.filter((key) => key.startsWith("us-east-1:")).length).toBe(1);
+
+    // Same token still hits within TTL.
+    mockFetch.mockClear();
+    const hitToken = "mantle-cache-hit-token"; // pragma: allowlist secret
+    await discoverMantleModels({
+      region: "us-west-2",
+      bearerToken: hitToken,
+      fetchFn: mockFetch as unknown as typeof fetch,
+      now: () => now,
+    });
+    await discoverMantleModels({
+      region: "us-west-2",
+      bearerToken: hitToken,
+      fetchFn: mockFetch as unknown as typeof fetch,
+      now: () => now + 30_000,
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it("returns stale cache on fetch failure", async () => {

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -2,6 +2,7 @@
  * Amazon Bedrock Mantle discovery and bearer-token handling. It resolves
  * explicit tokens, IAM-generated tokens, model catalogs, and implicit provider config.
  */
+import { createHash } from "node:crypto";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/core";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -289,6 +290,15 @@ type MantleDiscoveryConfig = {
 
 const discoveryCache = new Map<string, MantleCacheEntry>();
 
+/** Stable non-reversible cache identity; never log or export this value. */
+function fingerprintMantleBearerToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+function buildMantleDiscoveryCacheKey(region: string, bearerToken: string): string {
+  return `${normalizeLowercaseStringOrEmpty(region)}:${fingerprintMantleBearerToken(bearerToken)}`;
+}
+
 /** Clear the Mantle discovery cache for tests. */
 export function resetMantleDiscoveryCacheForTest(): void {
   discoveryCache.clear();
@@ -306,7 +316,8 @@ export function resetMantleDiscoveryCacheForTest(): void {
  * { "data": [{ "id": "anthropic.claude-sonnet-4-6", "object": "model", "owned_by": "anthropic" }] }
  * ```
  *
- * Results are cached per region for `DEFAULT_REFRESH_INTERVAL_SECONDS`.
+ * Results are cached per region + credential fingerprint for
+ * `DEFAULT_REFRESH_INTERVAL_SECONDS` (token plaintext is never stored in the key).
  * Returns an empty array if the request fails (no permission, network error, etc.).
  */
 /** Discover Mantle models for one region/config. */
@@ -318,8 +329,8 @@ export async function discoverMantleModels(params: {
 }): Promise<ModelDefinitionConfig[]> {
   const { region, bearerToken, fetchFn = fetch, now = Date.now } = params;
 
-  // Check cache
-  const cacheKey = region;
+  // Check cache (region alone is not an authorization boundary).
+  const cacheKey = buildMantleDiscoveryCacheKey(region, bearerToken);
   const cached = discoveryCache.get(cacheKey);
   if (cached && now() - cached.fetchedAt < DEFAULT_REFRESH_INTERVAL_SECONDS * 1000) {
     return cached.models;

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -290,6 +290,9 @@ type MantleDiscoveryConfig = {
 
 const discoveryCache = new Map<string, MantleCacheEntry>();
 
+/** Match Ollama/agent discovery caps: hard bound under credential rotation. */
+const MAX_MANTLE_DISCOVERY_CACHE_ENTRIES = 64;
+
 /** Stable non-reversible cache identity; never log or export this value. */
 function fingerprintMantleBearerToken(token: string): string {
   return createHash("sha256").update(token, "utf8").digest("hex");
@@ -299,9 +302,51 @@ function buildMantleDiscoveryCacheKey(region: string, bearerToken: string): stri
   return `${normalizeLowercaseStringOrEmpty(region)}:${fingerprintMantleBearerToken(bearerToken)}`;
 }
 
+function mantleDiscoveryCacheTtlMs(): number {
+  return DEFAULT_REFRESH_INTERVAL_SECONDS * 1000;
+}
+
+function isMantleDiscoveryCacheFresh(entry: MantleCacheEntry, nowMs: number): boolean {
+  return nowMs - entry.fetchedAt < mantleDiscoveryCacheTtlMs();
+}
+
+function purgeExpiredMantleDiscoveryCache(nowMs: number): void {
+  for (const [key, entry] of discoveryCache) {
+    if (!isMantleDiscoveryCacheFresh(entry, nowMs)) {
+      discoveryCache.delete(key);
+    }
+  }
+}
+
+function setMantleDiscoveryCacheEntry(key: string, entry: MantleCacheEntry, nowMs: number): void {
+  purgeExpiredMantleDiscoveryCache(nowMs);
+  if (discoveryCache.has(key)) {
+    discoveryCache.delete(key);
+  }
+  while (discoveryCache.size >= MAX_MANTLE_DISCOVERY_CACHE_ENTRIES) {
+    const oldestKey = discoveryCache.keys().next().value;
+    if (typeof oldestKey !== "string") {
+      break;
+    }
+    discoveryCache.delete(oldestKey);
+  }
+  discoveryCache.set(key, entry);
+}
+
 /** Clear the Mantle discovery cache for tests. */
 export function resetMantleDiscoveryCacheForTest(): void {
   discoveryCache.clear();
+}
+
+/** Test-only cache inspection; keys are region:fingerprint (never raw tokens). */
+export function getMantleDiscoveryCacheSnapshotForTest(): {
+  size: number;
+  keys: string[];
+} {
+  return {
+    size: discoveryCache.size,
+    keys: [...discoveryCache.keys()],
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -332,7 +377,7 @@ export async function discoverMantleModels(params: {
   // Check cache (region alone is not an authorization boundary).
   const cacheKey = buildMantleDiscoveryCacheKey(region, bearerToken);
   const cached = discoveryCache.get(cacheKey);
-  if (cached && now() - cached.fetchedAt < DEFAULT_REFRESH_INTERVAL_SECONDS * 1000) {
+  if (cached && isMantleDiscoveryCacheFresh(cached, now())) {
     return cached.models;
   }
 
@@ -373,7 +418,7 @@ export async function discoverMantleModels(params: {
       }))
       .toSorted((a, b) => a.id.localeCompare(b.id));
 
-    discoveryCache.set(cacheKey, { models, fetchedAt: now() });
+    setMantleDiscoveryCacheEntry(cacheKey, { models, fetchedAt: now() }, now());
     return models;
   } catch (error) {
     log.debug?.("Mantle model discovery error", {


### PR DESCRIPTION
## What Problem This Solves

Amazon Bedrock Mantle model discovery cached catalog results in an unbounded in-process `Map`. Under credential rotation (or many distinct bearer tokens), each credential fingerprints a separate cache key, so the map can grow without bound and retain expired entries longer than needed.

## Why This Change Was Made

PR base `f756d1ff` already isolates discovery cache entries by credential fingerprint so a rotated token cannot reuse another credential's catalog. This follow-up keeps that isolation while bounding memory: cap the discovery cache at `MAX_MANTLE_DISCOVERY_CACHE_ENTRIES = 64`, purge expired entries on write, and evict oldest entries when the cap is reached.

## User Impact

Operators who rotate Mantle / Bedrock bearer credentials (or exercise many credential identities in one process) no longer risk unbounded discovery-cache growth. Fresh discovery still runs per credential when the cache misses or expires; catalog isolation across credentials is preserved.

## Evidence

- **Parent / base chain:** built on `f756d1ff` (`fix(bedrock-mantle): isolate discovery cache by credential`).
- **New HEAD:** `caaf17cc858f0db639f1ab3b940341205e62c630` (`fix(bedrock-mantle): bound discovery cache under credential rotation`).
- **Node:** `v24.18.0`
- **Tests (FALLBACK local vitest):** `node scripts/run-vitest.mjs extensions/amazon-bedrock-mantle/discovery.test.ts` → **34 passed** (1 file).
- **Whitespace:** `git diff --check` clean on the commit.
- **Bounded cache:** `MAX_MANTLE_DISCOVERY_CACHE_ENTRIES = 64` plus `purgeExpiredMantleDiscoveryCache` before insert / eviction of oldest keys when full (`extensions/amazon-bedrock-mantle/discovery.ts`).

### Real behavior proof (verbose)

| Field | Value |
| --- | --- |
| Surface | `extensions/amazon-bedrock-mantle` discovery cache |
| Entry | `discoverMantleModels` / `setMantleDiscoveryCacheEntry` |
| Invariant | Cache key includes credential fingerprint; max live entries ≤ 64; expired entries purged on write |
| Local proof | Vitest discovery suite, 34/34 pass |
| Commands | `node scripts/run-vitest.mjs extensions/amazon-bedrock-mantle/discovery.test.ts` |
| Environment | Windows worktree `codex/mantle-discovery-cache-bound`; Node `v24.18.0` |
| AWS / Mantle live | **Not run** — environment has no `AWS_BEARER_TOKEN_BEDROCK`, AWS access keys, or `AWS_PROFILE` |

**Live Mantle credential-switch proof NOT run** — no `AWS_BEARER_TOKEN_BEDROCK` / AWS keys / `AWS_PROFILE` in environment. Patch quality improved (bounded + purge + unit coverage); **proof:sufficient** is likely still blocked until the user supplies two rotating credentials for a live switch test.

### Not tested

- Live Mantle / Bedrock credential-switch discovery against AWS
