### PR TITLE
fix(pdf): reject unsafe page numbers before analysis

### DIFF
--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -79,6 +79,16 @@ describe("parsePageRange", () => {
     expect(() => parsePageRange("1,2.5", 20)).toThrow('Invalid page number: "2.5"');
   });
 
+  it("throws on unsafe integer page numbers and ranges", () => {
+    const unsafePage = String(Number.MAX_SAFE_INTEGER + 1);
+    expect(() => parsePageRange(unsafePage, Number.MAX_SAFE_INTEGER + 1)).toThrow(
+      `Invalid page number: "${unsafePage}"`,
+    );
+    expect(() => parsePageRange(`1-${unsafePage}`, Number.MAX_SAFE_INTEGER + 1)).toThrow(
+      `Invalid page range: "${unsafePage}"`,
+    );
+  });
+
   it("throws on invalid range (start > end)", () => {
     expect(() => parsePageRange("5-3", 20)).toThrow("Invalid page range");
   });

--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -81,10 +81,11 @@ describe("parsePageRange", () => {
 
   it("throws on unsafe integer page numbers and ranges", () => {
     const unsafePage = String(Number.MAX_SAFE_INTEGER + 1);
-    expect(() => parsePageRange(unsafePage, Number.MAX_SAFE_INTEGER + 1)).toThrow(
+    const maxPages = 20;
+    expect(() => parsePageRange(unsafePage, maxPages)).toThrow(
       `Invalid page number: "${unsafePage}"`,
     );
-    expect(() => parsePageRange(`1-${unsafePage}`, Number.MAX_SAFE_INTEGER + 1)).toThrow(
+    expect(() => parsePageRange(`1-${unsafePage}`, maxPages)).toThrow(
       `Invalid page range: "${unsafePage}"`,
     );
   });

--- a/src/agents/tools/pdf-tool.helpers.ts
+++ b/src/agents/tools/pdf-tool.helpers.ts
@@ -47,6 +47,14 @@ export function providerSupportsNativePdf(provider: string): boolean {
 }
 
 /** Parses a page range string into sorted, unique, 1-based page numbers within `maxPages`. */
+function readPageNumber(value: string, errorLabel: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${errorLabel}: "${value}"`);
+  }
+  return parsed;
+}
+
 export function parsePageRange(range: string, maxPages: number): number[] {
   const pages = new Set<number>();
   const parts = range.split(",").map((p) => p.trim());
@@ -56,9 +64,9 @@ export function parsePageRange(range: string, maxPages: number): number[] {
     }
     const dashMatch = /^(\d+)\s*-\s*(\d+)$/.exec(part);
     if (dashMatch) {
-      const start = Number(dashMatch[1]);
-      const end = Number(dashMatch[2]);
-      if (!Number.isFinite(start) || !Number.isFinite(end) || start < 1 || end < start) {
+      const start = readPageNumber(dashMatch[1] ?? "", "Invalid page range");
+      const end = readPageNumber(dashMatch[2] ?? "", "Invalid page range");
+      if (end < start) {
         throw new Error(`Invalid page range: "${part}"`);
       }
       for (let i = start; i <= Math.min(end, maxPages); i++) {
@@ -68,10 +76,7 @@ export function parsePageRange(range: string, maxPages: number): number[] {
       if (!/^\d+$/.test(part)) {
         throw new Error(`Invalid page number: "${part}"`);
       }
-      const num = Number(part);
-      if (!Number.isFinite(num) || num < 1) {
-        throw new Error(`Invalid page number: "${part}"`);
-      }
+      const num = readPageNumber(part, "Invalid page number");
       if (num <= maxPages) {
         pages.add(num);
       }

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -625,8 +625,9 @@ describe("createPdfTool", () => {
   it.each([
     ["1.5", "1.5"],
     ["1,2.5", "2.5"],
+    [`1,${String(Number.MAX_SAFE_INTEGER + 1)}`, String(Number.MAX_SAFE_INTEGER + 1)],
   ])(
-    "rejects fractional page selection %s before loading or fallback extraction",
+    "rejects invalid page selection %s before loading or fallback extraction",
     async (pages, invalidPage) => {
       await withTempPdfAgentDir(async (agentDir) => {
         const { loadSpy } = await stubPdfToolInfra(agentDir, {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting PDF pages with numbers larger than JavaScript can safely represent could pass an unsafe page token through the `pdf` tool's page-selection parser before PDF loading or model analysis.

## Why This Change Was Made

The page range parser now accepts only safe positive integers for both individual page tokens and range endpoints. This keeps the fix inside the existing PDF tool parsing boundary and does not change schema, config, provider, or fallback behavior.

## User Impact

Unsafe PDF page selections now fail fast with the existing invalid-page validation path before any PDF load, fallback extraction, or model analysis work starts.

## Evidence

- Claim proved: a real `pdf` tool invocation rejects the unsafe mixed page selection `1,9007199254740992` with `Invalid page number` before PDF loading, extraction, native PDF analysis, or model completion in `src/agents/tools/pdf-tool.ts`.
- Current-head follow-up at `6ec8afdcb843dc2f56027b4a1e5c746bac5861fb`: repaired the unsafe-range regression test so it uses a bounded `maxPages = 20` while keeping the unsafe endpoint and expected rejection. This closes the ClawSweeper P2 finding without changing production code.

```text
real PDF tool proof
tool=pdf
pages=1,9007199254740992
result=rejected
error=Invalid page number: "9007199254740992"
before_pdf_load=true
downstream_model_required=false
```

- Focused regression proof on current head: `node scripts/run-vitest.mjs src/agents/tools/pdf-tool.helpers.test.ts src/agents/tools/pdf-tool.test.ts` passed with 2 files and 55 tests.
- Formatting: `node_modules\.bin\oxfmt.CMD --check --threads=1 src\agents\tools\pdf-tool.helpers.test.ts` passed.
- Diff hygiene: `git diff --check` passed.
- Earlier review proof: local autoreview passed with no accepted/actionable findings before the production-code commit; this follow-up changed only the bounded regression test.
- Duplicate check: open self PRs and searches for `pdf pages safe integer`, `parsePageRange pdf unsafe`, and `pdfMaxPages unsafe page` showed no same-root overlap.