### PR TITLE
fix(performance): accept disabled gateway health proof

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -50,7 +50,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 61dad0a08f5eee7c632fb104c15f9b0bb8df7987
+        default: cb25bb609d341df41baf198b0b4b3bf83ba1fe50
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -153,7 +153,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '61dad0a08f5eee7c632fb104c15f9b0bb8df7987' }}
+      KOVA_REF: ${{ inputs.kova_ref || 'cb25bb609d341df41baf198b0b4b3bf83ba1fe50' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -83,7 +83,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "61dad0a08f5eee7c632fb104c15f9b0bb8df7987";
+    const kovaRef = "cb25bb609d341df41baf198b0b4b3bf83ba1fe50";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release performance validation marked no-service local-agent runs `INCOMPLETE` even though their Gateway was intentionally disabled and the post-agent status command passed.

## Why This Change Was Made

Pins Kova to [openclaw/Kova#54](https://github.com/openclaw/Kova/pull/54), which requires explicit not-applicable final-health evidence for disabled Gateways while keeping the running-Gateway zero-failure contract strict. The workflow default, runtime fallback, and pin contract test move together.

## User Impact

Main and LTS release performance validation can complete no-service agent evidence without fabricating health samples for a disabled Gateway.

## Evidence

- Exact main/LTS release artifacts: all affected records had matching disabled service/final-health state, explicit null health fields, and passing post-agent status commands.
- Kova Linux/macOS full CI: https://github.com/openclaw/Kova/actions/runs/29190245667
- Testbox `tbx_01kxb0b41sakw7rxzvwszh7j3c`: 29/29 performance-workflow tests and `pnpm check:workflows` passed
- Fresh autoreview: clean, no accepted/actionable findings
