### PR TITLE
refactor(gateway): remove stale testing aliases

### DIFF
--- a/src/gateway/control-plane-rate-limit.ts
+++ b/src/gateway/control-plane-rate-limit.ts
@@ -115,4 +115,3 @@ export const testing = {
     controlPlaneBuckets.clear();
   },
 };
-export { testing as __testing };

--- a/src/gateway/server-methods/nodes-wake-state.ts
+++ b/src/gateway/server-methods/nodes-wake-state.ts
@@ -41,4 +41,3 @@ export const testing = {
     nodeWakeNudgeById.clear();
   },
 };
-export { testing as __testing };

--- a/src/gateway/server/plugins-http.suspension-admission.test.ts
+++ b/src/gateway/server/plugins-http.suspension-admission.test.ts
@@ -14,7 +14,7 @@ import {
   resetGatewayWorkAdmission,
   tryBeginGatewaySuspendAdmission,
 } from "../../process/gateway-work-admission.js";
-import { __testing as controlPlaneRateLimitTesting } from "../control-plane-rate-limit.js";
+import { testing as controlPlaneRateLimitTesting } from "../control-plane-rate-limit.js";
 import type { GatewayRequestContext } from "../server-methods/types.js";
 import { makeMockHttpResponse } from "../test-http-response.js";
 import { createTestRegistry } from "./__tests__/test-utils.js";


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested dead-code cleanup: two gateway modules exposed both `testing` and `__testing` for the same test seam. The duplicate names increased internal API surface and left tests using inconsistent spellings.

## Why This Change Was Made

Remove the redundant aliases from the two modules with no open pull-request file overlap, and migrate the remaining alias consumer to the canonical `testing` export. Runtime behavior is unchanged.

## User Impact

No user-visible behavior change. Internal gateway tests now use one canonical test-seam name.

## Evidence

- Testbox `tbx_01kxaz32n17wfsfg3wseqgr5xv`: 198 focused tests passed across control-plane rate limiting, suspension admission, config patching, and node wake-state cleanup.
- `OPENCLAW_TESTBOX=1 pnpm check:changed -- src/gateway/control-plane-rate-limit.ts src/gateway/server-methods/nodes-wake-state.ts src/gateway/server/plugins-http.suspension-admission.test.ts`
- Fresh autoreview: `gpt-5.6-sol`, medium reasoning, clean with 0.97 confidence.
- Live open-PR file pagination confirmed no overlap for the two changed production files.
