### PR TITLE
refactor(infra): remove obsolete git testing alias

### DIFF
--- a/src/infra/git-commit.ts
+++ b/src/infra/git-commit.ts
@@ -261,4 +261,3 @@ export const resolveCommitHash = (
 export const testing = {
   clearCachedGitCommits,
 };
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes an obsolete internal `__testing` alias that duplicates the canonical
`testing` export in the git commit resolver.

## Why This Change Was Made

The alias was introduced as a compatibility re-export during the underscore
lint migration, but no repository consumer imports the old name and it is not
part of a public package barrel. Neighboring infra aliases were intentionally
excluded because active pull requests modify those modules or their required
consumer migrations.

## User Impact

No user-visible behavior changes. Runtime commit resolution and the canonical
test cache-reset hook remain unchanged.

## Evidence

- Codebase-memory import and call graph plus repository search: zero
  `__testing` consumers; the canonical `testing.clearCachedGitCommits` hook is
  used only by `git-commit.test.ts`.
- Live overlap audit: checked 2,808 open pull requests, including 144 remainder
  pages across 40 oversized PRs; none modifies `src/infra/git-commit.ts`.
- `corepack pnpm test:serial src/infra/git-commit.test.ts`
  - 14 tests passed in Testbox `tbx_01kxb1fg12s05tw4rterx0tres`.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed -- src/infra/git-commit.ts`
  - Passed in the same Testbox.
- Knip `6.8.0` production export scan after the patch reports only the canonical
  `testing` export.
- Fresh `gpt-5.6-sol` autoreview at medium reasoning: clean, confidence `0.91`.
