### PR TITLE
fix(canvas): hosted pages fail on macOS with scoped Gateway auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Canvas Gateway and macOS reliability:** resolve hosted Canvas routes through freshly scoped node capabilities, keep bridge actions available before page scripts and when live reload is disabled, restore file watching beneath hidden state directories, prefer path capabilities over stale queries, preserve false and empty eval results, and restrict macOS hosted actions to the exact trusted A2UI document. Fixes #91083. Thanks @Medicalmusings, @LaPhilosophie, @Lucenx9, and @hanZeng-08.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.
 - **Cron delivery status:** keep successful isolated agent turns at `status=ok` when downstream delivery fails, while preserving the send failure separately in delivery state and run logs. (#95419) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Canvas Gateway and macOS reliability:** resolve hosted Canvas routes through freshly scoped node capabilities, keep bridge actions available before page scripts and when live reload is disabled, restore file watching beneath hidden state directories, prefer path capabilities over stale queries, preserve false and empty eval results, and restrict macOS hosted actions to the exact trusted A2UI document. Fixes #91083. Thanks @Medicalmusings, @LaPhilosophie, @Lucenx9, and @hanZeng-08.
 - **Gradium TTS credential egress:** reject non-HTTPS, foreign-host, and hostname-lookalike base URLs before dispatching API keys, and pin guarded transport to Gradium's documented API hostname. (#101280) Thanks @zhangguiping-xydt.
 - **Gateway command SecretRefs:** preserve authoritative active-snapshot values when another command secret remains unresolved, falling back locally only for missing paths instead of emitting a per-turn `secrets.resolve` failure. (#96661) Thanks @SunnyShu0925.
 - **Cron delivery status:** keep successful isolated agent turns at `status=ok` when downstream delivery fails, while preserving the send failure separately in delivery state and run logs. (#95419) Thanks @Alix-007.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -20339,7 +20339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1013,
+      "line": 983,
       "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
       "source": "approvalSource requires matching systemRunPlan",
       "surface": "apple",
@@ -20347,7 +20347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1014,
+      "line": 984,
       "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
       "source": "explicit approval requires matching systemRunPlan",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -16563,7 +16563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 223,
+      "line": 233,
       "path": "apps/macos/Sources/OpenClaw/CanvasManager.swift",
       "source": "Degraded",
       "surface": "apple",
@@ -20339,7 +20339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 989,
+      "line": 1013,
       "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
       "source": "approvalSource requires matching systemRunPlan",
       "surface": "apple",
@@ -20347,7 +20347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 990,
+      "line": 1014,
       "path": "apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift",
       "source": "explicit approval requires matching systemRunPlan",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/CanvasA2UIActionMessageHandler.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasA2UIActionMessageHandler.swift
@@ -7,38 +7,69 @@ final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHandler {
     static let messageName = "openclawCanvasA2UIAction"
     static let allMessageNames = [messageName]
 
-    /// Compatibility helper for debug/test shims. Runtime dispatch remains
-    /// limited to in-app canvas schemes in `didReceive`.
-    static func isLocalNetworkCanvasURL(_ url: URL) -> Bool {
-        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
-            return false
-        }
-        guard let host = url.host?.lowercased(), !host.isEmpty else {
-            return false
-        }
-        if host == "localhost" {
-            return true
-        }
-        guard let ip = Self.parseIPv4(host) else {
-            return false
-        }
-        return Self.isLocalNetworkIPv4(ip)
-    }
-
     private let sessionKey: String
+    private var expectedRemoteURL: URL?
 
     init(sessionKey: String) {
         self.sessionKey = sessionKey
         super.init()
     }
 
+    func setTrustedRemoteURL(_ url: URL?) {
+        self.expectedRemoteURL = url.flatMap {
+            CanvasHostedURLResolver.isCapabilityScopedA2UIURL($0) ? $0 : nil
+        }
+    }
+
+    func updateTrustForMainFrameNavigation(to url: URL) {
+        guard let expectedRemoteURL = self.expectedRemoteURL else { return }
+        // Hosted action trust is load-scoped. Once the main frame leaves the
+        // selected A2UI request, page navigation must never re-arm it.
+        if !Self.isExactRemoteSourceURL(url, expectedRemoteURL: expectedRemoteURL) {
+            self.expectedRemoteURL = nil
+        }
+    }
+
+    func isTrustedSourceURL(_ url: URL) -> Bool {
+        Self.isTrustedSourceURL(url, expectedRemoteURL: self.expectedRemoteURL)
+    }
+
+    static func isTrustedSourceURL(_ url: URL, expectedRemoteURL: URL?) -> Bool {
+        if let scheme = url.scheme?.lowercased(), CanvasScheme.allSchemes.contains(scheme) {
+            return true
+        }
+        return self.isExactRemoteSourceURL(url, expectedRemoteURL: expectedRemoteURL)
+    }
+
+    private static func isExactRemoteSourceURL(_ url: URL, expectedRemoteURL: URL?) -> Bool {
+        guard let expectedRemoteURL,
+              CanvasHostedURLResolver.isCapabilityScopedA2UIURL(expectedRemoteURL),
+              let actual = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let expected = URLComponents(url: expectedRemoteURL, resolvingAgainstBaseURL: false),
+              let actualScheme = actual.scheme?.lowercased(),
+              let expectedScheme = expected.scheme?.lowercased(),
+              actualScheme == expectedScheme,
+              actual.host?.lowercased() == expected.host?.lowercased(),
+              self.effectivePort(actual) == self.effectivePort(expected),
+              actual.user == nil,
+              actual.password == nil,
+              expected.user == nil,
+              expected.password == nil
+        else {
+            return false
+        }
+        return actual.percentEncodedPath == expected.percentEncodedPath &&
+            actual.percentEncodedQuery == expected.percentEncodedQuery
+    }
+
     func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
         guard Self.allMessageNames.contains(message.name) else { return }
 
-        // Only accept actions from the in-app canvas scheme. Local-network HTTP
-        // pages are regular web content and must not get direct agent dispatch.
-        guard let webView = message.webView, let url = webView.url else { return }
-        guard let scheme = url.scheme, CanvasScheme.allSchemes.contains(scheme) else {
+        // Only the main in-app document or the exact capability-scoped A2UI
+        // document may dispatch. Other web content remains render-only.
+        guard message.frameInfo.isMainFrame else { return }
+        guard let webView = message.webView, let url = message.frameInfo.request.url else { return }
+        guard self.isTrustedSourceURL(url) else {
             return
         }
 
@@ -122,23 +153,13 @@ final class CanvasA2UIActionMessageHandler: NSObject, WKScriptMessageHandler {
         }
     }
 
-    private static func parseIPv4(_ host: String) -> (UInt8, UInt8, UInt8, UInt8)? {
-        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
-        guard parts.count == 4 else { return nil }
-        let bytes = parts.compactMap { UInt8($0) }
-        guard bytes.count == 4 else { return nil }
-        return (bytes[0], bytes[1], bytes[2], bytes[3])
-    }
-
-    private static func isLocalNetworkIPv4(_ ip: (UInt8, UInt8, UInt8, UInt8)) -> Bool {
-        let (a, b, _, _) = ip
-        if a == 10 { return true }
-        if a == 172, (16...31).contains(Int(b)) { return true }
-        if a == 192, b == 168 { return true }
-        if a == 127 { return true }
-        if a == 169, b == 254 { return true }
-        if a == 100, (64...127).contains(Int(b)) { return true }
-        return false
+    private static func effectivePort(_ components: URLComponents) -> Int? {
+        if let port = components.port { return port }
+        return switch components.scheme?.lowercased() {
+        case "http": 80
+        case "https": 443
+        default: nil
+        }
     }
     // Formatting helpers live in OpenClawKit (`OpenClawCanvasA2UIAction`).
 }

--- a/apps/macos/Sources/OpenClaw/CanvasHostedURLResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasHostedURLResolver.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+struct CanvasHostedTarget: Equatable {
+    let url: URL
+    let allowsA2UIActions: Bool
+}
+
+enum CanvasHostedURLResolver {
+    private static let canvasPath = "/__openclaw__/canvas"
+    private static let a2uiPath = "/__openclaw__/a2ui"
+    private static let capabilityMarker = "/__openclaw__/cap/"
+
+    static func resolve(surfaceURL rawSurfaceURL: String?, target rawTarget: String) -> CanvasHostedTarget? {
+        guard let target = self.relativeHostedTarget(rawTarget),
+              var surface = self.capabilitySurface(rawSurfaceURL)
+        else {
+            return nil
+        }
+
+        var surfacePath = surface.percentEncodedPath
+        while surfacePath.hasSuffix("/") {
+            surfacePath.removeLast()
+        }
+        surface.percentEncodedPath = surfacePath + target.percentEncodedPath
+        surface.percentEncodedQuery = target.percentEncodedQuery
+        surface.fragment = target.fragment
+        guard let url = surface.url else { return nil }
+        return CanvasHostedTarget(
+            url: url,
+            allowsA2UIActions: self.isA2UIPath(target.percentEncodedPath))
+    }
+
+    static func resolveA2UIURL(surfaceURL: String?) -> String? {
+        self.resolve(
+            surfaceURL: surfaceURL,
+            target: "\(self.a2uiPath)/?platform=macos")?.url.absoluteString
+    }
+
+    static func isHostedTarget(_ rawTarget: String) -> Bool {
+        self.relativeHostedTarget(rawTarget) != nil
+    }
+
+    static func isCapabilityScopedA2UIURL(_ url: URL) -> Bool {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              self.isWebURL(components),
+              let marker = components.percentEncodedPath.range(of: self.capabilityMarker)
+        else {
+            return false
+        }
+        let suffix = components.percentEncodedPath[marker.upperBound...]
+        guard let separator = suffix.firstIndex(of: "/"), separator != suffix.startIndex else {
+            return false
+        }
+        let encodedCapability = String(suffix[..<separator])
+        guard let capability = encodedCapability.removingPercentEncoding, !capability.isEmpty else {
+            return false
+        }
+        let hostedPath = String(suffix[separator...])
+        return self.isCanonicalHostedPath(hostedPath) && self.isA2UIPath(hostedPath)
+    }
+
+    private static func relativeHostedTarget(_ rawTarget: String) -> URLComponents? {
+        let target = rawTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard target.hasPrefix("/"),
+              let components = URLComponents(string: target),
+              components.scheme == nil,
+              components.host == nil,
+              components.user == nil,
+              components.password == nil,
+              self.isCanonicalHostedPath(components.percentEncodedPath),
+              self.isCanvasPath(components.percentEncodedPath) || self.isA2UIPath(components.percentEncodedPath)
+        else {
+            return nil
+        }
+        return components
+    }
+
+    private static func capabilitySurface(_ rawSurfaceURL: String?) -> URLComponents? {
+        let raw = rawSurfaceURL?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !raw.isEmpty,
+              let components = URLComponents(string: raw),
+              self.isWebURL(components),
+              components.user == nil,
+              components.password == nil,
+              components.percentEncodedQuery == nil,
+              components.fragment == nil
+        else {
+            return nil
+        }
+
+        let segments = components.percentEncodedPath.split(separator: "/", omittingEmptySubsequences: true)
+        guard segments.count >= 3,
+              segments[segments.count - 3] == "__openclaw__",
+              segments[segments.count - 2] == "cap",
+              let capability = String(segments[segments.count - 1]).removingPercentEncoding,
+              !capability.isEmpty
+        else {
+            return nil
+        }
+        return components
+    }
+
+    private static func isWebURL(_ components: URLComponents) -> Bool {
+        let scheme = components.scheme?.lowercased()
+        return (scheme == "http" || scheme == "https") && components.host?.isEmpty == false
+    }
+
+    private static func isCanonicalHostedPath(_ path: String) -> Bool {
+        let segments = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard segments.first?.isEmpty == true else { return false }
+
+        for (index, encodedSegment) in segments.enumerated() {
+            if index == 0 || (index == segments.count - 1 && encodedSegment.isEmpty) {
+                continue
+            }
+            guard !encodedSegment.isEmpty else { return false }
+            var segment = String(encodedSegment)
+            while true {
+                guard let decoded = segment.removingPercentEncoding else { return false }
+                if decoded == segment { break }
+                segment = decoded
+            }
+            if segment == "." || segment == ".." || segment.contains("/") || segment.contains("\\") {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func isCanvasPath(_ path: String) -> Bool {
+        path == self.canvasPath || path.hasPrefix("\(self.canvasPath)/")
+    }
+
+    private static func isA2UIPath(_ path: String) -> Bool {
+        path == self.a2uiPath || path.hasPrefix("\(self.a2uiPath)/")
+    }
+}

--- a/apps/macos/Sources/OpenClaw/CanvasManager.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasManager.swift
@@ -29,19 +29,29 @@ final class CanvasManager {
         return base.appendingPathComponent("OpenClaw/canvas", isDirectory: true)
     }()
 
-    func show(sessionKey: String, path: String? = nil, placement: CanvasPlacement? = nil) throws -> String {
-        try self.showDetailed(sessionKey: sessionKey, target: path, placement: placement).directory
+    func show(
+        sessionKey: String,
+        path: String? = nil,
+        placement: CanvasPlacement? = nil,
+        trustedA2UIActions: Bool = false) throws -> String
+    {
+        try self.showDetailed(
+            sessionKey: sessionKey,
+            target: path,
+            placement: placement,
+            trustedA2UIActions: trustedA2UIActions).directory
     }
 
     func showDetailed(
         sessionKey: String,
         target: String? = nil,
-        placement: CanvasPlacement? = nil) throws -> CanvasShowResult
+        placement: CanvasPlacement? = nil,
+        trustedA2UIActions: Bool = false) throws -> CanvasShowResult
     {
         Self.logger.debug(
             """
             showDetailed start session=\(sessionKey, privacy: .public) \
-            target=\(target ?? "", privacy: .public) \
+            hasTarget=\(target != nil) \
             placement=\(placement != nil)
             """)
         let anchorProvider = self.defaultAnchorProvider ?? Self.mouseAnchorProvider
@@ -61,7 +71,7 @@ final class CanvasManager {
 
             // Existing session: only navigate when an explicit target was provided.
             if let normalizedTarget {
-                controller.load(target: normalizedTarget)
+                controller.load(target: normalizedTarget, trustedA2UIActions: trustedA2UIActions)
                 return self.makeShowResult(
                     directory: controller.directoryPath,
                     target: target,
@@ -99,8 +109,8 @@ final class CanvasManager {
 
         // New session: default to "/" so the user sees either the welcome page or `index.html`.
         let effectiveTarget = normalizedTarget ?? "/"
-        Self.logger.debug("showDetailed showCanvas effectiveTarget=\(effectiveTarget, privacy: .public)")
-        controller.showCanvas(path: effectiveTarget)
+        Self.logger.debug("showDetailed showCanvas hasExplicitTarget=\(normalizedTarget != nil)")
+        controller.showCanvas(path: effectiveTarget, trustedA2UIActions: trustedA2UIActions)
         Self.logger.debug("showDetailed showCanvas done")
         if normalizedTarget == nil {
             self.maybeAutoNavigateToA2UIAsync(controller: controller)
@@ -158,9 +168,9 @@ final class CanvasManager {
         if raw.isEmpty {
             Self.logger.debug("canvas plugin surface URL missing in gateway snapshot")
         } else {
-            Self.logger.debug("canvas plugin surface URL snapshot=\(raw, privacy: .public)")
+            Self.logger.debug("canvas plugin surface URL present in gateway snapshot")
         }
-        let a2uiUrl = Self.resolveA2UIHostUrl(from: raw)
+        let a2uiUrl = CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: raw)
         if a2uiUrl == nil, !raw.isEmpty {
             Self.logger.debug("canvas plugin surface URL invalid; cannot resolve A2UI")
         }
@@ -193,14 +203,14 @@ final class CanvasManager {
             Self.logger.debug("canvas auto-nav skipped; target unchanged")
             return
         }
-        Self.logger.debug("canvas auto-nav -> \(a2uiUrl, privacy: .public)")
-        controller.load(target: a2uiUrl)
+        Self.logger.debug("canvas auto-nav to capability-scoped A2UI")
+        controller.load(target: a2uiUrl, trustedA2UIActions: true)
         self.lastAutoA2UIUrl = a2uiUrl
     }
 
     private func resolveA2UIHostUrl() async -> String? {
         let raw = await GatewayConnection.shared.canvasPluginSurfaceUrl()
-        return Self.resolveA2UIHostUrl(from: raw)
+        return CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: raw)
     }
 
     func refreshDebugStatus() {
@@ -230,12 +240,6 @@ final class CanvasManager {
             subtitle = mode.rawValue
         }
         controller.updateDebugStatus(enabled: enabled, title: title, subtitle: subtitle)
-    }
-
-    private static func resolveA2UIHostUrl(from raw: String?) -> String? {
-        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !trimmed.isEmpty, let base = URL(string: trimmed) else { return nil }
-        return base.appendingPathComponent("__openclaw__/a2ui/").absoluteString + "?platform=macos"
     }
 
     // MARK: - Anchoring

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Navigation.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Navigation.swift
@@ -15,7 +15,6 @@ extension CanvasWindowController {
             return
         }
         let scheme = url.scheme?.lowercased()
-
         // Deep links: allow local Canvas content to invoke the agent without bouncing through NSWorkspace.
         if scheme == "openclaw" {
             if let currentScheme = self.webView.url?.scheme,
@@ -23,8 +22,7 @@ extension CanvasWindowController {
             {
                 Task { await DeepLinkHandler.shared.handle(url: url) }
             } else {
-                canvasWindowLogger
-                    .debug("ignoring deep link from non-canvas page \(url.absoluteString, privacy: .public)")
+                canvasWindowLogger.debug("ignoring deep link from non-canvas page")
             }
             decisionHandler(.cancel)
             return
@@ -53,9 +51,29 @@ extension CanvasWindowController {
                 configuration: NSWorkspace.OpenConfiguration(),
                 completionHandler: nil)
         } else {
-            canvasWindowLogger.debug("no application to open url \(url.absoluteString, privacy: .public)")
+            canvasWindowLogger.debug("no application to open scheme=\(scheme ?? "-", privacy: .public)")
         }
         decisionHandler(.cancel)
+    }
+
+    @MainActor
+    func webView(
+        _: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping @MainActor @Sendable (WKNavigationResponsePolicy) -> Void)
+    {
+        // Revoke only once navigation produces a response. Requests canceled
+        // above leave the original trusted A2UI document active.
+        if navigationResponse.isForMainFrame, let url = navigationResponse.response.url {
+            self.updateA2UITrustForMainFrameNavigation(to: url)
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView, didCommit _: WKNavigation?) {
+        if let url = webView.url {
+            self.updateA2UITrustForMainFrameNavigation(to: url)
+        }
     }
 
     func webView(_: WKWebView, didFinish _: WKNavigation?) {

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Testing.swift
@@ -23,28 +23,5 @@ extension CanvasWindowController {
         self.storeRestoredFrame(frame, sessionKey: sessionKey)
         return self.loadRestoredFrame(sessionKey: sessionKey)
     }
-
-    static func _testParseIPv4(_ host: String) -> (UInt8, UInt8, UInt8, UInt8)? {
-        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
-        guard parts.count == 4 else { return nil }
-        let bytes: [UInt8] = parts.compactMap { UInt8($0) }
-        guard bytes.count == 4 else { return nil }
-        return (bytes[0], bytes[1], bytes[2], bytes[3])
-    }
-
-    static func _testIsLocalNetworkIPv4(_ ip: (UInt8, UInt8, UInt8, UInt8)) -> Bool {
-        let (a, b, _, _) = ip
-        if a == 10 { return true }
-        if a == 172, (16...31).contains(Int(b)) { return true }
-        if a == 192, b == 168 { return true }
-        if a == 127 { return true }
-        if a == 169, b == 254 { return true }
-        if a == 100, (64...127).contains(Int(b)) { return true }
-        return false
-    }
-
-    static func _testIsLocalNetworkCanvasURL(_ url: URL) -> Bool {
-        CanvasA2UIActionMessageHandler.isLocalNetworkCanvasURL(url)
-    }
 }
 #endif

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -50,8 +50,8 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
 
         // Bridge A2UI "a2uiaction" DOM events back into the native agent loop.
         //
-        // Keep the bridge on the trusted in-app canvas scheme only, and do not
-        // expose unattended deep-link credentials to page JavaScript.
+        // This fallback event bridge runs only on the app-owned scheme. The
+        // script-message handler separately gates hosted A2UI to its exact URL.
         canvasWindowLogger.debug("CanvasWindowController init building A2UI bridge script")
         let injectedSessionKey = sessionKey.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty ?? "main"
         let allowedSchemesJSON = (
@@ -82,7 +82,6 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
 
                 const context = Array.isArray(action?.context) ? action.context : [];
                 const userAction = {
-                  id: (globalThis.crypto?.randomUUID?.() ?? String(Date.now())),
                   name,
                   surfaceId: payload.surfaceId ?? 'main',
                   sourceComponentId: payload.sourceComponentId ?? '',
@@ -185,11 +184,11 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
         self.preferredPlacement = placement
     }
 
-    func showCanvas(path: String? = nil) {
+    func showCanvas(path: String? = nil, trustedA2UIActions: Bool = false) {
         if case let .panel(anchorProvider) = self.presentation {
             self.presentAnchoredPanel(anchorProvider: anchorProvider)
             if let path {
-                self.load(target: path)
+                self.load(target: path, trustedA2UIActions: trustedA2UIActions)
             }
             return
         }
@@ -198,7 +197,7 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
         self.window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         if let path {
-            self.load(target: path)
+            self.load(target: path, trustedA2UIActions: trustedA2UIActions)
         }
         self.onVisibilityChanged?(true)
     }
@@ -211,13 +210,18 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
         self.onVisibilityChanged?(false)
     }
 
-    func load(target: String) {
+    func load(target: String, trustedA2UIActions: Bool = false) {
         let trimmed = target.trimmingCharacters(in: .whitespacesAndNewlines)
         self.currentTarget = trimmed
+        self.a2uiActionMessageHandler?.setTrustedRemoteURL(nil)
 
         if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() {
             if scheme == "https" || scheme == "http" {
-                canvasWindowLogger.debug("canvas load url \(url.absoluteString, privacy: .public)")
+                if trustedA2UIActions {
+                    self.a2uiActionMessageHandler?.setTrustedRemoteURL(url)
+                }
+                canvasWindowLogger.debug(
+                    "canvas load web scheme=\(scheme, privacy: .public) host=\(url.host ?? "-", privacy: .public)")
                 self.webView.load(URLRequest(url: url))
                 return
             }
@@ -246,11 +250,15 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
         else {
             canvasWindowLogger
                 .error(
-                    "invalid canvas url session=\(self.sessionKey, privacy: .public) path=\(trimmed, privacy: .public)")
+                    "invalid canvas url session=\(self.sessionKey, privacy: .public)")
             return
         }
-        canvasWindowLogger.debug("canvas load canvas \(url.absoluteString, privacy: .public)")
+        canvasWindowLogger.debug("canvas load local canvas")
         self.webView.load(URLRequest(url: url))
+    }
+
+    func updateA2UITrustForMainFrameNavigation(to url: URL) {
+        self.a2uiActionMessageHandler?.updateTrustForMainFrameNavigation(to: url)
     }
 
     func updateDebugStatus(enabled: Bool, title: String?, subtitle: String?) {
@@ -304,12 +312,10 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
             ])
         }
 
-        let path: String
-        if let outPath, !outPath.isEmpty {
-            path = outPath
+        let path: String = if let outPath, !outPath.isEmpty {
+            outPath
         } else {
-            let ts = Int(Date().timeIntervalSince1970)
-            path = "/tmp/openclaw-canvas-\(CanvasWindowController.sanitizeSessionKey(self.sessionKey))-\(ts).png"
+            "/tmp/openclaw-canvas-\(CanvasWindowController.sanitizeSessionKey(self.sessionKey))-\(UUID().uuidString).png"
         }
 
         try png.write(to: URL(fileURLWithPath: path), options: [.atomic])

--- a/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController.swift
@@ -312,10 +312,11 @@ final class CanvasWindowController: NSWindowController, WKNavigationDelegate, WK
             ])
         }
 
+        let snapshotID = "\(CanvasWindowController.sanitizeSessionKey(self.sessionKey))-\(UUID().uuidString)"
         let path: String = if let outPath, !outPath.isEmpty {
             outPath
         } else {
-            "/tmp/openclaw-canvas-\(CanvasWindowController.sanitizeSessionKey(self.sessionKey))-\(UUID().uuidString).png"
+            "/tmp/openclaw-canvas-\(snapshotID).png"
         }
 
         try png.write(to: URL(fileURLWithPath: path), options: [.atomic])

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCanvasHostedSurfaceResolver.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCanvasHostedSurfaceResolver.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct MacNodeCanvasHostedSurfaceResolver: Sendable {
+    private let currentSurfaceURL: @Sendable () async -> String?
+    private let refreshSurfaceURL: @Sendable () async -> String?
+
+    init(
+        currentSurfaceURL: @escaping @Sendable () async -> String?,
+        refreshSurfaceURL: @escaping @Sendable () async -> String?)
+    {
+        self.currentSurfaceURL = currentSurfaceURL
+        self.refreshSurfaceURL = refreshSurfaceURL
+    }
+
+    func resolveA2UIURL(forceRefresh: Bool = false) async -> String? {
+        if !forceRefresh,
+           let currentSurface = await currentSurfaceURL(),
+           let current = CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: currentSurface)
+        {
+            return current
+        }
+        let refreshedSurface = await refreshSurfaceURL()
+        return CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: refreshedSurface)
+    }
+
+    func resolveTarget(_ target: String?) async throws -> CanvasHostedTarget? {
+        guard let target, CanvasHostedURLResolver.isHostedTarget(target) else { return nil }
+        if let refreshedSurface = await refreshSurfaceURL(),
+           let resolved = CanvasHostedURLResolver.resolve(surfaceURL: refreshedSurface, target: target)
+        {
+            return resolved
+        }
+        if let currentSurface = await currentSurfaceURL(),
+           let resolved = CanvasHostedURLResolver.resolve(surfaceURL: currentSurface, target: target)
+        {
+            return resolved
+        }
+        throw NSError(domain: "Canvas", code: 32, userInfo: [
+            NSLocalizedDescriptionKey: "CANVAS_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
+        ])
+    }
+}

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -22,8 +22,7 @@ actor MacNodeRuntime {
     private let browserControlEnabled: @Sendable () -> Bool
     // Injectable so tests pin the gate instead of racing on process-global UserDefaults.
     private let computerControlEnabled: @Sendable () -> Bool
-    private let canvasSurfaceUrl: @Sendable () async -> String?
-    private let refreshCanvasSurfaceUrl: @Sendable () async -> String?
+    private let canvasHostedSurfaceResolver: MacNodeCanvasHostedSurfaceResolver
     private let codexThreadCatalogEnabled: @Sendable () -> Bool
     private let codexThreadListRequest: @Sendable (String?) async throws -> String
     private let codexThreadTurnsRequest: @Sendable (String?) async throws -> String
@@ -94,8 +93,9 @@ actor MacNodeRuntime {
         self.browserProxyRequest = browserProxyRequest
         self.browserControlEnabled = browserControlEnabled
         self.computerControlEnabled = computerControlEnabled
-        self.canvasSurfaceUrl = canvasSurfaceUrl
-        self.refreshCanvasSurfaceUrl = refreshCanvasSurfaceUrl
+        self.canvasHostedSurfaceResolver = MacNodeCanvasHostedSurfaceResolver(
+            currentSurfaceURL: canvasSurfaceUrl,
+            refreshSurfaceURL: refreshCanvasSurfaceUrl)
         self.codexThreadCatalogEnabled = codexThreadCatalogEnabled
         self.codexThreadListRequest = codexThreadListRequest
         self.codexThreadTurnsRequest = codexThreadTurnsRequest
@@ -233,7 +233,7 @@ extension MacNodeRuntime {
                 OpenClawCanvasPresentParams()
             let urlTrimmed = params.url?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             let url = urlTrimmed.isEmpty ? nil : urlTrimmed
-            let hostedTarget = try await self.resolveHostedCanvasTargetWithCapabilityRefresh(url)
+            let hostedTarget = try await self.canvasHostedSurfaceResolver.resolveTarget(url)
             let effectiveURL = hostedTarget?.url.absoluteString ?? url
             let placement = params.placement.map {
                 CanvasPlacement(x: $0.x, y: $0.y, width: $0.width, height: $0.height)
@@ -255,7 +255,7 @@ extension MacNodeRuntime {
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.navigate.rawValue:
             let params = try Self.decodeParams(OpenClawCanvasNavigateParams.self, from: req.paramsJSON)
-            let hostedTarget = try await self.resolveHostedCanvasTargetWithCapabilityRefresh(params.url)
+            let hostedTarget = try await self.canvasHostedSurfaceResolver.resolveTarget(params.url)
             let effectiveURL = hostedTarget?.url.absoluteString ?? params.url
             let sessionKey = self.mainSessionKey
             try await MainActor.run {
@@ -730,7 +730,7 @@ extension MacNodeRuntime {
         if await self.isA2UIReady() {
             return
         }
-        guard let a2uiUrl = await resolveA2UIHostUrlWithCapabilityRefresh() else {
+        guard let a2uiUrl = await self.canvasHostedSurfaceResolver.resolveA2UIURL() else {
             throw NSError(domain: "Canvas", code: 30, userInfo: [
                 NSLocalizedDescriptionKey: "A2UI_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
             ])
@@ -745,7 +745,7 @@ extension MacNodeRuntime {
         if await self.isA2UIReady(poll: true) {
             return
         }
-        if let refreshedUrl = await resolveA2UIHostUrlWithCapabilityRefresh(forceRefresh: true) {
+        if let refreshedUrl = await self.canvasHostedSurfaceResolver.resolveA2UIURL(forceRefresh: true) {
             _ = try await MainActor.run {
                 try CanvasManager.shared.show(
                     sessionKey: sessionKey,
@@ -758,36 +758,6 @@ extension MacNodeRuntime {
         }
         throw NSError(domain: "Canvas", code: 31, userInfo: [
             NSLocalizedDescriptionKey: "A2UI_HOST_UNAVAILABLE: A2UI host not reachable",
-        ])
-    }
-
-    private func resolveA2UIHostUrl() async -> String? {
-        let canvasSurfaceUrl = await self.canvasSurfaceUrl()
-        return CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: canvasSurfaceUrl)
-    }
-
-    func resolveA2UIHostUrlWithCapabilityRefresh(forceRefresh: Bool = false) async -> String? {
-        if !forceRefresh, let current = await resolveA2UIHostUrl() {
-            return current
-        }
-        let refreshedCanvasSurfaceUrl = await refreshCanvasSurfaceUrl()
-        return CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: refreshedCanvasSurfaceUrl)
-    }
-
-    func resolveHostedCanvasTargetWithCapabilityRefresh(_ target: String?) async throws -> CanvasHostedTarget? {
-        guard let target, CanvasHostedURLResolver.isHostedTarget(target) else { return nil }
-        if let refreshedSurface = await refreshCanvasSurfaceUrl(),
-           let resolved = CanvasHostedURLResolver.resolve(surfaceURL: refreshedSurface, target: target)
-        {
-            return resolved
-        }
-        if let currentSurface = await canvasSurfaceUrl(),
-           let resolved = CanvasHostedURLResolver.resolve(surfaceURL: currentSurface, target: target)
-        {
-            return resolved
-        }
-        throw NSError(domain: "Canvas", code: 32, userInfo: [
-            NSLocalizedDescriptionKey: "CANVAS_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
         ])
     }
 

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -233,6 +233,8 @@ extension MacNodeRuntime {
                 OpenClawCanvasPresentParams()
             let urlTrimmed = params.url?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             let url = urlTrimmed.isEmpty ? nil : urlTrimmed
+            let hostedTarget = try await self.resolveHostedCanvasTargetWithCapabilityRefresh(url)
+            let effectiveURL = hostedTarget?.url.absoluteString ?? url
             let placement = params.placement.map {
                 CanvasPlacement(x: $0.x, y: $0.y, width: $0.width, height: $0.height)
             }
@@ -240,8 +242,9 @@ extension MacNodeRuntime {
             try await MainActor.run {
                 _ = try CanvasManager.shared.showDetailed(
                     sessionKey: sessionKey,
-                    target: url,
-                    placement: placement)
+                    target: effectiveURL,
+                    placement: placement,
+                    trustedA2UIActions: hostedTarget?.allowsA2UIActions == true)
             }
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.hide.rawValue:
@@ -252,9 +255,14 @@ extension MacNodeRuntime {
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.navigate.rawValue:
             let params = try Self.decodeParams(OpenClawCanvasNavigateParams.self, from: req.paramsJSON)
+            let hostedTarget = try await self.resolveHostedCanvasTargetWithCapabilityRefresh(params.url)
+            let effectiveURL = hostedTarget?.url.absoluteString ?? params.url
             let sessionKey = self.mainSessionKey
             try await MainActor.run {
-                _ = try CanvasManager.shared.show(sessionKey: sessionKey, path: params.url)
+                _ = try CanvasManager.shared.show(
+                    sessionKey: sessionKey,
+                    path: effectiveURL,
+                    trustedA2UIActions: hostedTarget?.allowsA2UIActions == true)
             }
             return BridgeInvokeResponse(id: req.id, ok: true)
         case OpenClawCanvasCommand.evalJS.rawValue:
@@ -729,14 +737,20 @@ extension MacNodeRuntime {
         }
         let sessionKey = self.mainSessionKey
         _ = try await MainActor.run {
-            try CanvasManager.shared.show(sessionKey: sessionKey, path: a2uiUrl)
+            try CanvasManager.shared.show(
+                sessionKey: sessionKey,
+                path: a2uiUrl,
+                trustedA2UIActions: true)
         }
         if await self.isA2UIReady(poll: true) {
             return
         }
         if let refreshedUrl = await resolveA2UIHostUrlWithCapabilityRefresh(forceRefresh: true) {
             _ = try await MainActor.run {
-                try CanvasManager.shared.show(sessionKey: sessionKey, path: refreshedUrl)
+                try CanvasManager.shared.show(
+                    sessionKey: sessionKey,
+                    path: refreshedUrl,
+                    trustedA2UIActions: true)
             }
             if await self.isA2UIReady(poll: true) {
                 return
@@ -749,14 +763,7 @@ extension MacNodeRuntime {
 
     private func resolveA2UIHostUrl() async -> String? {
         let canvasSurfaceUrl = await self.canvasSurfaceUrl()
-        return Self.resolveA2UIHostUrl(from: canvasSurfaceUrl)
-    }
-
-    private static func resolveA2UIHostUrl(from raw: String?) -> String? {
-        guard let raw else { return nil }
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, let baseUrl = URL(string: trimmed) else { return nil }
-        return baseUrl.appendingPathComponent("__openclaw__/a2ui/").absoluteString + "?platform=macos"
+        return CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: canvasSurfaceUrl)
     }
 
     func resolveA2UIHostUrlWithCapabilityRefresh(forceRefresh: Bool = false) async -> String? {
@@ -764,7 +771,24 @@ extension MacNodeRuntime {
             return current
         }
         let refreshedCanvasSurfaceUrl = await refreshCanvasSurfaceUrl()
-        return Self.resolveA2UIHostUrl(from: refreshedCanvasSurfaceUrl)
+        return CanvasHostedURLResolver.resolveA2UIURL(surfaceURL: refreshedCanvasSurfaceUrl)
+    }
+
+    func resolveHostedCanvasTargetWithCapabilityRefresh(_ target: String?) async throws -> CanvasHostedTarget? {
+        guard let target, CanvasHostedURLResolver.isHostedTarget(target) else { return nil }
+        if let refreshedSurface = await refreshCanvasSurfaceUrl(),
+           let resolved = CanvasHostedURLResolver.resolve(surfaceURL: refreshedSurface, target: target)
+        {
+            return resolved
+        }
+        if let currentSurface = await canvasSurfaceUrl(),
+           let resolved = CanvasHostedURLResolver.resolve(surfaceURL: currentSurface, target: target)
+        {
+            return resolved
+        }
+        throw NSError(domain: "Canvas", code: 32, userInfo: [
+            NSLocalizedDescriptionKey: "CANVAS_HOST_NOT_CONFIGURED: gateway did not advertise canvas host",
+        ])
     }
 
     private func isA2UIReady(poll: Bool = false) async -> Bool {

--- a/apps/macos/Tests/OpenClawIPCTests/CanvasWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CanvasWindowSmokeTests.swift
@@ -79,4 +79,65 @@ struct CanvasWindowSmokeTests {
         #expect(controller
             .shouldAutoNavigateToA2UI(lastAutoTarget: currentTarget, candidateTarget: currentTarget) == false)
     }
+
+    @Test func `hosted Canvas URL resolver keeps capability scope and only trusts A2UI`() throws {
+        let surface = "https://gateway.example/root/__openclaw__/cap/token%20value"
+        let canvas = try #require(CanvasHostedURLResolver.resolve(
+            surfaceURL: surface,
+            target: "/__openclaw__/canvas/demo%20page.html?mode=proof#result"))
+        #expect(canvas.url.absoluteString ==
+            "https://gateway.example/root/__openclaw__/cap/token%20value/__openclaw__/canvas/demo%20page.html?mode=proof#result")
+        #expect(canvas.allowsA2UIActions == false)
+
+        let a2ui = try #require(CanvasHostedURLResolver.resolve(
+            surfaceURL: surface,
+            target: "/__openclaw__/a2ui/?platform=macos"))
+        #expect(a2ui.url.absoluteString ==
+            "https://gateway.example/root/__openclaw__/cap/token%20value/__openclaw__/a2ui/?platform=macos")
+        #expect(a2ui.allowsA2UIActions)
+
+        #expect(CanvasHostedURLResolver.resolve(surfaceURL: surface, target: "/local.html") == nil)
+        #expect(CanvasHostedURLResolver.resolve(surfaceURL: surface, target: "https://example.com/") == nil)
+        #expect(CanvasHostedURLResolver.resolve(
+            surfaceURL: surface,
+            target: "/__openclaw__/a2ui/../canvas/") == nil)
+        #expect(CanvasHostedURLResolver.resolve(
+            surfaceURL: surface,
+            target: "/__openclaw__/a2ui/%252e%252e/canvas/") == nil)
+        #expect(CanvasHostedURLResolver.resolve(
+            surfaceURL: surface,
+            target: "/__openclaw__/a2ui/%25252525252e%25252525252e/canvas/") == nil)
+        #expect(CanvasHostedURLResolver.resolve(
+            surfaceURL: "https://gateway.example/not-capability-scoped",
+            target: "/__openclaw__/canvas/") == nil)
+    }
+
+    @Test func `A2UI action trust is exact and capability scoped`() throws {
+        let expected = try #require(URL(string:
+            "https://gateway.example/__openclaw__/cap/current-token/__openclaw__/a2ui/?platform=macos"))
+        let sameWithFragment = try #require(URL(string: expected.absoluteString + "#card"))
+        let staleCapability = try #require(URL(string:
+            "https://gateway.example/__openclaw__/cap/stale-token/__openclaw__/a2ui/?platform=macos"))
+        let changedQuery = try #require(URL(string:
+            "https://gateway.example/__openclaw__/cap/current-token/__openclaw__/a2ui/?platform=other"))
+        let canvasPage = try #require(URL(string:
+            "https://gateway.example/__openclaw__/cap/current-token/__openclaw__/canvas/"))
+        let traversingA2UI = try #require(URL(string:
+            "https://gateway.example/__openclaw__/cap/current-token/__openclaw__/a2ui/%2e%2e/canvas/"))
+        let localCanvas = try #require(URL(string: "openclaw-canvas://main/"))
+
+        #expect(CanvasA2UIActionMessageHandler.isTrustedSourceURL(expected, expectedRemoteURL: expected))
+        #expect(CanvasA2UIActionMessageHandler.isTrustedSourceURL(sameWithFragment, expectedRemoteURL: expected))
+        #expect(!CanvasA2UIActionMessageHandler.isTrustedSourceURL(staleCapability, expectedRemoteURL: expected))
+        #expect(!CanvasA2UIActionMessageHandler.isTrustedSourceURL(changedQuery, expectedRemoteURL: expected))
+        #expect(!CanvasA2UIActionMessageHandler.isTrustedSourceURL(canvasPage, expectedRemoteURL: expected))
+        #expect(!CanvasHostedURLResolver.isCapabilityScopedA2UIURL(traversingA2UI))
+        #expect(CanvasA2UIActionMessageHandler.isTrustedSourceURL(localCanvas, expectedRemoteURL: nil))
+
+        let handler = CanvasA2UIActionMessageHandler(sessionKey: "main")
+        handler.setTrustedRemoteURL(expected)
+        #expect(handler.isTrustedSourceURL(expected))
+        handler.updateTrustForMainFrameNavigation(to: canvasPage)
+        #expect(!handler.isTrustedSourceURL(expected))
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -431,14 +431,8 @@ struct LowCoverageHelperTests {
         UserDefaults.standard.removeObject(forKey: key)
         #expect(loaded?.size.width == rect.size.width)
 
-        let parsed = CanvasWindowController._testParseIPv4("192.168.1.2")
-        #expect(parsed != nil)
-        if let parsed {
-            #expect(CanvasWindowController._testIsLocalNetworkIPv4(parsed))
-        }
-
-        let url = try #require(URL(string: "http://192.168.1.2"))
-        #expect(CanvasWindowController._testIsLocalNetworkCanvasURL(url))
-        #expect(CanvasWindowController._testParseIPv4("not-an-ip") == nil)
+        let trusted = try #require(URL(string:
+            "http://127.0.0.1:18789/__openclaw__/cap/token/__openclaw__/a2ui/?platform=macos"))
+        #expect(CanvasA2UIActionMessageHandler.isTrustedSourceURL(trusted, expectedRemoteURL: trusted))
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -343,16 +343,16 @@ struct MacNodeRuntimeTests {
 
     @Test func `A2UI host capability refresh uses injected node session refresher`() async {
         let probe = CanvasRefreshProbe()
-        let runtime = MacNodeRuntime(
-            canvasSurfaceUrl: { "http://127.0.0.1:18789/__openclaw__/cap/current-token" },
-            refreshCanvasSurfaceUrl: { await probe.refresh() })
+        let resolver = MacNodeCanvasHostedSurfaceResolver(
+            currentSurfaceURL: { "http://127.0.0.1:18789/__openclaw__/cap/current-token" },
+            refreshSurfaceURL: { await probe.refresh() })
 
-        let current = await runtime.resolveA2UIHostUrlWithCapabilityRefresh()
+        let current = await resolver.resolveA2UIURL()
         #expect(current ==
             "http://127.0.0.1:18789/__openclaw__/cap/current-token/__openclaw__/a2ui/?platform=macos")
         #expect(await probe.calls == 0)
 
-        let refreshed = await runtime.resolveA2UIHostUrlWithCapabilityRefresh(forceRefresh: true)
+        let refreshed = await resolver.resolveA2UIURL(forceRefresh: true)
         #expect(refreshed ==
             "http://127.0.0.1:18789/__openclaw__/cap/refreshed-token/__openclaw__/a2ui/?platform=macos")
         #expect(await probe.calls == 1)
@@ -360,18 +360,18 @@ struct MacNodeRuntimeTests {
 
     @Test func `hosted Canvas commands refresh capability and preserve target components`() async throws {
         let probe = CanvasRefreshProbe()
-        let runtime = MacNodeRuntime(
-            canvasSurfaceUrl: { "http://127.0.0.1:18789/__openclaw__/cap/current-token" },
-            refreshCanvasSurfaceUrl: { await probe.refresh() })
+        let resolver = MacNodeCanvasHostedSurfaceResolver(
+            currentSurfaceURL: { "http://127.0.0.1:18789/__openclaw__/cap/current-token" },
+            refreshSurfaceURL: { await probe.refresh() })
 
-        let resolved = try await runtime.resolveHostedCanvasTargetWithCapabilityRefresh(
+        let resolved = try await resolver.resolveTarget(
             "/__openclaw__/canvas/demo%20page.html?mode=proof#result")
         #expect(resolved?.url.absoluteString ==
             "http://127.0.0.1:18789/__openclaw__/cap/refreshed-token/__openclaw__/canvas/demo%20page.html?mode=proof#result")
         #expect(resolved?.allowsA2UIActions == false)
         #expect(await probe.calls == 1)
 
-        let external = try await runtime.resolveHostedCanvasTargetWithCapabilityRefresh("https://example.com/")
+        let external = try await resolver.resolveTarget("https://example.com/")
         #expect(external == nil)
         #expect(await probe.calls == 1)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -57,7 +57,7 @@ struct MacNodeRuntimeTests {
 
         func refresh() -> String? {
             self.calls += 1
-            return "http://127.0.0.1:18789/refreshed"
+            return "http://127.0.0.1:18789/__openclaw__/cap/refreshed-token"
         }
     }
 
@@ -344,15 +344,35 @@ struct MacNodeRuntimeTests {
     @Test func `A2UI host capability refresh uses injected node session refresher`() async {
         let probe = CanvasRefreshProbe()
         let runtime = MacNodeRuntime(
-            canvasSurfaceUrl: { "http://127.0.0.1:18789/current" },
+            canvasSurfaceUrl: { "http://127.0.0.1:18789/__openclaw__/cap/current-token" },
             refreshCanvasSurfaceUrl: { await probe.refresh() })
 
         let current = await runtime.resolveA2UIHostUrlWithCapabilityRefresh()
-        #expect(current == "http://127.0.0.1:18789/current/__openclaw__/a2ui/?platform=macos")
+        #expect(current ==
+            "http://127.0.0.1:18789/__openclaw__/cap/current-token/__openclaw__/a2ui/?platform=macos")
         #expect(await probe.calls == 0)
 
         let refreshed = await runtime.resolveA2UIHostUrlWithCapabilityRefresh(forceRefresh: true)
-        #expect(refreshed == "http://127.0.0.1:18789/refreshed/__openclaw__/a2ui/?platform=macos")
+        #expect(refreshed ==
+            "http://127.0.0.1:18789/__openclaw__/cap/refreshed-token/__openclaw__/a2ui/?platform=macos")
+        #expect(await probe.calls == 1)
+    }
+
+    @Test func `hosted Canvas commands refresh capability and preserve target components`() async throws {
+        let probe = CanvasRefreshProbe()
+        let runtime = MacNodeRuntime(
+            canvasSurfaceUrl: { "http://127.0.0.1:18789/__openclaw__/cap/current-token" },
+            refreshCanvasSurfaceUrl: { await probe.refresh() })
+
+        let resolved = try await runtime.resolveHostedCanvasTargetWithCapabilityRefresh(
+            "/__openclaw__/canvas/demo%20page.html?mode=proof#result")
+        #expect(resolved?.url.absoluteString ==
+            "http://127.0.0.1:18789/__openclaw__/cap/refreshed-token/__openclaw__/canvas/demo%20page.html?mode=proof#result")
+        #expect(resolved?.allowsA2UIActions == false)
+        #expect(await probe.calls == 1)
+
+        let external = try await runtime.resolveHostedCanvasTargetWithCapabilityRefresh("https://example.com/")
+        #expect(external == nil)
         #expect(await probe.calls == 1)
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/CanvasA2UI/a2ui.bundle.js
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/CanvasA2UI/a2ui.bundle.js
@@ -12025,6 +12025,15 @@ const statusBlur = isAndroid ? "10px" : "14px";
 const postNativeMessage = (handler, payload) => {
 	Reflect.apply(handler.postMessage, handler, [payload]);
 };
+const createSecureActionId = () => {
+	const crypto = globalThis.crypto;
+	if (typeof crypto?.randomUUID === "function") return crypto.randomUUID();
+	if (typeof crypto?.getRandomValues === "function") {
+		const bytes = crypto.getRandomValues(/* @__PURE__ */ new Uint8Array(16));
+		return `a2ui_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+	}
+	return null;
+};
 const openclawTheme = {
 	components: {
 		AudioPlayer: emptyClasses(),
@@ -12326,7 +12335,7 @@ var OpenClawA2UIHost = class extends i$7 {
 		}
 	}
 	#makeActionId() {
-		return globalThis.crypto?.randomUUID?.() ?? `a2ui_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+		return createSecureActionId();
 	}
 	#setToast(text, kind = "ok", timeoutMs = 1400) {
 		const toast = {
@@ -12405,6 +12414,10 @@ var OpenClawA2UIHost = class extends i$7 {
 			}
 		}
 		const actionId = this.#makeActionId();
+		if (!actionId) {
+			this.#setToast("Secure action identifiers unavailable", "error", 4500);
+			return;
+		}
 		this.pendingAction = {
 			id: actionId,
 			name,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/WebViewJavaScriptSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/WebViewJavaScriptSupport.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import Foundation
 #if canImport(WebKit)
 import WebKit
@@ -36,13 +37,21 @@ public enum WebViewJavaScriptSupport {
                     cont.resume(throwing: error)
                     return
                 }
-                if let result {
-                    cont.resume(returning: String(describing: result))
-                } else {
-                    cont.resume(returning: "")
-                }
+                cont.resume(returning: self.evaluationResultString(result))
             }
         }
+    }
+
+    static func evaluationResultString(_ result: Any?) -> String {
+        guard let result else { return "" }
+        // WebKit bridges JavaScript booleans and numbers through NSNumber.
+        // Preserve the Boolean contract before generic numeric description.
+        if let number = result as? NSNumber,
+           CFGetTypeID(number) == CFBooleanGetTypeID()
+        {
+            return number.boolValue ? "true" : "false"
+        }
+        return String(describing: result)
     }
 
     public static func jsValue(_ value: String?) -> String {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/WebViewJavaScriptSupportTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/WebViewJavaScriptSupportTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Testing
+@testable import OpenClawKit
+
+#if canImport(WebKit)
+struct WebViewJavaScriptSupportTests {
+    @Test func `evaluation results preserve boolean and numeric scalars`() {
+        #expect(WebViewJavaScriptSupport.evaluationResultString(NSNumber(value: false)) == "false")
+        #expect(WebViewJavaScriptSupport.evaluationResultString(NSNumber(value: true)) == "true")
+        #expect(WebViewJavaScriptSupport.evaluationResultString(NSNumber(value: 0)) == "0")
+        #expect(WebViewJavaScriptSupport.evaluationResultString(NSNumber(value: 1)) == "1")
+        #expect(WebViewJavaScriptSupport.evaluationResultString(NSNumber(value: 1.5)) == "1.5")
+        #expect(WebViewJavaScriptSupport.evaluationResultString("") == "")
+        #expect(WebViewJavaScriptSupport.evaluationResultString(nil) == "")
+    }
+}
+#endif

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -474,6 +474,7 @@ Notes:
 - Mobile nodes use a bundled app-owned A2UI page for action-capable rendering.
 - Only A2UI v0.8 JSONL is supported (v0.9/createSurface is rejected).
 - iOS and Android render remote Gateway Canvas pages, but A2UI button actions are dispatched only from the bundled app-owned A2UI page. Gateway-hosted HTTP/HTTPS A2UI pages are render-only on those mobile clients.
+- macOS can dispatch actions from the exact capability-scoped Gateway A2UI page selected by the app. Other HTTP/HTTPS pages remain render-only.
 
 ## Photos + videos (node camera)
 

--- a/docs/platforms/mac/canvas.md
+++ b/docs/platforms/mac/canvas.md
@@ -44,7 +44,7 @@ snapshot image:
 
 ```bash
 openclaw nodes canvas present --node <id>
-openclaw nodes canvas navigate --node <id> --url "/"
+openclaw nodes canvas navigate --node <id> "/"
 openclaw nodes canvas eval --node <id> --js "document.title"
 openclaw nodes canvas snapshot --node <id>
 ```
@@ -52,13 +52,20 @@ openclaw nodes canvas snapshot --node <id>
 `canvas.navigate` accepts local canvas paths, `http(s)` URLs, and `file://`
 URLs. Passing `"/"` shows the local scaffold or `index.html`.
 
+Gateway-hosted targets under `/__openclaw__/canvas/` and
+`/__openclaw__/a2ui/` are resolved through the node session's current scoped
+Canvas URL. The app refreshes that short-lived capability before navigation;
+you do not need to construct or copy a capability URL yourself.
+
 ## A2UI in Canvas
 
 A2UI is hosted by the Gateway canvas host and rendered inside the Canvas
 panel. When the Gateway advertises a Canvas host, the macOS app auto-navigates
 to the A2UI host page on first open.
 
-Default A2UI host URL: `http://<gateway-host>:18789/__openclaw__/a2ui/`
+The advertised URL is capability-scoped, for example
+`http://<gateway-host>:18789/__openclaw__/cap/<token>/__openclaw__/a2ui/?platform=macos`.
+Treat it as ephemeral credentials, not a stable link.
 
 ### A2UI commands (v0.8)
 
@@ -109,6 +116,10 @@ fields; keyed links use the normal Gateway run path.
 - Canvas scheme blocks directory traversal; files must live under the session root.
 - Local Canvas content uses a custom scheme (no loopback server required).
 - External `http(s)` URLs are allowed only when explicitly navigated.
+- Ordinary web pages are render-only. Agent actions are accepted only from the
+  app-owned Canvas scheme or the exact capability-scoped Gateway A2UI document
+  selected by the app; subframes, redirects, stale capabilities, and changed
+  queries cannot dispatch actions.
 
 ## Related
 

--- a/extensions/canvas/src/cli.test.ts
+++ b/extensions/canvas/src/cli.test.ts
@@ -156,6 +156,22 @@ describe("canvas CLI", () => {
     expect(writtenFiles).toHaveLength(0);
   });
 
+  it("prints an empty canvas eval result instead of a success placeholder", async () => {
+    const program = new Command();
+    program.exitOverride();
+    const nodes = program.command("nodes");
+    const { deps, runtime } = createCanvasCliDeps();
+    vi.mocked(deps.callGatewayCli).mockResolvedValueOnce({ payload: { result: "" } });
+
+    registerNodesCanvasCommands(nodes, deps);
+    await program.parseAsync(["nodes", "canvas", "eval", `""`, "--node", "ios-node"], {
+      from: "user",
+    });
+
+    expect(runtime.log).toHaveBeenCalledWith("");
+    expect(runtime.log).not.toHaveBeenCalledWith("canvas eval ok");
+  });
+
   it.each([
     ["--max-width", "640px", "--max-width must be a positive integer."],
     ["--quality", "0.8x", "--quality must be a number."],

--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -413,7 +413,7 @@ export function registerNodesCanvasCommands(nodes: Command, deps: CanvasCliDepen
             typeof raw === "object" && raw !== null
               ? (raw as { payload?: { result?: string } }).payload
               : undefined;
-          if (payload?.result) {
+          if (typeof payload?.result === "string") {
             deps.defaultRuntime.log(payload.result);
           } else {
             const { ok } = deps.getNodesTheme();

--- a/extensions/canvas/src/host/a2ui-app/bootstrap.js
+++ b/extensions/canvas/src/host/a2ui-app/bootstrap.js
@@ -112,6 +112,18 @@ const postNativeMessage = (handler, payload) => {
   Reflect.apply(handler.postMessage, handler, [payload]);
 };
 
+const createSecureActionId = () => {
+  const crypto = globalThis.crypto;
+  if (typeof crypto?.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  if (typeof crypto?.getRandomValues === "function") {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    return `a2ui_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+  return null;
+};
+
 const openclawTheme = {
   components: {
     AudioPlayer: emptyClasses(),
@@ -382,10 +394,7 @@ class OpenClawA2UIHost extends LitElement {
   }
 
   #makeActionId() {
-    return (
-      globalThis.crypto?.randomUUID?.() ??
-      `a2ui_${Date.now()}_${Math.random().toString(16).slice(2)}`
-    );
+    return createSecureActionId();
   }
 
   #setToast(text, kind = "ok", timeoutMs = 1400) {
@@ -476,6 +485,10 @@ class OpenClawA2UIHost extends LitElement {
     }
 
     const actionId = this.#makeActionId();
+    if (!actionId) {
+      this.#setToast("Secure action identifiers unavailable", "error", 4500);
+      return;
+    }
     this.pendingAction = { id: actionId, name, phase: "sending", startedAt: Date.now() };
     this.requestUpdate();
 

--- a/extensions/canvas/src/host/a2ui-shared.ts
+++ b/extensions/canvas/src/host/a2ui-shared.ts
@@ -1,8 +1,6 @@
 /**
  * Shared A2UI/Canvas host paths and live-reload injection helpers.
  */
-import { lowercasePreservingWhitespace } from "openclaw/plugin-sdk/string-coerce-runtime";
-
 /** Hosted path prefix for bundled A2UI assets. */
 export const A2UI_PATH = "/__openclaw__/a2ui";
 
@@ -17,8 +15,126 @@ export function isA2uiPath(pathname: string): boolean {
   return pathname === A2UI_PATH || pathname.startsWith(`${A2UI_PATH}/`);
 }
 
-/** Injects Canvas bridge helpers and live-reload WebSocket code into HTML. */
-export function injectCanvasLiveReload(html: string): string {
+function findTagEnd(html: string, start: number): number | undefined {
+  let quote: '"' | "'" | undefined;
+  for (let index = start; index < html.length; index += 1) {
+    const char = html[index];
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ">") {
+      return index + 1;
+    }
+  }
+  return undefined;
+}
+
+function findRuntimeInjectionIndex(html: string): number {
+  let cursor = 0;
+  let fallback = 0;
+  while (cursor < html.length) {
+    const tagStart = html.indexOf("<", cursor);
+    if (tagStart < 0) {
+      return fallback;
+    }
+    if (html.startsWith("<!--", tagStart)) {
+      const commentEnd = html.indexOf("-->", tagStart + 4);
+      if (commentEnd < 0) {
+        return tagStart;
+      }
+      cursor = commentEnd + 3;
+      continue;
+    }
+    if (html.startsWith("<![CDATA[", tagStart)) {
+      const cdataEnd = html.indexOf("]]>", tagStart + 9);
+      if (cdataEnd < 0) {
+        return tagStart;
+      }
+      cursor = cdataEnd + 3;
+      continue;
+    }
+
+    const tagEnd = findTagEnd(html, tagStart + 1);
+    if (!tagEnd) {
+      return tagStart;
+    }
+    const content = html.slice(tagStart + 1, tagEnd - 1).trimStart();
+    if (/^!doctype(?:\s|$)/iu.test(content)) {
+      fallback = tagEnd;
+      cursor = tagEnd;
+      continue;
+    }
+    if (content.startsWith("!") || content.startsWith("?")) {
+      cursor = tagEnd;
+      continue;
+    }
+    if (content.startsWith("/")) {
+      return fallback || tagStart;
+    }
+    const tagName = /^([a-z][^\s/>]*)/iu.exec(content)?.[1]?.toLowerCase();
+    if (tagName === "html") {
+      fallback = tagEnd;
+      cursor = tagEnd;
+      continue;
+    }
+    if (tagName === "head") {
+      return tagEnd;
+    }
+    // Fragment documents and malformed prologues still need the runtime before
+    // their first authored element or script.
+    return fallback || tagStart;
+  }
+  return fallback;
+}
+
+/** Injects Canvas bridge helpers and optional live-reload code into HTML. */
+export function injectCanvasRuntime(html: string, options: { liveReload?: boolean } = {}): string {
+  const liveReloadSnippet =
+    options.liveReload === false
+      ? ""
+      : `
+  let liveReloadErrorReported = false;
+  let pageUnloading = false;
+  globalThis.addEventListener?.("pagehide", () => { pageUnloading = true; });
+  globalThis.addEventListener?.("pageshow", () => { pageUnloading = false; });
+  function reportCanvasLiveReloadError() {
+    if (liveReloadErrorReported) return;
+    liveReloadErrorReported = true;
+    try {
+      // WebSocket error objects may expose the capability-bearing URL.
+      console.error("OpenClaw canvas live reload unavailable");
+    } catch {}
+  }
+
+  try {
+    const capMatch = String(location.pathname || "").match(/\\/__openclaw__\\/cap\\/([^/]+)(?:\\/|$)/);
+    let pathCapability = "";
+    try {
+      pathCapability = capMatch?.[1] ? decodeURIComponent(capMatch[1]) : "";
+    } catch {}
+    const cap = pathCapability || new URLSearchParams(location.search).get("oc_cap");
+    const proto = location.protocol === "https:" ? "wss" : "ws";
+    const capQuery = cap ? "?oc_cap=" + encodeURIComponent(cap) : "";
+    const ws = new WebSocket(proto + "://" + location.host + ${JSON.stringify(CANVAS_WS_PATH)} + capQuery);
+    ws.onmessage = (ev) => {
+      if (String(ev.data || "") === "reload") location.reload();
+    };
+    ws.onerror = () => {
+      reportCanvasLiveReloadError();
+    };
+    ws.onclose = (ev) => {
+      if (ev.code !== 1000 && !(ev.code === 1001 && pageUnloading)) {
+        reportCanvasLiveReloadError();
+      }
+    };
+  } catch {
+    reportCanvasLiveReloadError();
+  }`;
   const snippet = `
 <script>
 (() => {
@@ -27,15 +143,13 @@ export function injectCanvasLiveReload(html: string): string {
   // - iOS: window.webkit.messageHandlers.openclawCanvasA2UIAction.postMessage(...)
   // - Android: window.openclawCanvasA2UIAction.postMessage(...)
   const handlerNames = ["openclawCanvasA2UIAction"];
-  let liveReloadErrorReported = false;
-  let pageUnloading = false;
-  globalThis.addEventListener?.("pagehide", () => { pageUnloading = true; }, { once: true });
-  function reportCanvasLiveReloadError(err) {
-    if (liveReloadErrorReported) return;
-    liveReloadErrorReported = true;
-    try {
-      console.error("OpenClaw canvas live reload unavailable:", err);
-    } catch {}
+  function createActionId() {
+    const crypto = globalThis.crypto;
+    if (typeof crypto?.randomUUID === "function") return crypto.randomUUID();
+    if (typeof crypto?.getRandomValues === "function") {
+      const bytes = crypto.getRandomValues(new Uint8Array(16));
+      return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+    }
   }
   function postToNode(payload) {
     try {
@@ -57,10 +171,10 @@ export function injectCanvasLiveReload(html: string): string {
     return false;
   }
   function sendUserAction(userAction) {
+    const baseAction = userAction && typeof userAction === "object" ? userAction : {};
     const id =
-      (userAction && typeof userAction.id === "string" && userAction.id.trim()) ||
-      (globalThis.crypto?.randomUUID?.() ?? String(Date.now()));
-    const action = { ...userAction, id };
+      (typeof baseAction.id === "string" && baseAction.id.trim()) || createActionId();
+    const action = id ? { ...baseAction, id } : { ...baseAction };
     return postToNode({ userAction: action });
   }
   globalThis.OpenClaw = globalThis.OpenClaw ?? {};
@@ -68,33 +182,11 @@ export function injectCanvasLiveReload(html: string): string {
   globalThis.OpenClaw.sendUserAction = sendUserAction;
   globalThis.openclawPostMessage = postToNode;
   globalThis.openclawSendUserAction = sendUserAction;
-
-  try {
-    const cap = new URLSearchParams(location.search).get("oc_cap");
-    const proto = location.protocol === "https:" ? "wss" : "ws";
-    const capQuery = cap ? "?oc_cap=" + encodeURIComponent(cap) : "";
-    const ws = new WebSocket(proto + "://" + location.host + ${JSON.stringify(CANVAS_WS_PATH)} + capQuery);
-    ws.onmessage = (ev) => {
-      if (String(ev.data || "") === "reload") location.reload();
-    };
-    ws.onerror = (ev) => {
-      reportCanvasLiveReloadError(ev);
-    };
-    ws.onclose = (ev) => {
-      if (ev.code !== 1000 && !(ev.code === 1001 && pageUnloading)) {
-        reportCanvasLiveReloadError(ev);
-      }
-    };
-  } catch (err) {
-    reportCanvasLiveReloadError(err);
-  }
+${liveReloadSnippet}
 })();
 </script>
 `.trim();
 
-  const idx = lowercasePreservingWhitespace(html).lastIndexOf("</body>");
-  if (idx >= 0) {
-    return `${html.slice(0, idx)}\n${snippet}\n${html.slice(idx)}`;
-  }
-  return `${html}\n${snippet}\n`;
+  const index = findRuntimeInjectionIndex(html);
+  return `${html.slice(0, index)}\n${snippet}\n${html.slice(index)}`;
 }

--- a/extensions/canvas/src/host/a2ui.ts
+++ b/extensions/canvas/src/host/a2ui.ts
@@ -7,14 +7,14 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { detectMime } from "openclaw/plugin-sdk/media-mime";
 import { lowercasePreservingWhitespace } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { A2UI_PATH, injectCanvasLiveReload, isA2uiPath } from "./a2ui-shared.js";
+import { A2UI_PATH, injectCanvasRuntime, isA2uiPath } from "./a2ui-shared.js";
 import { resolveFileWithinRoot } from "./file-resolver.js";
 
 export {
   A2UI_PATH,
   CANVAS_HOST_PATH,
   CANVAS_WS_PATH,
-  injectCanvasLiveReload,
+  injectCanvasRuntime,
   isA2uiPath,
 } from "./a2ui-shared.js";
 
@@ -86,6 +86,7 @@ async function handleA2uiHttpRequestWithRootResolver(
   req: IncomingMessage,
   res: ServerResponse,
   resolveRootReal: A2uiRootResolver,
+  options: { liveReload?: boolean },
 ): Promise<boolean> {
   const urlRaw = req.url;
   if (!urlRaw) {
@@ -139,7 +140,7 @@ async function handleA2uiHttpRequestWithRootResolver(
     if (mime === "text/html") {
       const buf = await result.handle.readFile({ encoding: "utf8" });
       res.setHeader("Content-Type", "text/html; charset=utf-8");
-      res.end(injectCanvasLiveReload(buf));
+      res.end(injectCanvasRuntime(buf, options));
       return true;
     }
 
@@ -154,11 +155,17 @@ async function handleA2uiHttpRequestWithRootResolver(
 /** Creates an HTTP handler for a specific hosted A2UI asset root. */
 export function createA2uiHttpRequestHandler(params: {
   rootDir: string;
+  liveReload?: boolean;
 }): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
   let rootRealPromise: Promise<string> | null = null;
   return async (req, res) => {
     rootRealPromise ??= fs.realpath(params.rootDir);
-    return await handleA2uiHttpRequestWithRootResolver(req, res, async () => await rootRealPromise);
+    return await handleA2uiHttpRequestWithRootResolver(
+      req,
+      res,
+      async () => await rootRealPromise,
+      { liveReload: params.liveReload },
+    );
   };
 }
 
@@ -166,6 +173,7 @@ export function createA2uiHttpRequestHandler(params: {
 export async function handleA2uiHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
+  options: { liveReload?: boolean } = {},
 ): Promise<boolean> {
-  return await handleA2uiHttpRequestWithRootResolver(req, res, resolveA2uiRootReal);
+  return await handleA2uiHttpRequestWithRootResolver(req, res, resolveA2uiRootReal, options);
 }

--- a/extensions/canvas/src/host/server.test.ts
+++ b/extensions/canvas/src/host/server.test.ts
@@ -7,17 +7,20 @@ import type { Duplex } from "node:stream";
 import vm from "node:vm";
 import { defaultRuntime } from "openclaw/plugin-sdk/runtime-env";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  A2UI_PATH,
-  CANVAS_HOST_PATH,
-  CANVAS_WS_PATH,
-  injectCanvasLiveReload,
-} from "./a2ui-shared.js";
+import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH, injectCanvasRuntime } from "./a2ui-shared.js";
 
 type MockWatcher = {
   on: (event: string, cb: (...args: unknown[]) => void) => MockWatcher;
   close: () => Promise<void>;
   __emit: (event: string, ...args: unknown[]) => void;
+};
+
+type CanvasWatchFactory = NonNullable<
+  Parameters<typeof import("./server.js").createCanvasHostHandler>[0]["watchFactory"]
+>;
+type CanvasWatchCall = {
+  root: Parameters<CanvasWatchFactory>[0];
+  options: Parameters<CanvasWatchFactory>[1];
 };
 
 type TrackingWebSocket = {
@@ -41,6 +44,7 @@ type HttpRequestHandler = (
 
 function createMockWatcherState() {
   const watchers: MockWatcher[] = [];
+  const watchCalls: CanvasWatchCall[] = [];
   const createWatcher = () => {
     const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
     const api: MockWatcher = {
@@ -62,7 +66,11 @@ function createMockWatcherState() {
   };
   return {
     watchers,
-    watchFactory: () => createWatcher(),
+    watchCalls,
+    watchFactory: ((root: CanvasWatchCall["root"], options: CanvasWatchCall["options"]) => {
+      watchCalls.push({ root, options });
+      return createWatcher();
+    }) as unknown as CanvasWatchFactory,
   };
 }
 
@@ -113,9 +121,14 @@ async function captureA2uiFixtureResponse(
   rootDir: string,
   url: string,
   method = "GET",
+  liveReload = true,
 ): Promise<CapturedResponse> {
   const { createA2uiHttpRequestHandler } = await import("./a2ui.js");
-  return await captureHttpResponse(createA2uiHttpRequestHandler({ rootDir }), url, method);
+  return await captureHttpResponse(
+    createA2uiHttpRequestHandler({ rootDir, liveReload }),
+    url,
+    method,
+  );
 }
 
 function extractInjectedScript(html: string): string {
@@ -132,9 +145,13 @@ type MockLiveReloadSocket = {
   onmessage?: (event: { data?: string }) => void;
 };
 
-function runInjectedScript(WebSocket: (this: MockLiveReloadSocket) => void) {
+function runInjectedScript(
+  WebSocket: (this: MockLiveReloadSocket, url: string) => void,
+  locationOverrides: Partial<{ pathname: string; search: string }> = {},
+) {
   const consoleError = vi.fn();
   let pagehide: (() => void) | undefined;
+  let pageshow: (() => void) | undefined;
   const runtime: Record<string, unknown> = {
     URLSearchParams,
     WebSocket,
@@ -142,14 +159,19 @@ function runInjectedScript(WebSocket: (this: MockLiveReloadSocket) => void) {
       if (event === "pagehide") {
         pagehide = listener;
       }
+      if (event === "pageshow") {
+        pageshow = listener;
+      }
     },
     console: { error: consoleError },
     encodeURIComponent,
     location: {
       host: "control.example",
       protocol: "https:",
+      pathname: "/__openclaw__/canvas/",
       reload: vi.fn(),
       search: "",
+      ...locationOverrides,
     },
   };
   runtime.window = runtime;
@@ -157,10 +179,14 @@ function runInjectedScript(WebSocket: (this: MockLiveReloadSocket) => void) {
   runtime.globalThis = runtime;
   vm.createContext(runtime);
   vm.runInContext(
-    extractInjectedScript(injectCanvasLiveReload("<html><body>Hello</body></html>")),
+    extractInjectedScript(injectCanvasRuntime("<html><body>Hello</body></html>")),
     runtime,
   );
-  return { consoleError, pagehide: () => pagehide?.() };
+  return {
+    consoleError,
+    pagehide: () => pagehide?.(),
+    pageshow: () => pageshow?.(),
+  };
 }
 
 describe("canvas host", () => {
@@ -232,12 +258,44 @@ describe("canvas host", () => {
     await fs.rm(fixtureRoot, { recursive: true, force: true });
   });
 
-  it("injects live reload script", () => {
-    const out = injectCanvasLiveReload("<html><body>Hello</body></html>");
+  it("injects the Canvas runtime before authored page scripts", () => {
+    const authoredScript = "globalThis.bridgeReadyAtStartup = typeof openclawSendUserAction";
+    const out = injectCanvasRuntime(
+      `<!doctype html><html><head><script>${authoredScript}</script></head><body>Hello</body></html>`,
+    );
     expect(out).toContain(CANVAS_WS_PATH);
     expect(out).toContain("location.reload");
     expect(out).toContain("openclawCanvasA2UIAction");
     expect(out).toContain("openclawSendUserAction");
+    expect(out).toContain("crypto?.getRandomValues");
+    expect(out).not.toContain("String(Date.now())");
+    expect(out.indexOf("globalThis.OpenClaw.postMessage")).toBeGreaterThan(out.indexOf("<head>"));
+    expect(out.indexOf("globalThis.OpenClaw.postMessage")).toBeLessThan(
+      out.indexOf(authoredScript),
+    );
+  });
+
+  it("keeps the Canvas bridge when live reload is disabled", () => {
+    const out = injectCanvasRuntime("<html><body>Hello</body></html>", { liveReload: false });
+    expect(out).toContain("openclawCanvasA2UIAction");
+    expect(out).toContain("openclawSendUserAction");
+    expect(out).not.toContain(CANVAS_WS_PATH);
+    expect(out).not.toContain("new WebSocket");
+  });
+
+  it("ignores commented tags and quoted closing brackets when injecting", () => {
+    const authoredScript = "globalThis.bridgeReadyAfterComment = typeof openclawSendUserAction";
+    const comment = "<!-- example: <head> -->";
+    const head = '<head data-note="quoted > bracket">';
+    const out = injectCanvasRuntime(
+      `${comment}\n${head}<script>${authoredScript}</script><body>Hello</body>`,
+    );
+
+    expect(out.indexOf("globalThis.OpenClaw.postMessage")).toBeGreaterThan(out.indexOf(head));
+    expect(out.indexOf("globalThis.OpenClaw.postMessage")).toBeLessThan(
+      out.indexOf(authoredScript),
+    );
+    expect(out.slice(0, out.indexOf(head))).toBe(`${comment}\n`);
   });
 
   it("reports websocket initialization errors instead of swallowing them silently", () => {
@@ -247,10 +305,7 @@ describe("canvas host", () => {
     const { consoleError } = runInjectedScript(ThrowingWebSocket);
 
     expect(consoleError).toHaveBeenCalledTimes(1);
-    expect(consoleError).toHaveBeenCalledWith(
-      "OpenClaw canvas live reload unavailable:",
-      expect.objectContaining({ message: "constructor failed" }),
-    );
+    expect(consoleError).toHaveBeenCalledWith("OpenClaw canvas live reload unavailable");
   });
 
   it("reports asynchronous websocket connection errors once", () => {
@@ -277,6 +332,36 @@ describe("canvas host", () => {
     sockets[0]?.onclose?.({ code: 1001, reason: "page closed" });
 
     expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("resets page-unload state when a persisted page is shown again", () => {
+    const sockets: MockLiveReloadSocket[] = [];
+    const { consoleError, pagehide, pageshow } = runInjectedScript(
+      function (this: MockLiveReloadSocket) {
+        sockets.push(this);
+      },
+    );
+
+    pagehide();
+    pageshow();
+    sockets[0]?.onclose?.({ code: 1001, reason: "server closed" });
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a path-scoped capability ahead of a stale query capability", () => {
+    const urls: string[] = [];
+    runInjectedScript(
+      function (this: MockLiveReloadSocket, url: string) {
+        urls.push(url);
+      },
+      {
+        pathname: "/__openclaw__/cap/current-token/__openclaw__/canvas/",
+        search: "?oc_cap=stale-token",
+      },
+    );
+
+    expect(urls).toEqual([`wss://control.example${CANVAS_WS_PATH}?oc_cap=current-token`]);
   });
 
   it("reports an abnormal close without a preceding error event", () => {
@@ -307,7 +392,7 @@ describe("canvas host", () => {
     }
   });
 
-  it("skips live reload injection when disabled", async () => {
+  it("keeps bridge injection but skips live reload when disabled", async () => {
     const dir = await createCaseDir();
     await fs.writeFile(path.join(dir, "index.html"), "<html><body>no-reload</body></html>", "utf8");
     const handler = await createTestCanvasHostHandler(dir, { liveReload: false });
@@ -316,10 +401,31 @@ describe("canvas host", () => {
       const response = await captureHandlerResponse(handler, `${CANVAS_HOST_PATH}/`);
       expect(response.status).toBe(200);
       expect(response.body).toContain("no-reload");
+      expect(response.body).toContain("openclawSendUserAction");
       expect(response.body).not.toContain(CANVAS_WS_PATH);
 
       const wsResponse = await captureHandlerResponse(handler, CANVAS_WS_PATH);
       expect(wsResponse.status).toBe(404);
+    } finally {
+      await handler.close();
+    }
+  });
+
+  it("watches Canvas content when the state directory is hidden", async () => {
+    const dir = path.join(fixtureRoot, ".openclaw", `case-${fixtureCount++}`);
+    await fs.mkdir(dir, { recursive: true });
+    const handler = await createTestCanvasHostHandler(dir);
+
+    try {
+      const call = watcherState.watchCalls.at(-1);
+      expect(call?.root).toBe(await fs.realpath(dir));
+      const ignored = call?.options?.ignored;
+      expect(ignored).toBeTypeOf("function");
+      const shouldIgnore = ignored as (candidatePath: string) => boolean;
+      expect(shouldIgnore(dir)).toBe(false);
+      expect(shouldIgnore(path.join(dir, "index.html"))).toBe(false);
+      expect(shouldIgnore(path.join(dir, ".draft.html"))).toBe(true);
+      expect(shouldIgnore(path.join(dir, "node_modules", "asset.js"))).toBe(true);
     } finally {
       await handler.close();
     }
@@ -607,6 +713,10 @@ describe("canvas host", () => {
       expect(res.status).toBe(200);
       expect(html).toContain("openclaw-a2ui-host");
       expect(html).toContain("openclawCanvasA2UIAction");
+
+      const noReloadRes = await captureA2uiFixtureResponse(a2uiRoot, `${A2UI_PATH}/`, "GET", false);
+      expect(noReloadRes.body).toContain("openclawCanvasA2UIAction");
+      expect(noReloadRes.body).not.toContain(CANVAS_WS_PATH);
 
       const bundleRes = await captureA2uiFixtureResponse(a2uiRoot, `${A2UI_PATH}/a2ui.bundle.js`);
       const js = bundleRes.body;

--- a/extensions/canvas/src/host/server.ts
+++ b/extensions/canvas/src/host/server.ts
@@ -24,7 +24,7 @@ import { type WebSocket, WebSocketServer } from "ws";
 import {
   CANVAS_HOST_PATH,
   CANVAS_WS_PATH,
-  injectCanvasLiveReload,
+  injectCanvasRuntime,
   isA2uiPath,
 } from "./a2ui-shared.js";
 import { normalizeUrlPath, resolveFileWithinRoot } from "./file-resolver.js";
@@ -101,7 +101,7 @@ function defaultIndexHTML() {
   <div class="card">
     <div class="title">
       <h1>OpenClaw Canvas</h1>
-      <div class="sub">Interactive test page (auto-reload enabled)</div>
+      <div class="sub">Interactive test page</div>
     </div>
 
     <div class="row">
@@ -267,6 +267,18 @@ function resolveDefaultWatchFactory(): ChokidarWatch {
   throw new Error("chokidar.watch unavailable");
 }
 
+function shouldIgnoreCanvasWatchPath(rootReal: string, candidatePath: string): boolean {
+  const relative = path.relative(rootReal, candidatePath);
+  if (!relative || relative === ".." || relative.startsWith(`..${path.sep}`)) {
+    return false;
+  }
+  // Chokidar evaluates ignored matchers against absolute paths. Scope the
+  // policy below the root so the default ~/.openclaw parent is still watched.
+  return relative
+    .split(/[\\/]/u)
+    .some((segment) => segment.startsWith(".") || segment === "node_modules");
+}
+
 /** Creates a Canvas static-file handler with optional live reload. */
 export async function createCanvasHostHandler(
   opts: CanvasHostHandlerOpts,
@@ -347,10 +359,7 @@ export async function createCanvasHostHandler(
           pollInterval: writePollIntervalMs,
         },
         usePolling: testMode,
-        ignored: [
-          /(^|[\\/])\../, // dotfiles
-          /(^|[\\/])node_modules([\\/]|$)/,
-        ],
+        ignored: (candidatePath) => shouldIgnoreCanvasWatchPath(rootReal, candidatePath),
       })
     : null;
   watcher?.on("all", () => scheduleReload());
@@ -453,7 +462,7 @@ export async function createCanvasHostHandler(
           res.end(html);
           return true;
         }
-        res.end(liveReload ? injectCanvasLiveReload(html) : html);
+        res.end(injectCanvasRuntime(html, { liveReload }));
         return true;
       }
 

--- a/extensions/canvas/src/http-route.ts
+++ b/extensions/canvas/src/http-route.ts
@@ -24,16 +24,21 @@ export function createCanvasHttpRouteHandler(params: {
   runtime: RuntimeEnv;
   allowInTests?: boolean;
 }): CanvasHttpRouteHandler {
+  let cachedHostConfig: ReturnType<typeof resolveCanvasHostConfig> | null = null;
+  const getHostConfig = () => {
+    cachedHostConfig ??= resolveCanvasHostConfig({
+      config: params.config,
+      pluginConfig: params.pluginConfig,
+    });
+    return cachedHostConfig;
+  };
   let hostHandlerPromise: Promise<CanvasHostHandler | null> | null = null;
   const loadHostHandler = async (): Promise<CanvasHostHandler | null> => {
     if (!isCanvasHostEnabled(params.config)) {
       return null;
     }
     hostHandlerPromise ??= (async () => {
-      const hostConfig = resolveCanvasHostConfig({
-        config: params.config,
-        pluginConfig: params.pluginConfig,
-      });
+      const hostConfig = getHostConfig();
       const handler = await createCanvasHostHandler({
         runtime: params.runtime,
         rootDir: hostConfig.root,
@@ -54,7 +59,7 @@ export function createCanvasHttpRouteHandler(params: {
       }
       const url = new URL(req.url ?? "/", "http://localhost");
       if (url.pathname === A2UI_PATH || url.pathname.startsWith(`${A2UI_PATH}/`)) {
-        return handleA2uiHttpRequest(req, res);
+        return handleA2uiHttpRequest(req, res, { liveReload: getHostConfig().liveReload });
       }
       return handler.handleHttpRequest(req, res);
     },

--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -168,6 +168,21 @@ describe("Canvas tool", () => {
     );
   });
 
+  it("preserves an empty canvas eval result", async () => {
+    mocks.callGatewayTool.mockResolvedValue({ payload: { result: "" } });
+    const tool = createCanvasTool();
+
+    const result = await tool.execute("tool-call-1", {
+      action: "eval",
+      javaScript: `""`,
+    });
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "" }],
+      details: { result: "" },
+    });
+  });
+
   it("dispatches valid A2UI v0.8 JSONL unchanged", async () => {
     const tool = createCanvasTool();
 

--- a/extensions/canvas/src/tool.ts
+++ b/extensions/canvas/src/tool.ts
@@ -159,7 +159,7 @@ export function createCanvasTool(options?: CanvasToolOptions): AnyAgentTool {
             payload?: { result?: string };
           };
           const result = raw?.payload?.result;
-          if (result) {
+          if (typeof result === "string") {
             return {
               content: [{ type: "text", text: result }],
               details: { result },

--- a/src/gateway/plugin-node-capability.test.ts
+++ b/src/gateway/plugin-node-capability.test.ts
@@ -56,6 +56,19 @@ describe("plugin node capability helpers", () => {
     });
   });
 
+  test("treats the scoped path capability as authoritative over a stale query", () => {
+    const normalized = normalizePluginNodeCapabilityScopedUrl(
+      "/__openclaw__/cap/current-token/__openclaw__/canvas/?oc_cap=stale-token",
+    );
+    expect(normalized).toEqual({
+      pathname: "/__openclaw__/canvas/",
+      capability: "current-token",
+      rewrittenUrl: "/__openclaw__/canvas/?oc_cap=current-token",
+      scopedPath: true,
+      malformedScopedPath: false,
+    });
+  });
+
   test("replaces scoped capability tokens without nesting capability prefixes", () => {
     expect(
       replacePluginNodeCapabilityInScopedHostUrl(

--- a/src/gateway/plugin-node-capability.ts
+++ b/src/gateway/plugin-node-capability.ts
@@ -192,9 +192,9 @@ export function normalizePluginNodeCapabilityScopedUrl(
         malformedScopedPath = true;
       } else {
         url.pathname = canonicalPath;
-        if (!url.searchParams.has(PLUGIN_NODE_CAPABILITY_QUERY_PARAM)) {
-          url.searchParams.set(PLUGIN_NODE_CAPABILITY_QUERY_PARAM, capabilityFromPath);
-        }
+        // The path is the minted node URL. A copied stale query must never
+        // override the capability the current scoped path authorizes.
+        url.searchParams.set(PLUGIN_NODE_CAPABILITY_QUERY_PARAM, capabilityFromPath);
         rewrittenUrl = `${url.pathname}${url.search}`;
       }
     }


### PR DESCRIPTION
Closes #91083

Supersedes #83095 and #89577. Builds on #91443 while aligning hosted URL construction with the current node-capability contract.

## What Problem This Solves

Fixes an issue where macOS users opening Gateway-hosted Canvas or A2UI pages could get a local 404 or unauthorized page because reserved hosted paths were treated as app-local Canvas paths and the advertised node capability was not refreshed.

The same audit found related Canvas regressions: authored startup scripts could run before the bridge existed, disabling live reload also removed the bridge, the default hidden state directory was excluded from file watching, stale query capabilities could override valid path capabilities, JavaScript `false` and empty-string results were lost, and hosted web content had an overly coarse action trust boundary.

## Why This Change Was Made

Reserved Gateway Canvas/A2UI targets now resolve through a freshly scoped node-session surface, while local and external targets keep their existing owners. The Canvas runtime is injected before authored content independently of live reload; the path capability is authoritative; and macOS accepts hosted agent actions only from the exact capability-scoped, main-frame A2UI document selected by the app. Secure action identifiers, scalar eval preservation, hidden-root watching, capability-safe logging, and focused docs/tests complete the same behavior boundary.

## User Impact

Gateway-hosted Canvas and A2UI views now load reliably in the macOS panel, reload when files change, expose their bridge during page startup, and return exact scalar eval results. A2UI buttons continue to trigger agents from the trusted hosted renderer, while ordinary web pages, changed queries, subframes, redirects, and navigated-away documents remain render-only.

## Evidence

- Blacksmith Testbox `amber-crayfish-8819`: 141 focused assertions passed across Canvas host/CLI/tool/plugin and Gateway capability auth; full `pnpm check:changed` passed in 8m53s, including format, all TypeScript type/lint lanes, generated A2UI/native sync, plugin SDK baseline, mac packaging/tooling tests, storage/auth/cycle guards, and docs lanes.
- macOS Swift: full app suite passed (1,193 tests / 138 suites); final focused Canvas suite passed 5/5; shared JavaScript result conversion test passed 1/1; SwiftFormat passed with zero findings.
- Signed exact-source app: packaged and verified with Developer ID Application team `FWJYW4S8P8`; hosted Canvas rendered in the real panel and produced a visually inspected PNG snapshot.
- Live Mac/Gateway matrix: present, repeated hosted navigation, early bridge, truthy/`true`/`false`/zero/empty eval, PNG snapshot, hide/restore, hidden-root reload, A2UI push/render/button/context dispatch, external rendering, and stale-query path-capability precedence all passed.
- Live security matrix: missing and stale capabilities returned 401; changed-query, subframe, committed-navigation spoof, ordinary Canvas, and external-page actions were rejected; canceled navigation retained the original trusted A2UI document.
- Independent source-blind validator: all 8 exercised user workflows passed with no failures—hosted render, startup helper, repeated navigation, exact eval results, PNG snapshot, hide/restore, A2UI render, and external render-only behavior. Its prohibited mutation/action probes were covered by the separate live security matrix above.
- Fresh structured autoreview completed twice with no actionable findings; final exact-diff confidence 0.86.
