### PR TITLE
fix(sqlite): restore session files after interrupted migration

### DIFF
--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -2,7 +2,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { z } from "zod";
 import { resolveStateDir } from "../config/paths.js";
 import * as replaceFile from "../infra/replace-file.js";
 import { VERSION } from "../version.js";
@@ -46,7 +46,7 @@ export type SessionSqliteMigrationManifest = {
     jsonPath: string;
     markdownPath: string;
   };
-  manifestVersion: 1;
+  manifestVersion: 1 | 2;
   openClawVersion: string;
   restore?: {
     attemptedAt: string;
@@ -67,20 +67,114 @@ export type ActiveSessionSqliteMigrationRun = {
 
 const SESSION_SQLITE_MIGRATION_RUNS_DIR = "session-sqlite-migration-runs";
 const COMPLETED_MIGRATION_RUN_RETENTION = 50;
+const AbsolutePathSchema = z
+  .string()
+  .min(1)
+  .refine((value) => !value.includes("\0") && path.isAbsolute(value))
+  .transform((value) => path.resolve(value));
+const MigrationMoveSchema = z.object({
+  archivePath: AbsolutePathSchema,
+  kind: z.enum(["legacy-store", "transcript", "trajectory", "unreferenced-jsonl"]),
+  sessionKey: z.string().optional(),
+  sourcePath: AbsolutePathSchema,
+});
+const MigrationIssueSchema = z.object({
+  code: z.string().min(1),
+  message: z.string(),
+  sessionKey: z.string().optional(),
+});
+const RestoreConflictSchema = z.object({
+  archivePath: AbsolutePathSchema,
+  reason: z.string(),
+  sourcePath: AbsolutePathSchema,
+});
+const MigrationTargetSchema = z
+  .object({
+    agentId: z.string().min(1),
+    completedMoves: z.array(MigrationMoveSchema),
+    issues: z.array(MigrationIssueSchema),
+    plannedMoves: z.array(MigrationMoveSchema),
+    sqlitePath: AbsolutePathSchema,
+    storePath: AbsolutePathSchema,
+    validationBeforeArchive: z.enum(["not_run", "passed", "failed"]),
+  })
+  .superRefine((target, context) => {
+    const plannedMoveKeys = new Set<string>();
+    for (const move of target.plannedMoves) {
+      if (!isRestoreMoveWithinTarget(move, target)) {
+        context.addIssue({ code: "custom", message: "restore move is outside target paths" });
+      }
+      const moveKey = migrationMoveKey(move);
+      if (plannedMoveKeys.has(moveKey)) {
+        context.addIssue({ code: "custom", message: "duplicate planned restore move" });
+      }
+      plannedMoveKeys.add(moveKey);
+    }
+    const completedMoveKeys = new Set<string>();
+    for (const move of target.completedMoves) {
+      const moveKey = migrationMoveKey(move);
+      if (
+        !isRestoreMoveWithinTarget(move, target) ||
+        !plannedMoveKeys.has(moveKey) ||
+        completedMoveKeys.has(moveKey)
+      ) {
+        context.addIssue({ code: "custom", message: "invalid completed restore move" });
+      }
+      completedMoveKeys.add(moveKey);
+    }
+  });
+const MigrationManifestSchema = z
+  .object({
+    completedAt: z.string().optional(),
+    failedAt: z.string().optional(),
+    failureReports: z
+      .object({
+        jsonPath: AbsolutePathSchema,
+        markdownPath: AbsolutePathSchema,
+      })
+      .optional(),
+    manifestVersion: z.union([z.literal(1), z.literal(2)]),
+    openClawVersion: z.string().min(1),
+    restore: z
+      .object({
+        attemptedAt: z.string().min(1),
+        conflicts: z.array(RestoreConflictSchema),
+        restoredFiles: z.array(AbsolutePathSchema),
+        skippedFiles: z.array(AbsolutePathSchema),
+        status: z.enum(["restored", "partial", "conflicts", "failed", "noop"]),
+      })
+      .optional(),
+    runId: z.string().min(1),
+    startedAt: z.string().min(1),
+    targets: z.array(MigrationTargetSchema),
+  })
+  .superRefine((manifest, context) => {
+    const targetKeys = new Set<string>();
+    for (const target of manifest.targets) {
+      const targetKey = sessionSqliteMigrationTargetKey(target);
+      if (targetKeys.has(targetKey)) {
+        context.addIssue({ code: "custom", message: "duplicate migration target" });
+      }
+      targetKeys.add(targetKey);
+    }
+  });
 
 export function createSessionSqliteMigrationRun(
   env: NodeJS.ProcessEnv,
   targets: readonly SessionSqliteMigrationTargetInput[],
 ): ActiveSessionSqliteMigrationRun {
+  for (const target of targets) {
+    assertSafeMigrationTargetTopology(target);
+  }
   const runId = `session-sqlite-${Date.now()}-${randomUUID().slice(0, 8)}`;
   const manifestPath = path.join(resolveSessionSqliteMigrationRunsDir(env), `${runId}.json`);
   const manifest: SessionSqliteMigrationManifest = {
-    manifestVersion: 1,
+    manifestVersion: 2,
     openClawVersion: VERSION,
     runId,
     startedAt: new Date().toISOString(),
     targets: targets.map((target) => ({
-      ...target,
+      ...normalizeMigrationTarget(target),
       completedMoves: [],
       issues: [],
       plannedMoves: [],
@@ -175,12 +269,13 @@ function recordMigrationMoves(
   const knownMoves = new Set(targetMoves.map(migrationMoveKey));
   let changed = false;
   for (const move of moves) {
-    const key = migrationMoveKey(move);
+    const normalizedMove = normalizeMigrationMove(move);
+    const key = migrationMoveKey(normalizedMove);
     if (knownMoves.has(key)) {
       continue;
     }
     knownMoves.add(key);
-    targetMoves.push(move);
+    targetMoves.push(normalizedMove);
     changed = true;
   }
   if (changed) {
@@ -194,7 +289,7 @@ function migrationMoveKey(move: SessionSqliteMigrationMove): string {
 
 export function restoreSessionSqliteMigrationRuns(params: {
   env: NodeJS.ProcessEnv;
-  targetKeys?: ReadonlySet<string>;
+  trustedTargets: readonly SessionSqliteMigrationTargetInput[];
 }): DoctorSessionSqliteRestoreReport {
   const restoreReport: DoctorSessionSqliteRestoreReport = emptyRestoreReport();
   for (const manifestPath of listSessionSqliteMigrationManifestPaths(params.env)) {
@@ -202,7 +297,7 @@ export function restoreSessionSqliteMigrationRuns(params: {
     if (!manifest) {
       continue;
     }
-    const targetManifests = filterRestoreManifestTargets(manifest, params.targetKeys);
+    const targetManifests = filterRestoreManifestTargets(manifest, params.trustedTargets);
     if (targetManifests.length === 0) {
       continue;
     }
@@ -222,7 +317,7 @@ export function restoreSessionSqliteMigrationRuns(params: {
 
 export function restoreSessionSqliteMigrationRun(params: {
   manifestPath: string;
-  targetKeys?: ReadonlySet<string>;
+  trustedTargets: readonly SessionSqliteMigrationTargetInput[];
 }): DoctorSessionSqliteRestoreReport {
   const restoreReport: DoctorSessionSqliteRestoreReport = {
     ...emptyRestoreReport(),
@@ -237,29 +332,50 @@ export function restoreSessionSqliteMigrationRun(params: {
     });
     return restoreReport;
   }
-  restoreSessionSqliteMigrationManifest(
-    manifest,
-    filterRestoreManifestTargets(manifest, params.targetKeys),
-    restoreReport,
-  );
+  const targetManifests = filterRestoreManifestTargets(manifest, params.trustedTargets);
+  if (targetManifests.length === 0) {
+    restoreReport.conflicts.push({
+      archivePath: params.manifestPath,
+      reason: "manifest does not match a trusted session target",
+      sourcePath: params.manifestPath,
+    });
+    return restoreReport;
+  }
+  restoreSessionSqliteMigrationManifest(manifest, targetManifests, restoreReport);
   writeSessionSqliteMigrationManifest({ manifest, manifestPath: params.manifestPath });
   return restoreReport;
 }
 
 export function findLatestFailedSessionSqliteMigrationManifest(
   env: NodeJS.ProcessEnv,
-  targetKeys?: ReadonlySet<string>,
-): { manifest: SessionSqliteMigrationManifest; manifestPath: string } | undefined {
+  trustedTargets: readonly SessionSqliteMigrationTargetInput[],
+):
+  | {
+      manifest: SessionSqliteMigrationManifest;
+      manifestPath: string;
+      targets: SessionSqliteMigrationTargetManifest[];
+    }
+  | undefined {
   return listSessionSqliteMigrationManifestPaths(env)
-    .map((manifestPath) => ({
-      manifest: readSessionSqliteMigrationManifest(manifestPath),
-      manifestPath,
-    }))
+    .map((manifestPath) => {
+      const manifest = readSessionSqliteMigrationManifest(manifestPath);
+      return {
+        manifest,
+        manifestPath,
+        targets: manifest ? filterRestoreManifestTargets(manifest, trustedTargets) : [],
+      };
+    })
     .filter(
-      (item): item is { manifest: SessionSqliteMigrationManifest; manifestPath: string } =>
+      (
+        item,
+      ): item is {
+        manifest: SessionSqliteMigrationManifest;
+        manifestPath: string;
+        targets: SessionSqliteMigrationTargetManifest[];
+      } =>
         item.manifest !== undefined &&
         isFailedSessionSqliteMigrationManifest(item.manifest) &&
-        filterRestoreManifestTargets(item.manifest, targetKeys).length > 0,
+        item.targets.length > 0,
     )
     .toSorted(
       (left, right) => manifestSortTime(right.manifest) - manifestSortTime(left.manifest),
@@ -307,7 +423,7 @@ export function writeSessionSqliteMigrationFailureReports(
 
 export function createSessionSqliteMigrationFailureIssue(
   manifestPath: string,
-  targetKeys?: ReadonlySet<string>,
+  trustedTargets?: readonly SessionSqliteMigrationTargetInput[],
 ): SessionSqliteMigrationFailureIssue | undefined {
   const manifest = readSessionSqliteMigrationManifest(manifestPath);
   if (!manifest) {
@@ -315,7 +431,9 @@ export function createSessionSqliteMigrationFailureIssue(
   }
   const title = `Session SQLite migration recovery report (${manifest.runId})`;
   const bodyPath = manifest.failureReports?.markdownPath;
-  const targets = filterRestoreManifestTargets(manifest, targetKeys);
+  const targets = trustedTargets
+    ? filterRestoreManifestTargets(manifest, trustedTargets)
+    : manifest.targets;
   const reportBody = renderFailureMarkdown({
     generatedAt: new Date().toISOString(),
     manifestPath: sanitizeFailureReportText(shortenFailureReportPath(manifestPath)),
@@ -356,7 +474,7 @@ export function sessionSqliteMigrationTargetKey(target: {
   agentId: string;
   storePath: string;
 }): string {
-  return `${target.agentId}\u0000${path.resolve(target.storePath)}`;
+  return `${target.agentId}\u0000${canonicalMigrationFilePath(target.storePath)}`;
 }
 
 function findMigrationManifestTarget(
@@ -416,7 +534,33 @@ function restoreMigrationMove(
   const sourceExists = fs.existsSync(move.sourcePath);
   const archiveExists = fs.existsSync(move.archivePath);
   if (!sourceExists && archiveExists) {
-    fs.mkdirSync(path.dirname(move.sourcePath), { recursive: true, mode: 0o700 });
+    if (!isRegularFileWithoutFollowingSymlinks(move.archivePath)) {
+      restoreReport.conflicts.push({
+        archivePath: move.archivePath,
+        reason: "archive is not a regular file; refusing restore",
+        sourcePath: move.sourcePath,
+      });
+      return;
+    }
+    const sourceDir = path.dirname(move.sourcePath);
+    const archiveDir = path.dirname(move.archivePath);
+    if (hasSymbolicLinkInDirectoryPath(sourceDir) || hasSymbolicLinkInDirectoryPath(archiveDir)) {
+      restoreReport.conflicts.push({
+        archivePath: move.archivePath,
+        reason: "source or archive parent is a symbolic link; refusing restore",
+        sourcePath: move.sourcePath,
+      });
+      return;
+    }
+    fs.mkdirSync(sourceDir, { recursive: true, mode: 0o700 });
+    if (hasSymbolicLinkInDirectoryPath(sourceDir) || hasSymbolicLinkInDirectoryPath(archiveDir)) {
+      restoreReport.conflicts.push({
+        archivePath: move.archivePath,
+        reason: "source or archive parent is a symbolic link; refusing restore",
+        sourcePath: move.sourcePath,
+      });
+      return;
+    }
     fs.renameSync(move.archivePath, move.sourcePath);
     restoreReport.restoredFiles.push(move.sourcePath);
     return;
@@ -440,6 +584,56 @@ function restoreMigrationMove(
   });
 }
 
+export function assertSafeSessionSqliteMigrationMove(
+  move: SessionSqliteMigrationMove,
+  target: SessionSqliteMigrationTargetInput,
+): void {
+  if (!isRestoreMoveWithinTarget(move, target)) {
+    throw new Error(
+      `Migration source is outside the target sessions directory: ${move.sourcePath}`,
+    );
+  }
+  if (!isRegularFileWithoutFollowingSymlinks(move.sourcePath)) {
+    throw new Error(`Migration source is not a regular file: ${move.sourcePath}`);
+  }
+  assertSafeSessionSqliteMigrationDirectory(path.dirname(move.sourcePath));
+  assertSafeSessionSqliteMigrationDirectory(path.dirname(move.archivePath));
+}
+
+export function assertSafeSessionSqliteMigrationDirectory(directoryPath: string): void {
+  if (hasSymbolicLinkInDirectoryPath(directoryPath)) {
+    throw new Error(`Refusing session SQLite migration through symbolic link: ${directoryPath}`);
+  }
+}
+
+function isRegularFileWithoutFollowingSymlinks(filePath: string): boolean {
+  try {
+    return fs.lstatSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function hasSymbolicLinkInDirectoryPath(directoryPath: string): boolean {
+  const resolvedPath = path.resolve(directoryPath);
+  const root = path.parse(resolvedPath).root;
+  let currentPath = root;
+  for (const segment of path.relative(root, resolvedPath).split(path.sep).filter(Boolean)) {
+    currentPath = path.join(currentPath, segment);
+    try {
+      if (fs.lstatSync(currentPath).isSymbolicLink()) {
+        return true;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
 function resolveRestoreStatus(
   report: DoctorSessionSqliteRestoreReport,
 ): NonNullable<SessionSqliteMigrationManifest["restore"]>["status"] {
@@ -460,16 +654,21 @@ function resolveRestoreStatus(
 
 function filterRestoreManifestTargets(
   manifest: SessionSqliteMigrationManifest,
-  targetKeys: ReadonlySet<string> | undefined,
+  trustedTargets: readonly SessionSqliteMigrationTargetInput[],
 ): SessionSqliteMigrationTargetManifest[] {
-  if (!targetKeys) {
-    return manifest.targets;
-  }
-  if (targetKeys.size === 0) {
+  if (trustedTargets.length === 0) {
     return [];
   }
-  return manifest.targets.filter((target) =>
-    targetKeys.has(sessionSqliteMigrationTargetKey(target)),
+  const trustedSqlitePaths = new Map(
+    trustedTargets.map((target) => [
+      sessionSqliteMigrationTargetKey(target),
+      canonicalMigrationFilePath(target.sqlitePath),
+    ]),
+  );
+  return manifest.targets.filter(
+    (target) =>
+      trustedSqlitePaths.get(sessionSqliteMigrationTargetKey(target)) ===
+      canonicalMigrationFilePath(target.sqlitePath),
   );
 }
 
@@ -493,12 +692,158 @@ export function readSessionSqliteMigrationManifest(
 ): SessionSqliteMigrationManifest | undefined {
   try {
     const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as unknown;
-    if (!isRecord(parsed) || parsed.manifestVersion !== 1 || typeof parsed.runId !== "string") {
+    const result = MigrationManifestSchema.safeParse(parsed);
+    if (!result.success) {
       return undefined;
     }
-    return parsed as SessionSqliteMigrationManifest;
+    if (result.data.manifestVersion === 1) {
+      if (hasUnsupportedV1DirectorySymlink(result.data)) {
+        return undefined;
+      }
+      const normalized = {
+        ...result.data,
+        targets: result.data.targets.map(normalizeMigrationTargetManifest),
+      };
+      const normalizedResult = MigrationManifestSchema.safeParse(normalized);
+      return normalizedResult.success
+        ? (normalizedResult.data as SessionSqliteMigrationManifest)
+        : undefined;
+    }
+    // New manifests are canonicalized when written. Do not realpath retained entries here:
+    // a symlink inserted after the write must remain visible to the restore safety checks.
+    return result.data as SessionSqliteMigrationManifest;
   } catch {
     return undefined;
+  }
+}
+
+function isRestoreMoveWithinTarget(
+  move: SessionSqliteMigrationMove,
+  target: Pick<SessionSqliteMigrationTargetManifest, "storePath">,
+): boolean {
+  const sourcePath = path.resolve(move.sourcePath);
+  const archivePath = path.resolve(move.archivePath);
+  if (sourcePath === archivePath) {
+    return false;
+  }
+  const storePath = path.resolve(target.storePath);
+  const sessionsDir = path.dirname(storePath);
+  const archiveDir = path.join(path.dirname(sessionsDir), "session-sqlite-import-archive");
+  if (path.dirname(archivePath) !== archiveDir) {
+    return false;
+  }
+  return move.kind === "legacy-store"
+    ? sourcePath === storePath
+    : path.dirname(sourcePath) === sessionsDir;
+}
+
+function normalizeMigrationTarget(
+  target: SessionSqliteMigrationTargetInput,
+): SessionSqliteMigrationTargetInput {
+  return {
+    agentId: target.agentId,
+    sqlitePath: canonicalMigrationFilePath(target.sqlitePath),
+    storePath: canonicalMigrationFilePath(target.storePath),
+  };
+}
+
+function normalizeMigrationTargetManifest(
+  target: SessionSqliteMigrationTargetManifest,
+): SessionSqliteMigrationTargetManifest {
+  return {
+    ...target,
+    ...normalizeMigrationTarget(target),
+    completedMoves: target.completedMoves.map(normalizeMigrationMove),
+    plannedMoves: target.plannedMoves.map(normalizeMigrationMove),
+  };
+}
+
+function normalizeMigrationMove(move: SessionSqliteMigrationMove): SessionSqliteMigrationMove {
+  return {
+    archivePath: canonicalMigrationFilePath(move.archivePath),
+    kind: move.kind,
+    ...(move.sessionKey ? { sessionKey: move.sessionKey } : {}),
+    sourcePath: canonicalMigrationFilePath(move.sourcePath),
+  };
+}
+
+function hasUnsupportedV1DirectorySymlink(manifest: SessionSqliteMigrationManifest): boolean {
+  const directoryPaths = manifest.targets.flatMap((target) => [
+    path.dirname(target.sqlitePath),
+    path.dirname(target.storePath),
+    ...target.plannedMoves.flatMap((move) => [
+      path.dirname(move.archivePath),
+      path.dirname(move.sourcePath),
+    ]),
+    ...target.completedMoves.flatMap((move) => [
+      path.dirname(move.archivePath),
+      path.dirname(move.sourcePath),
+    ]),
+  ]);
+  return directoryPaths.some((directoryPath) => {
+    const resolvedPath = path.resolve(directoryPath);
+    const root = path.parse(resolvedPath).root;
+    let currentPath = root;
+    for (const segment of path.relative(root, resolvedPath).split(path.sep).filter(Boolean)) {
+      currentPath = path.join(currentPath, segment);
+      try {
+        const stat = fs.lstatSync(currentPath);
+        // Version 1 predates canonical paths. Only filesystem-root aliases such as
+        // macOS /var and /tmp are safe to normalize without trusting manifest data.
+        if (stat.isSymbolicLink() && path.dirname(currentPath) !== root) {
+          return true;
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          return true;
+        }
+      }
+    }
+    return false;
+  });
+}
+
+function canonicalMigrationFilePath(filePath: string): string {
+  const resolvedPath = path.resolve(filePath);
+  const fileName = path.basename(resolvedPath);
+  const directoryPath = path.dirname(resolvedPath);
+  const suffix: string[] = [];
+  let currentPath = directoryPath;
+  while (true) {
+    try {
+      return path.join(fs.realpathSync.native(currentPath), ...suffix, fileName);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      const parentPath = path.dirname(currentPath);
+      if ((code !== "ENOENT" && code !== "ENOTDIR") || parentPath === currentPath) {
+        return resolvedPath;
+      }
+      suffix.unshift(path.basename(currentPath));
+      currentPath = parentPath;
+    }
+  }
+}
+
+function assertSafeMigrationTargetTopology(target: SessionSqliteMigrationTargetInput): void {
+  for (const filePath of [target.storePath, target.sqlitePath]) {
+    if (isSymbolicLinkPath(filePath) || isSymbolicLinkPath(path.dirname(filePath))) {
+      throw new Error(`Refusing session SQLite migration through symbolic link: ${filePath}`);
+    }
+  }
+  const sessionsDir = path.dirname(canonicalMigrationFilePath(target.storePath));
+  assertSafeSessionSqliteMigrationDirectory(
+    path.join(path.dirname(sessionsDir), "session-sqlite-import-archive"),
+  );
+}
+
+function isSymbolicLinkPath(filePath: string): boolean {
+  try {
+    return fs.lstatSync(filePath).isSymbolicLink();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
   }
 }
 

--- a/src/commands/doctor-session-sqlite-recover-report.ts
+++ b/src/commands/doctor-session-sqlite-recover-report.ts
@@ -6,8 +6,8 @@ import {
   findLatestFailedSessionSqliteMigrationManifest,
   resolveSessionSqliteMigrationRunsDir,
   restoreSessionSqliteMigrationRun,
-  sessionSqliteMigrationTargetKey,
   writeSessionSqliteMigrationFailureReports,
+  type SessionSqliteMigrationTargetInput,
 } from "./doctor-session-sqlite-migration-run.js";
 import { readOnlySqliteDbStats, resolveTargetSqlitePath } from "./doctor-session-sqlite-readers.js";
 import type {
@@ -27,8 +27,8 @@ export async function recoverDoctorSessionSqliteTargets(params: {
   targets: readonly SessionStoreTarget[];
   validateTarget: SessionSqliteRecoverTargetValidator;
 }): Promise<DoctorSessionSqliteReport> {
-  const selectedTargetKeys = resolveRecoverTargetKeys(params.options, params.targets);
-  const failedRun = findLatestFailedSessionSqliteMigrationManifest(params.env, selectedTargetKeys);
+  const trustedTargets = resolveRecoverTargets(params.targets);
+  const failedRun = findLatestFailedSessionSqliteMigrationManifest(params.env, trustedTargets);
   if (!failedRun) {
     const recoveredCorruptTargets = recoverCorruptSqliteTargets(params.targets);
     if (recoveredCorruptTargets.length > 0) {
@@ -43,14 +43,10 @@ export async function recoverDoctorSessionSqliteTargets(params: {
   }
   const restore = restoreSessionSqliteMigrationRun({
     manifestPath: failedRun.manifestPath,
-    targetKeys: selectedTargetKeys,
+    trustedTargets,
   });
   const targetReports: DoctorSessionSqliteTargetReport[] = [];
-  const manifestTargets = filterRecoveryManifestTargets(
-    failedRun.manifest.targets,
-    selectedTargetKeys,
-  );
-  for (const manifestTarget of manifestTargets) {
+  for (const manifestTarget of failedRun.targets) {
     targetReports.push(
       await params.validateTarget({
         agentId: manifestTarget.agentId,
@@ -79,7 +75,7 @@ export async function recoverDoctorSessionSqliteTargets(params: {
   };
   report.supportIssue = createSessionSqliteMigrationFailureIssue(
     failedRun.manifestPath,
-    selectedTargetKeys,
+    trustedTargets,
   );
   return report;
 }
@@ -180,26 +176,13 @@ function isSqliteCorruptionError(error: unknown): boolean {
   return message.includes("database disk image is malformed") || message.includes("not a database");
 }
 
-function resolveRecoverTargetKeys(
-  options: DoctorSessionSqliteOptions,
+function resolveRecoverTargets(
   targets: readonly SessionStoreTarget[],
-): ReadonlySet<string> | undefined {
-  const hasSelector = Boolean(options.agent || options.allAgents || options.store);
-  return hasSelector
-    ? new Set(targets.map((target) => sessionSqliteMigrationTargetKey(target)))
-    : undefined;
-}
-
-function filterRecoveryManifestTargets<T extends { agentId: string; storePath: string }>(
-  targets: readonly T[],
-  selectedTargetKeys: ReadonlySet<string> | undefined,
-): T[] {
-  if (!selectedTargetKeys) {
-    return [...targets];
-  }
-  return targets.filter((target) =>
-    selectedTargetKeys.has(sessionSqliteMigrationTargetKey(target)),
-  );
+): SessionSqliteMigrationTargetInput[] {
+  return targets.map((target) => ({
+    ...target,
+    sqlitePath: resolveTargetSqlitePath(target),
+  }));
 }
 
 function createSyntheticRecoverTargetReport(

--- a/src/commands/doctor-session-sqlite-restore-report.ts
+++ b/src/commands/doctor-session-sqlite-restore-report.ts
@@ -3,7 +3,6 @@ import type { SessionStoreTarget } from "../config/sessions/targets.js";
 import {
   resolveSessionSqliteMigrationRunsDir,
   restoreSessionSqliteMigrationRuns,
-  sessionSqliteMigrationTargetKey,
 } from "./doctor-session-sqlite-migration-run.js";
 import { readSqliteEntryCount, resolveTargetSqlitePath } from "./doctor-session-sqlite-readers.js";
 import type {
@@ -13,16 +12,16 @@ import type {
 
 export async function restoreDoctorSessionSqliteTargets(params: {
   env: NodeJS.ProcessEnv;
-  restoreAllManifests: boolean;
   targets: readonly SessionStoreTarget[];
 }): Promise<DoctorSessionSqliteReport> {
   const targetReports = params.targets.map((target) => createEmptyTargetReport(target));
-  const targetKeys = params.restoreAllManifests
-    ? undefined
-    : new Set(params.targets.map((target) => sessionSqliteMigrationTargetKey(target)));
+  const trustedTargets = params.targets.map((target) => ({
+    ...target,
+    sqlitePath: resolveTargetSqlitePath(target),
+  }));
   const restore = restoreSessionSqliteMigrationRuns({
     env: params.env,
-    targetKeys,
+    trustedTargets,
   });
   const reportTarget =
     targetReports[0] ??

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -13,7 +13,12 @@ import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import * as replaceFile from "../infra/replace-file.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import type { SessionSqliteMigrationManifest } from "./doctor-session-sqlite-migration-run.js";
+import {
+  assertSafeSessionSqliteMigrationMove,
+  restoreSessionSqliteMigrationRun,
+  type SessionSqliteMigrationManifest,
+} from "./doctor-session-sqlite-migration-run.js";
+import { resolveTargetSqlitePath } from "./doctor-session-sqlite-readers.js";
 import { runDoctorSessionSqlite } from "./doctor-session-sqlite.js";
 
 type TestStore = {
@@ -32,6 +37,9 @@ const previousEnv = {
   OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
   OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
 };
+const lexicalTempDir = path.resolve(os.tmpdir());
+const realTempDir = fs.realpathSync.native(os.tmpdir());
+const hasPlatformTempAlias = lexicalTempDir !== realTempDir;
 
 beforeEach(() => {
   closeOpenClawAgentDatabasesForTest();
@@ -431,6 +439,7 @@ describe("runDoctorSessionSqlite", () => {
 
   it("writes a migration manifest with planned and completed archive moves", async () => {
     const store = createLegacyStore();
+    const expectedStorePath = fs.realpathSync.native(store.storePath);
 
     const report = await runDoctorSessionSqlite({
       env: store.env,
@@ -441,9 +450,10 @@ describe("runDoctorSessionSqlite", () => {
     const target = manifest.targets[0];
 
     expect(report.migrationRun?.runId).toBe(manifest.runId);
+    expect(manifest.manifestVersion).toBe(2);
     expect(target).toMatchObject({
       agentId: "main",
-      storePath: store.storePath,
+      storePath: expectedStorePath,
       validationBeforeArchive: "passed",
     });
     expect(target.plannedMoves).toHaveLength(4);
@@ -569,6 +579,39 @@ describe("runDoctorSessionSqlite", () => {
     expect(fs.existsSync(store.unreferencedJsonlPath)).toBe(true);
   });
 
+  it.each([false, true])(
+    "restores archived artifacts after the replacement SQLite file is removed (allAgents=%s)",
+    async (allAgents) => {
+      const store = createLegacyStore();
+      const importReport = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+      const sqlitePath = importReport.targets[0]?.sqlitePath;
+      if (!sqlitePath) {
+        throw new Error("expected imported SQLite path");
+      }
+      closeOpenClawAgentDatabasesForTest();
+      for (const filePath of [sqlitePath, `${sqlitePath}-wal`, `${sqlitePath}-shm`]) {
+        fs.rmSync(filePath, { force: true });
+      }
+
+      const restore = await runDoctorSessionSqlite({
+        ...(allAgents ? { allAgents: true } : {}),
+        cfg: {},
+        env: store.env,
+        mode: "restore",
+      });
+
+      expect(restore.totals.issues).toBe(0);
+      expect(restore.targets[0]?.restore?.restoredFiles).toEqual(
+        expect.arrayContaining(canonicalTestPaths([store.transcriptPath, store.trajectoryPath])),
+      );
+      expect(fs.existsSync(store.transcriptPath)).toBe(true);
+    },
+  );
+
   it("restores planned moves when a crash prevented completed move recording", async () => {
     const store = createLegacyStore();
     const importReport = await runDoctorSessionSqlite({
@@ -594,6 +637,447 @@ describe("runDoctorSessionSqlite", () => {
     );
     expect(fs.existsSync(store.transcriptPath)).toBe(true);
     expect(fs.existsSync(store.trajectoryPath)).toBe(true);
+  });
+
+  it("rejects malformed restore manifests without throwing", () => {
+    const store = createLegacyStore();
+    const manifestPath = path.join(store.tempDir, "malformed-manifest.json");
+    fs.writeFileSync(
+      manifestPath,
+      `${JSON.stringify({
+        manifestVersion: 1,
+        runId: "malformed",
+        targets: {},
+      })}\n`,
+      { mode: 0o600 },
+    );
+
+    const restore = restoreSessionSqliteMigrationRun({
+      manifestPath,
+      trustedTargets: [trustedMigrationTarget(store)],
+    });
+
+    expect(restore).toMatchObject({
+      conflicts: [
+        {
+          archivePath: manifestPath,
+          reason: "manifest is missing or unreadable",
+          sourcePath: manifestPath,
+        },
+      ],
+      restoredFiles: [],
+      skippedFiles: [],
+    });
+  });
+
+  it("rejects restore moves outside the manifest target archive boundary", async () => {
+    const store = createLegacyStore();
+    const importReport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const manifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+    const manifest = readMigrationManifest(manifestPath);
+    const outsideSourcePath = path.join(store.tempDir, "outside-source.jsonl");
+    const outsideArchivePath = path.join(store.tempDir, "outside-archive.jsonl");
+    fs.writeFileSync(outsideArchivePath, '{"type":"outside"}\n', { mode: 0o600 });
+    const unsafeMove = {
+      archivePath: outsideArchivePath,
+      kind: "transcript" as const,
+      sourcePath: outsideSourcePath,
+    };
+    manifest.targets[0].plannedMoves = [unsafeMove];
+    manifest.targets[0].completedMoves = [unsafeMove];
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+
+    const restore = restoreSessionSqliteMigrationRun({
+      manifestPath,
+      trustedTargets: [trustedMigrationTarget(store)],
+    });
+
+    expect(restore.conflicts).toEqual([
+      {
+        archivePath: manifestPath,
+        reason: "manifest is missing or unreadable",
+        sourcePath: manifestPath,
+      },
+    ]);
+    expect(fs.existsSync(outsideSourcePath)).toBe(false);
+    expect(fs.existsSync(outsideArchivePath)).toBe(true);
+  });
+
+  it("rejects migration sources outside the target sessions directory", () => {
+    const store = createLegacyStore();
+    const outsideSourcePath = path.join(store.tempDir, "outside-source.jsonl");
+    const archivePath = path.join(
+      path.dirname(store.sessionDir),
+      "session-sqlite-import-archive",
+      "outside-source.jsonl.imported-1",
+    );
+    fs.writeFileSync(outsideSourcePath, '{"type":"outside"}\n', { mode: 0o600 });
+
+    expect(() =>
+      assertSafeSessionSqliteMigrationMove(
+        {
+          archivePath,
+          kind: "transcript",
+          sourcePath: outsideSourcePath,
+        },
+        trustedMigrationTarget(store),
+      ),
+    ).toThrow("Migration source is outside the target sessions directory");
+    expect(fs.existsSync(outsideSourcePath)).toBe(true);
+  });
+
+  it("rejects a coherently rewritten target that is not trusted by the caller", async () => {
+    const store = createLegacyStore();
+    const importReport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const manifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+    const manifest = readMigrationManifest(manifestPath);
+    const outsideSessionsDir = path.join(store.tempDir, "outside-agent", "sessions");
+    const outsideStorePath = path.join(outsideSessionsDir, "sessions.json");
+    const outsideSourcePath = path.join(outsideSessionsDir, "outside.jsonl");
+    const outsideArchiveDir = path.join(
+      path.dirname(outsideSessionsDir),
+      "session-sqlite-import-archive",
+    );
+    const outsideArchivePath = path.join(outsideArchiveDir, "outside.jsonl.imported-1");
+    fs.mkdirSync(outsideArchiveDir, { recursive: true });
+    fs.writeFileSync(outsideArchivePath, '{"type":"outside"}\n', { mode: 0o600 });
+    const rewrittenMove = {
+      archivePath: outsideArchivePath,
+      kind: "transcript" as const,
+      sourcePath: outsideSourcePath,
+    };
+    manifest.targets[0].storePath = outsideStorePath;
+    manifest.targets[0].plannedMoves = [rewrittenMove];
+    manifest.targets[0].completedMoves = [rewrittenMove];
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+
+    const restore = restoreSessionSqliteMigrationRun({
+      manifestPath,
+      trustedTargets: [trustedMigrationTarget(store)],
+    });
+
+    expect(restore.conflicts).toEqual([
+      {
+        archivePath: manifestPath,
+        reason: "manifest does not match a trusted session target",
+        sourcePath: manifestPath,
+      },
+    ]);
+    expect(fs.existsSync(outsideSourcePath)).toBe(false);
+    expect(fs.existsSync(outsideArchivePath)).toBe(true);
+  });
+
+  it("rejects recovery manifests with a rewritten SQLite path", async () => {
+    const store = createLegacyStore();
+    const importReport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const manifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+    const manifest = readMigrationManifest(manifestPath);
+    const outsideSqlitePath = path.join(store.tempDir, "outside.sqlite");
+    manifest.failedAt = "2030-01-01T00:00:00.000Z";
+    manifest.targets[0].issues = [{ code: "startup_failure", message: "failed after archive" }];
+    manifest.targets[0].sqlitePath = outsideSqlitePath;
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+
+    const recover = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "recover",
+      store: store.storePath,
+    });
+
+    expect(recover.migrationRun).toBeUndefined();
+    expect(recover.targets[0]?.issues[0]?.code).toBe("recover_manifest_missing");
+    expect(fs.existsSync(outsideSqlitePath)).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "uses normalized restore paths instead of symlink-parent traversal paths",
+    async () => {
+      const store = createLegacyStore();
+      const importReport = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+      const manifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+      const manifest = readMigrationManifest(manifestPath);
+      const archiveDir = path.dirname(manifest.targets[0].plannedMoves[0].archivePath);
+      const outsideDir = path.join(store.tempDir, "outside", "nested");
+      const outsideArchivePath = path.join(path.dirname(outsideDir), "payload.jsonl");
+      const traversalArchivePath = path.join(archiveDir, "escape", "..", "payload.jsonl");
+      const sourcePath = path.join(store.sessionDir, "payload.jsonl");
+      fs.mkdirSync(outsideDir, { recursive: true });
+      fs.symlinkSync(outsideDir, path.join(archiveDir, "escape"));
+      fs.writeFileSync(outsideArchivePath, '{"type":"outside"}\n', { mode: 0o600 });
+      const traversalMove = {
+        archivePath: traversalArchivePath,
+        kind: "transcript" as const,
+        sourcePath,
+      };
+      manifest.targets[0].plannedMoves = [traversalMove];
+      manifest.targets[0].completedMoves = [traversalMove];
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+
+      const restore = restoreSessionSqliteMigrationRun({
+        manifestPath,
+        trustedTargets: [trustedMigrationTarget(store)],
+      });
+
+      expect(restore.conflicts).toEqual([
+        {
+          archivePath: path.join(archiveDir, "payload.jsonl"),
+          reason: "source and archive are both missing",
+          sourcePath,
+        },
+      ]);
+      expect(fs.existsSync(sourcePath)).toBe(false);
+      expect(fs.existsSync(outsideArchivePath)).toBe(true);
+    },
+  );
+
+  it.skipIf(!hasPlatformTempAlias)(
+    "restores version 1 manifests written through a platform root alias",
+    async () => {
+      const store = createLegacyStore();
+      const importReport = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+      const manifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+      const manifest = readMigrationManifest(manifestPath);
+      const aliasPath = (filePath: string) =>
+        path.join(lexicalTempDir, path.relative(realTempDir, filePath));
+      manifest.manifestVersion = 1;
+      for (const target of manifest.targets) {
+        target.sqlitePath = aliasPath(target.sqlitePath);
+        target.storePath = aliasPath(target.storePath);
+        for (const move of [...target.plannedMoves, ...target.completedMoves]) {
+          move.archivePath = aliasPath(move.archivePath);
+          move.sourcePath = aliasPath(move.sourcePath);
+        }
+      }
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+
+      const restore = restoreSessionSqliteMigrationRun({
+        manifestPath,
+        trustedTargets: [trustedMigrationTarget(store)],
+      });
+
+      expect(restore.conflicts).toEqual([]);
+      expect(restore.restoredFiles).toContain(canonicalTestPath(store.transcriptPath));
+      expect(fs.existsSync(store.transcriptPath)).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects version 1 manifests through non-root directory symlinks",
+    async () => {
+      const store = createLegacyStore();
+      const importReport = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+      const manifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+      const manifest = readMigrationManifest(manifestPath);
+      const move = manifest.targets[0].plannedMoves.find(
+        (candidate) => candidate.kind === "transcript",
+      );
+      expect(move).toBeDefined();
+      manifest.manifestVersion = 1;
+      manifest.startedAt = "2999-01-01T00:00:00.000Z";
+      manifest.targets[0].plannedMoves = move ? [move] : [];
+      manifest.targets[0].completedMoves = move ? [move] : [];
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+      const agentDir = path.dirname(store.sessionDir);
+      const relocatedAgentDir = path.join(store.tempDir, "relocated-v1-agent");
+      fs.renameSync(agentDir, relocatedAgentDir);
+      fs.symlinkSync(relocatedAgentDir, agentDir);
+
+      const restore = restoreSessionSqliteMigrationRun({
+        manifestPath,
+        trustedTargets: [trustedMigrationTarget(store)],
+      });
+
+      expect(restore.conflicts).toEqual([
+        {
+          archivePath: manifestPath,
+          reason: "manifest is missing or unreadable",
+          sourcePath: manifestPath,
+        },
+      ]);
+      expect(fs.existsSync(move?.sourcePath ?? "")).toBe(false);
+      expect(fs.existsSync(move?.archivePath ?? "")).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a symlinked ancestor shared by restore directories",
+    async () => {
+      const store = createLegacyStore();
+      const importReport = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+      const manifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+      const manifest = readMigrationManifest(manifestPath);
+      const move = manifest.targets[0].plannedMoves.find(
+        (candidate) => candidate.kind === "transcript",
+      );
+      expect(move).toBeDefined();
+      manifest.targets[0].plannedMoves = move ? [move] : [];
+      manifest.targets[0].completedMoves = move ? [move] : [];
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+      const agentDir = path.dirname(store.sessionDir);
+      const relocatedAgentDir = path.join(store.tempDir, "relocated-agent");
+      fs.renameSync(agentDir, relocatedAgentDir);
+      fs.symlinkSync(relocatedAgentDir, agentDir);
+
+      const restore = restoreSessionSqliteMigrationRun({
+        manifestPath,
+        trustedTargets: [trustedMigrationTarget(store)],
+      });
+
+      expect(restore.conflicts).toEqual([
+        {
+          archivePath: move?.archivePath,
+          reason: "source or archive parent is a symbolic link; refusing restore",
+          sourcePath: move?.sourcePath,
+        },
+      ]);
+      expect(restore.restoredFiles).toEqual([]);
+      expect(fs.existsSync(move?.archivePath ?? "")).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects restores through a symlinked source directory",
+    async () => {
+      const store = createLegacyStore();
+      const importReport = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+      const manifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+      const manifest = readMigrationManifest(manifestPath);
+      const move = manifest.targets[0].plannedMoves.find(
+        (candidate) => candidate.kind === "transcript",
+      );
+      expect(move).toBeDefined();
+      manifest.targets[0].plannedMoves = move ? [move] : [];
+      manifest.targets[0].completedMoves = move ? [move] : [];
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+      const relocatedSessionDir = path.join(store.tempDir, "relocated-sessions");
+      fs.renameSync(store.sessionDir, relocatedSessionDir);
+      fs.symlinkSync(relocatedSessionDir, store.sessionDir);
+
+      const restore = restoreSessionSqliteMigrationRun({
+        manifestPath,
+        trustedTargets: [trustedMigrationTarget(store)],
+      });
+
+      expect(restore.conflicts).toEqual([
+        {
+          archivePath: move?.archivePath,
+          reason: "source or archive parent is a symbolic link; refusing restore",
+          sourcePath: move?.sourcePath,
+        },
+      ]);
+      expect(restore.restoredFiles).toEqual([]);
+      expect(fs.existsSync(move?.archivePath ?? "")).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects restores through a symlinked archive directory",
+    async () => {
+      const store = createLegacyStore();
+      const importReport = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+      const manifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+      const manifest = readMigrationManifest(manifestPath);
+      const move = manifest.targets[0].plannedMoves.find(
+        (candidate) => candidate.kind === "transcript",
+      );
+      expect(move).toBeDefined();
+      manifest.targets[0].plannedMoves = move ? [move] : [];
+      manifest.targets[0].completedMoves = move ? [move] : [];
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+      const archiveDir = path.dirname(move?.archivePath ?? "");
+      const relocatedArchiveDir = path.join(store.tempDir, "relocated-archive");
+      fs.renameSync(archiveDir, relocatedArchiveDir);
+      fs.symlinkSync(relocatedArchiveDir, archiveDir);
+
+      const restore = restoreSessionSqliteMigrationRun({
+        manifestPath,
+        trustedTargets: [trustedMigrationTarget(store)],
+      });
+
+      expect(restore.conflicts).toEqual([
+        {
+          archivePath: move?.archivePath,
+          reason: "source or archive parent is a symbolic link; refusing restore",
+          sourcePath: move?.sourcePath,
+        },
+      ]);
+      expect(restore.restoredFiles).toEqual([]);
+      expect(fs.existsSync(move?.archivePath ?? "")).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")("rejects symlinked archive entries", async () => {
+    const store = createLegacyStore();
+    const importReport = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+    const manifestPath = requireMigrationManifestPath(importReport.migrationRun?.manifestPath);
+    const manifest = readMigrationManifest(manifestPath);
+    const move = manifest.targets[0].plannedMoves.find(
+      (candidate) => candidate.kind === "transcript",
+    );
+    expect(move).toBeDefined();
+    manifest.targets[0].plannedMoves = move ? [move] : [];
+    manifest.targets[0].completedMoves = move ? [move] : [];
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+    const outsidePath = path.join(store.tempDir, "outside-payload.jsonl");
+    fs.writeFileSync(outsidePath, '{"type":"outside"}\n', { mode: 0o600 });
+    fs.rmSync(move?.archivePath ?? "");
+    fs.symlinkSync(outsidePath, move?.archivePath ?? "");
+
+    const restore = restoreSessionSqliteMigrationRun({
+      manifestPath,
+      trustedTargets: [trustedMigrationTarget(store)],
+    });
+
+    expect(restore.conflicts).toEqual([
+      {
+        archivePath: move?.archivePath,
+        reason: "archive is not a regular file; refusing restore",
+        sourcePath: move?.sourcePath,
+      },
+    ]);
+    expect(restore.restoredFiles).toEqual([]);
+    expect(fs.existsSync(move?.sourcePath ?? "")).toBe(false);
+    expect(fs.existsSync(outsidePath)).toBe(true);
   });
 
   it("treats repeated restore as idempotent when files are already restored", async () => {
@@ -756,6 +1240,51 @@ describe("runDoctorSessionSqlite", () => {
     expect(fs.existsSync(store.transcriptPath)).toBe(true);
   });
 
+  it.skipIf(process.platform === "win32")(
+    "rejects symlink-backed legacy stores before migration",
+    async () => {
+      const store = createLegacyStore();
+      const realStorePath = path.join(store.tempDir, "real-sessions.json");
+      fs.renameSync(store.storePath, realStorePath);
+      fs.symlinkSync(realStorePath, store.storePath);
+
+      await expect(
+        runDoctorSessionSqlite({
+          env: store.env,
+          mode: "import",
+          store: store.storePath,
+        }),
+      ).rejects.toThrow("Refusing session SQLite migration through symbolic link");
+
+      expect(fs.lstatSync(store.storePath).isSymbolicLink()).toBe(true);
+      expect(fs.existsSync(realStorePath)).toBe(true);
+      expect(fs.existsSync(store.transcriptPath)).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects symlink-backed archive directories before migration",
+    async () => {
+      const store = createLegacyStore();
+      const archiveDir = path.join(path.dirname(store.sessionDir), "session-sqlite-import-archive");
+      const outsideArchiveDir = path.join(store.tempDir, "outside-archive");
+      fs.mkdirSync(outsideArchiveDir, { recursive: true });
+      fs.symlinkSync(outsideArchiveDir, archiveDir);
+
+      await expect(
+        runDoctorSessionSqlite({
+          env: store.env,
+          mode: "import",
+          store: store.storePath,
+        }),
+      ).rejects.toThrow("Refusing session SQLite migration through symbolic link");
+
+      expect(fs.existsSync(store.storePath)).toBe(true);
+      expect(fs.existsSync(store.transcriptPath)).toBe(true);
+      expect(fs.readdirSync(outsideArchiveDir)).toEqual([]);
+    },
+  );
+
   it("imports aliases that share one legacy transcript before archiving it", async () => {
     const store = createLegacyStore();
     const legacyStore = JSON.parse(fs.readFileSync(store.storePath, "utf-8")) as Record<
@@ -795,7 +1324,7 @@ describe("runDoctorSessionSqlite", () => {
     ).toBe("session-1");
   });
 
-  it("archives a legacy transcript symlink without moving the symlink target", async () => {
+  it("leaves legacy transcript symlinks in place instead of archiving them", async () => {
     const store = createLegacyStore();
     const outsideTranscriptPath = path.join(store.tempDir, "outside-session-1.jsonl");
     fs.renameSync(store.transcriptPath, outsideTranscriptPath);
@@ -807,13 +1336,16 @@ describe("runDoctorSessionSqlite", () => {
       store: store.storePath,
     });
 
-    const archivedTranscriptPath = report.targets[0]?.archivedTranscriptFiles.find((filePath) =>
-      filePath.includes("session-1.jsonl"),
+    expect(report.targets[0]?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: expect.stringMatching(/archive_failed$/),
+        }),
+      ]),
     );
-    expect(archivedTranscriptPath).toBeTruthy();
+    expect(report.targets[0]?.archivedTranscriptFiles).toEqual([]);
     expect(fs.existsSync(outsideTranscriptPath)).toBe(true);
-    expect(fs.existsSync(store.transcriptPath)).toBe(false);
-    expect(fs.lstatSync(archivedTranscriptPath ?? "").isSymbolicLink()).toBe(true);
+    expect(fs.lstatSync(store.transcriptPath).isSymbolicLink()).toBe(true);
   });
 
   it("imports explicit stores into the agent database owned by the path", async () => {
@@ -1416,6 +1948,14 @@ function requireMigrationManifestPath(manifestPath: string | undefined): string 
     throw new Error("expected migration manifest path");
   }
   return manifestPath;
+}
+
+function trustedMigrationTarget(store: TestStore) {
+  const target = { agentId: "main", storePath: store.storePath };
+  return {
+    ...target,
+    sqlitePath: resolveTargetSqlitePath(target),
+  };
 }
 
 function writeFailedManifest(

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -14,6 +14,7 @@ import { normalizeStoreSessionKey } from "../config/sessions/store-entry.js";
 import { normalizeSessionEntryDelivery } from "../config/sessions/store-load.js";
 import {
   resolveAgentSessionStoreTargetsSync,
+  resolveAllAgentSessionStoreCandidateTargetsSync,
   resolveAllAgentSessionStoreTargetsSync,
   resolveSessionStoreTargets,
   type SessionStoreTarget,
@@ -21,8 +22,11 @@ import {
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveStoredSessionOwnerAgentId } from "../gateway/session-store-key.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { compactDoctorSessionSqliteTarget } from "./doctor-session-sqlite-compact.js";
 import {
+  assertSafeSessionSqliteMigrationDirectory,
+  assertSafeSessionSqliteMigrationMove,
   createSessionSqliteMigrationRun,
   recordCompletedMigrationMove,
   recordCompletedMigrationMoves,
@@ -100,8 +104,6 @@ export async function runDoctorSessionSqlite(
   if (options.mode === "restore") {
     return restoreDoctorSessionSqliteTargets({
       env,
-      restoreAllManifests:
-        targets.length === 0 && !options.agent && !options.allAgents && !options.store,
       targets,
     });
   }
@@ -171,6 +173,16 @@ function resolveDoctorSessionSqliteTargets(params: {
       resolveSessionStoreTargets(params.cfg, { store: params.store }, { env: params.env }),
       params.mode,
     );
+  }
+  if (params.mode === "restore" || params.mode === "recover") {
+    const candidates = resolveAllAgentSessionStoreCandidateTargetsSync(params.cfg, {
+      env: params.env,
+    });
+    if (!params.agent) {
+      return candidates;
+    }
+    const requestedAgentId = normalizeAgentId(params.agent);
+    return candidates.filter((target) => normalizeAgentId(target.agentId) === requestedAgentId);
   }
   if (params.agent) {
     return filterLegacySessionStoreTargets(
@@ -664,8 +676,10 @@ function archiveUnreferencedJsonlFiles(
   // restore moved files even when the completion checkpoint was never written.
   recordPlannedMigrationMoves(activeRun, createMigrationTargetInput(target), plannedMoves);
   const completedMoves: SessionSqliteMigrationMove[] = [];
+  const migrationTarget = createMigrationTargetInput(target);
   for (const move of plannedMoves) {
     try {
+      assertSafeSessionSqliteMigrationMove(move, migrationTarget);
       fs.renameSync(move.sourcePath, move.archivePath);
       report.archivedUnreferencedJsonlFiles.push(move.archivePath);
       completedMoves.push(move);
@@ -1083,9 +1097,11 @@ function moveSessionJsonlToArchive(params: {
   target: SessionStoreTarget;
 }): string {
   const move = planSessionJsonlArchiveMove(params);
-  recordPlannedMigrationMove(params.activeRun, createMigrationTargetInput(params.target), move);
+  const migrationTarget = createMigrationTargetInput(params.target);
+  recordPlannedMigrationMove(params.activeRun, migrationTarget, move);
+  assertSafeSessionSqliteMigrationMove(move, migrationTarget);
   fs.renameSync(move.sourcePath, move.archivePath);
-  recordCompletedMigrationMove(params.activeRun, createMigrationTargetInput(params.target), move);
+  recordCompletedMigrationMove(params.activeRun, migrationTarget, move);
   return move.archivePath;
 }
 
@@ -1098,13 +1114,23 @@ function planSessionJsonlArchiveMove(params: {
   sourcePathRaw: string;
   target: SessionStoreTarget;
 }): SessionSqliteMigrationMove {
-  const sourcePath = path.resolve(params.sourcePathRaw);
-  const stat = fs.statSync(sourcePath);
+  const sourcePathRaw = path.resolve(params.sourcePathRaw);
+  const stat = fs.lstatSync(sourcePathRaw);
   if (!stat.isFile()) {
     throw new Error("source is not a regular file");
   }
+  const sourcePath = path.join(
+    canonicalFilePath(path.dirname(sourcePathRaw)),
+    path.basename(sourcePathRaw),
+  );
+  const sessionsDir = canonicalFilePath(path.dirname(path.resolve(params.target.storePath)));
+  if (path.dirname(sourcePath) !== sessionsDir) {
+    throw new Error(`Migration source is outside the target sessions directory: ${sourcePath}`);
+  }
   const archiveDir = resolveImportedTranscriptArchiveDir(params.target.storePath);
+  assertSafeSessionSqliteMigrationDirectory(archiveDir);
   fs.mkdirSync(archiveDir, { recursive: true });
+  assertSafeSessionSqliteMigrationDirectory(archiveDir);
   const baseName = params.baseNameRaw.replace(/[^A-Za-z0-9_.-]+/g, "_").slice(0, 160) || "artifact";
   const keySlug = params.archiveKey.replace(/[^A-Za-z0-9_.-]+/g, "_").slice(0, 120) || "session";
   for (let attempt = 0; attempt < 100; attempt += 1) {
@@ -1127,7 +1153,7 @@ function planSessionJsonlArchiveMove(params: {
 }
 
 function resolveImportedTranscriptArchiveDir(storePath: string): string {
-  const storeDir = path.dirname(path.resolve(storePath));
+  const storeDir = canonicalFilePath(path.dirname(path.resolve(storePath)));
   return path.join(path.dirname(storeDir), "session-sqlite-import-archive");
 }
 

--- a/src/config/sessions/targets.test.ts
+++ b/src/config/sessions/targets.test.ts
@@ -8,6 +8,7 @@ import { resolveStorePath } from "./paths.js";
 import { replaceSessionEntry } from "./session-accessor.js";
 import {
   resolveAgentSessionStoreTargetsSync,
+  resolveAllAgentSessionStoreCandidateTargetsSync,
   resolveAllAgentSessionStoreTargetsSync,
   resolveSessionStoreTargets,
 } from "./targets.js";
@@ -430,6 +431,80 @@ describe("resolveAllAgentSessionStoreTargetsSync", () => {
       expect(
         targets.some((target) => target.storePath === path.join(junkSessionsDir, "sessions.json")),
       ).toBe(false);
+    });
+  });
+});
+
+describe("resolveAllAgentSessionStoreCandidateTargetsSync", () => {
+  it("includes configured targets before either state file exists", async () => {
+    await withTempHome(async (home) => {
+      const stateDir = path.join(home, ".openclaw");
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const storePath = resolveStorePath(undefined, { agentId: "main", env });
+
+      expect(
+        resolveAllAgentSessionStoreCandidateTargetsSync(
+          { agents: { list: [{ default: true, id: "main" }] } },
+          { env },
+        ),
+      ).toContainEqual({ agentId: "main", storePath });
+    });
+  });
+
+  it("includes retired agent directories after both state files are removed", async () => {
+    await withTempHome(async (home) => {
+      const stateDir = path.join(home, ".openclaw");
+      const retiredAgentDir = path.join(stateDir, "agents", "retired");
+      await fs.mkdir(retiredAgentDir, { recursive: true });
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      expect(resolveAllAgentSessionStoreCandidateTargetsSync({}, { env })).toContainEqual({
+        agentId: "retired",
+        storePath: path.join(retiredAgentDir, "sessions", "sessions.json"),
+      });
+    });
+  });
+
+  it("skips candidate session directories that escape through symlinks", async () => {
+    await withTempHome(async (home) => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const stateDir = path.join(home, ".openclaw");
+      const agentDir = path.join(stateDir, "agents", "retired");
+      const outsideSessionsDir = path.join(home, "outside-sessions");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.mkdir(outsideSessionsDir, { recursive: true });
+      await fs.symlink(outsideSessionsDir, path.join(agentDir, "sessions"));
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+
+      expect(resolveAllAgentSessionStoreCandidateTargetsSync({}, { env })).not.toContainEqual({
+        agentId: "retired",
+        storePath: path.join(agentDir, "sessions", "sessions.json"),
+      });
+    });
+  });
+
+  it("skips configured agent session directories that escape through symlinks", async () => {
+    await withTempHome(async (home) => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const customRoot = path.join(home, "custom-state");
+      const agentDir = path.join(customRoot, "agents", "ops");
+      const outsideSessionsDir = path.join(home, "outside-configured-sessions");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.mkdir(outsideSessionsDir, { recursive: true });
+      await fs.symlink(outsideSessionsDir, path.join(agentDir, "sessions"));
+
+      expect(
+        resolveAllAgentSessionStoreCandidateTargetsSync(createCustomRootCfg(customRoot), {
+          env: process.env,
+        }),
+      ).not.toContainEqual({
+        agentId: "ops",
+        storePath: path.join(agentDir, "sessions", "sessions.json"),
+      });
     });
   });
 });

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -147,6 +147,41 @@ function resolveValidatedDiscoveredStorePathSync(params: {
     : undefined;
 }
 
+function isValidatedRecoveryCandidateSessionsDir(params: {
+  allowMissingAgentDir?: boolean;
+  realAgentsRoot: string;
+  sessionsDir: string;
+}): boolean {
+  const agentDir = path.dirname(params.sessionsDir);
+  try {
+    const agentStat = fsSync.lstatSync(agentDir);
+    if (agentStat.isSymbolicLink() || !agentStat.isDirectory()) {
+      return false;
+    }
+    if (!isWithinRoot(fsSync.realpathSync.native(agentDir), params.realAgentsRoot)) {
+      return false;
+    }
+    try {
+      const sessionsStat = fsSync.lstatSync(params.sessionsDir);
+      return (
+        !sessionsStat.isSymbolicLink() &&
+        sessionsStat.isDirectory() &&
+        isWithinRoot(fsSync.realpathSync.native(params.sessionsDir), params.realAgentsRoot)
+      );
+    } catch (err) {
+      return (err as NodeJS.ErrnoException).code === "ENOENT";
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return params.allowMissingAgentDir === true;
+    }
+    if (shouldSkipDiscoveryError(err)) {
+      return false;
+    }
+    throw err;
+  }
+}
+
 function resolveSessionStoreDiscoveryState(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv,
@@ -260,6 +295,82 @@ export function resolveAllAgentSessionStoreTargetsSync(
         const target = validatedStorePath
           ? toDiscoveredSessionStoreTarget(sessionsDir, validatedStorePath)
           : undefined;
+        return target ? [target] : [];
+      });
+    } catch (err) {
+      if (shouldSkipDiscoveryError(err)) {
+        return [];
+      }
+      throw err;
+    }
+  });
+  return dedupeTargetsBySqliteTarget([...validatedConfiguredTargets, ...discoveredTargets]);
+}
+
+/**
+ * Resolves recovery candidates without requiring either the legacy store or SQLite file.
+ * Callers must validate the selected artifact before performing filesystem mutations.
+ */
+export function resolveAllAgentSessionStoreCandidateTargetsSync(
+  cfg: OpenClawConfig,
+  params: { env?: NodeJS.ProcessEnv } = {},
+): SessionStoreTarget[] {
+  const env = params.env ?? process.env;
+  const { configuredTargets, agentsRoots } = resolveSessionStoreDiscoveryState(cfg, env);
+  const realAgentsRoots = new Map<string, string | undefined>();
+  const getRealAgentsRoot = (agentsRoot: string): string | undefined => {
+    if (realAgentsRoots.has(agentsRoot)) {
+      return realAgentsRoots.get(agentsRoot);
+    }
+    try {
+      const realAgentsRoot = fsSync.realpathSync.native(agentsRoot);
+      realAgentsRoots.set(agentsRoot, realAgentsRoot);
+      return realAgentsRoot;
+    } catch (err) {
+      if (shouldSkipDiscoveryError(err)) {
+        realAgentsRoots.set(agentsRoot, undefined);
+        return undefined;
+      }
+      throw err;
+    }
+  };
+  const validatedConfiguredTargets = configuredTargets.flatMap((target) => {
+    const agentsRoot = resolveAgentsDirFromSessionStorePath(target.storePath);
+    if (!agentsRoot) {
+      return [target];
+    }
+    if (!fsSync.existsSync(agentsRoot)) {
+      return [target];
+    }
+    const realAgentsRoot = getRealAgentsRoot(agentsRoot);
+    return realAgentsRoot &&
+      isValidatedRecoveryCandidateSessionsDir({
+        allowMissingAgentDir: true,
+        realAgentsRoot,
+        sessionsDir: path.dirname(target.storePath),
+      })
+      ? [target]
+      : [];
+  });
+  const discoveredTargets = agentsRoots.flatMap((agentsDir) => {
+    try {
+      const realAgentsRoot = getRealAgentsRoot(agentsDir);
+      if (!realAgentsRoot) {
+        return [];
+      }
+      return resolveAgentSessionDirsFromAgentsDirSync(agentsDir).flatMap((sessionsDir) => {
+        if (
+          !isValidatedRecoveryCandidateSessionsDir({
+            realAgentsRoot,
+            sessionsDir,
+          })
+        ) {
+          return [];
+        }
+        const target = toDiscoveredSessionStoreTarget(
+          sessionsDir,
+          path.join(sessionsDir, "sessions.json"),
+        );
         return target ? [target] : [];
       });
     } catch (err) {

--- a/src/gateway/server-startup-session-migration.test.ts
+++ b/src/gateway/server-startup-session-migration.test.ts
@@ -338,6 +338,13 @@ describe("runStartupSessionMigration", () => {
 
     expect(restoreSessionSqliteMigrationRun).toHaveBeenCalledWith({
       manifestPath: "/tmp/run.json",
+      trustedTargets: [
+        {
+          agentId: "main",
+          sqlitePath: "/tmp/openclaw-agent.sqlite",
+          storePath: "/tmp/sessions.json",
+        },
+      ],
     });
     expect(writeSessionSqliteMigrationFailureReports).toHaveBeenCalledWith("/tmp/run.json", {
       reason: "startup blocked on 1 session SQLite issue(s)",

--- a/src/gateway/server-startup-session-migration.ts
+++ b/src/gateway/server-startup-session-migration.ts
@@ -18,6 +18,7 @@ type SessionSqliteStartupImportRunner = (params: {
 
 type SessionSqliteStartupRestoreRunner = (params: {
   manifestPath: string;
+  trustedTargets: Array<{ agentId: string; sqlitePath: string; storePath: string }>;
 }) => DoctorSessionSqliteRestoreReport;
 
 type SessionSqliteStartupFailureReportWriter = (
@@ -137,7 +138,14 @@ async function restoreFailedStartupSessionSqliteRun(
     writeSessionSqliteMigrationFailureReports ??=
       doctorModule.writeSessionSqliteMigrationFailureReports;
   }
-  const restore = restoreSessionSqliteMigrationRun({ manifestPath });
+  const restore = restoreSessionSqliteMigrationRun({
+    manifestPath,
+    trustedTargets: report.targets.map(({ agentId, sqlitePath, storePath }) => ({
+      agentId,
+      sqlitePath,
+      storePath,
+    })),
+  });
   const failureReports = writeSessionSqliteMigrationFailureReports(manifestPath, {
     reason: `startup blocked on ${blockingIssues.length} session SQLite issue(s)`,
   });


### PR DESCRIPTION
Related: #101290

## What Problem This Solves

Fixes an issue where operators recovering from an interrupted session SQLite migration could lose the automated restore path when migration manifests were malformed, tampered with, bound to the wrong target, or referenced files through unsafe filesystem topology. Recovery could also miss an agent after both the legacy store and replacement SQLite database had been removed.

## Why This Change Was Made

Migration manifests now use a validated version 2 shape with canonical paths, exact trusted target and SQLite binding, bounded move paths, and fail-closed symlink checks at planning and rename time. Recovery discovers configured and on-disk agent targets even when both store files are absent; version 1 manifests remain readable only across safe filesystem-root aliases needed by existing macOS paths.

## User Impact

Interrupted imports can restore archived session stores, transcripts, trajectories, and orphan JSONL files more reliably without following rewritten paths or symlinks. Unsafe or inconsistent manifests are reported as conflicts instead of moving files outside the intended agent sessions/archive directories.

## Evidence

- Exact branch head: `72477ff02175b2ecd3e7365e7017939014863d68`
- Testbox-through-Crabbox: `tbx_01kxb33pg2ja415vz41aknjhgs`
- Actions run: https://github.com/openclaw/openclaw/actions/runs/29191793624
- Focused restore/startup/target suite: 93 passed, 1 expected Linux skip
- `tsgo:core`: passed
- `tsgo:core:test`: passed
- Scoped oxfmt and oxlint: passed
- Path-scoped `pnpm check:changed`: passed (`core, coreTests`), including full core lint, Plugin SDK baseline, database-first storage guard, runtime sidecar guard, and import-cycle guard
- Broad sparse-overlay `check:changed` was also attempted; it conservatively selected unrelated repository paths and exposed current shrinkwrap drift outside this branch. The supported path-scoped gate above isolated and passed the nine touched files.
- Structured autoreview: clean after resolving source-containment and symlink-topology findings
- Adversarial coverage includes malformed manifests, target and SQLite path rewriting, traversal, symlink parents/ancestors/archive entries, v1 root-alias compatibility, deleted replacement SQLite files, missing legacy files, and out-of-target migration sources

AI-assisted. I reviewed the implementation and validation results and understand the restore and migration safety contracts changed here.
