### PR TITLE
fix(cron): ensure throttle update on session reaper errors

### DIFF
--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -125,9 +125,12 @@ export async function sweepCronRunSessions(params: {
   } catch (err) {
     params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
     return { swept: false, pruned: 0 };
+  } finally {
+    // Always update the throttle timestamp, even on error, to prevent
+    // unbounded retry loops when the store has a persistent problem
+    // (e.g. EACCES, disk full).
+    lastSweepAtMsByStore.set(storePath, now);
   }
-
-  lastSweepAtMsByStore.set(storePath, now);
 
   if (transcriptCleanupError) {
     params.log.warn(


### PR DESCRIPTION
Closes #105188

## What Problem This Solves

Resolves a problem where the session reaper cron job catches a persistence error (e.g., EACCES, disk full) and immediately enters an unbounded retry loop. Because the throttle timestamp was never updated on error, the reaper would instantly retry on every subsequent timer tick, causing severe CPU and disk I/O thrashing.

## Why This Change Was Made

The throttle update was placed at the end of the success path. In `src/cron/session-reaper.ts`, we wrapped this update in a `finally` block so that the throttle timestamp is always updated regardless of success or failure. This ensures the standard cooldown period is respected even during errors.

## User Impact

Prevents system instability, high CPU usage, and disk I/O exhaustion in environments with temporary disk or permission issues.

## Evidence

The existing test file `src/cron/service.session-reaper-in-finally.test.ts` validates that the reaper runs its cleanup hooks safely. The change moves the throttle setting to the `finally` block inside `sweepCronRunSessions`:
```typescript
  } catch (err) {
    params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
    return { swept: false, pruned: 0 };
  } finally {
    lastSweepAtMsByStore.set(storePath, now);
  }
```
Checked locally via Vitest to confirm everything runs and passes.
