### PR TITLE
fix(ui): keep current worktree branch options

### DIFF
--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -310,4 +310,37 @@ describe("WorktreesPage lifecycle", () => {
     await vi.waitFor(() => expect(page.createBranches).toEqual(["main"]));
     expect(page.createBaseRef).toBe("main");
   });
+
+  it("ignores a stale branch failure after a newer request succeeds", async () => {
+    const firstBranches = deferred<unknown>();
+    let branchRequests = 0;
+    const request = vi.fn((method: string) => {
+      if (method === "worktrees.branches") {
+        branchRequests += 1;
+        return branchRequests === 1
+          ? firstBranches.promise
+          : Promise.resolve({ branches: [{ name: "main" }], headBranch: "main" });
+      }
+      return Promise.resolve({ worktrees: [] });
+    });
+    const page = document.createElement("openclaw-worktrees-page") as WorktreesPageTestElement;
+    page.context = contextWithGateway(
+      gatewayWithClient({ request } as unknown as GatewayBrowserClient),
+    );
+    page.createRepoRoot = "/tmp/repo";
+    document.body.append(page);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("worktrees.list", {}));
+
+    page.loadCreateBranches();
+    page.loadCreateBranches();
+    await vi.waitFor(() => expect(page.createBranches).toEqual(["main"]));
+    expect(page.createBaseRef).toBe("main");
+
+    firstBranches.reject(new Error("stale branch failure"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(page.createBranches).toEqual(["main"]);
+    expect(page.createBaseRef).toBe("main");
+  });
 });

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -51,6 +51,7 @@ class WorktreesPage extends OpenClawLightDomElement {
   private gatewaySource?: ApplicationContext["gateway"];
   private hasBoundGateway = false;
   private loadGeneration = 0;
+  private branchesGeneration = 0;
   private operationEpoch = 0;
   private readonly subscriptions = new SubscriptionsController(this).effect(
     () => this.context?.gateway,
@@ -259,6 +260,7 @@ class WorktreesPage extends OpenClawLightDomElement {
   }
 
   private loadCreateBranches() {
+    const generation = ++this.branchesGeneration;
     const scope = this.captureOperationScope();
     const repoRoot = this.createRepoRoot.trim();
     if (!scope || !repoRoot) {
@@ -268,7 +270,8 @@ class WorktreesPage extends OpenClawLightDomElement {
     void scope.client
       .request<WorktreeBranchesResult>("worktrees.branches", { repoRoot })
       .then((result) => {
-        if (this.isOperationScopeCurrent(scope) && repoRoot === this.createRepoRoot.trim()) {
+        // Only the latest picker request owns branch state, including after same-path retries.
+        if (generation === this.branchesGeneration && this.isOperationScopeCurrent(scope)) {
           this.createBranches = result.branches.map((branch) => branch.name);
           if (!this.createBaseRef) {
             this.createBaseRef = result.defaultBranch ?? result.headBranch ?? "";
@@ -276,7 +279,7 @@ class WorktreesPage extends OpenClawLightDomElement {
         }
       })
       .catch(() => {
-        if (this.isOperationScopeCurrent(scope)) {
+        if (generation === this.branchesGeneration && this.isOperationScopeCurrent(scope)) {
           this.createBranches = [];
         }
       });


### PR DESCRIPTION
Closes #105308

## What Problem This Solves

Fixes an issue where users changing the Worktrees create form's Repository could briefly receive the new repository's valid branches, then lose every option when an older branch lookup failed later. The selected base remained visible, but alternate branches disappeared until the repository field changed again or the page reloaded.

## Why This Change Was Made

Branch discovery now has a monotonically increasing request generation. Both fulfillment and rejection may update picker state only when they belong to the latest request and the same live Gateway operation epoch. This also handles repeated requests for the same repository, which path equality alone cannot distinguish.

## User Impact

The Worktrees branch picker now keeps the latest repository's options when older requests settle out of order. Correcting an invalid path, switching repositories, or retrying the same path no longer lets stale async work overwrite the current form.

## Evidence

- Real Gateway + source-built Control UI + Playwright, before: the valid repository loaded `branches=["main"]`; after the older real missing-repository rejection settled, `branches=[]`.
- Same live path after: `branches=["main"]` both before and after the stale rejection; Base branch remained `main`, and browser errors stayed empty.
- Focused Testbox regression: `corepack pnpm test ui/src/pages/worktrees/worktrees-page.test.ts` — 8/8 passed (lease `tbx_01kxazjs4dcq4w9e8xza7mcwjr`).
- Source UI build: `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build` — passed.
- Testbox UI build: `corepack pnpm ui:build` — passed.
- Testbox changed gate: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed, including formatting, UI/core-test typechecks, lint, and repository guards.
- Fresh autoreview: clean; no accepted/actionable findings (`patch is correct`, 0.97).
- `git diff --check` — passed.

No screenshots are attached because public image upload was not authorized; the before/after browser state was captured as structured Playwright output.

## AI Assistance

- [x] AI-assisted; the author reviewed the complete change and its request-ownership lifecycle.
