### PR TITLE
refactor(auto-reply): remove obsolete testing aliases

### DIFF
--- a/src/auto-reply/reply/acp-reset-target.ts
+++ b/src/auto-reply/reply/acp-reset-target.ts
@@ -183,4 +183,3 @@ export function resolveEffectiveResetTargetSessionKey(params: {
   }
   return activeAcpSessionKey;
 }
-export { testing as __testing };

--- a/src/auto-reply/reply/queue/cleanup.ts
+++ b/src/auto-reply/reply/queue/cleanup.ts
@@ -72,4 +72,3 @@ export function clearSessionQueues(keys: Array<string | undefined>): ClearSessio
 
   return { followupCleared, laneCleared, keys: clearedKeys };
 }
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes two obsolete internal `__testing` aliases that duplicate the canonical
`testing` exports in isolated auto-reply modules.

## Why This Change Was Made

The aliases were introduced as compatibility re-exports during the underscore
lint migration, but no repository consumer still imports either old name.
The overlapping `abort` and reply-run registry aliases are intentionally left
untouched because active pull requests currently modify those files.

## User Impact

No user-visible behavior changes. This reduces redundant internal test surface
without changing runtime logic or the canonical test hooks.

## Evidence

- Codebase-memory import graph and repository search: zero `__testing` consumers
  for both changed modules; neither hook reaches a public package barrel.
- `corepack pnpm test:serial src/auto-reply/reply/abort.test.ts src/auto-reply/reply/commands-acp.test.ts src/auto-reply/reply/queue/cleanup.test.ts src/agents/openclaw-tools.subagents.scope.test.ts`
  - 103 tests passed across two Vitest shards in Testbox `tbx_01kxb0gzp16mfyx8fck9hww6k0`.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed -- src/auto-reply/reply/acp-reset-target.ts src/auto-reply/reply/queue/cleanup.ts`
  - Passed in the same Testbox.
- Knip `6.8.0` production export scan after the patch reports only the canonical
  `testing` export for both modules.
- Fresh `gpt-5.6-sol` autoreview at medium reasoning: clean, confidence `0.97`.
