### PR TITLE
refactor(doctor): remove obsolete testing aliases

### DIFF
--- a/src/commands/doctor/shared/plugin-dependency-cleanup.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.ts
@@ -480,4 +480,3 @@ export const testing = {
   detectLegacyPluginDependencyStateIssues,
   legacyPluginDependencyStateIssueToHealthFinding,
 };
-export { testing as __testing };

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
@@ -330,6 +330,4 @@ export async function repairStaleOAuthProfileShadows(params: {
 export const testing = {
   removeStaleProfilesFromStore,
   repairStaleOAuthProfilesForAgent,
-  shouldRemoveLocalOAuthShadow,
 };
-export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Removes stale duplicate internal test exports from two doctor repair helpers. These aliases remained after tests migrated to the canonical `testing` export and now add dead API surface without serving a caller.

## Why This Change Was Made

The plugin dependency cleanup keeps its canonical test hooks and drops only the unused `__testing` alias. The stale OAuth shadow repair also drops its unused alias and removes one unconsumed member from the canonical test object while leaving the production helper private and active.

The two files have zero exact-path overlap across the current 2,810 open pull requests.

## User Impact

No user-visible behavior changes. Doctor detection and repair behavior remains unchanged; this only narrows internal test-only exports.

## Evidence

- `blacksmith testbox run --id tbx_01kxb2hcd3ebwzdgsy9n55h987 "pnpm test:serial src/commands/doctor/shared/plugin-dependency-cleanup.test.ts src/commands/doctor/shared/stale-oauth-profile-shadows.test.ts"`: 18 tests passed
- Path-scoped `pnpm check:changed` in the same Testbox: passed
- Full codebase-memory graph: 304,901 nodes / 1,260,356 edges; no `__testing` consumers
- Fresh `gpt-5.6-sol` medium autoreview: clean, no actionable findings
- `git diff --check`: passed

AI-assisted; implementation and validation were reviewed before submission. No session transcript is attached.
