### PR TITLE
fix(qa): exercise graceful Matrix replay restart

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -197,7 +197,6 @@ describe("qa scenario catalog", () => {
     expect(scenarios.map((scenario) => scenario.id).toSorted()).toEqual([
       "kitchen-sink-live-openai",
       "matrix-post-restart-room-continue",
-      "matrix-restart-replay-dedupe",
       "matrix-restart-resume",
       "slack-restart-resume",
       "subagent-stale-child-links",
@@ -209,6 +208,15 @@ describe("qa scenario catalog", () => {
         .filter((scenario) => scenario.execution.suiteIsolation !== "isolated")
         .map((scenario) => scenario.id),
     ).toEqual([]);
+  });
+
+  it("uses only graceful gateway restart for Matrix replay dedupe", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("matrix-restart-replay-dedupe"));
+
+    expect(flowContainsCall(scenario.execution.flow, "env.gateway.restart")).toBe(true);
+    expect(flowContainsCall(scenario.execution.flow, "env.gateway.restartAfterStateMutation")).toBe(
+      false,
+    );
   });
 
   it("loads scenario-declared gateway runtime options from YAML", () => {

--- a/extensions/qa-lab/src/suite-runtime-types.ts
+++ b/extensions/qa-lab/src/suite-runtime-types.ts
@@ -11,6 +11,7 @@ type QaRuntimeGatewayClient = {
   getProcessCpuMs?: () => number | null;
   getProcessRssBytes?: () => number | null;
   logs?: () => string;
+  restart?: () => Promise<void>;
   restartAfterStateMutation?: (
     mutateState: (context: {
       configPath: string;

--- a/qa/scenarios/channels/matrix-restart-replay-dedupe.yaml
+++ b/qa/scenarios/channels/matrix-restart-replay-dedupe.yaml
@@ -56,14 +56,9 @@ flow:
           value:
             expr: "getTransportSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - assert:
-            expr: "typeof env.gateway.restartAfterStateMutation === 'function'"
-            message: qa gateway child does not expose restartAfterStateMutation
-        - call: env.gateway.restartAfterStateMutation
-          args:
-            - lambda:
-                async: true
-                params: [ctx]
-                expr: "Promise.resolve()"
+            expr: "typeof env.gateway.restart === 'function'"
+            message: qa gateway child does not expose restart
+        - call: env.gateway.restart
         - call: waitForGatewayHealthy
           args: [{ ref: env }, 60000]
         - call: waitForTransportReady


### PR DESCRIPTION
## What Problem This Solves

The Matrix replay-dedupe QA scenario claims to verify behavior across a Gateway restart, but it currently calls `restartAfterStateMutation` with a no-op mutation. That helper stops the child and spawns a replacement, so the scenario duplicates cold-restart coverage and never exercises the product's graceful SIGUSR1 restart lifecycle.

## Why This Change Was Made

Call the QA gateway child's existing `restart()` method for this replay-dedupe scenario. Keep the sibling Matrix restart scenarios on `restartAfterStateMutation` so both restart mechanisms remain covered, and add a catalog assertion that protects this distinction.

## User Impact

No product runtime behavior changes. QA now verifies that completed Matrix delivery is not replayed across the real graceful Gateway restart path and that fresh delivery continues afterward.

## Evidence

- `corepack pnpm test:serial extensions/qa-lab/src/scenario-catalog.test.ts` on Testbox `tbx_01kxazxsnaj9bnj5fxq90tsd8t`: 39/39 passed.
- Exact `matrix-restart-replay-dedupe` scenario on the same Testbox: passed 1/1 with `mock-openai`.
- `corepack pnpm check:changed` on Testbox `tbx_01kxazxkejtzesj2406me2e7pt`: passed in 5m26s.
- Fresh branch autoreview against current `origin/main`: clean, no accepted/actionable findings.
