### PR TITLE
ci(performance): restore proven Kova evaluator

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -50,7 +50,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: cb25bb609d341df41baf198b0b4b3bf83ba1fe50
+        default: 2b02b7d33418db0c6952c4cf8fe8a608e7964859
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -153,7 +153,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || 'cb25bb609d341df41baf198b0b4b3bf83ba1fe50' }}
+      KOVA_REF: ${{ inputs.kova_ref || '2b02b7d33418db0c6952c4cf8fe8a608e7964859' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -83,7 +83,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "cb25bb609d341df41baf198b0b4b3bf83ba1fe50";
+    const kovaRef = "2b02b7d33418db0c6952c4cf8fe8a608e7964859";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release performance validation is blocked because the current Kova evaluator produces incomplete `agent-cold-warm-message` evidence.

## Why This Change Was Made

Restore the last evaluator revision that passed the same release workflow and exact beta6 candidate. Keep the workflow default, runtime fallback, and contract test pinned to one SHA.

## User Impact

No product behavior changes. Maintainers can run authoritative release performance validation without the known evaluator regression.

## Evidence

- Current evaluator `61dad0a08f5eee7c632fb104c15f9b0bb8df7987` failed twice with the same incomplete record:
  - https://github.com/openclaw/openclaw/actions/runs/29189909915
  - https://github.com/openclaw/openclaw/actions/runs/29189907811
- Restored evaluator `2b02b7d33418db0c6952c4cf8fe8a608e7964859` passed the exact beta6 candidate:
  - https://github.com/openclaw/openclaw/actions/runs/29188434979
- `git diff --check`
- Workflow pin consistency probe
- Autoreview clean
