### PR TITLE
improve(ui): highlight chat pane during file drag

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -554,6 +554,12 @@ function requireElement(container: Element, selector: string, label: string): El
   return element;
 }
 
+function createDragEvent(type: string, types = ["Files"]): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: { types } });
+  return event;
+}
+
 function itemAt<T>(items: ArrayLike<T>, index: number, label: string): T {
   return expectDefined(items[index], `${label} ${index}`);
 }
@@ -3532,18 +3538,13 @@ describe("chat attachment picker", () => {
     const second = renderChatView();
     const firstChat = requireElement(first, "section.card.chat", "first chat drop target");
     const secondChat = requireElement(second, "section.card.chat", "second chat drop target");
-    const fileDragEvent = (type: string) => {
-      const event = new Event(type, { bubbles: true, cancelable: true });
-      Object.defineProperty(event, "dataTransfer", { value: { types: ["Files"] } });
-      return event;
-    };
 
-    secondChat.dispatchEvent(fileDragEvent("dragenter"));
+    secondChat.dispatchEvent(createDragEvent("dragenter"));
 
     expect(firstChat.hasAttribute("data-attachment-drop-active")).toBe(false);
     expect(secondChat.hasAttribute("data-attachment-drop-active")).toBe(true);
 
-    secondChat.dispatchEvent(fileDragEvent("dragleave"));
+    secondChat.dispatchEvent(createDragEvent("dragleave"));
 
     expect(secondChat.hasAttribute("data-attachment-drop-active")).toBe(false);
   });
@@ -3551,25 +3552,16 @@ describe("chat attachment picker", () => {
   it("keeps the file drop overlay stable across nested drag targets", () => {
     const container = renderChatView();
     const chat = requireElement(container, "section.card.chat", "chat drop target");
-    const fileDragEvent = (type: string) => {
-      const event = new Event(type, { bubbles: true, cancelable: true });
-      Object.defineProperty(event, "dataTransfer", { value: { types: ["Files"] } });
-      return event;
-    };
 
-    chat.dispatchEvent(fileDragEvent("dragenter"));
-    chat.dispatchEvent(fileDragEvent("dragenter"));
-    chat.dispatchEvent(fileDragEvent("dragleave"));
+    chat.dispatchEvent(createDragEvent("dragenter"));
+    chat.dispatchEvent(createDragEvent("dragenter"));
+    chat.dispatchEvent(createDragEvent("dragleave"));
     expect(chat.hasAttribute("data-attachment-drop-active")).toBe(true);
 
-    chat.dispatchEvent(fileDragEvent("dragleave"));
+    chat.dispatchEvent(createDragEvent("dragleave"));
     expect(chat.hasAttribute("data-attachment-drop-active")).toBe(false);
 
-    const sessionDrag = new Event("dragenter", { bubbles: true, cancelable: true });
-    Object.defineProperty(sessionDrag, "dataTransfer", {
-      value: { types: ["application/x-openclaw-session"] },
-    });
-    chat.dispatchEvent(sessionDrag);
+    chat.dispatchEvent(createDragEvent("dragenter", ["application/x-openclaw-session"]));
     expect(chat.hasAttribute("data-attachment-drop-active")).toBe(false);
   });
 

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3527,6 +3527,52 @@ describe("chat slash menu accessibility", () => {
 });
 
 describe("chat attachment picker", () => {
+  it("highlights only the chat pane receiving a file drag", () => {
+    const first = renderChatView();
+    const second = renderChatView();
+    const firstChat = requireElement(first, "section.card.chat", "first chat drop target");
+    const secondChat = requireElement(second, "section.card.chat", "second chat drop target");
+    const fileDragEvent = (type: string) => {
+      const event = new Event(type, { bubbles: true, cancelable: true });
+      Object.defineProperty(event, "dataTransfer", { value: { types: ["Files"] } });
+      return event;
+    };
+
+    secondChat.dispatchEvent(fileDragEvent("dragenter"));
+
+    expect(firstChat.hasAttribute("data-attachment-drop-active")).toBe(false);
+    expect(secondChat.hasAttribute("data-attachment-drop-active")).toBe(true);
+
+    secondChat.dispatchEvent(fileDragEvent("dragleave"));
+
+    expect(secondChat.hasAttribute("data-attachment-drop-active")).toBe(false);
+  });
+
+  it("keeps the file drop overlay stable across nested drag targets", () => {
+    const container = renderChatView();
+    const chat = requireElement(container, "section.card.chat", "chat drop target");
+    const fileDragEvent = (type: string) => {
+      const event = new Event(type, { bubbles: true, cancelable: true });
+      Object.defineProperty(event, "dataTransfer", { value: { types: ["Files"] } });
+      return event;
+    };
+
+    chat.dispatchEvent(fileDragEvent("dragenter"));
+    chat.dispatchEvent(fileDragEvent("dragenter"));
+    chat.dispatchEvent(fileDragEvent("dragleave"));
+    expect(chat.hasAttribute("data-attachment-drop-active")).toBe(true);
+
+    chat.dispatchEvent(fileDragEvent("dragleave"));
+    expect(chat.hasAttribute("data-attachment-drop-active")).toBe(false);
+
+    const sessionDrag = new Event("dragenter", { bubbles: true, cancelable: true });
+    Object.defineProperty(sessionDrag, "dataTransfer", {
+      value: { types: ["application/x-openclaw-session"] },
+    });
+    chat.dispatchEvent(sessionDrag);
+    expect(chat.hasAttribute("data-attachment-drop-active")).toBe(false);
+  });
+
   it("turns large pasted plain text into a compact attachment", async () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -60,6 +60,10 @@ import type { ChatRunUiStatus } from "./run-lifecycle.ts";
 import type { CompactionStatus, FallbackStatus } from "./tool-stream.ts";
 import "../../components/resizable-divider.ts";
 
+function isFileDrag(dataTransfer: DataTransfer | null): boolean {
+  return Array.from(dataTransfer?.types ?? []).includes("Files");
+}
+
 export type ChatProps = {
   paneId: string;
   sessionKey: string;
@@ -224,6 +228,31 @@ export function renderChat(props: ChatProps) {
   };
   const sideChatVisible = isSideChatPanelVisible(sideChatProps);
   let chatSection: HTMLElement | null = null;
+  // Nested dragenter/dragleave events must stay balanced so crossing transcript
+  // children does not flicker the pane-level file drop affordance.
+  let attachmentDragDepth = 0;
+  const setAttachmentDropActive = (event: DragEvent, active: boolean) => {
+    const target = event.currentTarget;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+    if (active) {
+      if (!canCompose || !isFileDrag(event.dataTransfer)) {
+        return;
+      }
+      attachmentDragDepth += 1;
+    } else {
+      attachmentDragDepth = Math.max(0, attachmentDragDepth - 1);
+    }
+    target.toggleAttribute("data-attachment-drop-active", attachmentDragDepth > 0);
+  };
+  const clearAttachmentDropActive = (event: DragEvent) => {
+    attachmentDragDepth = 0;
+    const target = event.currentTarget;
+    if (target instanceof HTMLElement) {
+      target.removeAttribute("data-attachment-drop-active");
+    }
+  };
 
   const thread = renderChatThread({
     paneId: props.paneId,
@@ -356,11 +385,19 @@ export function renderChat(props: ChatProps) {
       )}
       @drop=${(event: DragEvent) => {
         event.preventDefault();
+        clearAttachmentDropActive(event);
         if (canCompose) {
           handleChatAttachmentDrop(event, props);
         }
       }}
-      @dragover=${(event: DragEvent) => event.preventDefault()}
+      @dragenter=${(event: DragEvent) => setAttachmentDropActive(event, true)}
+      @dragleave=${(event: DragEvent) => setAttachmentDropActive(event, false)}
+      @dragover=${(event: DragEvent) => {
+        event.preventDefault();
+        if (canCompose && event.dataTransfer && isFileDrag(event.dataTransfer)) {
+          event.dataTransfer.dropEffect = "copy";
+        }
+      }}
       @keydown=${(event: KeyboardEvent) => {
         if (event.key === "Escape" && props.replyTarget && !event.defaultPrevented) {
           event.preventDefault();

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -43,8 +43,17 @@ openclaw-chat-page {
   opacity: 0.1;
 }
 
+.chat > * {
+  transition: opacity 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.chat[data-attachment-drop-active] > * {
+  opacity: 0.5;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .chat::after {
+  .chat::after,
+  .chat > * {
     transition-duration: 0ms;
   }
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -28,6 +28,27 @@ openclaw-chat-page {
   box-shadow: none !important;
 }
 
+.chat::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 90;
+  pointer-events: none;
+  background: var(--accent);
+  opacity: 0;
+  transition: opacity 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.chat[data-attachment-drop-active]::after {
+  opacity: 0.1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat::after {
+    transition-duration: 0ms;
+  }
+}
+
 .chat-workbench__main {
   /* Positioning context for the floating rail openers so they pin to the
      thread column instead of overlapping an open right-docked rail. */


### PR DESCRIPTION
## What Problem This Solves

Dragging an image or file anywhere over a chat already attaches it to that chat, but the Control UI does not show which pane will receive the drop. This is especially ambiguous in split view.

## Why This Change Was Made

This proposal adds pane-local drag feedback for file drags: the target chat receives a low-opacity accent wash and its content fades while the pointer remains over it. Session drags and non-composable chats keep their existing behavior.

## User Impact

Users can see the exact chat pane that will receive a dropped image or file before releasing it, including in split view.

## Evidence

### Before — current `main`

The file drag is accepted, but neither pane shows a drop target.

![Before: split chat without file-drop feedback](https://faint-lichen-k7v5.here.now/before.png)

### After — proposed in this PR

Only the destination pane receives the accent wash and reduced content opacity.

![After: destination split-chat pane highlighted during a file drag](https://faint-lichen-k7v5.here.now/after.png)

Validated with:

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts` — 183 tests passed
- `node_modules/.bin/oxfmt --check --threads=1 ui/src/pages/chat/chat-view.ts ui/src/pages/chat/chat-view.test.ts ui/src/styles/chat/layout.css`
- `git diff --check origin/main...HEAD`

The focused regression coverage verifies that file drags activate only the destination pane, remain stable across nested drag targets, and do not activate for session drags.

## AI-assisted contribution

- [x] AI-assisted
- [x] I understand the implementation and reviewed the final diff
- [x] Focused automated and visual verification completed
