### PR TITLE
docs(plugin-sdk): correct beta compatibility contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ Skills own workflows; root owns hard policy and routing.
 - Extension tests: `pnpm test:extensions`, `pnpm test extensions`, `pnpm test extensions/<id>`.
 - Typecheck: `tsgo` lanes only (`pnpm tsgo*`, `pnpm check:test-types`); never add `tsc --noEmit`, `typecheck`, `check:types`.
 - Formatting: `oxfmt`, not Prettier. Use repo wrappers (`pnpm format:*`, `scripts/run-oxlint.mjs`; full `pnpm lint:*` only when scope requires).
+- SDK surface gate: `pnpm plugin-sdk:surface:check`; no `plugin-sdk:surface-report` script.
 - Build before push when build output, packaging, lazy/module boundaries, dynamic imports, or published surfaces can change; agent builds default to the selected remote box unless platform-specific proof requires another remote host.
 
 ## Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@ Skills own workflows; root owns hard policy and routing.
 - GitHub Actions: resolve workflow files from `.github/workflows` or API; never infer filenames from display names.
 - zsh: quote command globs; unmatched patterns abort before the tool runs.
 - `scripts/pr` artifacts: preserve template enum values; validate before prepare.
+- `scripts/pr` subcommands require a PR number; no subcommand `--help` placeholder.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.
 - No unsolicited PR labels/retitles/rebases/fixups/landing. Comments/reviews ok only for reviewable findings, pre-merge proof, or close/duplicate reason after explicit close/sweep/landing request.
 - Maintainer decision closes the cluster: if deciding reported behavior/proposed fix is not planned, comment+close all directly associated open issues/PRs unless explicitly told to keep one open. Associated means linked PRs/issues, duplicates, companion workaround PRs, and the canonical issue for the rejected behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - **Installed plugin loading:** make native-module fallback use jiti's transform path instead of retrying the same synchronous ESM load, preventing Node 24 startup races when official plugins import SDK contract modules.
 - **QA profile channel execution:** partition mixed Crabline channel scenarios into one aggregate host suite so taxonomy-backed profile commands and evidence workflows no longer abort before execution.
 - **Plugin SDK API baseline:** cover every public entrypoint, preserve complete declaration shapes without source-line churn, and run baseline and export-surface guards from changed-file validation.
+- **Official plugin beta compatibility:** keep the exact beta.5 session-store helper imports working over SQLite through the documented deprecation window, preventing installed Codex and Feishu plugins from failing during package acceptance and upgrades. (#105287) Thanks @vincentkoc.
 - **SQLite terminal session recovery:** track physical transcript mutation time in the agent database so killed or timed-out main sessions rotate when transcript writes outlive the registry update, while preserving legacy transcript mtimes during doctor import.
 - **Gateway chat typecheck:** import chat event types from their owning protocol schema after the retired aggregate type module was removed, restoring full project typechecks.
 - **Packaged Crabbox commands:** include the lease-freshness helper imported by the published wrapper so `crabbox:*` commands do not fail with `ERR_MODULE_NOT_FOUND` in npm installs.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a44018dc9a44028bdd1c7160ee4cb82120f2f3e3ca3eeed63c4be5e2efbd08e8  plugin-sdk-api-baseline.json
-925568ac3b770c2da4603e133bd952a01c34687b5b3dc577f0c36ab52d3f79f1  plugin-sdk-api-baseline.jsonl
+c4341e07a8d52e45747e4c2ca54ea6417f197c9303456f942f3d0cbf820b4652  plugin-sdk-api-baseline.json
+d2ceb379239ee66eceb494b50fb9ab9a1d989d00c97aeb4f97c74a7fd13a49a1  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -806,15 +806,17 @@ major release. Every entry maps the old API to its canonical replacement.
   </Accordion>
 
   <Accordion title="Removed session and transcript file APIs">
-    The SQLite session/transcript flip removes plugin-facing APIs that exposed
-    active `sessions.json` stores, JSONL transcript paths, or lists of session
-    files. Runtime plugins should use session identity and SDK runtime helpers
-    instead of resolving or mutating active files.
+    The SQLite session/transcript flip removes or deprecates plugin-facing APIs
+    that exposed active `sessions.json` stores, JSONL transcript paths, or lists
+    of session files. Runtime plugins should use session identity and SDK runtime
+    helpers instead of resolving or mutating active files.
 
-    | Removed surface | Replacement |
-    | ---------------- | ----------- |
-    | `loadSessionStore(...)`, `saveSessionStore(...)`, `updateSessionStore(...)` | Gateway-owned session runtime APIs; plugin code should request session state through documented runtime/context helpers instead of reading the active store file. |
-    | `resolveSessionFilePath(...)`, `resolveSessionTranscriptPathInDir(...)`, `resolveAndPersistSessionFile(...)` | Session identity (`sessionKey`, `sessionId`, and SDK runtime target helpers) plus Gateway methods that operate on the current session. |
+    | Migrating surface | Replacement |
+    | ----------------- | ----------- |
+    | Deprecated `loadSessionStore(...)`, `updateSessionStore(...)`, and `resolveSessionStoreEntry(...)` | `getSessionEntry(...)`, `listSessionEntries(...)`, and row-level session mutations. |
+    | Deprecated `resolveSessionFilePath(...)` | Session identity (`sessionKey`, `sessionId`, and SDK runtime target helpers) plus Gateway methods that operate on the current session. |
+    | Removed `saveSessionStore(...)` | Gateway-owned session runtime APIs; plugin code should request or mutate session state through documented runtime/context helpers instead of writing the active store file. |
+    | Removed `resolveSessionTranscriptPathInDir(...)` and `resolveAndPersistSessionFile(...)` | Session identity and Gateway methods that operate on the current session. |
     | `readLatestAssistantTextFromSessionTranscript(...)` | Identity-backed transcript readers exposed by the current runtime context, or Gateway history/session methods when the plugin is outside the transcript owner path. |
     | `SessionTranscriptUpdate.sessionFile` | `SessionTranscriptUpdate.target` with `agentId`, `sessionKey`, and `sessionId`. |
     | Memory sync inputs such as `sessionFiles` | Identity-backed transcript/session sources provided by the host; do not crawl active JSONL files for live sessions. |
@@ -823,6 +825,12 @@ major release. Every entry maps the old API to its canonical replacement.
     Legacy JSONL transcript files remain valid as import, archive, export, and
     support artifacts. They are no longer the steady-state runtime contract for
     active sessions.
+
+    Official plugins released with `v2026.7.1-beta.5` imported the four
+    deprecated helpers above. `openclaw/plugin-sdk/session-store-runtime` keeps
+    that exact bridge through 2026-10-12; new plugins must use the replacements.
+    `resolveStorePath(...)` remains a supported SDK helper and is not part of
+    this deprecation.
 
     `openclaw plugins inspect --all --runtime` reports non-bundled plugins whose
     load errors or diagnostics still reference these removed file APIs. The

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -30,6 +30,7 @@ import {
   formatSqliteSessionFileMarker,
   parseSqliteSessionFileMarker,
 } from "../config/sessions/sqlite-marker.js";
+import { resolveSessionStoreEntry as resolveSessionStoreEntryFromStore } from "../config/sessions/store-entry.js";
 import { normalizeResolvedMaintenanceConfigInput } from "../config/sessions/store-maintenance.js";
 import type { ResolvedSessionMaintenanceConfigInput } from "../config/sessions/store.js";
 import type { AmbientTranscriptWatermark, SessionEntry } from "../config/sessions/types.js";
@@ -312,12 +313,12 @@ export function resolveSessionFilePath(
 }
 
 /**
- * @deprecated Use the target-aware session accessor APIs.
+ * Resolves the configured session store path.
  *
  * Beta.5 resolves a configured path with an agent id, then passes only the
  * path to loadSessionStore/updateSessionStore. Its shipped callers either
  * consume the selection synchronously or dedupe by path, so retaining the
- * latest selection preserves that bounded contract.
+ * latest selection preserves that bounded compatibility contract.
  */
 export function resolveStorePath(
   store?: string,
@@ -328,6 +329,19 @@ export function resolveStorePath(
     legacyStoreAgentIds.set(path.resolve(storePath), options.agentId);
   }
   return storePath;
+}
+
+/**
+ * @deprecated Use getSessionEntry with a storage-neutral session identity.
+ *
+ * Official plugins released with v2026.7.1-beta.5 import this whole-store
+ * lookup helper. Keep it through 2026-10-12 with the other beta.5 bridge.
+ */
+export function resolveSessionStoreEntry(params: {
+  store: Record<string, SessionEntry>;
+  sessionKey: string;
+}) {
+  return resolveSessionStoreEntryFromStore(params);
 }
 
 /** Loads one session entry by agent/session identity. */
@@ -496,7 +510,6 @@ export async function cleanupSessionLifecycleArtifacts(
   });
 }
 
-export { resolveSessionStoreEntry } from "../config/sessions/store-entry.js";
 export {
   formatSqliteSessionFileMarker,
   parseSqliteSessionFileMarker,


### PR DESCRIPTION
## What Problem This Solves

PR #105287 restored the official beta.5 session-store bridge, but its public contract metadata incorrectly deprecated supported resolveStorePath while leaving resolveSessionStoreEntry undocumented and described all bridged APIs as removed.

## Why This Change Was Made

Move the deprecation marker to the actual whole-store compatibility helper, document the exact four beta.5 imports and 2026-10-12 removal date, update the generated API baseline, and retain the contributor-facing changelog credit. The invocation note records the exact SDK surface gate after a failed guessed command.

## User Impact

Official beta.5 Codex and Feishu plugins retain the compatibility bridge landed in #105287. Plugin authors now receive accurate migration guidance: resolveStorePath remains supported, while loadSessionStore, updateSessionStore, resolveSessionFilePath, and resolveSessionStoreEntry are temporary deprecated APIs.

## Evidence

- Functionality and 113 focused tests were proven on the extracted bridge before #105287 landed.
- Full build, Plugin SDK API baseline, exact surface budget, documentation formatting, and boundary tests were green on that extraction.
- Fresh commit-scoped autoreview completed clean with no accepted or actionable findings.
- This follow-up is five files and changes only contract metadata, documentation, generated baseline, changelog credit, and the invocation note.
- Hosted CI reruns on exact head b2b6c46844990918db5165c3d04f352951c5200b.