### PR TITLE
fix(qa): wait for Control UI composer readiness

### DIFF
--- a/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
+++ b/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
@@ -85,37 +85,36 @@ flow:
                 expr: liveTurnTimeoutMs(env, 45000)
         - try:
             actions:
-              - call: waitForCondition
-                saveAs: uiReadySnapshot
-                args:
-                  - lambda:
-                      async: true
-                      expr: "await (async () => { const snapshot = await webSnapshot({ pageId: uiPageId, maxChars: 12000, timeoutMs: liveTurnTimeoutMs(env, 30000) }); const text = normalizeLowercaseStringOrEmpty(snapshot.text); return text.includes('ready to chat') ? snapshot : undefined; })()"
-                  - expr: liveTurnTimeoutMs(env, 45000)
-                  - 500
-            catch:
-              - call: webSnapshot
-                saveAs: uiReadyFailureSnapshot
+              - call: webWait
                 args:
                   - pageId:
                       ref: uiPageId
-                    maxChars: 12000
+                    selector: .agent-chat__composer-combobox textarea
+                    timeoutMs:
+                      expr: liveTurnTimeoutMs(env, 45000)
+              - call: webEvaluate
+                saveAs: uiReadyState
+                args:
+                  - pageId:
+                      ref: uiPageId
+                    expression: "(() => { const fallback = document.getElementById('openclaw-mount-fallback'); return { appDefined: Boolean(customElements.get('openclaw-app')), shellPresent: Boolean(document.querySelector('openclaw-app-shell')), composerPresent: Boolean(document.querySelector('.agent-chat__composer-combobox textarea')), fallbackHidden: fallback?.hidden === true }; })()"
                     timeoutMs:
                       expr: liveTurnTimeoutMs(env, 15000)
+            catch:
               - call: webEvaluate
                 saveAs: uiReadyFailureState
                 args:
                   - pageId:
                       ref: uiPageId
-                    expression: "(() => { const app = document.querySelector('openclaw-app'); const resources = performance.getEntriesByType('resource').map((entry) => ({ name: entry.name, type: entry.initiatorType, duration: Math.round(entry.duration), transferSize: entry.transferSize, decodedBodySize: entry.decodedBodySize })); return { url: location.href, readyState: document.readyState, appDefined: Boolean(customElements.get('openclaw-app')), appState: app ? { sessionKey: app.sessionKey, settingsSessionKey: app.settings?.sessionKey, lastActiveSessionKey: app.settings?.lastActiveSessionKey, chatMessages: Array.isArray(app.chatMessages) ? app.chatMessages.length : null, chatLoading: app.chatLoading, lastError: app.lastError, connected: app.connected, tab: app.tab } : null, scripts: Array.from(document.scripts).map((script) => script.src || script.textContent?.slice(0, 80)), links: Array.from(document.querySelectorAll('link')).map((link) => link.href), resources, bodyHtml: document.body.innerHTML.slice(0, 400) }; })()"
+                    expression: "(() => { const fallback = document.getElementById('openclaw-mount-fallback'); return { appDefined: Boolean(customElements.get('openclaw-app')), shellPresent: Boolean(document.querySelector('openclaw-app-shell')), composerPresent: Boolean(document.querySelector('.agent-chat__composer-combobox textarea')), fallbackHidden: fallback?.hidden === true }; })()"
                     timeoutMs:
                       expr: liveTurnTimeoutMs(env, 15000)
               - throw:
-                  expr: "`control ui did not become ready. state=${JSON.stringify(uiReadyFailureState)} diagnostics=${JSON.stringify(uiReadyFailureSnapshot.diagnostics ?? [])} snapshot: ${uiReadyFailureSnapshot.text}`"
+                  expr: "`control ui composer did not become ready. state=${JSON.stringify(uiReadyFailureState)}`"
         - assert:
             expr: "Boolean(uiPageId)"
             message: control ui page was not available
-      detailsExpr: "uiReadySnapshot.text"
+      detailsExpr: "JSON.stringify(uiReadyState)"
     - name: text injected through qa-channel gets a correct transport reply
       actions:
         - set: firstInboundStartIndex


### PR DESCRIPTION
## What Problem This Solves

The Control UI QA image-roundtrip scenario waits for removed, locale-dependent copy (`ready to chat`) before exercising the real workflow. Current `main` renders a usable chat composer but the scenario times out during readiness.

## Why This Change Was Made

Use the existing QA web driver's bounded selector wait for the canonical chat composer, then capture a compact structural state for success and failure diagnostics. This follows the UI's actual readiness contract instead of visible copy.

## User Impact

No product behavior changes. The Control UI QA scenario can proceed when the composer is visibly ready and no longer fails because welcome copy changed.

## Evidence

- Current `main` (`71a10846df5`) on Testbox `tbx_01kxaz5zd4gmj3cnc65z7v2q0x`: scenario failed 0/1 after retry. The failure snapshot contained the rendered chat composer while `ready to chat` was absent.
- Branch `4cd9fcb7ca8` on Testbox `tbx_01kxaz5z9j1mq9gv3kxpjrcvd2`: exact scenario passed 1/1 in 25.72s.
- Branch patch on Testbox `tbx_01kxaz67dwg74w9g2qw3j70432`: `corepack pnpm check:changed` passed in 5m50s.
- Fresh branch autoreview against current `origin/main`: clean, no accepted/actionable findings.
