### PR TITLE
fix(agents): skip model-override repair and visibility gate for locked sessions

### DIFF
--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -168,6 +168,7 @@ export async function resolveEmbeddedModelSelection(params: {
   }
 
   if (
+    !isModelSelectionLocked(sessionEntry) &&
     sessionEntry &&
     params.sessionStore &&
     params.sessionKey &&
@@ -233,6 +234,10 @@ export async function resolveEmbeddedModelSelection(params: {
       hasLegacyAutoFallbackOverrideWithoutOrigin =
         adoptedHasStoredOverride && hasLegacyAutoFallbackWithoutOrigin(sessionEntry);
     }
+  }
+
+  if (isModelSelectionLocked(sessionEntry)) {
+    hasLegacyAutoFallbackOverrideWithoutOrigin = false;
   }
 
   const storedProviderOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
@@ -306,7 +311,10 @@ export async function resolveEmbeddedModelSelection(params: {
       storedAlias?.model ?? storedModelOverride,
       params.modelManifestContext,
     );
-    if (visibilityPolicy.allowsKey(modelKey(normalizedStored.provider, normalizedStored.model))) {
+    if (
+      isModelSelectionLocked(sessionEntry) ||
+      visibilityPolicy.allowsKey(modelKey(normalizedStored.provider, normalizedStored.model))
+    ) {
       provider = normalizedStored.provider;
       model = normalizedStored.model;
       requestedRouteResolution =
@@ -372,7 +380,9 @@ export async function resolveEmbeddedModelSelection(params: {
     requestedRouteResolution = "resolved";
   }
   const unresolvedSelectionKey = modelKey(provider, model);
-  const allowedInitialSelection = visibilityPolicy.resolveSelection({ provider, model });
+  const allowedInitialSelection = isModelSelectionLocked(sessionEntry)
+    ? { provider, model }
+    : visibilityPolicy.resolveSelection({ provider, model });
   if (!allowedInitialSelection) {
     const policyPath = visibilityPolicy.allowConfigPath ?? "modelPolicy.allow";
     throw new Error(

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -2360,6 +2360,7 @@ describe("createModelSelectionState degraded-catalog override preservation", () 
     cfg: OpenClawConfig;
     snapshotEntries: unknown[];
     authoritative: boolean;
+    modelSelectionLocked?: true;
   }): Promise<{
     state: Awaited<ReturnType<typeof createModelSelectionState>>;
     sessionEntry: SessionEntry;
@@ -2369,7 +2370,10 @@ describe("createModelSelectionState degraded-catalog override preservation", () 
       routeVariants: params.snapshotEntries,
       authoritative: params.authoritative,
     });
-    const sessionEntry = makeOverrideEntry();
+    const sessionEntry = {
+      ...makeOverrideEntry(),
+      ...(params.modelSelectionLocked ? { modelSelectionLocked: true as const } : {}),
+    };
     const sessionStore = { [sessionKey]: sessionEntry };
     const state = await createModelSelectionState({
       cfg: params.cfg,
@@ -2401,6 +2405,20 @@ describe("createModelSelectionState degraded-catalog override preservation", () 
     // The pin is untouched and the turn falls back to primary.
     expect(sessionEntry.modelOverride).toBe("gpt-4o");
     expect(state.model).toBe("gpt-4o-mini");
+  });
+
+  it("keeps a locked pin active without a degraded-catalog fallback notice", async () => {
+    const { state, sessionEntry } = await run({
+      cfg: restrictiveCfg,
+      snapshotEntries: [],
+      authoritative: false,
+      modelSelectionLocked: true,
+    });
+    expect(state.resetModelOverride).toBe(false);
+    expect(state.resetModelOverrideReason).toBeUndefined();
+    expect(state.resetModelOverrideRef).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBe("gpt-4o");
+    expect(state.model).toBe("gpt-4o");
   });
 
   it("destroys a genuinely-disallowed pin on an authoritative catalog", async () => {

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -16,7 +16,6 @@ import { resolveModelCandidateChain } from "../../agents/model-fallback-candidat
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
-import { MODEL_SELECTION_LOCKED_MESSAGE } from "../../sessions/model-overrides.js";
 import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
 
 const DEFAULT_MOCK_CATALOG_ENTRIES = vi.hoisted(() => [
@@ -1220,7 +1219,7 @@ describe("createModelSelectionState respects session model override", () => {
     expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
   });
 
-  it("rejects automatic repair of a locked disallowed override", async () => {
+  it("preserves a locked disallowed override without resetting it", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -1240,23 +1239,20 @@ describe("createModelSelectionState respects session model override", () => {
     });
     const sessionStore = { [sessionKey]: sessionEntry };
 
-    await expect(
-      createModelSelectionState({
-        cfg,
-        agentCfg: cfg.agents?.defaults,
-        sessionEntry,
-        sessionStore,
-        sessionKey,
-        defaultProvider: "openai",
-        defaultModel: "gpt-4o",
-        provider: "openai",
-        model: "gpt-4o",
-        hasModelDirective: false,
-      }),
-    ).rejects.toMatchObject({
-      name: "ModelSelectionLockedError",
-      message: MODEL_SELECTION_LOCKED_MESSAGE,
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o",
+      provider: "openai",
+      model: "gpt-4o",
+      hasModelDirective: false,
     });
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o-mini");
     expect(sessionStore[sessionKey]).toMatchObject({
       providerOverride: "openai",
       modelOverride: "gpt-4o-mini",

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -362,10 +362,10 @@ export async function createModelSelectionState(params: {
     const overrideAllowed = visibilityPolicy.allowsKey(key);
     // A degraded catalog cannot prove a pin is disallowed. Preserve it while the turn falls back
     // to primary, then re-evaluate after discovery recovers; config-proven stale pins still reset.
-    const overrideTemporarilyUnavailable =
-      !staleDirectStoredOverride && !overrideAllowed && !catalogAuthoritative;
     const shouldResetOverride =
       (staleDirectStoredOverride || !overrideAllowed) && !modelSelectionLocked;
+    const overrideTemporarilyUnavailable =
+      shouldResetOverride && !staleDirectStoredOverride && !catalogAuthoritative;
     if (overrideTemporarilyUnavailable) {
       resetModelOverrideRef = key;
       resetModelOverrideReason = "temporarily-unavailable";

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -211,6 +211,7 @@ export async function createModelSelectionState(params: {
   const primaryProvider = params.primaryProvider ?? defaultProvider;
   const primaryModel = params.primaryModel ?? defaultModel;
   const hasOneTurnModelOverride = params.hasOneTurnModelOverride === true;
+  const modelSelectionLocked = sessionEntry?.modelSelectionLocked === true;
   const agentEntry = params.agentId ? resolveAgentConfig(cfg, params.agentId) : undefined;
 
   let visibilityPolicy: ModelVisibilityPolicy = createModelVisibilityPolicy({
@@ -363,10 +364,12 @@ export async function createModelSelectionState(params: {
     // to primary, then re-evaluate after discovery recovers; config-proven stale pins still reset.
     const overrideTemporarilyUnavailable =
       !staleDirectStoredOverride && !overrideAllowed && !catalogAuthoritative;
+    const shouldResetOverride =
+      (staleDirectStoredOverride || !overrideAllowed) && !modelSelectionLocked;
     if (overrideTemporarilyUnavailable) {
       resetModelOverrideRef = key;
       resetModelOverrideReason = "temporarily-unavailable";
-    } else if (staleDirectStoredOverride || !overrideAllowed) {
+    } else if (shouldResetOverride) {
       const initialSessionEntry = { ...sessionEntry };
       const nextSessionEntry = { ...sessionEntry };
       const { updated } = applyModelOverrideToSessionEntry({
@@ -466,7 +469,7 @@ export async function createModelSelectionState(params: {
       runtimeModelNormalization,
     );
     const key = modelKey(normalizedStoredOverride.provider, normalizedStoredOverride.model);
-    if (visibilityPolicy.allowsKey(key)) {
+    if (modelSelectionLocked || visibilityPolicy.allowsKey(key)) {
       provider = normalizedStoredOverride.provider;
       model = normalizedStoredOverride.model;
       requestedRouteResolution =
@@ -474,7 +477,9 @@ export async function createModelSelectionState(params: {
     }
   }
 
-  if (!params.hasModelDirective && !hasOneTurnModelOverride) {
+  const skipResolveSelection =
+    params.hasModelDirective || hasOneTurnModelOverride || modelSelectionLocked;
+  if (!skipResolveSelection) {
     const unresolvedSelectionKey = modelKey(provider, model);
     const allowedInitialSelection = visibilityPolicy.resolveSelection({
       provider,

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -1412,20 +1412,16 @@ describe("agentCommand", () => {
         { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
       ]);
 
-      await expect(
-        agentCommand(
-          {
-            message: "hi",
-            sessionKey: "agent:main:subagent:locked-legacy-auto",
-          },
-          runtime,
-        ),
-      ).rejects.toMatchObject({
-        name: "ModelSelectionLockedError",
-        message: MODEL_SELECTION_LOCKED_MESSAGE,
-      });
+      await agentCommand(
+        {
+          message: "hi",
+          sessionKey: "agent:main:subagent:locked-legacy-auto",
+        },
+        runtime,
+      );
 
-      expect(runEmbeddedAgent).not.toHaveBeenCalled();
+      expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+      expectLastRunProviderModel("anthropic", "claude-opus-4-6");
       const persisted = readSessionStore<{
         providerOverride?: string;
         modelOverride?: string;
@@ -1549,7 +1545,7 @@ describe("agentCommand", () => {
     });
   });
 
-  it("rejects a locked disallowed stored override without clearing it", async () => {
+  it("allows a locked disallowed stored override to run without clearing it", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions-locked-disallowed-override.json");
       const sessionKey = "agent:main:subagent:locked-disallowed";
@@ -1567,6 +1563,7 @@ describe("agentCommand", () => {
       mockConfig(home, store, {
         model: { primary: "openai/gpt-4.1-mini" },
         models: {
+          "anthropic/claude-opus-4-6": {},
           "openai/gpt-4.1-mini": {},
         },
         modelPolicy: { allow: ["openai/gpt-4.1-mini"] },
@@ -1576,11 +1573,9 @@ describe("agentCommand", () => {
         { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
       ]);
 
-      await expect(runAgentWithSessionKey(sessionKey)).rejects.toMatchObject({
-        name: "ModelSelectionLockedError",
-        message: MODEL_SELECTION_LOCKED_MESSAGE,
-      });
-      expect(runEmbeddedAgent).not.toHaveBeenCalled();
+      await runAgentWithSessionKey(sessionKey);
+      expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+      expectLastRunProviderModel("anthropic", "claude-opus-4-6");
       expect(
         readSessionStore<{
           providerOverride?: string;


### PR DESCRIPTION
## What Problem This Solves

When a session is model-selection-locked (e.g. Claude Code catalog adoption via the anthropic extension, or durable harness-owned sessions), multiple code paths could reject the locked model override as unrecognized, reset it to the agent's default model, or normalize it away — all of which tripped `ModelSelectionLockedError`.

**Result:** Users who adopted a Claude Code session in the Control UI could see and preview the session, but sending any message would fail with "Model selection is locked for this session."

## Solution

Six guard additions across two files:

**`src/agents/agent-command.ts`:**

1. Skip the repair block for locked sessions (line 1610)
2. Allow locked overrides through the visibility-policy gate (line 1740)
3. Skip resolveSelection normalization for locked sessions (line 1799)
4. Clear legacy auto-fallback flags for locked sessions so the stored override is applied (line 1677)

**`src/auto-reply/reply/model-selection.ts`:**

5. Skip stale/disallowed override reset for locked sessions (line 325)
6. Allow locked overrides through the visibility-policy gate (line 408)
7. Skip resolveSelection normalization for locked sessions (line 414)

**`src/agents/agent-command.live-model-switch.test.ts` / `src/commands/agent.test.ts` / `src/auto-reply/reply/model-selection.test.ts`:**

Updated three test expectations to reflect the new behavior where locked sessions proceed with their locked model instead of throwing.

### Why `isModelSelectionLocked` (not `isValidAgentHarnessSessionStoreEntry`)

The repair block at line 1610 already guards with `!isValidAgentHarnessSessionStoreEntry(...)`, which covers durable harness-owned sessions (codex, etc.) but does _not_ cover CLI-backend-owned locked sessions (e.g. `plugin:anthropic:catalog-adopt:claude:...`). CLI-backend sessions carry `modelSelectionLocked: true` without an `agentHarnessId` or harness-shaped session key, so `isValidAgentHarnessSessionStoreEntry` returns `false` for them.

Using `isModelSelectionLocked(sessionEntry)` directly is correct because:

- `modelSelectionLocked` can only be set by a plugin via the `createSessionEntry` API. Ordinary user or UI sessions never carry this flag.
- Every session that has this flag — harness-owned, CLI-backend-owned, or otherwise — was intentionally locked by its owning plugin and should not have its model overrides repaired, reset, or visibility-filtered by generic runtime paths.
- The existing guard (`isValidAgentHarnessSessionStoreEntry`) already implies `modelSelectionLocked === true`; our change widens the exemption from "harness locks only" to "all durable locks," which is the correct invariant.

## User Impact

- Users running Claude Code v2.x can adopt and continue Claude Code sessions from the OpenClaw Control UI without hitting a model-selection-locked error
- The fix applies to all model-selection-locked sessions, not just Claude Code catalog adoption
- No change to non-locked sessions

## Evidence

- `pnpm build` — passed
- `pnpm vitest run src/agents/agent-command.live-model-switch.test.ts` — 192/194 passed; 2 failures pre-existing (Windows path mismatch)
- `pnpm vitest run src/commands/agent.test.ts` — 42/42 passed
- `pnpm vitest run src/auto-reply/reply/model-selection.test.ts` — 61/63 passed; 2 failures pre-existing (Windows EPERM during temp dir cleanup)
- `pnpm test:extension anthropic` — 17 test files, 219 tests, all passing
- `pnpm test:contracts` — channel contracts: 426/426 passed; plugin contracts: 952/986 passed (34 EBUSY failures pre-existing on Windows)
- `pnpm check` — all preflight guards passed (only pre-existing npm shrinkwrap staleness)
- Screenshots (before/after):
**Before**
<img width="949" height="283" alt="屏幕截图 2026-07-12 205922" src="https://github.com/user-attachments/assets/84920567-5175-4541-a465-b2ff2340007e" />

**After**
<img width="1464" height="233" alt="屏幕截图 2026-07-12 200103" src="https://github.com/user-attachments/assets/cf335cf2-f16e-49eb-9986-7ca5ce761423" />


> This PR was authored with AI assistance (Claude Code).
Closes #105378 
