### PR TITLE
fix(gateway): enforce maxRestartsPerHour on pending restarts

### DIFF
--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -183,7 +183,9 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           }
 
           pruneOldRestarts(record, now);
-          if (!continuingPendingRestart && record.restartsThisHour.length >= maxRestartsPerHour) {
+          // Pending restarts still count towards the hourly budget to prevent
+          // infinite restart loops on permanently stuck channels.
+          if (record.restartsThisHour.length >= maxRestartsPerHour) {
             log.warn?.(
               `[${channelId}:${accountId}] health-monitor: hit ${maxRestartsPerHour} restarts/hour limit, skipping`,
             );
@@ -194,11 +196,13 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
           log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
 
+          // Always record the restart attempt (even for pending restarts)
+          // so the hourly budget is correctly tracked.
           if (!continuingPendingRestart) {
             record.lastRestartAt = now;
-            record.restartsThisHour.push({ at: now });
-            restartRecords.set(key, record);
           }
+          record.restartsThisHour.push({ at: now });
+          restartRecords.set(key, record);
 
           try {
             if (status.running) {


### PR DESCRIPTION
Closes #105189

## What Problem This Solves

Fixes an issue where a channel permanently stuck in a pending restart state would aggressively loop, bypass the `maxRestartsPerHour` budget limit, and thrash the channel manager with endless restarts and log spam.

## Why This Change Was Made

The monitor previously skipped both the budget check and recording for pending restarts via `!continuingPendingRestart` checks. We removed this guard from the budget check and tracking logic in `src/gateway/channel-health-monitor.ts`. Now, pending restarts are properly recorded in `restartsThisHour` and capped by `maxRestartsPerHour`, while still bypassing the standard cooldown interval (as they need to resolve their recovery sequence).

## User Impact

Prevents resource thrashing and infinite restart loops on permanently unhealthy channels.

## Evidence

The modified logic in `src/gateway/channel-health-monitor.ts`:
```typescript
          // Pending restarts still count towards the hourly budget to prevent
          // infinite restart loops on permanently stuck channels.
          if (record.restartsThisHour.length >= maxRestartsPerHour) {
            log.warn?.(
              `[${channelId}:${accountId}] health-monitor: hit ${maxRestartsPerHour} restarts/hour limit, skipping`,
            );
            continue;
          }
```
And:
```typescript
          // Always record the restart attempt (even for pending restarts)
          // so the hourly budget is correctly tracked.
          if (!continuingPendingRestart) {
            record.lastRestartAt = now;
          }
          record.restartsThisHour.push({ at: now });
          restartRecords.set(key, record);
```
Checked locally via Vitest to confirm everything runs and passes.
