### PR TITLE
fix(ci): keep LTS Telegram QA model compatible

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -2035,6 +2035,7 @@ jobs:
           OPENCLAW_QA_TELEGRAM_SUT_UID: ${{ steps.create_sut.outputs.uid }}
           SUT_RUNTIME_ROOT: ${{ steps.create_sut.outputs.runtime_root }}
           SUT_UID: ${{ steps.create_sut.outputs.uid }}
+          TARGET_REF: ${{ inputs.target_ref }}
           TARGET_SHA: ${{ inputs.target_sha }}
         shell: bash
         run: |
@@ -2054,6 +2055,12 @@ jobs:
           trap terminate_sut_uid_on_exit EXIT
           trap 'exit 130' INT
           trap 'exit 143' TERM
+          qa_model="mock-openai/gpt-5.6-luna"
+          qa_alt_model="mock-openai/gpt-5.6-luna-alt"
+          if [[ "$TARGET_REF" == extended-stable/* ]]; then
+            qa_model="mock-openai/gpt-5.5"
+            qa_alt_model="mock-openai/gpt-5.5-alt"
+          fi
           {
             printf 'trusted_harness_sha=%s\n' "${{ needs.trusted_identity.outputs.workflow_sha }}"
             printf 'candidate_runtime_plugin_sha=%s\n' "$TARGET_SHA"
@@ -2075,8 +2082,8 @@ jobs:
                 --repo-root "$CANDIDATE_ROOT" \
                 --output-dir "${EVIDENCE_RELATIVE}/${output_name}" \
                 --provider-mode mock-openai \
-                --model mock-openai/gpt-5.6-luna \
-                --alt-model mock-openai/gpt-5.6-luna-alt \
+                --model "$qa_model" \
+                --alt-model "$qa_alt_model" \
                 --fast \
                 --credential-source convex \
                 --credential-role ci \

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -72,7 +72,6 @@ jobs:
           CALLER_WORKFLOW_SHA: ${{ github.workflow_sha }}
           EXPECTED_TRUSTED_WORKFLOW_SHA: ${{ inputs.expected_trusted_workflow_sha }}
           JOB_CONTEXT: ${{ toJSON(job) }}
-          TARGET_REF: ${{ inputs.target_ref }}
           TARGET_SHA: ${{ inputs.target_sha }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
@@ -2057,7 +2056,10 @@ jobs:
           trap 'exit 143' TERM
           qa_model="mock-openai/gpt-5.6-luna"
           qa_alt_model="mock-openai/gpt-5.6-luna-alt"
-          if [[ "$TARGET_REF" == extended-stable/* ]]; then
+          candidate_telegram_qa="$CANDIDATE_ROOT/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts"
+          if [[ -f "$candidate_telegram_qa" ]] &&
+            grep -Fq '"openai/gpt-5.5": {' "$candidate_telegram_qa" &&
+            ! grep -Fq '"openai/gpt-5.6-luna": {' "$candidate_telegram_qa"; then
             qa_model="mock-openai/gpt-5.5"
             qa_alt_model="mock-openai/gpt-5.5-alt"
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ Skills own workflows; root owns hard policy and routing.
 - `scripts/pr` artifacts: preserve template enum values; validate before prepare.
 - `scripts/pr` subcommands require a PR number; no subcommand `--help` placeholder.
 - `scripts/pr` review: checkout main baseline, then PR, before artifact validation.
-- `rg` patterns starting with `-`: put `--` before the pattern.
+- `rg`: options before `--`; use `--` before patterns starting with `-`.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.
 - No unsolicited PR labels/retitles/rebases/fixups/landing. Comments/reviews ok only for reviewable findings, pre-merge proof, or close/duplicate reason after explicit close/sweep/landing request.
 - Maintainer decision closes the cluster: if deciding reported behavior/proposed fix is not planned, comment+close all directly associated open issues/PRs unless explicitly told to keep one open. Associated means linked PRs/issues, duplicates, companion workaround PRs, and the canonical issue for the rejected behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,7 @@ Skills own workflows; root owns hard policy and routing.
 - zsh: quote command globs; unmatched patterns abort before the tool runs.
 - `scripts/pr` artifacts: preserve template enum values; validate before prepare.
 - `scripts/pr` subcommands require a PR number; no subcommand `--help` placeholder.
+- `rg` patterns starting with `-`: put `--` before the pattern.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.
 - No unsolicited PR labels/retitles/rebases/fixups/landing. Comments/reviews ok only for reviewable findings, pre-merge proof, or close/duplicate reason after explicit close/sweep/landing request.
 - Maintainer decision closes the cluster: if deciding reported behavior/proposed fix is not planned, comment+close all directly associated open issues/PRs unless explicitly told to keep one open. Associated means linked PRs/issues, duplicates, companion workaround PRs, and the canonical issue for the rejected behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,7 @@ Skills own workflows; root owns hard policy and routing.
 - zsh: quote command globs; unmatched patterns abort before the tool runs.
 - `scripts/pr` artifacts: preserve template enum values; validate before prepare.
 - `scripts/pr` subcommands require a PR number; no subcommand `--help` placeholder.
+- `scripts/pr` review: checkout main baseline, then PR, before artifact validation.
 - `rg` patterns starting with `-`: put `--` before the pattern.
 - Bare issue/PR URL/number: inspect live and take the efficient maintainer path; switch branches/refs when useful.
 - No unsolicited PR labels/retitles/rebases/fixups/landing. Comments/reviews ok only for reviewable findings, pre-merge proof, or close/duplicate reason after explicit close/sweep/landing request.

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -526,11 +526,12 @@ describe("release Telegram QA workflow", () => {
     expect(runStep?.env?.OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS).toBe("60000");
     expect(runStep?.env?.OPENCLAW_QA_CREDENTIAL_LEASE_TTL_MS).toBe("7200000");
     expect(runStep?.env?.OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS).toBe("60000");
-    expect(runStep?.env?.TARGET_REF).toBe("${{ inputs.target_ref }}");
     expect(runStep?.run).toContain("trap terminate_sut_uid_on_exit EXIT");
     expect(runStep?.run).toContain('"$OPENCLAW_QA_TELEGRAM_SUT_OPENCLAW_COMMAND" --terminate-uid');
     expect(runStep?.run).toContain("run_qa_attempt preflight --scenario channel-canary");
-    expect(runStep?.run).toContain('if [[ "$TARGET_REF" == extended-stable/* ]]');
+    expect(runStep?.run).toContain('candidate_telegram_qa="$CANDIDATE_ROOT/extensions/qa-lab');
+    expect(runStep?.run).toContain('grep -Fq \'"openai/gpt-5.5": {\'');
+    expect(runStep?.run).toContain('! grep -Fq \'"openai/gpt-5.6-luna": {\'');
     expect(runStep?.run).toContain('qa_model="mock-openai/gpt-5.5"');
     expect(runStep?.run).toContain('--model "$qa_model"');
     expect(runStep?.run).toContain(

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -530,8 +530,8 @@ describe("release Telegram QA workflow", () => {
     expect(runStep?.run).toContain('"$OPENCLAW_QA_TELEGRAM_SUT_OPENCLAW_COMMAND" --terminate-uid');
     expect(runStep?.run).toContain("run_qa_attempt preflight --scenario channel-canary");
     expect(runStep?.run).toContain('candidate_telegram_qa="$CANDIDATE_ROOT/extensions/qa-lab');
-    expect(runStep?.run).toContain('grep -Fq \'"openai/gpt-5.5": {\'');
-    expect(runStep?.run).toContain('! grep -Fq \'"openai/gpt-5.6-luna": {\'');
+    expect(runStep?.run).toContain("grep -Fq '\"openai/gpt-5.5\": {'");
+    expect(runStep?.run).toContain("! grep -Fq '\"openai/gpt-5.6-luna\": {'");
     expect(runStep?.run).toContain('qa_model="mock-openai/gpt-5.5"');
     expect(runStep?.run).toContain('--model "$qa_model"');
     expect(runStep?.run).toContain(

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -526,9 +526,13 @@ describe("release Telegram QA workflow", () => {
     expect(runStep?.env?.OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS).toBe("60000");
     expect(runStep?.env?.OPENCLAW_QA_CREDENTIAL_LEASE_TTL_MS).toBe("7200000");
     expect(runStep?.env?.OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS).toBe("60000");
+    expect(runStep?.env?.TARGET_REF).toBe("${{ inputs.target_ref }}");
     expect(runStep?.run).toContain("trap terminate_sut_uid_on_exit EXIT");
     expect(runStep?.run).toContain('"$OPENCLAW_QA_TELEGRAM_SUT_OPENCLAW_COMMAND" --terminate-uid');
     expect(runStep?.run).toContain("run_qa_attempt preflight --scenario channel-canary");
+    expect(runStep?.run).toContain('if [[ "$TARGET_REF" == extended-stable/* ]]');
+    expect(runStep?.run).toContain('qa_model="mock-openai/gpt-5.5"');
+    expect(runStep?.run).toContain('--model "$qa_model"');
     expect(runStep?.run).toContain(
       "Telegram channel canary failed; skipping the remaining scenarios.",
     );


### PR DESCRIPTION
## What Problem This Solves

Frozen extended-stable candidates stopped replying in the trusted Telegram release canary after the main QA harness migrated its mock model from GPT-5.5 to GPT-5.6. The exact LTS candidate timed out twice in two independent hosted runs while beta passed with the same harness.

## Why This Change Was Made

Keep current candidates on the GPT-5.6 mock model, but select the GPT-5.5 mock model for `extended-stable/*` targets that predate the migration. This fixes the trusted harness boundary without backporting unrelated GPT-5.6 product support into LTS.

## User Impact

No runtime product behavior changes. Extended-stable release validation can exercise Telegram with the mock model contract supported by the frozen candidate.

## Evidence

- Reproduced: https://github.com/openclaw/openclaw/actions/runs/29188877850
- Exact rerun: https://github.com/openclaw/openclaw/actions/runs/29191068744
- `git diff --check`
- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- Fresh autoreview: clean, correctness 0.93
