### PR TITLE
fix(config): log orphan backup cleanup failures instead of swallowing them

### DIFF
--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -1,5 +1,6 @@
 // Rotates config backup files while preserving recent recovery points.
 import path from "node:path";
+import { logVerbose } from "../globals.js";
 
 const CONFIG_BACKUP_COUNT = 5;
 
@@ -77,8 +78,11 @@ async function cleanOrphanBackups(configPath: string, ioFs: BackupRotationFs): P
   let entries: string[];
   try {
     entries = await ioFs.readdir(dir);
-  } catch {
-    return; // best-effort
+  } catch (error) {
+    // best-effort: surface the reason so operators can see why orphan cleanup
+    // did not run instead of silently accumulating backups (#105199).
+    logVerbose(`config orphan backup cleanup skipped: cannot read ${dir}: ${String(error)}`);
+    return;
   }
 
   for (const entry of entries) {
@@ -89,8 +93,11 @@ async function cleanOrphanBackups(configPath: string, ioFs: BackupRotationFs): P
     if (validSuffixes.has(suffix)) {
       continue;
     }
-    await ioFs.unlink(path.join(dir, entry)).catch(() => {
-      // best-effort
+    const orphanPath = path.join(dir, entry);
+    await ioFs.unlink(orphanPath).catch((error: unknown) => {
+      // best-effort: log so a locked/undeletable orphan does not accumulate
+      // silently and slowly exhaust disk without any operator signal (#105199).
+      logVerbose(`config orphan backup cleanup failed to remove ${orphanPath}: ${String(error)}`);
     });
   }
 }

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -1,6 +1,13 @@
 // Covers config backup rotation limits and cleanup behavior.
 import fs from "node:fs/promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const logVerboseMock = vi.hoisted(() => vi.fn());
+vi.mock("../globals.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../globals.js")>()),
+  logVerbose: logVerboseMock,
+}));
+
 import { createPreUpdateConfigSnapshot, maintainConfigBackups } from "./backup-rotation.js";
 import {
   expectPosixMode,
@@ -179,6 +186,38 @@ describe("config backup rotation", () => {
         await expectRegularFile(snapshotPath);
         await expect(fs.readFile(snapshotPath, "utf-8")).resolves.toBe(content);
       }
+    });
+  });
+
+  it("logs an orphan backup cleanup failure instead of swallowing it (#105199)", async () => {
+    await withTempHome(async () => {
+      logVerboseMock.mockClear();
+      const configPath = resolveConfigPathFromTempState();
+      await fs.writeFile(configPath, JSON.stringify({ token: "secret" }), { mode: 0o600 });
+      const lockedOrphan = `${configPath}.bak.orphan`;
+      await fs.writeFile(lockedOrphan, "orphan");
+
+      // A locked/undeletable orphan: unlink rejects for this entry only, so rotate/copy/harden
+      // still run on the real fs and only the orphan prune step hits the failure path.
+      const ioFs = {
+        ...fs,
+        unlink: (target: string) =>
+          target === lockedOrphan
+            ? Promise.reject(
+                Object.assign(new Error("EPERM: operation not permitted, unlink"), {
+                  code: "EPERM",
+                }),
+              )
+            : fs.unlink(target),
+      };
+
+      // maintainConfigBackups must not throw, and the swallowed prune failure is now surfaced.
+      await maintainConfigBackups(configPath, ioFs);
+
+      const logged = logVerboseMock.mock.calls.map((call) => String(call[0]));
+      expect(logged.some((line) => line.includes(lockedOrphan) && line.includes("EPERM"))).toBe(
+        true,
+      );
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`cleanOrphanBackups` silently swallowed every `unlink` rejection (and the `readdir` failure). When an orphan `.bak.<suffix>` file is locked or otherwise undeletable, cleanup drops the error on the floor, so the orphan accumulates indefinitely and slowly consumes disk with **no operator signal** (#105199).

## Why This Change Was Made

The cleanup is intentionally best-effort — it must not throw and abort the surrounding config write / backup maintenance. But "best-effort" was implemented as "no visibility at all". This change keeps the best-effort contract (still never throws) while logging the reason for each failure at verbose/debug level, so operators can see why orphans are not being pruned. Both silent swallow points in the function are covered: the `readdir` failure (cleanup skipped) and each per-file `unlink` rejection.

`logVerbose` (from `src/globals.ts`) is used rather than a warning so routine, expected transient failures do not alarm operators; the trace is available when verbose/debug logging is on.

## User Impact

- A locked/undeletable orphan backup now leaves a verbose/debug trace naming the file and error, instead of silently accumulating.
- No behavior change otherwise: cleanup still completes best-effort and never throws.

## Evidence

**Regression test** (`node scripts/run-vitest.mjs run src/config/config.backup-rotation.test.ts` → 9/9): `cleanOrphanBackups logs a failed orphan removal instead of swallowing it (#105199)` injects an `ioFs.unlink` that rejects with `EPERM` for one locked orphan and asserts `logVerbose` was called with a line naming that path and the error, while the call still resolves without throwing.

**Discriminator**: reverting only `backup-rotation.ts` fails the new test — the failure is swallowed and nothing is logged.

Fixes #105199
