### PR TITLE
fix(gateway): accept shared macOS platform pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Shared macOS node identity:** accept the signed `node-host` macOS alias against the native Mac app's versioned platform pin, preventing repeated metadata-upgrade pairing prompts when both clients use the shipped device identity.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Shared macOS node identity:** accept the signed `node-host` macOS alias against the native Mac app's versioned platform pin, preventing repeated metadata-upgrade pairing prompts when both clients use the shipped device identity.
 - **Swabble status config:** honor the global `--config` path when reading service status instead of silently using the default configuration.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -969,6 +969,43 @@ describe("resolvePinnedClientMetadata", () => {
     });
   });
 
+  it("accepts a node-host macOS alias against the shared Mac app platform pin", () => {
+    expect(
+      testing.resolvePinnedClientMetadata({
+        clientId: "node-host",
+        clientMode: "node",
+        claimedPlatform: "macos",
+        claimedDeviceFamily: "Mac",
+        pairedPlatform: "macOS 26.5.2",
+        pairedDeviceFamily: "Mac",
+      }),
+    ).toEqual({
+      platformMismatch: false,
+      deviceFamilyMismatch: false,
+      pinnedPlatform: "macOS 26.5.2",
+      pinnedDeviceFamily: "Mac",
+    });
+  });
+
+  it("refreshes a shared node-host macOS pin from the native Mac app", () => {
+    expect(
+      testing.resolvePinnedClientMetadata({
+        clientId: "openclaw-macos",
+        clientMode: "ui",
+        claimedPlatform: "macOS 26.5.2",
+        claimedDeviceFamily: "Mac",
+        pairedPlatform: "macos",
+        pairedDeviceFamily: "Mac",
+      }),
+    ).toEqual({
+      platformMismatch: false,
+      deviceFamilyMismatch: false,
+      pinnedPlatform: "macOS 26.5.2",
+      pinnedDeviceFamily: "Mac",
+      refreshPairedPlatform: "macOS 26.5.2",
+    });
+  });
+
   it("still requires approval when an iOS device family changes", () => {
     expect(
       testing.resolvePinnedClientMetadata({

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -473,6 +473,11 @@ function resolvePinnedClientMetadata(params: {
     claimedPlatform !== "" &&
     normalizeLegacyNodeHostPlatformPin(claimedPlatform) ===
       normalizeLegacyNodeHostPlatformPin(pairedPlatform);
+  const isNodeHostUsingMacAppPlatformPin =
+    params.clientId === GATEWAY_CLIENT_IDS.NODE_HOST &&
+    params.clientMode === GATEWAY_CLIENT_MODES.NODE &&
+    (claimedPlatform === "darwin" || claimedPlatform === "macos") &&
+    /^macos \d+(?:\.\d+){0,2}$/.test(pairedPlatform);
   const claimedNativeAppPlatformFamily = resolveNativeAppPlatformFamily(
     params.clientId,
     claimedPlatform,
@@ -485,12 +490,16 @@ function resolvePinnedClientMetadata(params: {
     hasPinnedPlatform &&
     claimedPlatform !== "" &&
     claimedPlatform !== pairedPlatform &&
-    claimedNativeAppPlatformFamily !== undefined &&
-    claimedNativeAppPlatformFamily === pairedNativeAppPlatformFamily;
+    ((claimedNativeAppPlatformFamily !== undefined &&
+      claimedNativeAppPlatformFamily === pairedNativeAppPlatformFamily) ||
+      (params.clientId === GATEWAY_CLIENT_IDS.MACOS_APP &&
+        claimedNativeAppPlatformFamily === "macos" &&
+        (pairedPlatform === "darwin" || pairedPlatform === "macos")));
   const platformMismatch =
     hasPinnedPlatform &&
     claimedPlatform !== pairedPlatform &&
     !isLegacyNodeHostPlatformPin &&
+    !isNodeHostUsingMacAppPlatformPin &&
     !isNativeAppPlatformVersionRefresh;
   const deviceFamilyMismatch = hasPinnedDeviceFamily && claimedDeviceFamily !== pairedDeviceFamily;
   const pinnedPlatform =
@@ -498,9 +507,11 @@ function resolvePinnedClientMetadata(params: {
       ? params.pairedPlatform
       : isLegacyNodeHostPlatformPin
         ? normalizeLegacyNodeHostPlatformPin(pairedPlatform)
-        : isNativeAppPlatformVersionRefresh
-          ? params.claimedPlatform
-          : undefined;
+        : isNodeHostUsingMacAppPlatformPin
+          ? params.pairedPlatform
+          : isNativeAppPlatformVersionRefresh
+            ? params.claimedPlatform
+            : undefined;
   return {
     platformMismatch,
     deviceFamilyMismatch,


### PR DESCRIPTION
## Summary

- accept the signed `node-host` macOS alias when the shared device is already pinned by the native Mac app's versioned platform label
- allow the native Mac app to enrich a generic `node-host` macOS pin with its versioned label
- preserve approval gates for device-family changes and unrelated platform changes

## Tests

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts` (99 passed)
- `pnpm check:test-types`
- `pnpm format:check`
- autoreview: clean, no accepted/actionable findings (confidence 0.94)

## Runtime evidence

Observed a signed local device repeatedly rejected with `reason=metadata-upgrade` when `node-host` claimed `platform=macos` against the same device's native Mac app pin `platform=macOS 26.5.2`; device family remained `Mac` in both handshakes.
