### PR TITLE
fix(ui): show current branch for local worktrees

### DIFF
--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -12,8 +12,11 @@ type WorktreesPageTestElement = HTMLElement & {
   busyId: string | null;
   creating: boolean;
   createRepoRoot: string;
+  createBaseRef: string;
+  createBranches: string[];
   updateComplete: Promise<boolean>;
   requestUpdate: () => void;
+  loadCreateBranches: () => void;
   createWorktree: () => Promise<void>;
   removeWorktree: (record: WorktreeRecord) => Promise<void>;
   restore: (record: WorktreeRecord) => Promise<void>;
@@ -285,5 +288,26 @@ describe("WorktreesPage lifecycle", () => {
     await creating;
     expect(page.creating).toBe(false);
     expect(page.error).toBeNull();
+  });
+
+  it("uses the current branch when a repository has no remote default", async () => {
+    const request = vi.fn((method: string) => {
+      if (method === "worktrees.branches") {
+        return Promise.resolve({ branches: [{ name: "main" }], headBranch: "main" });
+      }
+      return Promise.resolve({ worktrees: [] });
+    });
+    const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
+    page.context = contextWithGateway(
+      gatewayWithClient({ request } as unknown as GatewayBrowserClient),
+    );
+    page.createRepoRoot = "/tmp/repo";
+    document.body.append(page);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+
+    page.loadCreateBranches();
+
+    await vi.waitFor(() => expect(page.createBranches).toEqual(["main"]));
+    expect(page.createBaseRef).toBe("main");
   });
 });

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -15,7 +15,11 @@ import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 
 type WorktreesListResult = { worktrees: WorktreeRecord[] };
 type WorktreesRemoveResult = { removed: boolean; snapshotError?: string };
-type WorktreeBranchesResult = { branches: Array<{ name: string }>; defaultBranch?: string };
+type WorktreeBranchesResult = {
+  branches: Array<{ name: string }>;
+  defaultBranch?: string;
+  headBranch?: string;
+};
 
 type WorktreeOperationScope = {
   gateway: ApplicationContext["gateway"];
@@ -266,8 +270,8 @@ class WorktreesPage extends OpenClawLightDomElement {
       .then((result) => {
         if (this.isOperationScopeCurrent(scope) && repoRoot === this.createRepoRoot.trim()) {
           this.createBranches = result.branches.map((branch) => branch.name);
-          if (!this.createBaseRef && result.defaultBranch) {
-            this.createBaseRef = result.defaultBranch;
+          if (!this.createBaseRef) {
+            this.createBaseRef = result.defaultBranch ?? result.headBranch ?? "";
           }
         }
       })


### PR DESCRIPTION
Closes #105294

## What Problem This Solves

Fixes an issue where users creating managed worktrees from a local-only repository would see a blank Base branch even though the Gateway identified the current checkout branch. Submitting the blank form hid the actual base choice and triggered an unnecessary `git fetch origin` attempt before falling back to `HEAD`.

## Why This Change Was Made

The Worktrees page now consumes the existing `headBranch` response field and selects `defaultBranch ?? headBranch`, matching the New Session worktree flow. The Gateway and worktree service contracts are unchanged.

## User Impact

Repositories without a configured remote default now show their current branch as the selected worktree base. Users can see and change the exact base before creating the worktree instead of relying on an implicit fallback.

## Evidence

- Real Gateway + source-built Control UI + Playwright, before: `worktrees.branches` returned `headBranch="main"`, options contained `main`, but `worktreeBaseRef=""`.
- Same live path after: the response and options were unchanged, while `worktreeBaseRef="main"`; browser errors remained empty.
- Focused Testbox regression: `corepack pnpm test ui/src/pages/worktrees/worktrees-page.test.ts` — 7/7 passed ([run](https://github.com/openclaw/openclaw/actions/runs/29189528891), lease `tbx_01kxaymxhm4vs5k36awr9wg9aw`).
- Source UI build: `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build` — passed.
- Testbox UI build: `corepack pnpm ui:build` — passed.
- Testbox changed gate: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed, including formatting, UI/core-test typechecks, lint, and repository guards.
- Fresh autoreview: clean; no accepted/actionable findings (`patch is correct`, 0.98).
- `git diff --check` — passed.

No screenshots are attached because public image upload was not authorized; the before/after browser state was captured as structured Playwright output.

## AI Assistance

- [x] AI-assisted; the author reviewed the complete change and its owner/caller/server contract.
