### PR TITLE
fix(config): retry pre-update snapshot after transient I/O failure

### DIFF
--- a/src/config/backup-rotation.ts
+++ b/src/config/backup-rotation.ts
@@ -114,7 +114,10 @@ interface PreUpdateSnapshotFs {
   existsSync: (path: string) => boolean;
 }
 
-const preUpdateConfigSnapshotsWritten = new Set<string>();
+// In-flight or completed snapshot ops keyed by resolved config path.
+// Success stays mapped so concurrent and later callers share one snapshot;
+// failure removes the entry so a later call can retry after transient I/O errors.
+const preUpdateConfigSnapshotOps = new Map<string, Promise<void>>();
 
 /**
  * Captures the first on-disk config state for an update attempt.
@@ -130,22 +133,29 @@ export async function createPreUpdateConfigSnapshot(params: {
     return;
   }
   const snapshotKey = path.resolve(params.configPath);
-  if (preUpdateConfigSnapshotsWritten.has(snapshotKey)) {
+  const existing = preUpdateConfigSnapshotOps.get(snapshotKey);
+  if (existing) {
+    await existing;
     return;
   }
-  // Mark before I/O so a failed best-effort write cannot loop on every later write.
-  preUpdateConfigSnapshotsWritten.add(snapshotKey);
-  const snapshotPath = `${params.configPath}.pre-update`;
-  try {
-    const content = await params.fs.readFile(params.configPath, "utf-8");
-    await params.fs.writeFile(snapshotPath, content, {
-      encoding: "utf-8",
-      mode: 0o600,
-      flag: "w",
-    });
-  } catch {
-    // best-effort, do not block update
-  }
+
+  const op = (async () => {
+    const snapshotPath = `${params.configPath}.pre-update`;
+    try {
+      const content = await params.fs.readFile(params.configPath, "utf-8");
+      await params.fs.writeFile(snapshotPath, content, {
+        encoding: "utf-8",
+        mode: 0o600,
+        flag: "w",
+      });
+    } catch {
+      // best-effort, do not block update — drop the slot so a later call can retry
+      preUpdateConfigSnapshotOps.delete(snapshotKey);
+    }
+  })();
+
+  preUpdateConfigSnapshotOps.set(snapshotKey, op);
+  await op;
 }
 
 /** Runs rotation, primary copy, permission hardening, then orphan pruning. */

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -244,12 +244,14 @@ describe("config backup rotation", () => {
       const { existsSync } = await import("node:fs");
 
       let readAttempts = 0;
-      const flakyRead: typeof fs.readFile = async (filePath, encoding) => {
+      // Narrow stub matches PreUpdateSnapshotFs.readFile; full typeof fs.readFile
+      // claims buffer overloads and fails check-test-types (TS2322).
+      const flakyRead = async (filePath: string, encoding: "utf-8"): Promise<string> => {
         readAttempts += 1;
         if (readAttempts === 1) {
           throw Object.assign(new Error("EACCES"), { code: "EACCES" });
         }
-        return fs.readFile(filePath as string, encoding as "utf-8");
+        return fs.readFile(filePath, encoding);
       };
 
       await createPreUpdateConfigSnapshot({
@@ -276,12 +278,17 @@ describe("config backup rotation", () => {
       const { existsSync } = await import("node:fs");
 
       let writeAttempts = 0;
-      const flakyWrite: typeof fs.writeFile = async (filePath, data, options) => {
+      // Narrow stub matches PreUpdateSnapshotFs.writeFile (not full fs.writeFile).
+      const flakyWrite = async (
+        filePath: string,
+        data: string,
+        options: { encoding: "utf-8"; mode: number; flag: "w" },
+      ): Promise<void> => {
         writeAttempts += 1;
         if (writeAttempts === 1) {
           throw Object.assign(new Error("ENOSPC"), { code: "ENOSPC" });
         }
-        return fs.writeFile(filePath as string, data as string, options as { mode?: number });
+        await fs.writeFile(filePath, data, options);
       };
 
       await createPreUpdateConfigSnapshot({
@@ -313,14 +320,19 @@ describe("config backup rotation", () => {
       });
       let readAttempts = 0;
       let writeAttempts = 0;
-      const gatedRead: typeof fs.readFile = async (filePath, encoding) => {
+      // Narrow stubs match PreUpdateSnapshotFs; full fs overloads fail check-test-types.
+      const gatedRead = async (filePath: string, encoding: "utf-8"): Promise<string> => {
         readAttempts += 1;
         await readGate;
-        return fs.readFile(filePath as string, encoding as "utf-8");
+        return fs.readFile(filePath, encoding);
       };
-      const countingWrite: typeof fs.writeFile = async (filePath, data, options) => {
+      const countingWrite = async (
+        filePath: string,
+        data: string,
+        options: { encoding: "utf-8"; mode: number; flag: "w" },
+      ): Promise<void> => {
         writeAttempts += 1;
-        return fs.writeFile(filePath as string, data as string, options as { mode?: number });
+        await fs.writeFile(filePath, data, options);
       };
 
       const first = createPreUpdateConfigSnapshot({

--- a/src/config/config.backup-rotation.test.ts
+++ b/src/config/config.backup-rotation.test.ts
@@ -235,4 +235,108 @@ describe("config backup rotation", () => {
       await expectPathMissing(`${configPath}.pre-update`);
     });
   });
+
+  it("createPreUpdateConfigSnapshot retries after a failed read", async () => {
+    await withTempHome(async () => {
+      const configPath = resolveConfigPathFromTempState();
+      const content = JSON.stringify({ version: "retry-read" });
+      await fs.writeFile(configPath, content, { mode: 0o600 });
+      const { existsSync } = await import("node:fs");
+
+      let readAttempts = 0;
+      const flakyRead: typeof fs.readFile = async (filePath, encoding) => {
+        readAttempts += 1;
+        if (readAttempts === 1) {
+          throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+        }
+        return fs.readFile(filePath as string, encoding as "utf-8");
+      };
+
+      await createPreUpdateConfigSnapshot({
+        configPath,
+        fs: { writeFile: fs.writeFile, readFile: flakyRead, existsSync },
+      });
+      await expectPathMissing(`${configPath}.pre-update`);
+
+      await createPreUpdateConfigSnapshot({
+        configPath,
+        fs: { writeFile: fs.writeFile, readFile: flakyRead, existsSync },
+      });
+
+      await expect(fs.readFile(`${configPath}.pre-update`, "utf-8")).resolves.toBe(content);
+      expect(readAttempts).toBe(2);
+    });
+  });
+
+  it("createPreUpdateConfigSnapshot retries after a failed write", async () => {
+    await withTempHome(async () => {
+      const configPath = resolveConfigPathFromTempState();
+      const content = JSON.stringify({ version: "retry-write" });
+      await fs.writeFile(configPath, content, { mode: 0o600 });
+      const { existsSync } = await import("node:fs");
+
+      let writeAttempts = 0;
+      const flakyWrite: typeof fs.writeFile = async (filePath, data, options) => {
+        writeAttempts += 1;
+        if (writeAttempts === 1) {
+          throw Object.assign(new Error("ENOSPC"), { code: "ENOSPC" });
+        }
+        return fs.writeFile(filePath as string, data as string, options as { mode?: number });
+      };
+
+      await createPreUpdateConfigSnapshot({
+        configPath,
+        fs: { writeFile: flakyWrite, readFile: fs.readFile, existsSync },
+      });
+      await expectPathMissing(`${configPath}.pre-update`);
+
+      await createPreUpdateConfigSnapshot({
+        configPath,
+        fs: { writeFile: flakyWrite, readFile: fs.readFile, existsSync },
+      });
+
+      await expect(fs.readFile(`${configPath}.pre-update`, "utf-8")).resolves.toBe(content);
+      expect(writeAttempts).toBe(2);
+    });
+  });
+
+  it("createPreUpdateConfigSnapshot dedupes concurrent callers for one snapshot", async () => {
+    await withTempHome(async () => {
+      const configPath = resolveConfigPathFromTempState();
+      const content = JSON.stringify({ version: "concurrent" });
+      await fs.writeFile(configPath, content, { mode: 0o600 });
+      const { existsSync } = await import("node:fs");
+
+      let releaseRead!: () => void;
+      const readGate = new Promise<void>((resolve) => {
+        releaseRead = resolve;
+      });
+      let readAttempts = 0;
+      let writeAttempts = 0;
+      const gatedRead: typeof fs.readFile = async (filePath, encoding) => {
+        readAttempts += 1;
+        await readGate;
+        return fs.readFile(filePath as string, encoding as "utf-8");
+      };
+      const countingWrite: typeof fs.writeFile = async (filePath, data, options) => {
+        writeAttempts += 1;
+        return fs.writeFile(filePath as string, data as string, options as { mode?: number });
+      };
+
+      const first = createPreUpdateConfigSnapshot({
+        configPath,
+        fs: { writeFile: countingWrite, readFile: gatedRead, existsSync },
+      });
+      const second = createPreUpdateConfigSnapshot({
+        configPath,
+        fs: { writeFile: countingWrite, readFile: gatedRead, existsSync },
+      });
+      releaseRead();
+      await Promise.all([first, second]);
+
+      await expect(fs.readFile(`${configPath}.pre-update`, "utf-8")).resolves.toBe(content);
+      expect(readAttempts).toBe(1);
+      expect(writeAttempts).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
Closes #105193

## What Problem This Solves

Fixes an issue where operators running `openclaw update` (or any path that calls `createPreUpdateConfigSnapshot`) would permanently lose the `.pre-update` config rollback snapshot for the rest of the process when the first snapshot read or write failed transiently (for example a brief lock, permission, or disk error). Later successful attempts for the same config path never retried, so upgrade-time rollback protection stayed missing.

## Why This Change Was Made

Replace the process-wide “mark path before I/O” set with a shared in-flight/completed promise map per resolved config path. Successful snapshots still dedupe concurrent and later callers to a single first capture; failed attempts remove the map entry so a later call can retry. This matches the ClawSweeper-recommended narrow fix and preserves concurrent-call safety.

## User Impact

After a transient snapshot failure, a later update step in the same process can still create the operator-visible `.pre-update` rollback file. Concurrent snapshot callers continue to share one I/O attempt instead of racing writes.

## Evidence

Verification host: local macOS (Crabbox bypass)

Focused behavior tests (primary surface):

```text
node scripts/run-vitest.mjs src/config/config.backup-rotation.test.ts
# 11 tests passed, including:
# - retries after a failed read
# - retries after a failed write
# - dedupes concurrent callers for one snapshot
# - existing once-per-process success / missing-config cases
```

ClawSweeper follow-up (this revision):
- Narrowed `flakyRead` / `gatedRead` (and matching write stubs) to the helper’s UTF-8 `(path, "utf-8") => Promise<string>` / write signature so stubs no longer claim full Node `fs` overloads (fixes the reported `check-test-types` TS2322 risk).
- Re-ran focused vitest: 11/11 pass.
- `pnpm exec oxfmt --check` on touched test file: pass.

## Real behavior proof

- Behavior addressed: After a transient failed pre-update config snapshot read/write, a later call for the same config path retries and can write `.pre-update` instead of permanently no-op'ing for the process lifetime.
- Environment: local macOS openclaw checkout; Node 24; real temp config file on disk; production helper `createPreUpdateConfigSnapshot` from `src/config/backup-rotation.ts` (same entry used by `update-cli`’s `createUpdateConfigSnapshot`).
- Current-main contrast: On main, `createPreUpdateConfigSnapshot` adds the resolved path to `preUpdateConfigSnapshotsWritten` before I/O and never removes it on failure, so a second call after an injected `readFile`/`writeFile` error returns without attempting I/O and leaves no `.pre-update` file.
- Exact steps or command run after this patch:
  1. Real-path same-process retry (update-sequence equivalent, not Vitest):
     `node_modules/.bin/tsx /tmp/pre-update-snapshot-retry-proof.mjs`
     Script: real temp `openclaw.json`, flaky first `readFile` (`EACCES`), then second call must create `.pre-update`; third call after success must not re-read.
  2. Focused regression: `node scripts/run-vitest.mjs src/config/config.backup-rotation.test.ts`
- Evidence after fix (redacted terminal transcript):

```text
[proof] configPath= /var/folders/.../openclaw-pre-update-proof-*/openclaw.json
[proof] call #1 (expect no .pre-update after transient read failure)
[proof] readFile attempt=1 path=openclaw.json
[proof] injecting transient failure: EACCES
[proof] after call#1: .pre-update exists=false readAttempts=1
[proof] call #2 same process (must retry and write .pre-update)
[proof] readFile attempt=2 path=openclaw.json
[proof] after call#2: .pre-update exists=true readAttempts=2
[proof] snapshot matches config=true
[proof] snapshot bytes=70
[proof] call #3 after success: readAttempts unchanged=true (2)
[proof] PASS: retry after transient failure created .pre-update
```

```text
node scripts/run-vitest.mjs src/config/config.backup-rotation.test.ts
# Test Files  1 passed (1)
# Tests  11 passed (11)
```

- Control check: After a successful snapshot, a later same-process call does not re-read or rewrite (readAttempts stays 2). Concurrent Vitest case still asserts a single shared capture.
- Observed result after fix: Transient I/O failure no longer permanently blocks pre-update snapshots; concurrent callers still share one successful capture; test stubs type to the helper’s narrow UTF-8 interface.
- What was not tested: Full live `openclaw update` npm/package upgrade against a real managed install with an externally OS-locked config file; multi-process updater races across separate Node processes.

## AI disclosure

This fix was authored with AI assistance (Grok). Human operator ran the automated find→fix pipeline in auto mode. Follow-up proof/code handled via process-openclaw-pr-reviews after ClawSweeper needs-proof + type finding.
