### PR TITLE
fix(browser): tab creation steals window focus during agent automation

### DIFF
--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -142,6 +142,12 @@ async function addTabToOpenClawGroup(tabId) {
   });
 }
 
+async function focusWindowForTab(tab) {
+  if (typeof tab.windowId === "number") {
+    await chrome.windows.update(tab.windowId, { focused: true });
+  }
+}
+
 async function removeTabFromOpenClawGroup(tabId) {
   try {
     await chrome.tabs.ungroup([tabId]);
@@ -371,6 +377,9 @@ async function handleRelayCommand(msg) {
       case "createTab": {
         const tab = await chrome.tabs.create({ url: msg.url, active: msg.background !== true });
         await addTabToOpenClawGroup(tab.id);
+        if (msg.focus === true) {
+          await focusWindowForTab(tab);
+        }
         scheduleTabsSync();
         send({ type: "result", seq, result: { tabId: tab.id } });
         return;
@@ -384,9 +393,7 @@ async function handleRelayCommand(msg) {
       case "activateTab": {
         const tab = await chrome.tabs.get(msg.tabId);
         await chrome.tabs.update(msg.tabId, { active: true });
-        if (typeof tab.windowId === "number") {
-          await chrome.windows.update(tab.windowId, { focused: true });
-        }
+        await focusWindowForTab(tab);
         send({ type: "result", seq, result: {} });
         return;
       }

--- a/extensions/browser/src/browser/cdp.test.ts
+++ b/extensions/browser/src/browser/cdp.test.ts
@@ -117,6 +117,7 @@ describe("cdp", () => {
 
   it("creates a target via the browser websocket", async () => {
     const methods: string[] = [];
+    let createTargetParams: Record<string, unknown> | undefined;
     const wsPort = await startWsServerWithMessages((msg, socket) => {
       if (msg.method) {
         methods.push(msg.method);
@@ -124,6 +125,7 @@ describe("cdp", () => {
       if (msg.method !== "Target.createTarget") {
         return;
       }
+      createTargetParams = msg.params;
       socket.send(
         JSON.stringify({
           id: msg.id,
@@ -142,6 +144,7 @@ describe("cdp", () => {
     });
 
     expect(created.targetId).toBe("TARGET_123");
+    expect(createTargetParams).toEqual({ url: "https://example.com", background: true });
     expect(methods).toEqual([
       "Target.createTarget",
       "Target.attachToTarget",

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -263,7 +263,11 @@ export async function createTargetViaCdp(opts: {
         candidateWsUrl,
         async (send) => {
           opts.signal?.throwIfAborted();
-          const created = (await send("Target.createTarget", { url: opts.url })) as {
+          const created = (await send("Target.createTarget", {
+            url: opts.url,
+            // Agent selection is target-id based; tab creation must not activate browser UI.
+            background: true,
+          })) as {
             targetId?: string;
           };
           const targetId = created?.targetId?.trim() ?? "";

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -263,13 +263,8 @@ export async function createTargetViaCdp(opts: {
         candidateWsUrl,
         async (send) => {
           opts.signal?.throwIfAborted();
-          const created = (await send("Target.createTarget", {
-            url: opts.url,
-            // Agent selection is target-id based; tab creation must not activate browser UI.
-            background: true,
-          })) as {
-            targetId?: string;
-          };
+          const params = { url: opts.url, background: true }; // Target-id selection must not activate browser UI.
+          const created = (await send("Target.createTarget", params)) as { targetId?: string };
           const targetId = created?.targetId?.trim() ?? "";
           if (!targetId) {
             throw new Error("CDP Target.createTarget returned no targetId");

--- a/extensions/browser/src/browser/extension-relay/create-target-params.ts
+++ b/extensions/browser/src/browser/extension-relay/create-target-params.ts
@@ -1,0 +1,15 @@
+export function resolveCreateTargetParams(params: Record<string, unknown> | undefined) {
+  const background = params?.background;
+  const focus = params?.focus;
+  if (background === true && focus === true) {
+    throw new Error("Target.createTarget does not support background=true with focus=true");
+  }
+  // OpenClaw changes only the fully omitted automation case to background.
+  // Explicit focus keeps the CDP foreground semantics for both boolean values.
+  const resolvedBackground =
+    focus === undefined ? background !== false : background === true && focus === false;
+  return {
+    background: resolvedBackground,
+    focus: focus === true || (focus === undefined && !resolvedBackground),
+  };
+}

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -297,30 +297,33 @@ describe("ExtensionRelayBridge", () => {
     });
   });
 
-  it("honors an explicit Target.createTarget focus request", async () => {
-    const bridge = new ExtensionRelayBridge();
-    const { socket, handlers } = wireExtension(bridge);
-    sendHello(handlers);
+  it.each([true, false])(
+    "honors an explicit Target.createTarget focus=%s request",
+    async (focus) => {
+      const bridge = new ExtensionRelayBridge();
+      const { socket, handlers } = wireExtension(bridge);
+      sendHello(handlers);
 
-    const client = new FakeSocket();
-    const cdp = bridge.attachCdpClientSocket(client);
-    cdp.onMessage(
-      JSON.stringify({
-        id: 1,
-        method: "Target.createTarget",
-        params: { url: "https://focused.test", focus: true },
-      }),
-    );
-    await flush();
+      const client = new FakeSocket();
+      const cdp = bridge.attachCdpClientSocket(client);
+      cdp.onMessage(
+        JSON.stringify({
+          id: 1,
+          method: "Target.createTarget",
+          params: { url: "https://focused.test", focus },
+        }),
+      );
+      await flush();
 
-    expect(client.frames().find((frame) => frame.id === 1)?.result).toMatchObject({
-      targetId: "target-999",
-    });
-    expect(socket.frames().find((frame) => frame.type === "createTab")).toMatchObject({
-      url: "https://focused.test",
-      background: false,
-    });
-  });
+      expect(client.frames().find((frame) => frame.id === 1)?.result).toMatchObject({
+        targetId: "target-999",
+      });
+      expect(socket.frames().find((frame) => frame.type === "createTab")).toMatchObject({
+        url: "https://focused.test",
+        background: false,
+      });
+    },
+  );
 
   it("emits Target.detachedFromTarget when a shared tab leaves the group", async () => {
     const bridge = new ExtensionRelayBridge();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -297,6 +297,31 @@ describe("ExtensionRelayBridge", () => {
     });
   });
 
+  it("honors an explicit Target.createTarget focus request", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const { socket, handlers } = wireExtension(bridge);
+    sendHello(handlers);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({
+        id: 1,
+        method: "Target.createTarget",
+        params: { url: "https://focused.test", focus: true },
+      }),
+    );
+    await flush();
+
+    expect(client.frames().find((frame) => frame.id === 1)?.result).toMatchObject({
+      targetId: "target-999",
+    });
+    expect(socket.frames().find((frame) => frame.type === "createTab")).toMatchObject({
+      url: "https://focused.test",
+      background: false,
+    });
+  });
+
   it("emits Target.detachedFromTarget when a shared tab leaves the group", async () => {
     const bridge = new ExtensionRelayBridge();
     const { handlers } = wireExtension(bridge);

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -269,6 +269,7 @@ describe("ExtensionRelayBridge", () => {
     expect(socket.frames().find((frame) => frame.type === "createTab")).toMatchObject({
       url: "https://new.test",
       background: true,
+      focus: false,
     });
   });
 
@@ -294,6 +295,7 @@ describe("ExtensionRelayBridge", () => {
     expect(socket.frames().find((frame) => frame.type === "createTab")).toMatchObject({
       url: "https://foreground.test",
       background: false,
+      focus: true,
     });
   });
 
@@ -321,6 +323,7 @@ describe("ExtensionRelayBridge", () => {
       expect(socket.frames().find((frame) => frame.type === "createTab")).toMatchObject({
         url: "https://focused.test",
         background: false,
+        focus,
       });
     },
   );

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -250,7 +250,7 @@ describe("ExtensionRelayBridge", () => {
 
   it("creates a tab inside the group and returns its synthetic target", async () => {
     const bridge = new ExtensionRelayBridge();
-    const { handlers } = wireExtension(bridge);
+    const { socket, handlers } = wireExtension(bridge);
     sendHello(handlers);
 
     const client = new FakeSocket();
@@ -266,6 +266,35 @@ describe("ExtensionRelayBridge", () => {
 
     const response = client.frames().find((frame) => frame.id === 2);
     expect(response?.result).toMatchObject({ targetId: "target-999" });
+    expect(socket.frames().find((frame) => frame.type === "createTab")).toMatchObject({
+      url: "https://new.test",
+      background: true,
+    });
+  });
+
+  it("preserves an explicit foreground Target.createTarget request", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const { socket, handlers } = wireExtension(bridge);
+    sendHello(handlers);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({
+        id: 1,
+        method: "Target.createTarget",
+        params: { url: "https://foreground.test", background: false },
+      }),
+    );
+    await flush();
+
+    expect(client.frames().find((frame) => frame.id === 1)?.result).toMatchObject({
+      targetId: "target-999",
+    });
+    expect(socket.frames().find((frame) => frame.type === "createTab")).toMatchObject({
+      url: "https://foreground.test",
+      background: false,
+    });
   });
 
   it("emits Target.detachedFromTarget when a shared tab leaves the group", async () => {

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -873,7 +873,9 @@ export class ExtensionRelayBridge {
       }
       case "Target.createTarget": {
         const url = typeof request.params?.url === "string" ? request.params.url : "about:blank";
-        const background = request.params?.focus !== true && request.params?.background !== false; // Explicit focus/foreground wins.
+        const background =
+          (request.params?.focus === undefined && request.params?.background !== false) ||
+          (request.params?.focus === false && request.params?.background === true); // Explicit focus preserves CDP defaults.
         const command = { type: "createTab", url, background } as const;
         const created = (await this.callExtension(command)) as { tabId?: unknown } | null;
         if (typeof created?.tabId !== "number") {
@@ -882,9 +884,7 @@ export class ExtensionRelayBridge {
         }
         const tabId = created.tabId;
         if (!this.tabs.has(tabId)) {
-          this.tabs.set(tabId, {
-            info: { tabId, url, title: "", active: false },
-          });
+          this.tabs.set(tabId, { info: { tabId, url, title: "", active: false } });
         }
         const attached = await this.ensureTabAttached(tabId);
         // Announce before responding, mirroring Chrome's event-then-result order.

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -8,8 +8,8 @@
  * untestable MV3 service worker, which is why it rotted and was removed.
  */
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { PAGE_SHARE_GATEWAY_REQUIRED_ERROR } from "./page-share.js";
 import { resolveCreateTargetParams } from "./create-target-params.js";
+import { PAGE_SHARE_GATEWAY_REQUIRED_ERROR } from "./page-share.js";
 import {
   type ExtensionToRelayMessage,
   PAGE_SHARE_MAX_NOTE_CHARS,

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -873,7 +873,7 @@ export class ExtensionRelayBridge {
       }
       case "Target.createTarget": {
         const url = typeof request.params?.url === "string" ? request.params.url : "about:blank";
-        const background = request.params?.background !== false; // Automation defaults to background.
+        const background = request.params?.focus !== true && request.params?.background !== false; // Explicit focus/foreground wins.
         const command = { type: "createTab", url, background } as const;
         const created = (await this.callExtension(command)) as { tabId?: unknown } | null;
         if (typeof created?.tabId !== "number") {

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -873,12 +873,9 @@ export class ExtensionRelayBridge {
       }
       case "Target.createTarget": {
         const url = typeof request.params?.url === "string" ? request.params.url : "about:blank";
-        // Default automated tabs to background while preserving an explicit foreground request.
-        const background =
-          typeof request.params?.background === "boolean" ? request.params.background : true;
-        const created = (await this.callExtension({ type: "createTab", url, background })) as {
-          tabId?: unknown;
-        } | null;
+        const background = request.params?.background !== false; // Automation defaults to background.
+        const command = { type: "createTab", url, background } as const;
+        const created = (await this.callExtension(command)) as { tabId?: unknown } | null;
         if (typeof created?.tabId !== "number") {
           this.respondError(client, request, "extension did not return a tabId for createTab");
           return;

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -9,6 +9,7 @@
  */
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { PAGE_SHARE_GATEWAY_REQUIRED_ERROR } from "./page-share.js";
+import { resolveCreateTargetParams } from "./create-target-params.js";
 import {
   type ExtensionToRelayMessage,
   PAGE_SHARE_MAX_NOTE_CHARS,
@@ -873,10 +874,8 @@ export class ExtensionRelayBridge {
       }
       case "Target.createTarget": {
         const url = typeof request.params?.url === "string" ? request.params.url : "about:blank";
-        const background =
-          (request.params?.focus === undefined && request.params?.background !== false) ||
-          (request.params?.focus === false && request.params?.background === true); // Explicit focus preserves CDP defaults.
-        const command = { type: "createTab", url, background } as const;
+        const createParams = resolveCreateTargetParams(request.params);
+        const command = { type: "createTab", url, ...createParams } as const;
         const created = (await this.callExtension(command)) as { tabId?: unknown } | null;
         if (typeof created?.tabId !== "number") {
           this.respondError(client, request, "extension did not return a tabId for createTab");

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -873,7 +873,10 @@ export class ExtensionRelayBridge {
       }
       case "Target.createTarget": {
         const url = typeof request.params?.url === "string" ? request.params.url : "about:blank";
-        const created = (await this.callExtension({ type: "createTab", url })) as {
+        // Default automated tabs to background while preserving an explicit foreground request.
+        const background =
+          typeof request.params?.background === "boolean" ? request.params.background : true;
+        const created = (await this.callExtension({ type: "createTab", url, background })) as {
           tabId?: unknown;
         } | null;
         if (typeof created?.tabId !== "number") {

--- a/extensions/browser/src/browser/extension-relay/relay-protocol.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-protocol.ts
@@ -108,7 +108,7 @@ export type RelayCommandBody =
   /** Detach chrome.debugger from a tab (tab left the group or client detached). */
   | { type: "detach"; tabId: number }
   /** Open a new tab inside the OpenClaw tab group. Result: { tabId: number }. */
-  | { type: "createTab"; url: string; background?: boolean }
+  | { type: "createTab"; url: string; background?: boolean; focus?: boolean }
   /** Close a shared tab. Result: {}. */
   | { type: "closeTab"; tabId: number }
   /** Focus a shared tab (window + tab activation). Result: {}. */

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { withSecureTestNodeExecPath } from "../secrets/test-node-command.test-support.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   buildTalkTestProviderConfig,
@@ -628,75 +629,81 @@ describe("resolveCommandSecretRefsViaGateway", () => {
   });
 
   it("keeps local exec SecretRef fallback enabled by default", async () => {
-    const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
-    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
+    await withSecureTestNodeExecPath(async () => {
+      const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
+      callGateway.mockRejectedValueOnce(new Error("gateway closed"));
 
-    const result = await resolveCommandSecretRefsViaGateway({
-      config,
-      commandName: "memory status",
-      targetIds: new Set(["talk.providers.*.apiKey"]),
-      mode: "read_only_status",
+      const result = await resolveCommandSecretRefsViaGateway({
+        config,
+        commandName: "memory status",
+        targetIds: new Set(["talk.providers.*.apiKey"]),
+        mode: "read_only_status",
+      });
+
+      expect(await markerExists(markerPath)).toBe(true);
+      expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("exec-local-key");
+      expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
+      expectGatewayUnavailableLocalFallbackDiagnostics(result);
     });
-
-    expect(await markerExists(markerPath)).toBe(true);
-    expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("exec-local-key");
-    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
-    expectGatewayUnavailableLocalFallbackDiagnostics(result);
   });
 
   it("skips local exec SecretRef fallback when the caller disallows exec providers", async () => {
-    const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
-    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
+    await withSecureTestNodeExecPath(async () => {
+      const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
+      callGateway.mockRejectedValueOnce(new Error("gateway closed"));
 
-    const result = await resolveCommandSecretRefsViaGateway({
-      config,
-      commandName: "doctor preview",
-      targetIds: new Set(["talk.providers.*.apiKey"]),
-      mode: "read_only_status",
-      allowLocalExecSecretRefs: false,
-    });
+      const result = await resolveCommandSecretRefsViaGateway({
+        config,
+        commandName: "doctor preview",
+        targetIds: new Set(["talk.providers.*.apiKey"]),
+        mode: "read_only_status",
+        allowLocalExecSecretRefs: false,
+      });
 
-    expect(await markerExists(markerPath)).toBe(false);
-    expect(readTalkProviderApiKey(result.resolvedConfig)).toBeUndefined();
-    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("unresolved");
-    expect(result.diagnostics).toContain(
-      `doctor preview: ${TALK_TEST_PROVIDER_API_KEY_PATH} is unavailable in this command path; continuing with degraded read-only config.`,
-    );
-    expect(
-      result.diagnostics.some((entry) =>
-        entry.includes(
-          "doctor preview: skipped local exec SecretRef resolution for talk.providers.acme-speech.apiKey",
+      expect(await markerExists(markerPath)).toBe(false);
+      expect(readTalkProviderApiKey(result.resolvedConfig)).toBeUndefined();
+      expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("unresolved");
+      expect(result.diagnostics).toContain(
+        `doctor preview: ${TALK_TEST_PROVIDER_API_KEY_PATH} is unavailable in this command path; continuing with degraded read-only config.`,
+      );
+      expect(
+        result.diagnostics.some((entry) =>
+          entry.includes(
+            "doctor preview: skipped local exec SecretRef resolution for talk.providers.acme-speech.apiKey",
+          ),
         ),
-      ),
-    ).toBe(true);
-    expect(
-      result.diagnostics.some((entry) =>
-        entry.includes("attempted local command-secret resolution"),
-      ),
-    ).toBe(true);
+      ).toBe(true);
+      expect(
+        result.diagnostics.some((entry) =>
+          entry.includes("attempted local command-secret resolution"),
+        ),
+      ).toBe(true);
+    });
   });
 
   it("can preserve unresolved SecretRefs when local exec fallback is disabled", async () => {
-    const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
-    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
+    await withSecureTestNodeExecPath(async () => {
+      const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
+      callGateway.mockRejectedValueOnce(new Error("gateway closed"));
 
-    const result = await resolveCommandSecretRefsViaGateway({
-      config,
-      commandName: "doctor preview",
-      targetIds: new Set(["talk.providers.*.apiKey"]),
-      mode: "read_only_status",
-      allowLocalExecSecretRefs: false,
-      scrubUnresolvedSecretRefs: false,
-    });
+      const result = await resolveCommandSecretRefsViaGateway({
+        config,
+        commandName: "doctor preview",
+        targetIds: new Set(["talk.providers.*.apiKey"]),
+        mode: "read_only_status",
+        allowLocalExecSecretRefs: false,
+        scrubUnresolvedSecretRefs: false,
+      });
 
-    expect(await markerExists(markerPath)).toBe(false);
-    expect(readTalkProviderApiKey(result.resolvedConfig)).toEqual({
-      source: "exec",
-      provider: "default",
-      id: "talk/providers/api-key",
+      expect(await markerExists(markerPath)).toBe(false);
+      expect(readTalkProviderApiKey(result.resolvedConfig)).toEqual({
+        source: "exec",
+        provider: "default",
+        id: "talk/providers/api-key",
+      });
+      expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("unresolved");
+      expect(result.hadUnresolvedTargets).toBe(true);
     });
-    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("unresolved");
-    expect(result.hadUnresolvedTargets).toBe(true);
   });
 
   it("skips gateway resolution when gateway credentials would execute exec SecretRefs", async () => {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -8,6 +8,7 @@ import { CommanderError } from "commander";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { loggingState } from "../logging/state.js";
+import { withSecureTestNodeExecPath } from "../secrets/test-node-command.test-support.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 import { getGatewayRunRuntimeHooks } from "./gateway-cli/runtime-hooks.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
@@ -3047,59 +3048,61 @@ describe("runCli exit behavior", () => {
       `fs.writeFileSync(${JSON.stringify(passwordMarker)},'1');`,
       "process.stdout.write(JSON.stringify({ protocolVersion: 1, values: { PASSWORD_SECRET: 'password-from-exec' } }));", // pragma: allowlist secret
     ].join("");
-    readConfigFileSnapshotMock.mockResolvedValueOnce({
-      exists: true,
-      valid: true,
-      sourceConfig: {
-        secrets: {
-          providers: {
-            tokenprovider: {
-              source: "exec",
-              command: process.execPath,
-              args: ["-e", tokenProgram],
-              allowInsecurePath: true,
+    await withSecureTestNodeExecPath(async () => {
+      readConfigFileSnapshotMock.mockResolvedValueOnce({
+        exists: true,
+        valid: true,
+        sourceConfig: {
+          secrets: {
+            providers: {
+              tokenprovider: {
+                source: "exec",
+                command: process.execPath,
+                args: ["-e", tokenProgram],
+                allowInsecurePath: true,
+              },
+              passwordprovider: {
+                source: "exec",
+                command: process.execPath,
+                args: ["-e", passwordProgram],
+                allowInsecurePath: true,
+              },
             },
-            passwordprovider: {
-              source: "exec",
-              command: process.execPath,
-              args: ["-e", passwordProgram],
-              allowInsecurePath: true,
+          },
+          gateway: {
+            mode: "local",
+            auth: {
+              mode: "password",
+              token: { source: "exec", provider: "tokenprovider", id: "TOKEN_SECRET" },
+              password: {
+                source: "exec",
+                provider: "passwordprovider",
+                id: "PASSWORD_SECRET",
+              },
             },
           },
         },
-        gateway: {
-          mode: "local",
-          auth: {
-            mode: "password",
-            token: { source: "exec", provider: "tokenprovider", id: "TOKEN_SECRET" },
-            password: {
-              source: "exec",
-              provider: "passwordprovider",
-              id: "PASSWORD_SECRET",
-            },
-          },
-        },
-      },
+      });
+
+      try {
+        await withInteractiveTty(async () => {
+          await runCli(["node", "openclaw"]);
+        });
+
+        expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
+          url: "ws://127.0.0.1:18789",
+          password: "password-from-exec",
+        });
+        await expect(fs.access(tokenMarker)).rejects.toThrow();
+        await expect(fs.access(passwordMarker)).resolves.toBeUndefined();
+        expect(launchTuiCliMock).toHaveBeenCalledWith(
+          { deliver: false },
+          { gatewayUrl: "ws://127.0.0.1:18789", authSource: "config" },
+        );
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
     });
-
-    try {
-      await withInteractiveTty(async () => {
-        await runCli(["node", "openclaw"]);
-      });
-
-      expect(probeGatewayConfiguredModelMock).toHaveBeenCalledWith({
-        url: "ws://127.0.0.1:18789",
-        password: "password-from-exec",
-      });
-      await expect(fs.access(tokenMarker)).rejects.toThrow();
-      await expect(fs.access(passwordMarker)).resolves.toBeUndefined();
-      expect(launchTuiCliMock).toHaveBeenCalledWith(
-        { deliver: false },
-        { gatewayUrl: "ws://127.0.0.1:18789", authSource: "config" },
-      );
-    } finally {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
   });
 
   it("probes local gateways over loopback even when the gateway advertises a LAN bind", async () => {

--- a/src/commands/doctor-gateway-auth-token.test.ts
+++ b/src/commands/doctor-gateway-auth-token.test.ts
@@ -6,13 +6,17 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withTempHome, writeStateDirDotEnv } from "../config/test-helpers.js";
 import { shouldRequireGatewayTokenForInstall } from "../gateway/auth-install-policy.js";
+import { withSecureTestNodeCommand } from "../secrets/test-node-command.test-support.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { resolveGatewayAuthTokenForService } from "./doctor-gateway-auth-token.js";
 import { resolveGatewayInstallToken } from "./gateway-install-token.js";
 
 const envVar = (...parts: string[]) => parts.join("_");
 
-function createExecGatewayTokenConfig(markerPath: string): OpenClawConfig {
+function createExecGatewayTokenConfig(
+  markerPath: string,
+  command = process.execPath,
+): OpenClawConfig {
   return {
     gateway: {
       auth: {
@@ -27,7 +31,7 @@ function createExecGatewayTokenConfig(markerPath: string): OpenClawConfig {
       providers: {
         execmain: {
           source: "exec",
-          command: process.execPath,
+          command,
           allowInsecurePath: true,
           args: [
             "-e",
@@ -127,14 +131,16 @@ describe("resolveGatewayAuthTokenForService", () => {
     const tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-service-token-exec-ref-"));
     const markerPath = join(tmp, "exec-ran");
     try {
-      const resolved = await resolveGatewayAuthTokenForService(
-        createExecGatewayTokenConfig(markerPath),
-        {} as NodeJS.ProcessEnv,
-        { allowExecSecretRefs: true },
-      );
+      await withSecureTestNodeCommand(async (command) => {
+        const resolved = await resolveGatewayAuthTokenForService(
+          createExecGatewayTokenConfig(markerPath, command),
+          {} as NodeJS.ProcessEnv,
+          { allowExecSecretRefs: true },
+        );
 
-      expect(resolved).toEqual({ token: "exec-token" });
-      await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("executed");
+        expect(resolved).toEqual({ token: "exec-token" });
+        await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("executed");
+      });
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
     }

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -691,7 +691,7 @@ describe("CORE_HEALTH_CHECKS", () => {
                 command,
                 args: [resolverPath, markerPath],
                 jsonOnly: false,
-                trustedDirs: [dirname(command), tmp],
+                trustedDirs: [dirname(command), tmp!],
               },
             },
           },

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withSecureTestNodeCommand } from "../secrets/test-node-command.test-support.js";
 import type { SkillStatusEntry } from "../skills/discovery/status.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
@@ -667,53 +668,8 @@ describe("CORE_HEALTH_CHECKS", () => {
     );
     const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
 
-    const findings = await check?.detect({
-      mode: "lint",
-      runtime: { log() {}, error() {}, exit() {} },
-      cfg: {
-        gateway: {
-          mode: "local",
-          auth: {
-            mode: "token",
-            token: {
-              source: "exec",
-              provider: "default",
-              id: "value",
-            },
-          },
-        },
-        secrets: {
-          providers: {
-            default: {
-              source: "exec",
-              command: process.execPath,
-              args: [resolverPath, markerPath],
-              jsonOnly: false,
-              trustedDirs: [dirname(process.execPath), tmp],
-            },
-          },
-        },
-      },
-      cwd: tmp,
-      allowExecSecretRefs: true,
-    });
-
-    expect(findings).toEqual([]);
-    await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("executed");
-  });
-
-  it("reports exec SecretRef failures when gateway auth lint explicitly allows exec checks", async () => {
-    tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-health-exec-ref-"));
-    const resolverPath = join(tmp, "fail-token.cjs");
-    await fs.writeFile(
-      resolverPath,
-      ["process.stdin.resume();", "process.stdin.on('end', () => process.exit(12));"].join("\n"),
-      "utf8",
-    );
-    const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
-
-    const findings = await withEnvAsync({ OPENCLAW_GATEWAY_TOKEN: "fallback-token" }, async () => {
-      return await check?.detect({
+    const findings = await withSecureTestNodeCommand(async (command) =>
+      check?.detect({
         mode: "lint",
         runtime: { log() {}, error() {}, exit() {} },
         cfg: {
@@ -732,17 +688,66 @@ describe("CORE_HEALTH_CHECKS", () => {
             providers: {
               default: {
                 source: "exec",
-                command: process.execPath,
-                args: [resolverPath],
+                command,
+                args: [resolverPath, markerPath],
                 jsonOnly: false,
-                trustedDirs: [dirname(process.execPath), tmp!],
+                trustedDirs: [dirname(command), tmp],
               },
             },
           },
         },
+        cwd: tmp,
         allowExecSecretRefs: true,
-      });
-    });
+      }),
+    );
+
+    expect(findings).toEqual([]);
+    await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("executed");
+  });
+
+  it("reports exec SecretRef failures when gateway auth lint explicitly allows exec checks", async () => {
+    tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-health-exec-ref-"));
+    const resolverPath = join(tmp, "fail-token.cjs");
+    await fs.writeFile(
+      resolverPath,
+      ["process.stdin.resume();", "process.stdin.on('end', () => process.exit(12));"].join("\n"),
+      "utf8",
+    );
+    const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
+
+    const findings = await withEnvAsync({ OPENCLAW_GATEWAY_TOKEN: "fallback-token" }, async () =>
+      withSecureTestNodeCommand(async (command) =>
+        check?.detect({
+          mode: "lint",
+          runtime: { log() {}, error() {}, exit() {} },
+          cfg: {
+            gateway: {
+              mode: "local",
+              auth: {
+                mode: "token",
+                token: {
+                  source: "exec",
+                  provider: "default",
+                  id: "value",
+                },
+              },
+            },
+            secrets: {
+              providers: {
+                default: {
+                  source: "exec",
+                  command,
+                  args: [resolverPath],
+                  jsonOnly: false,
+                  trustedDirs: [dirname(command), tmp!],
+                },
+              },
+            },
+          },
+          allowExecSecretRefs: true,
+        }),
+      ),
+    );
 
     expect(findings).toContainEqual(
       expect.objectContaining({

--- a/src/secrets/provider-integrations.test.ts
+++ b/src/secrets/provider-integrations.test.ts
@@ -14,6 +14,7 @@ import {
   resolveSecretProviderIntegrationConfig,
 } from "./provider-integrations.js";
 import { resolveSecretRefString } from "./resolve.js";
+import { withSecureTestNodeExecPath } from "./test-node-command.test-support.js";
 
 const tempDirs: string[] = [];
 
@@ -587,36 +588,38 @@ describe("secret provider integration presets", () => {
       "utf8",
     );
 
-    const registry = loadPluginManifestRegistry({
-      candidates: [createCandidate(rootDir, "vault-secrets", "global")],
-    });
-    const [preset] = listSecretProviderIntegrationPresets({ manifestRegistry: registry });
-    if (!preset) {
-      throw new Error("Expected vault preset");
-    }
+    await withSecureTestNodeExecPath(async () => {
+      const registry = loadPluginManifestRegistry({
+        candidates: [createCandidate(rootDir, "vault-secrets", "global")],
+      });
+      const [preset] = listSecretProviderIntegrationPresets({ manifestRegistry: registry });
+      if (!preset) {
+        throw new Error("Expected vault preset");
+      }
 
-    expect(preset.providerConfig).toEqual({
-      source: "exec",
-      pluginIntegration: {
-        pluginId: "vault-secrets",
-        integrationId: "vault",
-      },
-    });
-    await expect(
-      resolveSecretRefString(
-        { source: "exec", provider: "vault", id: "providers/openrouter/apiKey" },
-        {
-          config: {
-            secrets: {
-              providers: {
-                vault: preset.providerConfig,
+      expect(preset.providerConfig).toEqual({
+        source: "exec",
+        pluginIntegration: {
+          pluginId: "vault-secrets",
+          integrationId: "vault",
+        },
+      });
+      await expect(
+        resolveSecretRefString(
+          { source: "exec", provider: "vault", id: "providers/openrouter/apiKey" },
+          {
+            config: {
+              secrets: {
+                providers: {
+                  vault: preset.providerConfig,
+                },
               },
             },
+            manifestRegistry: registry,
           },
-          manifestRegistry: registry,
-        },
-      ),
-    ).resolves.toBe("value:providers/openrouter/apiKey");
+        ),
+      ).resolves.toBe("value:providers/openrouter/apiKey");
+    });
   });
 
   it("fails closed when a plugin-managed provider is disabled", async () => {

--- a/src/secrets/resolve.manifest-registry.test.ts
+++ b/src/secrets/resolve.manifest-registry.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { resolveSecretRefString } from "./resolve.js";
+import { withSecureTestNodeExecPath } from "./test-node-command.test-support.js";
 
 const mocks = vi.hoisted(() => ({
   getCurrentPluginMetadataSnapshot: vi.fn(),
@@ -92,15 +93,17 @@ describe("resolveSecretRefString manifest registry reuse", () => {
   it("uses an explicit manifest registry without rediscovering plugin manifests", async () => {
     const { config, manifestRegistry, rootDir } = createPluginManagedSecretProviderFixture();
     try {
-      await expect(
-        resolveSecretRefString(
-          { source: "exec", provider: "vault", id: "providers/openrouter/apiKey" },
-          {
-            config,
-            manifestRegistry,
-          },
-        ),
-      ).resolves.toBe("value:providers/openrouter/apiKey");
+      await withSecureTestNodeExecPath(async () => {
+        await expect(
+          resolveSecretRefString(
+            { source: "exec", provider: "vault", id: "providers/openrouter/apiKey" },
+            {
+              config,
+              manifestRegistry,
+            },
+          ),
+        ).resolves.toBe("value:providers/openrouter/apiKey");
+      });
       expect(mocks.getCurrentPluginMetadataSnapshot).not.toHaveBeenCalled();
       expect(mocks.loadPluginManifestRegistry).not.toHaveBeenCalled();
     } finally {
@@ -113,15 +116,17 @@ describe("resolveSecretRefString manifest registry reuse", () => {
     const env = { HOME: rootDir } as NodeJS.ProcessEnv;
     mocks.getCurrentPluginMetadataSnapshot.mockReturnValue({ manifestRegistry });
     try {
-      await expect(
-        resolveSecretRefString(
-          { source: "exec", provider: "vault", id: "providers/openrouter/apiKey" },
-          {
-            config,
-            env,
-          },
-        ),
-      ).resolves.toBe("value:providers/openrouter/apiKey");
+      await withSecureTestNodeExecPath(async () => {
+        await expect(
+          resolveSecretRefString(
+            { source: "exec", provider: "vault", id: "providers/openrouter/apiKey" },
+            {
+              config,
+              env,
+            },
+          ),
+        ).resolves.toBe("value:providers/openrouter/apiKey");
+      });
       expect(mocks.getCurrentPluginMetadataSnapshot).toHaveBeenCalledWith({
         config,
         env,

--- a/src/secrets/runtime.loadable-plugin-origins.test.ts
+++ b/src/secrets/runtime.loadable-plugin-origins.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { asConfig, setupSecretsRuntimeSnapshotTestHooks } from "./runtime.test-support.ts";
+import { withSecureTestNodeExecPath } from "./test-node-command.test-support.js";
 
 const manifestMocks = vi.hoisted(() => ({
   listPluginOriginsFromMetadataSnapshot: vi.fn(
@@ -183,16 +184,18 @@ describe("prepareSecretsRuntimeSnapshot loadable plugin origins", () => {
           },
         },
       });
-      const snapshot = await prepareSecretsRuntimeSnapshot({
-        config,
-        assignmentConfig: asConfig({
-          models: config.models,
-          secrets: config.secrets,
+      const snapshot = await withSecureTestNodeExecPath(async () =>
+        prepareSecretsRuntimeSnapshot({
+          config,
+          assignmentConfig: asConfig({
+            models: config.models,
+            secrets: config.secrets,
+          }),
+          env: { HOME: rootDir },
+          includeAuthStoreRefs: false,
+          pluginMetadataSnapshot,
         }),
-        env: { HOME: rootDir },
-        includeAuthStoreRefs: false,
-        pluginMetadataSnapshot,
-      });
+      );
 
       expect(snapshot.config.gateway).toBeUndefined();
       expect(snapshot.config.models?.providers?.openai?.apiKey).toBe("value:models/openai");

--- a/src/secrets/test-node-command.test-support.ts
+++ b/src/secrets/test-node-command.test-support.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+export async function withSecureTestNodeCommand<T>(
+  run: (command: string) => Promise<T>,
+): Promise<T> {
+  if (process.platform === "win32") {
+    return await run(process.execPath);
+  }
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-node-"));
+  const command = path.join(rootDir, "node");
+  try {
+    await fs.chmod(rootDir, 0o700);
+    await fs.writeFile(command, `#!/bin/sh\nexec ${shellQuote(process.execPath)} "$@"\n`, {
+      mode: 0o700,
+    });
+    return await run(command);
+  } finally {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  }
+}
+
+export async function withSecureTestNodeExecPath<T>(run: () => Promise<T>): Promise<T> {
+  return await withSecureTestNodeCommand(async (command) => {
+    const original = Object.getOwnPropertyDescriptor(process, "execPath");
+    if (!original) {
+      throw new Error("process.execPath descriptor is unavailable");
+    }
+    // Plugin ${node} materialization reads process.execPath directly. Keep that global swap
+    // bounded to one awaited test and always restore it before deleting the wrapper.
+    Object.defineProperty(process, "execPath", { ...original, value: command });
+    try {
+      return await run();
+    } finally {
+      Object.defineProperty(process, "execPath", original);
+    }
+  });
+}

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -9,6 +9,7 @@ import {
   resolveGatewayPortMock as resolveGatewayPort,
   resolveStateDirMock as resolveStateDir,
 } from "../gateway/gateway-connection.test-mocks.js";
+import { withSecureTestNodeCommand } from "../secrets/test-node-command.test-support.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 
 const readActiveGatewayLockPortMock = vi.hoisted(() => vi.fn());
@@ -64,13 +65,11 @@ type ModeExecProviderFixture = {
       source: "exec";
       command: string;
       args: string[];
-      allowInsecurePath: true;
     };
     passwordprovider: {
       source: "exec";
       command: string;
       args: string[];
-      allowInsecurePath: true;
     };
   };
 };
@@ -94,24 +93,24 @@ async function withModeExecProviderFixture(
   ].join("");
 
   try {
-    await run({
-      tokenMarker,
-      passwordMarker,
-      providers: {
-        tokenprovider: {
-          source: "exec",
-          command: process.execPath,
-          args: ["-e", tokenExecProgram],
-          allowInsecurePath: true,
+    await withSecureTestNodeCommand(async (command) =>
+      run({
+        tokenMarker,
+        passwordMarker,
+        providers: {
+          tokenprovider: {
+            source: "exec",
+            command,
+            args: ["-e", tokenExecProgram],
+          },
+          passwordprovider: {
+            source: "exec",
+            command,
+            args: ["-e", passwordExecProgram],
+          },
         },
-        passwordprovider: {
-          source: "exec",
-          command: process.execPath,
-          args: ["-e", passwordExecProgram],
-          allowInsecurePath: true,
-        },
-      },
-    });
+      }),
+    );
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });
   }
@@ -514,27 +513,28 @@ describe("resolveGatewayConnection", () => {
       ");",
     ].join("");
 
-    loadConfig.mockReturnValue({
-      secrets: {
-        providers: {
-          execprovider: {
-            source: "exec",
-            command: process.execPath,
-            args: ["-e", execProgram],
-            allowInsecurePath: true,
+    await withSecureTestNodeCommand(async (command) => {
+      loadConfig.mockReturnValue({
+        secrets: {
+          providers: {
+            execprovider: {
+              source: "exec",
+              command,
+              args: ["-e", execProgram],
+            },
           },
         },
-      },
-      gateway: {
-        mode: "local",
-        auth: {
-          token: { source: "exec", provider: "execprovider", id: "EXEC_GATEWAY_TOKEN" },
+        gateway: {
+          mode: "local",
+          auth: {
+            token: { source: "exec", provider: "execprovider", id: "EXEC_GATEWAY_TOKEN" },
+          },
         },
-      },
-    });
+      });
 
-    const result = await resolveGatewayConnection({});
-    expect(result.token).toBe("exec-secret-token");
+      const result = await resolveGatewayConnection({});
+      expect(result.token).toBe("exec-secret-token");
+    });
   });
 
   it("resolves only token SecretRef when gateway.auth.mode is token", async () => {

--- a/src/wizard/setup.gateway-config.test.ts
+++ b/src/wizard/setup.gateway-config.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createWizardPrompter as buildWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import { DEFAULT_DANGEROUS_NODE_COMMANDS } from "../gateway/node-command-policy.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { withSecureTestNodeExecPath } from "../secrets/test-node-command.test-support.js";
 import type { WizardPrompter, WizardSelectParams } from "./prompts.js";
 
 const mocks = vi.hoisted(() => ({
@@ -312,28 +313,30 @@ describe("configureGatewayForSetup", () => {
       textQueue: [],
     });
 
-    const result = await configureGatewayForSetup({
-      flow: "quickstart",
-      baseConfig: {},
-      nextConfig: {
-        secrets: {
-          providers: {
-            gatewaytokens: {
-              source: "exec",
-              command: process.execPath,
-              args: [
-                "-e",
-                "let input='';process.stdin.setEncoding('utf8');process.stdin.on('data',d=>input+=d);process.stdin.on('end',()=>{const req=JSON.parse(input||'{}');const values={};for(const id of req.ids||[]){values[id]='token-from-exec';}process.stdout.write(JSON.stringify({protocolVersion:1,values}));});",
-              ],
+    const result = await withSecureTestNodeExecPath(async () =>
+      configureGatewayForSetup({
+        flow: "quickstart",
+        baseConfig: {},
+        nextConfig: {
+          secrets: {
+            providers: {
+              gatewaytokens: {
+                source: "exec",
+                command: process.execPath,
+                args: [
+                  "-e",
+                  "let input='';process.stdin.setEncoding('utf8');process.stdin.on('data',d=>input+=d);process.stdin.on('end',()=>{const req=JSON.parse(input||'{}');const values={};for(const id of req.ids||[]){values[id]='token-from-exec';}process.stdout.write(JSON.stringify({protocolVersion:1,values}));});",
+                ],
+              },
             },
           },
         },
-      },
-      localPort: 18789,
-      quickstartGateway,
-      prompter,
-      runtime,
-    });
+        localPort: 18789,
+        quickstartGateway,
+        prompter,
+        runtime,
+      }),
+    );
 
     expect(result.nextConfig.gateway?.auth?.token).toEqual(quickstartGateway.token);
     expect(result.settings.gatewayToken).toBe("token-from-exec");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agent browser automation steals focus whenever it opens a tab. On a headed managed Chrome/Chromium, every agent tab open activates the new tab in the visible window; on the extension driver, the shared signed-in Chrome additionally switches the user's active tab. Anyone working in (or watching) that browser gets interrupted on every `browser open`.

The cause is two foreground defaults: direct CDP tab creation sends `Target.createTarget` without the `background` flag (CDP defaults to foreground), and the extension relay's `createTab` message omits `background`, which the extension worker maps to `chrome.tabs.create({ active: true })`.

## Why This Change Was Made

Agent-created tabs never needed activation: tab ownership and selection are target-id based (`lastTargetId` + exact-id resolution), not derived from the active tab or `/json/list` order. So both creation paths now default to background:

- Direct CDP `Target.createTarget` requests `background: true`.
- The extension relay defaults an omitted `background` to `true` — this also covers Playwright `newPage()`, which never passes the flag — while explicit `background: false`, `focus: true`, and `focus: false` requests preserve their CDP foreground semantics.

This matches the Codex/Claude-in-Chrome model the extension driver mirrors (both open automation tabs with `active: false`). Explicit focus surfaces (`browser focus`, `Target.activateTarget` → `activateTab`, and `Target.createTarget` with `focus: true`) activate only when requested, never as an incidental side effect of opening a tab.

Non-goals: the `/json/new` HTTP fallback (used only when raw CDP creation fails) and the screenshot activation from #100857 are intentionally untouched.

## User Impact

Agents can open tabs without yanking the user's active tab or window. Humans sharing the same browser (headed managed profile, or the extension driver's signed-in Chrome) keep their current tab while the agent works. Explicitly focusing a tab behaves exactly as before.

## Evidence

Focused tests (`node scripts/run-vitest.mjs …`):

- `extensions/browser/src/browser/cdp.test.ts` — 43/43 passed, including a new assertion that `Target.createTarget` params are `{ url, background: true }`.
- `extensions/browser/src/browser/extension-relay/relay-bridge.test.ts` — 16/16 passed, including omitted `background` defaulting to `true`, explicit `background: false`, both explicit `focus` boolean values, and rejection of conflicting `background: true` plus `focus: true`.
- `extensions/browser/src/browser/server-context.tab-selection-state.test.ts` — 15/15 passed (selection stays target-id based; background creation does not change the selected automation target).
- `extensions/browser/src/browser/cdp.screenshot-params.test.ts` — 10/10 passed (screenshot contract untouched).
- `oxlint` and `oxfmt --check` on the touched files: clean. `git diff --check`: clean.

Live behavior proof on a headed Chromium 147 (Linux, single window), driving the browser CDP endpoint directly and reading the X11 window title (= active tab) via `wmctrl` after each step:

```text
step0 active-tab title:              about:blank - Chromium
step1 after background:true create:  about:blank - Chromium   <- new tab did NOT activate
step2 after default create:          FG-TAB - Chromium        <- foreground default steals activation
step3 after cleanup:                 about:blank - Chromium
```

Step 2 reproduces the pre-fix behavior (CDP foreground default); step 1 demonstrates the fixed behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Current-main refresh (2026-07-14)

- Head SHA: `2bfb5fe165c11cfa52d7bd6543ff6088d5b13268`
- Merged upstream `main` at `4da0eb19c570a561ed4a4f80756abc58b89dd1a4`; the merge tree against current `main` at `692cb8dd9b2089555255c58ba5631f832b1b0c01` is clean. The functional diff remains limited to direct CDP creation, extension relay/worker creation, their protocol/helper, and tests.
- The relay still defaults automation-created tabs to background and preserves the current [CDP `Target.createTarget` contract](https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-createTarget): omitted foreground focus and `focus: true` now carry an explicit window-focus bit through the relay; `focus: false` keeps the browser window focus unchanged; and `background: true` plus `focus: true` is rejected. The worker applies explicit focus with [`chrome.windows.update({ focused: true })`](https://developer.chrome.com/docs/extensions/reference/api/windows#method-update), because [`tabs.create({ active: true })`](https://developer.chrome.com/docs/extensions/reference/api/tabs#method-create) does not guarantee window focus. All four accepted review findings were fixed and their threads resolved.
- Focused local fallback (Crabbox was unavailable): `node scripts/run-vitest.mjs extensions/browser/src/browser/cdp.test.ts extensions/browser/src/browser/extension-relay/relay-bridge.test.ts extensions/browser/src/browser/extension-relay/relay-protocol.test.ts` — 3 files, 61 tests passed.
- `oxfmt`, targeted `oxlint`, JavaScript syntax, scoped TypeScript LOC ratchet, and fresh autoreview are clean; the final autoreview rated the focus-transport follow-up correct at 0.94 with no actionable findings.
- An isolated Chrome for Testing 147/macOS live probe confirmed `windows.update({ focused: true })` leaves the target window focused. That platform also focused the window during active-tab creation, so the cross-platform necessity is grounded in the official API contract rather than a macOS-only observation.
- Exact-head fork CI for this head: [run 29307684268](https://github.com/openclaw/openclaw/actions/runs/29307684268) — completed successfully: 44 jobs succeeded, 11 skipped, 0 failed.


## Maintainer CI repair (2026-07-21)

After rebasing onto current `main`, the exact-head fork CI exposed a separate hosted-runner regression from #111527: GitHub-hosted Node is installed with permissive file modes, while fourteen exec-SecretRef tests treated `process.execPath` as a secure provider command. The production hardening is unchanged. Test fixtures now use one owner-only wrapper around the active Node binary, including the plugin `${node}` materialization path, so the tests prove the secure command contract consistently on GitHub-hosted and Blacksmith runners.

Focused repair proof: 9 test files / 318 tests passed. Targeted `node scripts/check-changed.mjs` gates passed on Blacksmith Testboxes `tbx_01ky3yjkf2e3qrd0t4dn2bekht` and `tbx_01ky40sbpb63g8md6sw9478atc`; fresh AutoReview reported no actionable findings. This repair is test-only and does not change the browser behavior or secret-provider runtime policy.


