### PR TITLE
docs: note workflow filename resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,7 @@ Skills own workflows; root owns hard policy and routing.
 - Issue/PR start: `git status -sb`; if clean, `git pull --ff-only`; if dirty, yell before pull/rebase.
 - PR refs: `gh pr view/diff` or `gh api`, not web search. Prefer `gitcrawl` for maintainer discovery; missing/stale `gitcrawl` falls through to live `gh`, not contributor setup. Verify live with `gh` before mutation.
 - zsh: quote `gh api` endpoints containing `?` or brackets; otherwise glob expansion corrupts the invocation.
+- GitHub Actions: resolve workflow files from `.github/workflows` or API; never infer filenames from display names.
 - zsh: quote command globs; unmatched patterns abort before the tool runs.
 - `scripts/pr` artifacts: preserve template enum values; validate before prepare.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.


### PR DESCRIPTION
## What Problem This Solves

GitHub Actions display names do not necessarily match workflow filenames. Inferring the filename can make an otherwise valid workflow query return 404.

## Why This Change Was Made

Add a terse maintainer invocation rule requiring workflow filenames to be resolved from the repository workflow directory or GitHub API.

## User Impact

None. Maintainer documentation only.

## Evidence

- `git diff --check`
- One-line `AGENTS.md` change only
